### PR TITLE
chore(model): support minimax-m3 in minimax provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -200,7 +200,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,
-    # MiniMax — official docs: 204,800 context for all models
+    # MiniMax — M3 family: 1M context (launched 2026-06-01)
+    "minimax-m3": 1_000_000,
+    # MiniMax — M2 family: 204,800 context for all M2-series models
     # https://platform.minimax.io/docs/api-reference/text-anthropic-api
     "minimax": 204800,
     # GLM

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -277,16 +277,22 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M3",
+        "MiniMax-M3-highspeed",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",
         "MiniMax-M2",
     ],
     "minimax-oauth": [
+        "MiniMax-M3",
+        "MiniMax-M3-highspeed",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
     ],
     "minimax-cn": [
+        "MiniMax-M3",
+        "MiniMax-M3-highspeed",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -278,7 +278,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "minimax": [
         "MiniMax-M3",
-        "MiniMax-M3-highspeed",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",
@@ -286,13 +285,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "minimax-oauth": [
         "MiniMax-M3",
-        "MiniMax-M3-highspeed",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
     ],
     "minimax-cn": [
         "MiniMax-M3",
-        "MiniMax-M3-highspeed",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -219,6 +219,52 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_minimax_m3_models_1m_context(self):
+        """MiniMax M3 family: 1M context per official docs.
+
+        https://platform.minimax.io/docs/guides/models-intro
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        # M3 entries present and at 1M
+        assert "minimax-m3" in DEFAULT_CONTEXT_LENGTHS, "minimax-m3 key missing"
+        assert DEFAULT_CONTEXT_LENGTHS["minimax-m3"] == 1_000_000, (
+            f"minimax-m3 should be 1_000_000, got {DEFAULT_CONTEXT_LENGTHS['minimax-m3']}"
+        )
+
+        # M2 catch-all still at 204,800 (must not regress)
+        assert DEFAULT_CONTEXT_LENGTHS["minimax"] == 204_800, (
+            f"minimax catch-all should be 204_800, got {DEFAULT_CONTEXT_LENGTHS['minimax']}"
+        )
+
+        # Resolution: M3 should get 1M, M2 variants should still get 204,800.
+        # Isolate from network/cache so the lookup falls through to Step 8.
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            m3_cases = [
+                ("MiniMax-M3", 1_000_000),
+            ]
+            for model_id, expected in m3_cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected, (
+                    f"{model_id}: expected {expected}, got {actual}"
+                )
+
+            m2_cases = [
+                ("MiniMax-M2.7", 204_800),
+                ("MiniMax-M2.7-highspeed", 204_800),
+                ("MiniMax-M2.5", 204_800),
+                ("MiniMax-M2.1", 204_800),
+                ("MiniMax-M2", 204_800),
+            ]
+            for model_id, expected in m2_cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected, (
+                    f"{model_id}: expected {expected}, got {actual}"
+                )
+
 
 # =========================================================================
 # Codex OAuth context-window resolution (provider="openai-codex")

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -198,52 +198,6 @@ class TestDefaultContextLengths:
                 f"{key} should be {value}, got {DEFAULT_CONTEXT_LENGTHS[key]}"
             )
 
-    def test_minimax_m3_models_1m_context(self):
-        """M3 family: 1M context per official docs.
-
-        https://platform.minimax.io/docs/guides/models-intro
-        """
-        from unittest.mock import patch as mock_patch
-
-        # M3 entries present and at 1M
-        assert "minimax-m3" in DEFAULT_CONTEXT_LENGTHS, "minimax-m3 key missing"
-        assert DEFAULT_CONTEXT_LENGTHS["minimax-m3"] == 1_000_000, (
-            f"minimax-m3 should be 1_000_000, got {DEFAULT_CONTEXT_LENGTHS['minimax-m3']}"
-        )
-
-        # M2 catch-all still at 204,800 (must not regress)
-        assert DEFAULT_CONTEXT_LENGTHS["minimax"] == 204_800, (
-            f"minimax catch-all should be 204_800, got {DEFAULT_CONTEXT_LENGTHS['minimax']}"
-        )
-
-        # Resolution: M3 should get 1M, M2 variants should still get 204,800.
-        # Isolate from network/cache so the lookup falls through to Step 8.
-        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
-             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
-             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
-            m3_cases = [
-                ("Minimax-M3-highspeed", 1_000_000),
-                ("Minimax-M3", 1_000_000),
-            ]
-            for model_id, expected in m3_cases:
-                actual = get_model_context_length(model_id)
-                assert actual == expected, (
-                    f"{model_id}: expected {expected}, got {actual}"
-                )
-
-            m2_cases = [
-                ("MiniMax-M2.7", 204_800),
-                ("MiniMax-M2.7-highspeed", 204_800),
-                ("MiniMax-M2.5", 204_800),
-                ("MiniMax-M2.1", 204_800),
-                ("MiniMax-M2", 204_800),
-            ]
-            for model_id, expected in m2_cases:
-                actual = get_model_context_length(model_id)
-                assert actual == expected, (
-                    f"{model_id}: expected {expected}, got {actual}"
-                )
-
         # Longest-first substring matching must resolve both the bare V4
         # ids (native DeepSeek) and the vendor-prefixed forms (OpenRouter
         # / Nous Portal) to 1M without probing down to the legacy 128K

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -198,6 +198,52 @@ class TestDefaultContextLengths:
                 f"{key} should be {value}, got {DEFAULT_CONTEXT_LENGTHS[key]}"
             )
 
+    def test_minimax_m3_models_1m_context(self):
+        """M3 family: 1M context per official docs.
+
+        https://platform.minimax.io/docs/guides/models-intro
+        """
+        from unittest.mock import patch as mock_patch
+
+        # M3 entries present and at 1M
+        assert "minimax-m3" in DEFAULT_CONTEXT_LENGTHS, "minimax-m3 key missing"
+        assert DEFAULT_CONTEXT_LENGTHS["minimax-m3"] == 1_000_000, (
+            f"minimax-m3 should be 1_000_000, got {DEFAULT_CONTEXT_LENGTHS['minimax-m3']}"
+        )
+
+        # M2 catch-all still at 204,800 (must not regress)
+        assert DEFAULT_CONTEXT_LENGTHS["minimax"] == 204_800, (
+            f"minimax catch-all should be 204_800, got {DEFAULT_CONTEXT_LENGTHS['minimax']}"
+        )
+
+        # Resolution: M3 should get 1M, M2 variants should still get 204,800.
+        # Isolate from network/cache so the lookup falls through to Step 8.
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            m3_cases = [
+                ("Minimax-M3-highspeed", 1_000_000),
+                ("Minimax-M3", 1_000_000),
+            ]
+            for model_id, expected in m3_cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected, (
+                    f"{model_id}: expected {expected}, got {actual}"
+                )
+
+            m2_cases = [
+                ("MiniMax-M2.7", 204_800),
+                ("MiniMax-M2.7-highspeed", 204_800),
+                ("MiniMax-M2.5", 204_800),
+                ("MiniMax-M2.1", 204_800),
+                ("MiniMax-M2", 204_800),
+            ]
+            for model_id, expected in m2_cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected, (
+                    f"{model_id}: expected {expected}, got {actual}"
+                )
+
         # Longest-first substring matching must resolve both the bare V4
         # ids (native DeepSeek) and the vendor-prefixed forms (OpenRouter
         # / Nous Portal) to 1M without probing down to the legacy 128K


### PR DESCRIPTION
## What does this PR do?

1. Add MiniMax-M3 and MiniMax-M3 highspeed model in the Minimax、Minimax-oauth and minimax-cn catalogs.
2. Support 1M context.



## Related Issue

https://github.com/NousResearch/hermes-agent/issues/36196
