### PR TITLE
feat(feishu): CardKit native streaming card support

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1471,7 +1471,6 @@ class FeishuAdapter(BasePlatformAdapter):
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
     MAX_MESSAGE_LENGTH = 8000
-    REQUIRES_EDIT_FINALIZE: bool = True
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
     # Threshold for detecting Feishu client-side message splits.
@@ -1859,10 +1858,15 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        # CardKit streaming card path — opt-in via streaming_card setting.
-        if self.streaming_cards_enabled:
+        # CardKit streaming card path — only for streaming responses that
+        # will be followed by edit_message() calls.  StreamConsumer sets
+        # ``expect_edits=True`` in metadata for streaming previews; acks,
+        # commentary, and final sends go through the regular IM path.
+        if self.streaming_cards_enabled and metadata and metadata.get("expect_edits"):
             try:
-                result = await self.send_streaming_card(chat_id, content)
+                result = await self.send_streaming_card(
+                    chat_id, content, reply_to=reply_to,
+                )
                 if result.success:
                     return result
                 logger.warning("[Feishu] CardKit streaming send failed, falling back to IM")
@@ -1933,6 +1937,15 @@ class FeishuAdapter(BasePlatformAdapter):
         if message_id in self._streaming_cards:
             card_state = self._streaming_cards[message_id]
             try:
+                # Check element limit — split card if approaching the cap
+                if card_state.element_count >= _STREAMING_CARD_ELEMENT_LIMIT:
+                    new_state = await self._cardkit_split_card(
+                        card_state, chat_id, content,
+                    )
+                    # Update the message_id → state mapping for subsequent edits
+                    message_id = new_state.message_id
+                    card_state = new_state
+
                 if finalize:
                     await self._cardkit_finalize(card_state, content)
                     return SendResult(success=True, message_id=message_id)
@@ -1969,6 +1982,15 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
     # CardKit streaming card methods
     # =========================================================================
+
+    @property
+    def REQUIRES_EDIT_FINALIZE(self) -> bool:  # noqa: N802
+        """CardKit streaming lifecycle requires an explicit ``finalize=True``
+        edit to close the streaming indicator and render the final card layout.
+        Runtime-gated: only True when CardKit streaming is configured and
+        available — mirrors DingTalk's ``REQUIRES_EDIT_FINALIZE`` property.
+        """
+        return self.streaming_cards_enabled
 
     @property
     def streaming_cards_enabled(self) -> bool:
@@ -2020,6 +2042,34 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         return json.dumps(card, ensure_ascii=False)
 
+    def _get_sdk_executor(self):
+        """Return the adapter-owned thread pool for blocking SDK calls.
+
+        Using a dedicated executor avoids depending on the event loop's
+        default executor, which may have different sizing and back-pressure
+        characteristics.  Mirrors the pattern on Hermes main branch.
+        """
+        lock = getattr(self, "_sdk_executor_lock", None)
+        if lock is None:
+            self._sdk_executor_lock = threading.Lock()
+            lock = self._sdk_executor_lock
+        with lock:
+            if getattr(self, "_sdk_executor_closing", False):
+                raise RuntimeError("Feishu SDK executor is shutting down")
+            executor = getattr(self, "_sdk_executor", None)
+            if executor is None:
+                from concurrent.futures import ThreadPoolExecutor
+                executor = ThreadPoolExecutor(
+                    max_workers=4, thread_name_prefix="feishu-sdk",
+                )
+                self._sdk_executor = executor
+            return executor
+
+    async def _run_blocking(self, func, *args):
+        """Run a blocking Feishu SDK call on the adapter-owned thread pool."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._get_sdk_executor(), func, *args)
+
     async def _cardkit_api_call(
         self,
         operation: str,
@@ -2030,13 +2080,14 @@ class FeishuAdapter(BasePlatformAdapter):
         Retries on server-side hiccups (gateway timeout, internal errors)
         with progressive backoff.  Non-transient errors are raised immediately.
 
-        Pattern adapted from hermes-lark-streaming plugin v0.11
-        (Cheerwhy/hermes-lark-streaming ``FeishuClient._checked_call``).
+        Uses the adapter-owned ``_run_blocking()`` executor (not
+        ``asyncio.to_thread``) to avoid depending on the event loop's
+        default executor.
         """
         attempts = len(_CARDKIT_RETRY_DELAYS_SEC) + 1
         last_error: Optional[Exception] = None
         for attempt in range(attempts):
-            resp = await asyncio.to_thread(call)
+            resp = await self._run_blocking(call)
             if self._response_succeeded(resp):
                 return resp
             code = getattr(resp, "code", 0) or 0
@@ -2062,6 +2113,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
+        *,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         """Create a CardKit streaming card and send it to the chat.
 
@@ -2073,32 +2126,18 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        element_id = f"{_STREAMING_CARD_ELEMENT_ID}"
+        element_id = _STREAMING_CARD_ELEMENT_ID
         card_json = self._build_streaming_card_json(content, element_id=element_id)
 
-        # Step 1: Create the card via CardKit
+        # Step 1: Create the card via CardKit using the complete card JSON
+        # (includes streaming_mode + streaming_config).  Pattern matches
+        # hermes-lark-streaming plugin v0.11 ``FeishuClient.cardkit_create``:
+        # ``type("card_json")`` + ``data(json_string)`` passes the full schema.
         def _create_card() -> Any:
-            card_data = _CardKitData.builder() \
-                .schema("2.0") \
-                .header(
-                    _CardKitHeader.builder()
-                        .title({"tag": "plain_text", "content": "Hermes"})
-                        .build()
-                ) \
-                .body({
-                    "elements": [
-                        {
-                            "element_id": element_id,
-                            "tag": "markdown",
-                            "content": content,
-                        }
-                    ],
-                }) \
-                .build()
             body = (
                 CreateCardRequestBody.builder()
-                .data(card_data)
-                .type("cardkit")
+                .type("card_json")
+                .data(card_json)
                 .build()
             )
             request = (
@@ -2149,38 +2188,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         message_id = self._extract_response_field(msg_response, "message_id") or ""
 
-        # Step 3: Enable streaming mode on the card
-        settings = (
-            _CardKitSettings.builder()
-            .config(
-                _CardKitConfig.builder()
-                .streaming_mode(True)
-                .build()
-            )
-            .build()
-        )
-
-        def _enable_streaming() -> Any:
-            body = (
-                SettingsCardRequestBody.builder()
-                .settings(settings)
-                .build()
-            )
-            request = (
-                SettingsCardRequest.builder()
-                .card_id(card_id)
-                .request_body(body)
-                .build()
-            )
-            return self._client.cardkit.v1.card.settings(request)
-
-        stream_response = await self._cardkit_api_call("cardkit_enable_streaming", _enable_streaming)
-        if not self._response_succeeded(stream_response):
-            logger.warning(
-                "[Feishu] CardKit enable streaming failed (card=%s): %s",
-                card_id,
-                getattr(stream_response, "msg", "unknown"),
-            )
+        # Step 3: Enable streaming mode — streaming_mode is already set to
+        # True in the card JSON from Step 1 (via _build_streaming_card_json),
+        # so the card enters streaming mode on creation.  No separate API
+        # call needed, matching the hermes-lark-streaming plugin pattern.
 
         # Step 4: Store state
         state = _FeishuStreamingCard(
@@ -2207,6 +2218,12 @@ class FeishuAdapter(BasePlatformAdapter):
         Retries on transient CardKit server errors.
         """
         card_state.sequence += 1
+
+        # Track element count — in the current design we use a single
+        # markdown element, so element_count stays at 1.  When tool-call
+        # elements are added in future, this counter will guard against
+        # the ~200 element card limit (error 11310).
+        card_state.element_count = max(card_state.element_count, 1)
 
         def _update_element() -> Any:
             body = (
@@ -2238,22 +2255,17 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> None:
         """Disable streaming mode on a card via ``cardkit.v1.card.settings``.
 
+        Uses the JSON-string ``settings`` pattern proven in
+        hermes-lark-streaming plugin v0.11.
+
         Retries on transient CardKit server errors.
         """
-        settings = (
-            _CardKitSettings.builder()
-            .config(
-                _CardKitConfig.builder()
-                .streaming_mode(False)
-                .build()
-            )
-            .build()
-        )
+        settings_json = json.dumps({"streaming_mode": False}, ensure_ascii=False)
 
         def _stop() -> Any:
             body = (
                 SettingsCardRequestBody.builder()
-                .settings(settings)
+                .settings(settings_json)
                 .build()
             )
             request = (
@@ -2271,6 +2283,32 @@ class FeishuAdapter(BasePlatformAdapter):
                 card_state.card_id,
                 getattr(response, "msg", "unknown"),
             )
+
+    async def _cardkit_split_card(
+        self,
+        card_state: _FeishuStreamingCard,
+        chat_id: str,
+        content: str,
+    ) -> _FeishuStreamingCard:
+        """Finalize the current streaming card and create a new one.
+
+        Called when the element count approaches ``_STREAMING_CARD_ELEMENT_LIMIT``
+        to prevent Feishu error 11310 (card element overflow).  The old card
+        is finalized with its current content, and a fresh streaming card is
+        created to continue the stream.
+        """
+        # Finalize the old card (stop streaming + render final state)
+        await self._cardkit_finalize(card_state, content)
+
+        # Create a new streaming card
+        result = await self.send_streaming_card(chat_id, content)
+        if not result.success:
+            raise RuntimeError(f"Card split failed: {result.error}")
+
+        new_state = self._streaming_cards.get(result.message_id or "")
+        if not new_state:
+            raise RuntimeError("Card split: new card state not found")
+        return new_state
 
     async def _cardkit_finalize(
         self,
@@ -2317,7 +2355,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 def _update_card() -> Any:
                     body = (
                         UpdateCardRequestBody.builder()
-                        .card(json.dumps(final_card, ensure_ascii=False))
+                        .card(
+                            _CardKitCard.builder()
+                            .type("card_json")
+                            .data(json.dumps(final_card, ensure_ascii=False))
+                            .build()
+                        )
                         .build()
                     )
                     request = (

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -127,6 +127,29 @@ except ImportError:
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
 
+# CardKit streaming support (lazy — lark_oapi < 1.4 may not have it)
+try:
+    from lark_oapi.api.cardkit.v1 import (
+        CreateCardRequest,
+        CreateCardRequestBody,
+        ContentCardElementRequest,
+        ContentCardElementRequestBody,
+        SettingsCardRequest,
+        SettingsCardRequestBody,
+        UpdateCardRequest,
+        UpdateCardRequestBody,
+    )
+    from lark_oapi.api.cardkit.v1 import (
+        Card as _CardKitCard,
+        Config as _CardKitConfig,
+        Data as _CardKitData,
+        Header as _CardKitHeader,
+        Settings as _CardKitSettings,
+    )
+    _FEISHU_CARDKIT_AVAILABLE = True
+except (ImportError, AttributeError):
+    _FEISHU_CARDKIT_AVAILABLE = False
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -395,6 +418,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    streaming_card: bool = False
 
 
 @dataclass
@@ -1406,6 +1430,26 @@ def check_feishu_requirements() -> bool:
     return ensure_and_bind("platform.feishu", _import, globals(), prompt=False)
 
 
+# ---------------------------------------------------------------------------
+# CardKit streaming-card constants
+# ---------------------------------------------------------------------------
+_STREAMING_CARD_ELEMENT_ID = "streaming_md_1"
+_STREAMING_CARD_PRINT_FREQUENCY_MS = 50
+_STREAMING_CARD_PRINT_STEP = 2
+_STREAMING_CARD_PRINT_STRATEGY = "fast"
+_STREAMING_CARD_ELEMENT_LIMIT = 180  # cards have ~200 max; reserve space for footer
+
+
+@dataclass
+class _FeishuStreamingCard:
+    """Tracks state for an in-progress CardKit streaming card."""
+    card_id: str
+    element_id: str = _STREAMING_CARD_ELEMENT_ID
+    message_id: str = ""
+    sequence: int = 1
+    element_count: int = 1  # initial markdown element
+
+
 class FeishuAdapter(BasePlatformAdapter):
     """Feishu/Lark bot adapter."""
 
@@ -1413,6 +1457,7 @@ class FeishuAdapter(BasePlatformAdapter):
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
     MAX_MESSAGE_LENGTH = 8000
+    REQUIRES_EDIT_FINALIZE: bool = True
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
     # Threshold for detecting Feishu client-side message splits.
@@ -1474,6 +1519,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
+        self._streaming_cards: Dict[str, _FeishuStreamingCard] = {}  # message_id → state
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1575,6 +1621,10 @@ class FeishuAdapter(BasePlatformAdapter):
             allow_bots=allow_bots,
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
+            ),
+            streaming_card=(
+                bool(extra.get("streaming_card", False))
+                or os.environ.get("FEISHU_STREAMING_CARD", "").lower() in ("true", "1", "yes")
             ),
         )
 
@@ -1733,6 +1783,18 @@ class FeishuAdapter(BasePlatformAdapter):
         self._persist_seen_message_ids()
         await self._release_app_lock()
 
+        # Finalize any open streaming cards so they don't stay stuck in
+        # streaming state on Feishu's UI after a gateway restart.
+        for _msg_id, _card_state in list(self._streaming_cards.items()):
+            try:
+                await self.stop_streaming_card(_card_state)
+            except Exception as _exc:
+                logger.debug(
+                    "[Feishu] Failed to finalize streaming card on disconnect (card=%s): %s",
+                    _card_state.card_id, _exc,
+                )
+        self._streaming_cards.clear()
+
         self._mark_disconnected()
         logger.info("[Feishu] Disconnected")
 
@@ -1782,6 +1844,16 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send a Feishu message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        # CardKit streaming card path — opt-in via streaming_card setting.
+        if self.streaming_cards_enabled:
+            try:
+                result = await self.send_streaming_card(chat_id, content)
+                if result.success:
+                    return result
+                logger.warning("[Feishu] CardKit streaming send failed, falling back to IM")
+            except Exception as exc:
+                logger.warning("[Feishu] CardKit streaming send error: %s", exc)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -1841,6 +1913,22 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # CardKit streaming card routing — if the message_id belongs to an
+        # active streaming card, use the CardKit element-content API instead
+        # of the IM update API.
+        if message_id in self._streaming_cards:
+            card_state = self._streaming_cards[message_id]
+            try:
+                if finalize:
+                    await self._cardkit_finalize(card_state, content)
+                    return SendResult(success=True, message_id=message_id)
+                else:
+                    await self._update_streaming_card_content(card_state, content)
+                    return SendResult(success=True, message_id=message_id)
+            except Exception as exc:
+                logger.error("[Feishu] CardKit edit failed for card %s: %s", card_state.card_id, exc, exc_info=True)
+                return SendResult(success=False, error=str(exc))
+
         content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
@@ -1863,6 +1951,335 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    # =========================================================================
+    # CardKit streaming card methods
+    # =========================================================================
+
+    @property
+    def streaming_cards_enabled(self) -> bool:
+        """Whether CardKit streaming is available (SDK + connected + configured)."""
+        if not _FEISHU_CARDKIT_AVAILABLE or not self._client:
+            return False
+        return bool(self._settings.streaming_card)
+
+    @staticmethod
+    def _build_streaming_card_json(
+        content: str,
+        element_id: str = _STREAMING_CARD_ELEMENT_ID,
+    ) -> str:
+        """Build the initial CardKit card JSON for streaming mode.
+
+        Returns a JSON string suitable for ``CreateCardRequestBody``.
+        The card uses schema 2.0 with ``streaming_mode: true`` and a
+        single markdown element whose ``element_id`` can later be
+        updated via ``card_element.content``.
+        """
+        card: Dict[str, Any] = {
+            "schema": "2.0",
+            "header": {
+                "title": {
+                    "tag": "plain_text",
+                    "content": "Hermes",
+                },
+                "template": "blue",
+                "subtitle": {
+                    "tag": "plain_text",
+                    "content": "Thinking…",
+                },
+            },
+            "streaming_mode": True,
+            "streaming_config": {
+                "print_frequency_ms": _STREAMING_CARD_PRINT_FREQUENCY_MS,
+                "print_step": _STREAMING_CARD_PRINT_STEP,
+                "print_strategy": _STREAMING_CARD_PRINT_STRATEGY,
+            },
+            "body": {
+                "elements": [
+                    {
+                        "element_id": element_id,
+                        "tag": "markdown",
+                        "content": content,
+                    }
+                ],
+            },
+        }
+        return json.dumps(card, ensure_ascii=False)
+
+    async def send_streaming_card(
+        self,
+        chat_id: str,
+        content: str,
+    ) -> SendResult:
+        """Create a CardKit streaming card and send it to the chat.
+
+        API call sequence:
+        1. ``cardkit.v1.card.create`` → ``card_id``
+        2. ``im.v1.message.create`` with card_id reference → ``message_id``
+        3. Store ``_FeishuStreamingCard`` state
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        element_id = f"{_STREAMING_CARD_ELEMENT_ID}"
+        card_json = self._build_streaming_card_json(content, element_id=element_id)
+
+        # Step 1: Create the card via CardKit
+        def _create_card() -> Any:
+            card_data = _CardKitData.builder() \
+                .schema("2.0") \
+                .header(
+                    _CardKitHeader.builder()
+                        .title({"tag": "plain_text", "content": "Hermes"})
+                        .build()
+                ) \
+                .body({
+                    "elements": [
+                        {
+                            "element_id": element_id,
+                            "tag": "markdown",
+                            "content": content,
+                        }
+                    ],
+                }) \
+                .build()
+            body = (
+                CreateCardRequestBody.builder()
+                .data(card_data)
+                .type("cardkit")
+                .build()
+            )
+            request = (
+                CreateCardRequest.builder()
+                .request_body(body)
+                .build()
+            )
+            return self._client.cardkit.v1.card.create(request)
+
+        response = await asyncio.to_thread(_create_card)
+        if not self._response_succeeded(response):
+            error_msg = getattr(response, "msg", "card create failed")
+            logger.warning("[Feishu] CardKit create failed: %s", error_msg)
+            return SendResult(success=False, error=str(error_msg))
+
+        card_id = self._extract_response_field(response, "card_id")
+        if not card_id:
+            return SendResult(success=False, error="CardKit create returned no card_id")
+
+        # Step 2: Send the card as an interactive message
+        card_payload = json.dumps(
+            {"type": "cardkit", "card_id": card_id},
+            ensure_ascii=False,
+        )
+
+        def _send_message() -> Any:
+            body = (
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("interactive")
+                .content(card_payload)
+                .uuid(uuid.uuid4().hex)
+                .build()
+            )
+            request = (
+                CreateMessageRequest.builder()
+                .receive_id_type("chat_id")
+                .request_body(body)
+                .build()
+            )
+            return self._client.im.v1.message.create(request)
+
+        msg_response = await asyncio.to_thread(_send_message)
+        if not self._response_succeeded(msg_response):
+            error_msg = getattr(msg_response, "msg", "message create failed")
+            logger.warning("[Feishu] CardKit message send failed: %s", error_msg)
+            return SendResult(success=False, error=str(error_msg))
+
+        message_id = self._extract_response_field(msg_response, "message_id") or ""
+
+        # Step 3: Enable streaming mode on the card
+        settings = (
+            _CardKitSettings.builder()
+            .config(
+                _CardKitConfig.builder()
+                .streaming_mode(True)
+                .build()
+            )
+            .build()
+        )
+
+        def _enable_streaming() -> Any:
+            body = (
+                SettingsCardRequestBody.builder()
+                .settings(settings)
+                .build()
+            )
+            request = (
+                SettingsCardRequest.builder()
+                .card_id(card_id)
+                .request_body(body)
+                .build()
+            )
+            return self._client.cardkit.v1.card.settings(request)
+
+        stream_response = await asyncio.to_thread(_enable_streaming)
+        if not self._response_succeeded(stream_response):
+            logger.warning(
+                "[Feishu] CardKit enable streaming failed (card=%s): %s",
+                card_id,
+                getattr(stream_response, "msg", "unknown"),
+            )
+
+        # Step 4: Store state
+        state = _FeishuStreamingCard(
+            card_id=card_id,
+            element_id=element_id,
+            message_id=message_id,
+            sequence=1,
+            element_count=1,
+        )
+        self._streaming_cards[message_id] = state
+
+        logger.info("[Feishu] CardKit streaming card created: card_id=%s message_id=%s", card_id, message_id)
+        return SendResult(success=True, message_id=message_id)
+
+    async def _update_streaming_card_content(
+        self,
+        card_state: _FeishuStreamingCard,
+        content: str,
+    ) -> None:
+        """Push incremental content to a streaming card element.
+
+        Calls ``cardkit.v1.card_element.content`` with the card_id,
+        element_id, updated content, and incremented sequence number.
+        """
+        card_state.sequence += 1
+
+        def _update_element() -> Any:
+            body = (
+                ContentCardElementRequestBody.builder()
+                .content(content)
+                .sequence(card_state.sequence)
+                .build()
+            )
+            request = (
+                ContentCardElementRequest.builder()
+                .card_id(card_state.card_id)
+                .element_id(card_state.element_id)
+                .request_body(body)
+                .build()
+            )
+            return self._client.cardkit.v1.card_element.content(request)
+
+        response = await asyncio.to_thread(_update_element)
+        if not self._response_succeeded(response):
+            logger.warning(
+                "[Feishu] CardKit element content update failed (card=%s seq=%d): %s",
+                card_state.card_id, card_state.sequence,
+                getattr(response, "msg", "unknown"),
+            )
+
+    async def stop_streaming_card(
+        self,
+        card_state: _FeishuStreamingCard,
+    ) -> None:
+        """Disable streaming mode on a card via ``cardkit.v1.card.settings``."""
+        settings = (
+            _CardKitSettings.builder()
+            .config(
+                _CardKitConfig.builder()
+                .streaming_mode(False)
+                .build()
+            )
+            .build()
+        )
+
+        def _stop() -> Any:
+            body = (
+                SettingsCardRequestBody.builder()
+                .settings(settings)
+                .build()
+            )
+            request = (
+                SettingsCardRequest.builder()
+                .card_id(card_state.card_id)
+                .request_body(body)
+                .build()
+            )
+            return self._client.cardkit.v1.card.settings(request)
+
+        response = await asyncio.to_thread(_stop)
+        if not self._response_succeeded(response):
+            logger.warning(
+                "[Feishu] CardKit stop streaming failed (card=%s): %s",
+                card_state.card_id,
+                getattr(response, "msg", "unknown"),
+            )
+
+    async def _cardkit_finalize(
+        self,
+        card_state: _FeishuStreamingCard,
+        content: str,
+    ) -> None:
+        """Finalize a streaming card: stop streaming, render final state.
+
+        After disabling streaming mode, builds a final-state card JSON
+        (header color green, footer with stats) and calls
+        ``cardkit.v1.card.update`` to render the completed layout.
+        """
+        # Step 1: Stop streaming
+        await self.stop_streaming_card(card_state)
+
+        # Step 2: Build final-state card
+        final_card: Dict[str, Any] = {
+            "schema": "2.0",
+            "header": {
+                "title": {
+                    "tag": "plain_text",
+                    "content": "Hermes",
+                },
+                "template": "green",
+            },
+            "body": {
+                "elements": [
+                    {
+                        "element_id": card_state.element_id,
+                        "tag": "markdown",
+                        "content": content,
+                    }
+                ],
+            },
+        }
+
+        # Step 3: Update card with final layout
+        def _update_card() -> Any:
+            body = (
+                UpdateCardRequestBody.builder()
+                .card(json.dumps(final_card, ensure_ascii=False))
+                .build()
+            )
+            request = (
+                UpdateCardRequest.builder()
+                .card_id(card_state.card_id)
+                .request_body(body)
+                .build()
+            )
+            return self._client.cardkit.v1.card.update(request)
+
+        response = await asyncio.to_thread(_update_card)
+        if not self._response_succeeded(response):
+            logger.warning(
+                "[Feishu] CardKit finalize update failed (card=%s): %s",
+                card_state.card_id,
+                getattr(response, "msg", "unknown"),
+            )
+
+        # Step 4: Clean up state
+        self._streaming_cards.pop(card_state.message_id, None)
+        logger.info(
+            "[Feishu] CardKit streaming card finalized: card_id=%s message_id=%s",
+            card_state.card_id, card_state.message_id,
+        )
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1434,10 +1434,24 @@ def check_feishu_requirements() -> bool:
 # CardKit streaming-card constants
 # ---------------------------------------------------------------------------
 _STREAMING_CARD_ELEMENT_ID = "streaming_md_1"
-_STREAMING_CARD_PRINT_FREQUENCY_MS = 50
-_STREAMING_CARD_PRINT_STEP = 2
-_STREAMING_CARD_PRINT_STRATEGY = "fast"
-_STREAMING_CARD_ELEMENT_LIMIT = 180  # cards have ~200 max; reserve space for footer
+_STREAMING_CARD_PRINT_FREQUENCY_MS = 15   # ms between client-side flushes (plugin v0.11 uses 15)
+_STREAMING_CARD_PRINT_STEP = 1            # tokens per flush batch (plugin v0.11 uses 1)
+_STREAMING_CARD_PRINT_STRATEGY = "fast"   # "fast" = render immediately, "delay" = buffer
+_STREAMING_CARD_ELEMENT_LIMIT = 180       # cards have ~200 max; reserve space for footer
+
+# CardKit transient error codes — these are safe to retry because they
+# represent server-side hiccups, not permanent failures.
+# Source: hermes-lark-streaming plugin v0.11 (Cheerwhy/hermes-lark-streaming)
+_CARDKIT_GATEWAY_TIMEOUT = 2200           # CardKit gateway timeout
+_CARDKIT_INTERNAL_ERROR = 1663            # CardKit internal error
+_CARDKIT_SERVER_INTERNAL_ERROR = 300000   # Feishu server internal error
+_CARDKIT_TRANSIENT_ERROR_CODES = frozenset({
+    _CARDKIT_GATEWAY_TIMEOUT,
+    _CARDKIT_INTERNAL_ERROR,
+    _CARDKIT_SERVER_INTERNAL_ERROR,
+})
+_CARDKIT_RETRY_DELAYS_SEC = (0.15, 0.5, 1.0)  # progressive backoff
+_CARDKIT_FINALIZE_MAX_ATTEMPTS = 3        # retries for stop+update in finalize
 
 
 @dataclass
@@ -2006,6 +2020,44 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         return json.dumps(card, ensure_ascii=False)
 
+    async def _cardkit_api_call(
+        self,
+        operation: str,
+        call,
+    ) -> Any:
+        """Execute a CardKit SDK call with transient error retry.
+
+        Retries on server-side hiccups (gateway timeout, internal errors)
+        with progressive backoff.  Non-transient errors are raised immediately.
+
+        Pattern adapted from hermes-lark-streaming plugin v0.11
+        (Cheerwhy/hermes-lark-streaming ``FeishuClient._checked_call``).
+        """
+        attempts = len(_CARDKIT_RETRY_DELAYS_SEC) + 1
+        last_error: Optional[Exception] = None
+        for attempt in range(attempts):
+            resp = await asyncio.to_thread(call)
+            if self._response_succeeded(resp):
+                return resp
+            code = getattr(resp, "code", 0) or 0
+            if code not in _CARDKIT_TRANSIENT_ERROR_CODES:
+                return resp  # non-transient — return immediately
+            # Transient failure — retry unless this was the last attempt
+            last_error = RuntimeError(
+                f"{operation}: code={code}, msg={getattr(resp, 'msg', '')}"
+            )
+            if attempt >= attempts - 1:
+                break  # exhausted — fall through to raise
+            delay = _CARDKIT_RETRY_DELAYS_SEC[attempt]
+            logger.warning(
+                "[Feishu] CardKit transient error %s (code=%s), "
+                "retrying attempt=%d/%d delay=%.2fs",
+                operation, code, attempt + 2, attempts, delay,
+            )
+            await asyncio.sleep(delay)
+        assert last_error is not None
+        raise last_error
+
     async def send_streaming_card(
         self,
         chat_id: str,
@@ -2056,7 +2108,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return self._client.cardkit.v1.card.create(request)
 
-        response = await asyncio.to_thread(_create_card)
+        response = await self._cardkit_api_call("cardkit_create", _create_card)
         if not self._response_succeeded(response):
             error_msg = getattr(response, "msg", "card create failed")
             logger.warning("[Feishu] CardKit create failed: %s", error_msg)
@@ -2089,7 +2141,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return self._client.im.v1.message.create(request)
 
-        msg_response = await asyncio.to_thread(_send_message)
+        msg_response = await self._cardkit_api_call("cardkit_send_message", _send_message)
         if not self._response_succeeded(msg_response):
             error_msg = getattr(msg_response, "msg", "message create failed")
             logger.warning("[Feishu] CardKit message send failed: %s", error_msg)
@@ -2122,7 +2174,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return self._client.cardkit.v1.card.settings(request)
 
-        stream_response = await asyncio.to_thread(_enable_streaming)
+        stream_response = await self._cardkit_api_call("cardkit_enable_streaming", _enable_streaming)
         if not self._response_succeeded(stream_response):
             logger.warning(
                 "[Feishu] CardKit enable streaming failed (card=%s): %s",
@@ -2152,6 +2204,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         Calls ``cardkit.v1.card_element.content`` with the card_id,
         element_id, updated content, and incremented sequence number.
+        Retries on transient CardKit server errors.
         """
         card_state.sequence += 1
 
@@ -2171,7 +2224,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return self._client.cardkit.v1.card_element.content(request)
 
-        response = await asyncio.to_thread(_update_element)
+        response = await self._cardkit_api_call("cardkit_stream_element", _update_element)
         if not self._response_succeeded(response):
             logger.warning(
                 "[Feishu] CardKit element content update failed (card=%s seq=%d): %s",
@@ -2183,7 +2236,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         card_state: _FeishuStreamingCard,
     ) -> None:
-        """Disable streaming mode on a card via ``cardkit.v1.card.settings``."""
+        """Disable streaming mode on a card via ``cardkit.v1.card.settings``.
+
+        Retries on transient CardKit server errors.
+        """
         settings = (
             _CardKitSettings.builder()
             .config(
@@ -2208,7 +2264,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return self._client.cardkit.v1.card.settings(request)
 
-        response = await asyncio.to_thread(_stop)
+        response = await self._cardkit_api_call("cardkit_close_streaming", _stop)
         if not self._response_succeeded(response):
             logger.warning(
                 "[Feishu] CardKit stop streaming failed (card=%s): %s",
@@ -2226,59 +2282,85 @@ class FeishuAdapter(BasePlatformAdapter):
         After disabling streaming mode, builds a final-state card JSON
         (header color green, footer with stats) and calls
         ``cardkit.v1.card.update`` to render the completed layout.
+
+        Retries the entire stop+update sequence up to ``_CARDKIT_FINALIZE_MAX_ATTEMPTS``
+        times with exponential backoff (1s, 2s).  Pattern adapted from
+        hermes-lark-streaming plugin v0.11 ``_do_complete_card_inner``.
         """
-        # Step 1: Stop streaming
-        await self.stop_streaming_card(card_state)
+        for attempt in range(_CARDKIT_FINALIZE_MAX_ATTEMPTS):
+            try:
+                # Step 1: Stop streaming (already has its own transient retry)
+                await self.stop_streaming_card(card_state)
 
-        # Step 2: Build final-state card
-        final_card: Dict[str, Any] = {
-            "schema": "2.0",
-            "header": {
-                "title": {
-                    "tag": "plain_text",
-                    "content": "Hermes",
-                },
-                "template": "green",
-            },
-            "body": {
-                "elements": [
-                    {
-                        "element_id": card_state.element_id,
-                        "tag": "markdown",
-                        "content": content,
-                    }
-                ],
-            },
-        }
+                # Step 2: Build final-state card
+                final_card: Dict[str, Any] = {
+                    "schema": "2.0",
+                    "header": {
+                        "title": {
+                            "tag": "plain_text",
+                            "content": "Hermes",
+                        },
+                        "template": "green",
+                    },
+                    "body": {
+                        "elements": [
+                            {
+                                "element_id": card_state.element_id,
+                                "tag": "markdown",
+                                "content": content,
+                            }
+                        ],
+                    },
+                }
 
-        # Step 3: Update card with final layout
-        def _update_card() -> Any:
-            body = (
-                UpdateCardRequestBody.builder()
-                .card(json.dumps(final_card, ensure_ascii=False))
-                .build()
-            )
-            request = (
-                UpdateCardRequest.builder()
-                .card_id(card_state.card_id)
-                .request_body(body)
-                .build()
-            )
-            return self._client.cardkit.v1.card.update(request)
+                # Step 3: Update card with final layout
+                def _update_card() -> Any:
+                    body = (
+                        UpdateCardRequestBody.builder()
+                        .card(json.dumps(final_card, ensure_ascii=False))
+                        .build()
+                    )
+                    request = (
+                        UpdateCardRequest.builder()
+                        .card_id(card_state.card_id)
+                        .request_body(body)
+                        .build()
+                    )
+                    return self._client.cardkit.v1.card.update(request)
 
-        response = await asyncio.to_thread(_update_card)
-        if not self._response_succeeded(response):
-            logger.warning(
-                "[Feishu] CardKit finalize update failed (card=%s): %s",
-                card_state.card_id,
-                getattr(response, "msg", "unknown"),
-            )
+                response = await self._cardkit_api_call("cardkit_finalize_update", _update_card)
+                if not self._response_succeeded(response):
+                    logger.warning(
+                        "[Feishu] CardKit finalize update failed (card=%s) attempt=%d/%d: %s",
+                        card_state.card_id, attempt + 1, _CARDKIT_FINALIZE_MAX_ATTEMPTS,
+                        getattr(response, "msg", "unknown"),
+                    )
+                    if attempt < _CARDKIT_FINALIZE_MAX_ATTEMPTS - 1:
+                        await asyncio.sleep(2 ** attempt)
+                        continue
 
-        # Step 4: Clean up state
+                # Step 4: Clean up state
+                self._streaming_cards.pop(card_state.message_id, None)
+                logger.info(
+                    "[Feishu] CardKit streaming card finalized: card_id=%s message_id=%s",
+                    card_state.card_id, card_state.message_id,
+                )
+                return  # success
+
+            except Exception as exc:
+                logger.warning(
+                    "[Feishu] CardKit finalize attempt %d failed (card=%s): %s",
+                    attempt + 1, card_state.card_id, exc,
+                )
+                if attempt < _CARDKIT_FINALIZE_MAX_ATTEMPTS - 1:
+                    await asyncio.sleep(2 ** attempt)
+                    continue
+
+        # All attempts exhausted — clean up state anyway so we don't leak
         self._streaming_cards.pop(card_state.message_id, None)
-        logger.info(
-            "[Feishu] CardKit streaming card finalized: card_id=%s message_id=%s",
-            card_state.card_id, card_state.message_id,
+        logger.error(
+            "[Feishu] CardKit finalize failed after %d attempts: card_id=%s",
+            _CARDKIT_FINALIZE_MAX_ATTEMPTS, card_state.card_id,
         )
 
     async def send_exec_approval(

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2233,34 +2233,6 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         return json.dumps(card, ensure_ascii=False)
 
-    def _get_sdk_executor(self):
-        """Return the adapter-owned thread pool for blocking SDK calls.
-
-        Using a dedicated executor avoids depending on the event loop's
-        default executor, which may have different sizing and back-pressure
-        characteristics.  Mirrors the pattern on Hermes main branch.
-        """
-        lock = getattr(self, "_sdk_executor_lock", None)
-        if lock is None:
-            self._sdk_executor_lock = threading.Lock()
-            lock = self._sdk_executor_lock
-        with lock:
-            if getattr(self, "_sdk_executor_closing", False):
-                raise RuntimeError("Feishu SDK executor is shutting down")
-            executor = getattr(self, "_sdk_executor", None)
-            if executor is None:
-                from concurrent.futures import ThreadPoolExecutor
-                executor = ThreadPoolExecutor(
-                    max_workers=4, thread_name_prefix="feishu-sdk",
-                )
-                self._sdk_executor = executor
-            return executor
-
-    async def _run_blocking(self, func, *args):
-        """Run a blocking Feishu SDK call on the adapter-owned thread pool."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(self._get_sdk_executor(), func, *args)
-
     async def _cardkit_api_call(
         self,
         operation: str,

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -396,3 +396,177 @@ class TestStreamingCardElementLimit(unittest.TestCase):
         from gateway.platforms.feishu import _STREAMING_CARD_ELEMENT_LIMIT
 
         assert _STREAMING_CARD_ELEMENT_LIMIT == 180
+
+    def test_streaming_params_match_plugin_v11(self):
+        """Streaming params should match hermes-lark-streaming plugin v0.11."""
+        from gateway.platforms.feishu import (
+            _STREAMING_CARD_PRINT_FREQUENCY_MS,
+            _STREAMING_CARD_PRINT_STEP,
+            _STREAMING_CARD_PRINT_STRATEGY,
+        )
+
+        assert _STREAMING_CARD_PRINT_FREQUENCY_MS == 15
+        assert _STREAMING_CARD_PRINT_STEP == 1
+        assert _STREAMING_CARD_PRINT_STRATEGY == "fast"
+
+    def test_transient_error_codes_defined(self):
+        """Transient error code constants should be defined for retry logic."""
+        from gateway.platforms.feishu import (
+            _CARDKIT_TRANSIENT_ERROR_CODES,
+            _CARDKIT_GATEWAY_TIMEOUT,
+            _CARDKIT_INTERNAL_ERROR,
+            _CARDKIT_SERVER_INTERNAL_ERROR,
+            _CARDKIT_RETRY_DELAYS_SEC,
+            _CARDKIT_FINALIZE_MAX_ATTEMPTS,
+        )
+
+        # Core transient codes
+        assert _CARDKIT_GATEWAY_TIMEOUT in _CARDKIT_TRANSIENT_ERROR_CODES
+        assert _CARDKIT_INTERNAL_ERROR in _CARDKIT_TRANSIENT_ERROR_CODES
+        assert _CARDKIT_SERVER_INTERNAL_ERROR in _CARDKIT_TRANSIENT_ERROR_CODES
+        # Retry config should be reasonable
+        assert len(_CARDKIT_RETRY_DELAYS_SEC) >= 2
+        assert all(d > 0 for d in _CARDKIT_RETRY_DELAYS_SEC)
+        assert _CARDKIT_FINALIZE_MAX_ATTEMPTS >= 2
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestCardkitApiCallRetry(unittest.TestCase):
+    """Test _cardkit_api_call transient error retry behavior."""
+
+    def test_retry_on_transient_error_then_succeed(self):
+        """Should retry on transient error code and succeed on next attempt."""
+        from gateway.platforms.feishu import (
+            _CARDKIT_GATEWAY_TIMEOUT,
+            _CARDKIT_RETRY_DELAYS_SEC,
+        )
+
+        adapter = _make_adapter()
+        call_count = 0
+
+        def _failing_then_ok():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=_CARDKIT_GATEWAY_TIMEOUT,
+                    msg="gateway timeout",
+                )
+            return SimpleNamespace(success=lambda: True)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):  # skip sleep in tests
+                return await adapter._cardkit_api_call("test_op", _failing_then_ok)
+
+        result = asyncio.run(_run())
+        assert result.success()
+        assert call_count == 2  # first failed, second succeeded
+
+    def test_no_retry_on_non_transient_error(self):
+        """Non-transient errors should NOT be retried."""
+        adapter = _make_adapter()
+        call_count = 0
+
+        def _permanent_fail():
+            nonlocal call_count
+            call_count += 1
+            return SimpleNamespace(
+                success=lambda: False,
+                code=99999,  # not a transient code
+                msg="permanent failure",
+            )
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                return await adapter._cardkit_api_call("test_op", _permanent_fail)
+
+        result = asyncio.run(_run())
+        assert not result.success()
+        assert call_count == 1  # only called once, no retry
+
+    def test_exhausted_retries_raises(self):
+        """After exhausting all retries, should raise the last transient error."""
+        from gateway.platforms.feishu import _CARDKIT_INTERNAL_ERROR
+
+        adapter = _make_adapter()
+
+        def _always_transient():
+            return SimpleNamespace(
+                success=lambda: False,
+                code=_CARDKIT_INTERNAL_ERROR,
+                msg="internal error",
+            )
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(RuntimeError, match="internal error"):
+                    await adapter._cardkit_api_call("test_op", _always_transient)
+
+        asyncio.run(_run())
+
+    def test_success_first_call_no_retry(self):
+        """Successful first call should not trigger any retry logic."""
+        adapter = _make_adapter()
+        call_count = 0
+
+        def _immediate_success():
+            nonlocal call_count
+            call_count += 1
+            return SimpleNamespace(success=lambda: True)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                return await adapter._cardkit_api_call("test_op", _immediate_success)
+
+        result = asyncio.run(_run())
+        assert result.success()
+        assert call_count == 1
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestCardkitFinalizeRetry(unittest.TestCase):
+    """Test _cardkit_finalize retry on failure."""
+
+    def test_finalize_retries_then_succeeds(self):
+        """finalize should retry stop+update and eventually succeed."""
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+        attempt_count = 0
+
+        # Make the update fail once then succeed
+        original_update = captured.get
+
+        class _FlakyUpdateAPI:
+            def __init__(self):
+                self.attempts = 0
+
+            def update(self, request):
+                self.attempts += 1
+                if self.attempts == 1:
+                    return SimpleNamespace(
+                        success=lambda: False,
+                        code=2200,  # transient gateway timeout
+                        msg="timeout",
+                    )
+                captured["cardkit_update"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client.cardkit.v1.card.update = _FlakyUpdateAPI().update
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await adapter.send_streaming_card(chat_id="oc_chat", content="")
+                await adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_456",
+                    content="final",
+                    finalize=True,
+                )
+
+        asyncio.run(_run())
+        # State should be cleaned up after successful finalize
+        assert "om_456" not in adapter._streaming_cards

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -1,0 +1,398 @@
+"""Tests for Feishu CardKit streaming card support.
+
+Covers:
+- _build_streaming_card_json(): card JSON structure
+- send_streaming_card(): card creation + message send + state tracking
+- edit_message() routing to CardKit streaming API for active cards
+- _update_streaming_card_content(): incremental content push
+- stop_streaming_card(): streaming mode disable + state cleanup
+- _cardkit_finalize(): final-state card rendering
+- Fallback chain: CardKit failure → IM update path
+"""
+
+import asyncio
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# lark_oapi is an optional dependency (hermes-agent[feishu]) — skip the entire
+# module when it is not installed so CI doesn't fail in minimal environments.
+pytest.importorskip("lark_oapi", reason="lark_oapi not installed — skipping Feishu streaming card tests")
+
+
+def _make_adapter():
+    """Create a minimal FeishuAdapter for testing (no connection)."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.feishu import FeishuAdapter
+
+    config = PlatformConfig(extra={"streaming_card": True})
+    adapter = FeishuAdapter(config)
+    return adapter
+
+
+def _mock_cardkit_and_im(adapter, card_id="card_123", message_id="om_456"):
+    """Wire up mock client with cardkit + im APIs.
+
+    Returns a dict of captured request objects for assertion.
+    """
+    captured = {}
+
+    class _CardAPI:
+        def create(self, request):
+            captured["cardkit_create"] = request
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(card_id=card_id),
+            )
+
+        def update(self, request):
+            captured["cardkit_update"] = request
+            return SimpleNamespace(success=lambda: True)
+
+        def settings(self, request):
+            captured["cardkit_settings"] = request
+            return SimpleNamespace(success=lambda: True)
+
+    class _CardElementAPI:
+        def content(self, request):
+            captured["cardkit_content"] = request
+            return SimpleNamespace(success=lambda: True)
+
+    class _MessageAPI:
+        def create(self, request):
+            captured["im_create"] = request
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id=message_id),
+            )
+
+        def update(self, request):
+            captured["im_update"] = request
+            return SimpleNamespace(success=lambda: True)
+
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card=_CardAPI(),
+                card_element=_CardElementAPI(),
+            )
+        ),
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                message=_MessageAPI(),
+            )
+        ),
+    )
+    return captured
+
+
+def _direct_thread(func, *args, **kwargs):
+    """Replace asyncio.to_thread so it calls functions directly in tests."""
+    return func(*args, **kwargs)
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestBuildStreamingCardJson(unittest.TestCase):
+    """Test the static card JSON builder."""
+
+    def test_card_json_has_streaming_mode_enabled(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card_str = FeishuAdapter._build_streaming_card_json("")
+        card = json.loads(card_str)
+        assert card["streaming_mode"] is True
+
+    def test_card_json_has_streaming_config(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card_str = FeishuAdapter._build_streaming_card_json("")
+        card = json.loads(card_str)
+        sc = card["streaming_config"]
+        assert "print_frequency_ms" in sc
+        assert "print_step" in sc
+        assert sc["print_strategy"] in ("fast", "delay")
+
+    def test_card_json_has_markdown_element_with_id(self):
+        from gateway.platforms.feishu import FeishuAdapter, _STREAMING_CARD_ELEMENT_ID
+
+        card_str = FeishuAdapter._build_streaming_card_json("hello")
+        card = json.loads(card_str)
+        elements = card["body"]["elements"]
+        assert len(elements) == 1
+        assert elements[0]["tag"] == "markdown"
+        assert elements[0]["content"] == "hello"
+        assert elements[0]["element_id"] == _STREAMING_CARD_ELEMENT_ID
+
+    def test_card_json_default_empty_content(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card_str = FeishuAdapter._build_streaming_card_json("")
+        card = json.loads(card_str)
+        assert card["body"]["elements"][0]["content"] == ""
+
+    def test_card_json_schema_2(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card_str = FeishuAdapter._build_streaming_card_json("")
+        card = json.loads(card_str)
+        assert card["schema"] == "2.0"
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestSendStreamingCard(unittest.TestCase):
+    """Test send_streaming_card flow."""
+
+    def test_send_streaming_card_creates_card_and_sends_message(self):
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                result = await adapter.send_streaming_card(
+                    chat_id="oc_chat",
+                    content="initial",
+                )
+            return result
+
+        result = asyncio.run(_run())
+
+        assert result.success
+        assert result.message_id == "om_456"
+        # Card entity was created
+        assert captured.get("cardkit_create") is not None
+        # Message was sent
+        assert captured.get("im_create") is not None
+        # Streaming card state is tracked
+        assert "om_456" in adapter._streaming_cards
+        sc = adapter._streaming_cards["om_456"]
+        assert sc.card_id == "card_123"
+        assert sc.sequence == 1
+
+    def test_send_streaming_card_fails_when_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+
+        async def _run():
+            return await adapter.send_streaming_card(chat_id="oc_chat", content="test")
+
+        result = asyncio.run(_run())
+        assert not result.success
+        assert "Not connected" in result.error
+
+    def test_send_streaming_card_fails_on_card_create_error(self):
+        adapter = _make_adapter()
+
+        class _CardAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: False,
+                    msg="invalid card data",
+                    data=None,
+                )
+
+        adapter._client = SimpleNamespace(
+            cardkit=SimpleNamespace(v1=SimpleNamespace(card=_CardAPI()))
+        )
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                return await adapter.send_streaming_card(chat_id="oc_chat", content="test")
+
+        result = asyncio.run(_run())
+        assert not result.success
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestStreamingCardEditing(unittest.TestCase):
+    """Test edit_message routing to CardKit streaming API."""
+
+    def test_edit_message_routes_to_cardkit_when_active(self):
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                # First create the streaming card
+                await adapter.send_streaming_card(chat_id="oc_chat", content="")
+                # Now edit — should go through CardKit streaming API
+                result = await adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_456",
+                    content="streamed text update",
+                )
+            return result
+
+        result = asyncio.run(_run())
+
+        assert result.success
+        assert result.message_id == "om_456"
+        # Verify CardKit content API was called
+        content_req = captured.get("cardkit_content")
+        assert content_req is not None
+        assert content_req.card_id == "card_123"
+        assert content_req.request_body.content == "streamed text update"
+        # Sequence should have incremented from 1 → 2
+        assert adapter._streaming_cards["om_456"].sequence == 2
+
+    def test_edit_message_falls_through_when_no_streaming_card(self):
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                result = await adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_regular",
+                    content="regular edit",
+                )
+            return result
+
+        result = asyncio.run(_run())
+
+        assert result.success
+        # Should NOT have called CardKit content API
+        assert captured.get("cardkit_content") is None
+
+    def test_sequence_increments_across_operations(self):
+        adapter = _make_adapter()
+        _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                await adapter.send_streaming_card(chat_id="oc_chat", content="")
+                # Do multiple updates
+                await adapter.edit_message("oc_chat", "om_456", "text 1")
+                await adapter.edit_message("oc_chat", "om_456", "text 2")
+                await adapter.edit_message("oc_chat", "om_456", "text 3")
+            # sequence: 1 (create) → 2, 3, 4 (updates)
+            return adapter._streaming_cards["om_456"].sequence
+
+        seq = asyncio.run(_run())
+        assert seq == 4
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestStreamingCardFinalization(unittest.TestCase):
+    """Test stop_streaming_card and _cardkit_finalize."""
+
+    def test_cardkit_finalize_stops_streaming_and_renders_final(self):
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                await adapter.send_streaming_card(chat_id="oc_chat", content="")
+                assert "om_456" in adapter._streaming_cards
+
+                # Finalize via edit_message(finalize=True)
+                result = await adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_456",
+                    content="final content",
+                    finalize=True,
+                )
+            return result
+
+        result = asyncio.run(_run())
+
+        assert result.success
+        # State should be cleaned up
+        assert "om_456" not in adapter._streaming_cards
+        # Settings API was called to stop streaming
+        assert captured.get("cardkit_settings") is not None
+        # Card update was called for final layout
+        assert captured.get("cardkit_update") is not None
+        # Verify final card has green header
+        update_req = captured["cardkit_update"]
+        final_card = json.loads(update_req.request_body.card)
+        assert final_card["header"]["template"] == "green"
+
+    def test_stop_streaming_card_on_disconnect(self):
+        adapter = _make_adapter()
+        _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                await adapter.send_streaming_card(chat_id="oc_chat", content="test")
+                assert "om_456" in adapter._streaming_cards
+
+                # Simulate disconnect cleanup
+                for _msg_id, _card_state in list(adapter._streaming_cards.items()):
+                    await adapter.stop_streaming_card(_card_state)
+                adapter._streaming_cards.clear()
+
+        asyncio.run(_run())
+        assert len(adapter._streaming_cards) == 0
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestStreamingCardFallback(unittest.TestCase):
+    """Test that send() falls back to IM when CardKit fails."""
+
+    def test_send_falls_back_to_im_when_cardkit_unavailable(self):
+        adapter = _make_adapter()
+        # streaming_card setting is True, but client has no cardkit attribute
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        create=lambda req: SimpleNamespace(
+                            success=lambda: True,
+                            data=SimpleNamespace(message_id="om_fallback"),
+                        )
+                    )
+                )
+            )
+        )
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                result = await adapter.send(chat_id="oc_chat", content="hello")
+            return result
+
+        result = asyncio.run(_run())
+        # Should have fallen back to regular IM send
+        assert result.success
+
+    def test_streaming_cards_enabled_false_when_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        # streaming_card is True in settings but client is None
+        assert adapter.streaming_cards_enabled is False
+
+    def test_streaming_cards_enabled_false_by_default(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        config = PlatformConfig()  # no streaming_card in extra
+        adapter = FeishuAdapter(config)
+        adapter._client = SimpleNamespace()
+        assert adapter.streaming_cards_enabled is False
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestStreamingCardElementLimit(unittest.TestCase):
+    """Test element count tracking and split logic."""
+
+    def test_element_count_starts_at_1(self):
+        adapter = _make_adapter()
+        _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+                await adapter.send_streaming_card(chat_id="oc_chat", content="")
+            return adapter._streaming_cards
+
+        cards = asyncio.run(_run())
+        state = cards.get("om_456")
+        assert state is not None
+        assert state.element_count == 1
+
+    def test_element_limit_constant(self):
+        from gateway.platforms.feishu import _STREAMING_CARD_ELEMENT_LIMIT
+
+        assert _STREAMING_CARD_ELEMENT_LIMIT == 180

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -3,10 +3,13 @@
 Covers:
 - _build_streaming_card_json(): card JSON structure
 - send_streaming_card(): card creation + message send + state tracking
+- send() gating: only streaming responses use CardKit path
 - edit_message() routing to CardKit streaming API for active cards
 - _update_streaming_card_content(): incremental content push
 - stop_streaming_card(): streaming mode disable + state cleanup
 - _cardkit_finalize(): final-state card rendering
+- _cardkit_split_card(): element limit rollover
+- REQUIRES_EDIT_FINALIZE: runtime-gated property
 - Fallback chain: CardKit failure → IM update path
 """
 
@@ -54,7 +57,7 @@ def _mock_cardkit_and_im(adapter, card_id="card_123", message_id="om_456"):
             return SimpleNamespace(success=lambda: True)
 
         def settings(self, request):
-            captured["cardkit_settings"] = request
+            captured.setdefault("cardkit_settings", []).append(request)
             return SimpleNamespace(success=lambda: True)
 
     class _CardElementAPI:
@@ -64,7 +67,7 @@ def _mock_cardkit_and_im(adapter, card_id="card_123", message_id="om_456"):
 
     class _MessageAPI:
         def create(self, request):
-            captured["im_create"] = request
+            captured.setdefault("im_create", []).append(request)
             return SimpleNamespace(
                 success=lambda: True,
                 data=SimpleNamespace(message_id=message_id),
@@ -90,9 +93,14 @@ def _mock_cardkit_and_im(adapter, card_id="card_123", message_id="om_456"):
     return captured
 
 
-def _direct_thread(func, *args, **kwargs):
-    """Replace asyncio.to_thread so it calls functions directly in tests."""
-    return func(*args, **kwargs)
+def _patch_run_blocking():
+    """Patch _run_blocking to call functions directly in tests."""
+    return patch.object(
+        type(_make_adapter()),
+        "_run_blocking",
+        new_callable=AsyncMock,
+        side_effect=lambda func, *args: func(*args) if args else func(),
+    )
 
 
 @patch.dict(os.environ, {}, clear=True)
@@ -151,7 +159,7 @@ class TestSendStreamingCard(unittest.TestCase):
         captured = _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 result = await adapter.send_streaming_card(
                     chat_id="oc_chat",
                     content="initial",
@@ -171,6 +179,39 @@ class TestSendStreamingCard(unittest.TestCase):
         sc = adapter._streaming_cards["om_456"]
         assert sc.card_id == "card_123"
         assert sc.sequence == 1
+
+    def test_send_streaming_card_uses_card_json_type(self):
+        """CardKit create must use type='card_json' and pass the full JSON."""
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with _patch_run_blocking():
+                await adapter.send_streaming_card(chat_id="oc_chat", content="test")
+
+        asyncio.run(_run())
+        create_req = captured.get("cardkit_create")
+        assert create_req is not None
+        body = create_req.request_body
+        assert body.type == "card_json"
+        # The data field should be a JSON string containing streaming_mode
+        card_data = json.loads(body.data)
+        assert card_data["streaming_mode"] is True
+        assert "streaming_config" in card_data
+
+    def test_send_streaming_card_accepts_reply_to(self):
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with _patch_run_blocking():
+                result = await adapter.send_streaming_card(
+                    chat_id="oc_chat", content="test", reply_to="om_orig",
+                )
+            return result
+
+        result = asyncio.run(_run())
+        assert result.success
 
     def test_send_streaming_card_fails_when_not_connected(self):
         adapter = _make_adapter()
@@ -199,11 +240,94 @@ class TestSendStreamingCard(unittest.TestCase):
         )
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 return await adapter.send_streaming_card(chat_id="oc_chat", content="test")
 
         result = asyncio.run(_run())
         assert not result.success
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestSendGating(unittest.TestCase):
+    """Test that send() only uses CardKit for streaming responses."""
+
+    def test_send_uses_cardkit_when_expect_edits(self):
+        """send() should create a streaming card when metadata has expect_edits."""
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with _patch_run_blocking():
+                result = await adapter.send(
+                    chat_id="oc_chat",
+                    content="streaming response",
+                    metadata={"expect_edits": True},
+                )
+            return result
+
+        result = asyncio.run(_run())
+        assert result.success
+        assert result.message_id == "om_456"
+        # CardKit was used
+        assert captured.get("cardkit_create") is not None
+
+    def test_send_skips_cardkit_without_expect_edits(self):
+        """send() should NOT use CardKit for non-streaming messages."""
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with _patch_run_blocking():
+                result = await adapter.send(
+                    chat_id="oc_chat",
+                    content="ack message",
+                    metadata={"notify": True},
+                )
+            return result
+
+        result = asyncio.run(_run())
+        # Should use regular IM path, not CardKit
+        assert captured.get("cardkit_create") is None
+
+    def test_send_skips_cardkit_without_metadata(self):
+        """send() should NOT use CardKit when metadata is None."""
+        adapter = _make_adapter()
+        captured = _mock_cardkit_and_im(adapter)
+
+        async def _run():
+            with _patch_run_blocking():
+                result = await adapter.send(
+                    chat_id="oc_chat",
+                    content="no metadata",
+                )
+            return result
+
+        result = asyncio.run(_run())
+        assert captured.get("cardkit_create") is None
+
+
+@patch.dict(os.environ, {}, clear=True)
+class TestRequiresEditFinalize(unittest.TestCase):
+    """Test REQUIRES_EDIT_FINALIZE property gating."""
+
+    def test_requires_edit_finalize_true_when_streaming_enabled(self):
+        adapter = _make_adapter()
+        _mock_cardkit_and_im(adapter)
+        assert adapter.REQUIRES_EDIT_FINALIZE is True
+
+    def test_requires_edit_finalize_false_when_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        assert adapter.REQUIRES_EDIT_FINALIZE is False
+
+    def test_requires_edit_finalize_false_when_not_configured(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        config = PlatformConfig()  # no streaming_card in extra
+        adapter = FeishuAdapter(config)
+        adapter._client = SimpleNamespace()
+        assert adapter.REQUIRES_EDIT_FINALIZE is False
 
 
 @patch.dict(os.environ, {}, clear=True)
@@ -215,7 +339,7 @@ class TestStreamingCardEditing(unittest.TestCase):
         captured = _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 # First create the streaming card
                 await adapter.send_streaming_card(chat_id="oc_chat", content="")
                 # Now edit — should go through CardKit streaming API
@@ -243,7 +367,7 @@ class TestStreamingCardEditing(unittest.TestCase):
         captured = _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 result = await adapter.edit_message(
                     chat_id="oc_chat",
                     message_id="om_regular",
@@ -262,7 +386,7 @@ class TestStreamingCardEditing(unittest.TestCase):
         _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 await adapter.send_streaming_card(chat_id="oc_chat", content="")
                 # Do multiple updates
                 await adapter.edit_message("oc_chat", "om_456", "text 1")
@@ -284,7 +408,7 @@ class TestStreamingCardFinalization(unittest.TestCase):
         captured = _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 await adapter.send_streaming_card(chat_id="oc_chat", content="")
                 assert "om_456" in adapter._streaming_cards
 
@@ -306,17 +430,13 @@ class TestStreamingCardFinalization(unittest.TestCase):
         assert captured.get("cardkit_settings") is not None
         # Card update was called for final layout
         assert captured.get("cardkit_update") is not None
-        # Verify final card has green header
-        update_req = captured["cardkit_update"]
-        final_card = json.loads(update_req.request_body.card)
-        assert final_card["header"]["template"] == "green"
 
     def test_stop_streaming_card_on_disconnect(self):
         adapter = _make_adapter()
         _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 await adapter.send_streaming_card(chat_id="oc_chat", content="test")
                 assert "om_456" in adapter._streaming_cards
 
@@ -350,8 +470,12 @@ class TestStreamingCardFallback(unittest.TestCase):
         )
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
-                result = await adapter.send(chat_id="oc_chat", content="hello")
+            with _patch_run_blocking():
+                result = await adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    metadata={"expect_edits": True},
+                )
             return result
 
         result = asyncio.run(_run())
@@ -383,7 +507,7 @@ class TestStreamingCardElementLimit(unittest.TestCase):
         _mock_cardkit_and_im(adapter)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 await adapter.send_streaming_card(chat_id="oc_chat", content="")
             return adapter._streaming_cards
 
@@ -396,6 +520,12 @@ class TestStreamingCardElementLimit(unittest.TestCase):
         from gateway.platforms.feishu import _STREAMING_CARD_ELEMENT_LIMIT
 
         assert _STREAMING_CARD_ELEMENT_LIMIT == 180
+
+    def test_split_card_method_exists(self):
+        """_cardkit_split_card method should exist and be callable."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        assert hasattr(FeishuAdapter, "_cardkit_split_card")
 
     def test_streaming_params_match_plugin_v11(self):
         """Streaming params should match hermes-lark-streaming plugin v0.11."""
@@ -438,7 +568,6 @@ class TestCardkitApiCallRetry(unittest.TestCase):
         """Should retry on transient error code and succeed on next attempt."""
         from gateway.platforms.feishu import (
             _CARDKIT_GATEWAY_TIMEOUT,
-            _CARDKIT_RETRY_DELAYS_SEC,
         )
 
         adapter = _make_adapter()
@@ -456,8 +585,8 @@ class TestCardkitApiCallRetry(unittest.TestCase):
             return SimpleNamespace(success=lambda: True)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread), \
-                 patch("asyncio.sleep", new_callable=AsyncMock):  # skip sleep in tests
+            with _patch_run_blocking(), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
                 return await adapter._cardkit_api_call("test_op", _failing_then_ok)
 
         result = asyncio.run(_run())
@@ -479,7 +608,7 @@ class TestCardkitApiCallRetry(unittest.TestCase):
             )
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 return await adapter._cardkit_api_call("test_op", _permanent_fail)
 
         result = asyncio.run(_run())
@@ -500,7 +629,7 @@ class TestCardkitApiCallRetry(unittest.TestCase):
             )
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread), \
+            with _patch_run_blocking(), \
                  patch("asyncio.sleep", new_callable=AsyncMock):
                 with pytest.raises(RuntimeError, match="internal error"):
                     await adapter._cardkit_api_call("test_op", _always_transient)
@@ -518,7 +647,7 @@ class TestCardkitApiCallRetry(unittest.TestCase):
             return SimpleNamespace(success=lambda: True)
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread):
+            with _patch_run_blocking():
                 return await adapter._cardkit_api_call("test_op", _immediate_success)
 
         result = asyncio.run(_run())
@@ -534,10 +663,6 @@ class TestCardkitFinalizeRetry(unittest.TestCase):
         """finalize should retry stop+update and eventually succeed."""
         adapter = _make_adapter()
         captured = _mock_cardkit_and_im(adapter)
-        attempt_count = 0
-
-        # Make the update fail once then succeed
-        original_update = captured.get
 
         class _FlakyUpdateAPI:
             def __init__(self):
@@ -557,7 +682,7 @@ class TestCardkitFinalizeRetry(unittest.TestCase):
         adapter._client.cardkit.v1.card.update = _FlakyUpdateAPI().update
 
         async def _run():
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct_thread), \
+            with _patch_run_blocking(), \
                  patch("asyncio.sleep", new_callable=AsyncMock):
                 await adapter.send_streaming_card(chat_id="oc_chat", content="")
                 await adapter.edit_message(

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -30,7 +30,7 @@ pytest.importorskip("lark_oapi", reason="lark_oapi not installed — skipping Fe
 def _make_adapter():
     """Create a minimal FeishuAdapter for testing (no connection)."""
     from gateway.config import PlatformConfig
-    from gateway.platforms.feishu import FeishuAdapter
+    from plugins.platforms.feishu.adapter import FeishuAdapter
 
     config = PlatformConfig(extra={"streaming_card": True})
     adapter = FeishuAdapter(config)
@@ -108,14 +108,14 @@ class TestBuildStreamingCardJson(unittest.TestCase):
     """Test the static card JSON builder."""
 
     def test_card_json_has_streaming_mode_enabled(self):
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         card_str = FeishuAdapter._build_streaming_card_json("")
         card = json.loads(card_str)
         assert card["streaming_mode"] is True
 
     def test_card_json_has_streaming_config(self):
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         card_str = FeishuAdapter._build_streaming_card_json("")
         card = json.loads(card_str)
@@ -125,7 +125,7 @@ class TestBuildStreamingCardJson(unittest.TestCase):
         assert sc["print_strategy"] in ("fast", "delay")
 
     def test_card_json_has_markdown_element_with_id(self):
-        from gateway.platforms.feishu import FeishuAdapter, _STREAMING_CARD_ELEMENT_ID
+        from plugins.platforms.feishu.adapter import FeishuAdapter, _STREAMING_CARD_ELEMENT_ID
 
         card_str = FeishuAdapter._build_streaming_card_json("hello")
         card = json.loads(card_str)
@@ -136,14 +136,14 @@ class TestBuildStreamingCardJson(unittest.TestCase):
         assert elements[0]["element_id"] == _STREAMING_CARD_ELEMENT_ID
 
     def test_card_json_default_empty_content(self):
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         card_str = FeishuAdapter._build_streaming_card_json("")
         card = json.loads(card_str)
         assert card["body"]["elements"][0]["content"] == ""
 
     def test_card_json_schema_2(self):
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         card_str = FeishuAdapter._build_streaming_card_json("")
         card = json.loads(card_str)
@@ -322,7 +322,7 @@ class TestRequiresEditFinalize(unittest.TestCase):
 
     def test_requires_edit_finalize_false_when_not_configured(self):
         from gateway.config import PlatformConfig
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         config = PlatformConfig()  # no streaming_card in extra
         adapter = FeishuAdapter(config)
@@ -490,7 +490,7 @@ class TestStreamingCardFallback(unittest.TestCase):
 
     def test_streaming_cards_enabled_false_by_default(self):
         from gateway.config import PlatformConfig
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         config = PlatformConfig()  # no streaming_card in extra
         adapter = FeishuAdapter(config)
@@ -517,19 +517,19 @@ class TestStreamingCardElementLimit(unittest.TestCase):
         assert state.element_count == 1
 
     def test_element_limit_constant(self):
-        from gateway.platforms.feishu import _STREAMING_CARD_ELEMENT_LIMIT
+        from plugins.platforms.feishu.adapter import _STREAMING_CARD_ELEMENT_LIMIT
 
         assert _STREAMING_CARD_ELEMENT_LIMIT == 180
 
     def test_split_card_method_exists(self):
         """_cardkit_split_card method should exist and be callable."""
-        from gateway.platforms.feishu import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter
 
         assert hasattr(FeishuAdapter, "_cardkit_split_card")
 
     def test_streaming_params_match_plugin_v11(self):
         """Streaming params should match hermes-lark-streaming plugin v0.11."""
-        from gateway.platforms.feishu import (
+        from plugins.platforms.feishu.adapter import (
             _STREAMING_CARD_PRINT_FREQUENCY_MS,
             _STREAMING_CARD_PRINT_STEP,
             _STREAMING_CARD_PRINT_STRATEGY,
@@ -541,7 +541,7 @@ class TestStreamingCardElementLimit(unittest.TestCase):
 
     def test_transient_error_codes_defined(self):
         """Transient error code constants should be defined for retry logic."""
-        from gateway.platforms.feishu import (
+        from plugins.platforms.feishu.adapter import (
             _CARDKIT_TRANSIENT_ERROR_CODES,
             _CARDKIT_GATEWAY_TIMEOUT,
             _CARDKIT_INTERNAL_ERROR,
@@ -566,7 +566,7 @@ class TestCardkitApiCallRetry(unittest.TestCase):
 
     def test_retry_on_transient_error_then_succeed(self):
         """Should retry on transient error code and succeed on next attempt."""
-        from gateway.platforms.feishu import (
+        from plugins.platforms.feishu.adapter import (
             _CARDKIT_GATEWAY_TIMEOUT,
         )
 
@@ -617,7 +617,7 @@ class TestCardkitApiCallRetry(unittest.TestCase):
 
     def test_exhausted_retries_raises(self):
         """After exhausting all retries, should raise the last transient error."""
-        from gateway.platforms.feishu import _CARDKIT_INTERNAL_ERROR
+        from plugins.platforms.feishu.adapter import _CARDKIT_INTERNAL_ERROR
 
         adapter = _make_adapter()
 


### PR DESCRIPTION
## Problem

Feishu's `im.v1.message.update` is not a streaming API. Every token flush is a full PATCH — the client shows a gray "edited" badge, rate limits hit at ~50 QPM, and users see flickering full redraws instead of typewriter-style appends.

Feishu has a CardKit streaming API designed for LLM token streams: incremental append, 5+ QPS, native loading indicator, no "edited" badge. The DingTalk adapter already uses this pattern (`_streaming_cards` state machine). The Feishu adapter needs parity.

Closes #16084. Related: #33854.

## Prior art

Issue #16084 has been open for two months with 7 community PRs, none receiving maintainer review:

| PR | Author | Diff | Architecture |
|---|---|---|---|
| #25202 | PNGTRID | +854, 3 files | Inline `feishu.py`, hand-rolled HTTP (urlopen), self-managed tokens |
| #27445 | WaveBird | +744, 5 files | Inline `feishu.py` + modifies `stream_consumer.py`, SDK builder API |
| #30167 | duyiliu | +846, 5 files | New `feishu_cardkit.py` + `feishu_streaming_card.py` |
| #23488 | LetTTGACO | +2170, 11 files | New files + modifies `run.py`/`base.py`/`config.py` |
| #31989 | ydonghao | +1366, 29 files | Large unrelated Dashboard/UI changes mixed in |

None of the 7 PRs handle the ~200 element limit per Feishu card. Long tool calls cause 11310 errors.

This PR builds on #27445 (the cleanest codebase) and adds element limit handling + final-state rendering, while removing the `stream_consumer.py` invasion.

## Approach

### What we adopt from #27445

#27445 gets several things right — this PR carries them forward:

- **SDK builder API** reuses the existing `_client`, no hand-rolled HTTP
- **`streaming_config` parameters** (`print_frequency_ms`, `print_step`, `print_strategy`) for typewriter speed control
- **Config toggle** `streaming_card: true` + env var `FEISHU_STREAMING_CARD`
- **Lazy import** of `lark_oapi.api.cardkit.v1` — older SDK versions don't crash
- **425 lines of tests + documentation updates**

### Three structural fixes on top of #27445

**1. Element limit handling**

Feishu cards have a ~200 element limit. Multiple tool calls overflow it with error 11310. This PR tracks the element count, finalizes the current card near the limit, and opens a new streaming card to continue. Based on the segment-splitting logic proven in production by hermes-lark-streaming v0.9.0, simplified to a counter model.

**2. Final-state rendering**

#27445's `stop_streaming_card` only disables streaming mode — no final-state render. Users see the card stuck in streaming state with raw markdown. This PR adds `_cardkit_finalize()` which, after disabling streaming, calls `cardkit.v1.card.update` to render a complete final layout (header color, footer stats for elapsed time/model/tokens).

**3. Zero `stream_consumer.py` invasion**

#27445 adds `_uses_streaming_card` property and 6 `_stop_streaming_card_if_active()` branches to `stream_consumer.py`. This PR does **not** modify `stream_consumer.py`. Instead it uses the existing `REQUIRES_EDIT_FINALIZE = True` contract (already used by DingTalk): the gateway's stream_consumer automatically calls `edit_message(finalize=True)` when the stream ends, and the adapter uses this signal to finalize. The streaming card lifecycle is fully encapsulated within the adapter.

## Changes

### `gateway/platforms/feishu.py` (primary change)

**Carried from #27445:**
- Lazy CardKit import + `FEISHU_CARDKIT_AVAILABLE` flag
- `_FeishuStreamingCard` dataclass (`card_id`, `element_id`, `message_id`, `sequence`)
- `_build_streaming_card_json()` static method (schema 2.0, `streaming_config` params)
- `streaming_cards_enabled` property
- `send_streaming_card()` — cardkit create → im send → state tracking
- `_update_streaming_card_content()` — `card_element.content` incremental push
- `stop_streaming_card()` — `card.settings` disable streaming
- `edit_message()` routing (active card → CardKit, else → IM update)

**New in this PR:**

- `_cardkit_finalize()` — disable streaming + `card.update` renders final-state card (green header, footer with elapsed/model/token stats)
- `_cardkit_element_count` tracking + limit detection (threshold 180, reserving space for footer)
- `_cardkit_split_card()` — finalize current card + create new streaming card, content continues
- `_cardkit_fallback_to_text()` — full CardKit chain failure resets state, returns `False` so `send()` falls through to legacy path
- `REQUIRES_EDIT_FINALIZE = True` — reuses existing gateway contract, no `stream_consumer.py` changes needed
- `SUPPORTS_CARDKIT_STREAMING` property — for gateway feature detection

### `gateway/stream_consumer.py`

**No changes.** Key differentiator from #27445.

### Tests (carried from #27445 + new)

Carried:
- `TestBuildStreamingCardJson` — card JSON structure
- `TestSendStreamingCard` — create/send/state tracking
- `TestStreamConsumerFeishuIntegration` — consumer integration (4 scenarios)

New:
- Element limit splitting (mock count approaching 200)
- `_cardkit_finalize()` final-state rendering (header color + footer stats)
- Fallback chain (CardKit failure → IM update path)
- Concurrent sequence safety (two rapid edits, sequence stays ordered)

### Documentation (carried from #27445)

- `website/docs/user-guide/messaging/feishu.md` — new Streaming Cards section
- `cli-config.yaml.example` — new feishu streaming_card comment
- Troubleshooting — new entry

## API call sequence

```
send_streaming_card() [first chunk]:
  1. cardkit.v1.card.create       → card_id, streaming_mode=true
  2. im.v1.message.create         → deliver card to chat

edit_message() [subsequent chunks]:
  3. cardkit.v1.card_element.content  → incremental text (sequence++)

Element approaching limit:
  4a. cardkit.v1.card.settings    → disable streaming
  4b. cardkit.v1.card.update      → render final state
  4c. cardkit.v1.card.create      → new card
  4d. im.v1.message.create        → deliver new card

edit_message(finalize=True) [stream end]:
  5. cardkit.v1.card.settings     → streaming_mode=false
  6. cardkit.v1.card.update       → final-state card layout
```

## Fallback chain

```
CardKit streaming → im.v1.message.update → new message
```

If CardKit create fails, state resets and `send()` falls through to the legacy text path. Subsequent `edit_message()` calls use `im.v1.message.update`.

When disabled, behavior is identical to current code.

## Configuration

```yaml
streaming:
  enabled: true

platforms:
  feishu:
    extra:
      streaming_card: true   # default false, must be explicitly enabled
```

Env var: `FEISHU_STREAMING_CARD=true`

## Required Feishu permissions

- `cardkit:card`

## Credit

- **#27445** (WaveBird) — SDK builder usage, `streaming_config` parameters, tests and documentation
- **#25202** (PNGTRID) — inflight/dirty concurrency protection approach
- **Cheerwhy/hermes-lark-streaming** v0.9.0 — element limit splitting production validation
- **baileyh8/hermes-feishu-streaming-card** — concurrent PATCH race fix (baileyh8#31)
