### PR TITLE
fix(profiles): handle cross-device profile renames

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1557,8 +1557,9 @@ def rename_profile(old_name: str, new_name: str) -> Path:
         _cleanup_gateway_service(old_canon, old_dir)
         _stop_gateway_process(old_dir)
 
-    # 2. Rename directory
-    old_dir.rename(new_dir)
+    # 2. Rename directory. shutil.move() preserves the fast rename path on the
+    # same filesystem and falls back to copy+remove across mounts.
+    shutil.move(str(old_dir), str(new_dir))
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")
 
     # 3. Update profile-scoped Honcho host blocks, preserving aiPeer identity

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -7,6 +7,8 @@ and shell completion generation.
 
 import json
 import io
+import errno
+import os
 import tarfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -729,6 +731,29 @@ class TestRenameProfile:
         assert not old_dir.is_dir()
         assert new_dir.is_dir()
         assert new_dir == tmp_path / ".hermes" / "profiles" / "newname"
+
+    def test_renames_directory_across_devices(self, profile_env):
+        tmp_path = profile_env
+        create_profile("oldname", no_alias=True)
+        old_dir = tmp_path / ".hermes" / "profiles" / "oldname"
+        new_dir = tmp_path / ".hermes" / "profiles" / "newname"
+
+        real_rename = os.rename
+
+        def rename_side_effect(src, dst, *args, **kwargs):
+            if Path(os.fspath(src)) == old_dir and Path(os.fspath(dst)) == new_dir:
+                raise OSError(errno.EXDEV, "Invalid cross-device link")
+            return real_rename(src, dst, *args, **kwargs)
+
+        with (
+            patch("os.rename", side_effect=rename_side_effect),
+            patch("hermes_cli.profiles.check_alias_collision", return_value="skip"),
+        ):
+            renamed_dir = rename_profile("oldname", "newname")
+
+        assert not old_dir.exists()
+        assert renamed_dir.is_dir()
+        assert renamed_dir == new_dir
 
     def test_renames_root_honcho_host_without_changing_ai_peer(self, profile_env):
         tmp_path = profile_env


### PR DESCRIPTION
## Summary
- replace direct `Path.rename()` with `shutil.move()` in `rename_profile()` so cross-mount profile renames fall back safely
- add a regression test that forces `EXDEV` and proves the rename still succeeds

## Verification
- `uv run --frozen pytest tests/hermes_cli/test_profiles.py -k 'TestRenameProfile'
- `uv run --frozen ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py`
- `git diff --check`

Closes #36152
