### PR TITLE
chore(attribution): map SiTaggart for PR #35583

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1411,6 +1411,7 @@ AUTHOR_MAP = {
     # batch salvage PR #35758 (perf micro-fixes)
     "116212274+amathxbt@users.noreply.github.com": "amathxbt",  # PR #22155 (cache tool_output_limits)
     "takis312@hotmail.com": "ErnestHysa",  # PRs #32636/#32708 (MCP asyncio.sleep + O(n^2) watcher drain)
+    "me@simontaggart.com": "SiTaggart",  # PR #35583 (docker_forward_env empty-secret .env fallback)
 }
 
 


### PR DESCRIPTION
Adds `me@simontaggart.com` → `SiTaggart` to `AUTHOR_MAP` in `scripts/release.py`.

The `check-attribution` CI gate fails on #35583 because Simon Taggart's commit email isn't mapped yet. This backfills the mapping so #35583 (the `docker_forward_env` empty-secret `.env` fallback fix, closes #35580) can pass attribution and merge cleanly.

Pure data addition — no logic change.