### PR TITLE
fix(file-ops): translate MSYS/WSL/Cygwin drive paths on Windows (phantom C:\c\ tree)

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -736,7 +736,29 @@ class ShellFileOperations(FileOperations):
         """
         if not path:
             return path
-        
+
+        # ── MSYS / git-bash / WSL drive-path normalization (Windows only) ──
+        # On Windows the "local" terminal backend is a busybox-style shell
+        # whose filesystem root ``/`` maps to the CURRENT DRIVE root (C:\),
+        # NOT through a git-bash mount table. So a git-bash-style path like
+        # ``/c/dev/x`` does NOT resolve to ``C:\dev\x`` — the shell reads it
+        # literally as ``C:\c\dev\x``, silently writing files into a phantom
+        # ``C:\c\`` tree the user never sees (write succeeds, file "vanishes").
+        #
+        # The agent and the user naturally refer to paths in git-bash form
+        # (``/c/dev/...``). Translate a leading ``/<drive>/`` segment — plus
+        # the WSL ``/mnt/<drive>/`` and Cygwin ``/cygdrive/<drive>/`` variants
+        # — into drive-letter form with FORWARD slashes (``c:/dev/...``).
+        # Forward slashes are load-bearing: both busybox-w32 and git-bash
+        # resolve ``c:/dev`` correctly, and they survive single-quote shell
+        # escaping where backslashes would not.
+        if os.name == 'nt':
+            drive_match = re.match(r'^/(?:mnt/|cygdrive/)?([A-Za-z])(?:/|$)', path)
+            if drive_match:
+                drive = drive_match.group(1)
+                rest = path[drive_match.end():]
+                path = f"{drive}:/{rest}"
+
         # Handle ~ and ~user
         if path.startswith('~'):
             # Get home directory via the terminal environment


### PR DESCRIPTION
## Problem

On Windows, `ShellFileOperations._expand_path()` does not translate git-bash-style POSIX drive paths (e.g. `/c/dev/x`). When such a path reaches a native-Python file layer, the leading `/` is resolved relative to the **current drive root**, so `/c/dev/x` silently becomes `C:\c\dev\x` — a phantom tree.

The write **succeeds and reports success**, but the file lands under `C:\c\` instead of `C:\dev\`, so from the user's perspective files "vanish." This is especially confusing because Git Bash *itself* resolves `/c/` correctly — the mangling happens at the native-Python layer (`open("/c/dev/x")` on Windows → `C:\c\dev\x`), not in the shell.

Real-world repro: agent asked to write `/c/dev/sod-products/file.html`; tool reported success; file was later found at `C:\c\dev\sod-products\file.html`.

## Fix

Normalize a leading `/<drive>/` segment — plus the WSL `/mnt/<drive>/` and Cygwin `/cygdrive/<drive>/` variants — to drive-letter form with **forward slashes** (`c:/dev/x`), in the single shared `_expand_path()` normalizer (used by `read_file`, `write_file`, `patch`, `move`, `search`).

```python
if os.name == 'nt':
    drive_match = re.match(r'^/(?:mnt/|cygdrive/)?([A-Za-z])(?:/|$)', path)
    if drive_match:
        drive = drive_match.group(1)
        rest = path[drive_match.end():]
        path = f"{drive}:/{rest}"
```

Forward-slash drive form resolves correctly under **Git Bash, busybox-w32, and native Python `open()`**, and survives single-quote shell escaping where backslashes would not.

Windows-only. POSIX paths, already-Windows paths, UNC (`//server`) paths, and relative paths are left unchanged. This complements the existing `_msys_to_windows_path()` helper in `environments/local.py`, which only normalized `cwd`, not file arguments.

## Verification

Unit test of the real patched function:

| input | output |
|---|---|
| `/c/dev/sod-products/x.html` | `c:/dev/sod-products/x.html` |
| `/c/dev` | `c:/dev` |
| `/c` | `c:/` |
| `/e/data/file.txt` | `e:/data/file.txt` |
| `/mnt/c/dev/x` | `c:/dev/x` |
| `/cygdrive/d/stuff` | `d:/stuff` |
| `/tmp/foo` | `/tmp/foo` (unchanged) |
| `C:/dev/already.txt` | unchanged |
| `relative/path.md` | unchanged |

End-to-end through the real `ShellFileOperations` + `LocalEnvironment` stack:

```
write_file("/c/Users/.../probe.html")  ->  error: None
  lands at  C:\Users\...\probe.html   (correct)
  NOT at    C:\c\Users\...\probe.html (phantom)
  read_file_raw round-trip: OK
```

Idempotent: the regex requires a leading `/`, so an already-normalized `c:/dev` is left untouched.