### PR TITLE
fix(feishu): distinguish quote replies from topic sessions

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3253,14 +3253,34 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        chat_id = getattr(message, "chat_id", "") or ""
+        chat_info = await self.get_chat_info(chat_id)
+        source_chat_type = self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type)
+
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
             or getattr(message, "root_id", None)
             or None
         )
+        thread_id = self._resolve_inbound_thread_id(
+            message,
+            source_chat_type=source_chat_type,
+        )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        reply_media_urls: List[str] = []
+        reply_media_types: List[str] = []
+        if reply_to_message_id:
+            reply_media_urls, reply_media_types = await self._fetch_message_media(reply_to_message_id)
+            if reply_media_urls:
+                attachment_note = f"[Replied-to message has {len(reply_media_urls)} media attachment(s)]"
+                reply_to_text = f"{reply_to_text}\n{attachment_note}" if reply_to_text else attachment_note
+                # Feishu reply events only carry the new message body; when a user replies
+                # to an image/file and @mentions the bot, the quoted media lives on the
+                # parent message. Attach the parent's media to the normalized event so the
+                # agent can actually see what the user is referring to.
+                media_urls.extend(reply_media_urls)
+                media_types.extend(reply_media_types)
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -3269,7 +3289,7 @@ class FeishuAdapter(BasePlatformAdapter):
             or "<unknown>"
         )
         logger.info(
-            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d",
+            "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s sender=%s:%s text=%r media=%d reply_media=%d",
             "dm" if chat_type == "p2p" else "group",
             message_id,
             inbound_type.value,
@@ -3278,15 +3298,14 @@ class FeishuAdapter(BasePlatformAdapter):
             sender_primary,
             text[:120],
             len(media_urls),
+            len(reply_media_urls),
         )
 
-        chat_id = getattr(message, "chat_id", "") or ""
-        chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
+            chat_type=source_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=thread_id,
@@ -4033,6 +4052,25 @@ class FeishuAdapter(BasePlatformAdapter):
             return "dm"
         return "group"
 
+    @staticmethod
+    def _resolve_inbound_thread_id(message: Any, *, source_chat_type: str) -> Optional[str]:
+        """Return the Hermes session/thread route for a Feishu inbound message.
+
+        Feishu/Lark uses several message-id fields with different semantics:
+        ``thread_id`` is the explicit topic/thread route, while ``root_id``,
+        ``parent_id``, and ``upper_message_id`` are also present on ordinary
+        quote/reply events. Treating ``root_id`` as a universal thread fallback
+        makes normal replies in DMs or groups fork into side topics. Forum chats
+        are the exception: older Feishu payloads may omit ``thread_id`` there,
+        so ``root_id`` remains a compatibility fallback for that chat surface.
+        """
+        explicit_thread_id = getattr(message, "thread_id", None) or None
+        if explicit_thread_id:
+            return explicit_thread_id
+        if source_chat_type == "forum":
+            return getattr(message, "root_id", None) or None
+        return None
+
     async def _resolve_sender_profile(
         self,
         sender_id: Any,
@@ -4170,15 +4208,9 @@ class FeishuAdapter(BasePlatformAdapter):
             self._message_text_cache.move_to_end(message_id)
             return self._message_text_cache[message_id]
         try:
-            request = self._build_get_message_request(message_id)
-            response = await self._run_blocking(self._client.im.v1.message.get, request)
-            if not response or getattr(response, "success", lambda: False)() is False:
-                code = getattr(response, "code", "unknown")
-                msg = getattr(response, "msg", "message lookup failed")
-                logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
+            parent = await self._fetch_message_item(message_id)
+            if parent is None:
                 return None
-            items = getattr(getattr(response, "data", None), "items", None) or []
-            parent = items[0] if items else None
             body = getattr(parent, "body", None)
             msg_type = getattr(parent, "msg_type", "") or ""
             raw_content = getattr(body, "content", "") or ""
@@ -4192,6 +4224,47 @@ class FeishuAdapter(BasePlatformAdapter):
             while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
                 self._message_text_cache.popitem(last=False)
             return text
+        except Exception:
+            logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
+            return None
+
+    async def _fetch_message_media(self, message_id: str) -> tuple[List[str], List[str]]:
+        if not self._client or not message_id:
+            return [], []
+        try:
+            parent = await self._fetch_message_item(message_id)
+            if parent is None:
+                return [], []
+            body = getattr(parent, "body", None)
+            msg_type = getattr(parent, "msg_type", "") or ""
+            raw_content = getattr(body, "content", "") or ""
+            normalized = normalize_feishu_message(
+                message_type=msg_type,
+                raw_content=raw_content,
+                mentions=getattr(parent, "mentions", None),
+                bot=self._bot_identity(),
+            )
+            return await self._download_feishu_message_resources(
+                message_id=message_id,
+                normalized=normalized,
+            )
+        except Exception:
+            logger.warning("[Feishu] Failed to fetch parent message media %s", message_id, exc_info=True)
+            return [], []
+
+    async def _fetch_message_item(self, message_id: str) -> Optional[Any]:
+        if not self._client or not message_id:
+            return None
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await self._run_blocking(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message lookup failed")
+                logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
+                return None
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            return items[0] if items else None
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2105,6 +2105,215 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_text, "父消息内容")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_p2p_reply_does_not_become_thread_session(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="被引用消息")
+        adapter._fetch_message_media = AsyncMock(return_value=([], []))
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id="om_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"这个只是回复引用"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertEqual(event.reply_to_text, "被引用消息")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_p2p_topic_preserves_explicit_thread_session(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="话题根消息")
+        adapter._fetch_message_media = AsyncMock(return_value=([], []))
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt_dm_topic",
+            root_id="om_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"这个是在 DM 话题里回复"}',
+            message_id="om_topic_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_topic_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "omt_dm_topic")
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertEqual(event.reply_to_text, "话题根消息")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_group_reply_does_not_become_thread_session(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="群里被引用消息")
+        adapter._fetch_message_media = AsyncMock(return_value=([], []))
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id=None,
+            root_id="om_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"@bot 这个只是群聊回复引用"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+        self.assertEqual(event.reply_to_text, "群里被引用消息")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_group_topic_preserves_explicit_thread_session(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="群话题根消息")
+        adapter._fetch_message_media = AsyncMock(return_value=([], []))
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id="omt_group_topic",
+            root_id="om_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"@bot 群话题里回复"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "omt_group_topic")
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_forum_reply_can_fall_back_to_root_id_thread(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_forum", "name": "Feishu Topic Group", "type": "forum"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="话题根消息")
+        adapter._fetch_message_media = AsyncMock(return_value=([], []))
+        message = SimpleNamespace(
+            chat_id="oc_forum",
+            thread_id=None,
+            root_id="om_forum_root",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"@bot 话题里回复"}',
+            message_id="om_forum_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_forum_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.chat_type, "forum")
+        self.assertEqual(event.source.thread_id, "om_forum_root")
+        self.assertEqual(event.reply_to_message_id, "om_forum_root")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -491,6 +491,49 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert adapter.edits[0]["message_id"] == "progress-1"
 
 
+@pytest.mark.asyncio
+async def test_run_agent_feishu_dm_reply_uses_main_chat_not_topic(monkeypatch, tmp_path):
+    """Feishu DM replies should quote for context but answer in the main DM stream."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_dm",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="引用上一条问一下",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-dm-reply",
+        session_key="agent:main:feishu:dm:oc_dm",
+        event_message_id=None,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert all(call["reply_to"] is None for call in adapter.sent)
+    assert all(call["metadata"] is None for call in adapter.sent)
+    assert all(call["metadata"] in (None, {"stopped": True}) for call in adapter.typing)
+
+
 # ---------------------------------------------------------------------------
 # Preview truncation tests (all/new mode respects tool_preview_length)
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -19,7 +19,11 @@ The integration supports both connection modes:
 |---------|----------|
 | Direct messages | Hermes responds to every message. |
 | Group chats | Hermes responds only when the bot is @mentioned in the chat. |
+| Message replies | Hermes keeps the quoted parent as context, but ordinary replies stay in the main DM or group chat. |
+| Feishu topics / threads | Hermes preserves explicit Feishu/Lark topic routing so replies made inside a topic stay inside that topic. |
 | Shared group chats | By default, session history is isolated per user inside a shared chat. |
+
+Feishu/Lark message events include several IDs with different meanings. Hermes treats `thread_id` as the topic/session route, while `root_id`, `parent_id`, and `upper_message_id` are quote/reply context for ordinary messages. This prevents a normal quote-reply from accidentally creating a side topic while still preserving real topic conversations.
 
 This shared-chat behavior is controlled by `config.yaml`:
 


### PR DESCRIPTION
## Problem

In normal conversation, quoting a message is intended to inject or emphasize context within the current conversation.

Previously, Feishu reply metadata such as `root_id` could be promoted into the Hermes thread route. As a result, an ordinary quote reply could be routed into a separate topic-scoped session. From the user's perspective, quoting a message unexpectedly opened a fresh context instead of reinforcing the current one.

![Quote context versus session routing](https://raw.githubusercontent.com/SergioYin/hermes-agent/pr-assets/pull/36233/feishu-quote-context-vs-session-routing.png)

## What changed

This PR makes the distinction explicit in the active Feishu adapter at `plugins/platforms/feishu/adapter.py`:

- quote metadata remains reply context;
- an explicit `thread_id` selects a topic-scoped session;
- ordinary DM and group quote replies remain in the current session;
- the forum-only `root_id` compatibility fallback is preserved;
- quoted text and media remain available to the agent as context.

In short:

> Quoting adds context. It does not define a session boundary.

## Behavior

- **Ordinary quote reply:** continue the current DM/group session and attach the quoted message as context.
- **Explicit topic reply:** route through the Feishu `thread_id` and continue the topic-scoped session.
- **Legacy forum payload:** allow the scoped `root_id` fallback when an explicit `thread_id` is unavailable.

This avoids the previous behavior where quoting a message could silently move the user into a different Hermes session.

## Changes made

- `plugins/platforms/feishu/adapter.py`
  - Adds `_resolve_inbound_thread_id()` to centralize reply/topic routing semantics.
  - Separates the reply anchor from the session-routing identifier.
  - Preserves quoted text/media retrieval through the adapter's blocking-call executor.
- `tests/gateway/test_feishu.py`
  - Adds regressions for ordinary DM/group replies, explicit topics, quoted media, and forum fallback behavior.
- `tests/gateway/test_run_progress_topics.py`
  - Verifies ordinary Feishu quote replies do not receive topic progress metadata, while explicit topics retain it.
- `website/docs/user-guide/messaging/feishu.md`
  - Documents quote-reply versus topic-routing behavior.

## Related issue

Fixes #20548.

Related context: #20562, #29467, #30164, #20851.

## Type of change

- [x] Bug fix
- [x] Documentation update
- [x] Tests added or improved
- [ ] New feature
- [ ] Refactor without behavior change

## Validation

Relevant gateway test suite:

```text
377 passed
```

Additional checks:

```text
Ruff passed
Python compile checks passed
git diff --check passed
```

Tested on Ubuntu/WSL2 with a Feishu/Lark gateway, including real-workspace validation of quote replies and topic replies.

## Checklist

- [x] The change targets the active plugin adapter.
- [x] The commit follows Conventional Commits.
- [x] The PR contains only changes related to this bug fix.
- [x] Regression tests cover the affected routing behavior.
- [x] Relevant documentation has been updated.
- [x] Cross-platform impact has been considered; no platform-specific filesystem behavior was added.
