### PR TITLE
fix(gateway): reject malformed MEDIA path tokens in extract_media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1205,6 +1205,8 @@ MEDIA_TAG_CLEANUP_RE = re.compile(
     re.IGNORECASE,
 )
 
+_MEDIA_LOCAL_PATH_PREFIX_RE = re.compile(r"^(?:~/|/|[A-Za-z]:[/\\])")
+
 
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
@@ -2626,6 +2628,10 @@ class BasePlatformAdapter(ABC):
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            if path and not _MEDIA_LOCAL_PATH_PREFIX_RE.match(path):
+                # Reject placeholders / malformed captures early so downstream
+                # send_* calls never see non-path artifacts.
+                continue
             if path:
                 try:
                     media.append((os.path.expanduser(path), has_voice_tag))

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -348,6 +348,18 @@ class TestExtractMedia:
         assert media == [("/tmp/x.jpg", False)]  # voice flag stays False
         assert "[[as_document]]" not in cleaned
 
+    def test_media_tag_skips_placeholder_path_tokens(self):
+        content = "MEDIA:<path>"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == "MEDIA:<path>"
+
+    def test_media_tag_skips_regex_like_tokens(self):
+        content = r"MEDIA:\s*(?P<path>foo.ogg)"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == r"MEDIA:\s*(?P<path>foo.ogg)"
+
     def test_both_directives_can_coexist(self):
         """A response could (rarely) contain both [[audio_as_voice]] for an
         ogg file AND [[as_document]] for an attached image. The voice flag


### PR DESCRIPTION
## What does this PR do?

Hardens `BasePlatformAdapter.extract_media()` so only local-path-shaped `MEDIA:` payloads are accepted (absolute `/...`, home-relative `~/...`, or Windows drive-root `X:/...` / `X:\\...`). This prevents malformed captures such as placeholders (`<path>`) or regex-like text from being forwarded toward media send paths.

## Related Issue

Fixes #21527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: added `_MEDIA_LOCAL_PATH_PREFIX_RE` and a guard in `extract_media()` to skip non-path-shaped `MEDIA:` captures before expansion/attachment routing.
- `tests/gateway/test_platform_base.py`: added regressions for `MEDIA:<path>` and `MEDIA:\\s*(?P<path>foo.ogg)` to ensure malformed tokens are ignored.

## How to Test

1. Run `pytest -q tests/gateway/test_platform_base.py -x`.
2. Verify new tests pass: `test_media_tag_skips_placeholder_path_tokens` and `test_media_tag_skips_regex_like_tokens`.
3. Confirm touched-file safety checks pass: `python scripts/check-windows-footguns.py gateway/platforms/base.py tests/gateway/test_platform_base.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (local worktree)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused test run: `127 passed, 2 skipped` in `tests/gateway/test_platform_base.py`.
- `scripts/check-windows-footguns.py` (touched files): clean.

<!-- autocontrib:worker-id=issue-new-1104609e kind=pr-open -->