### PR TITLE
fix(tools): split concatenated streamed tool-call args

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -39,6 +39,42 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+
+def _split_concatenated_tool_call_arguments(raw_args: str) -> list[str] | None:
+    """Split ``{"..."}{"..."}`` tool-call payloads into separate JSON objects.
+
+    Some providers can concatenate multiple complete top-level argument
+    objects without delimiters when emitting parallel tool calls in a single
+    streaming chunk. Only return a split when the entire payload can be
+    losslessly decoded as 2+ complete dict objects; otherwise return None so
+    existing truncation handling stays in control.
+    """
+    if not isinstance(raw_args, str):
+        return None
+
+    raw_stripped = raw_args.strip()
+    if not raw_stripped:
+        return None
+
+    decoder = json.JSONDecoder()
+    pos = 0
+    decoded: list[str] = []
+    while pos < len(raw_stripped):
+        while pos < len(raw_stripped) and raw_stripped[pos].isspace():
+            pos += 1
+        if pos >= len(raw_stripped):
+            break
+        try:
+            parsed, end = decoder.raw_decode(raw_stripped, pos)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        decoded.append(json.dumps(parsed, separators=(",", ":")))
+        pos = end
+
+    return decoded if len(decoded) > 1 else None
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -1907,6 +1943,26 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 tc = tool_calls_acc[idx]
                 arguments = tc["function"]["arguments"]
                 tool_name = tc["function"]["name"] or "?"
+                split_arguments = _split_concatenated_tool_call_arguments(arguments)
+                if split_arguments:
+                    logger.warning(
+                        "Split concatenated tool_call arguments for %s into %d calls",
+                        tool_name,
+                        len(split_arguments),
+                    )
+                    base_id = tc["id"] or f"call_{idx}"
+                    for split_idx, split_arg in enumerate(split_arguments):
+                        split_id = base_id if split_idx == 0 else f"{base_id}_split_{split_idx}"
+                        mock_tool_calls.append(SimpleNamespace(
+                            id=split_id,
+                            type=tc["type"],
+                            extra_content=tc.get("extra_content"),
+                            function=SimpleNamespace(
+                                name=tc["function"]["name"],
+                                arguments=split_arg,
+                            ),
+                        ))
+                    continue
                 if arguments and arguments.strip():
                     try:
                         json.loads(arguments)

--- a/tests/test_model_tools_tool_call_payload_repair.py
+++ b/tests/test_model_tools_tool_call_payload_repair.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent import chat_completion_helpers as helper
+
+
+def test_split_concatenated_tool_call_arguments_returns_complete_dict_json_objects():
+    result = helper._split_concatenated_tool_call_arguments(
+        '{"path":"README.md"}{"query":"tool calls"}'
+    )
+    assert result == ['{"path":"README.md"}', '{"query":"tool calls"}']
+    assert [json.loads(item) for item in result] == [
+        {"path": "README.md"},
+        {"query": "tool calls"},
+    ]
+
+
+def test_split_concatenated_tool_call_arguments_rejects_single_partial_or_non_dict_payloads():
+    assert helper._split_concatenated_tool_call_arguments('{"path":"README.md"}') is None
+    assert helper._split_concatenated_tool_call_arguments('{"path":"README.md"}{"query":') is None
+    assert helper._split_concatenated_tool_call_arguments('[1,2]{"path":"README.md"}') is None
+    assert helper._split_concatenated_tool_call_arguments('') is None
+
+
+def test_streaming_reconstruction_wires_concatenated_argument_splitter():
+    source = Path(helper.__file__).read_text(encoding="utf-8")
+    assert "split_arguments = _split_concatenated_tool_call_arguments(arguments)" in source
+    assert "mock_tool_calls.append(SimpleNamespace(" in source
+    assert "split_idx" in source
+    assert "continue" in source


### PR DESCRIPTION
## What does this PR do?

Fixes streamed tool-call handling when a model emits multiple concatenated JSON tool-call argument payloads in one streamed argument buffer.

The repair splits adjacent complete JSON object payloads before reconstructing streamed mock tool calls, preventing concatenated tool-call arguments from being treated as a single invalid JSON blob.




## Related Issue


Fixes tool-call argument streaming failures observed with local Hermes/Qwen-style runtime usage.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Adds `_split_concatenated_tool_call_arguments(...)` handling in `agent/chat_completion_helpers.py`.
- Applies the splitter before streamed `mock_tool_calls` reconstruction.
- Adds focused regression coverage in `tests/test_model_tools_tool_call_payload_repair.py`.
- Preserves existing single-payload behavior and rejects incomplete/partial concatenations.

## How to Test

1. `./venv/bin/python -m pytest -q tests/test_model_tools_tool_call_payload_repair.py`
2. Confirm result: `3 passed`.
3. Confirm the branch contains only:
   - `agent/chat_completion_helpers.py`
   - `tests/test_model_tools_tool_call_payload_repair.py`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope): ...`)
- [x] I searched for existing PRs to make sure this isn’t a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / Fedora


### Documentation & Housekeeping


- [x] I've updated relevant documentation — N/A, behavior-only bug fix with regression test
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure Python parsing helper, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

 [x] N/A — this PR does not add a skill

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

