### PR TITLE
fix(gateway): Slack/Discord チャンネルにリセット前セッションの軽量な継続ヒントを出す

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1032,6 +1032,7 @@ from gateway.session import (
     SessionContext,
     build_session_context,
     build_session_context_prompt,
+    build_channel_continuity_note,
     build_session_key,
     is_shared_multi_user_session,
 )
@@ -8537,6 +8538,14 @@ class GatewayRunner:
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
             else:
                 context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
+            # Slack/Discord channels/threads are long-lived: point the agent at
+            # the specific prior same-channel session so it recalls that context
+            # via session_search instead of an unrelated recent session.  Returns
+            # None (appends nothing) for other platforms or when there's no prior
+            # activity to recall.  Deterministic — no extra API/DB calls.
+            continuity_note = build_channel_continuity_note(session_entry, source)
+            if continuity_note:
+                context_note = context_note + "\n\n" + continuity_note
             context_prompt = context_note + "\n\n" + context_prompt
 
             # Send a user-facing notification explaining the reset, unless:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -421,6 +421,46 @@ def build_session_context_prompt(
     return "\n".join(lines)
 
 
+def build_channel_continuity_note(
+    entry: "SessionEntry",
+    source: SessionSource,
+) -> Optional[str]:
+    """Build a lightweight session-continuity hint for Slack/Discord channels.
+
+    Slack and Discord channels/threads are long-lived: when the daily/idle
+    reset policy starts a fresh session, the agent loses the thread's prior
+    context and can mistakenly bind a new request to an unrelated recent
+    session.  This deterministic one-line hint points the agent at the
+    specific prior session in *this* channel/thread so it recalls that
+    context via ``session_search`` before acting.
+
+    Returns ``None`` (and the caller adds nothing) unless **all** hold:
+      - the source platform is Slack or Discord,
+      - this session was created by an auto-reset that had real activity,
+      - the previous session_id was recorded on the entry.
+
+    No LLM calls, no extra API/DB lookups — the previous session id is
+    already known from :meth:`SessionStore.get_or_create_session`.
+    """
+    if source.platform not in (Platform.SLACK, Platform.DISCORD):
+        return None
+    if not getattr(entry, "reset_had_activity", False):
+        return None
+    prev = getattr(entry, "prev_session_id", None)
+    if not prev:
+        return None
+
+    where = "thread" if source.thread_id else "channel"
+    return (
+        f"[System note: This {where} had an earlier Hermes session "
+        f"(session_id: {prev}) that was auto-reset. If the user refers to "
+        f"earlier work here, or the request depends on this {where}'s history, "
+        f"use the session_search tool to recall that prior session before "
+        f"acting — do not assume an unrelated recent session is the right "
+        f"context.]"
+    )
+
+
 @dataclass
 class SessionEntry:
     """
@@ -458,6 +498,13 @@ class SessionEntry:
     was_auto_reset: bool = False
     auto_reset_reason: Optional[str] = None  # "idle" or "daily"
     reset_had_activity: bool = False  # whether the expired session had any messages
+
+    # When this session was created by an auto-reset, the session_id of the
+    # session it replaced.  Used to give Slack/Discord channels/threads a
+    # lightweight continuity hint (see build_channel_continuity_note) so the
+    # agent recalls the prior same-channel session via session_search instead
+    # of binding the request to an unrelated recent session.
+    prev_session_id: Optional[str] = None
 
     # Set by reset_session() when the user explicitly sends /new or /reset.
     # Consumed once by _handle_message_with_agent to trigger topic/channel
@@ -521,6 +568,7 @@ class SessionEntry:
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
+            "prev_session_id": self.prev_session_id,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -573,6 +621,7 @@ class SessionEntry:
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
             reset_had_activity=data.get("reset_had_activity", False),
+            prev_session_id=data.get("prev_session_id"),
         )
 
 
@@ -909,10 +958,12 @@ class SessionStore:
                     # Track whether the expired session had any real conversation
                     reset_had_activity = entry.total_tokens > 0
                     db_end_session_id = entry.session_id
+                    prev_session_id = entry.session_id
             else:
                 was_auto_reset = False
                 auto_reset_reason = None
                 reset_had_activity = False
+                prev_session_id = None
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -929,6 +980,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                prev_session_id=prev_session_id,
             )
 
             self._entries[session_key] = entry

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -1,0 +1,137 @@
+"""Tests for the lightweight Slack/Discord channel session-continuity hint.
+
+Covers:
+- SessionStore records the previous session_id on auto-reset (and only then).
+- prev_session_id survives a to_dict() → from_dict() roundtrip (gateway restart).
+- build_channel_continuity_note() emits a hint only for Slack/Discord sessions
+  that were auto-reset with real prior activity, and stays silent otherwise.
+"""
+
+from datetime import datetime, timedelta
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import (
+    SessionEntry,
+    SessionSource,
+    SessionStore,
+    build_channel_continuity_note,
+)
+
+
+def _make_store(policy=None, tmp_path=None):
+    config = GatewayConfig()
+    if policy:
+        config.default_reset_policy = policy
+    return SessionStore(sessions_dir=tmp_path or "/tmp/test-sessions", config=config)
+
+
+def _slack_source(thread_id=None):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="thread" if thread_id else "channel",
+        user_id="U1",
+        thread_id=thread_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SessionStore records prev_session_id on auto-reset
+# ---------------------------------------------------------------------------
+
+class TestPrevSessionIdCapture:
+    def test_prev_session_id_set_on_auto_reset(self, tmp_path):
+        store = _make_store(SessionResetPolicy(mode="idle", idle_minutes=1), tmp_path)
+        source = _slack_source(thread_id="T9")
+
+        entry1 = store.get_or_create_session(source)
+        assert entry1.prev_session_id is None  # fresh session, nothing replaced
+
+        entry1.total_tokens = 4000  # had real conversation
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+        assert entry2.was_auto_reset is True
+        assert entry2.prev_session_id == entry1.session_id
+
+    def test_prev_session_id_none_without_reset(self, tmp_path):
+        store = _make_store(tmp_path=tmp_path)
+        source = _slack_source()
+
+        entry = store.get_or_create_session(source)
+        assert entry.prev_session_id is None
+
+    def test_prev_session_id_persists_across_roundtrip(self, tmp_path):
+        store = _make_store(SessionResetPolicy(mode="idle", idle_minutes=1), tmp_path)
+        source = _slack_source()
+
+        entry1 = store.get_or_create_session(source)
+        entry1.total_tokens = 1000
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+        assert entry2.prev_session_id == entry1.session_id
+
+        # Simulate gateway restart: reload from disk.
+        store._loaded = False
+        store._entries.clear()
+        store._ensure_loaded()
+
+        reloaded = store._entries.get(entry2.session_key)
+        assert reloaded is not None
+        assert reloaded.prev_session_id == entry1.session_id
+
+
+# ---------------------------------------------------------------------------
+# build_channel_continuity_note
+# ---------------------------------------------------------------------------
+
+def _reset_entry(platform, prev="20240101_000000_abc", had_activity=True):
+    return SessionEntry(
+        session_key="k",
+        session_id="20240101_010000_def",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=platform,
+        was_auto_reset=True,
+        auto_reset_reason="daily",
+        reset_had_activity=had_activity,
+        prev_session_id=prev,
+    )
+
+
+class TestBuildChannelContinuityNote:
+    def test_slack_channel_emits_hint(self):
+        entry = _reset_entry(Platform.SLACK)
+        note = build_channel_continuity_note(entry, _slack_source())
+        assert note is not None
+        assert "session_search" in note
+        assert entry.prev_session_id in note
+        assert "channel" in note
+
+    def test_discord_thread_uses_thread_wording(self):
+        entry = _reset_entry(Platform.DISCORD)
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="c",
+            chat_type="thread",
+            thread_id="T1",
+        )
+        note = build_channel_continuity_note(entry, source)
+        assert note is not None
+        assert "thread" in note
+
+    def test_other_platform_returns_none(self):
+        entry = _reset_entry(Platform.TELEGRAM)
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="c", user_id="u")
+        assert build_channel_continuity_note(entry, source) is None
+
+    def test_no_activity_returns_none(self):
+        entry = _reset_entry(Platform.SLACK, had_activity=False)
+        assert build_channel_continuity_note(entry, _slack_source()) is None
+
+    def test_no_prev_session_id_returns_none(self):
+        entry = _reset_entry(Platform.SLACK, prev=None)
+        assert build_channel_continuity_note(entry, _slack_source()) is None


### PR DESCRIPTION
## 概要

Slack / Discord のチャンネル・スレッドは長寿命だが、`session_reset`（daily / idle）で新セッションが始まると、エージェントはそのスレッドの過去文脈を失う。結果として、新しい依頼を**同じチャンネルの過去セッションではなく、無関係な直近セッションに紐付けてしまう**ことがある。

実例: Discord スレッド「pochico-marketingの自動運用するための改修」が daily リセットされた後、新セッションが直近の無関係な `eval gate / pochinin-skills` セッションを参照し、誤ったリポジトリに PR を作ってしまった。

本 PR は**超軽量な決定論的ヒント**でこれを緩和する。LLM 要約・チャンネル履歴 API・全件スキャン・追加の API 呼び出しは一切行わない。

## 変更内容

1. `SessionEntry.prev_session_id` を追加。auto-reset で新セッションを作るときだけ、直前セッションの `session_id` を記録する（`get_or_create_session()` が既に握っている値を使うだけ。新規 DB 呼び出しなし）。`sessions.json` に永続化し、gateway 再起動をまたいでも残る。
2. `build_channel_continuity_note()` を追加。**Slack / Discord** かつ **活動のあった auto-reset** かつ **prev_session_id がある** ときだけ、1 文のヒントを返す。それ以外は `None`（＝何も足さない）。
3. `gateway/run.py` の既存 auto-reset 通知ブロックで、その 1 文を context note に追記。これは**新セッション最初の 1 メッセージにだけ**載る既存の prepend に相乗りするため、system prompt のキャッシュには影響しない。

ヒント文（例）:

> [System note: This thread had an earlier Hermes session (session_id: …) that was auto-reset. If the user refers to earlier work here, or the request depends on this thread's history, use the session_search tool to recall that prior session before acting — do not assume an unrelated recent session is the right context.]

### 軽量性

- 追加の LLM 呼び出し: なし
- 追加の Slack / Discord API 呼び出し: なし
- 追加の DB クエリ / 全件スキャン: なし（既知の値を使うだけ）
- 埋め込み / 新規インデックス / cron / 常駐プロセス: なし
- プロンプト肥大: なし（該当時のみ 1 文、しかも初回メッセージだけ）

## 実施したテスト

- `python -m pytest tests/gateway/test_channel_continuity_hint.py tests/gateway/test_session_reset_notify.py -q -o 'addopts='` → **24 passed**（新規テスト含む）
  - prev_session_id が auto-reset 時のみ記録される / 非リセット時は None
  - to_dict → from_dict ラウンドトリップ（再起動）で prev_session_id が残る
  - `build_channel_continuity_note()` が Slack channel / Discord thread で文言を出し分け、非対象プラットフォーム・活動なし・prev なしでは None を返す
- `python -m pytest tests/gateway/test_session.py tests/gateway/test_pii_redaction.py tests/gateway/test_fresh_reset_skill_injection.py tests/gateway/test_restart_resume_pending.py -q -o 'addopts='` → **164 passed**（回帰なし）
- `python -m py_compile gateway/run.py gateway/session.py` → OK
- `git diff --check` → 空白エラーなし

フルスイートは重いため未実施。変更領域に絞った上記のみ実行。
