### PR TITLE
feat: explain Quick Setup vs Full setup inline in first-time setup menu

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3004,10 +3004,14 @@ def run_setup_wizard(args):
         if migration_ran:
             config = load_config()
 
-        setup_mode = prompt_choice("How would you like to set up Hermes?", [
-            "Quick Setup (Nous Portal) — OAuth login, model & messaging (recommended)",
-            "Full setup — configure everything",
-        ], 0)
+        setup_mode = prompt_choice(
+            "How would you like to set up Hermes?",
+            [
+                "Quick Setup (Nous Portal) — free OAuth login, no API keys, model + tools (recommended)",
+                "Full setup — configure every provider, tool & option yourself (bring your own keys)",
+            ],
+            0,
+        )
 
         if setup_mode == 0:
             _run_first_time_quick_setup(config, hermes_home, is_existing)


### PR DESCRIPTION
## Summary
First-time `hermes setup` now explains what each option does — inline on each choice line — instead of showing two bare labels.

The setup-mode chooser previously showed only:
- `Quick Setup (Nous Portal) — OAuth login, model & messaging (recommended)`
- `Full setup — configure everything`

…with no indication of what Quick Setup actually is (free Nous Portal account, OAuth login, no API keys, bundled tools). The labels now carry a concise inline explanation:
- `Quick Setup (Nous Portal) — free OAuth login, no API keys, model + tools (recommended)`
- `Full setup — configure every provider, tool & option yourself (bring your own keys)`

## Changes
- `hermes_cli/setup.py`: expand the two setup-mode choice labels so each line explains the option. Single-file change to the label strings — no new plumbing.

## Validation
- Live-rendered both the curses and numbered-fallback paths; default selection (Quick Setup) returns index 0.
- The key selling point ("free OAuth login, no API keys") leads the line, so it survives an 80-col truncation even though the full label is ~96 cols.

## Infographic
![hermes-setup-menu-explainer](https://v3b.fal.media/files/b/0a9c8065/iYwtAhNMW_2BYRphYE6Vo_TiBH9EzX.png)
