### PR TITLE
fix(gateway): stop typing cleanup from hanging post-delivery callbacks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4108,15 +4108,15 @@ class BasePlatformAdapter(ABC):
                 )
             else:
                 _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
+            # Stop typing indicator
+            await _stop_typing_task()
             if callable(_post_cb):
                 try:
                     _post_result = _post_cb()
                     if inspect.isawaitable(_post_result):
-                        await _post_result
+                        await asyncio.wait_for(_post_result, timeout=30.0)
                 except Exception:
                     pass
-            # Stop typing indicator
-            await _stop_typing_task()
             # Also cancel any platform-level persistent typing tasks (e.g. Discord)
             # that may have been recreated by _keep_typing after the last stop_typing()
             try:

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -633,3 +633,75 @@ async def test_post_delivery_callback_generation_snapshot_happens_after_bind():
     assert fired == []
     assert session_key in adapter._post_delivery_callbacks
     assert adapter._post_delivery_callbacks[session_key][0] == 2
+
+
+@pytest.mark.asyncio
+async def test_post_delivery_callback_runs_after_typing_task_stops():
+    """Regression: cleanup stops typing before post-delivery callback awaits."""
+    import inspect
+    from gateway.platforms.base import BasePlatformAdapter
+
+    source_text = inspect.getsource(BasePlatformAdapter._process_message_background)
+    stop_idx = source_text.find("await _stop_typing_task()")
+    cb_idx = source_text.find("if callable(_post_cb):")
+
+    assert stop_idx != -1 and cb_idx != -1
+    assert stop_idx < cb_idx
+
+
+@pytest.mark.asyncio
+async def test_post_delivery_callback_await_is_timeout_bounded(monkeypatch):
+    """Regression: awaited post-delivery callbacks must be bounded by timeout."""
+    import asyncio
+    import inspect
+    import gateway.platforms.base as base_module
+    from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    callback_released = asyncio.Event()
+    seen_timeouts = []
+    real_wait_for = asyncio.wait_for
+
+    class _ConcreteAdapter(BasePlatformAdapter):
+        platform = Platform.TELEGRAM
+
+        async def connect(self):
+            pass
+
+        async def disconnect(self):
+            pass
+
+        async def send(self, chat_id, content, **kwargs):
+            return SendResult(success=True, message_id="m2")
+
+        async def get_chat_info(self, chat_id):
+            return {}
+
+    adapter = _ConcreteAdapter(
+        PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM
+    )
+
+    async def fake_handler(event):
+        return "ok"
+
+    async def fake_wait_for(awaitable, timeout):
+        seen_timeouts.append(timeout)
+        if timeout == 30.0:
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise asyncio.TimeoutError()
+        return await real_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(base_module.asyncio, "wait_for", fake_wait_for)
+    adapter.set_message_handler(fake_handler)
+    event = MessageEvent(text="hello", source=source, message_id="m2")
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    async def _blocked_callback():
+        await callback_released.wait()
+
+    adapter._post_delivery_callbacks[session_key] = _blocked_callback
+    await adapter._process_message_background(event, session_key)
+
+    assert 30.0 in seen_timeouts


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway cleanup ordering bug where a stuck post-delivery callback could prevent typing-task cleanup from running, leaving the platform in a persistent "typing" state after the reply was already sent. This change makes typing cleanup run first and adds a timeout guard to awaited post-delivery callbacks so cleanup paths cannot block indefinitely.

## Related Issue

Fixes #24971

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/base.py`: moved `await _stop_typing_task()` ahead of post-delivery callback execution in `_process_message_background` finalization.
- `gateway/platforms/base.py`: wrapped awaited post-delivery callbacks with `asyncio.wait_for(..., timeout=30.0)` and kept exception swallowing behavior to preserve cleanup robustness.
- `tests/gateway/test_status_command.py`: added regression coverage verifying (a) `_stop_typing_task()` appears before callback execution in `_process_message_background`, and (b) post-delivery await path uses a 30s timeout boundary.

## What changed and why

- Reordered finalization so typing cleanup cannot be starved by slow or hung callback work.
- Added a 30s bound for awaited callbacks to keep post-delivery hooks from hanging cleanup indefinitely under transient network/socket failures.

## How to Test

1. Run focused regression tests:
   - `pytest tests/gateway/test_status_command.py -q`
2. Optional sanity check for modified files:
   - `ruff check gateway/platforms/base.py tests/gateway/test_status_command.py`
3. Optional full gateway-related run in CI / broader local suite.

## What platforms tested on

- macOS (darwin-arm64), local worktree run

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local focused test run: `pytest tests/gateway/test_status_command.py -q` → **16 passed**.
- `ruff check gateway/platforms/base.py tests/gateway/test_status_command.py` → **All checks passed**.
- `python scripts/check-windows-footguns.py` was run without file path arguments and returned guidance output (`No staged files to scan...`), so no blocking hits were reported for this diff.
- Full-suite wrapper (`bash scripts/run_tests.sh`) surfaced unrelated baseline failures in untouched files (e.g. `tests/agent/lsp/test_client_e2e.py`, `tests/agent/test_anthropic_adapter.py`, `tests/agent/test_auxiliary_transport_autodetect.py`) during the run.

<!-- autocontrib:worker-id=issue-new-602238c2 kind=pr-open -->