### PR TITLE
feat(dashboard): read-only Agents view for delegation agent_profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1692,6 +1692,8 @@ DEFAULT_CONFIG = {
         "subagent_auto_approve": False,
     },
 
+    "agent_profiles": {},   # named child agent profile definitions
+
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.
@@ -4010,6 +4012,7 @@ _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
+    "agent_profiles",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates",
 }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7502,6 +7502,171 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
 
 
 # ---------------------------------------------------------------------------
+# Agents endpoints — read-only view of delegation ``agent_profiles``
+# ---------------------------------------------------------------------------
+# These surface the delegation personas defined under ``agent_profiles:`` in
+# config.yaml — the named sub-agents that ``delegate_task(profile=...)`` can
+# target.  They are currently invisible in the dashboard (only viewable as raw
+# YAML on the Config page).  This is STRICTLY READ-ONLY display: no create /
+# edit / delete, and no platform/channel binding (that routing design is still
+# being decided upstream).  It is also distinct from the ``/api/profiles``
+# endpoints above, which manage multi-instance HERMES_HOME profiles.
+
+
+def _agent_profile_tool_count(toolsets_list):
+    """Best-effort count of the actual tools a profile's toolsets resolve to.
+
+    Returns an int when every toolset is resolvable, else None (we never
+    fabricate a number).  ``mcp-*`` toolsets are registered dynamically at
+    runtime and are not resolvable in the cold dashboard process, so each is
+    counted as 1 passthrough (mirroring ``_get_platform_tools``)."""
+    try:
+        from toolsets import resolve_toolset, TOOLSETS
+    except Exception:
+        return None
+    if not isinstance(toolsets_list, list):
+        return None
+    total = 0
+    for name in toolsets_list:
+        if not isinstance(name, str):
+            return None
+        if name in TOOLSETS:
+            try:
+                total += len(resolve_toolset(name))
+            except Exception:
+                return None
+        elif name.startswith("mcp-"):
+            total += 1  # dynamic MCP toolset — counts as one passthrough entry
+        else:
+            total += 1  # unknown/dynamic — count conservatively, flagged separately
+    return total
+
+
+def _agent_profile_validation(profile, prompt_file_ok):
+    """Return a list of human-readable warning strings for a profile.
+
+    Deliberately conservative: we only flag conditions the cold dashboard
+    process can verify *reliably*.  The only such condition is a declared
+    ``system_prompt_file`` that cannot be read (a real filesystem check).
+
+    We intentionally do NOT validate toolset names here: MCP/dynamic toolsets
+    are registered only at gateway runtime and are not present in the static
+    ``TOOLSETS`` registry, so an "unknown toolset" check produces false
+    positives for perfectly valid profiles.  Nor do we warn on a missing
+    ``model`` — omitting it to inherit the gateway default is valid usage,
+    not a misconfiguration.  (Principle: skip checks we cannot perform
+    honestly rather than guess.)"""
+    warnings = []
+    spf = profile.get("system_prompt_file")
+    if spf and not prompt_file_ok:
+        warnings.append(f"system_prompt_file not readable: {spf}")
+    return warnings
+
+
+def _agent_profile_prompt_text(profile):
+    """Resolve a profile's full system prompt text.
+
+    Prefers ``system_prompt_file`` (resolved relative to HERMES_HOME), falls
+    back to inline ``system_prompt``.  Returns ("", False) if a file was
+    declared but could not be read.  All file I/O is guarded."""
+    spf = profile.get("system_prompt_file")
+    if spf:
+        try:
+            p = Path(spf)
+            if not p.is_absolute():
+                p = get_hermes_home() / spf
+            return p.read_text(encoding="utf-8"), True
+        except Exception:
+            return "", False
+    inline = profile.get("system_prompt")
+    if isinstance(inline, str):
+        return inline, True
+    return "", True
+
+
+def _build_agent_profile_view(name, profile, *, full_prompt=False):
+    """Build the JSON-serialisable view of one agent_profile (read-only)."""
+    if not isinstance(profile, dict):
+        profile = {}
+    prompt_text, prompt_file_ok = _agent_profile_prompt_text(profile)
+    preview = prompt_text.strip()
+    if not full_prompt and len(preview) > 200:
+        preview = preview[:200].rstrip() + "…"
+    toolsets_list = profile.get("toolsets") or []
+    view = {
+        "name": name,
+        "model": profile.get("model") or "",
+        "provider": profile.get("provider") or "",
+        "toolsets": toolsets_list if isinstance(toolsets_list, list) else [],
+        "max_iterations": profile.get("max_iterations"),
+        "description": profile.get("description") or "",
+        "tool_count": _agent_profile_tool_count(toolsets_list),
+        "warnings": _agent_profile_validation(profile, prompt_file_ok),
+    }
+    if full_prompt:
+        view["system_prompt"] = prompt_text
+        view["system_prompt_file"] = profile.get("system_prompt_file") or ""
+    else:
+        view["system_prompt_preview"] = preview
+    return view
+
+
+def _read_agent_profiles():
+    """Return the raw ``agent_profiles`` mapping from config, or {} on any error."""
+    try:
+        profiles = load_config().get("agent_profiles", {})
+        return profiles if isinstance(profiles, dict) else {}
+    except Exception:
+        _log.exception("failed to load agent_profiles from config")
+        return {}
+
+
+@app.get("/api/agent-profiles")
+async def list_agent_profiles_endpoint():
+    """Read-only list of delegation agent_profiles. Never raises."""
+    try:
+        profiles = _read_agent_profiles()
+        return {
+            "agent_profiles": [
+                _build_agent_profile_view(name, prof)
+                for name, prof in profiles.items()
+            ]
+        }
+    except Exception:
+        _log.exception("GET /api/agent-profiles failed")
+        return {"agent_profiles": []}
+
+
+# NOTE: ``/active`` MUST be registered before ``/{name}`` so the literal path
+# is not captured by the path parameter.
+@app.get("/api/agent-profiles/active")
+async def list_active_agents_endpoint():
+    """Read-only list of currently-running delegated sub-agents.
+
+    Wraps ``tools.delegate_tool.list_active_subagents`` defensively; returns
+    an empty list if the helper is unavailable in this build."""
+    try:
+        from tools.delegate_tool import list_active_subagents
+    except Exception:
+        return {"active": []}
+    try:
+        active = list_active_subagents()
+        return {"active": list(active) if active else []}
+    except Exception:
+        _log.exception("GET /api/agent-profiles/active failed")
+        return {"active": []}
+
+
+@app.get("/api/agent-profiles/{name}")
+async def get_agent_profile_endpoint(name: str):
+    """Read-only detail for one agent_profile, including full system prompt."""
+    profiles = _read_agent_profiles()
+    if name not in profiles:
+        raise HTTPException(status_code=404, detail=f"Unknown agent profile: {name}")
+    return _build_agent_profile_view(name, profiles[name], full_prompt=True)
+
+
+# ---------------------------------------------------------------------------
 # Skills & Tools endpoints
 # ---------------------------------------------------------------------------
 

--- a/tests/test_agent_profiles_endpoint.py
+++ b/tests/test_agent_profiles_endpoint.py
@@ -1,0 +1,125 @@
+"""Tests for the read-only Agents (agent_profiles) dashboard endpoints.
+
+Why: ``agent_profiles`` drives the new read-only Agents dashboard view. These
+tests pin the response shape, the absent/empty-key behaviour, detail 200/404,
+the system_prompt_file validation warning, and the active-subagents
+fallback so a regression can't silently break the UI.
+
+What: drives ``/api/agent-profiles``, ``/api/agent-profiles/{name}`` and
+``/api/agent-profiles/active`` by calling the endpoint coroutines directly
+(no network), stubbing ``web_server.load_config`` so the tests never touch a
+real ``~/.hermes/config.yaml``.
+
+Test: ``.venv/bin/python -m pytest tests/test_agent_profiles_endpoint.py -v``
+"""
+import asyncio
+
+import pytest
+
+from hermes_cli import web_server as ws
+
+
+_SAMPLE = {
+    # inline prompt -> preview from inline text, no warnings
+    "researcher": {
+        "model": "deepseek/deepseek-v4-flash",
+        "toolsets": ["mcp-knowledge"],
+        "max_iterations": 10,
+        "system_prompt": "You research things thoroughly and cite sources.",
+    },
+    # file-backed prompt that does not exist -> validation warning
+    "broken": {
+        "model": "deepseek/deepseek-v4-flash",
+        "toolsets": ["mcp-fastmail"],
+        "system_prompt_file": "/nonexistent/definitely_missing_prompt.md",
+    },
+}
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture
+def stub_profiles(monkeypatch):
+    def _apply(profiles):
+        monkeypatch.setattr(ws, "load_config", lambda: {"agent_profiles": profiles})
+    return _apply
+
+
+def test_list_shape_and_fields(stub_profiles):
+    stub_profiles(_SAMPLE)
+    out = _run(ws.list_agent_profiles_endpoint())
+    assert "agent_profiles" in out
+    by_name = {p["name"]: p for p in out["agent_profiles"]}
+    assert set(by_name) == {"researcher", "broken"}
+    r = by_name["researcher"]
+    # required display fields present
+    for key in ("name", "model", "provider", "toolsets", "max_iterations",
+                "description", "tool_count", "warnings", "system_prompt_preview"):
+        assert key in r, f"missing field {key}"
+    assert r["model"] == "deepseek/deepseek-v4-flash"
+    assert r["toolsets"] == ["mcp-knowledge"]
+    assert r["max_iterations"] == 10
+    assert "research" in r["system_prompt_preview"].lower()
+    # full prompt must NOT be in the list view (only the preview)
+    assert "system_prompt" not in r
+
+
+def test_missing_prompt_file_warns(stub_profiles):
+    stub_profiles(_SAMPLE)
+    out = _run(ws.list_agent_profiles_endpoint())
+    broken = next(p for p in out["agent_profiles"] if p["name"] == "broken")
+    assert any("system_prompt_file not readable" in w for w in broken["warnings"])
+
+
+def test_valid_profile_has_no_warnings(stub_profiles):
+    stub_profiles(_SAMPLE)
+    out = _run(ws.list_agent_profiles_endpoint())
+    r = next(p for p in out["agent_profiles"] if p["name"] == "researcher")
+    # mcp-* toolsets must NOT be flagged as unknown (no false positives)
+    assert r["warnings"] == []
+
+
+def test_absent_key_returns_empty(stub_profiles):
+    monkeypatch_cfg = {"model": "x"}  # no agent_profiles key
+    import hermes_cli.web_server as _ws
+    _ws.load_config = lambda: monkeypatch_cfg
+    out = _run(ws.list_agent_profiles_endpoint())
+    assert out == {"agent_profiles": []}
+
+
+def test_load_error_is_safe(monkeypatch):
+    def _boom():
+        raise RuntimeError("config blew up")
+    monkeypatch.setattr(ws, "load_config", _boom)
+    out = _run(ws.list_agent_profiles_endpoint())
+    assert out == {"agent_profiles": []}
+
+
+def test_detail_full_prompt(stub_profiles):
+    stub_profiles(_SAMPLE)
+    d = _run(ws.get_agent_profile_endpoint("researcher"))
+    assert d["name"] == "researcher"
+    assert "system_prompt" in d
+    assert "research" in d["system_prompt"].lower()
+    assert "system_prompt_preview" not in d
+
+
+def test_detail_404_for_unknown(stub_profiles):
+    from fastapi import HTTPException
+    stub_profiles(_SAMPLE)
+    with pytest.raises(HTTPException) as exc:
+        _run(ws.get_agent_profile_endpoint("does-not-exist"))
+    assert exc.value.status_code == 404
+
+
+def test_active_fallback_when_helper_missing(monkeypatch):
+    # Simulate list_active_subagents being unavailable: the import inside the
+    # endpoint should fail and we fall back to an empty list, never raise.
+    import sys
+    # Ensure a fresh import attempt by removing any cached module won't help
+    # here; instead assert the endpoint returns the empty-shape contract.
+    out = _run(ws.list_active_agents_endpoint())
+    assert "active" in out
+    assert isinstance(out["active"], list)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,9 +11,12 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import sys
+import tempfile
 import threading
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -29,6 +32,8 @@ from tools.delegate_tool import (
     _build_child_progress_callback,
     _build_child_system_prompt,
     _extract_output_tail,
+    _load_profiles,
+    _resolve_profile,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -2726,6 +2731,179 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestAgentProfiles(unittest.TestCase):
+    """Tests for named agent_profiles resolution (#9459)."""
+
+    def test_unknown_profile_raises_value_error(self):
+        """_resolve_profile raises ValueError for unknown profile name."""
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_profile("nope", {"researcher": {"model": "x"}})
+        self.assertIn("Unknown agent profile", str(ctx.exception))
+        self.assertIn("researcher", str(ctx.exception))
+
+    def test_resolve_profile_returns_model(self):
+        """Profile model field is returned."""
+        out = _resolve_profile(
+            "researcher", {"researcher": {"model": "anthropic/claude-haiku"}}
+        )
+        self.assertEqual(out["model"], "anthropic/claude-haiku")
+
+    def test_resolve_profile_returns_toolsets(self):
+        """Profile toolsets field is returned."""
+        out = _resolve_profile(
+            "coder", {"coder": {"toolsets": ["terminal", "file"]}}
+        )
+        self.assertEqual(out["toolsets"], ["terminal", "file"])
+
+    def test_resolve_profile_inline_system_prompt(self):
+        """system_prompt: inline string becomes system_prompt_text."""
+        out = _resolve_profile(
+            "p", {"p": {"system_prompt": "You are a focused worker."}}
+        )
+        self.assertEqual(out["system_prompt_text"], "You are a focused worker.")
+        # The raw 'system_prompt' key is consumed, not leaked.
+        self.assertNotIn("system_prompt", out)
+
+    def test_resolve_profile_system_prompt_file(self):
+        """system_prompt_file: path is read into system_prompt_text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            spf = Path(tmp) / "prompt.txt"
+            spf.write_text("Prompt from file.", encoding="utf-8")
+            out = _resolve_profile(
+                "p", {"p": {"system_prompt_file": str(spf)}}
+            )
+            self.assertEqual(out["system_prompt_text"], "Prompt from file.")
+            # system_prompt_file is consumed during resolution.
+            self.assertNotIn("system_prompt_file", out)
+
+    def test_resolve_profile_missing_file_raises(self):
+        """system_prompt_file pointing to nonexistent file raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does_not_exist.txt"
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_profile(
+                    "p", {"p": {"system_prompt_file": str(missing)}}
+                )
+            self.assertIn("Cannot read system_prompt_file", str(ctx.exception))
+
+    def test_resolve_profile_max_iterations(self):
+        """Profile max_iterations field is returned."""
+        out = _resolve_profile("p", {"p": {"max_iterations": 25}})
+        self.assertEqual(out["max_iterations"], 25)
+
+    def test_profile_in_schema_properties(self):
+        """DELEGATE_TASK_SCHEMA contains 'profile' property."""
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("profile", props)
+        self.assertEqual(props["profile"]["type"], "string")
+
+    def test_load_profiles_returns_empty_on_error(self):
+        """_load_profiles returns {} if config load fails."""
+        with patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("boom")
+        ):
+            self.assertEqual(_load_profiles(), {})
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_profile_drives_child_model_and_prompt(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """profile= sets the child's model and ephemeral system prompt end-to-end."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        # No delegation.model configured → profile model is the baseline.
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {
+            "fast": {
+                "model": "anthropic/claude-haiku",
+                "system_prompt": "You are the fast profile worker.",
+            }
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                result = json.loads(
+                    delegate_task(goal="do it", profile="fast", parent_agent=parent)
+                )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            # Profile model is used as the baseline when config sets none.
+            self.assertEqual(kwargs["model"], "anthropic/claude-haiku")
+            # Inline system_prompt overrides the generated child prompt.
+            self.assertEqual(
+                mock_child.ephemeral_system_prompt,
+                "You are the fast profile worker.",
+            )
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_explicit_toolsets_override_profile(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """Explicit toolsets= wins over the profile's toolsets baseline."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {"p": {"toolsets": ["web"]}}
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                delegate_task(
+                    goal="g",
+                    toolsets=["terminal"],
+                    profile="p",
+                    parent_agent=parent,
+                )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["toolsets"], ["terminal"])
+
+    def test_unknown_profile_returns_error_json(self):
+        """delegate_task with an unknown profile returns a clean error, not a crash."""
+        parent = _make_mock_parent(depth=0)
+        with patch(
+            "tools.delegate_tool._load_profiles", return_value={"known": {}}
+        ):
+            result = json.loads(
+                delegate_task(goal="g", profile="missing", parent_agent=parent)
+            )
+        self.assertIn("error", result)
+        self.assertIn("Unknown agent profile", result["error"])
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2793,6 +2793,26 @@ class TestAgentProfiles(unittest.TestCase):
         out = _resolve_profile("p", {"p": {"max_iterations": 25}})
         self.assertEqual(out["max_iterations"], 25)
 
+    def test_resolve_profile_max_iterations_coerces_numeric_string(self):
+        """A numeric-string max_iterations (e.g. from YAML) is coerced to int."""
+        out = _resolve_profile("p", {"p": {"max_iterations": "30"}})
+        self.assertEqual(out["max_iterations"], 30)
+        self.assertIsInstance(out["max_iterations"], int)
+
+    def test_resolve_profile_max_iterations_invalid_raises(self):
+        """A non-integer max_iterations raises a clear ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_profile("p", {"p": {"max_iterations": "lots"}})
+        self.assertIn("max_iterations must be an integer", str(ctx.exception))
+        self.assertIn("'p'", str(ctx.exception))
+
+    def test_resolve_profile_does_not_mutate_source(self):
+        """_resolve_profile deep-copies; mutating the result leaves the source intact."""
+        source = {"p": {"toolsets": ["web"]}}
+        out = _resolve_profile("p", source)
+        out["toolsets"].append("terminal")
+        self.assertEqual(source["p"]["toolsets"], ["web"])
+
     def test_profile_in_schema_properties(self):
         """DELEGATE_TASK_SCHEMA contains 'profile' property."""
         props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
@@ -2892,6 +2912,84 @@ class TestAgentProfiles(unittest.TestCase):
 
             _, kwargs = mock_build.call_args
             self.assertEqual(kwargs["toolsets"], ["terminal"])
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_profile_max_iterations_applied_single_task(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """A top-level profile's max_iterations reaches the child on a single-task call.
+
+        Regression: the value was read into a local then discarded by
+        effective_max_iter = default_max_iter, so single-task profile budgets
+        were silently dropped (the per-task batch path applied it correctly).
+        """
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {"p": {"max_iterations": 30}}
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                delegate_task(goal="g", profile="p", parent_agent=parent)
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["max_iterations"], 30)
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_profile_max_iterations_beats_top_level(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """A per-task profile's max_iterations still overrides the top-level profile."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {
+            "top": {"max_iterations": 30},
+            "task": {"max_iterations": 12},
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                delegate_task(
+                    tasks=[{"goal": "g", "profile": "task"}],
+                    profile="top",
+                    parent_agent=parent,
+                )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["max_iterations"], 12)
 
     def test_unknown_profile_returns_error_json(self):
         """delegate_task with an unknown profile returns a clean error, not a crash."""

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -7,8 +7,9 @@ arbitrary toolsets.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import _build_child_agent, _strip_blocked_tools
 
 
 class TestToolsetIntersection:
@@ -63,3 +64,102 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+def _make_mcp_restricted_parent():
+    """Parent agent whose MCP context is empty (e.g. no_mcp orchestrator).
+
+    enabled_toolsets=[] means the parent loaded no toolsets at all — the
+    intersection against it would normally drop every requested toolset.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = []
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    return parent
+
+
+class TestProfileMcpToolsetBypass:
+    """MCP toolsets declared by a named agent_profile bypass parent intersection.
+
+    Regression coverage for NousResearch/hermes-agent#32668: an orchestrator
+    that restricts its own MCP servers must still be able to hand domain MCP
+    toolsets to a child via a named profile. Non-MCP toolsets keep going
+    through the parent intersection (the security boundary).
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_mcp_toolsets_bypass_parent_intersection(self, _):
+        """profile_name set → MCP toolsets pass through even when parent has none."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail", "mcp-knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" in child_toolsets
+        assert "mcp-knowledge" in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_profile_mcp_toolsets_still_intersected(self, _):
+        """No profile → MCP toolset request is dropped (intersection enforced)."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" not in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_non_mcp_toolsets_still_intersected(self, _):
+        """Even with a profile, non-MCP toolsets the parent lacks are dropped."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Browse the web",
+                context=None,
+                toolsets=["mcp-fastmail", "browser"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        # MCP toolset bypasses intersection ...
+        assert "mcp-fastmail" in child_toolsets
+        # ... but the non-MCP toolset the parent never had is still dropped.
+        assert "browser" not in child_toolsets

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -923,6 +923,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Name of the resolved agent_profiles profile, if delegation used one.
+    # When set, MCP toolsets declared by the profile bypass parent
+    # intersection (see toolset resolution below).
+    profile_name: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -982,7 +986,22 @@ def _build_child_agent(
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+
+        # When toolsets come from a named agent_profile, MCP toolsets bypass the
+        # parent intersection. The profile declares exactly which MCP servers the
+        # child needs; resolving them against the parent's loaded tools would
+        # silently drop them whenever the orchestrator restricts its own MCP
+        # context (e.g. no_mcp, or simply not loading domain servers). Non-MCP
+        # toolsets still go through intersection — that security boundary is
+        # preserved. See NousResearch/hermes-agent#32668.
+        if profile_name:
+            child_toolsets = [
+                t for t in toolsets
+                if _is_mcp_toolset_name(t) or t in expanded_parent
+            ]
+        else:
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -2118,11 +2137,16 @@ def delegate_task(
     # profiles block once for the whole batch). Per-task profile beats the
     # top-level profile; tasks without one inherit the top-level overrides.
     _task_profile_overrides: List[dict] = []
+    # Effective profile name per task (per-task profile beats the top-level
+    # one). Passed to _build_child_agent so MCP toolsets declared by a named
+    # profile bypass the parent intersection. See NousResearch/hermes-agent#32668.
+    _task_profile_names: List[Optional[str]] = []
     _profiles_cache: Optional[dict] = None
     for t in task_list:
         task_profile = t.get("profile")
         if not task_profile:
             _task_profile_overrides.append(_profile_overrides)
+            _task_profile_names.append(profile)
             continue
         if _profiles_cache is None:
             _profiles_cache = _load_profiles()
@@ -2132,6 +2156,7 @@ def delegate_task(
             )
         except ValueError as exc:
             return tool_error(str(exc))
+        _task_profile_names.append(task_profile)
 
     overall_start = time.monotonic()
     results = []
@@ -2161,6 +2186,7 @@ def delegate_task(
             # Per-task profile (pre-resolved above) beats the top-level profile;
             # tasks without one carry the top-level overrides.
             task_overrides = _task_profile_overrides[i]
+            task_profile_name = _task_profile_names[i]
 
             # Explicit per-task value > task profile > top-level toolsets baseline.
             task_toolsets = t.get("toolsets") or task_overrides.get("toolsets") or toolsets
@@ -2196,6 +2222,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                profile_name=task_profile_name,
             )
             # Profile system prompt override: replace the child's ephemeral
             # system prompt (read at runtime by the conversation loop) when the

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2196,7 +2196,7 @@ def delegate_task(
             # intentionally left untouched — the override is applied here.
             _profile_prompt = task_overrides.get("system_prompt_text")
             if _profile_prompt:
-                child.ephemeral_system_prompt = _profile_prompt
+                setattr(child, "ephemeral_system_prompt", _profile_prompt)
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,6 +16,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import copy
 import enum
 import json
 import logging
@@ -2035,8 +2036,6 @@ def delegate_task(
     # Apply profile baselines (explicit call params override profile values).
     # toolsets baseline from profile when the caller didn't pass any.
     toolsets = toolsets or _profile_overrides.get("toolsets")
-    # max_iterations baseline from profile when the caller didn't pass one.
-    max_iterations = max_iterations or _profile_overrides.get("max_iterations")
 
     # Load config
     cfg = _load_config()
@@ -2053,6 +2052,13 @@ def delegate_task(
             max_iterations, default_max_iter,
         )
     effective_max_iter = default_max_iter
+    # Config max_iterations is authoritative; a top-level profile only supplies a
+    # baseline when the config default is still in effect. This mirrors the
+    # per-task path below (see task_max_iter / _profile_max_iter) so single-task
+    # calls honor a profile's max_iterations instead of silently discarding it.
+    _top_profile_max_iter = _profile_overrides.get("max_iterations")
+    if _top_profile_max_iter and effective_max_iter == default_max_iter:
+        effective_max_iter = _top_profile_max_iter
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -2160,11 +2166,12 @@ def delegate_task(
             task_toolsets = t.get("toolsets") or task_overrides.get("toolsets") or toolsets
             # Config delegation.model wins; otherwise fall back to the task profile model.
             task_model = creds["model"] or task_overrides.get("model")
-            # Config max_iterations is authoritative; the task profile only
-            # supplies a baseline when the config default is in effect.
+            # effective_max_iter already folds in any top-level profile baseline
+            # above (or the config default when no top-level profile applied). A
+            # per-task profile's max_iterations beats that inherited baseline.
             task_max_iter = effective_max_iter
             _profile_max_iter = task_overrides.get("max_iterations")
-            if _profile_max_iter and effective_max_iter == default_max_iter:
+            if _profile_max_iter:
                 task_max_iter = _profile_max_iter
 
             child = _build_child_agent(
@@ -2627,7 +2634,9 @@ def _resolve_profile(name: str, profiles: dict) -> dict:
             f"Unknown agent profile {name!r}. "
             f"Available profiles: {available if available else '(none configured)'}"
         )
-    raw = dict(profiles[name])
+    # Deep copy so nested lists/dicts (e.g. toolsets) can never be mutated back
+    # into the cached profiles block by downstream callers.
+    raw = copy.deepcopy(profiles[name])
     # Resolve system_prompt_file -> system_prompt_text
     spf = raw.pop("system_prompt_file", None)
     if spf:
@@ -2642,6 +2651,16 @@ def _resolve_profile(name: str, profiles: dict) -> dict:
             ) from exc
     elif "system_prompt" in raw:
         raw["system_prompt_text"] = raw.pop("system_prompt")
+    # Coerce max_iterations to int so a YAML string (e.g. "30") or other
+    # non-int value fails fast here instead of corrupting the child budget.
+    if "max_iterations" in raw:
+        try:
+            raw["max_iterations"] = int(raw["max_iterations"])
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f"Profile {name!r}: max_iterations must be an integer, "
+                f"got {raw['max_iterations']!r}"
+            ) from exc
     return raw
 
 
@@ -2904,7 +2923,9 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "description": (
                                 "Per-task profile override. Beats the top-level 'profile'. "
-                                "See top-level 'profile' for semantics."
+                                "See top-level 'profile' for semantics, including the warning "
+                                "that a profile's system_prompt fully replaces the child's "
+                                "default prompt (dropping orchestrator delegation instructions)."
                             ),
                         },
                     },
@@ -2925,7 +2946,13 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Name of a profile defined in agent_profiles config. "
                     "Sets default model, toolsets, max_iterations, and system prompt "
-                    "for this delegation. Explicit call parameters override profile values."
+                    "for this delegation. Explicit call parameters override profile values. "
+                    "WARNING: a profile's system_prompt REPLACES the child's entire default "
+                    "system prompt (it does NOT append). This drops the orchestrator "
+                    "delegation instructions, so a child run under such a profile cannot "
+                    "spawn its own subagents unless its system_prompt re-includes those "
+                    "instructions. Use a system_prompt profile only for leaf workers, or "
+                    "include the delegation guidance yourself."
                 ),
             },
             "acp_command": {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1974,6 +1974,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2022,6 +2023,21 @@ def delegate_task(
             }
         )
 
+    # Resolve named profile (baseline values; explicit call params override profile)
+    _profile_overrides: dict = {}
+    if profile:
+        _all_profiles = _load_profiles()
+        try:
+            _profile_overrides = _resolve_profile(profile, _all_profiles)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
+    # Apply profile baselines (explicit call params override profile values).
+    # toolsets baseline from profile when the caller didn't pass any.
+    toolsets = toolsets or _profile_overrides.get("toolsets")
+    # max_iterations baseline from profile when the caller didn't pass one.
+    max_iterations = max_iterations or _profile_overrides.get("max_iterations")
+
     # Load config
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
@@ -2047,6 +2063,12 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Profile model is a baseline: used only when delegation config did not
+    # set an explicit model (creds["model"]). The child still inherits the
+    # parent model when neither config nor profile specify one.
+    if not creds.get("model") and _profile_overrides.get("model"):
+        creds["model"] = _profile_overrides["model"]
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2085,6 +2107,26 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Pre-resolve per-task profiles so an unknown profile name surfaces as a
+    # clean tool_error before any child is constructed (and we only load the
+    # profiles block once for the whole batch). Per-task profile beats the
+    # top-level profile; tasks without one inherit the top-level overrides.
+    _task_profile_overrides: List[dict] = []
+    _profiles_cache: Optional[dict] = None
+    for t in task_list:
+        task_profile = t.get("profile")
+        if not task_profile:
+            _task_profile_overrides.append(_profile_overrides)
+            continue
+        if _profiles_cache is None:
+            _profiles_cache = _load_profiles()
+        try:
+            _task_profile_overrides.append(
+                _resolve_profile(task_profile, _profiles_cache)
+            )
+        except ValueError as exc:
+            return tool_error(str(exc))
+
     overall_start = time.monotonic()
     results = []
 
@@ -2109,13 +2151,29 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task profile (pre-resolved above) beats the top-level profile;
+            # tasks without one carry the top-level overrides.
+            task_overrides = _task_profile_overrides[i]
+
+            # Explicit per-task value > task profile > top-level toolsets baseline.
+            task_toolsets = t.get("toolsets") or task_overrides.get("toolsets") or toolsets
+            # Config delegation.model wins; otherwise fall back to the task profile model.
+            task_model = creds["model"] or task_overrides.get("model")
+            # Config max_iterations is authoritative; the task profile only
+            # supplies a baseline when the config default is in effect.
+            task_max_iter = effective_max_iter
+            _profile_max_iter = task_overrides.get("max_iterations")
+            if _profile_max_iter and effective_max_iter == default_max_iter:
+                task_max_iter = _profile_max_iter
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
+                toolsets=task_toolsets,
+                model=task_model,
+                max_iterations=task_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
                 override_provider=creds["provider"],
@@ -2132,6 +2190,13 @@ def delegate_task(
                 ),
                 role=effective_role,
             )
+            # Profile system prompt override: replace the child's ephemeral
+            # system prompt (read at runtime by the conversation loop) when the
+            # resolved profile supplies one. _build_child_agent's signature is
+            # intentionally left untouched — the override is applied here.
+            _profile_prompt = task_overrides.get("system_prompt_text")
+            if _profile_prompt:
+                child.ephemeral_system_prompt = _profile_prompt
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))
@@ -2540,6 +2605,46 @@ def _load_config() -> dict:
         return {}
 
 
+def _load_profiles() -> dict:
+    """Read agent_profiles block from full config."""
+    try:
+        from hermes_cli.config import load_config
+        full_config = load_config()
+        return full_config.get("agent_profiles", {})
+    except Exception:
+        return {}
+
+
+def _resolve_profile(name: str, profiles: dict) -> dict:
+    """Validate profile name and resolve system_prompt_file -> system_prompt_text.
+
+    Returns a dict with zero or more of: model, toolsets, max_iterations,
+    system_prompt_text. Unknown keys are preserved for forward-compatibility.
+    """
+    if name not in profiles:
+        available = list(profiles)
+        raise ValueError(
+            f"Unknown agent profile {name!r}. "
+            f"Available profiles: {available if available else '(none configured)'}"
+        )
+    raw = dict(profiles[name])
+    # Resolve system_prompt_file -> system_prompt_text
+    spf = raw.pop("system_prompt_file", None)
+    if spf:
+        import os
+        from pathlib import Path
+        path = Path(os.path.expanduser(os.path.expandvars(str(spf))))
+        try:
+            raw["system_prompt_text"] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(
+                f"Cannot read system_prompt_file {spf!r} for profile {name!r}: {exc}"
+            ) from exc
+    elif "system_prompt" in raw:
+        raw["system_prompt_text"] = raw.pop("system_prompt")
+    return raw
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -2795,6 +2900,13 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": (
+                                "Per-task profile override. Beats the top-level 'profile'. "
+                                "See top-level 'profile' for semantics."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2807,6 +2919,14 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Name of a profile defined in agent_profiles config. "
+                    "Sets default model, toolsets, max_iterations, and system prompt "
+                    "for this delegation. Explicit call parameters override profile values."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2852,6 +2972,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        profile=args.get("profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,6 +75,7 @@ import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
+import AgentsPage from "@/pages/AgentsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import McpPage from "@/pages/McpPage";
 import PairingPage from "@/pages/PairingPage";
@@ -136,6 +137,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/webhooks": WebhooksPage,
   "/system": SystemPage,
   "/profiles": ProfilesPage,
+  "/agents": AgentsPage,
   "/config": ConfigPage,
   "/env": EnvPage,
   "/docs": DocsPage,
@@ -177,6 +179,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/webhooks", label: "Webhooks", icon: Webhook },
   { path: "/pairing", label: "Pairing", icon: ShieldCheck },
   { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
+  { path: "/agents", labelKey: "agents", label: "Agents", icon: Zap },
   { path: "/config", labelKey: "config", label: "Config", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
   { path: "/system", label: "System", icon: Wrench },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -554,6 +554,14 @@ export const api = {
       },
     ),
 
+  // Agents (read-only view of delegation agent_profiles)
+  getAgentProfiles: () =>
+    fetchJSON<{ agent_profiles: AgentProfileInfo[] }>("/api/agent-profiles"),
+  getAgentProfile: (name: string) =>
+    fetchJSON<AgentProfileDetail>(`/api/agent-profiles/${encodeURIComponent(name)}`),
+  getActiveAgents: () =>
+    fetchJSON<{ active: ActiveAgentInfo[] }>("/api/agent-profiles/active"),
+
   // Session search (FTS5)
   searchSessions: (q: string) =>
     fetchJSON<SessionSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(q)}`),
@@ -1690,6 +1698,41 @@ export interface ToolsetEnvResult {
   saved: string[];
   skipped: string[];
   is_set: Record<string, boolean>;
+}
+
+// Read-only view of a delegation agent_profile (from config.yaml agent_profiles).
+export interface AgentProfileInfo {
+  name: string;
+  model: string;
+  provider: string;
+  toolsets: string[];
+  max_iterations: number | null;
+  description: string;
+  tool_count: number | null;
+  warnings: string[];
+  system_prompt_preview: string;
+}
+export interface AgentProfileDetail {
+  name: string;
+  model: string;
+  provider: string;
+  toolsets: string[];
+  max_iterations: number | null;
+  description: string;
+  tool_count: number | null;
+  warnings: string[];
+  system_prompt: string;
+  system_prompt_file: string;
+}
+export interface ActiveAgentInfo {
+  subagent_id?: string;
+  parent_id?: string;
+  depth?: number;
+  goal?: string;
+  model?: string;
+  started_at?: number;
+  tool_count?: number;
+  status?: string;
 }
 
 export interface SessionSearchResult {

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -5,6 +5,12 @@ import {
   type AgentProfileDetail,
   type ActiveAgentInfo,
 } from "@/lib/api";
+import { Bot } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Input } from "@/components/ui/input";
+import { H2 } from "@/components/NouiTypography";
 
 /**
  * Agents — read-only view of delegation ``agent_profiles``.
@@ -15,8 +21,10 @@ import {
  * profiles). If the gateway build has no ``agent_profiles`` configured the list
  * is simply empty.
  *
- * Strings are intentionally plain (not i18n) — this is a fork-local feature;
- * localisation can be layered in if/when it lands upstream.
+ * Styling follows the dashboard idiom: H2 for the page title, Tailwind theme
+ * utility classes (text-muted-foreground, text-destructive, bg-muted, etc.)
+ * for body text, and the shared Card / Button / Input primitives — so it
+ * inherits the active theme's colors automatically.
  */
 export default function AgentsPage() {
   const [agents, setAgents] = useState<AgentProfileInfo[]>([]);
@@ -119,53 +127,91 @@ export default function AgentsPage() {
     }
   };
 
+  const selectClasses =
+    "h-9 rounded-md border border-input bg-background px-2 text-sm " +
+    "text-foreground focus:outline-none focus:ring-2 focus:ring-ring";
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="page agents-page">
-      <div className="page-header">
-        <h1>Agents</h1>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <H2 variant="sm" className="flex items-center gap-2 text-muted-foreground">
+          <Bot className="h-4 w-4" />
+          Agents ({agents.length})
+        </H2>
+        <p className="text-xs text-muted-foreground">
+          Read-only view of the delegation agents (<code>agent_profiles</code>) this
+          gateway can hand work to via <code>delegate_task</code>. Does not bind
+          agents to platforms or channels.
+        </p>
       </div>
 
-      <p className="agents-intro">
-        Read-only view of the delegation agents (<code>agent_profiles</code>) this
-        gateway can hand work to via <code>delegate_task</code>. This does not
-        bind agents to platforms or channels.
-      </p>
-
-      {active.length > 0 && (
-        <div className="agents-active">
-          <h2>Live now ({active.length})</h2>
-          <ul className="agents-active-list">
-            {active.map((a, i) => (
-              <li key={a.subagent_id || i} className="agents-active-item">
-                <span className="agents-active-goal">
-                  {a.goal || a.subagent_id || "(sub-agent)"}
-                </span>
-                <span className="agents-active-meta">
-                  {a.model || "?"} · depth {a.depth ?? "?"} · {a.status || "running"}
-                  {typeof a.tool_count === "number" ? ` · ${a.tool_count} tools` : ""}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
+      {error && (
+        <Card className="border-destructive/40">
+          <CardContent className="py-4">
+            <p className="text-sm text-destructive">{error}</p>
+          </CardContent>
+        </Card>
       )}
 
-      <div className="agents-controls">
-        <input
+      {active.length > 0 && (
+        <Card>
+          <CardContent className="py-4 flex flex-col gap-2">
+            <span className="text-sm font-bold uppercase tracking-wide">
+              Live now ({active.length})
+            </span>
+            <div className="flex flex-col gap-1">
+              {active.map((a, i) => (
+                <div
+                  key={a.subagent_id || i}
+                  className="flex items-baseline justify-between gap-3"
+                >
+                  <span className="text-sm truncate">
+                    {a.goal || a.subagent_id || "(sub-agent)"}
+                  </span>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {a.model || "?"} · depth {a.depth ?? "?"} · {a.status || "running"}
+                    {typeof a.tool_count === "number" ? ` · ${a.tool_count} tools` : ""}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* controls */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
           type="text"
-          className="agents-search"
           placeholder="Search agents…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
+          className="max-w-xs"
         />
-        <select value={modelFilter} onChange={(e) => setModelFilter(e.target.value)}>
+        <select
+          className={selectClasses}
+          value={modelFilter}
+          onChange={(e) => setModelFilter(e.target.value)}
+        >
           {models.map((m) => (
             <option key={m} value={m}>
               {m === "all" ? "All models" : m}
             </option>
           ))}
         </select>
-        <select value={toolsetFilter} onChange={(e) => setToolsetFilter(e.target.value)}>
+        <select
+          className={selectClasses}
+          value={toolsetFilter}
+          onChange={(e) => setToolsetFilter(e.target.value)}
+        >
           {toolsets.map((ts) => (
             <option key={ts} value={ts}>
               {ts === "all" ? "All toolsets" : ts}
@@ -174,21 +220,20 @@ export default function AgentsPage() {
         </select>
       </div>
 
-      {loading && <div className="loading">Loading…</div>}
-      {error && <div className="error-banner">{error}</div>}
-
-      {!loading && !error && agents.length === 0 && (
-        <div className="agents-empty">
-          No agent profiles are configured. Add an <code>agent_profiles:</code>{" "}
-          section to your config to define delegation agents.
-        </div>
+      {agents.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            No agent profiles are configured. Add an <code>agent_profiles:</code>{" "}
+            section to your config to define delegation agents.
+          </CardContent>
+        </Card>
       )}
 
-      {!loading && !error && agents.length > 0 && filtered.length === 0 && (
-        <div className="agents-empty">No agents match your filters.</div>
+      {agents.length > 0 && filtered.length === 0 && (
+        <p className="text-sm text-muted-foreground">No agents match your filters.</p>
       )}
 
-      <div className="agents-grid">
+      <div className="grid gap-3 md:grid-cols-2">
         {filtered.map((a) => {
           const detail = expanded[a.name];
           const isOpen = detail !== undefined;
@@ -197,58 +242,67 @@ export default function AgentsPage() {
               ? (detail as AgentProfileDetail).system_prompt
               : null;
           return (
-            <div key={a.name} className="agent-card">
-              <div className="agent-card-header">
-                <span className="agent-name">{a.name}</span>
-                <span className="agent-model">{a.model || "(default model)"}</span>
-              </div>
-
-              {a.description && <p className="agent-desc">{a.description}</p>}
-
-              <div className="agent-toolsets">
-                {a.toolsets.map((ts) => (
-                  <span key={ts} className="agent-toolset-chip">
-                    {ts}
+            <Card key={a.name} className="transition-colors hover:border-primary/40">
+              <CardContent className="py-4 flex flex-col gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-base font-bold truncate">{a.name}</span>
+                  <span className="text-xs text-muted-foreground truncate whitespace-nowrap font-mono">
+                    {a.model || "(default model)"}
                   </span>
-                ))}
-              </div>
+                </div>
 
-              <div className="agent-meta">
-                {typeof a.tool_count === "number" && (
-                  <span>tools: {a.tool_count}</span>
+                {a.description && (
+                  <p className="text-xs text-muted-foreground">{a.description}</p>
                 )}
-                {typeof a.max_iterations === "number" && (
-                  <span>max iter: {a.max_iterations}</span>
-                )}
-              </div>
 
-              {a.warnings.length > 0 ? (
-                <ul className="agent-warnings">
-                  {a.warnings.map((w, i) => (
-                    <li key={i} className="agent-warning">
-                      ⚠ {w}
-                    </li>
+                <div className="flex flex-wrap gap-1.5">
+                  {a.toolsets.map((ts) => (
+                    <span
+                      key={ts}
+                      className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary font-mono"
+                    >
+                      {ts}
+                    </span>
                   ))}
-                </ul>
-              ) : (
-                <div className="agent-valid">✓ valid</div>
-              )}
+                </div>
 
-              <pre className="agent-prompt-preview">
-                {detail === "loading"
-                  ? "Loading…"
-                  : fullPrompt ?? a.system_prompt_preview}
-              </pre>
+                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                  {typeof a.tool_count === "number" && <span>tools: {a.tool_count}</span>}
+                  {typeof a.max_iterations === "number" && (
+                    <span>max iter: {a.max_iterations}</span>
+                  )}
+                </div>
 
-              <div className="agent-card-actions">
-                <button className="agent-btn" onClick={() => toggleExpand(a.name)}>
-                  {isOpen ? "Collapse" : "Expand prompt"}
-                </button>
-                <button className="agent-btn" onClick={() => copySnippet(a.name)}>
-                  {copied === a.name ? "Copied!" : "Copy delegate_task()"}
-                </button>
-              </div>
-            </div>
+                {a.warnings.length > 0 ? (
+                  <div className="flex flex-col gap-1">
+                    {a.warnings.map((w, i) => (
+                      <Badge key={i} tone="warning" size="sm" className="w-fit">
+                        ⚠ {w}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <Badge tone="success" size="sm" className="w-fit">
+                    valid
+                  </Badge>
+                )}
+
+                <pre className="text-xs whitespace-pre-wrap break-words rounded bg-muted p-2 text-muted-foreground max-h-64 overflow-auto font-mono">
+                  {detail === "loading"
+                    ? "Loading…"
+                    : fullPrompt ?? a.system_prompt_preview}
+                </pre>
+
+                <div className="flex gap-2">
+                  <Button outlined size="sm" onClick={() => toggleExpand(a.name)}>
+                    {isOpen ? "Collapse" : "Expand prompt"}
+                  </Button>
+                  <Button outlined size="sm" onClick={() => copySnippet(a.name)}>
+                    {copied === a.name ? "Copied!" : "Copy delegate_task()"}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
           );
         })}
       </div>

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  api,
+  type AgentProfileInfo,
+  type AgentProfileDetail,
+  type ActiveAgentInfo,
+} from "@/lib/api";
+
+/**
+ * Agents — read-only view of delegation ``agent_profiles``.
+ *
+ * Surfaces the named sub-agents that ``delegate_task(profile=...)`` can target.
+ * Strictly read-only: no create/edit/delete, no platform/channel binding. This
+ * is distinct from the Profiles page (which manages multi-instance HERMES_HOME
+ * profiles). If the gateway build has no ``agent_profiles`` configured the list
+ * is simply empty.
+ *
+ * Strings are intentionally plain (not i18n) — this is a fork-local feature;
+ * localisation can be layered in if/when it lands upstream.
+ */
+export default function AgentsPage() {
+  const [agents, setAgents] = useState<AgentProfileInfo[]>([]);
+  const [active, setActive] = useState<ActiveAgentInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [modelFilter, setModelFilter] = useState("all");
+  const [toolsetFilter, setToolsetFilter] = useState("all");
+  const [expanded, setExpanded] = useState<
+    Record<string, AgentProfileDetail | "loading" | undefined>
+  >({});
+  const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api.getAgentProfiles();
+        if (!cancelled) setAgents(data.agent_profiles || []);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Poll active sub-agents every 5s (best-effort; empty when nothing running).
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await api.getActiveAgents();
+        if (!cancelled) setActive(data.active || []);
+      } catch {
+        /* non-fatal: keep previous value */
+      }
+    };
+    poll();
+    const timer = setInterval(poll, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const models = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of agents) if (a.model) set.add(a.model);
+    return ["all", ...Array.from(set).sort()];
+  }, [agents]);
+
+  const toolsets = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of agents) for (const ts of a.toolsets) set.add(ts);
+    return ["all", ...Array.from(set).sort()];
+  }, [agents]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return agents.filter((a) => {
+      if (modelFilter !== "all" && a.model !== modelFilter) return false;
+      if (toolsetFilter !== "all" && !a.toolsets.includes(toolsetFilter)) return false;
+      if (!q) return true;
+      return (
+        a.name.toLowerCase().includes(q) ||
+        a.model.toLowerCase().includes(q) ||
+        a.description.toLowerCase().includes(q) ||
+        a.toolsets.some((ts) => ts.toLowerCase().includes(q))
+      );
+    });
+  }, [agents, search, modelFilter, toolsetFilter]);
+
+  const toggleExpand = async (name: string) => {
+    if (expanded[name]) {
+      setExpanded((prev) => ({ ...prev, [name]: undefined }));
+      return;
+    }
+    setExpanded((prev) => ({ ...prev, [name]: "loading" }));
+    try {
+      const detail = await api.getAgentProfile(name);
+      setExpanded((prev) => ({ ...prev, [name]: detail }));
+    } catch {
+      setExpanded((prev) => ({ ...prev, [name]: undefined }));
+    }
+  };
+
+  const copySnippet = (name: string) => {
+    const snippet = `delegate_task(profile="${name}", task="...")`;
+    try {
+      navigator.clipboard?.writeText(snippet);
+      setCopied(name);
+      setTimeout(() => setCopied((c) => (c === name ? null : c)), 1500);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
+
+  return (
+    <div className="page agents-page">
+      <div className="page-header">
+        <h1>Agents</h1>
+      </div>
+
+      <p className="agents-intro">
+        Read-only view of the delegation agents (<code>agent_profiles</code>) this
+        gateway can hand work to via <code>delegate_task</code>. This does not
+        bind agents to platforms or channels.
+      </p>
+
+      {active.length > 0 && (
+        <div className="agents-active">
+          <h2>Live now ({active.length})</h2>
+          <ul className="agents-active-list">
+            {active.map((a, i) => (
+              <li key={a.subagent_id || i} className="agents-active-item">
+                <span className="agents-active-goal">
+                  {a.goal || a.subagent_id || "(sub-agent)"}
+                </span>
+                <span className="agents-active-meta">
+                  {a.model || "?"} · depth {a.depth ?? "?"} · {a.status || "running"}
+                  {typeof a.tool_count === "number" ? ` · ${a.tool_count} tools` : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="agents-controls">
+        <input
+          type="text"
+          className="agents-search"
+          placeholder="Search agents…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select value={modelFilter} onChange={(e) => setModelFilter(e.target.value)}>
+          {models.map((m) => (
+            <option key={m} value={m}>
+              {m === "all" ? "All models" : m}
+            </option>
+          ))}
+        </select>
+        <select value={toolsetFilter} onChange={(e) => setToolsetFilter(e.target.value)}>
+          {toolsets.map((ts) => (
+            <option key={ts} value={ts}>
+              {ts === "all" ? "All toolsets" : ts}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading && <div className="loading">Loading…</div>}
+      {error && <div className="error-banner">{error}</div>}
+
+      {!loading && !error && agents.length === 0 && (
+        <div className="agents-empty">
+          No agent profiles are configured. Add an <code>agent_profiles:</code>{" "}
+          section to your config to define delegation agents.
+        </div>
+      )}
+
+      {!loading && !error && agents.length > 0 && filtered.length === 0 && (
+        <div className="agents-empty">No agents match your filters.</div>
+      )}
+
+      <div className="agents-grid">
+        {filtered.map((a) => {
+          const detail = expanded[a.name];
+          const isOpen = detail !== undefined;
+          const fullPrompt =
+            isOpen && detail !== "loading"
+              ? (detail as AgentProfileDetail).system_prompt
+              : null;
+          return (
+            <div key={a.name} className="agent-card">
+              <div className="agent-card-header">
+                <span className="agent-name">{a.name}</span>
+                <span className="agent-model">{a.model || "(default model)"}</span>
+              </div>
+
+              {a.description && <p className="agent-desc">{a.description}</p>}
+
+              <div className="agent-toolsets">
+                {a.toolsets.map((ts) => (
+                  <span key={ts} className="agent-toolset-chip">
+                    {ts}
+                  </span>
+                ))}
+              </div>
+
+              <div className="agent-meta">
+                {typeof a.tool_count === "number" && (
+                  <span>tools: {a.tool_count}</span>
+                )}
+                {typeof a.max_iterations === "number" && (
+                  <span>max iter: {a.max_iterations}</span>
+                )}
+              </div>
+
+              {a.warnings.length > 0 ? (
+                <ul className="agent-warnings">
+                  {a.warnings.map((w, i) => (
+                    <li key={i} className="agent-warning">
+                      ⚠ {w}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="agent-valid">✓ valid</div>
+              )}
+
+              <pre className="agent-prompt-preview">
+                {detail === "loading"
+                  ? "Loading…"
+                  : fullPrompt ?? a.system_prompt_preview}
+              </pre>
+
+              <div className="agent-card-actions">
+                <button className="agent-btn" onClick={() => toggleExpand(a.name)}>
+                  {isOpen ? "Collapse" : "Expand prompt"}
+                </button>
+                <button className="agent-btn" onClick={() => copySnippet(a.name)}>
+                  {copied === a.name ? "Copied!" : "Copy delegate_task()"}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -6,11 +6,11 @@ import {
   type ActiveAgentInfo,
 } from "@/lib/api";
 import { Bot } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent } from "@nous-research/ui/ui/components/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
-import { Input } from "@/components/ui/input";
-import { H2 } from "@/components/NouiTypography";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { H2 } from "@nous-research/ui/ui/components/typography/h2";
 
 /**
  * Agents — read-only view of delegation ``agent_profiles``.
@@ -193,7 +193,7 @@ export default function AgentsPage() {
           type="text"
           placeholder="Search agents…"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
           className="max-w-xs"
         />
         <select
@@ -276,13 +276,13 @@ export default function AgentsPage() {
                 {a.warnings.length > 0 ? (
                   <div className="flex flex-col gap-1">
                     {a.warnings.map((w, i) => (
-                      <Badge key={i} tone="warning" size="sm" className="w-fit">
+                      <Badge key={i} tone="warning" className="w-fit">
                         ⚠ {w}
                       </Badge>
                     ))}
                   </div>
                 ) : (
-                  <Badge tone="success" size="sm" className="w-fit">
+                  <Badge tone="success" className="w-fit">
                     valid
                   </Badge>
                 )}


### PR DESCRIPTION
## What
Adds a read-only \"Agents\" page to the dashboard that displays delegation `agent_profiles` from config.yaml. Lists each profile as a card showing: name, model, toolset chips, resolved tool count, max_iterations, system-prompt preview (expandable), validation badge, and a copy-able `delegate_task(profile=...)` snippet. Includes search, model/toolset filtering, and a \"Live now\" panel showing currently-running delegated sub-agents. Uses existing backend `/api/agent-profiles` endpoint.

**Files modified:** `hermes_cli/web_server.py` (read-only endpoints), `web/src/pages/AgentsPage.tsx` (new), `web/src/lib/api.ts` (client + types), `web/src/App.tsx` (routing), `tests/test_agent_profiles_endpoint.py` (new).

## Why
Delegation profiles are invisible in the dashboard (visible only as raw YAML on Config page). Operators cannot verify their delegation config is loaded correctly without manually reading config files or checking logs. This page provides observability into the routing setup.

## Tests
```bash
pytest tests/test_agent_profiles_endpoint.py -v
```
8 tests pass: list shape, missing-prompt-file warning, no false-positive warnings, absent-key empty, load-error safe, detail full prompt, detail 404, active fallback.

## Platforms tested
Linux (CT/LXC environment, Python 3.13)