### PR TITLE
fix: persist resolved context_length after /model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1544,6 +1544,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             provider=agent.provider,
             api_mode=agent.api_mode,
         )
+        # Persist the resolved context length so the /model display path
+        # (cli.py) can read it via getattr(agent, "_config_context_length").
+        # Without this, the display always sees None (cleared at the top of
+        # switch_model) and falls through to the 256K default for custom
+        # providers that don't match any probe path.
+        if new_context_length and new_context_length > 0:
+            agent._config_context_length = new_context_length
 
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None


### PR DESCRIPTION
## Problem

After `switch_model()` clears `_config_context_length` to `None` (line 1411) so the new model can resolve its own context window, the display path in `cli.py` reads `None` via `getattr(agent, "_config_context_length", None)` and falls through every resolution step to the 256K default.

This affects all custom provider setups (LiteLLM, vertex-proxy, or any `custom_providers`/`providers` entry) where the model's context length resolves via `DEFAULT_CONTEXT_LENGTHS` or live probes rather than an explicit `config_context_length`.

**Observed behavior:** `/model` always shows `Context: 256,000 tokens` regardless of the actual model context window, even when switching between 200K and 1M models.

## Fix

The context compressor already resolves the correct value via `get_model_context_length()` during the switch. Write it back to `agent._config_context_length` so the `/model` confirmation message in `cli.py` (and gateway `/info`) can read the resolved value instead of `None`.

7-line change, no new dependencies.

## Testing

Manual testing with `providers:` config entries pointing at a local proxy (vertex-proxy on port 8788, Anthropic wire protocol). Before fix: `/model` always shows 256K. After fix: shows correct context length per model (1M for claude-opus-4.6, 200K for claude-sonnet-4, etc.).

Signed-off-by: Chris van Hoof <vanhoof@ouwish.com>