### PR TITLE
feat: add video_analyze support for Discord and all platforms

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -817,6 +817,79 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     return str(filepath)
 
 
+async def cache_video_from_url(url: str, ext: str = ".mp4", retries: int = 2) -> str:
+    """
+    Download a video file from a URL and save it to the local cache.
+
+    Retries on transient failures (timeouts, 429, 5xx) with exponential
+    backoff so a single slow CDN response doesn't lose the media.
+
+    Args:
+        url: The HTTP/HTTPS URL to download from.
+        ext: File extension including the dot (e.g. ".mp4", ".webm").
+        retries: Number of retry attempts on transient failures.
+
+    Returns:
+        Absolute path to the cached video file as a string.
+
+    Raises:
+        ValueError: If the URL targets a private/internal network (SSRF protection).
+    """
+    from tools.url_safety import is_safe_url
+    if not is_safe_url(url):
+        raise ValueError(f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}")
+
+    import httpx
+    _log = logging.getLogger(__name__)
+
+    async with httpx.AsyncClient(
+        timeout=60.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
+        for attempt in range(retries + 1):
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                        "Accept": "video/*,*/*;q=0.8",
+                    },
+                )
+                response.raise_for_status()
+                return cache_video_from_bytes(response.content, ext)
+            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
+                    raise
+                if attempt < retries:
+                    wait = 1.5 * (attempt + 1)
+                    _log.debug(
+                        "Video cache retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
+                    await asyncio.sleep(wait)
+            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
+                if attempt < retries:
+                    wait = 1.5 * (attempt + 1)
+                    _log.debug(
+                        "Video cache connect retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
+                    await asyncio.sleep(wait)
+        raise RuntimeError(
+            f"Failed to download video from {safe_url_for_log(url)} "
+            f"after {retries + 1} attempts"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Document cache utilities
 #

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8148,6 +8148,7 @@ class GatewayRunner:
         # Declare at outer scope so the audio-file-paths handling block below
         # remains safe when ``event.media_urls`` is empty (no inner block runs).
         audio_file_paths: list[str] = []
+        video_paths: list[str] = []
 
         if event.media_urls:
             image_paths = []
@@ -8165,6 +8166,8 @@ class GatewayRunner:
                     and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
                 ):
                     audio_paths.append(path)
+                elif mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
+                    video_paths.append(path)
 
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
@@ -8238,6 +8241,22 @@ class GatewayRunner:
                     f"[The user sent an audio file attachment: '{_display}'. "
                     f"It is saved at: {_agent_path}. "
                     f"Ask the user what they'd like you to do with it, or pass the path to a transcription or media tool.]"
+                )
+                message_text = f"{_note}\n\n{message_text}"
+
+        if video_paths:
+            from tools.credential_files import to_agent_visible_cache_path as _to_agent_path
+            for _vpath in video_paths:
+                _basename = os.path.basename(_vpath)
+                _parts = _basename.split("_", 2)
+                _display = _parts[2] if len(_parts) >= 3 else _basename
+                _display = re.sub(r'[^\w.\- ]', '_', _display)
+                _agent_path = _to_agent_path(_vpath)
+                _note = (
+                    f"[The user sent a video: '{_display}'. "
+                    f"It is saved at: {_agent_path}. "
+                    f"Use the video_analyze tool to view it. "
+                    f"Pass the file path as the video_url parameter.]"
                 )
                 message_text = f"{_note}\n\n{message_text}"
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -62,6 +62,8 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_url,
     cache_audio_from_bytes,
+    cache_video_from_url,
+    cache_video_from_bytes,
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
@@ -4450,6 +4452,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
         return await cache_audio_from_url(att.url, ext=ext)
 
+    async def _cache_discord_video(self, att, ext: str) -> str:
+        """Cache a Discord video attachment to local disk.
+
+        Primary path: ``att.read()`` + ``cache_video_from_bytes``
+        (authenticated, no SSRF gate).
+
+        Fallback: ``cache_video_from_url`` (plain httpx, SSRF-gated).
+        """
+        raw_bytes = await self._read_attachment_bytes(att)
+        if raw_bytes is not None:
+            try:
+                return cache_video_from_bytes(raw_bytes, ext=ext)
+            except Exception as e:
+                logger.debug(
+                    "[Discord] cache_video_from_bytes failed; falling back to URL: %s",
+                    e,
+                )
+        return await cache_video_from_url(att.url, ext=ext)
+
     async def _cache_discord_document(self, att, ext: str) -> bytes:
         """Download a Discord document attachment and return the raw bytes.
 
@@ -4703,6 +4724,19 @@ class DiscordAdapter(BasePlatformAdapter):
                     print(f"[Discord] Cached user audio: {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
+                    media_urls.append(att.url)
+                    media_types.append(content_type)
+            elif content_type.startswith("video/"):
+                try:
+                    ext = "." + content_type.split("/")[-1].split(";")[0]
+                    if ext not in {".mp4", ".webm", ".mov", ".avi", ".mkv", ".mpeg"}:
+                        ext = ".mp4"
+                    cached_path = await self._cache_discord_video(att, ext)
+                    media_urls.append(cached_path)
+                    media_types.append(content_type)
+                    print(f"[Discord] Cached user video: {cached_path}", flush=True)
+                except Exception as e:
+                    print(f"[Discord] Failed to cache video attachment: {e}", flush=True)
                     media_urls.append(att.url)
                     media_types.append(content_type)
             else:

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,8 +35,8 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
-    "vision_analyze", "image_generate",
+    # Vision + image generation + video
+    "vision_analyze", "image_generate", "video_analyze",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation


### PR DESCRIPTION
# feat: add video_analyze support for Discord and all platforms

## What does this PR do?

Fixes the end-to-end video attachment flow on Discord and makes `video_analyze` available on all platforms. Previously, video attachments on Discord were silently dropped at three separate points in the pipeline:

1. **Discord adapter** had no `video/` content-type handler — attachments fell into the document handler and were rejected as "unsupported document type"
2. **Gateway run.py** had no `MessageType.VIDEO` media handling — even if cached, the file path never reached the agent
3. **toolsets.py** — `video_analyze` wasn't in `_HERMES_CORE_TOOLS`, so the tool was missing on all platforms even after the `video` toolset was enabled

## Related Issue

Fixes # (no existing issue — this is a gap discovered during testing)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/base.py` — Add `cache_video_from_url()` async downloader with SSRF protection, retries, 60s timeout. Mirrors existing `cache_image_from_url` / `cache_audio_from_url` pattern.
- `plugins/platforms/discord/adapter.py` — Add `cache_video_from_bytes` + `cache_video_from_url` imports; add `_cache_discord_video()` method (mirrors `_cache_discord_audio`); add `video/` content-type branch in attachment loop between `audio/` and document handler
- `gateway/run.py` — Initialize `video_paths: list[str] = []` at outer scope (same pattern as `audio_file_paths`); collect video paths when `mtype.startswith("video/")` or `MessageType.VIDEO`; inject note into message text with file path and `video_analyze` usage hint
- `toolsets.py` — Add `video_analyze` to `_HERMES_CORE_TOOLS`

## How to Test

1. Enable the `video` toolset: `hermes tools enable video --platform discord` (it's in `_DEFAULT_OFF_TOOLSETS`)
2. Set video model: `hermes config set auxiliary.video.model google/gemini-3.1-flash-lite` and `AUXILIARY_VIDEO_MODEL` in `.env`
3. Send a video attachment on Discord — agent should receive path and call `video_analyze` directly
4. Verify the agent does NOT resort to ffmpeg frame extraction (previous fallback behavior)
5. Verify `cache_video_from_url` correctly rejects internal/private URLs (SSRF protection mirrors existing image/audio cache)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass *(tests to be run)*
- [ ] I've added tests for my changes *(follow-up)*
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no config key changes
- [x] N/A — no architecture changes to docs
- [x] Cross-platform: video cache uses same `cache_*_from_bytes` pattern as existing image/audio; Discord adapter mirrors existing `_cache_discord_audio`; gateway handler mirrors `audio_file_paths`
- [x] Tool schema unchanged — `video_analyze` was already registered with correct schema, just wasn't available on platforms
<img width="403" height="436" alt="pr2" src="https://github.com/user-attachments/assets/e43c21fc-e168-4bd9-a67f-59d2a646cfb6" />
<img width="391" height="343" alt="pr1" src="https://github.com/user-attachments/assets/feda0680-8fcc-4384-9c33-1652c3f1ad6c" />
