### PR TITLE
fix(discord): keep clarify prompts visible when embeds are hidden

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4185,6 +4185,25 @@ class DiscordAdapter(BasePlatformAdapter):
             if len(body) > max_desc:
                 body = body[: max_desc - 3] + "..."
 
+            # Defensive visibility fallback: Discord web/mobile has regressed on
+            # rendering embeds next to component buttons in some clients. Put the
+            # critical clarify prompt/draft in normal message content too so the
+            # user never has to approve a hidden embed-only prompt.
+            visible_content = (
+                f"❓ Hermes needs your input\n\n{body}"
+                if body else "❓ Hermes needs your input"
+            )
+            if len(visible_content) > 2000:
+                suffix = (
+                    "\n\n[Visible fallback truncated by Discord's 2000-character limit. "
+                    "Do not approve unless the full prompt/draft is visible elsewhere.]"
+                )
+                visible_content = (
+                    visible_content[: 2000 - len(suffix) - 3].rstrip()
+                    + "..."
+                    + suffix
+                )
+
             embed = discord.Embed(
                 title="❓ Hermes needs your input",
                 description=body,
@@ -4218,9 +4237,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 view = None
 
-            msg = await channel.send(embed=embed, view=view) if view else await channel.send(embed=embed)
             if view:
+                msg = await channel.send(content=visible_content, embed=embed, view=view)
                 view._message = msg  # store for on_timeout expiration editing
+            else:
+                msg = await channel.send(content=visible_content, embed=embed)
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, e)

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -297,7 +297,7 @@ class TestDiscordSendClarify:
         _clear_clarify_state()
 
     @pytest.mark.asyncio
-    async def test_multi_choice_attaches_view(self):
+    async def test_multi_choice_attaches_view_and_visible_content_fallback(self):
         adapter = _make_adapter(allowed_users={"42"})
         channel = MagicMock()
         sent_msg = MagicMock()
@@ -307,17 +307,22 @@ class TestDiscordSendClarify:
 
         result = await adapter.send_clarify(
             chat_id="9001",
-            question="Pick a color",
-            choices=["red", "green", "blue"],
+            question="Review this draft before posting:\n\nThis is exactly the draft text Carlton must see.",
+            choices=["post", "revise", "do not post"],
             clarify_id="cidM",
             session_key="sk-M",
         )
 
         assert result.success is True
         assert result.message_id == "123456"
-        # Verify channel.send was called with embed + view kwargs
+        # Verify channel.send was called with visible content fallback + embed + view kwargs.
+        # Discord has regressed on rendering embeds with components; the prompt/draft
+        # must remain readable in normal message content even when the embed is hidden.
         channel.send.assert_called_once()
         kwargs = channel.send.call_args.kwargs
+        assert "content" in kwargs
+        assert "Review this draft before posting" in kwargs["content"]
+        assert "This is exactly the draft text Carlton must see." in kwargs["content"]
         assert "embed" in kwargs
         assert "view" in kwargs
         assert isinstance(kwargs["view"], ClarifyChoiceView)


### PR DESCRIPTION
## Summary

Discord web/mobile can render the component buttons for an embed-backed prompt while hiding the embed body itself. That leaves `send_clarify()` prompts in a dangerous state: the user can see the choices, but not the question/draft text they are choosing about.

This adds a narrow defensive fallback for Discord `send_clarify()` only: the critical prompt body is also sent as normal `message.content`, while preserving the existing embed and button view.

Related: #33681

## Changes

- `plugins/platforms/discord/adapter.py`
  - adds visible normal-message content for Discord clarify prompts
  - keeps the existing embed + button UX intact
  - truncates the visible fallback at Discord's 2000-character content limit with an explicit warning not to approve unless the full prompt/draft is visible elsewhere
- `tests/gateway/test_discord_clarify_buttons.py`
  - updates the clarify send regression to assert the prompt/draft text is present in normal message content alongside the embed and view

## Scope

This intentionally covers only `send_clarify()`.

Issue #33681 notes the same Discord embed+components rendering class may affect `send_exec_approval`, `send_slash_confirm`, `send_update_prompt`, the model picker, and free-response cards. Those are left for a follow-up so this PR stays small and reviewable.

The reason to start with clarify is that clarify prompts can contain draft/approval text where choosing a button without seeing the body is unsafe.

## Validation

- `python -m pytest -o addopts='' tests/gateway/test_discord_clarify_buttons.py -q` → `14 passed`
- `python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_clarify_buttons.py`
- `git diff --check`
- Live Discord smoke test on a running gateway: clarify buttons rendered and the prompt/draft body was visible in normal message content above the buttons.
