### PR TITLE
feat(models): add MiniMax-M3 to native minimax providers + 1M context

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -200,8 +200,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,
-    # MiniMax — official docs: 204,800 context for all models
-    # https://platform.minimax.io/docs/api-reference/text-anthropic-api
+    # MiniMax — M3 is 1M context (max output 512K); M2.x series is 204,800.
+    # Keys use substring matching (longest-first), so "minimax-m3" wins over
+    # the generic "minimax" catch-all for the M3 slug on every surface
+    # (native MiniMax-M3, OpenRouter/Nous minimax/minimax-m3).
+    # https://platform.minimax.io/docs/api-reference/text-chat-openai
+    "minimax-m3": 1000000,
     "minimax": 204800,
     # GLM
     "glm": 202752,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -295,16 +295,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",
         "MiniMax-M2",
     ],
     "minimax-oauth": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
     ],
     "minimax-cn": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",


### PR DESCRIPTION
## Summary
`MiniMax-M3` now appears in the native MiniMax provider model pickers (`minimax`, `minimax-oauth`, `minimax-cn`), and resolves to its correct 1M context length on every surface.

## Why this needed a manual edit
The native MiniMax provider lists are hardcoded in `_PROVIDER_MODELS` — they are not in `_MODELS_DEV_PREFERRED`, have no `providers/` profile, and the MiniMax inference endpoint is Anthropic-format (`/anthropic`) with no OpenAI-style `/v1/models` listing. So new models don't auto-pull; they fall through to the static curated list and must be added by hand. (OpenRouter `minimax/minimax-m3` and the Nous list were already updated in PR #36191.)

## Changes
- `hermes_cli/models.py`: add `MiniMax-M3` to the top of the `minimax`, `minimax-oauth`, and `minimax-cn` lists.
- `agent/model_metadata.py`: add `DEFAULT_CONTEXT_LENGTHS` key `"minimax-m3": 1000000`. Longest-key-first substring matching makes it win over the generic `"minimax": 204800` catch-all, so M3 resolves to 1M (native + OpenRouter/Nous slug) while the M2.x series stays at 204,800.

## Model facts (from MiniMax docs)
- ID `MiniMax-M3`, 1M context, max output 524,288 (512K), multimodal (text + image + video).
- https://platform.minimax.io/docs/api-reference/text-chat-openai

## Validation
| Input | Resolves to |
|---|---|
| `MiniMax-M3` / `minimax/minimax-m3` | 1,000,000 ctx |
| `MiniMax-M2.7` / `minimax/minimax-m2.7` | 204,800 ctx (unchanged) |

E2E-verified via live resolver test: `MiniMax-M3` is first in all three native lists, and the longest-key-first substring match picks `minimax-m3` for M3 while M2.x still hits the generic `minimax` key.

## Infographic

![minimax-m3-native-providers](https://v3b.fal.media/files/b/0a9c7f44/Sb8emsnmNY121nJOVoeF7_7BzOsSAK.png)
