### PR TITLE
fix(dashboard-auth): drop /api/* paths from OAuth next= round trip

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -150,6 +150,16 @@ def _safe_next_target(request: Request) -> str:
         for p in ("/login", "/auth/", "/api/auth/")
     ):
         return ""
+    # Reject ALL ``/api/*`` paths. The 401-envelope code path fires for
+    # any unauthenticated SPA fetch (e.g. ``GET /api/analytics/models``
+    # from ModelsPage), and the SPA's global 401 handler full-page
+    # navigates to ``login_url``. After the OAuth round trip the user
+    # would land on the API URL and see raw JSON instead of the
+    # dashboard. SPA routes survive (they don't start with ``/api/``);
+    # the SPA's own ``sessionStorage["hermes.lastLocation"]`` fallback
+    # in ``web/src/lib/api.ts`` covers the deep-link case.
+    if path == "/api" or path.startswith("/api/"):
+        return ""
     # Preserve query string if present (e.g. /sessions?page=2).
     query = request.url.query
     target = f"{path}?{query}" if query else path

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -365,6 +365,15 @@ def _validate_post_login_target(raw: str) -> str:
         for p in ("/login", "/auth/", "/api/auth/")
     ):
         return ""
+    # Reject any ``/api/*`` target. The gate's ``_safe_next_target``
+    # already filters these out before they reach the cookie, but a
+    # malicious or stale ``next=`` value that re-enters via the
+    # callback URL must not be honoured: a successful redirect to an
+    # API endpoint renders raw JSON in the browser address bar — never
+    # a useful post-login destination, and indistinguishable from an
+    # attacker trying to weaponise the redirect.
+    if decoded == "/api" or decoded.startswith("/api/"):
+        return ""
     return decoded
 
 

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -163,12 +163,33 @@ class TestApi401Envelope:
             for c in set_cookies
         )
 
-    def test_login_url_carries_next_for_deep_api_path(self, gated_app):
+    def test_login_url_drops_next_for_deep_api_path(self, gated_app):
+        """Bug fix: ``/api/*`` paths must NOT round-trip into ``next=``.
+
+        Before the fix, an unauthenticated SPA fetch like ``GET
+        /api/analytics/models?days=30`` from ModelsPage round-tripped
+        through the OAuth dance and landed the user on the raw JSON
+        endpoint instead of the dashboard. The gate now drops API paths
+        from ``next=`` entirely; the SPA's own ``hermes.lastLocation``
+        fallback in ``web/src/lib/api.ts`` covers the deep-link case.
+        """
         r = gated_app.get("/api/sessions?page=2")
         body = r.json()
-        # next= is URL-encoded.
-        assert "next=" in body["login_url"]
-        assert quote("/api/sessions?page=2", safe="") in body["login_url"]
+        # ``login_url`` is the bare ``/login`` (no ``next=``) — the
+        # post-callback landing falls back to "/" rather than the API
+        # URL.
+        assert body["login_url"] == "/login"
+        assert "next=" not in body["login_url"]
+
+    def test_login_url_drops_next_for_analytics_path(self, gated_app):
+        """Specific repro for the ``/api/analytics/models?days=30``
+        case Ben reported: page on /models, session expires, SPA fires
+        getModelsAnalytics(), 401 envelope carries ``next=``, user ends
+        up staring at JSON post-callback."""
+        r = gated_app.get("/api/analytics/models?days=30")
+        body = r.json()
+        assert body["login_url"] == "/login"
+        assert "next=" not in body["login_url"]
 
 
 class TestHtmlRedirectNext:
@@ -252,6 +273,46 @@ class TestNextSameOriginValidation:
         assert _safe_next_target(FakeRequest("/login")) == ""
         assert _safe_next_target(FakeRequest("/auth/login")) == ""
         assert _safe_next_target(FakeRequest("/api/auth/me")) == ""
+
+    def test_safe_next_validator_rejects_api_paths(self):
+        """``/api/*`` paths must not round-trip through ``next=``.
+
+        Any API URL is a JSON endpoint; landing the browser there after
+        OAuth shows raw JSON instead of the dashboard. This is the bug
+        fix that closes the analytics-page redirect mishap.
+        """
+        from hermes_cli.dashboard_auth.middleware import _safe_next_target
+
+        class FakeRequest:
+            def __init__(self, path, query=""):
+                self.url = type("URL", (), {"path": path, "query": query})()
+
+        assert _safe_next_target(FakeRequest("/api/analytics/models")) == ""
+        assert (
+            _safe_next_target(FakeRequest("/api/analytics/models", "days=30"))
+            == ""
+        )
+        assert _safe_next_target(FakeRequest("/api/sessions")) == ""
+        assert _safe_next_target(FakeRequest("/api/config")) == ""
+        assert _safe_next_target(FakeRequest("/api/status")) == ""
+        # Exact ``/api`` (no trailing slash) also rejected — the dashboard
+        # has no such SPA route, but pinning the boundary keeps the rule
+        # crisp.
+        assert _safe_next_target(FakeRequest("/api")) == ""
+
+    def test_safe_next_validator_does_not_reject_api_prefix_lookalikes(self):
+        """Negative guard: ``/api-docs`` or ``/apis`` aren't ``/api/*``
+        and must remain valid landing targets."""
+        from hermes_cli.dashboard_auth.middleware import _safe_next_target
+
+        class FakeRequest:
+            def __init__(self, path):
+                self.url = type("URL", (), {"path": path, "query": ""})()
+
+        # ``/apidocs`` or ``/api-keys`` lookalike SPA routes — we must
+        # only match the ``/api/`` prefix or exact ``/api``.
+        assert _safe_next_target(FakeRequest("/apidocs")) == "%2Fapidocs"
+        assert _safe_next_target(FakeRequest("/api-keys")) == "%2Fapi-keys"
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +455,91 @@ class TestAuthCallbackNext:
         # No next= was in the PKCE cookie, so landing must be "/" —
         # NOT /internal-admin.
         assert r.headers["location"] == "/"
+
+    def test_callback_with_api_next_lands_at_root(self, gated_app):
+        """End-to-end repro of the analytics-redirect bug.
+
+        Drive ``/auth/login?next=/api/analytics/models?days=30`` —
+        exactly what the pre-fix gate would have stamped after a
+        ModelsPage 401. The validator at /auth/login MUST now drop
+        ``/api/*`` so the PKCE cookie never carries the API path, AND
+        the callback's ``_validate_post_login_target`` MUST drop it as
+        second-line defence. Either layer alone is enough; both means
+        a regression in one is caught by the other.
+
+        Discrimination: under the pre-fix code, both validators
+        accepted ``/api/*`` and the callback redirected to the raw
+        JSON endpoint. With the fix, the callback redirects to "/".
+        """
+        api_next = "/api/analytics/models?days=30"
+        r_to_idp = gated_app.get(
+            f"/auth/login?provider=stub&next={quote(api_next, safe='')}",
+            follow_redirects=False,
+        )
+        state = r_to_idp.headers["location"].split("state=")[1]
+        r = gated_app.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            follow_redirects=False,
+        )
+        assert r.status_code == 302
+        # Landing falls back to "/" — NOT the API URL.
+        assert r.headers["location"] == "/"
+
+
+# ---------------------------------------------------------------------------
+# Unit-level coverage: _validate_post_login_target on the callback boundary
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePostLoginTarget:
+    """Cover ``_validate_post_login_target`` directly — it's the second
+    half of the next= validator pair (the callback boundary). The gate
+    side has matching coverage in ``TestNextSameOriginValidation``.
+    """
+
+    def test_accepts_same_origin_paths(self):
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+        assert _validate_post_login_target("/sessions") == "/sessions"
+        # URL-encoded form (as the cookie carries it) round-trips through
+        # the validator's unquote step.
+        assert (
+            _validate_post_login_target("%2Fsessions%3Fpage%3D2")
+            == "/sessions?page=2"
+        )
+
+    def test_rejects_protocol_relative(self):
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+        assert _validate_post_login_target("//evil.com") == ""
+        assert _validate_post_login_target("%2F%2Fevil.com") == ""
+
+    def test_rejects_login_loop(self):
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+        assert _validate_post_login_target("/login") == ""
+        assert _validate_post_login_target("/auth/login") == ""
+        assert _validate_post_login_target("/api/auth/me") == ""
+
+    def test_rejects_api_paths(self):
+        """Bug fix: any ``/api/*`` target is dropped at the callback
+        boundary. Pin both the exact match and the trailing-slash forms
+        plus a few realistic SPA-API endpoints."""
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+        assert _validate_post_login_target("/api") == ""
+        assert _validate_post_login_target("/api/analytics/models") == ""
+        assert _validate_post_login_target("/api/analytics/models?days=30") == ""
+        assert _validate_post_login_target("/api/sessions") == ""
+        assert _validate_post_login_target("/api/config") == ""
+        # URL-encoded form — what the cookie actually carries.
+        assert (
+            _validate_post_login_target(
+                "%2Fapi%2Fanalytics%2Fmodels%3Fdays%3D30"
+            ) == ""
+        )
+
+    def test_does_not_reject_api_prefix_lookalikes(self):
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+        # SPA route lookalikes — must NOT be dropped.
+        assert _validate_post_login_target("/apidocs") == "/apidocs"
+        assert _validate_post_login_target("/api-keys") == "/api-keys"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Reported by Ben: open the dashboard with an expired/missing session while on `/models` (or any analytics-style page), get bounced through Nous Portal's OAuth screen, and **land on `$DOMAIN/api/analytics/models?days=30`** — raw JSON in the address bar instead of the dashboard.

Reproduces deterministically: whichever `/api/*` call a page fires first on mount owns the redirect race, so the bad landing URL varies by page but the bug fires every time.

## Root cause

Single bug at two boundaries:

1. **Gate side** (`_safe_next_target` in `hermes_cli/dashboard_auth/middleware.py`): the gated middleware computes `next=` from the request's own path. When an unauthenticated SPA fetch hits a gated endpoint, the path going into `next=` is the API URL the SPA was calling.

2. **Callback side** (`_validate_post_login_target` in `hermes_cli/dashboard_auth/routes.py`): only filters out `/login`, `/auth/`, and `/api/auth/`. Any other `/api/*` value is accepted as same-origin.

End-to-end flow:

```
ModelsPage.tsx mounts
  → api.getModelsAnalytics(30)  →  GET /api/analytics/models?days=30
  → 401 { login_url: "/login?next=%2Fapi%2Fanalytics%2Fmodels%3Fdays%3D30" }
  → web/src/lib/api.ts: window.location.assign(login_url)
  → /login → /auth/login (stores next in PKCE cookie)
  → Portal OAuth dance
  → /auth/callback (reads next= from cookie, validates as "same-origin", redirects)
  → /api/analytics/models?days=30  →  raw JSON in address bar
```

The SPA's own `sessionStorage["hermes.lastLocation"]` fallback in `api.ts` already saves the actual browser location, so dropping the server-stamped `next=` on `/api/*` requests doesn't lose any UX — the SPA recovers the deep link itself.

## Fix

Both validators now reject `/api/*` targets in addition to the existing `/login`, `/auth/`, `/api/auth/` exclusions. The match is anchored (`decoded == "/api"` or `decoded.startswith("/api/")`) so SPA route lookalikes like `/apidocs` or `/api-keys` remain valid landing targets.

**Why both validators get the same fix:** either layer alone is sufficient; pairing them means a regression in one is caught by the other. The callback-side validator is the load-bearing one (it's the last line of defence against a legacy cookie / regressed middleware / attacker-crafted `/auth/login?next=/api/...`), and the gate-side fix means the SPA's 401 handler navigates to a bare `/login` (clean, no useless redirect parameter) in the common case.

## Tests

Added to `tests/hermes_cli/test_dashboard_auth_401_reauth.py`:

- **`TestApi401Envelope`**: rewrote `test_login_url_carries_next_for_deep_api_path` (which had locked in the pre-fix behaviour) into `test_login_url_drops_next_for_deep_api_path`, plus added `test_login_url_drops_next_for_analytics_path` as the specific repro for Ben's report.
- **`TestNextSameOriginValidation`**: `test_safe_next_validator_rejects_api_paths` (covers `/api`, `/api/analytics/models`, `/api/sessions`, `/api/config`, `/api/status`) + `test_safe_next_validator_does_not_reject_api_prefix_lookalikes` (covers `/apidocs`, `/api-keys`).
- **`TestAuthCallbackNext`**: end-to-end `test_callback_with_api_next_lands_at_root` drives `/auth/login?next=/api/analytics/models?days=30` through to the callback and asserts the user lands at `/`, not the API URL.
- **`TestValidatePostLoginTarget`**: new class covering the callback-side validator directly, including the URL-encoded `%2Fapi%2F...` form the PKCE cookie actually carries.

## Verification

- Targeted: `bash scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_401_reauth.py` → 36/36 pass.
- Wider: `bash scripts/run_tests.sh tests/hermes_cli/` → 288 files, 5,938 tests, 100% pass.
- **Mutation-tested**: reverted both validators in place, ran the file, saw exactly the 5 new/rewritten `/api/*` assertions fail and the 31 other tests remain green. Each fix layer is independently tested.

## Files

| File | Change |
|------|--------|
| `hermes_cli/dashboard_auth/middleware.py` | `_safe_next_target` drops `/api/*` |
| `hermes_cli/dashboard_auth/routes.py` | `_validate_post_login_target` drops `/api/*` |
| `tests/hermes_cli/test_dashboard_auth_401_reauth.py` | +150 lines of coverage |

No SPA changes — `sessionStorage["hermes.lastLocation"]` was already saving the right value; this PR just stops the server from emitting a useless (and harmful) override.
