### PR TITLE
fix: add system prompt guidance when Tool Search is active

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,6 +187,15 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+TOOL_SEARCH_GUIDANCE = (
+    "Many MCP and plugin tools are loaded on demand via tool_search. "
+    "Before concluding a capability is unavailable, always call "
+    "tool_search(\"keyword\") to check for a matching deferred tool. "
+    "Deferred MCP tools are fully connected and authenticated — "
+    "prefer them over skill-based alternatives that may require "
+    "separate setup."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -223,6 +223,15 @@ SKILLS_GUIDANCE = (
     "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
 )
 
+TOOL_SEARCH_GUIDANCE = (
+    "Many MCP and plugin tools are loaded on demand via tool_search. "
+    "Before concluding a capability is unavailable, always call "
+    "tool_search(\"keyword\") to check for a matching deferred tool. "
+    "Deferred MCP tools are fully connected and authenticated — "
+    "prefer them over skill-based alternatives that may require "
+    "separate setup."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -41,6 +41,7 @@ from agent.prompt_builder import (
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
     TELEGRAM_RICH_MESSAGES_HINT,
+    TOOL_SEARCH_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
@@ -225,6 +226,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    if "tool_search" in agent.valid_tool_names:
+        tool_guidance.append(TOOL_SEARCH_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -45,6 +45,7 @@ from agent.prompt_builder import (
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
     TELEGRAM_RICH_MESSAGES_HINT,
+    TOOL_SEARCH_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
@@ -420,6 +421,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    if "tool_search" in agent.valid_tool_names:
+        tool_guidance.append(TOOL_SEARCH_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -260,6 +260,28 @@ def agent_with_memory_tool():
         return a
 
 
+@pytest.fixture()
+def agent_with_tool_search():
+    """Agent whose valid_tool_names includes 'tool_search'."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "tool_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-k...7890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()
@@ -1395,6 +1417,18 @@ class TestBuildSystemPrompt:
 
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
+
+    def test_tool_search_guidance_when_tool_loaded(self, agent_with_tool_search):
+        from agent.prompt_builder import TOOL_SEARCH_GUIDANCE
+
+        prompt = agent_with_tool_search._build_system_prompt()
+        assert TOOL_SEARCH_GUIDANCE in prompt
+
+    def test_no_tool_search_guidance_without_tool(self, agent):
+        from agent.prompt_builder import TOOL_SEARCH_GUIDANCE
+
+        prompt = agent._build_system_prompt()
+        assert TOOL_SEARCH_GUIDANCE not in prompt
 
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -201,6 +201,28 @@ def agent_with_memory_tool():
         return a
 
 
+@pytest.fixture()
+def agent_with_tool_search():
+    """Agent whose valid_tool_names includes 'tool_search'."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "tool_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-k...7890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()
@@ -914,6 +936,17 @@ class TestBuildSystemPrompt:
         assert MEMORY_GUIDANCE in prompt
 
 
+    def test_tool_search_guidance_when_tool_loaded(self, agent_with_tool_search):
+        from agent.prompt_builder import TOOL_SEARCH_GUIDANCE
+
+        prompt = agent_with_tool_search._build_system_prompt()
+        assert TOOL_SEARCH_GUIDANCE in prompt
+
+    def test_no_tool_search_guidance_without_tool(self, agent):
+        from agent.prompt_builder import TOOL_SEARCH_GUIDANCE
+
+        prompt = agent._build_system_prompt()
+        assert TOOL_SEARCH_GUIDANCE not in prompt
 
     def test_datetime_is_date_only_not_minute_precision(self, agent):
         """Timestamp must be date-only (no HH:MM) so the system prompt


### PR DESCRIPTION
## Problem

When Tool Search activates and defers MCP/plugin tools behind the bridge tools (`tool_search`/`tool_describe`/`tool_call`), there is no system prompt guidance telling the model to search for deferred tools before concluding a capability is unavailable.

**Observed behavior:** User asks "what is my first meeting tomorrow?" The model sees a `google-workspace` skill in the skills listing, loads it, finds missing OAuth credentials, and tells the user the capability isn't set up -- never discovering the fully-connected `mcp_google_workspace_get_events` tool that's deferred behind `tool_search`.

**Expected behavior:** The model should call `tool_search("calendar")` before falling back to skills or giving up, discovering the connected MCP tool.

## Fix

Add `TOOL_SEARCH_GUIDANCE` to `prompt_builder.py` and inject it into the system prompt when `tool_search` is in the session's `valid_tool_names`. Follows the existing pattern used by `MEMORY_GUIDANCE`, `SESSION_SEARCH_GUIDANCE`, and `SKILLS_GUIDANCE`.

The guidance tells the model:
- MCP and plugin tools are loaded on demand via `tool_search`
- Always call `tool_search` before concluding a capability is unavailable
- Deferred MCP tools are fully connected and authenticated
- Prefer them over skill-based alternatives that may require separate setup

12 lines across 2 files, no new dependencies.

Signed-off-by: Chris van Hoof <vanhoof@ouwish.com>