### PR TITLE
fix(api): add /api/cron/jobs route aliases for web UI Schedules (#36149)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4119,6 +4119,15 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
             self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+            # Aliases under /api/cron/jobs/* to match the web UI Schedules client.
+            self._app.router.add_get("/api/cron/jobs", self._handle_list_jobs)
+            self._app.router.add_post("/api/cron/jobs", self._handle_create_job)
+            self._app.router.add_get("/api/cron/jobs/{job_id}", self._handle_get_job)
+            self._app.router.add_patch("/api/cron/jobs/{job_id}", self._handle_update_job)
+            self._app.router.add_delete("/api/cron/jobs/{job_id}", self._handle_delete_job)
+            self._app.router.add_post("/api/cron/jobs/{job_id}/pause", self._handle_pause_job)
+            self._app.router.add_post("/api/cron/jobs/{job_id}/resume", self._handle_resume_job)
+            self._app.router.add_post("/api/cron/jobs/{job_id}/trigger", self._handle_run_job)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -10,6 +10,7 @@ Covers:
 - Cron module unavailability (501 when _CRON_AVAILABLE is False)
 """
 
+import inspect
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -693,3 +694,78 @@ class TestCronUnavailable:
             with patch(f"{_MOD}._CRON_AVAILABLE", False):
                 resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
                 assert resp.status == 501
+
+
+# ---------------------------------------------------------------------------
+# 19. test_cron_jobs_route_aliases — issue #36149
+# ---------------------------------------------------------------------------
+
+class TestCronJobsRouteAliases:
+    """The web UI Schedules client calls /api/cron/jobs/* (with /trigger).
+
+    The backend originally only exposed /api/jobs/* (with /run). Register
+    aliases on the same handlers so the UI works without breaking legacy
+    callers. See gateway issue #36149.
+    """
+
+    EXPECTED_ALIASES = [
+        ('add_get',    '"/api/cron/jobs"',                       '_handle_list_jobs'),
+        ('add_post',   '"/api/cron/jobs"',                       '_handle_create_job'),
+        ('add_get',    '"/api/cron/jobs/{job_id}"',              '_handle_get_job'),
+        ('add_patch',  '"/api/cron/jobs/{job_id}"',              '_handle_update_job'),
+        ('add_delete', '"/api/cron/jobs/{job_id}"',              '_handle_delete_job'),
+        ('add_post',   '"/api/cron/jobs/{job_id}/pause"',        '_handle_pause_job'),
+        ('add_post',   '"/api/cron/jobs/{job_id}/resume"',       '_handle_resume_job'),
+        ('add_post',   '"/api/cron/jobs/{job_id}/trigger"',      '_handle_run_job'),
+    ]
+
+    def test_cron_aliases_registered_in_connect(self):
+        """connect() registers /api/cron/jobs/* aliases on the same handlers."""
+        source = inspect.getsource(APIServerAdapter.connect)
+        for method, path, handler in self.EXPECTED_ALIASES:
+            needle = f'self._app.router.{method}({path}, self.{handler})'
+            assert needle in source, f"Missing alias registration: {needle}"
+
+    def test_legacy_jobs_routes_still_registered(self):
+        """Legacy /api/jobs/* routes must remain registered (no breaking change)."""
+        source = inspect.getsource(APIServerAdapter.connect)
+        legacy = [
+            'self._app.router.add_get("/api/jobs", self._handle_list_jobs)',
+            'self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)',
+        ]
+        for needle in legacy:
+            assert needle in source, f"Legacy route removed: {needle}"
+
+    @pytest.mark.asyncio
+    async def test_cron_alias_list_jobs_routes_to_handler(self, adapter):
+        """Live check: GET /api/cron/jobs hits _handle_list_jobs."""
+        app = web.Application(middlewares=[cors_middleware])
+        app["api_server_adapter"] = adapter
+        app.router.add_get("/api/cron/jobs", adapter._handle_list_jobs)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_list", return_value=[SAMPLE_JOB]
+            ):
+                resp = await cli.get("/api/cron/jobs")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["jobs"] == [SAMPLE_JOB]
+
+    @pytest.mark.asyncio
+    async def test_cron_alias_trigger_routes_to_run_handler(self, adapter):
+        """Live check: POST /api/cron/jobs/{id}/trigger hits _handle_run_job."""
+        app = web.Application(middlewares=[cors_middleware])
+        app["api_server_adapter"] = adapter
+        app.router.add_post(
+            "/api/cron/jobs/{job_id}/trigger", adapter._handle_run_job
+        )
+        mock_trigger = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_trigger", mock_trigger
+            ):
+                resp = await cli.post(
+                    f"/api/cron/jobs/{VALID_JOB_ID}/trigger"
+                )
+                assert resp.status == 200
+                mock_trigger.assert_called_once_with(VALID_JOB_ID)


### PR DESCRIPTION
## Summary

Fixes #36149. The web UI Schedules section fails to load because the frontend (`web/src/lib/api.ts`) calls endpoints under `/api/cron/jobs/*` (including `/trigger`), but the backend (`gateway/platforms/api_server.py`) only registers them under `/api/jobs/*` (with `/run`).

This PR registers route aliases under `/api/cron/jobs/*` pointing to the same existing handler methods, while preserving the legacy `/api/jobs/*` routes for backwards compatibility.

## Routes added

| Method | New alias | Existing handler |
|---|---|---|
| GET    | `/api/cron/jobs`                  | `_handle_list_jobs` |
| POST   | `/api/cron/jobs`                  | `_handle_create_job` |
| GET    | `/api/cron/jobs/{job_id}`         | `_handle_get_job` |
| PATCH  | `/api/cron/jobs/{job_id}`         | `_handle_update_job` |
| DELETE | `/api/cron/jobs/{job_id}`         | `_handle_delete_job` |
| POST   | `/api/cron/jobs/{job_id}/pause`   | `_handle_pause_job` |
| POST   | `/api/cron/jobs/{job_id}/resume`  | `_handle_resume_job` |
| POST   | `/api/cron/jobs/{job_id}/trigger` | `_handle_run_job` |

The legacy `/api/jobs/*` paths (including `/run`) remain registered.

## Tests

Added `TestCronJobsRouteAliases` in `tests/gateway/test_api_server_jobs.py`:
- Source-level assertion that all 8 aliases are registered
- Source-level assertion that legacy routes remain
- Live HTTP test for `GET /api/cron/jobs`
- Live HTTP test for `POST /api/cron/jobs/{id}/trigger`

`pytest tests/gateway/test_api_server_jobs.py` → 40 passed.

Closes #36149.