### PR TITLE
fix: honor MCP connect timeouts during discovery

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -164,6 +164,15 @@ def _apply_mcp_preset(
 
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
 
+def _connect_timeout_for_probe(config: dict) -> float:
+    """Return the configured MCP connection timeout for CLI probes."""
+    try:
+        timeout = float(config.get("connect_timeout", 30))
+    except (TypeError, ValueError):
+        return 30.0
+    return timeout if timeout > 0 else 30.0
+
+
 def _probe_single_server(
     name: str, config: dict, connect_timeout: float = 30
 ) -> List[Tuple[str, str]]:
@@ -580,7 +589,11 @@ def cmd_mcp_test(args):
     # Attempt connection
     start = time.monotonic()
     try:
-        tools = _probe_single_server(name, cfg)
+        tools = _probe_single_server(
+            name,
+            cfg,
+            connect_timeout=_connect_timeout_for_probe(cfg),
+        )
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -437,6 +437,28 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_test_uses_configured_connect_timeout(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "slow-http": {
+                "url": "https://example.com/mcp",
+                "connect_timeout": 180,
+            },
+        })
+        seen = {}
+
+        def mock_probe(name, config, **kw):
+            seen["connect_timeout"] = kw.get("connect_timeout")
+            return [("slow_tool", "Slow discovery")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="slow-http"))
+        capsys.readouterr()
+        assert seen["connect_timeout"] == 180.0
+
 
 # ---------------------------------------------------------------------------
 # Tests: env var interpolation

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1146,6 +1146,28 @@ class TestToolsetInjection:
             assert "mcp_broken_ping" in result2
             assert call_count == 1  # Only broken retried
 
+    def test_registration_outer_timeout_honors_slowest_connect_timeout(self):
+        """Parallel discovery wrapper must outlive the slowest configured server."""
+        fake_config = {
+            "slow": {"url": "https://example.com/mcp", "connect_timeout": 180},
+            "default": {"command": "npx", "args": []},
+        }
+        captured = {}
+
+        def fake_run_on_mcp_loop(coro_or_fn, timeout=None):
+            captured["timeout"] = timeout
+            return None
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._servers", {}), \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop", side_effect=fake_run_on_mcp_loop):
+            from tools.mcp_tool import register_mcp_servers
+
+            register_mcp_servers(fake_config)
+
+        assert captured["timeout"] == 190.0
+
 
 # ---------------------------------------------------------------------------
 # Graceful fallback

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3122,6 +3122,23 @@ def _parse_boolish(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _connect_timeout_value(config: dict) -> float:
+    """Return a positive per-server connect timeout from config."""
+    return float(_safe_numeric(
+        config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT),
+        _DEFAULT_CONNECT_TIMEOUT,
+        float,
+    ))
+
+
+def _registration_outer_timeout(servers: Dict[str, dict]) -> float:
+    """Return the wrapper timeout for parallel MCP discovery."""
+    if not servers:
+        return 120.0
+    max_connect_timeout = max(_connect_timeout_value(cfg) for cfg in servers.values())
+    return max(120.0, max_connect_timeout + 10.0)
+
+
 _UTILITY_CAPABILITY_METHODS = {
     "list_resources": "list_resources",
     "read_resource": "read_resource",
@@ -3345,7 +3362,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
 
     Returns list of registered tool names.
     """
-    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    connect_timeout = _connect_timeout_value(config)
     server = await asyncio.wait_for(
         _connect_server(name, config),
         timeout=connect_timeout,
@@ -3432,8 +3449,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 )
 
     # Per-server timeouts are handled inside _discover_and_register_server.
-    # The outer timeout is generous: 120s total for parallel discovery.
-    #
+    # The outer timeout must outlive the slowest configured server because the
+    # per-server discovery tasks run in parallel under this single wrapper.
+    discovery_timeout = _registration_outer_timeout(new_servers)
     # Temporarily clear the interrupt flag on the current thread so that MCP
     # discovery is never cancelled by a stale interrupt from a prior agent
     # session (executor threads get reused and may carry old interrupt state).
@@ -3442,7 +3460,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     if _was_interrupted:
         _set_interrupt(False)
     try:
-        _run_on_mcp_loop(_discover_all, timeout=120)
+        _run_on_mcp_loop(_discover_all, timeout=discovery_timeout)
     finally:
         if _was_interrupted:
             _set_interrupt(True)


### PR DESCRIPTION
## Summary
- make `hermes mcp test` honor each server's configured `connect_timeout`
- make runtime MCP discovery use an outer timeout that outlives the slowest configured server
- add regressions for slow HTTP MCP probe and startup discovery behavior

## Test Plan
- `/home/willoughby_winograd_org/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_config.py -q -o 'addopts='`
- live `hermes mcp test convective-ramp`, connected and discovered 100 tools in 126218ms
- live `register_mcp_servers({'convective-ramp': cfg})`, registered 13 selected tools and reported connected
