### PR TITLE
fix(kanban): correct type annotations for optional int params and narrowing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5423,7 +5423,7 @@ def _record_task_failure(
     error: str,
     *,
     outcome: str,
-    failure_limit: int = None,
+    failure_limit: int | None = None,
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
@@ -5578,7 +5578,7 @@ def _record_spawn_failure(
     task_id: str,
     error: str,
     *,
-    failure_limit: int = None,
+    failure_limit: int | None = None,
 ) -> bool:
     return _record_task_failure(
         conn, task_id, error,
@@ -6937,9 +6937,8 @@ def task_age(task: Task) -> dict:
     _co = _to_epoch(task.completed_at)
     age_since_created = now - _c if _c is not None else None
     age_since_started = now - _s if _s is not None else None
-    time_to_complete = (
-        _co - (_s or _c) if _co is not None else None
-    )
+    _start = _s if _s is not None else _c
+    time_to_complete = _co - _start if (_co is not None and _start is not None) else None
     return {
         "created_age_seconds": age_since_created,
         "started_age_seconds": age_since_started,


### PR DESCRIPTION
## Problem

`ty` reports three diagnostics in `hermes_cli/kanban_db.py` (issue #36181):

1. `_record_task_failure` — `failure_limit: int = None` assigns `None` to a plain `int` parameter  
2. `_record_spawn_failure` — same issue on its forwarding wrapper  
3. `task_age` — `_co - (_s or _c)` is typed as `int - (int | None)` because `_s or _c` doesn't narrow to `int` when both operands are `int | None`

## Fix

- **Lines 5426 / 5581**: `failure_limit: int = None` → `failure_limit: int | None = None`  
  (no behaviour change — the `if failure_limit is None` guard already handled `None` correctly)
- **`task_age`**: introduce `_start = _s if _s is not None else _c` so both operands of the subtraction are narrowed to `int` before use; guard with `_start is not None` to preserve the existing semantics

## Tests

All 205 existing `tests/hermes_cli/test_kanban_db.py` tests pass; no new tests needed (these are annotation-only / expression-narrowing fixes with no behaviour change).

```
205 passed in 7.67s
```