### PR TITLE
feat(tui): show active profile in status bar

### DIFF
--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -57,6 +57,7 @@ const findClickableWithText = (node: ReactNodeLike, needle: string): React.React
 describe('StatusRule session count click target', () => {
   it('makes the live session count itself clickable', () => {
     const openSwitcher = vi.fn()
+
     const element = StatusRule({
       bgCount: 0,
       busy: false,
@@ -80,5 +81,38 @@ describe('StatusRule session count click target', () => {
     expect(clickableSessionCount).not.toBeNull()
     clickableSessionCount!.props.onClick({ stopImmediatePropagation: vi.fn() })
     expect(openSwitcher).toHaveBeenCalledOnce()
+  })
+})
+
+describe('StatusRule active profile label', () => {
+  const renderStatusText = (profileName?: null | string) =>
+    textContent(
+      StatusRule({
+        bgCount: 0,
+        busy: false,
+        cols: 100,
+        cwdLabel: '~/repo',
+        liveSessionCount: 0,
+        model: 'kimi-k2.6',
+        profileName,
+        sessionStartedAt: null,
+        showCost: false,
+        status: 'ready',
+        statusColor: DEFAULT_THEME.color.ok,
+        t: DEFAULT_THEME,
+        turnStartedAt: null,
+        usage: { total: 0 },
+        voiceLabel: ''
+      })
+    )
+
+  it('shows named profiles in the status rule', () => {
+    expect(renderStatusText('research')).toContain('profile research')
+  })
+
+  it('keeps default profile labels quiet', () => {
+    expect(renderStatusText('default')).not.toContain('profile default')
+    expect(renderStatusText('custom')).not.toContain('profile custom')
+    expect(renderStatusText()).not.toContain('profile')
   })
 })

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -266,6 +266,12 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+const profileStatusLabel = (profileName?: null | string) => {
+  const value = String(profileName ?? '').trim()
+
+  return value && value !== 'default' && value !== 'custom' ? `profile ${value}` : ''
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -300,6 +306,7 @@ export function StatusRule({
   model,
   modelFast,
   modelReasoningEffort,
+  profileName,
   usage,
   bgCount,
   liveSessionCount,
@@ -320,8 +327,10 @@ export function StatusRule({
       : ''
 
   const bar = usage.context_max ? ctxBar(pct) : ''
+  const profileLabel = profileStatusLabel(profileName)
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel)
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
+
   const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
     event.stopImmediatePropagation?.()
     onSessionCountClick?.()
@@ -354,6 +363,12 @@ export function StatusRule({
           {' │ '}
           {modelLabel(model, modelReasoningEffort, modelFast)}
         </Text>
+        {profileLabel ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {profileLabel}
+          </Text>
+        ) : null}
         {ctxLabel ? (
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
@@ -530,6 +545,7 @@ interface StatusRuleProps {
   model: string
   modelFast?: boolean
   modelReasoningEffort?: string
+  profileName?: null | string
   sessionStartedAt?: null | number
   showCost: boolean
   status: string

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -252,8 +252,8 @@ const ComposerPane = memo(function ComposerPane({
           cols={composer.cols}
           compIdx={composer.compIdx}
           completions={composer.completions}
-          onActiveSessionSelect={actions.activateLiveSession}
           onActiveSessionClose={actions.closeLiveSession}
+          onActiveSessionSelect={actions.activateLiveSession}
           onModelSelect={actions.onModelSelect}
           onNewLiveSession={actions.newLiveSession}
           onNewPromptSession={actions.newPromptSession}
@@ -363,6 +363,7 @@ const StatusRulePane = memo(function StatusRulePane({
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
         modelReasoningEffort={ui.info?.reasoning_effort}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
+        profileName={ui.info?.profile_name}
         sessionStartedAt={status.sessionStartedAt}
         showCost={ui.showCost}
         status={ui.status}


### PR DESCRIPTION
## What does this PR do?

Shows the active Hermes profile in the TUI status bar for named profiles. This gives users a persistent profile indicator during normal work instead of relying only on the composer prompt.

Default and `custom` profiles stay quiet so the default UI does not get noisier.

## Related Issue

Part of #36081

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/appChrome.tsx` — render a `profile <name>` segment in the status rule for non-default/non-custom profiles.
- `ui-tui/src/components/appLayout.tsx` — pass the current `profile_name` from session info into the status rule.
- `ui-tui/src/__tests__/appChromeStatusRule.test.tsx` — cover named profile display and default/custom suppression.

## How to Test

1. Start Hermes TUI under a named profile.
2. Confirm the status bar includes `profile <name>`.
3. Start under the default profile and confirm no default-profile label is shown.

Automated:

```bash
cd ui-tui
npm ci
npm run build --prefix packages/hermes-ink
npm run test -- appChromeStatusRule.test.tsx
npx eslint src/components/appChrome.tsx src/components/appLayout.tsx src/__tests__/appChromeStatusRule.test.tsx
npm run build
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux local checkout with focused TUI test/build checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Focused TUI test:

```text
Test Files  1 passed (1)
Tests  3 passed (3)
```

`npx eslint` on changed TUI files exited 0 with one pre-existing warning in `appChrome.tsx` about `GoodVibesHeart` hook dependencies.

Note: full `npm run type-check` currently fails in `packages/hermes-ink/src/utils/execFileNoThrow.ts` due pre-existing Node stdio type errors unrelated to this change.
