### PR TITLE
fix(agent): harden handle_max_iterations as a hard stop

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1262,16 +1262,57 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
+def _scrub_summary_response_for_tool_calls(label: str, normalized) -> str:
+    """Safety net for the max-iterations summary path.
+
+    If the response still carries a ``tool_calls`` payload (i.e. the
+    model ignored the system stop message AND the
+    ``tool_choice='none'`` constraint), swap it for a fixed fallback
+    string so the user never sees the model's mid-thought "let me do
+    one more cross-check" prose standing in for a real summary. Logs
+    at WARNING so the agent log makes it visible when a downstream
+    model failed to honor the stop contract. See #36239.
+    """
+    if normalized.tool_calls:
+        logger.warning(
+            "handle_max_iterations: %s returned tool_calls=%d despite "
+            "tool_choice='none' and system stop; using fallback instead "
+            "of partial content.",
+            label,
+            len(normalized.tool_calls),
+        )
+        return "I reached the iteration limit and couldn't generate a summary."
+    return (normalized.content or "").strip()
+
+
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+    # Hard-stop for the iteration budget. Three layered defenses (see #36239):
+    #
+    # 1) System-role stop message — the function builds a `role=system`
+    #    message a few lines below; we append the stop to that same
+    #    system string instead of injecting a `role=user` "summarize
+    #    without tools" message. In long-context tool-heavy histories,
+    #    some models re-weight user messages and read "summarize
+    #    without tools" as "do one more cross-check then summarize".
+    #    A system-role instruction is more authoritative and survives
+    #    that re-weighting.
+    #
+    # 2) `tool_choice="none"` on the OpenAI Chat Completions /
+    #    OpenAI Responses summary call (a hard protocol-level
+    #    constraint that is honored by every provider we have tested).
+    #
+    # 3) If the model *still* returns a `tool_calls` payload despite
+    #    (1) and (2), the `_scrub_summary_response_for_tool_calls`
+    #    helper replaces the response with a fixed fallback string
+    #    so the user never sees a partial "I'm about to do one more
+    #    cross-check" message standing in for a real summary.
+    summary_stop_message = (
+        "Tool-calling budget exhausted. Produce a final summary in plain "
+        "text. Do not call any tools."
     )
-    messages.append({"role": "user", "content": summary_request})
 
     try:
         # Build API messages, stripping internal-only fields
@@ -1302,8 +1343,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         effective_system = agent._cached_system_prompt or ""
         if agent.ephemeral_system_prompt:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        # Hard-stop the iteration budget via a system-role instruction
+        # (more authoritative than a role=user prompt in long-context
+        # tool-heavy histories). See #36239.
         if effective_system:
-            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+            effective_system = effective_system + "\n\n" + summary_stop_message
+        else:
+            effective_system = summary_stop_message
+        api_messages = [{"role": "system", "content": effective_system}] + api_messages
         if agent.prefill_messages:
             sys_offset = 1 if effective_system else 0
             for idx, pfm in enumerate(agent.prefill_messages):
@@ -1361,14 +1408,25 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         if agent.api_mode == "codex_responses":
             codex_kwargs = agent._build_api_kwargs(api_messages)
             codex_kwargs.pop("tools", None)
+            # Mirror the OpenAI path's hard constraint. The OpenAI
+            # Responses API accepts `tool_choice="none"` to forbid tool
+            # calling. See #36239.
+            codex_kwargs["tool_choice"] = "none"
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
-            final_response = (_cnr_sum.content or "").strip()
+            final_response = _scrub_summary_response_for_tool_calls(
+                "codex_summary", _cnr_sum
+            )
         else:
             summary_kwargs = {
                 "model": agent.model,
                 "messages": api_messages,
+                # Hard constraint: the provider is told the model is
+                # not allowed to call any tools, regardless of what the
+                # system stop says. Every Chat Completions provider we
+                # have tested honors `tool_choice: "none"`. See #36239.
+                "tool_choice": "none",
             }
             if _summary_temperature is not None:
                 summary_kwargs["temperature"] = _summary_temperature
@@ -1425,11 +1483,15 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                preserve_dots=agent._anthropic_preserve_dots())
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
-                final_response = (_summary_result.content or "").strip()
+                final_response = _scrub_summary_response_for_tool_calls(
+                    "anthropic_summary", _summary_result
+                )
             else:
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
                 _summary_result = agent._get_transport().normalize_response(summary_response)
-                final_response = (_summary_result.content or "").strip()
+                final_response = _scrub_summary_response_for_tool_calls(
+                    "chat_completions_summary", _summary_result
+                )
 
         if final_response:
             if "<think>" in final_response:
@@ -1443,10 +1505,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "codex_responses":
                 codex_kwargs = agent._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
+                codex_kwargs["tool_choice"] = "none"
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)
-                final_response = (_cnr_retry.content or "").strip()
+                final_response = _scrub_summary_response_for_tool_calls(
+                    "codex_retry", _cnr_retry
+                )
             elif agent.api_mode == "anthropic_messages":
                 _tretry = agent._get_transport()
                 _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
@@ -1455,11 +1520,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                 preserve_dots=agent._anthropic_preserve_dots())
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)
-                final_response = (_retry_result.content or "").strip()
+                final_response = _scrub_summary_response_for_tool_calls(
+                    "anthropic_retry", _retry_result
+                )
             else:
                 summary_kwargs = {
                     "model": agent.model,
                     "messages": api_messages,
+                    "tool_choice": "none",
                 }
                 if _summary_temperature is not None:
                     summary_kwargs["temperature"] = _summary_temperature
@@ -1472,7 +1540,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
                 _retry_result = agent._get_transport().normalize_response(summary_response)
-                final_response = (_retry_result.content or "").strip()
+                final_response = _scrub_summary_response_for_tool_calls(
+                    "chat_completions_retry", _retry_result
+                )
 
             if final_response:
                 if "<think>" in final_response:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5959,3 +5959,169 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+
+class TestHandleMaxIterationsHardStop:
+    """Regression tests for #36239 — make the iteration-budget summary
+    a hard stop rather than a soft `role=user` prompt.
+
+    The three layered defenses added by the fix:
+      1) Stop message is now `role=system` (appended to the existing
+         system prompt), not `role=user`.
+      2) `tool_choice="none"` is sent on every summary call.
+      3) If the model *still* returns a `tool_calls` payload, the
+         response is replaced with a fixed fallback string instead of
+         surfacing the model's mid-thought prose.
+    """
+
+    def test_summary_sends_tool_choice_none_to_openai(self, agent):
+        """`tool_choice="none"` must appear in the OpenAI summary
+        kwargs so the provider refuses to emit tool calls even if the
+        model is in 'work in progress' mode."""
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs.get("tool_choice") == "none"
+
+    def test_summary_stop_is_system_role_not_user_role(self, agent):
+        """The stop instruction must ride on a `role=system` message,
+        not on a `role=user` "summarize without tools" message that
+        long-context models tend to re-weight as a user follow-up."""
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get(
+            "messages", []
+        )
+        assert sent_msgs, "no messages were sent on the wire"
+        # First message must be the system prompt with the stop appended.
+        first = sent_msgs[0]
+        assert first["role"] == "system"
+        assert "Tool-calling budget exhausted" in first["content"]
+        # The legacy soft-prompt phrasing must NOT be appended as a
+        # user-role message anywhere in the wire payload.
+        legacy_user_stops = [
+            m
+            for m in sent_msgs
+            if m.get("role") == "user"
+            and "summarizing what you've found" in (m.get("content") or "")
+        ]
+        assert legacy_user_stops == [], (
+            f"legacy soft user-role stop was injected: {legacy_user_stops}"
+        )
+
+    def test_summary_stop_appends_to_existing_system_prompt(self, agent):
+        """If a system prompt is already cached, the stop instruction
+        should be appended to it (one combined system message), not
+        sent as a separate second system message."""
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get(
+            "messages", []
+        )
+        system_msgs = [m for m in sent_msgs if m.get("role") == "system"]
+        assert len(system_msgs) == 1
+        assert "You are helpful." in system_msgs[0]["content"]
+        assert "Tool-calling budget exhausted" in system_msgs[0]["content"]
+
+    def test_summary_uses_fallback_when_response_has_tool_calls(self, agent):
+        """Even with `tool_choice="none"` and a system stop, some
+        downstream models still emit a `tool_calls` payload. The
+        runtime must NOT surface the model's mid-thought prose as the
+        final answer — it must use the fixed fallback string instead."""
+        bad_tool_call = _mock_tool_call(
+            name="search_files",
+            arguments='{"limit": 15}',
+            call_id="call_dangling",
+        )
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="最后做一次反查,确认我的 P0/P1 判断不会误报。",
+            tool_calls=[bad_tool_call],
+        )
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "I reached the iteration limit and couldn't generate a summary."
+
+    def test_summary_fallback_does_not_loop_into_retry(self, agent):
+        """When the first summary call already triggers the tool_calls
+        fallback, the runtime must NOT make a second retry call —
+        retrying with the same prompt will just hit the same model
+        state and produce the same tool_calls response."""
+        bad_tool_call = _mock_tool_call(
+            name="search_files",
+            arguments="{}",
+            call_id="call_dangling",
+        )
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="partial prose",
+            tool_calls=[bad_tool_call],
+        )
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        # Exactly one call — no retry, no second round-trip.
+        assert agent.client.chat.completions.create.call_count == 1
+
+    def test_scrub_helper_returns_content_when_no_tool_calls(self):
+        """Unit test: `_scrub_summary_response_for_tool_calls` returns
+        the normalized `.content` (stripped) when `tool_calls` is empty."""
+        from agent.chat_completion_helpers import (
+            _scrub_summary_response_for_tool_calls,
+        )
+        from agent.transports.types import NormalizedResponse
+
+        normalized = NormalizedResponse(
+            content="  Here is a summary.  ",
+            tool_calls=None,
+            finish_reason="stop",
+        )
+
+        result = _scrub_summary_response_for_tool_calls("test", normalized)
+
+        assert result == "Here is a summary."
+
+    def test_scrub_helper_returns_fallback_when_tool_calls_present(self):
+        """Unit test: when `tool_calls` is non-empty, the helper
+        returns the fixed fallback string and logs a warning — it
+        does NOT return the model's partial content."""
+        from agent.chat_completion_helpers import (
+            _scrub_summary_response_for_tool_calls,
+        )
+        from agent.transports.types import NormalizedResponse, ToolCall
+
+        dangling = ToolCall(
+            id="call_dangling",
+            name="search_files",
+            arguments="{}",
+        )
+        normalized = NormalizedResponse(
+            content="partial mid-thought prose",
+            tool_calls=[dangling],
+            finish_reason="tool_calls",
+        )
+
+        result = _scrub_summary_response_for_tool_calls("test", normalized)
+
+        assert result == "I reached the iteration limit and couldn't generate a summary."


### PR DESCRIPTION
## Summary

`handle_max_iterations` (`agent/chat_completion_helpers.py`) used a *soft* `role=user` "summarize without tools" prompt and only stripped the `tools` field from the summary call. In long-context tool-heavy histories, some models continue to emit a `tool_calls` payload in response — the runtime silently discards the tool call and surfaces the model's mid-thought "let me do one more cross-check" prose as the final answer.

This PR makes the summary path a **hard stop** with three layered defenses (mirroring the proposal in #36239):

1. The stop message is now `role=system` (appended to the existing system prompt), not `role=user`. In long-context histories, models tend to re-weight user messages and read the soft prompt as a follow-up request; a system-role instruction survives that re-weighting.
2. `summary_kwargs` (OpenAI Chat Completions) and `codex_kwargs` (OpenAI Responses) now carry `tool_choice="none"`. This is a hard protocol-level constraint that providers honor regardless of what the system stop says.
3. If the model *still* returns a `tool_calls` payload, the new `_scrub_summary_response_for_tool_calls` helper replaces the response with a fixed fallback string and logs a warning, so the user never sees partial tool-call prose standing in for a real summary.

All three defenses apply on both the initial summary call and the retry path. Codex Responses and Anthropic paths are wired up identically (Anthropic already strips `tools=None`, so just the scrub applies there).

## What does this PR do?

Closes the user-visible "model went past the iteration limit but appeared to finish" gap that #36239 reports. Concretely:

- 1 helper added at module scope: `_scrub_summary_response_for_tool_calls(label, normalized_response) -> str`. Pure function, easily unit-testable.
- 1 constant added inside `handle_max_iterations`: `summary_stop_message` (the new system-role stop text).
- 3 changes to the request shape: stop is now on the system message; `tool_choice="none"` is added to OpenAI and codex kwargs (initial + retry).
- 3 result-handling changes on the initial call, 3 on the retry call: all six sites now route through `_scrub_summary_response_for_tool_calls` instead of reading `(_X_result.content or "").strip()` directly.

Net diff: +82/-12 in `chat_completion_helpers.py`, +166/-0 in tests.

## Related Issue

Fixes #36239

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Cross-provider reproduction

Captured after opening this PR. Adds a second live-data point beyond the original repro in #36239, on a different model and transport.

**Session:** `67e642146639` (model=`MiniMax-M3`, provider=`minimax-cn`, platform=`webui`)

| Metric | Value |
|---|---|
| `api_calls` | 90/90 (budget exhausted) |
| `tool_turns` | 90 — every iteration issued `tool_calls`, zero text-only assistant turns |
| `response_len` | 335 chars — the soft-stop summary stood in for a real answer |
| Tool mix | 47 `read_file` + 38 `terminal` + 7 `search_files` |

**Control:** the same session's automatic "Review the conversation and update the skill library" follow-up turn (same model, same provider, same conversation history) ended cleanly: 8 API calls, `finish_reason=stop`, `response_len=1343`. The model *can* stop on its own — the soft-stop fails specifically at the max-iteration boundary.

**Why this matters for this PR:**
- Confirms the soft-stop issue is **not provider-specific**. It reproduces on the `minimax-cn` OpenAI-compatible transport, not only `openai-codex`.
- Confirms that `tool_choice="none"` + system-role stop are the right defense layer: they operate at the wire level and are honored by all OpenAI-compatible providers. Anthropic's restricted `tool_choice` shape is already handled separately by the scrub helper.
- Gives maintainers a concrete post-merge verification recipe that does not depend on the original `gpt-5.x` session. Set `max_iterations=5`, run any task that exceeds the limit on a `minimax-cn` or `openai-codex` model, and check the wire log: the summary call must carry `tool_choice="none"`, the first message must be `role=system` (not `role=user` "summarize what you've found"), and the final assistant message must be either a real summary or the fixed fallback string — never mid-thought prose.

## Changes Made

- `agent/chat_completion_helpers.py`
  - Added module-level helper `_scrub_summary_response_for_tool_calls` (lines 1265-1285) — returns fixed fallback when `tool_calls` is non-empty, logs WARNING.
  - `handle_max_iterations`: removed the `messages.append({"role": "user", "content": summary_request})` soft prompt.
  - `handle_max_iterations`: added `summary_stop_message` constant.
  - `handle_max_iterations`: the stop is now appended to `effective_system` and prepended as a single `role=system` message (line 1349-1355).
  - `handle_max_iterations`: `summary_kwargs` now includes `tool_choice="none"` (line 1421).
  - `handle_max_iterations`: `codex_kwargs` (Responses path) now sets `codex_kwargs["tool_choice"] = "none"` after popping `tools` (line 1414-1415).
  - `handle_max_iterations`: all six sites that read `(_X_result.content or "").strip()` now route through `_scrub_summary_response_for_tool_calls` (3 first-call sites + 3 retry sites).

- `tests/run_agent/test_run_agent.py`
  - Added new test class `TestHandleMaxIterationsHardStop` with 7 tests:
    - `test_summary_sends_tool_choice_none_to_openai` — wire-level assertion that `tool_choice="none"` is in the OpenAI kwargs.
    - `test_summary_stop_is_system_role_not_user_role` — wire-level assertion that the stop is on a `role=system` message and no legacy `role=user` "summarize what you've found" message is in the payload.
    - `test_summary_stop_appends_to_existing_system_prompt` — when a cached system prompt exists, the stop is appended to it (one combined system message), not a separate second system message.
    - `test_summary_uses_fallback_when_response_has_tool_calls` — when the mocked response carries a `tool_calls` payload, the runtime returns the fixed fallback string instead of the model's mid-thought prose.
    - `test_summary_fallback_does_not_loop_into_retry` — when the first call already triggers the fallback, the runtime does NOT make a second retry call (saves a round-trip on a model state that is guaranteed to fail the same way).
    - `test_scrub_helper_returns_content_when_no_tool_calls` — direct unit test of the helper.
    - `test_scrub_helper_returns_fallback_when_tool_calls_present` — direct unit test of the fallback path with a real `NormalizedResponse`/`ToolCall` pair.

## How to Test

```bash
cd /Users/xuefusong/.hermes/hermes-agent
.venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterationsHardStop tests/run_agent/test_run_agent.py::TestHandleMaxIterations -v
```

Expected: 17 passed (7 new + 10 existing). All assertions in the new class are wire-level / behavior-level — no live API calls, no flaky assertions.

Broader smoke test (sanity-check that I didn't break anything in adjacent transport code):

```bash
.venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_partial_stream_finish_reason.py tests/agent/test_non_stream_stale_timeout.py tests/agent/test_codex_ttfb_watchdog.py -q
```

Expected: 99 passed.

For end-to-end verification on a real model that previously triggered the issue (e.g. M3 / Claude Sonnet 4 in a long-context heavy-tool-use state past the iteration limit):

1. Configure a small `max_iterations` (e.g. 5).
2. Run a task that forces the agent to use tools up to the limit.
3. Inspect `agent.log`: the `handle_max_iterations` summary call should now include `"tool_choice": "none"` in the wire kwargs, the first message sent should be `role=system` with "Tool-calling budget exhausted..." content (not `role=user` "summarize what you've found..."), and the final assistant message returned to the user should either be a real summary OR the fixed fallback string `"I reached the iteration limit and couldn't generate a summary."` — never the model's mid-thought prose.

## Why this approach

- **Why not just `tool_choice="none"`?** It is the single most effective defense and is honored by every provider we have tested. But it is not bulletproof — Anthropic's `tool_choice` shape is restricted to `auto`/`any`/`tool` (no `"none"`), and a few non-default providers translate `"none"` inconsistently. Layered defenses keep us correct across all paths.
- **Why not just the system stop?** It works in most cases, but the long-context + heavy-tool-use failure mode that motivated #36239 is exactly the case where a soft prompt is unreliable. Hardening requires both the prompt change *and* a wire-level constraint.
- **Why not just the scrub?** It would still leave the wire shape "soft" — providers that count token usage or charge for `tool_calls` would still record a tool call we silently dropped. Putting `tool_choice="none"` on the wire is the right behavior on the provider side as well.
- **Why a separate helper instead of inline?** `_scrub_summary_response_for_tool_calls` is now a 5-line pure function that is unit-testable without standing up a full `AIAgent` mock. The 6 call sites all collapse to one-liners that read identically, making future review and future patches easier.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (searched: "handle_max_iterations", "max iterations stop", "tool_choice none", "iteration budget")
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` on the affected files and all tests pass (17/17 in the touched test class, 99/99 in adjacent transport smoke tests)
- [x] I've added tests for my changes (7 new tests, all wire-level / behavior-level)
