### PR TITLE
docker: cap compose log rotation

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -14,6 +14,11 @@ services:
     image: nousresearch/hermes-agent:latest
     container_name: hermes
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     volumes:
       - ${USERPROFILE}/.hermes:/opt/data
     environment:
@@ -25,6 +30,11 @@ services:
     image: nousresearch/hermes-agent:latest
     container_name: hermes-dashboard
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     depends_on:
       - gateway
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,11 @@ services:
     image: hermes-agent
     container_name: hermes
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     network_mode: host
     volumes:
       - ~/.hermes:/opt/data
@@ -64,6 +69,11 @@ services:
     image: hermes-agent
     container_name: hermes-dashboard
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     network_mode: host
     depends_on:
       - gateway

--- a/tests/e2e/matrix_xsign_bootstrap/docker-compose.yml
+++ b/tests/e2e/matrix_xsign_bootstrap/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   homeserver:
     image: ghcr.io/continuwuity/continuwuity:latest
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       CONTINUWUITY_SERVER_NAME: localhost
       CONTINUWUITY_DATABASE_PATH: /var/lib/conduwuit/conduwuit.db


### PR DESCRIPTION
## Description

Adds Docker `json-file` log rotation to every service in the repository's Docker Compose files:

```yaml
logging:
  driver: json-file
  options:
    max-size: "10m"
    max-file: "3"
```

This keeps local/dev containers from accumulating unbounded JSON logs while preserving the default Docker logging driver.

## Testing

- `docker compose -f <compose-file> config`
- YAML audit confirmed every service has `driver: json-file`, `max-size: 10m`, and `max-file: 3`
