### PR TITLE
fix(cli): eliminate single quotes from write_launcher heredoc template

### DIFF
--- a/scripts/setup_open_webui.sh
+++ b/scripts/setup_open_webui.sh
@@ -182,13 +182,13 @@ write_launcher() {
 #!/usr/bin/env bash
 set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-API_KEY=\$(python3 - <<'PY'
+API_KEY=\$(python3 - <<PY
 from pathlib import Path
-p = Path.home()/'.hermes'/'.env'
+p = Path.home()/".hermes"/".env"
 for raw in p.read_text().splitlines():
     line = raw.strip()
-    if line.startswith('API_SERVER_KEY='):
-        print(line.split('=', 1)[1])
+    if line.startswith("API_SERVER_KEY="):
+        print(line.split("=", 1)[1])
         break
 PY
 )


### PR DESCRIPTION
## Summary

- Replace `<<'PY'` with `<<PY` in `write_launcher()`'s embedded Python heredoc
- Rewrite the four Python string literals from single quotes to double quotes

## Problem

`write_launcher()` uses an **unquoted** `<<EOF` heredoc so that `${quoted_data_dir}`, `${quoted_name}`, and other shell variables expand correctly into the generated launcher script.

When `setup_open_webui.sh` is itself transmitted through a non-quoted bash heredoc layer (nested SSH sessions, remote-dispatch automation), bash processes the outer heredoc body and strips literal single quotes. This corrupts the embedded Python snippet:

```
# What's in setup_open_webui.sh:
p = Path.home()/'.hermes'/'.env'

# What bash writes to the launcher after quote-stripping:
p = Path.home()/.hermes/.env    ← SyntaxError
```

The generated launcher then fails at runtime with `SyntaxError: invalid syntax`. Fixes #36120.

## Fix

The Python block contains **no `$`-expansions**, so quoting the `PY` delimiter (`<<'PY'`) was never necessary for correctness — it was just defensive style. Dropping it to `<<PY` and switching the four Python string literals to double quotes removes all single quotes from the heredoc body. Bash has nothing to strip, and the generated launcher is semantically identical.

## Changes

- `scripts/setup_open_webui.sh`: 4 lines changed (1 heredoc delimiter + 3 Python string literals), single file, no logic change

## Verification

- Ran `write_launcher()` directly: generated launcher has correct double-quoted Python strings and `<<PY` delimiter, executes without error
- Confirmed `API_SERVER_KEY` extraction works as expected via `python3` inline
- Simulated nested heredoc invocation: single quotes no longer present in the heredoc body, no stripping occurs

## Existing PRs

Searched open and closed PRs — no prior attempt found for this issue.

## Checklist

- [x] Read the Contributing Guide
- [x] Commit follows Conventional Commits (`fix(cli):`)
- [x] Searched for existing PRs — none found
- [x] PR contains only changes related to this fix
- [x] Tested on macOS
- [x] No new dependencies introduced

**AI disclosure:** fix developed with Claude Sonnet 4.6 (arimu1 reviewed and approved the diff)