### PR TITLE
fix(webhook): replace blocking subprocess.run with asyncio.create_subprocess_exec in _deliver_github_comment

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -34,7 +34,6 @@ import hmac
 import json
 import logging
 import re
-import subprocess
 import time
 from typing import Any, Dict, List, Optional
 
@@ -842,31 +841,30 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "comment",
-                    str(pr_number),
-                    "--repo",
-                    repo,
-                    "--body",
-                    content,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
+            proc = await asyncio.create_subprocess_exec(
+                "gh", "pr", "comment", str(pr_number),
+                "--repo", repo, "--body", content,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
-            if result.returncode == 0:
+            try:
+                _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=30)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                logger.error("[webhook] gh pr comment timed out after 30s")
+                return SendResult(success=False, error="gh CLI timed out")
+            stderr = stderr_bytes.decode(errors="replace") if stderr_bytes else ""
+            if proc.returncode == 0:
                 logger.info(
                     "[webhook] Posted comment on %s#%s", repo, pr_number
                 )
                 return SendResult(success=True)
             else:
                 logger.error(
-                    "[webhook] gh pr comment failed: %s", result.stderr
+                    "[webhook] gh pr comment failed: %s", stderr
                 )
-                return SendResult(success=False, error=result.stderr)
+                return SendResult(success=False, error=stderr)
         except FileNotFoundError:
             logger.error(
                 "[webhook] 'gh' CLI not found — install GitHub CLI for "


### PR DESCRIPTION
## Summary

`WebhookAdapter._deliver_github_comment()` is `async def`, but used `subprocess.run(["gh", "pr", "comment", ...], timeout=30)` — a fully blocking call that froze the event loop for up to **30 seconds** on every GitHub PR/issue comment delivery. All other `_deliver_*` methods (cross-platform, email, etc.) use async I/O; this was the only outlier.

During the 30-second freeze, incoming webhook events queued unprocessed and concurrent agent sessions stalled. On slow networks or GitHub API congestion the full timeout was reached repeatedly.

## Changes

`gateway/platforms/webhook.py`:
- Replace `subprocess.run` with `asyncio.create_subprocess_exec` + `asyncio.wait_for(proc.communicate(), timeout=30)`
- Explicit `asyncio.TimeoutError` handler kills and drains the process, then returns a clean error `SendResult`
- Remove now-unused `import subprocess`

```python
# Before
result = subprocess.run(
    ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body", content],
    capture_output=True, text=True, timeout=30,
)

# After
proc = await asyncio.create_subprocess_exec(
    "gh", "pr", "comment", str(pr_number),
    "--repo", repo, "--body", content,
    stdout=asyncio.subprocess.PIPE,
    stderr=asyncio.subprocess.PIPE,
)
try:
    _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=30)
except asyncio.TimeoutError:
    proc.kill()
    await proc.communicate()
    return SendResult(success=False, error="gh CLI timed out")
```

Return values and error logging are semantically identical to the original.

## Test plan

- [ ] Trigger a webhook-based agent response configured for `github_comment` delivery; confirm the comment is posted and the event loop remains responsive during the gh CLI call
- [ ] Confirm `FileNotFoundError` (gh not installed) is still caught and returns the correct error
- [ ] Confirm a simulated timeout returns `SendResult(success=False, error="gh CLI timed out")`