### PR TITLE
fix(agent): skip completion notification for killed processes (#36184)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15419,8 +15419,9 @@ class GatewayRunner:
             if session.exited:
                 # --- Agent-triggered completion: inject synthetic message ---
                 # Skip if the agent already consumed the result via wait/poll/log
+                # or if the process was explicitly killed by the user (#36184)
                 from tools.process_registry import process_registry as _pr_check
-                if agent_notify and not _pr_check.is_completion_consumed(session_id):
+                if agent_notify and not _pr_check.is_completion_consumed(session_id) and not _pr_check.is_killed(session_id):
                     from tools.ansi_strip import strip_ansi
                     _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
                     # Truncate at line boundaries so notifications never start

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -171,6 +171,11 @@ class ProcessRegistry:
         # via wait/poll/log.  Drain loops skip notifications for these.
         self._completion_consumed: set = set()
 
+        # Track sessions that were explicitly killed by the user/agent.
+        # Completion watchers skip notifications for these so the agent
+        # doesn't present results the user already cancelled.  (#36184)
+        self._killed_sessions: set = set()
+
         # Global watch-match circuit breaker — across all sessions.
         # Prevents sibling processes from collectively flooding the user even
         # when each stays under its own per-session cap.
@@ -891,6 +896,14 @@ class ProcessRegistry:
         """Check if a completion notification was already consumed via wait/poll/log."""
         return session_id in self._completion_consumed
 
+    def mark_killed(self, session_id: str) -> None:
+        """Mark a session as explicitly killed so watchers skip notifications."""
+        self._killed_sessions.add(session_id)
+
+    def is_killed(self, session_id: str) -> bool:
+        """Return True if the session was explicitly killed by the user/agent."""
+        return session_id in self._killed_sessions
+
     def drain_notifications(self) -> "list[tuple[dict, str]]":
         """Pop all pending notification events and return formatted pairs.
 
@@ -1192,6 +1205,7 @@ class ProcessRegistry:
                 }
             session.exited = True
             session.exit_code = -15  # SIGTERM
+            self.mark_killed(session_id)
             self._move_to_finished(session)
             self._write_checkpoint()
             return {"status": "killed", "session_id": session.id}
@@ -1352,6 +1366,7 @@ class ProcessRegistry:
         for sid in expired:
             del self._finished[sid]
             self._completion_consumed.discard(sid)
+            self._killed_sessions.discard(sid)
 
         # If still over limit, remove oldest finished
         total = len(self._running) + len(self._finished)
@@ -1359,6 +1374,7 @@ class ProcessRegistry:
             oldest_id = min(self._finished, key=lambda sid: self._finished[sid].started_at)
             del self._finished[oldest_id]
             self._completion_consumed.discard(oldest_id)
+            self._killed_sessions.discard(oldest_id)
 
         # Drop any _completion_consumed entries whose sessions are no longer
         # tracked at all — belt-and-suspenders against module-lifetime growth
@@ -1367,6 +1383,9 @@ class ProcessRegistry:
         stale = self._completion_consumed - tracked
         if stale:
             self._completion_consumed -= stale
+        stale_killed = self._killed_sessions - tracked
+        if stale_killed:
+            self._killed_sessions -= stale_killed
 
     # ----- Checkpoint (crash recovery) -----
 


### PR DESCRIPTION
## Problem

When a user cancels a background process (says "no need" and the agent kills it via `process(action='kill')`), the process may still complete before the SIGTERM lands. The completion watcher then injects a `[IMPORTANT: Background process proc_xxx completed]` notification, causing the agent to present results the user explicitly said they did not want.

**Root cause**: The watcher checks `_completion_consumed` (set by `wait`/`poll`/`log`) but has no concept of "killed" sessions. When the agent kills a process, it doesn't poll the result, so `_completion_consumed` stays empty and the notification is still injected.

## Fix

Add a `_killed_sessions` set to `ProcessRegistry` that tracks sessions explicitly killed via `kill_process()`. The completion watcher checks this set and skips the notification for killed sessions.

### Changes

**`tools/process_registry.py`:**
- Add `self._killed_sessions: set = set()` in `__init__`
- Add `mark_killed(session_id)` and `is_killed(session_id)` methods
- Call `mark_killed()` in `kill_process()` after successful kill
- Add cleanup for `_killed_sessions` in `_gc_finished()` alongside `_completion_consumed`

**`gateway/run.py`:**
- Add `not _pr_check.is_killed(session_id)` check to the completion notification guard

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| User says "cancel", agent kills process, process exits before SIGTERM | Agent presents full results | Notification silently skipped |
| User says "cancel", agent kills process, process already exited | Agent presents full results | Notification silently skipped |
| Normal background process completion | Notification injected | Notification injected (unchanged) |
| Agent polls result via `wait`/`poll` | Notification skipped | Notification skipped (unchanged) |

## Tests

The fix is minimal and self-contained:
- `_killed_sessions` follows the same pattern as `_completion_consumed` (add on event, check before injection, cleanup on GC)
- No new external dependencies
- Existing `is_completion_consumed` behavior is unchanged

Fixes #36184
