### PR TITLE
feat(models): add MiniMax-M3 + highspeed variants to direct minimax provider list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -295,9 +295,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
     "minimax-oauth": [


### PR DESCRIPTION
## Summary

PR #36191 added `minimax/minimax-m3` to the OpenRouter and Nous portal curated lists, but the **direct** `minimax` provider list at `_PROVIDER_MODELS["minimax"]` was still missing M3 — so the `/model` picker did not surface M3 for users on the `api.minimax.io` endpoint.

While I was in there, I also added the `-highspeed` variants for M2.7, M2.5, M2.1 that were also missing.

## Changes

```diff
     "minimax": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
     ],
```

## Verification

Live API at `https://api.minimax.io/anthropic/v1/models` confirms all four new IDs are valid:
- `MiniMax-M3` (released 2026-06-01, natively multimodal, 1M context)
- `MiniMax-M2.7-highspeed`
- `MiniMax-M2.5-highspeed`
- `MiniMax-M2.1-highspeed`

Ref: https://platform.minimax.io/docs/guides/models-intro