### PR TITLE
fix(terminal): tolerate inaccessible cwd during cleanup

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -11,6 +11,21 @@ def teardown_function():
     terminal_tool._reset_cached_sudo_passwords()
 
 
+def test_get_env_config_uses_terminal_cwd_when_getcwd_is_inaccessible(monkeypatch):
+    """Configured TERMINAL_CWD should avoid os.getcwd() in macOS/TCC-denied cwd."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp/hermes-safe-cwd")
+
+    def _raise_getcwd():
+        raise PermissionError("Operation not permitted")
+
+    monkeypatch.setattr(terminal_tool.os, "getcwd", _raise_getcwd)
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == "/tmp/hermes-safe-cwd"
+
+
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -952,9 +952,18 @@ def _get_env_config() -> Dict[str, Any]:
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, and everything else starts in the backend's default
-    # root-like cwd.
+    # root-like cwd.  Prefer an explicit TERMINAL_CWD before touching
+    # os.getcwd(): on macOS a long-lived gateway/cleanup thread can inherit a
+    # TCC-denied or removed cwd, where os.getcwd() raises PermissionError.
+    configured_cwd = os.getenv("TERMINAL_CWD")
     if env_type == "local":
-        default_cwd = os.getcwd()
+        if configured_cwd:
+            default_cwd = configured_cwd
+        else:
+            try:
+                default_cwd = os.getcwd()
+            except (OSError, PermissionError):
+                default_cwd = os.path.expanduser("~")
     elif env_type == "ssh":
         default_cwd = "~"
     else:


### PR DESCRIPTION
## Summary
- Prefer explicit TERMINAL_CWD before calling os.getcwd() for local terminal config
- Fall back to the user home directory if os.getcwd() raises OSError/PermissionError
- Add regression coverage for macOS/TCC-denied cwd cleanup failures

## Test Plan
- python -m pytest tests/tools/test_terminal_tool.py::test_get_env_config_uses_terminal_cwd_when_getcwd_is_inaccessible -v -o 'addopts='
- python -m pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_terminal_requirements.py tests/tools/test_terminal_tool_requirements.py -q -o 'addopts='
- python -m pytest tests/tools/test_terminal*.py -q -o 'addopts='