### PR TITLE
Add Docker backend diagnostics to hermes doctor

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -45,3 +45,60 @@ def _ensure_utf8():
 
 
 _ensure_utf8()
+
+
+def _install_doctor_docker_backend_diagnostics():
+    """Patch hermes_cli.doctor with Docker-backend diagnostics on import.
+
+    This keeps the check isolated and best-effort: if the import hook cannot be
+    installed, doctor still runs with its existing behavior.
+    """
+    if "hermes_cli.doctor" in sys.modules:
+        try:
+            from .doctor_docker_backend import patch_doctor_module
+            patch_doctor_module(sys.modules["hermes_cli.doctor"])
+        except Exception:
+            pass
+        return
+
+    try:
+        import importlib.abc
+        import importlib.machinery
+    except Exception:
+        return
+
+    class _DoctorDockerDiagnosticsLoader(importlib.abc.Loader):
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def create_module(self, spec):
+            create_module = getattr(self._wrapped, "create_module", None)
+            if create_module is None:
+                return None
+            return create_module(spec)
+
+        def exec_module(self, module):
+            self._wrapped.exec_module(module)
+            try:
+                from .doctor_docker_backend import patch_doctor_module
+                patch_doctor_module(module)
+            except Exception:
+                pass
+
+    class _DoctorDockerDiagnosticsFinder(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname != "hermes_cli.doctor":
+                return None
+            spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+            if spec is None or spec.loader is None:
+                return spec
+            if isinstance(spec.loader, _DoctorDockerDiagnosticsLoader):
+                return spec
+            spec.loader = _DoctorDockerDiagnosticsLoader(spec.loader)
+            return spec
+
+    if not any(f.__class__.__name__ == "_DoctorDockerDiagnosticsFinder" for f in sys.meta_path):
+        sys.meta_path.insert(0, _DoctorDockerDiagnosticsFinder())
+
+
+_install_doctor_docker_backend_diagnostics()

--- a/hermes_cli/doctor_docker_backend.py
+++ b/hermes_cli/doctor_docker_backend.py
@@ -1,0 +1,142 @@
+"""Docker backend diagnostics for ``hermes doctor``.
+
+The terminal Docker backend fails early when the Docker CLI is installed but the
+Docker daemon is unavailable. These helpers make that failure visible in doctor
+without making doctor itself depend on Docker.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _read_yaml_config(hermes_home: Path) -> dict[str, Any]:
+    """Best-effort read of ``config.yaml``/``config.yml`` from HERMES_HOME."""
+    for name in ("config.yaml", "config.yml"):
+        path = hermes_home / name
+        if not path.exists():
+            continue
+        try:
+            import yaml
+
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _configured_terminal_backend(*, hermes_home: Path | None = None) -> str:
+    """Infer the terminal backend from env/config, defaulting to local."""
+    for env_name in ("TERMINAL_ENV", "HERMES_TERMINAL_BACKEND"):
+        value = os.getenv(env_name)
+        if value:
+            return value.strip().lower()
+
+    config = _read_yaml_config(hermes_home or Path.home() / ".hermes")
+    terminal = config.get("terminal")
+    if isinstance(terminal, dict):
+        value = terminal.get("backend") or terminal.get("env")
+        if value:
+            return str(value).strip().lower()
+    value = config.get("terminal_backend") or config.get("terminal_env")
+    return str(value).strip().lower() if value else "local"
+
+
+def _docker_backend_diagnostic(doctor_module: Any) -> dict[str, Any] | None:
+    """Return a diagnostic when Docker backend is configured but unhealthy.
+
+    The Docker daemon probe is intentionally skipped unless the configured
+    terminal backend is Docker *and* the Docker CLI is present.
+    """
+    hermes_home = Path(getattr(doctor_module, "HERMES_HOME", Path.home() / ".hermes"))
+    backend = _configured_terminal_backend(hermes_home=hermes_home)
+    if backend != "docker":
+        return None
+
+    docker_path = doctor_module.shutil.which("docker")
+    if not docker_path:
+        return None
+
+    try:
+        result = doctor_module.subprocess.run(
+            ["docker", "version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception as exc:
+        return {
+            "ok": False,
+            "summary": "Docker backend is configured but Docker daemon is not responding",
+            "detail": str(exc),
+            "remediation": [
+                "Start Docker Desktop",
+                "On Linux, run: sudo systemctl start docker",
+            ],
+        }
+
+    if getattr(result, "returncode", 1) == 0:
+        return None
+
+    detail = "\n".join(
+        part.strip()
+        for part in (getattr(result, "stderr", ""), getattr(result, "stdout", ""))
+        if part and part.strip()
+    )
+    return {
+        "ok": False,
+        "summary": "Docker backend is configured but Docker daemon is not responding",
+        "detail": detail or "docker version returned a non-zero exit status",
+        "remediation": [
+            "Start Docker Desktop",
+            "On Linux, run: sudo systemctl start docker",
+        ],
+    }
+
+
+def _emit_docker_backend_diagnostic(doctor_module: Any, diagnostic: dict[str, Any]) -> None:
+    """Print a Docker backend diagnostic using doctor helpers when available."""
+    summary = diagnostic["summary"]
+    try:
+        doctor_module.check_error("Docker backend", summary)
+    except Exception:
+        print(f"✗ Docker backend: {summary}")
+
+    detail = diagnostic.get("detail")
+    if detail:
+        for line in str(detail).splitlines():
+            if line.strip():
+                try:
+                    doctor_module.check_info("Docker daemon", line.strip())
+                except Exception:
+                    print(f"  {line.strip()}")
+
+    for item in diagnostic.get("remediation", []):
+        try:
+            doctor_module.check_info("Docker remediation", item)
+        except Exception:
+            print(f"  {item}")
+
+
+def patch_doctor_module(doctor_module: Any) -> None:
+    """Install Docker backend diagnostics into ``hermes_cli.doctor``."""
+    if getattr(doctor_module, "_docker_backend_diagnostics_patched", False):
+        return
+
+    def diagnostic_wrapper() -> dict[str, Any] | None:
+        return _docker_backend_diagnostic(doctor_module)
+
+    original_run_doctor = doctor_module.run_doctor
+
+    def run_doctor_with_docker_backend_diagnostics(*args, **kwargs):
+        diagnostic = diagnostic_wrapper()
+        if diagnostic:
+            _emit_docker_backend_diagnostic(doctor_module, diagnostic)
+        return original_run_doctor(*args, **kwargs)
+
+    doctor_module._docker_backend_diagnostic = diagnostic_wrapper
+    doctor_module.run_doctor = run_doctor_with_docker_backend_diagnostics
+    doctor_module._docker_backend_diagnostics_patched = True

--- a/tests/hermes_cli/test_doctor_docker_backend.py
+++ b/tests/hermes_cli/test_doctor_docker_backend.py
@@ -1,0 +1,104 @@
+"""Tests for Docker backend diagnostics in hermes doctor."""
+
+import contextlib
+import io
+import sys
+import types
+from argparse import Namespace
+
+import hermes_cli.doctor as doctor_mod
+
+
+def test_docker_backend_diagnostic_reports_daemon_failure(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("terminal:\n  backend: docker\n", encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/docker" if cmd == "docker" else None)
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["docker", "version"]
+        return types.SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?",
+        )
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    diagnostic = doctor_mod._docker_backend_diagnostic()
+
+    assert diagnostic is not None
+    assert diagnostic["summary"] == "Docker backend is configured but Docker daemon is not responding"
+    assert "Cannot connect to the Docker daemon" in diagnostic["detail"]
+
+
+def test_run_doctor_prints_docker_backend_daemon_remediation(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    (home / "config.yaml").write_text("terminal:\n  backend: docker\nmemory: {}\n", encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/docker" if cmd == "docker" else None)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["docker", "version"]:
+            return types.SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?",
+            )
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        ),
+    )
+
+    try:
+        from hermes_cli import auth as auth_mod
+
+        monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_gemini_oauth_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "Docker backend is configured but Docker daemon is not responding" in out
+    assert "Cannot connect to the Docker daemon" in out
+    assert "Start Docker Desktop" in out
+    assert "sudo systemctl start docker" in out
+
+
+def test_docker_backend_diagnostic_skips_probe_when_backend_is_local(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("terminal:\n  backend: local\n", encoding="utf-8")
+
+    calls = []
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: calls.append(("which", cmd)) or "/usr/bin/docker")
+    monkeypatch.setattr(doctor_mod.subprocess, "run", lambda *a, **kw: calls.append(("run", a, kw)))
+
+    assert doctor_mod._docker_backend_diagnostic() is None
+    assert calls == []


### PR DESCRIPTION
## Summary
- Adds Docker-backend health diagnostics for `hermes doctor`.
- Detects when the terminal backend is configured as Docker (`TERMINAL_ENV=docker` or `terminal.backend: docker`) and the Docker CLI is present.
- Probes `docker version` best-effort and surfaces daemon failures with remediation for Docker Desktop and Linux systemd.
- Adds focused tests for daemon failure reporting, full doctor output, and local-backend no-probe behavior.

## Testing
- Not run locally: the delegated environment has GitHub MCP access but no working local terminal/execute_code backend (Docker backend is broken), so I could not execute pytest from `/home/hermes`.
- Intended command: `python -m pytest tests/hermes_cli/test_doctor_docker_backend.py tests/hermes_cli/test_doctor.py::test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected`

## Notes
- This is opened as a draft for maintainer CI/feedback because local execution was blocked.