### PR TITLE
fix(tests): repair GUI and model catalog CI regressions

### DIFF
--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -60,12 +60,14 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok) as mock_install, \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup") as mock_fixup, \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
     mock_install.assert_called_once_with("/usr/bin/npm", root, capture_output=False)
+    mock_fixup.assert_called_once_with(desktop_dir)
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
     assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
@@ -85,6 +87,7 @@ def test_gui_forwards_desktop_environment_overrides(tmp_path, monkeypatch):
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
          pytest.raises(SystemExit):
         cli_main.cmd_gui(_ns(

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-31T03:27:32Z",
+  "updated_at": "2026-06-01T03:21:27Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -77,7 +77,7 @@
           "description": "recommended"
         },
         {
-          "id": "minimax/minimax-m2.7",
+          "id": "minimax/minimax-m3",
           "description": ""
         },
         {
@@ -178,7 +178,7 @@
           "id": "moonshotai/kimi-k2.6"
         },
         {
-          "id": "minimax/minimax-m2.7"
+          "id": "minimax/minimax-m3"
         },
         {
           "id": "z-ai/glm-5.1"


### PR DESCRIPTION
## Summary

Repairs two current `main` CI regressions that are unrelated to feature code:

- updates the desktop GUI launcher tests to mock the macOS relaunchability fixup added by #36198, so the existing `subprocess.run` launch assertions do not exhaust their mocked side effects
- regenerates `website/static/api/model-catalog.json` after the MiniMax model list moved from `minimax/minimax-m2.7` to `minimax/minimax-m3`

## Why

The current test workflow can fail on branches that only rebase onto recent `main` because these regressions are already present on `main`:

- `tests/hermes_cli/test_gui_command.py` fails with `StopIteration` after the new macOS fixup introduces an additional subprocess call inside the package path.
- `tests/hermes_cli/test_model_catalog.py` reports that `website/static/api/model-catalog.json` is out of sync with the in-repo provider model lists.

## Validation

```bash
python -m pytest -o addopts='' tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_model_catalog.py -q
python -m py_compile tests/hermes_cli/test_gui_command.py
git diff --check
```

Results:

- `36 passed`
- `py_compile ok`
- `diff check ok`
