### PR TITLE
feat(build-zeller): delegate code writes to Codex CLI

### DIFF
--- a/tests/tools/test_code_write_guard.py
+++ b/tests/tools/test_code_write_guard.py
@@ -1,0 +1,160 @@
+import json
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "app.py",
+        "component.tsx",
+        "styles.scss",
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "tsconfig.json",
+        "tsconfig.app.json",
+        "vite.config.ts",
+        "webpack.config.js",
+        "next.config.mjs",
+        "pyproject.toml",
+        "poetry.lock",
+        "requirements.txt",
+        "requirements-dev.txt",
+        "go.mod",
+        "go.sum",
+        "Cargo.toml",
+        "Cargo.lock",
+        "Dockerfile",
+        "Containerfile",
+        "docker-compose.yml",
+        "docker-compose.override.yaml",
+    ],
+)
+def test_code_write_guard_classifies_product_code_paths(monkeypatch, tmp_path, path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    assert file_tools._is_code_write_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "RESULT.md",
+        "phase_RESULT.md",
+        "evidence_manifest.json",
+        "phase_evidence_manifest_v2.json",
+        "run.log",
+        "README.md",
+        "notes.md",
+        "SOUL.md",
+        "CODEX.md",
+        "config.yaml",
+        "config.yml",
+    ],
+)
+def test_code_write_guard_classifies_non_product_artifacts(monkeypatch, tmp_path, path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    assert not file_tools._is_code_write_path(path)
+
+
+def test_code_write_guard_blocks_python_write_when_config_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(file_tools.write_file_tool("feature.py", "print('native')"))
+
+    assert "error" in result
+    assert "code_writes_require_codex" in result["error"]
+    assert not (tmp_path / "feature.py").exists()
+
+
+def test_code_write_guard_allows_markdown_result_when_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(file_tools.write_file_tool("RESULT.md", "ready for verification"))
+
+    assert result.get("error") in (None, False)
+    assert (tmp_path / "RESULT.md").read_text() == "ready for verification"
+
+
+def test_code_write_guard_blocks_package_manifest_when_config_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(file_tools.write_file_tool("package.json", "{}\n"))
+
+    assert "error" in result
+    assert "code_writes_require_codex" in result["error"]
+    assert not (tmp_path / "package.json").exists()
+
+
+@pytest.mark.parametrize("path", ["evidence_manifest.json", "phase_RESULT.md", "config.yaml"])
+def test_code_write_guard_allows_reporting_and_profile_artifacts_when_enabled(
+    monkeypatch,
+    tmp_path,
+    path,
+):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    target = tmp_path / path
+    result = json.loads(file_tools.write_file_tool(str(target), "artifact\n"))
+
+    assert result.get("error") in (None, False)
+    assert target.read_text() == "artifact\n"
+
+
+def test_code_write_guard_blocks_v4a_code_patch_when_config_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    target = tmp_path / "feature.py"
+    target.write_text("old = 1\n")
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": {"enabled": True}},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(
+        file_tools.patch_tool(
+            mode="patch",
+            patch="*** Begin Patch\n*** Update File: feature.py\n@@\n-old = 1\n+old = 2\n*** End Patch",
+        )
+    )
+
+    assert "error" in result
+    assert "delegate_to_codex" in result["error"]
+    assert target.read_text() == "old = 1\n"

--- a/tests/tools/test_code_write_guard.py
+++ b/tests/tools/test_code_write_guard.py
@@ -64,6 +64,23 @@ def test_code_write_guard_classifies_non_product_artifacts(monkeypatch, tmp_path
     assert not file_tools._is_code_write_path(path)
 
 
+def test_blocked_device_detects_relative_symlink_from_terminal_cwd(
+    monkeypatch, tmp_path
+):
+    import tools.file_tools as file_tools
+
+    terminal_cwd = tmp_path / "terminal"
+    process_cwd = tmp_path / "process"
+    terminal_cwd.mkdir()
+    process_cwd.mkdir()
+    (terminal_cwd / "link").symlink_to("/dev/zero")
+
+    monkeypatch.setenv("TERMINAL_CWD", str(terminal_cwd))
+    monkeypatch.chdir(process_cwd)
+
+    assert file_tools._is_blocked_device("link")
+
+
 def test_code_write_guard_blocks_python_write_when_config_enabled(monkeypatch, tmp_path):
     import tools.file_tools as file_tools
 

--- a/tests/tools/test_codex_delegate_tool.py
+++ b/tests/tools/test_codex_delegate_tool.py
@@ -1,0 +1,62 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+class _Completed:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_delegate_to_codex_uses_non_pty_exec_by_default(monkeypatch, tmp_path):
+    from tools import codex_delegate_tool as tool
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["exec", "--help"]:
+            return _Completed(stdout="Run Codex non-interactively")
+        return _Completed(returncode=0, stdout='{"event":"done"}\n', stderr="")
+
+    monkeypatch.setattr(tool.subprocess, "run", fake_run)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = json.loads(tool.delegate_to_codex_tool("write a noop", str(tmp_path)))
+
+    assert result["ok"] is True
+    assert result["execution_mode"] == "non_pty"
+    assert calls[-1][0][0].endswith("codex")
+    assert calls[-1][0][1:6] == ["exec", "--json", "--cd", str(tmp_path), "--skip-git-repo-check"]
+    assert calls[-1][0][-1] == "write a noop"
+    assert calls[-1][1]["stdin"] is None
+    assert calls[-1][1]["timeout"] == tool.DEFAULT_TIMEOUT_SECONDS
+
+
+def test_delegate_to_codex_timeout_returns_structured_error(monkeypatch, tmp_path):
+    from tools import codex_delegate_tool as tool
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=3, output="partial", stderr="slow")
+
+    monkeypatch.setattr(tool.subprocess, "run", fake_run)
+
+    result = json.loads(tool.delegate_to_codex_tool("slow task", str(tmp_path), timeout=3))
+
+    assert result["ok"] is False
+    assert result["error"] == "timeout"
+    assert result["timeout_seconds"] == 3
+    assert "partial" in result["stdout"]
+    assert "slow" in result["stderr"]
+
+
+def test_delegate_to_codex_rejects_missing_workdir(tmp_path):
+    from tools import codex_delegate_tool as tool
+
+    missing = tmp_path / "missing"
+    result = json.loads(tool.delegate_to_codex_tool("task", str(missing)))
+
+    assert result["ok"] is False
+    assert result["error"] == "invalid_working_directory"

--- a/tools/codex_delegate_tool.py
+++ b/tools/codex_delegate_tool.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Codex CLI delegation tool.
+
+This tool is intentionally small: Hermes constructs a bounded, non-interactive
+`codex exec` subprocess and returns structured evidence about the invocation.
+It does not parse or rewrite Codex output into success claims.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry, tool_error
+
+DEFAULT_TIMEOUT_SECONDS = 1800
+MAX_TIMEOUT_SECONDS = 7200
+
+
+def _profile_local_codex() -> str | None:
+    candidate = Path.home() / ".local" / "bin" / "codex"
+    if candidate.exists() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+
+def _codex_binary() -> str:
+    return shutil.which("codex") or _profile_local_codex() or "codex"
+
+
+def _bounded_timeout(timeout: int | None) -> int:
+    if timeout is None:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = int(timeout)
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+    return max(1, min(value, MAX_TIMEOUT_SECONDS))
+
+
+def _codex_env() -> dict[str, str]:
+    env = os.environ.copy()
+    local_bin = str(Path.home() / ".local" / "bin")
+    env["PATH"] = local_bin + os.pathsep + env.get("PATH", "")
+    env.setdefault("CODEX_HOME", str(Path.home() / ".codex"))
+    return env
+
+
+def delegate_to_codex_tool(
+    task: str,
+    working_directory: str,
+    context_files: list[str] | None = None,
+    timeout: int | None = None,
+    sandbox: str = "workspace-write",
+    model: str | None = None,
+) -> str:
+    """Run `codex exec` non-interactively and return structured evidence."""
+    if not task or not isinstance(task, str):
+        return json.dumps({"ok": False, "error": "missing_task"}, ensure_ascii=False)
+
+    workdir = Path(working_directory or "").expanduser().resolve()
+    if not workdir.exists() or not workdir.is_dir():
+        return json.dumps({
+            "ok": False,
+            "error": "invalid_working_directory",
+            "working_directory": str(workdir),
+        }, ensure_ascii=False)
+
+    timeout_seconds = _bounded_timeout(timeout)
+    prompt = task
+    if context_files:
+        prompt += "\n\nContext files to inspect first:\n" + "\n".join(f"- {p}" for p in context_files)
+
+    cmd = [
+        _codex_binary(),
+        "exec",
+        "--json",
+        "--cd",
+        str(workdir),
+        "--skip-git-repo-check",
+        "--sandbox",
+        sandbox or "workspace-write",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(workdir),
+            env=_codex_env(),
+            stdin=None,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return json.dumps({
+            "ok": False,
+            "error": "timeout",
+            "execution_mode": "non_pty",
+            "timeout_seconds": timeout_seconds,
+            "command": cmd[:6] + ["<prompt>"],
+            "stdout": exc.output or "",
+            "stderr": exc.stderr or "",
+        }, ensure_ascii=False)
+    except FileNotFoundError:
+        return json.dumps({
+            "ok": False,
+            "error": "codex_not_found",
+            "execution_mode": "non_pty",
+            "command": cmd[:1],
+        }, ensure_ascii=False)
+    except Exception as exc:
+        return json.dumps({
+            "ok": False,
+            "error": "subprocess_error",
+            "execution_mode": "non_pty",
+            "message": str(exc),
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "ok": completed.returncode == 0,
+        "error": None if completed.returncode == 0 else "codex_exec_failed",
+        "execution_mode": "non_pty",
+        "returncode": completed.returncode,
+        "timeout_seconds": timeout_seconds,
+        "working_directory": str(workdir),
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }, ensure_ascii=False)
+
+
+DELEGATE_TO_CODEX_SCHEMA: dict[str, Any] = {
+    "name": "delegate_to_codex",
+    "description": (
+        "Delegate code-writing work to the local Codex CLI via non-interactive `codex exec`. "
+        "Use this for product-code edits when Build Zeller has code_writes_require_codex enabled. "
+        "Returns structured subprocess evidence; verify changed files and tests separately."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {"type": "string", "description": "Self-contained Codex task brief."},
+            "working_directory": {"type": "string", "description": "Repository/workspace root for Codex."},
+            "context_files": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional files Codex should inspect first.",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": f"Timeout seconds, capped at {MAX_TIMEOUT_SECONDS}.",
+                "default": DEFAULT_TIMEOUT_SECONDS,
+            },
+            "sandbox": {
+                "type": "string",
+                "enum": ["read-only", "workspace-write", "danger-full-access"],
+                "default": "workspace-write",
+                "description": "Codex sandbox mode.",
+            },
+            "model": {"type": "string", "description": "Optional Codex model override."},
+        },
+        "required": ["task", "working_directory"],
+    },
+}
+
+
+def _handle_delegate_to_codex(args, **kw):
+    return delegate_to_codex_tool(
+        task=args.get("task", ""),
+        working_directory=args.get("working_directory", ""),
+        context_files=args.get("context_files"),
+        timeout=args.get("timeout"),
+        sandbox=args.get("sandbox", "workspace-write"),
+        model=args.get("model"),
+    )
+
+
+registry.register(
+    name="delegate_to_codex",
+    toolset="codex",
+    schema=DELEGATE_TO_CODEX_SCHEMA,
+    handler=_handle_delegate_to_codex,
+    emoji="🤖",
+    max_result_size_chars=100_000,
+)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -147,21 +147,27 @@ def _is_blocked_device_path(path: str) -> bool:
     return False
 
 
-def _is_blocked_device(filepath: str) -> bool:
+def _is_blocked_device(filepath: str, task_id: str = "default") -> bool:
     """Return True if the path would hang the process (infinite output or blocking input).
 
     Check the literal path first so aliases like /dev/stdin are caught before
-    they resolve to terminal-specific paths. Then check the resolved path so a
-    workspace symlink to /dev/zero cannot bypass the guard.
+    they resolve to terminal-specific paths. Then check the task-cwd-resolved
+    path so a workspace symlink to /dev/zero cannot bypass the guard.
     """
     normalized = os.path.expanduser(filepath)
     if _is_blocked_device_path(normalized):
         return True
     try:
-        resolved = os.path.realpath(normalized)
+        task_resolved = str(_resolve_path_for_task(normalized, task_id))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if _is_blocked_device_path(task_resolved):
+        return True
+    try:
+        task_realpath = os.path.realpath(task_resolved)
     except (OSError, ValueError):
         return False
-    if resolved != normalized and _is_blocked_device_path(resolved):
+    if task_realpath != task_resolved and _is_blocked_device_path(task_realpath):
         return True
     return False
 
@@ -627,7 +633,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        if _is_blocked_device(path):
+        if _is_blocked_device(path, task_id):
             return json.dumps({
                 "error": (
                     f"Cannot read '{path}': this is a device file that would "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import threading
 from pathlib import Path
+from typing import Iterable
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
@@ -172,6 +173,94 @@ _SENSITIVE_PATH_PREFIXES = (
     "/private/etc/", "/private/var/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
+
+_PRODUCT_CODE_SOURCE_EXTENSIONS = frozenset({
+    ".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+    ".go", ".rs", ".java", ".kt", ".kts", ".swift", ".c", ".h",
+    ".cc", ".cpp", ".cxx", ".hpp", ".cs", ".php", ".rb", ".sh",
+    ".bash", ".zsh", ".fish", ".ps1", ".sql", ".html", ".css",
+    ".scss", ".vue", ".svelte",
+})
+
+_PRODUCT_CODE_MANIFEST_FILENAMES = frozenset({
+    "package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock",
+    "pyproject.toml", "poetry.lock", "go.mod", "go.sum",
+    "cargo.toml", "cargo.lock", "dockerfile", "containerfile",
+})
+
+_PRODUCT_CODE_MANIFEST_PATTERNS = frozenset({
+    "tsconfig*.json", "vite.config.*", "webpack.config.*", "next.config.*",
+    "requirements*.txt", "docker-compose*.yml", "docker-compose*.yaml",
+})
+
+_NON_PRODUCT_ARTIFACT_FILENAMES = frozenset({
+    "result.md", "soul.md", "codex.md", "config.yaml", "config.yml",
+    "evidence_manifest.json",
+})
+
+_NON_PRODUCT_ARTIFACT_PATTERNS = frozenset({
+    "*result.md", "*evidence_manifest*.json", "*.log", "*.md",
+})
+
+
+def _code_writes_require_codex_enabled() -> bool:
+    """Return true when native Hermes code writes should be refused.
+
+    Supports both a simple boolean and a future-extensible object:
+    ``code_writes_require_codex: true`` or
+    ``code_writes_require_codex: {enabled: true}``.
+    """
+    if os.environ.get("HERMES_CODEX_DELEGATE_ACTIVE") == "1":
+        return False
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return False
+    value = cfg.get("code_writes_require_codex") if isinstance(cfg, dict) else None
+    if isinstance(value, dict):
+        return bool(value.get("enabled", False))
+    return bool(value)
+
+
+def _is_code_write_path(filepath: str, task_id: str = "default") -> bool:
+    """Return True when *filepath* is product code for code-write delegation.
+
+    Product code includes source files and code-affecting manifests/configs
+    that change build, dependency, runtime, or container behavior. Reporting,
+    evidence, profile, and Markdown artifacts are deliberately excluded so the
+    guard can still write verification notes while product-code edits route
+    through Codex.
+    """
+    import fnmatch
+
+    try:
+        resolved = _resolve_path_for_task(filepath, task_id)
+    except Exception:
+        resolved = Path(os.path.expanduser(filepath))
+    name = resolved.name.lower()
+    if name in _NON_PRODUCT_ARTIFACT_FILENAMES:
+        return False
+    if any(fnmatch.fnmatchcase(name, pattern) for pattern in _NON_PRODUCT_ARTIFACT_PATTERNS):
+        return False
+    if name in _PRODUCT_CODE_MANIFEST_FILENAMES:
+        return True
+    if any(fnmatch.fnmatchcase(name, pattern) for pattern in _PRODUCT_CODE_MANIFEST_PATTERNS):
+        return True
+    return resolved.suffix.lower() in _PRODUCT_CODE_SOURCE_EXTENSIONS
+
+
+def _check_codex_code_write_guard(paths: Iterable[str], task_id: str = "default") -> str | None:
+    if not _code_writes_require_codex_enabled():
+        return None
+    blocked = [p for p in paths if p and _is_code_write_path(p, task_id)]
+    if not blocked:
+        return None
+    return (
+        "code_writes_require_codex is enabled; refusing native Hermes file edit "
+        f"for code path(s): {', '.join(blocked)}. Use delegate_to_codex for "
+        "product-code changes, then verify artifacts/tests separately."
+    )
 
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
@@ -894,6 +983,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    codex_guard_err = _check_codex_code_write_guard([path], task_id)
+    if codex_guard_err:
+        return tool_error(codex_guard_err)
     if not cross_profile:
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
@@ -987,6 +1079,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        codex_guard_err = _check_codex_code_write_guard([_p], task_id)
+        if codex_guard_err:
+            return tool_error(codex_guard_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "delegate_to_codex",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -240,6 +240,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "codex": {
+        "description": "Delegate code-writing work to the local Codex CLI via codex exec",
+        "tools": ["delegate_to_codex"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -352,7 +358,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_codex",
         ],
         "includes": []
     },
@@ -380,7 +386,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_codex",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary
- Add Build Zeller `delegate_to_codex` tool wrapping non-interactive `codex exec`
- Add structural product-code write guard for native file tools
- Register Codex delegation in Hermes core/toolsets
- Add focused timeout, invocation, and guardrail tests

## Verification
- `pytest tests/tools/test_code_write_guard.py tests/tools/test_codex_delegate_tool.py -q` -> 45 passed

## Evidence status
Phase A and Phase B verified by Sam + Jason. This PR contains the Phase B migration code.
