### PR TITLE
[codex] Add generic webhook support for private notifiers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -394,7 +394,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=403,
             )
         if secret != _INSECURE_NO_AUTH:
-            if not self._validate_signature(request, raw_body, secret):
+            if not self._validate_signature(request, raw_body, secret, route_config):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
                 )
@@ -429,13 +429,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
 
         # Check event type filter
-        event_type = (
-            request.headers.get("X-GitHub-Event", "")
-            or request.headers.get("X-GitLab-Event", "")
-            or payload.get("event_type", "")
-            or payload.get("type", "")
-            or "unknown"
-        )
+        event_type = self._extract_event_type(request, payload, route_config)
         allowed_events = route_config.get("events", [])
         if allowed_events and event_type not in allowed_events:
             logger.debug(
@@ -444,8 +438,12 @@ class WebhookAdapter(BasePlatformAdapter):
                 route_name,
                 allowed_events,
             )
+            status_code = int(route_config.get("event_mismatch_status", 200))
+            if route_config.get("reject_unmatched_events"):
+                status_code = int(route_config.get("event_mismatch_status", 422))
             return web.json_response(
-                {"status": "ignored", "event": event_type}
+                {"status": "ignored", "event": event_type},
+                status=status_code,
             )
 
         # Format prompt from template
@@ -484,13 +482,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
         # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
-        )
+        delivery_id = self._extract_delivery_id(request, payload, route_config)
 
         # ── Idempotency ─────────────────────────────────────────
         # Skip duplicate deliveries (webhook retries).
@@ -509,8 +501,6 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
-        self._seen_deliveries[delivery_id] = now
-
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
         # deliver.  Use case: external services (Supabase, monitoring,
@@ -547,6 +537,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
 
             if result.success:
+                self._seen_deliveries[delivery_id] = now
                 return web.json_response(
                     {
                         "status": "delivered",
@@ -568,6 +559,8 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                 status=502,
             )
+
+        self._seen_deliveries[delivery_id] = now
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
@@ -631,16 +624,84 @@ class WebhookAdapter(BasePlatformAdapter):
     # Signature validation
     # ------------------------------------------------------------------
 
+    def _extract_header(self, request: "web.Request", name: str) -> str:
+        return (
+            request.headers.get(name, "")
+            or request.headers.get(name.lower(), "")
+            or request.headers.get(name.upper(), "")
+        )
+
+    def _extract_event_type(
+        self,
+        request: "web.Request",
+        payload: dict,
+        route_config: dict,
+    ) -> str:
+        """Resolve event type from route-configured or built-in sources."""
+        header_names = route_config.get("event_headers")
+        if header_names is None:
+            configured = route_config.get("event_header")
+            header_names = [configured] if configured else []
+        if isinstance(header_names, str):
+            header_names = [header_names]
+        for header_name in list(header_names or []) + [
+            "X-GitHub-Event",
+            "X-GitLab-Event",
+        ]:
+            if not header_name:
+                continue
+            value = self._extract_header(request, str(header_name))
+            if value:
+                return value
+
+        field_names = route_config.get("event_fields")
+        if field_names is None:
+            configured = route_config.get("event_field")
+            field_names = [configured] if configured else []
+        if isinstance(field_names, str):
+            field_names = [field_names]
+        for field_name in list(field_names or []) + ["event_type", "event", "type"]:
+            if not field_name:
+                continue
+            value = payload.get(str(field_name), "")
+            if value:
+                return str(value)
+        return "unknown"
+
+    def _extract_delivery_id(
+        self,
+        request: "web.Request",
+        payload: dict,
+        route_config: dict,
+    ) -> str:
+        """Resolve delivery id from route-configured or built-in sources."""
+        header_names = route_config.get("delivery_id_headers")
+        if header_names is None:
+            configured = route_config.get("delivery_id_header")
+            header_names = [configured] if configured else []
+        if isinstance(header_names, str):
+            header_names = [header_names]
+        for header_name in list(header_names or []) + [
+            "X-GitHub-Delivery",
+            "svix-id",
+            "X-Request-ID",
+        ]:
+            if not header_name:
+                continue
+            value = self._extract_header(request, str(header_name))
+            if value:
+                return value
+        return str(payload.get("delivery_id", str(int(time.time() * 1000))))
+
     def _validate_signature(
-        self, request: "web.Request", body: bytes, secret: str
+        self,
+        request: "web.Request",
+        body: bytes,
+        secret: str,
+        route_config: Optional[dict] = None,
     ) -> bool:
         """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
-        def _header(name: str) -> str:
-            return (
-                request.headers.get(name, "")
-                or request.headers.get(name.lower(), "")
-                or request.headers.get(name.upper(), "")
-            )
+        route_config = route_config or {}
 
         # Svix / AgentMail:
         #   svix-id: msg_...
@@ -648,9 +709,9 @@ class WebhookAdapter(BasePlatformAdapter):
         #   svix-signature: v1,<base64-hmac> [v1,<base64-hmac> ...]
         # Signed content is: "{id}.{timestamp}.{raw_body}".  Svix secrets
         # usually start with "whsec_" and the remainder is base64-encoded.
-        svix_id = _header("svix-id")
-        svix_timestamp = _header("svix-timestamp")
-        svix_signature = _header("svix-signature")
+        svix_id = self._extract_header(request, "svix-id")
+        svix_timestamp = self._extract_header(request, "svix-timestamp")
+        svix_signature = self._extract_header(request, "svix-signature")
         if svix_id or svix_timestamp or svix_signature:
             return self._validate_svix_signature(
                 body=body,
@@ -672,6 +733,28 @@ class WebhookAdapter(BasePlatformAdapter):
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
+
+        custom_sig_header = route_config.get("signature_header")
+        if custom_sig_header:
+            custom_sig = self._extract_header(request, str(custom_sig_header))
+            if custom_sig:
+                timestamp_header = route_config.get("signature_timestamp_header")
+                timestamp = (
+                    self._extract_header(request, str(timestamp_header))
+                    if timestamp_header else ""
+                )
+                signed_payload = body
+                signed_mode = route_config.get("signature_signed_payload", "raw_body")
+                if signed_mode == "timestamp.raw_body":
+                    if not timestamp:
+                        return False
+                    signed_payload = timestamp.encode() + b"." + body
+                digest = hmac.new(
+                    secret.encode(), signed_payload, hashlib.sha256
+                ).hexdigest()
+                prefix = route_config.get("signature_prefix", "")
+                expected = f"{prefix}{digest}"
+                return hmac.compare_digest(custom_sig, expected)
 
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4417,6 +4417,18 @@ class GatewayRunner:
         await self.hooks.emit("gateway:startup", {
             "platforms": [p.value for p in self.adapters.keys()],
         })
+
+        try:
+            from hermes_cli.plugins import invoke_hook
+            invoke_hook(
+                "gateway_startup",
+                gateway=self,
+                connected_platforms=[p.value for p in self.adapters.keys()],
+            )
+        except Exception:
+            logger.warning(
+                "plugin gateway_startup hook failed", exc_info=True,
+            )
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -150,6 +150,10 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Gateway startup hook. Fired once after configured platform adapters have
+    # connected and before startup notifications are sent.
+    # Kwargs: gateway: GatewayRunner, connected_platforms: list[str].
+    "gateway_startup",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -183,6 +183,59 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Webhook-Signature": sig})
         assert adapter._validate_signature(req, body, secret) is True
 
+    def test_validate_custom_signature_valid(self):
+        """Valid route-configured HMAC header is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event_type":"message.deliverable"}'
+        secret = "custom-secret"
+        sig = "sha256=" + _generic_signature(body, secret)
+        req = _mock_request(headers={"X-Custom-Signature": sig})
+        assert adapter._validate_signature(
+            req,
+            body,
+            secret,
+            {"signature_header": "X-Custom-Signature", "signature_prefix": "sha256="},
+        ) is True
+
+    def test_validate_custom_timestamp_signature_valid(self):
+        """Route-configured timestamp.raw_body signatures are accepted."""
+        adapter = _make_adapter()
+        body = b'{"event":"custom.event.created"}'
+        secret = "custom-secret"
+        timestamp = "2026-06-01T12:34:56Z"
+        signed_body = timestamp.encode() + b"." + body
+        sig = "sha256=" + _generic_signature(signed_body, secret)
+        req = _mock_request(
+            headers={
+                "X-Hawser-Signature": sig,
+                "X-Hawser-Timestamp": timestamp,
+            }
+        )
+        assert adapter._validate_signature(
+            req,
+            body,
+            secret,
+            {
+                "signature_header": "X-Hawser-Signature",
+                "signature_timestamp_header": "X-Hawser-Timestamp",
+                "signature_signed_payload": "timestamp.raw_body",
+                "signature_prefix": "sha256=",
+            },
+        ) is True
+
+    def test_validate_custom_signature_wrong_body_rejects(self):
+        """Custom signatures are bound to the exact raw request body."""
+        adapter = _make_adapter()
+        secret = "custom-secret"
+        sig = "sha256=" + _generic_signature(b'{"body":"one"}', secret)
+        req = _mock_request(headers={"X-Custom-Signature": sig})
+        assert adapter._validate_signature(
+            req,
+            b'{"body":"two"}',
+            secret,
+            {"signature_header": "X-Custom-Signature", "signature_prefix": "sha256="},
+        ) is False
+
     def test_validate_svix_signature_valid(self):
         """Valid Svix/AgentMail v1 signature headers are accepted."""
         adapter = _make_adapter()
@@ -1031,4 +1084,3 @@ class TestInsecureNoAuthSafetyRail:
             assert result is True
         finally:
             await adapter.disconnect()
-

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -14,6 +14,8 @@ Covers:
 """
 
 import asyncio
+import hashlib
+import hmac
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -120,6 +122,110 @@ class TestDeliverOnlyBypassesAgent:
         assert content_arg == "alice matched with bob!"
 
     @pytest.mark.asyncio
+    async def test_custom_headers_drive_event_delivery_and_idempotency(self):
+        routes = {
+            "custom-notif": {
+                "secret": "custom-secret",
+                "events": ["custom.event.created"],
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "12345"},
+                "prompt": "{message.subject}: {message.body}",
+                "event_header": "X-Custom-Event",
+                "delivery_id_header": "X-Custom-Delivery",
+                "signature_header": "X-Custom-Signature",
+                "signature_timestamp_header": "X-Custom-Timestamp",
+                "signature_signed_payload": "timestamp.raw_body",
+                "signature_prefix": "sha256=",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        body = json.dumps(
+            {
+                "event": "ignored-if-header-present",
+                "message": {
+                    "id": "msg-1",
+                    "subject": "Build finished",
+                    "body": "Tests passed",
+                },
+                "delivery_id": "payload-delivery",
+            }
+        ).encode()
+        timestamp = "2026-06-01T12:34:56Z"
+        signed_body = timestamp.encode() + b"." + body
+        sig = "sha256=" + hmac.new(
+            b"custom-secret", signed_body, hashlib.sha256
+        ).hexdigest()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/custom-notif",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Custom-Event": "custom.event.created",
+                    "X-Custom-Delivery": "delivery-1",
+                    "X-Custom-Signature": sig,
+                    "X-Custom-Timestamp": timestamp,
+                },
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["delivery_id"] == "delivery-1"
+
+            duplicate = await cli.post(
+                "/webhooks/custom-notif",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Custom-Event": "custom.event.created",
+                    "X-Custom-Delivery": "delivery-1",
+                    "X-Custom-Signature": sig,
+                    "X-Custom-Timestamp": timestamp,
+                },
+            )
+            assert duplicate.status == 200
+            dup_data = await duplicate.json()
+            assert dup_data["status"] == "duplicate"
+
+        mock_target.send.assert_awaited_once()
+        assert mock_target.send.await_args.args[1] == "Build finished: Tests passed"
+
+    @pytest.mark.asyncio
+    async def test_reject_unmatched_event_returns_non_2xx(self):
+        routes = {
+            "custom-notif": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["custom.event.created"],
+                "event_header": "X-Custom-Event",
+                "reject_unmatched_events": True,
+                "event_mismatch_status": 422,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "12345"},
+                "prompt": "{message.body}",
+            }
+        }
+        adapter = _make_adapter(routes)
+        _wire_mock_target(adapter)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/custom-notif",
+                json={"message": {"body": "should not deliver"}},
+                headers={
+                    "X-Custom-Event": "message.deleted",
+                    "X-Custom-Delivery": "event-mismatch-1",
+                },
+            )
+            assert resp.status == 422
+            data = await resp.json()
+            assert data["status"] == "ignored"
+
+    @pytest.mark.asyncio
     async def test_template_rendering_works(self):
         """Dot-notation template variables resolve in deliver_only mode."""
         routes = {
@@ -212,6 +318,47 @@ class TestDeliverOnlyStatusCodes:
             # Generic error — no adapter-level detail leaks
             assert data["error"] == "Delivery failed"
             assert "rate limited" not in json.dumps(data)
+
+    @pytest.mark.asyncio
+    async def test_failed_delivery_id_can_be_retried(self):
+        """A failed direct delivery must not poison the idempotency cache."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "retry me",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            side_effect=[
+                SendResult(success=False, error="temporary"),
+                SendResult(success=True),
+            ]
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "retry-delivery-1"},
+            )
+            assert first.status == 502
+
+            second = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "retry-delivery-1"},
+            )
+            assert second.status == 200
+            data = await second.json()
+            assert data["status"] == "delivered"
+
+        assert mock_target.send.await_count == 2
 
     @pytest.mark.asyncio
     async def test_delivery_exception_returns_502(self):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -330,6 +330,9 @@ class TestPluginHooks:
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
 
+    def test_valid_hooks_include_gateway_startup(self):
+        assert "gateway_startup" in VALID_HOOKS
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/plugins/test_private_integrations_not_bundled.py
+++ b/tests/plugins/test_private_integrations_not_bundled.py
@@ -1,0 +1,8 @@
+"""Guardrails for integrations that must ship outside Hermes core."""
+
+from pathlib import Path
+
+
+def test_hawser_notifier_is_not_bundled_plugin():
+    repo_root = Path(__file__).resolve().parents[2]
+    assert not (repo_root / "plugins" / "hawser_notifier").exists()


### PR DESCRIPTION
## Summary

Keeps the Hermes core side generic for private push-notifier plugins. The Hawser-specific plugin has been removed from this PR and moved to the private `dguerizec/hermes-hawser` repo.

## Details

- Adds a narrow `gateway_startup` plugin hook after gateway platform adapters connect.
- Extends the generic webhook adapter with route-configurable event headers/fields, delivery-id headers, and custom HMAC signature headers.
- Adds `timestamp.raw_body` HMAC support generically via route config, rather than hardcoding Hawser headers in core.
- Fixes `deliver_only` idempotency so a failed direct delivery does not mark the delivery id as seen; retries with the same id attempt delivery again.
- Allows routes to reject unmatched events with non-2xx status via `reject_unmatched_events` / `event_mismatch_status`.
- Adds a guard test ensuring the Hawser notifier is not bundled in Hermes core.
- Core tests now use non-Hawser custom event names; the exact Hawser V1 event constant lives only in the private plugin.

## Validation

- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py tests/hermes_cli/test_plugins.py tests/plugins/test_private_integrations_not_bundled.py -- --tb=short` -> 159 passed
- `$HOME/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/webhook.py hermes_cli/plugins.py gateway/run.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py tests/plugins/test_private_integrations_not_bundled.py` -> passed

Private plugin PR: https://github.com/dguerizec/hermes-hawser/pull/1