### PR TITLE
fix(gateway): fall back when s6 sleep is missing

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5796,6 +5796,17 @@ def _dispatch_all_via_service_manager_if_s6(action: str) -> bool:
     return True
 
 
+def _block_forever_until_signal() -> None:
+    """Keep the s6 CMD process alive without depending on external tools."""
+    pause = getattr(signal, "pause", None)
+    if pause is not None:
+        while True:
+            pause()
+
+    import threading
+
+    threading.Event().wait()
+
 
 def gateway_command(args):
     """Handle gateway subcommands."""
@@ -5885,7 +5896,17 @@ def _maybe_redirect_run_to_s6_supervision(args) -> bool:
     # process is a no-op heartbeat that keeps /init alive until
     # `docker stop` sends SIGTERM, at which point /init runs stage 3
     # shutdown (which tears down the supervised gateway cleanly).
-    os.execvp("sleep", ["sleep", "infinity"])
+    try:
+        os.execvp("sleep", ["sleep", "infinity"])
+    except FileNotFoundError:
+        print(
+            "→ `sleep` was not found; keeping the s6 CMD alive with Python "
+            "until the container is stopped.",
+            file=sys.stderr,
+            flush=True,
+        )
+        _block_forever_until_signal()
+    return True
 
 
 def _gateway_command_inner(args):

--- a/tests/hermes_cli/test_gateway_s6_dispatch.py
+++ b/tests/hermes_cli/test_gateway_s6_dispatch.py
@@ -433,6 +433,41 @@ def test_redirect_fires_inside_s6_container(
     assert excinfo.value.argv == ["sleep", "sleep", "infinity"]
 
 
+def test_redirect_falls_back_to_python_heartbeat_when_sleep_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Minimal s6 images may not have a ``sleep`` binary. The redirect
+    should keep the CMD alive with Python instead of crashing with
+    FileNotFoundError."""
+    from hermes_cli import gateway as gw
+
+    rec = _stub_s6(monkeypatch, on_s6=True)
+    monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+    execvp_calls: list[list[str]] = []
+    heartbeat_calls: list[str] = []
+
+    def missing_sleep(file: str, args: list[str]) -> None:
+        execvp_calls.append([file, *args])
+        raise FileNotFoundError(file)
+
+    monkeypatch.setattr("hermes_cli.gateway.os.execvp", missing_sleep)
+    monkeypatch.setattr(
+        "hermes_cli.gateway._block_forever_until_signal",
+        lambda: heartbeat_calls.append("entered"),
+    )
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+
+    assert gw._maybe_redirect_run_to_s6_supervision(_Args()) is True
+
+    assert rec.calls == [("start", "gateway-default")]
+    assert execvp_calls == [["sleep", "sleep", "infinity"]]
+    assert heartbeat_calls == ["entered"]
+    err = capsys.readouterr().err
+    assert "s6 supervision" in err
+    assert "`sleep` was not found" in err
+
+
 def test_redirect_short_circuits_supervised_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the s6 container startup path when the image does not provide a `sleep` executable.

## Bug

Inside an s6-managed container, `hermes gateway run` is redirected to the supervised gateway service and then execs `sleep infinity` as a lightweight CMD heartbeat. In minimal images where `sleep` is missing, that final exec raises `FileNotFoundError`, so the container shuts down during boot instead of leaving s6 supervision running.

## Root Cause

`hermes_cli/gateway.py` depended on an external `sleep` binary after successful s6 dispatch:

```python
os.execvp("sleep", ["sleep", "infinity"])
```

That assumption does not hold for the affected Docker/s6 runtime reported in #36208.

## Fix

Keep the existing `sleep infinity` exec path when it is available, but catch `FileNotFoundError` and fall back to a Python signal wait loop. This keeps the CMD process alive until container shutdown without introducing another external runtime dependency.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_s6_dispatch.py` — 26 passed
- `.venv/bin/python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_s6_dispatch.py` — passed
- `git diff --check` — passed

Fixes #36208
