### PR TITLE
fix(agent): honor auxiliary task extra_body

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4209,13 +4209,17 @@ def resolve_vision_provider_client(
     return requested, client, final_model
 
 
-def get_auxiliary_extra_body() -> dict:
+def get_auxiliary_extra_body(task: str = "") -> dict:
     """Return extra_body kwargs for auxiliary API calls.
-    
+
     Includes Nous Portal product tags when the auxiliary client is backed
-    by Nous Portal. Returns empty dict otherwise.
+    by Nous Portal, plus any task-specific ``auxiliary.<task>.extra_body``
+    configured in ``config.yaml``.
     """
-    return _nous_extra_body() if auxiliary_is_nous else {}
+    result = _nous_extra_body() if auxiliary_is_nous else {}
+    if task:
+        result.update(_get_task_extra_body(task))
+    return result
 
 
 def auxiliary_max_tokens_param(value: int) -> dict:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -446,7 +446,7 @@ def judge_goal(
             temperature=0,
             max_tokens=_goal_judge_max_tokens(),
             timeout=timeout,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("goal_judge") or None,
         )
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -333,7 +333,7 @@ def decompose_task(
             temperature=0.3,
             max_tokens=4000,
             timeout=timeout or 180,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("kanban_decomposer") or None,
         )
     except Exception as exc:
         logger.info(

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -192,7 +192,7 @@ def specify_task(
             temperature=0.3,
             max_tokens=HERMES_KANBAN_SPECIFY_MAX_TOKENS,
             timeout=timeout or 120,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("triage_specifier") or None,
         )
     except Exception as exc:
         logger.info(

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -246,7 +246,7 @@ def describe_profile(
             temperature=0.3,
             max_tokens=400,
             timeout=timeout or 60,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("profile_describer") or None,
         )
     except Exception as exc:
         logger.info("describe: API call failed for %s (%s)", canon, exc)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1995,6 +1995,33 @@ class TestStaleBaseUrlWarning:
 
 
 class TestAuxiliaryTaskExtraBody:
+    def test_get_auxiliary_extra_body_reads_task_config(self):
+        import agent.auxiliary_client as mod
+
+        config = {
+            "extra_body": {
+                "enable_thinking": False,
+                "reasoning": {"effort": "none"},
+            }
+        }
+
+        with patch.object(mod, "auxiliary_is_nous", False), patch.object(
+            mod, "_get_auxiliary_task_config", return_value=config
+        ):
+            assert mod.get_auxiliary_extra_body("profile_describer") == {
+                "enable_thinking": False,
+                "reasoning": {"effort": "none"},
+            }
+
+    def test_get_auxiliary_extra_body_preserves_legacy_nous_tags_without_task(self):
+        import agent.auxiliary_client as mod
+
+        with patch.object(mod, "auxiliary_is_nous", True), patch.object(
+            mod, "_nous_extra_body", return_value={"tags": ["nous"]}
+        ), patch.object(mod, "_get_auxiliary_task_config") as mock_task_config:
+            assert mod.get_auxiliary_extra_body() == {"tags": ["nous"]}
+            mock_task_config.assert_not_called()
+
     def test_sync_call_merges_task_extra_body_from_config(self):
         client = MagicMock()
         client.base_url = "https://api.example.com/v1"

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -112,6 +112,42 @@ def test_describer_writes_description_with_auto_true(profile_env, monkeypatch):
     assert meta["description_auto"] is True
 
 
+def test_describer_passes_task_extra_body(profile_env, monkeypatch):
+    monkeypatch.setattr(
+        profiles_mod, "profile_exists", lambda n: n == "myprof",
+    )
+    monkeypatch.setattr(
+        profiles_mod, "normalize_profile_name", lambda n: n,
+    )
+    monkeypatch.setattr(
+        profiles_mod, "get_profile_dir", lambda n: profile_env,
+    )
+
+    client = MagicMock()
+    client.chat.completions.create = MagicMock(
+        return_value=_fake_aux_response(
+            jsonlib.dumps({"description": "uses configured extra body"})
+        )
+    )
+
+    def _extra_body_for_task(task: str):
+        assert task == "profile_describer"
+        return {"enable_thinking": False}
+
+    with patch(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        return_value=(client, "test-model"),
+    ), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body",
+        side_effect=_extra_body_for_task,
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok, outcome.reason
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["extra_body"] == {"enable_thinking": False}
+
+
 def test_describer_refuses_to_overwrite_user_authored(profile_env, monkeypatch):
     profiles_mod.write_profile_meta(
         profile_env, description="curated", description_auto=False,


### PR DESCRIPTION
## Summary
- make `get_auxiliary_extra_body()` accept an optional auxiliary task key
- merge `auxiliary.<task>.extra_body` into direct auxiliary callers while preserving legacy no-task Nous Portal tags
- pass task keys from profile describer, kanban specify/decompose, and goal judge
- add focused regression coverage for the helper and profile describer passthrough

Fixes #35566.

## Notes
This is intentionally narrower than the auxiliary fallback cluster in #32411: it only fixes task-specific `extra_body` passthrough for the existing direct auxiliary callers.

## Verification
```bash
PYTHONPATH=. uv run --frozen --extra dev pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryTaskExtraBody tests/hermes_cli/test_profile_describer.py -q
PYTHONPATH=. uv run --frozen --extra dev pytest tests/hermes_cli/test_kanban_specify.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_goals.py -q
uv run --frozen --extra dev ruff check agent/auxiliary_client.py hermes_cli/profile_describer.py hermes_cli/kanban_specify.py hermes_cli/kanban_decompose.py hermes_cli/goals.py tests/agent/test_auxiliary_client.py tests/hermes_cli/test_profile_describer.py
git diff --check
```