### PR TITLE
fix(desktop): add missing PATCH /api/sessions/{id} so session rename works

### DIFF
--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -68,7 +68,8 @@ const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string
   },
   {
     test: msg => /method not allowed/i.test(msg),
-    summarize: () => 'The desktop backend does not support that audio endpoint yet. Restart Hermes Desktop.'
+    summarize: () =>
+      'The desktop backend rejected that request (405 Method Not Allowed). Try restarting Hermes Desktop.'
   },
   {
     test: msg => /microphone permission/i.test(msg),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3657,6 +3657,31 @@ async def delete_session_endpoint(session_id: str):
         db.close()
 
 
+class SessionRename(BaseModel):
+    title: Optional[str] = None
+
+
+@app.patch("/api/sessions/{session_id}")
+async def rename_session_endpoint(session_id: str, body: SessionRename):
+    """Rename a session (or clear its title when ``title`` is empty/null)."""
+    from hermes_state import SessionDB
+    db = SessionDB()
+    try:
+        sid = db.resolve_session_id(session_id)
+        if not sid:
+            raise HTTPException(status_code=404, detail="Session not found")
+        try:
+            updated = db.set_session_title(sid, body.title or "")
+        except ValueError as e:
+            # Title too long, invalid characters, or already in use.
+            raise HTTPException(status_code=400, detail=str(e))
+        if not updated:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return {"ok": True, "title": db.get_session_title(sid) or ""}
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # Log viewer endpoint
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -205,6 +205,51 @@ class TestWebServerEndpoints:
         assert captured["list"] == 3
         assert captured["count"] == 3
 
+    def test_rename_session_updates_title(self):
+        """PATCH /api/sessions/{id} renames a session (regression: the route
+        was missing entirely, so the desktop rename dialog got a 405)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="rename-me", source="cli")
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/rename-me", json={"title": "My Chat"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "title": "My Chat"}
+
+        db = SessionDB()
+        try:
+            assert db.get_session_title("rename-me") == "My Chat"
+        finally:
+            db.close()
+
+    def test_rename_session_clears_title_when_empty(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="clear-me", source="cli")
+            db.set_session_title("clear-me", "Has A Title")
+        finally:
+            db.close()
+
+        resp = self.client.patch("/api/sessions/clear-me", json={"title": ""})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "title": ""}
+
+        db = SessionDB()
+        try:
+            assert db.get_session_title("clear-me") is None
+        finally:
+            db.close()
+
+    def test_rename_session_not_found(self):
+        resp = self.client.patch("/api/sessions/does-not-exist", json={"title": "x"})
+        assert resp.status_code == 404
+
     def test_audio_transcription_endpoint(self, monkeypatch):
         import tools.transcription_tools as transcription_tools
 


### PR DESCRIPTION
## Summary
- Renaming a chat in the desktop app failed with **"Rename failed"** and a confusing detail. Root cause: the renderer calls `PATCH /api/sessions/{id}` (`renameSession` in `apps/desktop/src/hermes.ts`), but the backend only defined `GET` and `DELETE` for that path, so FastAPI returned **405 Method Not Allowed**.
- Added the missing `PATCH /api/sessions/{session_id}` endpoint in `hermes_cli/web_server.py`, backed by the existing `SessionDB.set_session_title` (handles title sanitization, uniqueness conflicts → 400, and clearing the title when empty/null). Resolves short IDs like the sibling `GET` handler and returns `{ "ok": true, "title": "<sanitized>" }` as the renderer expects.
- Fixed a misleading notification: the 405 was caught by an over-broad rule that summarized **any** "method not allowed" as `"The desktop backend does not support that audio endpoint yet"` (see screenshot). That rule was meant for audio routes only. Replaced it with an accurate, generic 405 message.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_web_server.py` — 189 passed (incl. 3 new: rename, clear-title, 404)
- [x] `npm run type-check` (apps/desktop) passes
- [ ] Manually rename a session in the desktop app and confirm the title updates without error