### PR TITLE
Fix Codex gpt-5.5 stream stalls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -464,7 +464,7 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
         claims = json.loads(base64.urlsafe_b64decode(payload_b64))
         acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
         if isinstance(acct_id, str) and acct_id:
-            headers["ChatGPT-Account-ID"] = acct_id
+            headers["ChatGPT-Account-Id"] = acct_id
     except Exception:
         pass
     return headers

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -17,12 +17,20 @@ compatibility.
 from __future__ import annotations
 
 import logging
+import json
 import os
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def run_codex_app_server_turn(
@@ -419,6 +427,103 @@ def _consume_codex_event_stream(
     return final
 
 
+def _iter_httpx_sse_events(response: Any):
+    """Yield raw SSE data frames from an httpx streaming response."""
+    data_lines: list[str] = []
+
+    def _flush():
+        if not data_lines:
+            return None
+        payload = "\n".join(data_lines).strip()
+        data_lines.clear()
+        if not payload or payload == "[DONE]":
+            return None
+        return json.loads(payload)
+
+    for line in response.iter_lines():
+        if isinstance(line, bytes):
+            line = line.decode("utf-8", errors="replace")
+        line = str(line)
+        if line == "":
+            event = _flush()
+            if event is not None:
+                yield event
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+
+    event = _flush()
+    if event is not None:
+        yield event
+
+
+def _should_use_raw_codex_httpx(agent) -> bool:
+    """Bypass the OpenAI SDK stream wrapper for ChatGPT Codex backend."""
+    if _env_enabled("HERMES_CODEX_DISABLE_RAW_HTTPX", default=False):
+        return False
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    base_url = str(getattr(agent, "base_url", "") or "").strip().lower()
+    return provider == "openai-codex" and "chatgpt.com/backend-api/codex" in base_url
+
+
+def _run_codex_raw_httpx_stream(agent, api_kwargs: dict, *, on_first_delta=None):
+    import httpx as _httpx
+
+    body = dict(api_kwargs)
+    extra_headers = body.pop("extra_headers", None)
+    timeout_value = body.pop("timeout", None)
+    body["stream"] = True
+    body = {key: value for key, value in body.items() if value is not None}
+
+    api_key = str(
+        getattr(agent, "api_key", "")
+        or getattr(agent, "_client_kwargs", {}).get("api_key", "")
+        or ""
+    ).strip()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+    default_headers = getattr(agent, "_client_kwargs", {}).get("default_headers")
+    if isinstance(default_headers, dict):
+        headers.update({str(k): str(v) for k, v in default_headers.items() if v is not None})
+    if isinstance(extra_headers, dict):
+        headers.update({str(k): str(v) for k, v in extra_headers.items() if v is not None})
+
+    read_timeout = os.getenv("HERMES_CODEX_RAW_READ_TIMEOUT_SECONDS")
+    if read_timeout is not None:
+        read_timeout_s = max(1.0, float(read_timeout))
+    elif isinstance(timeout_value, (int, float)) and not isinstance(timeout_value, bool):
+        read_timeout_s = max(10.0, float(timeout_value))
+    else:
+        read_timeout_s = 120.0
+
+    timeout = _httpx.Timeout(connect=20.0, read=read_timeout_s, write=30.0, pool=20.0)
+    url = f"{str(getattr(agent, 'base_url', '')).rstrip('/')}/responses"
+
+    def _on_text_delta(text: str) -> None:
+        agent._codex_streamed_text_parts.append(text)
+        agent._fire_stream_delta(text)
+
+    def _on_event(_event: Any) -> None:
+        agent._codex_stream_last_event_ts = time.time()
+        agent._touch_activity("receiving stream response")
+
+    with _httpx.Client(timeout=timeout) as http_client:
+        with http_client.stream("POST", url, headers=headers, json=body) as response:
+            response.raise_for_status()
+            return _consume_codex_event_stream(
+                _iter_httpx_sse_events(response),
+                model=api_kwargs.get("model"),
+                on_text_delta=_on_text_delta,
+                on_reasoning_delta=agent._fire_reasoning_delta,
+                on_first_delta=on_first_delta,
+                on_event=_on_event,
+                interrupt_check=lambda: bool(agent._interrupt_requested),
+            )
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
@@ -458,6 +563,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         stream_kwargs["stream"] = True
 
         try:
+            if _should_use_raw_codex_httpx(agent):
+                return _run_codex_raw_httpx_stream(
+                    agent, stream_kwargs, on_first_delta=on_first_delta
+                )
             event_stream = active_client.responses.create(**stream_kwargs)
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -16,7 +16,7 @@ all emit the same headers.
 These tests pin:
 - the originator value (must be ``codex_cli_rs`` — the whitelisted one)
 - the User-Agent shape (codex_cli_rs-prefixed)
-- ``ChatGPT-Account-ID`` extraction from the OAuth JWT (canonical casing,
+- ``ChatGPT-Account-Id`` extraction from the OAuth JWT (canonical casing,
   from codex-rs ``auth.rs``)
 - graceful handling of malformed tokens (drop the account-ID header, don't
   raise)
@@ -73,16 +73,16 @@ class TestCodexCloudflareHeaders:
         from agent.auxiliary_client import _codex_cloudflare_headers
         headers = _codex_cloudflare_headers(_make_codex_jwt("acct-abc-999"))
         # Canonical casing — matches codex-rs auth.rs
-        assert headers["ChatGPT-Account-ID"] == "acct-abc-999"
+        assert headers["ChatGPT-Account-Id"] == "acct-abc-999"
 
     def test_canonical_header_casing(self):
-        """Upstream codex-rs uses PascalCase with trailing -ID. Match exactly."""
+        """Upstream codex-rs uses PascalCase with trailing -Id. Match exactly."""
         from agent.auxiliary_client import _codex_cloudflare_headers
         headers = _codex_cloudflare_headers(_make_codex_jwt())
-        assert "ChatGPT-Account-ID" in headers
+        assert "ChatGPT-Account-Id" in headers
         # The lowercase/titlecase variants MUST NOT be used — pin to be explicit
         assert "chatgpt-account-id" not in headers
-        assert "ChatGPT-Account-Id" not in headers
+        assert "ChatGPT-Account-ID" not in headers
 
     def test_malformed_token_drops_account_id_without_raising(self):
         from agent.auxiliary_client import _codex_cloudflare_headers
@@ -90,13 +90,13 @@ class TestCodexCloudflareHeaders:
             headers = _codex_cloudflare_headers(bad)
             # Still returns base headers — never raises
             assert headers["originator"] == "codex_cli_rs"
-            assert "ChatGPT-Account-ID" not in headers
+            assert "ChatGPT-Account-Id" not in headers
 
     def test_non_string_token_handled(self):
         from agent.auxiliary_client import _codex_cloudflare_headers
         headers = _codex_cloudflare_headers(None)  # type: ignore[arg-type]
         assert headers["originator"] == "codex_cli_rs"
-        assert "ChatGPT-Account-ID" not in headers
+        assert "ChatGPT-Account-Id" not in headers
 
     def test_jwt_without_chatgpt_account_id_claim(self):
         """A valid JWT that lacks the account_id claim should still return headers."""
@@ -109,7 +109,7 @@ class TestCodexCloudflareHeaders:
         token = f"{b64url(b'{}')}.{payload}.{b64url(b'sig')}"
         headers = _codex_cloudflare_headers(token)
         assert headers["originator"] == "codex_cli_rs"
-        assert "ChatGPT-Account-ID" not in headers
+        assert "ChatGPT-Account-Id" not in headers
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +133,7 @@ class TestPrimaryClientWiring:
             )
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("originator") == "codex_cli_rs"
-            assert headers.get("ChatGPT-Account-ID") == "acct-primary-init"
+            assert headers.get("ChatGPT-Account-Id") == "acct-primary-init"
             assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
 
     def test_apply_client_headers_on_base_url_change(self):
@@ -158,7 +158,7 @@ class TestPrimaryClientWiring:
             )
             headers = agent._client_kwargs.get("default_headers") or {}
             assert headers.get("originator") == "codex_cli_rs"
-            assert headers.get("ChatGPT-Account-ID") == "acct-rotation"
+            assert headers.get("ChatGPT-Account-Id") == "acct-rotation"
             assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
 
     def test_apply_client_headers_clears_codex_headers_off_chatgpt(self):
@@ -229,7 +229,7 @@ class TestAuxiliaryClientWiring:
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("originator") == "codex_cli_rs"
-            assert headers.get("ChatGPT-Account-ID") == "acct-aux-try-codex"
+            assert headers.get("ChatGPT-Account-Id") == "acct-aux-try-codex"
             assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
 
     def test_resolve_provider_client_raw_codex_passes_codex_headers(self, monkeypatch):
@@ -249,5 +249,5 @@ class TestAuxiliaryClientWiring:
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("originator") == "codex_cli_rs"
-            assert headers.get("ChatGPT-Account-ID") == "acct-aux-raw-codex"
+            assert headers.get("ChatGPT-Account-Id") == "acct-aux-raw-codex"
             assert headers.get("User-Agent", "").startswith("codex_cli_rs/")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -41,6 +41,7 @@ def _patch_agent_bootstrap(monkeypatch):
 
 def _build_agent(monkeypatch):
     _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_DISABLE_RAW_HTTPX", "1")
 
     agent = run_agent.AIAgent(
         model="gpt-5-codex",
@@ -55,6 +56,51 @@ def _build_agent(monkeypatch):
     agent._persist_session = lambda messages, history=None: None
     agent._save_trajectory = lambda messages, user_message, completed: None
     return agent
+
+
+def test_codex_raw_httpx_bypass_only_targets_chatgpt_codex_backend(monkeypatch):
+    from agent.codex_runtime import _should_use_raw_codex_httpx
+
+    agent = SimpleNamespace(
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+    assert _should_use_raw_codex_httpx(agent) is True
+
+    monkeypatch.setenv("HERMES_CODEX_DISABLE_RAW_HTTPX", "1")
+    assert _should_use_raw_codex_httpx(agent) is False
+
+    monkeypatch.delenv("HERMES_CODEX_DISABLE_RAW_HTTPX")
+    assert _should_use_raw_codex_httpx(
+        SimpleNamespace(provider="openrouter", base_url="https://chatgpt.com/backend-api/codex")
+    ) is False
+    assert _should_use_raw_codex_httpx(
+        SimpleNamespace(provider="openai-codex", base_url="https://api.openai.com/v1")
+    ) is False
+
+
+def test_iter_httpx_sse_events_parses_data_frames():
+    from agent.codex_runtime import _iter_httpx_sse_events
+
+    response = SimpleNamespace(
+        iter_lines=lambda: iter(
+            [
+                "event: response.created",
+                'data: {"type":"response.created"}',
+                "",
+                "event: response.output_text.delta",
+                'data: {"type":"response.output_text.delta","delta":"ok"}',
+                "",
+                "data: [DONE]",
+                "",
+            ]
+        )
+    )
+
+    assert list(_iter_httpx_sse_events(response)) == [
+        {"type": "response.created"},
+        {"type": "response.output_text.delta", "delta": "ok"},
+    ]
 
 
 def _build_copilot_agent(monkeypatch, *, model="gpt-5.4"):


### PR DESCRIPTION
## Summary
- bypass the OpenAI SDK stream wrapper for ChatGPT Codex backend by consuming SSE directly with httpx
- keep the normal Hermes runtime/tool loop; this does not route through codex_app_server
- align ChatGPT-Account-Id header casing with the Codex client behavior

## Testing
- HERMES_HOME=/tmp/hermes-test PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider tests/agent/test_codex_cloudflare_headers.py tests/run_agent/test_run_agent_codex_responses.py -q
- hermes -z "Responda apenas: ok" --provider openai-codex --model gpt-5.5 --ignore-rules