### PR TITLE
fix(bedrock): guard temperature/top_p for Opus 4.7/4.8 on Converse

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -135,6 +135,19 @@ def invalidate_runtime_client(region: str) -> bool:
 # restarts. The fix is to evict the region's cached client so the next
 # attempt builds a new one.
 
+# Models that 400 on any non-default temperature/top_p with the Bedrock
+# Converse API: "'temperature' is deprecated for this model."
+# Mirrors anthropic_adapter._forbids_sampling_params() but kept local to avoid
+# a cross-adapter import. See issue #36151.
+_BEDROCK_NO_SAMPLING_PARAMS_SUBSTRINGS = ("opus-4-7", "opus-4-8", "opus-4.7", "opus-4.8")
+
+
+def _bedrock_forbids_sampling_params(model_id: str) -> bool:
+    """Return True for models that reject temperature/top_p in Converse."""
+    model_lower = model_id.lower()
+    return any(s in model_lower for s in _BEDROCK_NO_SAMPLING_PARAMS_SUBSTRINGS)
+
+
 _STALE_LIB_MODULE_PREFIXES = (
     "urllib3.",
     "botocore.",
@@ -900,10 +913,10 @@ def build_converse_kwargs(
     if system_prompt:
         kwargs["system"] = system_prompt
 
-    if temperature is not None:
+    if temperature is not None and not _bedrock_forbids_sampling_params(model):
         kwargs["inferenceConfig"]["temperature"] = temperature
 
-    if top_p is not None:
+    if top_p is not None and not _bedrock_forbids_sampling_params(model):
         kwargs["inferenceConfig"]["topP"] = top_p
 
     if stop_sequences:

--- a/tests/agent/test_bedrock_opus_sampling.py
+++ b/tests/agent/test_bedrock_opus_sampling.py
@@ -1,0 +1,135 @@
+"""Tests for Bedrock Opus sampling params guard (issue #36151)."""
+
+import pytest
+
+from agent.bedrock_adapter import (
+    _bedrock_forbids_sampling_params,
+    _BEDROCK_NO_SAMPLING_PARAMS_SUBSTRINGS,
+    build_converse_kwargs,
+)
+
+
+class TestBedrockForbidsSamplingParams:
+    """Tests for _bedrock_forbids_sampling_params()."""
+
+    def test_opus_4_7_variants(self):
+        """All Opus 4.7 variants reject sampling params."""
+        for model_id in [
+            "anthropic.claude-opus-4-7",
+            "anthropic.claude-opus-4.7",
+            "us.anthropic.claude-opus-4-7",
+            "us.anthropic.claude-opus-4.7",
+            "global.anthropic.claude-opus-4-7",
+            "global.anthropic.claude-opus-4.7",
+        ]:
+            assert _bedrock_forbids_sampling_params(model_id), f"{model_id} should forbid sampling params"
+
+    def test_opus_4_8_variants(self):
+        """All Opus 4.8 variants reject sampling params."""
+        for model_id in [
+            "anthropic.claude-opus-4-8",
+            "anthropic.claude-opus-4.8",
+            "us.anthropic.claude-opus-4-8",
+            "us.anthropic.claude-opus-4.8",
+            "global.anthropic.claude-opus-4-8",
+            "global.anthropic.claude-opus-4.8",
+        ]:
+            assert _bedrock_forbids_sampling_params(model_id), f"{model_id} should forbid sampling params"
+
+    def test_opus_4_6_allows_sampling_params(self):
+        """Opus 4.6 and earlier models allow sampling params."""
+        for model_id in [
+            "anthropic.claude-opus-4-6",
+            "anthropic.claude-opus-4-5",
+            "anthropic.claude-opus-4",
+            "anthropic.claude-3-5-sonnet",
+            "anthropic.claude-3-haiku",
+        ]:
+            assert not _bedrock_forbids_sampling_params(model_id), f"{model_id} should allow sampling params"
+
+    def test_non_anthropic_models_allows_sampling_params(self):
+        """Non-Anthropic models allow sampling params."""
+        for model_id in [
+            "meta.llama-3-70b",
+            "mistral.mistral-large-2402",
+            "amazon.titan-text-premier-v1:0:8k",
+        ]:
+            assert not _bedrock_forbids_sampling_params(model_id), f"{model_id} should allow sampling params"
+
+
+class TestBuildConverseKwargsOpusSamplingParams:
+    """Tests for build_converse_kwargs() sampling params guard."""
+
+    def test_opus_4_8_strips_temperature_and_top_p(self):
+        """Opus 4.8 should have temperature and topP stripped from inferenceConfig."""
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-8",
+            messages=[{"role": "user", "content": "test"}],
+            temperature=1.0,
+            top_p=0.9,
+            max_tokens=32,
+        )
+        inference_config = kwargs["inferenceConfig"]
+        assert inference_config == {"maxTokens": 32}, f"Expected only maxTokens, got {inference_config}"
+
+    def test_opus_4_7_strips_temperature_and_top_p(self):
+        """Opus 4.7 should have temperature and topP stripped from inferenceConfig."""
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-opus-4.7",
+            messages=[{"role": "user", "content": "test"}],
+            temperature=0.7,
+            top_p=0.8,
+            max_tokens=64,
+        )
+        inference_config = kwargs["inferenceConfig"]
+        assert inference_config == {"maxTokens": 64}, f"Expected only maxTokens, got {inference_config}"
+
+    def test_opus_4_6_includes_temperature_and_top_p(self):
+        """Opus 4.6 should include temperature and topP in inferenceConfig."""
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-opus-4-6",
+            messages=[{"role": "user", "content": "test"}],
+            temperature=0.5,
+            top_p=0.7,
+            max_tokens=128,
+        )
+        inference_config = kwargs["inferenceConfig"]
+        assert inference_config["maxTokens"] == 128
+        assert inference_config["temperature"] == 0.5
+        assert inference_config["topP"] == 0.7
+
+    def test_sonnet_includes_temperature_and_top_p(self):
+        """Sonnet models should include temperature and topP in inferenceConfig."""
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-3-5-sonnet",
+            messages=[{"role": "user", "content": "test"}],
+            temperature=0.8,
+            top_p=0.9,
+            max_tokens=4096,
+        )
+        inference_config = kwargs["inferenceConfig"]
+        assert inference_config["maxTokens"] == 4096
+        assert inference_config["temperature"] == 0.8
+        assert inference_config["topP"] == 0.9
+
+    def test_none_temperature_preserves_behavior(self):
+        """None temperature should not be added regardless of model."""
+        for model_id in ["anthropic.claude-opus-4-8", "anthropic.claude-3-5-sonnet"]:
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "test"}],
+                temperature=None,
+                max_tokens=32,
+            )
+            assert "temperature" not in kwargs["inferenceConfig"]
+
+    def test_none_top_p_preserves_behavior(self):
+        """None top_p should not be added regardless of model."""
+        for model_id in ["anthropic.claude-opus-4-8", "anthropic.claude-3-5-sonnet"]:
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "test"}],
+                top_p=None,
+                max_tokens=32,
+            )
+            assert "topP" not in kwargs["inferenceConfig"]


### PR DESCRIPTION
## What does this PR do?

Adds a guard in `agent/bedrock_adapter.py` to prevent sending non-default `temperature` and `top_p` parameters to Opus 4.7 and 4.8 models on AWS Bedrock Converse API, which reject them with HTTP 400: "temperature is deprecated for this model."

## Related Issue

Fixes #36151

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: Added `_BEDROCK_NO_SAMPLING_PARAMS_SUBSTRINGS` tuple and `_bedrock_forbids_sampling_params()` helper function to detect Opus 4.7/4.8 models; modified `build_converse_kwargs()` to strip `temperature` and `topP` from `inferenceConfig` when these models are detected.
- `tests/agent/test_bedrock_opus_sampling.py`: Added comprehensive test coverage for the new guard (10 tests covering Opus 4.7/4.8 variants, Opus 4.6 behavior, non-Anthropic models, and edge cases with `None` values).

## How to Test

1. Run the new test suite: `pytest tests/agent/test_bedrock_opus_sampling.py -xvs` (all 10 tests should pass)
2. Verify Opus 4.8/4.7 behavior: with `temperature=1.0, top_p=0.9`, `build_converse_kwargs()` should produce `inferenceConfig` with only `maxTokens` (sampling params stripped)
3. Verify Opus 4.6 behavior: with the same parameters, `build_converse_kwargs()` should include `temperature` and `topP` in `inferenceConfig` (preserving backward compatibility)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/bedrock_adapter.py::build_converse_kwargs` (direct callers: `call_converse`, `call_converse_stream`)
- Blast radius: LOW — scoped to Bedrock Converse path only, does not affect Anthropic-native or other provider adapters
- Related patterns: mirrors `agent/anthropic_adapter.py::_forbids_sampling_params()` but kept local to avoid cross-adapter imports; see issue #36151 for full context
