### PR TITLE
fix(kanban): clear kanban_db ty diagnostics

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2822,7 +2822,7 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
 
 def recompute_ready(
-    conn: sqlite3.Connection, failure_limit: int = None,
+    conn: sqlite3.Connection, failure_limit: Optional[int] = None,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -4814,14 +4814,25 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     if entry is None:
         return ("unknown", None)
     raw, _ = entry
+    wifexited = getattr(os, "WIFEXITED", None)
+    wexitstatus = getattr(os, "WEXITSTATUS", None)
+    wifsignaled = getattr(os, "WIFSIGNALED", None)
+    wtermsig = getattr(os, "WTERMSIG", None)
+    if (
+        wifexited is None
+        or wexitstatus is None
+        or wifsignaled is None
+        or wtermsig is None
+    ):
+        return ("unknown", None)
     try:
-        if os.WIFEXITED(raw):
-            code = os.WEXITSTATUS(raw)
+        if wifexited(raw):
+            code = wexitstatus(raw)
             if code == 0:
                 return ("clean_exit", 0)
             return ("nonzero_exit", code)
-        if os.WIFSIGNALED(raw):
-            return ("signaled", os.WTERMSIG(raw))
+        if wifsignaled(raw):
+            return ("signaled", wtermsig(raw))
     except Exception:
         pass
     return ("unknown", None)
@@ -5423,7 +5434,7 @@ def _record_task_failure(
     error: str,
     *,
     outcome: str,
-    failure_limit: int = None,
+    failure_limit: Optional[int] = None,
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
@@ -5578,7 +5589,7 @@ def _record_spawn_failure(
     task_id: str,
     error: str,
     *,
-    failure_limit: int = None,
+    failure_limit: Optional[int] = None,
 ) -> bool:
     return _record_task_failure(
         conn, task_id, error,
@@ -6937,8 +6948,9 @@ def task_age(task: Task) -> dict:
     _co = _to_epoch(task.completed_at)
     age_since_created = now - _c if _c is not None else None
     age_since_started = now - _s if _s is not None else None
+    _start = _s if _s is not None else _c
     time_to_complete = (
-        _co - (_s or _c) if _co is not None else None
+        _co - _start if _co is not None and _start is not None else None
     )
     return {
         "created_age_seconds": age_since_created,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2809,6 +2809,19 @@ def test_task_age_handles_corrupt_started_and_completed():
     assert age["time_to_complete_seconds"] is None
 
 
+def test_task_age_handles_completed_without_start_or_created():
+    """Completed-only corrupt rows should not try to subtract None."""
+    t = _make_task(
+        created_at=None,
+        started_at=None,
+        completed_at=1700000000,
+    )
+    age = kb.task_age(t)
+    assert age["created_age_seconds"] is None
+    assert age["started_age_seconds"] is None
+    assert age["time_to_complete_seconds"] is None
+
+
 def test_task_age_well_formed_task():
     """Regression: the safe-int path must not change behavior for normal data."""
     import time


### PR DESCRIPTION
Cleans up the current `ty` diagnostics in `hermes_cli/kanban_db.py` without changing the kanban state machine behavior.

The changes make nullable `failure_limit` parameters explicit, avoid direct POSIX-only `os.WIF*` attribute access for type checking, and narrow the `task_age` completion baseline before subtracting.

Adds a small regression case for completed-only corrupt timestamp rows so `task_age` keeps returning `None` instead of attempting `int - None`.

Closes #36181

Checked with:
- `python -m ty check --output-format concise hermes_cli/kanban_db.py`
- `python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- `python -m pytest --timeout-method=thread tests/hermes_cli/test_kanban_db.py -q -k "task_age or recompute_ready"`