### PR TITLE
Fix Google Workspace OAuth redirect and SDK parse retry handling

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -143,6 +143,21 @@ def _print_nous_entitlement_guidance(agent, capability: str) -> bool:
     return True
 
 
+_SDK_PARSE_TYPEERROR_SIGNALS = (
+    "not iterable",
+    "nonetype",
+    "object is not subscriptable",
+)
+
+
+def _is_retryable_sdk_parse_type_error(error: BaseException) -> bool:
+    """Whether a TypeError looks like upstream SDK/provider shape drift."""
+    if not isinstance(error, TypeError):
+        return False
+    err_text = str(error).lower()
+    return any(signal in err_text for signal in _SDK_PARSE_TYPEERROR_SIGNALS)
+
+
 def _is_nous_inference_route(provider: str, base_url: str) -> bool:
     provider = (provider or "").strip().lower()
     if provider == "nous":
@@ -3047,21 +3062,11 @@ def run_conversation(
                     # ssl.SSLError explicitly so the error classifier's
                     # retryable=True mapping takes effect instead.
                     and not isinstance(api_error, ssl.SSLError)
-                    # Provider/SDK "NoneType is not iterable" failures are
-                    # shape mismatches from upstream (e.g. chatgpt.com Codex
-                    # backend response.completed.output=null) — not local
-                    # programming bugs.  Even after #33042 made our own
-                    # consumer immune, third-party shims and mocked clients
-                    # can still surface this shape via TypeError.  Treat
-                    # them as retryable so the error classifier's normal
-                    # retry/fallback path runs instead of killing the turn
-                    # as non-retryable (which left Telegram users staring
-                    # at a bare "Non-retryable error" with no recovery).
-                    and not (
-                        isinstance(api_error, TypeError)
-                        and "nonetype" in str(api_error).lower()
-                        and "not iterable" in str(api_error).lower()
-                    )
+                    # Provider/SDK parse-shaped TypeErrors are upstream shape
+                    # mismatches (e.g. chatgpt.com Codex backend event drift),
+                    # not local programming bugs.  Treat them as retryable so
+                    # the error classifier's normal retry/fallback path runs.
+                    and not _is_retryable_sdk_parse_type_error(api_error)
                 )
                 # ``FailoverReason.billing`` (HTTP 402) is NOT in this
                 # exclusion set.  By the time we reach this block:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -55,10 +55,9 @@ SCOPES = [
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
 
-# OAuth redirect for "out of band" manual code copy flow.
-# Google deprecated OOB, so we use a localhost redirect and tell the user to
-# copy the code from the browser's URL bar (or the page body).
-REDIRECT_URI = "http://localhost:1"
+# OAuth redirect for the manual code-copy flow. Prefer the URI registered in
+# the OAuth client because Google rejects even harmless port differences.
+DEFAULT_REDIRECT_URI = "http://localhost"
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -90,6 +89,17 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
         f"{bullets}\n"
         "Run the Google Workspace setup again from this same Hermes profile to refresh consent."
     )
+
+
+def _redirect_uri() -> str:
+    """Return the OAuth redirect URI registered in the client secret."""
+    try:
+        payload = json.loads(CLIENT_SECRET_PATH.read_text())
+    except Exception:
+        return DEFAULT_REDIRECT_URI
+    client_config = payload.get("installed") or payload.get("web") or {}
+    redirect_uris = client_config.get("redirect_uris") or []
+    return redirect_uris[0] if redirect_uris else DEFAULT_REDIRECT_URI
 
 
 def install_deps():
@@ -248,14 +258,14 @@ def store_client_secret(path: str):
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
-def _save_pending_auth(*, state: str, code_verifier: str):
+def _save_pending_auth(*, state: str, code_verifier: str, redirect_uri: str):
     """Persist the OAuth session bits needed for a later token exchange."""
     PENDING_AUTH_PATH.write_text(
         json.dumps(
             {
                 "state": state,
                 "code_verifier": code_verifier,
-                "redirect_uri": REDIRECT_URI,
+                "redirect_uri": redirect_uri,
             },
             indent=2,
         )
@@ -308,18 +318,19 @@ def get_auth_url():
 
     _ensure_deps()
     from google_auth_oauthlib.flow import Flow
+    redirect_uri = _redirect_uri()
 
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),
         scopes=SCOPES,
-        redirect_uri=REDIRECT_URI,
+        redirect_uri=redirect_uri,
         autogenerate_code_verifier=True,
     )
     auth_url, state = flow.authorization_url(
         access_type="offline",
         prompt="consent",
     )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
+    _save_pending_auth(state=state, code_verifier=flow.code_verifier, redirect_uri=redirect_uri)
     # Print just the URL so the agent can extract it cleanly
     print(auth_url)
 
@@ -352,7 +363,7 @@ def exchange_auth_code(code: str):
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),
         scopes=granted_scopes,
-        redirect_uri=pending_auth.get("redirect_uri", REDIRECT_URI),
+        redirect_uri=pending_auth.get("redirect_uri", _redirect_uri()),
         state=pending_auth["state"],
         code_verifier=pending_auth["code_verifier"],
     )

--- a/tests/run_agent/test_jsondecodeerror_retryable.py
+++ b/tests/run_agent/test_jsondecodeerror_retryable.py
@@ -29,19 +29,15 @@ def _mirror_agent_predicate(err: BaseException) -> bool:
     sites import it.
     """
     import ssl
+    from agent.conversation_loop import _is_retryable_sdk_parse_type_error
 
     return (
         isinstance(err, (ValueError, TypeError))
         and not isinstance(err, (UnicodeEncodeError, json.JSONDecodeError))
         and not isinstance(err, ssl.SSLError)
-        # NoneType-is-not-iterable shape errors come from upstream SDK /
-        # provider response mismatches, not local programming bugs. See
-        # the agent/conversation_loop.py inline comment for #33136.
-        and not (
-            isinstance(err, TypeError)
-            and "nonetype" in str(err).lower()
-            and "not iterable" in str(err).lower()
-        )
+        # SDK/provider parse-shaped TypeErrors come from upstream response
+        # mismatches, not local programming bugs. See conversation_loop.py.
+        and not _is_retryable_sdk_parse_type_error(err)
     )
 
 
@@ -123,12 +119,14 @@ class TestNoneTypeNotIterableIsRetryable:
             "not a local bug. See #33136."
         )
 
-    def test_nonetype_not_iterable_uppercase_variants_still_retryable(self):
+    def test_sdk_parse_typeerror_variants_still_retryable(self):
         # The carve-out is case-insensitive; SDK message phrasing can vary.
         for msg in [
             "'NoneType' object is not iterable",
             "NoneType object is not iterable",
             "argument of type 'NoneType' is not iterable",
+            "'NoneType' object is not subscriptable",
+            "'ResponseCompletedEvent' object is not subscriptable",
         ]:
             err = TypeError(msg)
             assert not _mirror_agent_predicate(err), (
@@ -149,8 +147,8 @@ class TestAgentLoopSourceHasNoneTypeCarveOut:
         from agent import conversation_loop
         src = inspect.getsource(conversation_loop)
         assert "is_local_validation_error" in src
-        # The specific check must be present.
-        assert "nonetype" in src.lower() and "not iterable" in src.lower(), (
-            "agent/conversation_loop.py must carve out 'NoneType is not iterable' "
+        # The specific parse-shape helper must be present.
+        assert "_is_retryable_sdk_parse_type_error" in src, (
+            "agent/conversation_loop.py must carve out SDK parse-shaped "
             "TypeErrors from the is_local_validation_error classification — see #33136."
         )


### PR DESCRIPTION
## Summary
- use the redirect URI registered in the Google OAuth client secret for the manual Google Workspace auth flow
- persist the chosen redirect URI with pending OAuth state so the token exchange uses the same value
- keep `http://localhost` as the fallback when no redirect URI is available
- carry forward the local runtime resilience fix by treating SDK/provider parse-shaped `TypeError`s as retryable instead of local validation bugs

## Testing
- `git diff --check`
- `python3 -m py_compile agent/conversation_loop.py skills/productivity/google-workspace/scripts/setup.py`
- `python3 skills/productivity/google-workspace/scripts/setup.py --help`
- `uv run --extra dev pytest tests/run_agent/test_jsondecodeerror_retryable.py`