### PR TITLE
fix(image_gen/xai): guard against empty or whitespace-only prompt in generate()

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -176,8 +176,17 @@ class XAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect_ratio,
             )
 
-        model_id, meta = _resolve_model()
+        prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider=provider_name,
+                aspect_ratio=aspect,
+            )
+
+        model_id, meta = _resolve_model()
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()
         xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION


### PR DESCRIPTION
## Summary

`XAIImageGenProvider.generate()` passed empty strings and whitespace-only prompts directly to the xAI API, which returned an opaque HTTP 400 error. Every other image-gen provider validates the prompt before making a network call:

| Provider | Prompt strip + guard |
|----------|---------------------|
| `openai` | ✅ |
| `krea` | ✅ |
| `openai-codex` | ✅ |
| `xai` | ❌ (this PR) |

## Changes

`plugins/image_gen/xai/__init__.py` — add prompt validation symmetric with siblings:

```python
# Before (prompt sent raw to xAI API → HTTP 400)
model_id, meta = _resolve_model()
aspect = resolve_aspect_ratio(aspect_ratio)

# After
prompt = (prompt or "").strip()
aspect = resolve_aspect_ratio(aspect_ratio)
if not prompt:
    return error_response(
        error="Prompt is required and must be a non-empty string",
        error_type="invalid_argument",
        provider=provider_name,
        aspect_ratio=aspect,
    )

model_id, meta = _resolve_model()
```

`resolve_aspect_ratio()` is moved before `_resolve_model()` so the aspect is available in the error response and model resolution is skipped entirely for invalid input.

## Test plan

- [ ] Call `image_generate(prompt="")` with xAI provider configured; confirm clean `"Prompt is required and must be a non-empty string"` error is returned instead of HTTP 400
- [ ] Call `image_generate(prompt="   ")` (whitespace only); same result
- [ ] Call `image_generate(prompt="a cat")` with valid prompt; confirm image is generated normally