### PR TITLE
fix(whatsapp): offload blocking npm install to thread executor in connect()

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -593,12 +593,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     # Read timeout from environment variable, default to 300 seconds (5 minutes)
                     # to accommodate slower systems like Unraid NAS
                     npm_install_timeout = int(os.environ.get("WHATSAPP_NPM_INSTALL_TIMEOUT", "300"))
-                    install_result = subprocess.run(
-                        [_npm_bin, "install", "--silent"],
-                        cwd=str(bridge_dir),
-                        capture_output=True,
-                        text=True,
-                        timeout=npm_install_timeout,
+                    loop = asyncio.get_running_loop()
+                    install_result = await loop.run_in_executor(
+                        None,
+                        lambda: subprocess.run(
+                            [_npm_bin, "install", "--silent"],
+                            cwd=str(bridge_dir),
+                            capture_output=True,
+                            text=True,
+                            timeout=npm_install_timeout,
+                        ),
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")


### PR DESCRIPTION
## Summary

`WhatsAppAdapter.connect()` is `async def`, but the automatic npm dependency install ran `subprocess.run(npm install, timeout=300)` directly on the event loop. On first boot (or after `npm cache clean`) when `node_modules/` is absent, this froze the event loop for up to **5 minutes**, blocking all other platform adapters from connecting, starving signal handlers, and causing health-check timeouts that could trigger service-manager restart loops.

## Changes

`gateway/platforms/whatsapp.py` — wrap `subprocess.run` in `loop.run_in_executor(None, ...)` so the install runs in a thread while the event loop remains responsive.

```python
# Before
install_result = subprocess.run(
    [_npm_bin, "install", "--silent"],
    cwd=str(bridge_dir),
    ...
    timeout=npm_install_timeout,
)

# After
loop = asyncio.get_running_loop()
install_result = await loop.run_in_executor(
    None,
    lambda: subprocess.run(
        [_npm_bin, "install", "--silent"],
        cwd=str(bridge_dir),
        ...
        timeout=npm_install_timeout,
    ),
)
```

No behaviour change; the install logic, timeout, and error handling are identical. The `subprocess.Popen` call that launches the bridge process afterwards is non-blocking and is unaffected.

## Test plan

- [ ] Delete `node_modules/` from the WhatsApp bridge directory; start the gateway with WhatsApp enabled; confirm other platforms (e.g. Telegram) connect successfully during the npm install
- [ ] Confirm `connect()` returns `True` and the bridge starts correctly after install completes
- [ ] Confirm install failure still returns `False` with the error logged