### PR TITLE
feat(telegram): accept .html/.htm document uploads and inject stripped text

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1112,6 +1112,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".html": "text/html",
+    ".htm": "text/html",
 }
 
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5534,6 +5534,28 @@ class TelegramAdapter(BasePlatformAdapter):
                             "[Telegram] Could not decode text file as UTF-8, skipping content injection",
                             exc_info=True,
                         )
+                elif ext in {".html", ".htm"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                    try:
+                        try:
+                            from bs4 import BeautifulSoup  # type: ignore
+                            text_content = BeautifulSoup(raw_bytes, "html.parser").get_text("\n", strip=True)
+                        except ImportError:
+                            # Fallback: crude tag strip if bs4 is not installed
+                            import html as _html
+                            raw_text = raw_bytes.decode("utf-8", errors="replace")
+                            text_content = _html.unescape(re.sub(r"<[^>]+>", "", raw_text)).strip()
+                        display_name = original_filename or f"document{ext}"
+                        display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+                        injection = f"[Content of {display_name} (HTML stripped to text)]:\n{text_content}"
+                        if event.text:
+                            event.text = f"{injection}\n\n{event.text}"
+                        else:
+                            event.text = injection
+                    except Exception:
+                        logger.warning(
+                            "[Telegram] Could not extract HTML text, skipping content injection",
+                            exc_info=True,
+                        )
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)


### PR DESCRIPTION
## Problem

`.html` files attached as Telegram documents are currently rejected:

```
Unsupported document type '.html'. Supported types: .cfg, .csv, .docx, .ini, .json, .log, .md, .pdf, .pptx, .py, .sh, .toml, .ts, .txt, .xlsx, .xml, .yaml, .yml, .zip
```

This blocks a common workflow — sending exported web pages, saved articles, design runbooks, or HTML reports straight into a chat.

## Fix

1. Add `.html` and `.htm` → `text/html` to `SUPPORTED_DOCUMENT_TYPES` in `gateway/platforms/base.py`.
2. Extend the existing text-injection branch in `gateway/platforms/telegram.py` (currently only handles `.md` / `.txt`) with an HTML→text path:
   - Uses `BeautifulSoup` when available (clean structured strip).
   - Falls back to a small regex + `html.unescape` strip when `bs4` isn't installed — so this **does not introduce a new hard dependency**.
   - Reuses the same 100 KB injection cap.
   - `ImportError`-only fallback keeps genuine parse failures surfaceable via the outer `logger.warning`.

## Behaviour after the patch

User sends `runbook.html` (25 KB) → Hermes injects:

```
[Content of runbook.html (HTML stripped to text)]:
<clean text of the page>
```

…into `event.text` exactly like `.md` / `.txt` today. The cached file path is still attached to `media_urls`.

## Why inline-text injection (not just whitelisting)

Whitelisting alone would cache the file but leave the agent with raw `<div>` markup or no content at all. The existing `.md`/`.txt` injection pattern already establishes the precedent.

## Out of scope

- Discord adapter — same gap exists there (same log line); happy to follow up in a separate PR.
- Adding `beautifulsoup4` to `pyproject.toml` — left out intentionally; the regex fallback is sufficient and avoids dependency churn.

## Test plan

1. Send any `.html` file ≤100 KB from a Telegram chat to a Hermes instance.
2. Confirm agent receives the content (no rejection) and can answer questions grounded in the file.

Verified locally with a 25 KB `.html` runbook on a live Hermes profile.
