### PR TITLE
fix: honor custom fallback endpoint hints in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4686,7 +4686,17 @@ class HermesCLI:
                     if not _fb_provider or not _fb_model:
                         continue
                     try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
+                        if not _fb_explicit_key:
+                            _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
+                            if _fb_key_env:
+                                _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
+                        _fb_explicit_base_url = (_fb.get("base_url") or "").strip() or None
+                        runtime = resolve_runtime_provider(
+                            requested=_fb_provider,
+                            explicit_api_key=_fb_explicit_key,
+                            explicit_base_url=_fb_explicit_base_url,
+                        )
                         logger.warning(
                             "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
                             _primary_exc, _fb_provider, _fb_model,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -115,6 +115,55 @@ class TestFallbackChainInit:
             {"provider": "nous", "model": "Hermes-4"},
         ]
 
+    def test_auth_fallback_passes_custom_endpoint_hints(self, monkeypatch):
+        """CLI auth fallback must honor base_url/key_env on fallback entries."""
+        cli = _make_cli(config_overrides={
+            "model": {"default": "primary-model", "provider": "openai-codex"},
+            "fallback_providers": [{
+                "provider": "custom:cfai",
+                "model": "@cf/google/gemma-3-12b-it",
+                "base_url": "https://vault.useyouragents.com/ai-proxy/v1",
+                "key_env": "HERMES_CF_AI_PROXY_KEY",
+            }],
+        })
+        monkeypatch.setenv("HERMES_CF_AI_PROXY_KEY", "proxy-secret")
+
+        from hermes_cli.auth import AuthError
+        import hermes_cli.runtime_provider as runtime_provider
+
+        calls = []
+
+        def fake_resolve_runtime_provider(*, requested=None, explicit_api_key=None, explicit_base_url=None):
+            calls.append({
+                "requested": requested,
+                "explicit_api_key": explicit_api_key,
+                "explicit_base_url": explicit_base_url,
+            })
+            if requested == "openai-codex":
+                raise AuthError("forced primary failure")
+            return {
+                "api_key": explicit_api_key,
+                "base_url": explicit_base_url,
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            }
+
+        monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider)
+
+        assert cli._ensure_runtime_credentials() is True
+        assert calls[1] == {
+            "requested": "custom:cfai",
+            "explicit_api_key": "proxy-secret",
+            "explicit_base_url": "https://vault.useyouragents.com/ai-proxy/v1",
+        }
+        assert cli.requested_provider == "custom:cfai"
+        assert cli.model == "@cf/google/gemma-3-12b-it"
+        assert cli.api_key == "proxy-secret"
+        assert cli.base_url == "https://vault.useyouragents.com/ai-proxy/v1"
+
 
 class TestBusyInputMode:
     def test_default_busy_input_mode_is_interrupt(self):


### PR DESCRIPTION
## Summary
- pass fallback entry `base_url` into CLI runtime provider resolution
- resolve fallback `key_env`/`api_key_env` and pass it as the explicit API key
- add a CLI regression test for custom fallback endpoint hints

## Test
- `/opt/hermes/bin/python -m pytest tests/cli/test_cli_init.py::TestFallbackChainInit -q -o 'addopts='`
- `/opt/hermes/bin/python -m pytest tests/gateway/test_session_model_override_routing.py::test_gateway_auth_fallback_resolves_key_env_for_custom_provider -q -o 'addopts='`
