### PR TITLE
fix(desktop): darken light-mode code comment color for legibility

### DIFF
--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -30,6 +30,18 @@ interface HermesSyntaxHighlighterProps extends SyntaxHighlighterProps {
 
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
 
+/**
+ * `github-light-default` colors comments `#6e7781` (~4.2:1 against the code
+ * card background) — borderline unreadable at our 11px code size, and worst of
+ * all for shell snippets where a single `#` turns the rest of the line into one
+ * long comment span. Remap light-mode comments to GitHub's darker muted gray
+ * (`#57606a`, ~6.4:1). Dark mode (`#8b949e`, ~6.1:1) already reads fine, so we
+ * leave it untouched. Keyed per theme name so the bump only applies in light.
+ */
+const SHIKI_COLOR_REPLACEMENTS: Record<string, Record<string, string>> = {
+  'github-light-default': { '#6e7781': '#57606a' }
+}
+
 export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   components: { Pre },
   language,
@@ -76,6 +88,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
             <ShikiHighlighter
               addDefaultStyles={false}
               as="div"
+              colorReplacements={SHIKI_COLOR_REPLACEMENTS}
               defaultColor="light-dark()"
               delay={120}
               language={language || 'text'}


### PR DESCRIPTION
## Summary
- Bash/shell code blocks rendered nearly invisible in the desktop chat: Shiki's `github-light-default` theme colors comment tokens `#6e7781`, only ~4.2:1 contrast against the code card background (fails WCAG AA, worse at the 11px code font size).
- Shell makes this especially bad — a single `#` turns the rest of the line into one long comment span, so almost the whole snippet renders in that weak gray.
- Fix: remap light-mode comments to GitHub's darker muted gray `#57606a` (~6.4:1) via per-theme Shiki `colorReplacements` in `apps/desktop/src/components/chat/shiki-highlighter.tsx`. Dark mode (`#8b949e`, ~6.1:1) already reads fine and is left untouched.

This uses Shiki's native `colorReplacements` (remap at tokenization) rather than fighting the inline `light-dark()` colors with CSS `!important`. `#57606a` is an existing GitHub palette gray, so highlighting stays visually coherent.

## Test plan
- [x] `npm run type-check` passes
- [x] No new lint errors
- [ ] Visually confirm bash/shell comments are legible in light mode
- [ ] Confirm dark mode highlighting is unchanged