### PR TITLE
chore(models): bump minimax to minimax-m3 in OpenRouter + Nous lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -56,7 +56,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # MoonshotAI
     ("moonshotai/kimi-k2.6",                   "recommended"),
     # MiniMax
-    ("minimax/minimax-m2.7",                   ""),
+    ("minimax/minimax-m3",                     ""),
     # Z-AI
     ("z-ai/glm-5.1",                           ""),
     # Xiaomi
@@ -173,7 +173,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # MoonshotAI
         "moonshotai/kimi-k2.6",
         # MiniMax
-        "minimax/minimax-m2.7",
+        "minimax/minimax-m3",
         # Z-AI
         "z-ai/glm-5.1",
         # Xiaomi


### PR DESCRIPTION
## Summary
MiniMax model in the OpenRouter and Nous portal catalogs is now `minimax/minimax-m3` instead of `minimax/minimax-m2.7`.

## Changes
- `hermes_cli/models.py`: `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]` → `minimax/minimax-m3`

## Validation
Context length already covered by the `"minimax": 204800` substring entry in `agent/model_metadata.py` — no change needed there. Module imports clean; m3 present in both lists, m2.7 absent.

## Infographic

![minimax-m3-catalog-update](https://v3b.fal.media/files/b/0a9c7ebf/8Ukg1OLjnVQNiCztzY9qf_g7Woyz80.png)
