### PR TITLE
fix(docker): align compose examples with single-container dashboard pattern

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -10,7 +10,7 @@
 #   docker compose -f docker-compose.windows.yml up -d
 #
 services:
-  gateway:
+  hermes:
     image: nousresearch/hermes-agent:latest
     container_name: hermes
     restart: unless-stopped
@@ -19,20 +19,18 @@ services:
     environment:
       - HERMES_UID=10000
       - HERMES_GID=10000
-    command: ["gateway", "run"]
-
-  dashboard:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes-dashboard
-    restart: unless-stopped
-    depends_on:
-      - gateway
-    volumes:
-      - ${USERPROFILE}/.hermes:/opt/data
-    environment:
-      - HERMES_UID=10000
-      - HERMES_GID=10000
-      - HERMES_DASHBOARD_HOST=0.0.0.0
+      # Run the supervised web dashboard alongside the gateway in this
+      # container. Required so the dashboard's gateway-liveness check
+      # works — it needs to share a PID namespace with the gateway.
+      - HERMES_DASHBOARD=1
+      # The dashboard binds 0.0.0.0 inside the container by default so
+      # the published port is reachable from the host. The port mapping
+      # below restricts that to host loopback (127.0.0.1) so it isn't
+      # exposed on LAN. The bind being non-loopback inside the container
+      # makes the dashboard fail closed at startup unless an OAuth
+      # provider is registered or this opt-out is set. Replace with
+      # HERMES_DASHBOARD_OAUTH_CLIENT_ID for real auth.
+      - HERMES_DASHBOARD_INSECURE=1
     ports:
       - "127.0.0.1:9119:9119"
-    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open", "--insecure"]
+    command: ["gateway", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,15 @@
 # user via `s6-setuidgid`.
 #
 # Security notes:
-#   - The dashboard service binds to 127.0.0.1 by default. It stores API
-#     keys; exposing it on LAN without auth is unsafe. If you want remote
-#     access, use an SSH tunnel or put it behind a reverse proxy that
-#     adds authentication — do NOT pass --insecure --host 0.0.0.0.
+#   - The dashboard runs as a supervised s6-rc service inside the same
+#     container as the gateway, toggled via `HERMES_DASHBOARD=1`. It must
+#     share a PID namespace with the gateway for its liveness detection
+#     to work (a separate dashboard container is not supported — see
+#     website/docs/user-guide/docker.md). Bound to 127.0.0.1 here so it
+#     only listens on container loopback (which, under network_mode:
+#     host, is host loopback). For remote access tunnel via
+#     `ssh -L 9119:localhost:9119` or set up OAuth — do NOT switch the
+#     bind to 0.0.0.0 without auth, the dashboard stores API keys.
 #   - If you override entrypoint, keep `/init` as the first command in
 #     the chain (or let docker use the image's default ENTRYPOINT,
 #     which is `["/init", "/opt/hermes/docker/main-wrapper.sh"]`).
@@ -27,9 +32,9 @@
 #     this on an internet-facing host.
 #
 services:
-  gateway:
+  hermes:
     build: .
-    image: hermes-agent
+    image: nousresearch/hermes-agent
     container_name: hermes
     restart: unless-stopped
     network_mode: host
@@ -38,6 +43,11 @@ services:
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
+      # Run the supervised web dashboard alongside the gateway in this
+      # container. Required so the dashboard's gateway-liveness check
+      # works — it needs to share a PID namespace with the gateway.
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=127.0.0.1
       # To expose the OpenAI-compatible API server beyond localhost,
       # uncomment BOTH lines (API_SERVER_KEY is mandatory for auth):
       # - API_SERVER_HOST=0.0.0.0
@@ -59,18 +69,3 @@ services:
       # - GOOGLE_CHAT_SERVICE_ACCOUNT_JSON=${GOOGLE_CHAT_SERVICE_ACCOUNT_JSON}
       # - GOOGLE_CHAT_ALLOWED_USERS=${GOOGLE_CHAT_ALLOWED_USERS}
     command: ["gateway", "run"]
-
-  dashboard:
-    image: hermes-agent
-    container_name: hermes-dashboard
-    restart: unless-stopped
-    network_mode: host
-    depends_on:
-      - gateway
-    volumes:
-      - ~/.hermes:/opt/data
-    environment:
-      - HERMES_UID=${HERMES_UID:-10000}
-      - HERMES_GID=${HERMES_GID:-10000}
-    # Localhost-only. For remote access, tunnel via `ssh -L 9119:localhost:9119`.
-    command: ["dashboard", "--host", "127.0.0.1", "--no-open"]


### PR DESCRIPTION
## What

Updates `docker-compose.yml` and `docker-compose.windows.yml` to use the single-container dashboard pattern that [commit 5671059f6](https://github.com/NousResearch/hermes-agent/commit/5671059f62ab28fa118b15fa148d5ae9a4200574) introduced and the user-guide docs already document. Also fixes a broken `image:` tag in `docker-compose.yml`.

## Why

Commit 5671059f6 ("feat(docker): launch dashboard as side-process via HERMES_DASHBOARD=1") explicitly said in its message:

> - Rewrite the "Running the dashboard" doc section around the new single-container pattern.  Drops the previously-documented dashboard-as-its-own-container setup — that pattern relied on the deprecated env vars for cross-container gateway-liveness detection, and without them the dashboard would permanently report the gateway as "not running".
> - Collapse the two-service Compose example (gateway + dashboard container) into a single service with HERMES_DASHBOARD=1.  Removes the now-unnecessary bridge network and `depends_on`.

The docs, entrypoint script, and `s6-rc.d/dashboard/run` supervisor were updated in that commit, but `docker-compose.yml` and `docker-compose.windows.yml` were not. The compose files still ship a separate dashboard container — contradicting the user-guide statement at `website/docs/user-guide/docker.md` (still in `main`):

> Running the dashboard as a separate container is not supported: its gateway-liveness detection requires a shared PID namespace with the gateway process.

This PR finishes the collapse the original commit message promised.

## Changes

- Removes the standalone `dashboard:` service from both files (no more bridge network, no more `depends_on`).
- Renames the remaining service from `gateway` → `hermes` to match the canonical compose example in `website/docs/user-guide/docker.md`.
- Adds `HERMES_DASHBOARD=1` to launch the supervised dashboard as a sibling s6 service inside the same container.
- **Linux** (`docker-compose.yml`): keeps the dashboard bound to `127.0.0.1` via `HERMES_DASHBOARD_HOST` so the loopback-only behavior of the old separate dashboard service is preserved (under `network_mode: host`, container loopback == host loopback).
- **Windows** (`docker-compose.windows.yml`): keeps the old `--insecure` intent via `HERMES_DASHBOARD_INSECURE=1`. The default in-container bind is `0.0.0.0`; without this opt-out the dashboard would fail closed at startup since no `DashboardAuthProvider` is registered. The existing `127.0.0.1:9119:9119` port mapping restricts the published port to host loopback.
- Fixes the local-build image tag in `docker-compose.yml` from the unprefixed `hermes-agent` to `nousresearch/hermes-agent`, matching the published image name so the example file works as-is.
- `--no-open` is now hardcoded in `docker/s6-rc.d/dashboard/run`, so it no longer needs to appear on the compose command line.

## How to test

Linux / `docker-compose.yml`:

```sh
HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d
docker compose logs -f hermes        # see the gateway + supervised dashboard come up
curl -sf http://127.0.0.1:9119/ >/dev/null && echo "dashboard reachable on loopback"
docker compose exec hermes /opt/hermes/.venv/bin/hermes gateway status
```

Windows / `docker-compose.windows.yml`:

```sh
docker compose -f docker-compose.windows.yml up -d
# Dashboard reachable at http://127.0.0.1:9119 (loopback only, due to the port mapping)
```

## What I tested on

Tested on a Debian Linux homelab host. I ran the updated `docker-compose.yml` as-is using the pulled `nousresearch/hermes-agent` image. The supervised dashboard came up on `127.0.0.1:9119` and reported the gateway as running.

`docker-compose.windows.yml` not tested directly (no Windows host available); the diff is the structural mirror of the Linux change minus `network_mode: host` plus the existing port mapping.

## Related issues

Possibly closes or reduces noise on several open issues that look like downstream consequences of users copying the stale two-service example:

- #26181 — Dashboard `/api/status` reports gateway 'stopped' on Docker (PID-1)
- #34457, #34480 — s6-log lock collision in multi-container setups with shared `/opt/data`
- #23402 — Docker with HERMES_UID: permissions issue with the separate dashboard
- #20739 — Dashboard chat tab unusable in Docker image — four compounding bugs