### PR TITLE
fix(cli): complete launchd restart after self-restart signal

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3327,8 +3327,12 @@ def launchd_restart():
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
-            return
-        if pid is not None:
+            exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
+            if not exited:
+                print(
+                    f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
+                )
+        elif pid is not None:
             try:
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -580,27 +580,38 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
         ]
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_self_requests_graceful_restart_with_kickstart(self, monkeypatch, capsys):
         calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
         )
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
             gateway_cli,
             "_request_gateway_self_restart",
             lambda pid: calls.append(("self", pid)) or True,
         )
         monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: calls.append(("wait", timeout, force_after)) or True,
+        )
+        monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+            lambda cmd, check=False, **kwargs: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
         )
 
         gateway_cli.launchd_restart()
 
-        assert calls == [("self", 321)]
+        assert calls == [
+            ("self", 321),
+            ("wait", 12.0, None),
+            ["launchctl", "kickstart", "-k", target],
+        ]
         assert "restart requested" in capsys.readouterr().out.lower()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a macOS gateway restart regression where `launchd_restart()` returned immediately after sending SIGUSR1 when the gateway PID was an ancestor of the caller (for example when `hermes update` ran inside the gateway process tree). This change removes the early-exit behavior for that path so restart consistently completes with a launchd kickstart.

## Related Issue

Fixes #11932

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/gateway.py`: in `launchd_restart()`, replaced the SIGUSR1 self-restart early return with drain wait (`_wait_for_gateway_exit`) and then continued to `launchctl kickstart -k` like the other restart path.
- `tests/hermes_cli/test_gateway_service.py`: updated self-restart test to assert SIGUSR1 request, drain wait call with configured timeout, and `launchctl kickstart -k` execution.

## How to Test

1. Run targeted restart tests: `pytest tests/hermes_cli/test_gateway_service.py -q -k launchd_restart`
2. Run Windows footgun guard on changed files: `python scripts/check-windows-footguns.py hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
3. Run lint on changed files: `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`

## What platforms tested on

- Linux (worker sandbox), Python from shared project venv

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (sandbox)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-be058991 kind=pr-open -->