### PR TITLE
fix(gateway): preserve status context and scrub memory fences

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -45,18 +45,98 @@ _INTERNAL_CONTEXT_RE = re.compile(
     r'<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>',
     re.IGNORECASE,
 )
+_REVERSED_CONTEXT_RE = re.compile(
+    r'</\s*memory-context\s*>[\s\S]*?<\s*memory-context\s*>',
+    re.IGNORECASE,
+)
+_ORPHAN_CLOSE_CONTEXT_RE = re.compile(
+    r'</\s*memory-context\s*>[\s\S]*',
+    re.IGNORECASE,
+)
+# Greedy fallback: unclosed <memory-context> → strip everything after open tag
+_UNCLOSED_CONTEXT_RE = re.compile(
+    r'<\s*memory-context\s*>[\s\S]*',
+    re.IGNORECASE,
+)
 _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
+)
+_RESTART_RECOVERY_NOTE_RE = re.compile(
+    r'\[System note:\s*Your previous turn(?: in this session)? was interrupted.*?\]\s*',
+    re.IGNORECASE | re.DOTALL,
+)
+# Detect echoed system-prompt memory blocks (no <memory-context> tags).
+_ECHOED_MEMORY_HEADER_RE = re.compile(
+    r'^[═]{20,}\s*\n'
+    r'MEMORY \(your personal notes\).*\n'
+    r'[═]{20,}\s*\n'
+    r'[\s\S]*?'
+    r'(?=\n[═]{20,}\s*\n[^\n]*USER PROFILE|'
+    r'\n[═]{20,}\s*\n[^\n]*MEMORY \(|'
+    r'\n\n[A-Z][a-z]+[\s:—]|'
+    r'\Z)',
+    re.MULTILINE,
+)
+_ECHOED_USER_PROFILE_RE = re.compile(
+    r'^[═]{20,}\s*\n'
+    r'USER PROFILE \(who the user is\).*\n'
+    r'[═]{20,}\s*\n'
+    r'[\s\S]*?'
+    r'(?=\n[═]{20,}\s*\n[^\n]*(?:USER PROFILE|MEMORY)|'
+    r'\n\n[A-Z][a-z]+[\s:—]|'
+    r'\Z)',
+    re.MULTILINE,
+)
+_ECHOED_HINDSIGHT_RE = re.compile(
+    r'\[Hindsight Sidecar Recall[^\]]*\]\n[\s\S]*?'
+    r'(?=\n\[(?:Provider Recall|Hindsight|Persona|Atoms|Scenario)\]|\Z)',
+    re.MULTILINE,
+)
+_ECHOED_PROVIDER_RECALL_RE = re.compile(
+    r'\[Provider Recall\]\n[\s\S]*?'
+    r'(?=\n\[(?:Hindsight|Persona|Atoms|Scenario)\]|\Z)',
+    re.MULTILINE,
+)
+_ECHOED_LAYERS_RE = re.compile(
+    r'\[(?:Persona|Atoms|Scenario)\]\n[\s\S]*?'
+    r'(?=\n\[(?:Persona|Atoms|Scenario|Provider Recall|Hindsight)\]|\Z)',
+    re.MULTILINE,
 )
 
 
 def sanitize_context(text: str) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
+    _orig = text
+    # 1. Balanced <memory-context>...</memory-context> blocks
     text = _INTERNAL_CONTEXT_RE.sub('', text)
+    # 1b. Reversed/orphan close→open spans are malformed but still unsafe.
+    text = _REVERSED_CONTEXT_RE.sub('', text)
+    # 1c. Orphan close tags are malformed but unsafe; fail closed by dropping
+    #     the rest of the output rather than exposing possible context payload.
+    text = _ORPHAN_CLOSE_CONTEXT_RE.sub('', text)
+    # 2. System notes
     text = _INTERNAL_NOTE_RE.sub('', text)
+    text = _RESTART_RECOVERY_NOTE_RE.sub('', text)
+    # 3. Unclosed <memory-context> — greedy: strip everything after open tag.
+    #    This MUST run before generic fence-tag removal; otherwise the opener
+    #    would be deleted first and the payload after it would leak.
+    text = _UNCLOSED_CONTEXT_RE.sub('', text)
+    # 4. Orphan fence tags (for example stray closing tags) are stripped as
+    #    inert markup after all payload-bearing spans have been removed.
     text = _FENCE_TAG_RE.sub('', text)
-    return text
+    # 5. Echoed system-prompt memory content (no tags, just raw content)
+    text = _ECHOED_MEMORY_HEADER_RE.sub('', text)
+    text = _ECHOED_USER_PROFILE_RE.sub('', text)
+    text = _ECHOED_HINDSIGHT_RE.sub('', text)
+    text = _ECHOED_PROVIDER_RECALL_RE.sub('', text)
+    text = _ECHOED_LAYERS_RE.sub('', text)
+    # 6. Collapse excessive blank lines left by removals
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    result = text.strip()
+    if len(_orig) != len(result):
+        logger.warning("sanitize_context: %d -> %d chars (stripped %d)", len(_orig), len(result), len(_orig) - len(result))
+    return result
 
 
 class StreamingContextScrubber:
@@ -87,14 +167,17 @@ class StreamingContextScrubber:
 
     _OPEN_TAG = "<memory-context>"
     _CLOSE_TAG = "</memory-context>"
+    _TAG_NAME = "memory-context"
 
     def __init__(self) -> None:
         self._in_span: bool = False
+        self._drop_until_reset: bool = False
         self._buf: str = ""
         self._at_block_boundary: bool = True
 
     def reset(self) -> None:
         self._in_span = False
+        self._drop_until_reset = False
         self._buf = ""
         self._at_block_boundary = True
 
@@ -107,29 +190,40 @@ class StreamingContextScrubber:
         """
         if not text:
             return ""
+        if self._drop_until_reset:
+            return ""
         buf = self._buf + text
         self._buf = ""
         out: list[str] = []
 
         while buf:
             if self._in_span:
-                idx = buf.lower().find(self._CLOSE_TAG)
-                if idx == -1:
+                close_match = self._find_tag(buf, closing=True)
+                if close_match is None:
                     # Hold back a potential partial close tag; drop the rest
-                    held = self._max_partial_suffix(buf, self._CLOSE_TAG)
+                    held = self._max_possible_tag_suffix(buf)
                     self._buf = buf[-held:] if held else ""
                     return "".join(out)
                 # Found close — skip span content + tag, continue
-                buf = buf[idx + len(self._CLOSE_TAG):]
+                _, end = close_match
+                buf = buf[end:]
                 self._in_span = False
             else:
-                idx = self._find_boundary_open_tag(buf)
-                if idx == -1:
+                open_match = self._find_tag(buf, closing=False)
+                close_match = self._find_tag(buf, closing=True)
+                if close_match is not None and (
+                    open_match is None or close_match[0] < open_match[0]
+                ):
+                    start, end = close_match
+                    if start > 0:
+                        self._append_visible(out, buf[:start])
+                    self._buf = ""
+                    self._in_span = False
+                    self._drop_until_reset = True
+                    return "".join(out)
+                if open_match is None:
                     # No open tag — hold back a potential partial open tag
-                    held = (
-                        self._max_pending_open_suffix(buf)
-                        or self._max_partial_suffix(buf, self._OPEN_TAG)
-                    )
+                    held = self._max_possible_tag_suffix(buf)
                     if held:
                         self._append_visible(out, buf[:-held])
                         self._buf = buf[-held:]
@@ -137,9 +231,10 @@ class StreamingContextScrubber:
                         self._append_visible(out, buf)
                     return "".join(out)
                 # Emit text before the tag, enter span
-                if idx > 0:
-                    self._append_visible(out, buf[:idx])
-                buf = buf[idx + len(self._OPEN_TAG):]
+                start, end = open_match
+                if start > 0:
+                    self._append_visible(out, buf[:start])
+                buf = buf[end:]
                 self._in_span = True
 
         return "".join(out)
@@ -152,6 +247,9 @@ class StreamingContextScrubber:
         truncated answer).  Otherwise the held-back partial-tag tail is
         emitted verbatim (it turned out not to be a real tag).
         """
+        if self._drop_until_reset:
+            self._buf = ""
+            return ""
         if self._in_span:
             self._buf = ""
             self._in_span = False
@@ -160,55 +258,83 @@ class StreamingContextScrubber:
         self._buf = ""
         return tail
 
-    @staticmethod
-    def _max_partial_suffix(buf: str, tag: str) -> int:
-        """Return the length of the longest buf-suffix that is a tag-prefix.
+    def _find_tag(self, buf: str, *, closing: bool) -> tuple[int, int] | None:
+        """Find a complete memory-context tag using sanitizer-compatible grammar.
 
-        Case-insensitive.  Returns 0 if no suffix could start the tag.
+        Matches ``<\\s*memory-context\\s*>`` and
+        ``</\\s*memory-context\\s*>`` case-insensitively.  If a partial tag is
+        present at the end of ``buf`` it returns ``None`` so the caller can
+        hold the tail for the next chunk.
         """
-        tag_lower = tag.lower()
-        buf_lower = buf.lower()
-        max_check = min(len(buf_lower), len(tag_lower) - 1)
-        for i in range(max_check, 0, -1):
-            if tag_lower.startswith(buf_lower[-i:]):
-                return i
-        return 0
-
-    def _find_boundary_open_tag(self, buf: str) -> int:
-        """Find an opening fence only when it starts a block-like span."""
-        buf_lower = buf.lower()
+        lower = buf.lower()
+        tag_len = len(self._TAG_NAME)
         search_start = 0
         while True:
-            idx = buf_lower.find(self._OPEN_TAG, search_start)
+            idx = lower.find("<", search_start)
             if idx == -1:
-                return -1
-            if self._is_block_boundary(buf, idx) and self._has_block_opener_suffix(buf, idx):
-                return idx
+                return None
+            pos = idx + 1
+            if pos >= len(buf):
+                return None
+            if closing:
+                if lower[pos] != "/":
+                    search_start = idx + 1
+                    continue
+                pos += 1
+                if pos >= len(buf):
+                    return None
+            else:
+                if lower[pos] == "/":
+                    search_start = idx + 1
+                    continue
+            while pos < len(buf) and buf[pos].isspace():
+                pos += 1
+            if pos + tag_len > len(buf):
+                return None
+            if lower[pos:pos + tag_len] != self._TAG_NAME:
+                search_start = idx + 1
+                continue
+            pos += tag_len
+            while pos < len(buf) and buf[pos].isspace():
+                pos += 1
+            if pos >= len(buf):
+                return None
+            if buf[pos] == ">":
+                return idx, pos + 1
             search_start = idx + 1
 
-    def _max_pending_open_suffix(self, buf: str) -> int:
-        """Hold a complete boundary tag until the following char confirms it."""
-        if not buf.lower().endswith(self._OPEN_TAG):
-            return 0
-        idx = len(buf) - len(self._OPEN_TAG)
-        if not self._is_block_boundary(buf, idx):
-            return 0
-        return len(self._OPEN_TAG)
+    def _max_possible_tag_suffix(self, buf: str) -> int:
+        """Hold a tail that could become a whitespace-tolerant fence tag.
 
-    def _has_block_opener_suffix(self, buf: str, idx: int) -> bool:
-        after_idx = idx + len(self._OPEN_TAG)
-        if after_idx >= len(buf):
+        Whitespace inside the final sanitizer's tag regex is unbounded, so a
+        small fixed suffix cap is unsafe: ``<`` followed by a long whitespace
+        run can be split across chunks and must not be emitted before the tag
+        name arrives.  Scan every suffix; the strings are tiny streaming
+        deltas, and privacy beats micro-optimizing this path.
+        """
+        for size in range(len(buf), 0, -1):
+            tail = buf[-size:]
+            if self._could_be_tag_prefix(tail):
+                return size
+        return 0
+
+    def _could_be_tag_prefix(self, text: str) -> bool:
+        lower = text.lower()
+        if not lower.startswith("<"):
             return False
-        return buf[after_idx] in "\r\n"
-
-    def _is_block_boundary(self, buf: str, idx: int) -> bool:
-        if idx == 0:
-            return self._at_block_boundary
-        preceding = buf[:idx]
-        last_newline = preceding.rfind("\n")
-        if last_newline == -1:
-            return self._at_block_boundary and preceding.strip() == ""
-        return preceding[last_newline + 1:].strip() == ""
+        pos = 1
+        if pos < len(lower) and lower[pos] == "/":
+            pos += 1
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        typed = lower[pos:]
+        # If the tag name is complete, only whitespace or the final '>' may
+        # follow.  If incomplete, it must be a prefix of memory-context.
+        if len(typed) <= len(self._TAG_NAME):
+            return self._TAG_NAME.startswith(typed)
+        return typed.startswith(self._TAG_NAME) and all(
+            ch.isspace() or ch == ">" for ch in text[pos + len(self._TAG_NAME):]
+        )
 
     def _append_visible(self, out: list[str], text: str) -> None:
         if not text:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -298,6 +298,11 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return text
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    try:
+        from agent.memory_manager import sanitize_context as _sanitize_gateway_context
+        redacted = _sanitize_gateway_context(redacted).strip()
+    except Exception:
+        pass
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
@@ -9559,7 +9564,9 @@ class GatewayRunner:
             except Exception:
                 pass
 
-        # Resolve runtime credentials for probing
+        # Resolve runtime credentials for probing. Do this before custom-provider
+        # context lookup so provider-only configs (model.provider=custom:name,
+        # no top-level model.base_url) can still match by resolved base_url.
         try:
             runtime = _resolve_runtime_agent_kwargs()
             provider = provider or runtime.get("provider")
@@ -9567,6 +9574,20 @@ class GatewayRunner:
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        if config_context_length is None and base_url:
+            try:
+                from hermes_cli.config import get_custom_provider_context_length
+                cp_ctx = get_custom_provider_context_length(
+                    model,
+                    base_url,
+                    custom_providers=custom_provs,
+                    config=data,
+                )
+                if cp_ctx is not None:
+                    config_context_length = cp_ctx
+            except Exception:
+                pass
 
         context_length = get_model_context_length(
             model,
@@ -10018,6 +10039,9 @@ class GatewayRunner:
         ])
         if queue_depth:
             lines.append(t("gateway.status.queued", count=queue_depth))
+        session_info = self._format_session_info()
+        if session_info:
+            lines.extend(["", session_info])
         lines.extend([
             "",
             t("gateway.status.platforms", platforms=', '.join(connected_platforms)),

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -32,6 +32,7 @@ from gateway.config import (
     DEFAULT_STREAMING_BUFFER_THRESHOLD as _DEFAULT_STREAMING_BUFFER_THRESHOLD,
     DEFAULT_STREAMING_CURSOR as _DEFAULT_STREAMING_CURSOR,
 )
+from agent.memory_manager import StreamingContextScrubber as _StreamingContextScrubber
 
 logger = logging.getLogger("gateway.stream_consumer")
 
@@ -169,6 +170,11 @@ class GatewayStreamConsumer:
         self._in_think_block = False
         self._think_buffer = ""
 
+        # Memory-context scrubber — stateful filter that strips
+        # <memory-context>...</memory-context> blocks across chunk
+        # boundaries where one-shot regex would fail.
+        self._context_scrubber = _StreamingContextScrubber()
+
         # Native draft-streaming state.  Resolved at the start of run() based
         # on cfg.transport, cfg.chat_type, and the adapter's
         # supports_draft_streaming() probe.  When True, the consumer emits
@@ -261,6 +267,9 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        # Keep memory-context scrubber state across segment/tool boundaries.
+        # A tag can be split as "<" / segment-break / "memory-context>";
+        # resetting here loses the held prefix and leaks the payload.
         # Native draft streaming: bump the draft_id so the next text segment
         # animates as a fresh preview below the tool-progress bubbles, not
         # over the prior segment's already-finalized draft.  This is how
@@ -304,6 +313,12 @@ class GatewayStreamConsumer:
         discarded.  Partial tags at buffer boundaries are held back in
         ``_think_buffer`` until enough characters arrive to decide.
         """
+        # Scrub memory-context blocks BEFORE think-block filtering.
+        # The stateful scrubber handles <memory-context> tags split
+        # across deltas where one-shot regex would fail.
+        text = self._context_scrubber.feed(text)
+        if not text:
+            return
         buf = self._think_buffer + text
         self._think_buffer = ""
 
@@ -450,6 +465,11 @@ class GatewayStreamConsumer:
                 # tag is not lost.
                 if got_done:
                     self._flush_think_buffer()
+                    # Flush memory-context scrubber so held-back partial
+                    # tags that turned out not to be real tags are emitted.
+                    tail = self._context_scrubber.flush()
+                    if tail:
+                        self._accumulated += tail
 
                 # Decide whether to flush an edit
                 now = time.monotonic()
@@ -656,18 +676,20 @@ class GatewayStreamConsumer:
 
     @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA: directives, memory-context blocks, and internal markers from text before display.
 
         The streaming path delivers raw text chunks that may include
-        ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
-        the platform adapter's post-processing.  The actual media files are
+        ``MEDIA:<path>`` tags, ``[[audio_as_voice]]`` directives, memory-context
+        wrappers, or recovery system notes.  The actual media files are
         delivered separately via ``_deliver_media_from_response()`` after the
-        stream finishes — we just need to hide the raw directives from the
-        user.
+        stream finishes — we just need to hide the raw directives/internal notes
+        from the user.
         """
-        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
-            return text
-        cleaned = text.replace("[[audio_as_voice]]", "")
+        from agent.memory_manager import sanitize_context
+        cleaned = sanitize_context(text)
+        if "MEDIA:" not in cleaned and "[[audio_as_voice]]" not in cleaned:
+            return cleaned
+        cleaned = cleaned.replace("[[audio_as_voice]]", "")
         cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
         # Collapse excessive blank lines left behind by removed tags
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
@@ -1012,6 +1034,10 @@ class GatewayStreamConsumer:
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
+        # Commentary is user-visible assistant text too.  Route it through the
+        # same stateful memory-context scrubber as normal deltas so a fence
+        # split across a text/commentary boundary cannot leak.
+        text = self._context_scrubber.feed(text)
         text = self._clean_for_display(text)
         if not text.strip():
             return False

--- a/tests/gateway/test_memory_context_output_sanitization.py
+++ b/tests/gateway/test_memory_context_output_sanitization.py
@@ -1,0 +1,386 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.stream_consumer import _NEW_SEGMENT
+
+from agent.memory_manager import sanitize_context
+from gateway.run import _sanitize_gateway_final_response
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class TestSanitizeContextExtraSystemNotes:
+    def test_strips_resume_note(self):
+        text = (
+            "before\n"
+            "[System note: Your previous turn in this session was interrupted by a gateway shutdown. "
+            "The conversation history below is intact. If it contains unfinished tool result(s), "
+            "process them first and summarize what was accomplished, then address the user's new message below.]\n\n"
+            "after"
+        )
+        out = sanitize_context(text)
+        assert "Your previous turn in this session was interrupted" not in out
+        assert "before" in out
+        assert "after" in out
+
+
+class TestGatewayFinalResponseSanitization:
+    def test_gateway_final_response_strips_memory_context(self):
+        text = (
+            "before\n"
+            "<memory-context>\n[System note: The following is recalled memory context, "
+            "NOT new user input. Treat as authoritative reference data — this is the agent's persistent memory and should inform all responses.]\n\nsecret\n"
+            "</memory-context>\nafter"
+        )
+        out = _sanitize_gateway_final_response("telegram", text)
+        assert "memory-context" not in out.lower()
+        assert "secret" not in out
+        assert "before" in out
+        assert "after" in out
+
+    def test_unclosed_memory_context_strips_payload(self):
+        text = "before <memory-context>\nsecret"
+        out = _sanitize_gateway_final_response("telegram", text)
+        assert "memory-context" not in out.lower()
+        assert "secret" not in out
+        assert out == "before"
+
+    def test_reversed_memory_context_strips_payload(self):
+        text = "before </memory-context>secret<memory-context> after"
+        out = _sanitize_gateway_final_response("telegram", text)
+        assert "memory-context" not in out.lower()
+        assert "secret" not in out
+        assert "before" in out
+        assert "after" in out
+
+    def test_orphan_close_memory_context_strips_payload(self):
+        text = "before </ memory-context >secret after"
+        out = _sanitize_gateway_final_response("telegram", text)
+        assert "memory-context" not in out.lower()
+        assert "secret" not in out
+        assert out == "before"
+
+
+class TestGatewayStreamConsumerMemoryContext:
+    async def _run_consumer(self, deltas):
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for d in deltas:
+            if d is _NEW_SEGMENT:
+                consumer.on_segment_break()
+            else:
+                consumer.on_delta(d)
+        consumer.finish()
+        await task
+        return adapter
+
+    def test_streamed_memory_context_is_not_sent(self):
+        deltas = [
+            "hello ",
+            "<memory-context>\n[System note: The following is recalled memory context, ",
+            "NOT new user input. Treat as authoritative reference data — this is the agent's persistent memory and should inform all responses.]\n\nsecret\n",
+            "</memory-context> world",
+        ]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_inline_streamed_memory_context_is_not_sent(self):
+        deltas = [
+            "hello <memory-context>\nsecret\n",
+            "</memory-context> world",
+        ]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_unclosed_streamed_memory_context_is_not_sent(self):
+        deltas = ["hello ", "<memory-context>\nsecret"]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+
+    def test_streamed_memory_context_whitespace_variant_is_not_sent(self):
+        deltas = [
+            "hello < memory-",
+            "context >\nsecret\n",
+            "</ memory-context > world",
+        ]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_unclosed_streamed_memory_context_whitespace_variant_is_not_sent(self):
+        deltas = ["hello < memory-context >\nsecret"]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+
+    def test_streamed_memory_context_long_whitespace_split_is_not_sent(self):
+        spaces = " " * 50
+        deltas = [
+            f"hello <{spaces}",
+            f"memory-context>secret</{spaces}memory-context> world",
+        ]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_streamed_orphan_close_context_is_not_sent(self):
+        deltas = ["hello </memory-context>secret world"]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" not in visible
+
+    def test_streamed_repeated_orphan_close_context_stays_dropped(self):
+        deltas = ["hello </memory-context>secret</memory-context> after"]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "after" not in visible
+        assert "hello" in visible
+
+    def test_streamed_memory_context_split_across_segment_break_is_not_sent(self):
+        deltas = [
+            "hello <",
+            _NEW_SEGMENT,
+            "memory-context>secret</memory-context> world",
+        ]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_streamed_memory_context_whitespace_split_across_segment_break_is_not_sent(self):
+        spaces = " " * 50
+        deltas = [
+            f"hello <{spaces}",
+            _NEW_SEGMENT,
+            f"memory-context>secret</{spaces}memory-context> world",
+        ]
+
+        adapter = asyncio.run(self._run_consumer(deltas))
+        visible = "\n".join(
+            [
+                call.kwargs.get("content", "")
+                for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+            ]
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_memory_context_split_across_commentary_boundary_is_not_sent(self):
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+
+        async def _run():
+            task = asyncio.create_task(consumer.run())
+            consumer.on_delta("hello <")
+            consumer.on_commentary("memory-context>secret</memory-context> world")
+            consumer.finish()
+            await task
+
+        asyncio.run(_run())
+        visible = "\n".join(call.kwargs.get("content", "") for call in adapter.send.await_args_list)
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_memory_context_whitespace_split_across_commentary_boundary_is_not_sent(self):
+        spaces = " " * 50
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+
+        async def _run():
+            task = asyncio.create_task(consumer.run())
+            consumer.on_delta(f"hello <{spaces}")
+            consumer.on_commentary(f"memory-context>secret</{spaces}memory-context> world")
+            consumer.finish()
+            await task
+
+        asyncio.run(_run())
+        visible = "\n".join(call.kwargs.get("content", "") for call in adapter.send.await_args_list)
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_memory_context_split_from_commentary_to_delta_is_not_sent(self):
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+
+        async def _run():
+            task = asyncio.create_task(consumer.run())
+            consumer.on_commentary("hello <")
+            consumer.on_delta("memory-context>secret</memory-context> world")
+            consumer.finish()
+            await task
+
+        asyncio.run(_run())
+        visible = "\n".join(
+            call.kwargs.get("content", "")
+            for call in adapter.send.await_args_list + adapter.edit_message.await_args_list
+        )
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_memory_context_split_across_two_commentary_messages_is_not_sent(self):
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+
+        async def _run():
+            task = asyncio.create_task(consumer.run())
+            consumer.on_commentary("hello <")
+            consumer.on_commentary("memory-context>secret</memory-context> world")
+            consumer.finish()
+            await task
+
+        asyncio.run(_run())
+        visible = "\n".join(call.kwargs.get("content", "") for call in adapter.send.await_args_list)
+        assert "memory-context" not in visible.lower()
+        assert "secret" not in visible
+        assert "hello" in visible
+        assert "world" in visible
+
+    def test_commentary_resume_note_is_not_sent(self):
+        adapter = MagicMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        )
+
+        async def _run():
+            task = asyncio.create_task(consumer.run())
+            consumer.on_commentary(
+                "[System note: Your previous turn in this session was interrupted by a gateway shutdown. "
+                "The conversation history below is intact. If it contains unfinished tool result(s), "
+                "process them first and summarize what was accomplished, then address the user's new message below.]\n\nreal text"
+            )
+            consumer.finish()
+            await task
+
+        asyncio.run(_run())
+        sent = "\n".join(call.kwargs.get("content", "") for call in adapter.send.await_args_list)
+        assert "Your previous turn in this session was interrupted" not in sent
+        assert "real text" in sent

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -87,6 +87,37 @@ class TestFormatSessionInfo:
             info = runner._format_session_info()
         assert "1.0M" in info
 
+    def test_custom_provider_model_context_length_uses_resolved_base_url(self, runner, tmp_path):
+        config = """
+model:
+  default: gpt-5.5
+  provider: custom:cliproxy.yu8.lat
+custom_providers:
+  - name: cliproxy.yu8.lat
+    base_url: https://cliproxy.yu8.lat/v1
+    api_key: dummy
+    model: gpt-5.4
+    models:
+      gpt-5.4:
+        context_length: 1050000
+      gpt-5.5:
+        context_length: 1050000
+"""
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            config,
+            "gpt-5.5",
+            {
+                "provider": "custom:cliproxy.yu8.lat",
+                "base_url": "https://cliproxy.yu8.lat/v1",
+                "api_key": "dummy",
+            },
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info()
+        assert "1.1M" in info
+        assert "config" in info
+
     def test_missing_config(self, runner, tmp_path):
         """No config.yaml should not crash."""
         p1, p2, p3 = _patch_info(tmp_path, None,  # don't create config

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -58,6 +58,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     # Default: no DB row → /status reports 0 tokens.  Tests that exercise
     # the populated path override this.
     runner._session_db.get_session.return_value = None
+    runner._format_session_info = MagicMock(return_value="")
     runner._reasoning_config = None
     runner._provider_routing = {}
     runner._fallback_model = None
@@ -122,6 +123,28 @@ async def test_status_command_includes_session_title_when_present():
 
     assert "**Session ID:** `sess-1`" in result
     assert "**Title:** My titled session" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_session_info_block():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._format_session_info.return_value = "◆ Model: `test-model`\n◆ Provider: custom\n◆ Context: 32K (config)"
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "◆ Model: `test-model`" in result
+    assert "◆ Provider: custom" in result
+    assert "◆ Context: 32K (config)" in result
+    assert runner._format_session_info.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore gateway /status model/provider/context block
- resolve custom provider per-model context length via resolved base_url
- harden memory-context sanitization for final, streaming, segment, commentary, and malformed fence cases
- add gateway regression tests for status context and memory-context leak paths

## Test Plan
- /root/hermes-agent/venv/bin/python -m pytest tests/gateway/test_memory_context_output_sanitization.py tests/gateway/test_session_info.py tests/gateway/test_status_command.py -q
- independent reviewer subagent passed after leak repro/fix loop
- added security grep checks for hardcoded secrets, shell=True/os.system, eval/exec/pickle, SQL format patterns: 0 hits