### PR TITLE
fix(feishu): preserve video media intake order

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -138,6 +138,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_bytes,
     cache_image_from_bytes,
+    cache_video_from_bytes,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
@@ -851,13 +852,16 @@ def normalize_feishu_message(
             relation_kind="image",
             mentions=mention_refs,
         )
-    if normalized_type in {"file", "audio", "media"}:
+    if normalized_type in {"file", "audio", "media", "video"}:
         media_ref = _build_media_ref_from_payload(payload, resource_type=normalized_type)
         placeholder = _attachment_placeholder(media_ref.file_name)
+        preferred = "audio" if normalized_type == "audio" else "document"
+        if normalized_type == "video":
+            preferred = "video"
         return FeishuNormalizedMessage(
             raw_type=normalized_type,
             text_content="",
-            preferred_message_type="audio" if normalized_type == "audio" else "document",
+            preferred_message_type=preferred,
             media_refs=[media_ref] if media_ref.file_key else [],
             relation_kind=normalized_type,
             metadata={"placeholder_text": placeholder},
@@ -3033,6 +3037,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _dispatch_inbound_event(self, event: MessageEvent) -> None:
         """Apply Feishu-specific burst protection before entering the base adapter."""
+        if not self._should_batch_media_event(event):
+            await self._flush_pending_media_for_source(event)
         if event.message_type == MessageType.TEXT and not event.is_command():
             await self._enqueue_text_event(event)
             return
@@ -3040,6 +3046,16 @@ class FeishuAdapter(BasePlatformAdapter):
             await self._enqueue_media_event(event)
             return
         await self._handle_message_with_guards(event)
+
+    async def _flush_pending_media_for_source(self, event: MessageEvent) -> None:
+        """Flush buffered media before control/text messages can advance intake state."""
+        prefix = self._media_batch_key(event).rsplit(":media:", 1)[0] + ":media:"
+        matching_keys = [key for key in list(self._pending_media_batches) if key.startswith(prefix)]
+        for key in matching_keys:
+            task = self._pending_media_batch_tasks.pop(key, None)
+            if task is not None:
+                task.cancel()
+            await self._flush_media_batch_now(key)
 
     # =========================================================================
     # Media batching
@@ -3472,7 +3488,7 @@ class FeishuAdapter(BasePlatformAdapter):
         text = normalized.text_content
 
         if (
-            inbound_type in {MessageType.DOCUMENT, MessageType.AUDIO, MessageType.VIDEO, MessageType.PHOTO}
+            inbound_type in {MessageType.DOCUMENT, MessageType.AUDIO}
             and len(media_urls) == 1
             and normalized.preferred_message_type in {"document", "audio"}
         ):
@@ -3536,6 +3552,8 @@ class FeishuAdapter(BasePlatformAdapter):
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
+        if preferred == "video":
+            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.VIDEO)
         return MessageType.TEXT
 
     async def _maybe_extract_text_document(self, cached_path: str, media_type: str) -> str:
@@ -3643,9 +3661,8 @@ class FeishuAdapter(BasePlatformAdapter):
                     return cached_path, (media_type or f"audio/{ext.lstrip('.') or 'ogg'}")
 
                 if media_type.startswith("video/"):
-                    if not Path(filename).suffix:
-                        filename = f"{filename}.mp4"
-                    cached_path = cache_document_from_bytes(raw_bytes, filename)
+                    ext = self._guess_extension(filename, content_type, ".mp4", allowed=_VIDEO_EXTENSIONS)
+                    cached_path = cache_video_from_bytes(raw_bytes, ext=ext)
                     logger.info("[Feishu] Cached message video resource at %s", cached_path)
                     return cached_path, media_type
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1405,6 +1405,65 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_types, ["video/mp4"])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_extract_video_message_downloads_as_video(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._download_feishu_message_resource = AsyncMock(
+            return_value=("/tmp/feishu-video.mp4", "video/mp4")
+        )
+        message = SimpleNamespace(
+            message_type="video",
+            content='{"file_key":"file_video","file_name":"clip.mp4"}',
+            message_id="om_video",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(text, "")
+        self.assertEqual(msg_type.value, "video")
+        self.assertEqual(media_urls, ["/tmp/feishu-video.mp4"])
+        self.assertEqual(media_types, ["video/mp4"])
+        adapter._download_feishu_message_resource.assert_awaited_once_with(
+            message_id="om_video",
+            file_key="file_video",
+            resource_type="video",
+            fallback_filename="clip.mp4",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_download_video_resource_uses_video_cache(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        response = SimpleNamespace(
+            success=lambda: True,
+            file=SimpleNamespace(getvalue=lambda: b"video-bytes"),
+            file_name="clip.mov",
+            raw=SimpleNamespace(headers={"Content-Type": "video/quicktime"}),
+        )
+        client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message_resource=SimpleNamespace(get=Mock(return_value=response))))
+        )
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = client
+
+        with patch("gateway.platforms.feishu.cache_video_from_bytes", return_value="/tmp/video.mov") as cache_video:
+            cached_path, media_type = asyncio.run(
+                adapter._download_feishu_message_resource(
+                    message_id="om_video",
+                    file_key="file_video",
+                    resource_type="video",
+                    fallback_filename="clip.mov",
+                )
+            )
+
+        self.assertEqual(cached_path, "/tmp/video.mov")
+        self.assertEqual(media_type, "video/quicktime")
+        cache_video.assert_called_once_with(b"video-bytes", ext=".mov")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_text_from_raw_content_uses_relation_message_fallbacks(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1730,6 +1730,49 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertIn("第二张", event.text)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_control_text_flushes_pending_media_before_state_transition(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.session import SessionSource
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.handle_message = AsyncMock()
+        source = SessionSource(
+            platform=adapter.platform,
+            chat_id="oc_chat",
+            chat_name="Feishu DM",
+            chat_type="dm",
+            user_id="ou_user",
+            user_name="张三",
+        )
+
+        async def _run() -> None:
+            await adapter._dispatch_inbound_event(
+                MessageEvent(
+                    text="商品视频",
+                    message_type=MessageType.VIDEO,
+                    source=source,
+                    message_id="om_v1",
+                    media_urls=["/tmp/a.mp4"],
+                    media_types=["video/mp4"],
+                )
+            )
+            self.assertEqual(len(adapter._pending_media_batches), 1)
+            await adapter._dispatch_inbound_event(
+                MessageEvent(text="录入结束", message_type=MessageType.COMMAND, source=source, message_id="om_done")
+            )
+
+        asyncio.run(_run())
+
+        self.assertEqual(adapter.handle_message.await_count, 2)
+        first = adapter.handle_message.await_args_list[0].args[0]
+        second = adapter.handle_message.await_args_list[1].args[0]
+        self.assertEqual(first.message_type, MessageType.VIDEO)
+        self.assertEqual(first.media_urls, ["/tmp/a.mp4"])
+        self.assertEqual(second.text, "录入结束")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_image_downloads_then_uses_native_image_send(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- normalize inbound Feishu `video` payloads as video messages instead of generic documents
- cache downloaded Feishu video resources in the video cache
- flush pending media batches before non-media control messages advance intake state
- add regression coverage for video extraction, video caching, and command-order flushing

## Test Plan
- `python -m pytest tests/gateway/test_feishu.py -q`

## Notes
- This protects product-uploader / lark-product-intake flows from losing buffered videos when a user quickly sends `录入结束` or another control message after media.
