### PR TITLE
fix(agent): enforce tool-result adjacency after compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1626,7 +1626,47 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if not self.quiet_mode:
                 logger.info("Compression sanitizer: added %d stub tool result(s)", len(missing_results))
 
-        return messages
+        # 3. Enforce strict ordering: tool results must appear directly after
+        #    the assistant tool_calls block that created them.
+        ordered: List[Dict[str, Any]] = []
+        pending_call_ids: set[str] = set()
+        in_tool_block = False
+        dropped_misordered = 0
+
+        for msg in messages:
+            role = msg.get("role")
+            if role == "assistant":
+                ordered.append(msg)
+                pending_call_ids = {
+                    cid
+                    for tc in (msg.get("tool_calls") or [])
+                    if (cid := self._get_tool_call_id(tc))
+                }
+                in_tool_block = bool(pending_call_ids)
+                continue
+
+            if role == "tool":
+                cid = msg.get("tool_call_id")
+                if in_tool_block and cid and cid in pending_call_ids:
+                    ordered.append(msg)
+                    pending_call_ids.discard(cid)
+                    # Keep consuming contiguous tool messages until we hit a
+                    # non-tool role, even if all IDs are already satisfied.
+                    continue
+                dropped_misordered += 1
+                continue
+
+            ordered.append(msg)
+            pending_call_ids.clear()
+            in_tool_block = False
+
+        if dropped_misordered and not self.quiet_mode:
+            logger.info(
+                "Compression sanitizer: removed %d misordered tool result(s)",
+                dropped_misordered,
+            )
+
+        return ordered
 
     def _align_boundary_forward(self, messages: List[Dict[str, Any]], idx: int) -> int:
         """Push a compress-start boundary forward past any orphan tool results.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1209,6 +1209,30 @@ class TestCompressWithClient:
             "call_123"
         ]
 
+    def test_sanitizer_drops_tool_results_not_adjacent_to_calling_assistant(self, compressor):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search_files", "arguments": "{}"},
+                    }
+                ],
+            },
+            # Any non-tool message between assistant(tool_calls) and tool
+            # result makes the tool message invalid for provider APIs.
+            {"role": "user", "content": "summary boundary marker"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "late result"},
+            {"role": "assistant", "content": "continue"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        assert [m.get("role") for m in sanitized] == ["assistant", "user", "assistant"]
+
     def test_user_role_summary_carries_end_marker(self):
         """When the summary lands as standalone role='user' (e.g. head ends
         with assistant/tool), the message body must include the explicit


### PR DESCRIPTION
## What does this PR do?

Fixes a crash-level context compression correctness bug where a `role: "tool"` message could survive compaction even when it was no longer directly adjacent to its originating assistant `tool_calls` message. That invalid ordering triggers provider-side HTTP 400 errors and can force session resets.

## Related Issue

Fixes #20883

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: hardened `_sanitize_tool_pairs()` with a strict ordering pass that only keeps tool results when they are in the immediate assistant tool-results block and match pending `tool_call_id`s; misordered tool results are dropped with logging.
- `tests/agent/test_context_compressor.py`: added regression test `test_sanitizer_drops_tool_results_not_adjacent_to_calling_assistant` covering the boundary/order violation case.

## How to Test

1. Run the focused regression tests:
   - `pytest tests/agent/test_context_compressor.py -q -k "sanitizer_drops_tool_results_not_adjacent_to_calling_assistant or sanitizer_matches_responses_call_id_when_id_differs" --timeout=60`
2. Validate lint on touched files:
   - `ruff check agent/context_compressor.py tests/agent/test_context_compressor.py`
3. Optional broader verification in a full dev environment:
   - `pytest tests/agent/test_context_compressor.py -q -x --timeout=60`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## What platforms tested on

- macOS on darwin-arm64 (local)

## For New Skills

Not applicable.

## Screenshots / Logs

- `pytest tests/agent/test_context_compressor.py -q -k "sanitizer_drops_tool_results_not_adjacent_to_calling_assistant or sanitizer_matches_responses_call_id_when_id_differs" --timeout=60` → `2 passed, 90 deselected`
- `ruff check agent/context_compressor.py tests/agent/test_context_compressor.py` → `All checks passed!`
- `python scripts/check-windows-footguns.py` ran without finding blocking patterns in changed files.

<!-- autocontrib:worker-id=issue-new-d77a8174 kind=pr-open -->