### PR TITLE
fix(gateway): await asyncio.sleep in start_gateway --replace wait loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18955,7 +18955,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             for _ in range(20):
                 if not _pid_exists(existing_pid):
                     break  # Process is gone
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
             else:
                 # Still alive after 10s — force kill
                 logger.warning(
@@ -18964,7 +18964,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
                 try:
                     terminate_pid(existing_pid, force=True)
-                    time.sleep(0.5)
+                    await asyncio.sleep(0.5)
                 except (ProcessLookupError, PermissionError, OSError):
                     pass
             remove_pid_file()


### PR DESCRIPTION
## Summary

`start_gateway()` is `async def`, but the `--replace` wait loop used `time.sleep(0.5)` instead of `await asyncio.sleep(0.5)`. This blocked the entire event loop for up to **10.5 seconds** during a gateway restart:

- 20-iteration SIGTERM wait: `time.sleep(0.5)` × 20 = 10 s freeze
- Optional SIGKILL follow-up: `time.sleep(0.5)` = 0.5 s freeze

During this window, signal handlers (SIGTERM, SIGINT) and all other coroutines could not run. On systems using systemd or launchd to manage the gateway, this caused health-check timeouts and could trigger a restart loop.

## Changes

`gateway/run.py` — two `time.sleep(0.5)` calls inside `async def start_gateway()` replaced with `await asyncio.sleep(0.5)`.

```python
# Before
time.sleep(0.5)

# After
await asyncio.sleep(0.5)
```

No behaviour change; the wait duration and logic are identical.

## Test plan

- [ ] Run `hermes gateway run --replace` while another gateway instance is running; confirm the event loop stays responsive during the wait (e.g., a concurrent signal is handled promptly)
- [ ] Confirm gateway replaces successfully on Linux, macOS, and Windows