### PR TITLE
fix(codex): recover from NoneType crash when Codex stream lacks terminal event

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -182,7 +182,6 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
     max_stream_retries = 1
-    has_tool_calls = False
     first_delta_fired = False
     # Accumulate streamed text so we can recover if get_final_response()
     # returns empty output (e.g. chatgpt.com backend-api sends
@@ -192,6 +191,12 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        has_tool_calls = False
+        saw_terminal_event = False
+        saw_output_text_done = False
+        # Reset per-attempt accumulated text so a retry doesn't
+        # accidentally join deltas from a failed previous attempt.
+        agent._codex_streamed_text_parts: list = []
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:
@@ -221,6 +226,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     # Track tool calls to suppress text streaming
                     elif "function_call" in event_type:
                         has_tool_calls = True
+                    # Track output_text.done — we only synthesize text
+                    # responses when the stream completed at least one
+                    # output_text part (not just partial deltas).
+                    elif "output_text.done" in event_type:
+                        saw_output_text_done = True
                     # Fire reasoning callbacks
                     elif "reasoning" in event_type and "delta" in event_type:
                         reasoning_text = getattr(event, "delta", "")
@@ -236,6 +246,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             collected_output_items.append(done_item)
                     # Log non-completed terminal events for diagnostics
                     elif event_type in {"response.incomplete", "response.failed"}:
+                        saw_terminal_event = True
                         resp_obj = getattr(event, "response", None)
                         status = getattr(resp_obj, "status", None) if resp_obj else None
                         incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
@@ -246,7 +257,57 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                # The ChatGPT Codex backend can terminate a stream without
+                # a terminal event (response.completed / incomplete / failed).
+                # When that happens, the SDK's get_final_response() calls
+                # parse_response() which does ``for output in response.output``
+                # — but response.output is None (never populated). This
+                # crashes with ``TypeError: 'NoneType' object is not iterable``.
+                # We catch that specific error and reconstruct from collected
+                # stream events. Other TypeErrors are re-raised as they indicate
+                # unrelated parser bugs, malformed payloads, or SDK regressions.
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    if "'NoneType' object is not iterable" not in str(exc):
+                        raise
+                    # If the stream already emitted a terminal event
+                    # (response.incomplete / response.failed / response.completed),
+                    # the SDK crash is a secondary parsing failure — don't mask
+                    # the terminal status by reconstructing a synthetic response.
+                    # Only recover when the stream ended silently with no
+                    # terminal event at all (the known Codex backend quirk).
+                    if saw_terminal_event:
+                        raise
+                    # Reconstruct from collected output items or text deltas
+                    if collected_output_items:
+                        final_response = SimpleNamespace(
+                            output=list(collected_output_items),
+                        )
+                        logger.debug(
+                            "Codex stream: get_final_response crashed (TypeError), "
+                            "backfilled %d output items from stream events",
+                            len(collected_output_items),
+                        )
+                    elif agent._codex_streamed_text_parts and not has_tool_calls and saw_output_text_done:
+                        assembled = "".join(agent._codex_streamed_text_parts)
+                        final_response = SimpleNamespace(
+                            output=[SimpleNamespace(
+                                type="message",
+                                role="assistant",
+                                status="completed",
+                                content=[SimpleNamespace(
+                                    type="output_text", text=assembled,
+                                )],
+                            )],
+                        )
+                        logger.debug(
+                            "Codex stream: get_final_response crashed (TypeError), "
+                            "synthesized output from %d text deltas (%d chars)",
+                            len(agent._codex_streamed_text_parts), len(assembled),
+                        )
+                    else:
+                        raise  # Nothing to reconstruct — re-raise
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
@@ -258,7 +319,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             "Codex stream: backfilled %d output items from stream events",
                             len(collected_output_items),
                         )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
+                    elif agent._codex_streamed_text_parts and not has_tool_calls and saw_output_text_done:
                         assembled = "".join(agent._codex_streamed_text_parts)
                         final_response.output = [SimpleNamespace(
                             type="message",
@@ -355,6 +416,9 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
     terminal_response = None
     collected_output_items: list = []
     collected_text_deltas: list = []
+    has_tool_calls = False
+    saw_terminal_event = False
+    saw_output_text_done = False
     try:
         for event in stream_or_response:
             agent._touch_activity("receiving stream response")
@@ -391,6 +455,11 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                 from run_agent import _StreamErrorEvent
                 raise _StreamErrorEvent(err_message, code=err_code, param=err_param)
 
+            # Track function calls — if the stream closes with tool calls
+            # in flight we must not synthesize a text-only completion.
+            if event_type and "function_call" in event_type:
+                has_tool_calls = True
+
             # Collect output items and text deltas for backfill
             if event_type == "response.output_item.done":
                 done_item = getattr(event, "item", None)
@@ -404,10 +473,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                     delta = event.get("delta", "")
                 if delta:
                     collected_text_deltas.append(delta)
+            elif "output_text.done" in (event_type or ""):
+                saw_output_text_done = True
 
             if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                 continue
 
+            saw_terminal_event = True
             terminal_response = getattr(event, "response", None)
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
@@ -443,6 +515,43 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
 
     if terminal_response is not None:
         return terminal_response
+
+    # The stream ended without a terminal event. If we collected output
+    # items or text deltas, reconstruct the response from them instead
+    # of raising. The Codex backend can close the connection after
+    # streaming all output items without sending a terminal event.
+    #
+    # But if we DID see a terminal event (saw_terminal_event is True)
+    # yet terminal_response is still None, then the terminal event was
+    # emitted without a response payload — likely a dict-form event
+    # from a custom relay. Don't mask that failure with a synthetic
+    # successful response.
+    if saw_terminal_event:
+        raise RuntimeError(
+            "Responses create(stream=True) fallback emitted a terminal "
+            "event without a response payload."
+        )
+    if collected_output_items:
+        logger.debug(
+            "Codex fallback stream: no terminal response, "
+            "backfilled %d output items from stream events",
+            len(collected_output_items),
+        )
+        return SimpleNamespace(output=list(collected_output_items))
+    if collected_text_deltas and not has_tool_calls and saw_output_text_done:
+        assembled = "".join(collected_text_deltas)
+        logger.debug(
+            "Codex fallback stream: no terminal response, "
+            "synthesized output from %d text deltas (%d chars)",
+            len(collected_text_deltas), len(assembled),
+        )
+        return SimpleNamespace(
+            output=[SimpleNamespace(
+                type="message", role="assistant", status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )],
+        )
+
     raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
 
 

--- a/tests/agent/test_codex_runtime.py
+++ b/tests/agent/test_codex_runtime.py
@@ -1,0 +1,182 @@
+"""Tests for agent/codex_runtime.py — Codex stream recovery paths."""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, ".")
+from agent.codex_runtime import run_codex_stream
+
+
+class _FakeAgent:
+    """Minimal fake agent with attributes needed by run_codex_stream."""
+
+    def __init__(self):
+        self._interrupt_requested = False
+        self._codex_streamed_text_parts: list = []
+        self._codex_stream_last_event_ts = None
+        # Fire callbacks are no-ops for tests
+        self._fire_stream_delta = lambda text: None
+        self._fire_reasoning_delta = lambda text: None
+        self._fire_tool_gen_started = lambda name: None
+        self._touch_activity = lambda msg: None
+        self.log_prefix = "[test] "
+        self._client_log_context = lambda: "test_context"
+        self.verbose_logging = False
+        # Fallback hooks
+        self._run_codex_create_stream_fallback = MagicMock()
+
+    def _ensure_primary_openai_client(self, *, reason: str):
+        return MagicMock()
+
+    def _get_transport(self):
+        t = MagicMock()
+        t.preflight_kwargs = lambda kwargs, allow_stream=False: kwargs
+        return t
+
+
+class _FakeStream:
+    """Iterable stream mock — __iter__ on the class so Python resolves it.
+    Not a MagicMock because MagicMock fabricates an "output" attribute
+    which causes run_codex_create_stream_fallback to hit the early-return
+    compatibility shim instead of iterating events."""
+
+    def __init__(self, events):
+        self._events = events
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def close(self):
+        pass
+
+
+def _make_stream_with_crash(events):
+    """Return a stream that iterates `events` then crashes get_final_response()."""
+    mock_stream = MagicMock()
+    mock_stream.__iter__ = lambda self: iter(events)
+    mock_stream.get_final_response = MagicMock(
+        side_effect=TypeError("'NoneType' object is not iterable")
+    )
+    return mock_stream
+
+
+def test_run_codex_stream_recovers_from_none_output():
+    """When get_final_response() crashes with TypeError (response.output is None),
+    run_codex_stream should recover by reconstructing from collected output items."""
+    agent = _FakeAgent()
+
+    text_content = [SimpleNamespace(type="output_text", text="Hello from codex")]
+    output_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=text_content,
+    )
+
+    # Build events that the real codex backend emits
+    events = [
+        SimpleNamespace(type="response.created"),
+        SimpleNamespace(type="response.in_progress"),
+        SimpleNamespace(type="response.output_item.added"),
+        SimpleNamespace(type="response.content_part.added"),
+        SimpleNamespace(
+            type="response.output_text.delta", delta="Hello from codex",
+        ),
+        SimpleNamespace(type="response.output_text.done"),
+        SimpleNamespace(type="response.content_part.done"),
+        SimpleNamespace(type="response.output_item.done", item=output_item),
+    ]
+
+    mock_stream = _make_stream_with_crash(events)
+
+    fake_client = MagicMock()
+    fake_client.responses.stream.return_value.__enter__ = lambda self: mock_stream
+    fake_client.responses.stream.return_value.__exit__ = lambda *a: None
+
+    agent._ensure_primary_openai_client = lambda reason="": fake_client
+
+    result = run_codex_stream(
+        agent,
+        api_kwargs={"model": "gpt-5.5", "instructions": "Hi", "input": []},
+        client=fake_client,
+    )
+
+    assert result is not None
+    assert hasattr(result, "output")
+    assert isinstance(result.output, list)
+    assert len(result.output) > 0
+    assert result.output[0].content[0].text == "Hello from codex"
+
+
+def test_run_codex_stream_recovers_from_deltas_when_no_items():
+    """When no output_item.done events were collected but text deltas exist,
+    run_codex_stream should synthesize output from deltas."""
+    agent = _FakeAgent()
+
+    events = [
+        SimpleNamespace(type="response.created"),
+        SimpleNamespace(type="response.in_progress"),
+        SimpleNamespace(type="response.output_text.delta", delta="Hello"),
+        SimpleNamespace(type="response.output_text.done"),
+        SimpleNamespace(type="response.output_text.delta", delta=" world"),
+        SimpleNamespace(type="response.output_text.done"),
+    ]
+
+    mock_stream = _make_stream_with_crash(events)
+
+    fake_client = MagicMock()
+    fake_client.responses.stream.return_value.__enter__ = lambda self: mock_stream
+    fake_client.responses.stream.return_value.__exit__ = lambda *a: None
+
+    agent._ensure_primary_openai_client = lambda reason="": fake_client
+
+    result = run_codex_stream(
+        agent,
+        api_kwargs={"model": "gpt-5.5", "instructions": "Hi", "input": []},
+        client=fake_client,
+    )
+
+    assert result is not None
+    assert hasattr(result, "output")
+    assert isinstance(result.output, list)
+    assert result.output[0].content[0].text == "Hello world"
+
+
+def test_run_codex_create_stream_fallback_recovers_from_no_terminal_event():
+    """When the fallback stream emits no terminal event but has collected items,
+    it should reconstruct the response from them."""
+    from agent.codex_runtime import run_codex_create_stream_fallback
+
+    agent = _FakeAgent()
+
+    text_content = [SimpleNamespace(type="output_text", text="fallback text")]
+    output_item = SimpleNamespace(
+        type="message", role="assistant", status="completed",
+        content=text_content,
+    )
+
+    events = [
+        SimpleNamespace(type="response.output_item.done", item=output_item),
+    ]
+
+    mock_stream = _FakeStream(events)
+
+    fake_client = MagicMock()
+    fake_client.responses.create.return_value = mock_stream
+
+    agent._ensure_primary_openai_client = lambda reason="": fake_client
+
+    result = run_codex_create_stream_fallback(
+        agent,
+        api_kwargs={"model": "gpt-5.5", "instructions": "Hi", "input": [], "stream": True},
+        client=fake_client,
+    )
+
+    assert result is not None
+    assert hasattr(result, "output")
+    assert isinstance(result.output, list)
+    assert result.output[0].content[0].text == "fallback text"


### PR DESCRIPTION
## Problem

The ChatGPT Codex backend (`chatgpt.com/backend-api/codex`) can terminate a Responses API stream without a terminal event (`response.completed` / `response.incomplete` / `response.failed`). When this happens:

1. The OpenAI SDK v2.24.0's `stream.get_final_response()` internally calls `parse_response()` at `openai/lib/_parsing/_responses.py:61`
2. `parse_response()` does `for output in response.output:` — but `response.output` is `None` (never populated)
3. This crashes with `TypeError: 'NoneType' object is not iterable`
4. The existing backfill code in `run_codex_stream` never runs because the crash happens inside `get_final_response()`

This was reproduced with a live OAuth token against the production Codex backend.

## Fix

**`run_codex_stream`:** Wrap `stream.get_final_response()` in try/except, catch the specific `TypeError` with message `'NoneType' object is not iterable`, and reconstruct the response from collected output items or text deltas. Other `TypeError`s are re-raised to avoid masking unrelated bugs.

**`run_codex_create_stream_fallback`:** After the stream iteration loop ends without a terminal event, reconstruct the response from collected output items or text deltas instead of raising `RuntimeError`.

## Tests

Added `tests/agent/test_codex_runtime.py` with 3 tests:

- `test_run_codex_stream_recovers_from_none_output` — recovers when output items were collected
- `test_run_codex_stream_recovers_from_deltas_when_no_items` — synthesizes output from raw text deltas  
- `test_run_codex_create_stream_fallback_recovers_from_no_terminal_event` — recovers when fallback stream has no terminal event