### PR TITLE
fix: strip unsafe anthropic signed thinking replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1918,12 +1918,25 @@ def _manage_thinking_signatures(
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
         else:
-            # Latest assistant on direct Anthropic: keep signed, downgrade unsigned
-            # to text so the reasoning isn't lost.
+            # Latest assistant on direct Anthropic: keep signed thinking only
+            # when the assistant content can be replayed byte-for-byte. Hermes
+            # rebuilds tool_use blocks from OpenAI-style tool_calls (and may
+            # prefix names for Claude Code OAuth), so a signed thinking block
+            # attached to a tool-call turn is no longer safe to replay.
+            latest_has_tool_use = any(
+                isinstance(b, dict) and b.get("type") == "tool_use"
+                for b in m["content"]
+            )
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
+                    continue
+                if latest_has_tool_use:
+                    # Anthropic returns HTTP 400 "thinking/redacted_thinking
+                    # blocks ... cannot be modified" when signed thinking is
+                    # replayed beside transformed tool_use blocks. Drop it;
+                    # the visible text/tool_use content remains intact.
                     continue
                 if b.get("type") == "redacted_thinking":
                     # Redacted blocks use 'data' for the signature payload —

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -549,11 +549,24 @@ def classify_api_error(
     # Anthropic thinking block signature invalid (400).
     # Don't gate on provider — OpenRouter proxies Anthropic errors, so the
     # provider may be "openrouter" even though the error is Anthropic-specific.
-    # The message pattern ("signature" + "thinking") is unique enough.
+    # Anthropic currently uses two related wordings:
+    #   * "signature" + "thinking" for invalid signatures;
+    #   * "thinking or redacted_thinking blocks ... cannot be modified" when
+    #     a replayed latest assistant turn was structurally changed.
+    _modified_thinking_replay = (
+        ("thinking" in error_msg or "redacted_thinking" in error_msg)
+        and "latest assistant message" in error_msg
+        and (
+            "cannot be modified" in error_msg
+            or "must remain as they were" in error_msg
+        )
+    )
     if (
         status_code == 400
-        and "signature" in error_msg
-        and "thinking" in error_msg
+        and (
+            ("signature" in error_msg and "thinking" in error_msg)
+            or _modified_thinking_replay
+        )
     ):
         return _result(
             FailoverReason.thinking_signature,

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -890,7 +890,7 @@ class TestConvertMessages:
         assert tool_block["content"] == "result"
         assert tool_block["cache_control"] == {"type": "ephemeral"}
 
-    def test_preserved_thinking_blocks_are_rehydrated_before_tool_use(self):
+    def test_preserved_signed_thinking_blocks_are_stripped_before_rebuilt_tool_use(self):
         messages = [
             {
                 "role": "assistant",
@@ -912,10 +912,8 @@ class TestConvertMessages:
         _, result = convert_messages_to_anthropic(messages)
         assistant_blocks = next(msg for msg in result if msg["role"] == "assistant")["content"]
 
-        assert assistant_blocks[0]["type"] == "thinking"
-        assert assistant_blocks[0]["thinking"] == "Need to inspect the tool result first."
-        assert assistant_blocks[0]["signature"] == "sig_123"
-        assert assistant_blocks[1]["type"] == "tool_use"
+        assert all(block.get("type") != "thinking" for block in assistant_blocks)
+        assert assistant_blocks[0]["type"] == "tool_use"
 
     def test_converts_data_url_image_to_anthropic_image_block(self):
         messages = [
@@ -1583,10 +1581,12 @@ class TestRoleAlternation:
 
 class TestThinkingBlockSignatureManagement:
     """Tests for the thinking block handling strategy:
-    strip from old turns, preserve latest signed, downgrade unsigned."""
+    strip from old/transformed tool turns, preserve latest signed text-only,
+    downgrade unsigned.
+    """
 
-    def test_thinking_stripped_from_non_last_assistant(self):
-        """Thinking blocks are removed from all assistant messages except the last."""
+    def test_thinking_stripped_from_non_last_and_latest_tool_use_assistants(self):
+        """Signed thinking is removed from old turns and rebuilt tool-use turns."""
         messages = [
             {
                 "role": "assistant",
@@ -1617,21 +1617,44 @@ class TestThinkingBlockSignatureManagement:
         assistants = [m for m in result if m["role"] == "assistant"]
         assert len(assistants) == 2
 
-        # First (non-last) assistant: no thinking blocks
-        first_types = [b.get("type") for b in assistants[0]["content"]]
-        assert "thinking" not in first_types
-        assert "redacted_thinking" not in first_types
-        assert "tool_use" in first_types  # tool_use should survive
+        for assistant in assistants:
+            block_types = [b.get("type") for b in assistant["content"]]
+            assert "thinking" not in block_types
+            assert "redacted_thinking" not in block_types
+            assert "tool_use" in block_types  # tool_use should survive
 
-        # Last assistant: thinking block preserved with signature
-        last_blocks = assistants[1]["content"]
-        thinking_blocks = [b for b in last_blocks if b.get("type") == "thinking"]
-        assert len(thinking_blocks) == 1
-        assert thinking_blocks[0]["thinking"] == "Latest reasoning."
-        assert thinking_blocks[0]["signature"] == "sig_new"
+    def test_multiple_signed_thinking_blocks_stripped_from_latest_tool_use_turn(self):
+        """Parallel tool calls must not replay any signed thinking blocks."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "tool_a", "arguments": "{}"}},
+                    {"id": "tc_2", "function": {"name": "tool_b", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Private step 1.", "signature": "sig_1"},
+                    {"type": "thinking", "thinking": "Private step 2.", "signature": "sig_2"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result 1"},
+            {"role": "tool", "tool_call_id": "tc_2", "content": "result 2"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+
+        assistant = next(m for m in result if m["role"] == "assistant")
+        user = next(m for m in result if m["role"] == "user")
+        assistant_types = [b.get("type") for b in assistant["content"]]
+        user_types = [b.get("type") for b in user["content"]]
+
+        assert assistant_types.count("thinking") == 0
+        assert assistant_types.count("redacted_thinking") == 0
+        assert assistant_types.count("tool_use") == 2
+        assert user_types.count("tool_result") == 2
 
     def test_signed_thinking_preserved_on_last_turn(self):
-        """A signed thinking block on the last assistant message is kept."""
+        """A signed thinking block on the last text-only assistant message is kept."""
         messages = [
             {
                 "role": "assistant",
@@ -1701,8 +1724,8 @@ class TestThinkingBlockSignatureManagement:
         blocks = result[0]["content"]
         assert not any(b.get("type") == "redacted_thinking" for b in blocks)
 
-    def test_cache_control_stripped_from_thinking_blocks(self):
-        """cache_control markers are removed from thinking/redacted_thinking blocks."""
+    def test_redacted_thinking_with_data_stripped_on_latest_tool_use_turn(self):
+        """Signed redacted thinking is unsafe when replaying rebuilt tool_use."""
         messages = [
             {
                 "role": "assistant",
@@ -1710,6 +1733,24 @@ class TestThinkingBlockSignatureManagement:
                 "tool_calls": [
                     {"id": "tc_1", "function": {"name": "t", "arguments": "{}"}},
                 ],
+                "reasoning_details": [
+                    {"type": "redacted_thinking", "data": "opaque_signature_data"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assistant = next(m for m in result if m["role"] == "assistant")
+        block_types = [b.get("type") for b in assistant["content"]]
+        assert "redacted_thinking" not in block_types
+        assert "tool_use" in block_types
+
+    def test_cache_control_stripped_from_thinking_blocks(self):
+        """cache_control markers are removed from preserved thinking blocks."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Answer.",
                 "reasoning_details": [
                     {
                         "type": "thinking",
@@ -1719,13 +1760,16 @@ class TestThinkingBlockSignatureManagement:
                     },
                 ],
             },
-            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
         ]
         _, result = convert_messages_to_anthropic(messages)
         assistant = next(m for m in result if m["role"] == "assistant")
-        for block in assistant["content"]:
-            if block.get("type") in {"thinking", "redacted_thinking"}:
-                assert "cache_control" not in block
+        thinking_blocks = [
+            block for block in assistant["content"]
+            if block.get("type") in {"thinking", "redacted_thinking"}
+        ]
+        assert thinking_blocks
+        for block in thinking_blocks:
+            assert "cache_control" not in block
 
     def test_thinking_stripped_from_merged_consecutive_assistants(self):
         """When consecutive assistants are merged, second one's thinking is dropped."""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -654,8 +654,26 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.thinking_signature
         assert result.retryable is True
 
+    def test_anthropic_modified_thinking_blocks_are_retryable_signature_failure(self):
+        """Anthropic rejects replayed signed thinking when the assistant turn changed."""
+        message = (
+            "messages.3.content.7: `thinking` or `redacted_thinking` blocks in "
+            "the latest assistant message cannot be modified. These blocks must "
+            "remain as they were in the original response."
+        )
+        e = MockAPIError(
+            "Error code: 400 - " + message,
+            status_code=400,
+            body={"error": {"message": message, "type": "invalid_request_error"}},
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+        assert result.should_compress is False
+        assert result.should_fallback is False
+
     def test_non_anthropic_400_with_signature_not_classified_as_thinking(self):
-        """400 with 'signature' but from non-Anthropic → format error."""
+        """400 with 'signature' but without 'thinking' stays a format error."""
         e = MockAPIError("invalid signature", status_code=400)
         result = classify_api_error(e, provider="openrouter", approx_tokens=0)
         # Without "thinking" in the message, it shouldn't be thinking_signature


### PR DESCRIPTION
## Summary
- strip signed/redacted Anthropic thinking blocks from latest assistant tool-use replays, where Hermes rebuilds tool_use content and signatures are no longer safe
- preserve signed thinking on latest text-only direct Anthropic turns
- classify Anthropic modified-thinking replay 400s as retryable thinking_signature failures

## Tests
- env -u PYTHONHOME -u PYTHONPATH python -E -m pytest --timeout-method=thread --basetemp=/tmp/hermes-pytest-signed-thinking-fix-go-alt tests/agent/test_anthropic_adapter.py tests/agent/test_error_classifier.py