### PR TITLE
feat(build-zeller): add evidence-gated completion

### DIFF
--- a/scripts/clawpatch_weekly_evidence_gate.py
+++ b/scripts/clawpatch_weekly_evidence_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +20,26 @@ from tools.evidence_gate_tool import evidence_gate, log_evidence_gate_event
 DEFAULT_REPORT = REPO_ROOT / "reports" / "clawpatch" / "weekly" / "REPORT.md"
 DEFAULT_RESULT = REPO_ROOT / "reports" / "clawpatch" / "weekly" / "RESULT.md"
 DEFAULT_MANIFEST = REPO_ROOT / "reports" / "clawpatch" / "weekly" / "evidence_manifest.json"
+
+
+def _resolve_hermes_home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def _generate_command_env() -> dict[str, str]:
+    env = os.environ.copy()
+    profile_home = _resolve_hermes_home() / "home"
+    profile_bin = str(profile_home / ".local" / "bin")
+    path_parts = [part for part in env.get("PATH", "").split(os.pathsep) if part]
+    path_parts = [part for part in path_parts if part != profile_bin]
+    env["HOME"] = str(profile_home)
+    env["PATH"] = os.pathsep.join([profile_bin, *path_parts])
+    return env
 
 
 def _parse_args() -> argparse.Namespace:
@@ -67,7 +88,36 @@ def main() -> int:
     manifest = Path(args.manifest).expanduser().resolve()
 
     if not args.verify_only and args.generate_command:
-        proc = subprocess.run(args.generate_command, shell=True, text=True, check=False)
+        generate_env = _generate_command_env()
+        try:
+            preflight = subprocess.run(
+                ["codex", "--version"],
+                env=generate_env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            preflight_ok = preflight.returncode == 0
+        except OSError:
+            preflight_ok = False
+        if not preflight_ok:
+            payload = {
+                "status": "FAILED",
+                "requested_status": "COMPLETED",
+                "reason": "codex_profile_env_unhealthy",
+                "report": str(report),
+            }
+            log_evidence_gate_event("completion_refused", payload, args.log_path)
+            print(json.dumps(payload, sort_keys=True))
+            return 1
+
+        proc = subprocess.run(
+            args.generate_command,
+            shell=True,
+            text=True,
+            check=False,
+            env=generate_env,
+        )
         if proc.returncode != 0:
             payload = {
                 "status": "FAILED",

--- a/scripts/clawpatch_weekly_evidence_gate.py
+++ b/scripts/clawpatch_weekly_evidence_gate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Evidence gate for Clawpatch weekly reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.evidence_gate_tool import evidence_gate, log_evidence_gate_event
+
+
+DEFAULT_REPORT = REPO_ROOT / "reports" / "clawpatch" / "weekly" / "REPORT.md"
+DEFAULT_RESULT = REPO_ROOT / "reports" / "clawpatch" / "weekly" / "RESULT.md"
+DEFAULT_MANIFEST = REPO_ROOT / "reports" / "clawpatch" / "weekly" / "evidence_manifest.json"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Clawpatch weekly evidence gate.")
+    parser.add_argument("--verify-only", action="store_true", help="Only verify existing artifacts.")
+    parser.add_argument("--report", default=str(DEFAULT_REPORT), help="Expected Clawpatch weekly report path.")
+    parser.add_argument("--result", default=str(DEFAULT_RESULT), help="RESULT.md output path.")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST), help="Evidence manifest path to write.")
+    parser.add_argument("--log-path", default=None, help="Optional evidence-gate log path.")
+    parser.add_argument("--max-age-hours", type=float, default=168.0, help="Maximum report artifact age.")
+    parser.add_argument(
+        "--generate-command",
+        default=None,
+        help="Optional shell command to create/update Clawpatch artifacts before verification.",
+    )
+    return parser.parse_args()
+
+
+def _fresh_report_command(report: Path, max_age_hours: float) -> str:
+    code = (
+        "import pathlib, sys, time; "
+        f"p = pathlib.Path({str(report)!r}); "
+        f"max_age = {float(max_age_hours)!r} * 3600; "
+        "ok = p.exists() and p.is_file() and p.stat().st_size > 0 and "
+        "(time.time() - p.stat().st_mtime) <= max_age; "
+        "sys.exit(0 if ok else 1)"
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+
+
+def _write_manifest(manifest_path: Path, report: Path, result: Path, max_age_hours: float) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "requested_status": "COMPLETED",
+        "result_path": str(result),
+        "result_body": "Clawpatch weekly report artifacts verified through the evidence gate.",
+        "checks": [
+            {
+                "type": "file_exists",
+                "name": "Clawpatch weekly report exists",
+                "path": str(report),
+            },
+            {
+                "type": "command",
+                "name": "Clawpatch weekly report is fresh and non-empty",
+                "command": _fresh_report_command(report, max_age_hours),
+                "expected_exit_code": 0,
+                "timeout": 10,
+            },
+        ],
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = _parse_args()
+    report = Path(args.report).expanduser().resolve()
+    result = Path(args.result).expanduser().resolve()
+    manifest = Path(args.manifest).expanduser().resolve()
+
+    if not args.verify_only and args.generate_command:
+        proc = subprocess.run(args.generate_command, shell=True, text=True, check=False)
+        if proc.returncode != 0:
+            payload = {
+                "status": "FAILED",
+                "requested_status": "COMPLETED",
+                "reason": "generate_command_failed",
+                "exit_code": proc.returncode,
+                "report": str(report),
+            }
+            log_evidence_gate_event("completion_refused", payload, args.log_path)
+            print(json.dumps(payload, sort_keys=True))
+            return proc.returncode or 1
+
+    _write_manifest(manifest, report, result, args.max_age_hours)
+    gate_result = json.loads(
+        evidence_gate(
+            manifest_path=str(manifest),
+            requested_status="COMPLETED",
+            result_path=str(result),
+            log_path=args.log_path,
+        )
+    )
+    if gate_result.get("status") != "COMPLETED":
+        log_evidence_gate_event(
+            "completion_refused",
+            {
+                "status": gate_result.get("status"),
+                "requested_status": "COMPLETED",
+                "reason": "fresh_report_artifacts_missing",
+                "report": str(report),
+                "result_path": str(result),
+            },
+            args.log_path or gate_result.get("log_path"),
+        )
+        print(json.dumps(gate_result, sort_keys=True))
+        return 1
+
+    print(json.dumps(gate_result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clawpatch_weekly_evidence_gate.py
+++ b/scripts/clawpatch_weekly_evidence_gate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -38,18 +37,6 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _fresh_report_command(report: Path, max_age_hours: float) -> str:
-    code = (
-        "import pathlib, sys, time; "
-        f"p = pathlib.Path({str(report)!r}); "
-        f"max_age = {float(max_age_hours)!r} * 3600; "
-        "ok = p.exists() and p.is_file() and p.stat().st_size > 0 and "
-        "(time.time() - p.stat().st_mtime) <= max_age; "
-        "sys.exit(0 if ok else 1)"
-    )
-    return f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
-
-
 def _write_manifest(manifest_path: Path, report: Path, result: Path, max_age_hours: float) -> None:
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest = {
@@ -63,11 +50,10 @@ def _write_manifest(manifest_path: Path, report: Path, result: Path, max_age_hou
                 "path": str(report),
             },
             {
-                "type": "command",
+                "type": "file_fresh",
                 "name": "Clawpatch weekly report is fresh and non-empty",
-                "command": _fresh_report_command(report, max_age_hours),
-                "expected_exit_code": 0,
-                "timeout": 10,
+                "path": str(report),
+                "max_age_seconds": max_age_hours * 3600,
             },
         ],
     }

--- a/tests/scripts/test_clawpatch_weekly_evidence_gate.py
+++ b/tests/scripts/test_clawpatch_weekly_evidence_gate.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import subprocess
@@ -7,6 +8,14 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "clawpatch_weekly_evidence_gate.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("clawpatch_weekly_evidence_gate", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_clawpatch_verify_only_completes_with_fresh_report(tmp_path):
@@ -113,3 +122,96 @@ def test_clawpatch_verify_only_refuses_stale_report(tmp_path):
     assert payload["checks"][0]["passed"] is True
     assert payload["checks"][1]["type"] == "file_fresh"
     assert payload["checks"][1]["passed"] is False
+
+
+def test_generate_command_uses_profile_local_codex_env(monkeypatch, tmp_path):
+    module = _load_script_module()
+    hermes_home = tmp_path / "hermes-profile"
+    profile_home = hermes_home / "home"
+    profile_bin = str(profile_home / ".local" / "bin")
+    calls = []
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("PATH", os.pathsep.join(["/usr/bin", profile_bin, "/bin"]))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--generate-command",
+            "clawpatch weekly",
+            "--report",
+            str(tmp_path / "REPORT.md"),
+            "--result",
+            str(tmp_path / "RESULT.md"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+        ],
+    )
+    monkeypatch.setattr(module, "_write_manifest", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "evidence_gate",
+        lambda **kwargs: json.dumps({"status": "COMPLETED", "success": True}),
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module.main() == 0
+    assert calls[0][0] == ["codex", "--version"]
+    assert calls[1][0] == "clawpatch weekly"
+    generate_env = calls[1][1]["env"]
+    assert generate_env["HOME"].endswith("/home")
+    assert generate_env["HOME"] == str(profile_home)
+    path_parts = generate_env["PATH"].split(os.pathsep)
+    assert path_parts[0] == profile_bin
+    assert path_parts.count(profile_bin) == 1
+
+
+def test_generate_command_refuses_when_codex_preflight_fails(monkeypatch, capsys, tmp_path):
+    module = _load_script_module()
+    calls = []
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-profile"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT),
+            "--generate-command",
+            "clawpatch weekly",
+            "--report",
+            str(tmp_path / "REPORT.md"),
+            "--result",
+            str(tmp_path / "RESULT.md"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--log-path",
+            str(tmp_path / "gate.log"),
+        ],
+    )
+    monkeypatch.setattr(module, "_write_manifest", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "evidence_gate",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("evidence_gate should not run")),
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd == ["codex", "--version"]:
+            return subprocess.CompletedProcess(cmd, 127)
+        raise AssertionError("generate command should not run")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module.main() == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "FAILED"
+    assert payload["reason"] == "codex_profile_env_unhealthy"
+    assert [cmd for cmd, _kwargs in calls] == [["codex", "--version"]]
+    assert "codex_profile_env_unhealthy" in (tmp_path / "gate.log").read_text(encoding="utf-8")

--- a/tests/scripts/test_clawpatch_weekly_evidence_gate.py
+++ b/tests/scripts/test_clawpatch_weekly_evidence_gate.py
@@ -1,0 +1,42 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "clawpatch_weekly_evidence_gate.py"
+
+
+def test_clawpatch_verify_only_refuses_completion_without_fresh_report(tmp_path):
+    report = tmp_path / "missing-report.md"
+    result_path = tmp_path / "RESULT.md"
+    manifest = tmp_path / "manifest.json"
+    log_path = tmp_path / "evidence-gate.log"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--verify-only",
+            "--report",
+            str(report),
+            "--result",
+            str(result_path),
+            "--manifest",
+            str(manifest),
+            "--log-path",
+            str(log_path),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "FAILED"
+    assert payload["requested_status"] == "COMPLETED"
+    assert "Status: FAILED" in result_path.read_text(encoding="utf-8")
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "evidence_gate_refused" in log_text
+    assert "completion_refused" in log_text

--- a/tests/scripts/test_clawpatch_weekly_evidence_gate.py
+++ b/tests/scripts/test_clawpatch_weekly_evidence_gate.py
@@ -1,10 +1,48 @@
 import json
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "clawpatch_weekly_evidence_gate.py"
+
+
+def test_clawpatch_verify_only_completes_with_fresh_report(tmp_path):
+    report = tmp_path / "REPORT.md"
+    report.write_text("# Weekly\n\nVerified.\n", encoding="utf-8")
+    result_path = tmp_path / "RESULT.md"
+    manifest = tmp_path / "manifest.json"
+    log_path = tmp_path / "evidence-gate.log"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--verify-only",
+            "--report",
+            str(report),
+            "--result",
+            str(result_path),
+            "--manifest",
+            str(manifest),
+            "--log-path",
+            str(log_path),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "COMPLETED"
+    assert payload["success"] is True
+    assert "Status: COMPLETED" in result_path.read_text(encoding="utf-8")
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert manifest_payload["checks"][1]["type"] == "file_fresh"
+    assert "command" not in manifest_payload["checks"][1]
 
 
 def test_clawpatch_verify_only_refuses_completion_without_fresh_report(tmp_path):
@@ -40,3 +78,38 @@ def test_clawpatch_verify_only_refuses_completion_without_fresh_report(tmp_path)
     log_text = log_path.read_text(encoding="utf-8")
     assert "evidence_gate_refused" in log_text
     assert "completion_refused" in log_text
+
+
+def test_clawpatch_verify_only_refuses_stale_report(tmp_path):
+    report = tmp_path / "REPORT.md"
+    report.write_text("# Weekly\n\nOld.\n", encoding="utf-8")
+    stale = time.time() - 7200
+    os.utime(report, (stale, stale))
+    result_path = tmp_path / "RESULT.md"
+    manifest = tmp_path / "manifest.json"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--verify-only",
+            "--report",
+            str(report),
+            "--result",
+            str(result_path),
+            "--manifest",
+            str(manifest),
+            "--max-age-hours",
+            "1",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "FAILED"
+    assert payload["checks"][0]["passed"] is True
+    assert payload["checks"][1]["type"] == "file_fresh"
+    assert payload["checks"][1]["passed"] is False

--- a/tests/tools/test_code_write_guard.py
+++ b/tests/tools/test_code_write_guard.py
@@ -1,0 +1,160 @@
+import json
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "app.py",
+        "component.tsx",
+        "styles.scss",
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "tsconfig.json",
+        "tsconfig.app.json",
+        "vite.config.ts",
+        "webpack.config.js",
+        "next.config.mjs",
+        "pyproject.toml",
+        "poetry.lock",
+        "requirements.txt",
+        "requirements-dev.txt",
+        "go.mod",
+        "go.sum",
+        "Cargo.toml",
+        "Cargo.lock",
+        "Dockerfile",
+        "Containerfile",
+        "docker-compose.yml",
+        "docker-compose.override.yaml",
+    ],
+)
+def test_code_write_guard_classifies_product_code_paths(monkeypatch, tmp_path, path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    assert file_tools._is_code_write_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "RESULT.md",
+        "phase_RESULT.md",
+        "evidence_manifest.json",
+        "phase_evidence_manifest_v2.json",
+        "run.log",
+        "README.md",
+        "notes.md",
+        "SOUL.md",
+        "CODEX.md",
+        "config.yaml",
+        "config.yml",
+    ],
+)
+def test_code_write_guard_classifies_non_product_artifacts(monkeypatch, tmp_path, path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    assert not file_tools._is_code_write_path(path)
+
+
+def test_code_write_guard_blocks_python_write_when_config_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(file_tools.write_file_tool("feature.py", "print('native')"))
+
+    assert "error" in result
+    assert "code_writes_require_codex" in result["error"]
+    assert not (tmp_path / "feature.py").exists()
+
+
+def test_code_write_guard_allows_markdown_result_when_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(file_tools.write_file_tool("RESULT.md", "ready for verification"))
+
+    assert result.get("error") in (None, False)
+    assert (tmp_path / "RESULT.md").read_text() == "ready for verification"
+
+
+def test_code_write_guard_blocks_package_manifest_when_config_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(file_tools.write_file_tool("package.json", "{}\n"))
+
+    assert "error" in result
+    assert "code_writes_require_codex" in result["error"]
+    assert not (tmp_path / "package.json").exists()
+
+
+@pytest.mark.parametrize("path", ["evidence_manifest.json", "phase_RESULT.md", "config.yaml"])
+def test_code_write_guard_allows_reporting_and_profile_artifacts_when_enabled(
+    monkeypatch,
+    tmp_path,
+    path,
+):
+    import tools.file_tools as file_tools
+
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": True},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    target = tmp_path / path
+    result = json.loads(file_tools.write_file_tool(str(target), "artifact\n"))
+
+    assert result.get("error") in (None, False)
+    assert target.read_text() == "artifact\n"
+
+
+def test_code_write_guard_blocks_v4a_code_patch_when_config_enabled(monkeypatch, tmp_path):
+    import tools.file_tools as file_tools
+
+    target = tmp_path / "feature.py"
+    target.write_text("old = 1\n")
+    monkeypatch.setattr(file_tools, "_SENSITIVE_PATH_PREFIXES", ("/etc/", "/boot/", "/usr/lib/systemd/", "/private/etc/"))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"code_writes_require_codex": {"enabled": True}},
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = json.loads(
+        file_tools.patch_tool(
+            mode="patch",
+            patch="*** Begin Patch\n*** Update File: feature.py\n@@\n-old = 1\n+old = 2\n*** End Patch",
+        )
+    )
+
+    assert "error" in result
+    assert "delegate_to_codex" in result["error"]
+    assert target.read_text() == "old = 1\n"

--- a/tests/tools/test_code_write_guard.py
+++ b/tests/tools/test_code_write_guard.py
@@ -64,6 +64,23 @@ def test_code_write_guard_classifies_non_product_artifacts(monkeypatch, tmp_path
     assert not file_tools._is_code_write_path(path)
 
 
+def test_blocked_device_detects_relative_symlink_from_terminal_cwd(
+    monkeypatch, tmp_path
+):
+    import tools.file_tools as file_tools
+
+    terminal_cwd = tmp_path / "terminal"
+    process_cwd = tmp_path / "process"
+    terminal_cwd.mkdir()
+    process_cwd.mkdir()
+    (terminal_cwd / "link").symlink_to("/dev/zero")
+
+    monkeypatch.setenv("TERMINAL_CWD", str(terminal_cwd))
+    monkeypatch.chdir(process_cwd)
+
+    assert file_tools._is_blocked_device("link")
+
+
 def test_code_write_guard_blocks_python_write_when_config_enabled(monkeypatch, tmp_path):
     import tools.file_tools as file_tools
 

--- a/tests/tools/test_codex_delegate_tool.py
+++ b/tests/tools/test_codex_delegate_tool.py
@@ -1,0 +1,62 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+class _Completed:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_delegate_to_codex_uses_non_pty_exec_by_default(monkeypatch, tmp_path):
+    from tools import codex_delegate_tool as tool
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[1:3] == ["exec", "--help"]:
+            return _Completed(stdout="Run Codex non-interactively")
+        return _Completed(returncode=0, stdout='{"event":"done"}\n', stderr="")
+
+    monkeypatch.setattr(tool.subprocess, "run", fake_run)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = json.loads(tool.delegate_to_codex_tool("write a noop", str(tmp_path)))
+
+    assert result["ok"] is True
+    assert result["execution_mode"] == "non_pty"
+    assert calls[-1][0][0].endswith("codex")
+    assert calls[-1][0][1:6] == ["exec", "--json", "--cd", str(tmp_path), "--skip-git-repo-check"]
+    assert calls[-1][0][-1] == "write a noop"
+    assert calls[-1][1]["stdin"] is None
+    assert calls[-1][1]["timeout"] == tool.DEFAULT_TIMEOUT_SECONDS
+
+
+def test_delegate_to_codex_timeout_returns_structured_error(monkeypatch, tmp_path):
+    from tools import codex_delegate_tool as tool
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=3, output="partial", stderr="slow")
+
+    monkeypatch.setattr(tool.subprocess, "run", fake_run)
+
+    result = json.loads(tool.delegate_to_codex_tool("slow task", str(tmp_path), timeout=3))
+
+    assert result["ok"] is False
+    assert result["error"] == "timeout"
+    assert result["timeout_seconds"] == 3
+    assert "partial" in result["stdout"]
+    assert "slow" in result["stderr"]
+
+
+def test_delegate_to_codex_rejects_missing_workdir(tmp_path):
+    from tools import codex_delegate_tool as tool
+
+    missing = tmp_path / "missing"
+    result = json.loads(tool.delegate_to_codex_tool("task", str(missing)))
+
+    assert result["ok"] is False
+    assert result["error"] == "invalid_working_directory"

--- a/tests/tools/test_evidence_gate_tool.py
+++ b/tests/tools/test_evidence_gate_tool.py
@@ -1,5 +1,7 @@
 import json
+import os
 import subprocess
+import time
 from pathlib import Path
 
 from tools.evidence_gate_tool import MANUAL, evidence_gate
@@ -20,12 +22,7 @@ def test_evidence_gate_writes_completed_when_checks_pass(tmp_path):
             "result_path": "RESULT.md",
             "checks": [
                 {"type": "file_exists", "path": "artifact.txt"},
-                {
-                    "type": "command",
-                    "command": "python -c 'import sys; sys.exit(0)'",
-                    "expected_exit_code": 0,
-                    "timeout": 5,
-                },
+                {"type": "file_non_empty", "path": "artifact.txt"},
             ],
         },
     )
@@ -34,7 +31,87 @@ def test_evidence_gate_writes_completed_when_checks_pass(tmp_path):
 
     assert result["status"] == "COMPLETED"
     assert result["success"] is True
-    assert (tmp_path / "RESULT.md").read_text(encoding="utf-8").startswith("# Result\n\nStatus: COMPLETED")
+    assert (tmp_path / "RESULT.md").read_text(encoding="utf-8").startswith(
+        "# Result\n\nStatus: COMPLETED"
+    )
+
+
+def test_evidence_gate_refuses_command_checks_without_executing(tmp_path):
+    marker = tmp_path / "marker"
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [
+                {
+                    "type": "command",
+                    "name": "malicious command",
+                    "command": f"touch {marker}",
+                },
+            ],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest)))
+
+    assert result["status"] == "FAILED"
+    assert result["success"] is False
+    assert result["checks"][0]["type"] == "command"
+    assert "unsupported" in result["checks"][0]["message"]
+    assert not marker.exists()
+
+
+def test_evidence_gate_file_fresh_requires_non_empty_recent_file(tmp_path):
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("done\n", encoding="utf-8")
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [
+                {
+                    "type": "file_fresh",
+                    "path": "artifact.txt",
+                    "max_age_seconds": 60,
+                },
+            ],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest)))
+
+    assert result["status"] == "COMPLETED"
+    assert result["checks"][0]["size"] > 0
+    assert result["checks"][0]["age_seconds"] <= 60
+
+
+def test_evidence_gate_file_fresh_fails_for_stale_file(tmp_path):
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("done\n", encoding="utf-8")
+    stale = time.time() - 120
+    os.utime(artifact, (stale, stale))
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [
+                {
+                    "type": "file_fresh",
+                    "path": "artifact.txt",
+                    "max_age_seconds": 60,
+                },
+            ],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest)))
+
+    assert result["status"] == "FAILED"
+    assert result["checks"][0]["passed"] is False
+    assert result["checks"][0]["age_seconds"] > 60
 
 
 def test_evidence_gate_refuses_completed_and_logs_when_evidence_fails(tmp_path):

--- a/tests/tools/test_evidence_gate_tool.py
+++ b/tests/tools/test_evidence_gate_tool.py
@@ -1,0 +1,114 @@
+import json
+import subprocess
+from pathlib import Path
+
+from tools.evidence_gate_tool import MANUAL, evidence_gate
+
+
+def _write_manifest(path: Path, data: dict) -> Path:
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_evidence_gate_writes_completed_when_checks_pass(tmp_path):
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("done\n", encoding="utf-8")
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [
+                {"type": "file_exists", "path": "artifact.txt"},
+                {
+                    "type": "command",
+                    "command": "python -c 'import sys; sys.exit(0)'",
+                    "expected_exit_code": 0,
+                    "timeout": 5,
+                },
+            ],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest)))
+
+    assert result["status"] == "COMPLETED"
+    assert result["success"] is True
+    assert (tmp_path / "RESULT.md").read_text(encoding="utf-8").startswith("# Result\n\nStatus: COMPLETED")
+
+
+def test_evidence_gate_refuses_completed_and_logs_when_evidence_fails(tmp_path):
+    log_path = tmp_path / "evidence-gate.log"
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [{"type": "file_exists", "path": "missing.txt"}],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest), log_path=str(log_path)))
+
+    assert result["status"] == "FAILED"
+    assert result["success"] is False
+    assert "Status: FAILED" in (tmp_path / "RESULT.md").read_text(encoding="utf-8")
+    log_record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert log_record["event"] == "evidence_gate_refused"
+    assert log_record["reason"] == "completion_refused"
+    assert log_record["requested_status"] == "COMPLETED"
+
+
+def test_evidence_gate_manual_check_forces_manual_verification(tmp_path):
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [{"type": "manual", "name": "human signoff"}],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest)))
+
+    assert result["status"] == MANUAL
+    assert result["manual_count"] == 1
+    assert "Status: MANUAL_VERIFICATION_REQUIRED" in (tmp_path / "RESULT.md").read_text(encoding="utf-8")
+
+
+def test_evidence_gate_git_clean_respects_allowed_prefixes(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    (repo / "allowed.log").write_text("ok\n", encoding="utf-8")
+    (repo / "blocked.txt").write_text("dirty\n", encoding="utf-8")
+    manifest = _write_manifest(
+        tmp_path / "manifest.json",
+        {
+            "requested_status": "COMPLETED",
+            "result_path": "RESULT.md",
+            "checks": [
+                {
+                    "type": "git_clean",
+                    "repo_path": str(repo),
+                    "allowed_prefixes": ["allowed.log"],
+                }
+            ],
+        },
+    )
+
+    result = json.loads(evidence_gate(str(manifest), log_path=str(tmp_path / "gate.log")))
+
+    assert result["status"] == "FAILED"
+    assert result["checks"][0]["dirty"] == ["?? blocked.txt"]
+
+
+def test_evidence_gate_registered_in_core_toolset():
+    from toolsets import TOOLSETS, _HERMES_CORE_TOOLS
+    from tools.registry import registry
+
+    entry = registry.get_entry("evidence_gate")
+    assert entry is not None
+    assert entry.toolset == "evidence_gate"
+    assert "evidence_gate" in _HERMES_CORE_TOOLS
+    assert TOOLSETS["evidence_gate"]["tools"] == ["evidence_gate"]

--- a/tools/codex_delegate_tool.py
+++ b/tools/codex_delegate_tool.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Codex CLI delegation tool.
+
+This tool is intentionally small: Hermes constructs a bounded, non-interactive
+`codex exec` subprocess and returns structured evidence about the invocation.
+It does not parse or rewrite Codex output into success claims.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry, tool_error
+
+DEFAULT_TIMEOUT_SECONDS = 1800
+MAX_TIMEOUT_SECONDS = 7200
+
+
+def _profile_local_codex() -> str | None:
+    candidate = Path.home() / ".local" / "bin" / "codex"
+    if candidate.exists() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+
+def _codex_binary() -> str:
+    return shutil.which("codex") or _profile_local_codex() or "codex"
+
+
+def _bounded_timeout(timeout: int | None) -> int:
+    if timeout is None:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = int(timeout)
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+    return max(1, min(value, MAX_TIMEOUT_SECONDS))
+
+
+def _codex_env() -> dict[str, str]:
+    env = os.environ.copy()
+    local_bin = str(Path.home() / ".local" / "bin")
+    env["PATH"] = local_bin + os.pathsep + env.get("PATH", "")
+    env.setdefault("CODEX_HOME", str(Path.home() / ".codex"))
+    return env
+
+
+def delegate_to_codex_tool(
+    task: str,
+    working_directory: str,
+    context_files: list[str] | None = None,
+    timeout: int | None = None,
+    sandbox: str = "workspace-write",
+    model: str | None = None,
+) -> str:
+    """Run `codex exec` non-interactively and return structured evidence."""
+    if not task or not isinstance(task, str):
+        return json.dumps({"ok": False, "error": "missing_task"}, ensure_ascii=False)
+
+    workdir = Path(working_directory or "").expanduser().resolve()
+    if not workdir.exists() or not workdir.is_dir():
+        return json.dumps({
+            "ok": False,
+            "error": "invalid_working_directory",
+            "working_directory": str(workdir),
+        }, ensure_ascii=False)
+
+    timeout_seconds = _bounded_timeout(timeout)
+    prompt = task
+    if context_files:
+        prompt += "\n\nContext files to inspect first:\n" + "\n".join(f"- {p}" for p in context_files)
+
+    cmd = [
+        _codex_binary(),
+        "exec",
+        "--json",
+        "--cd",
+        str(workdir),
+        "--skip-git-repo-check",
+        "--sandbox",
+        sandbox or "workspace-write",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(workdir),
+            env=_codex_env(),
+            stdin=None,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return json.dumps({
+            "ok": False,
+            "error": "timeout",
+            "execution_mode": "non_pty",
+            "timeout_seconds": timeout_seconds,
+            "command": cmd[:6] + ["<prompt>"],
+            "stdout": exc.output or "",
+            "stderr": exc.stderr or "",
+        }, ensure_ascii=False)
+    except FileNotFoundError:
+        return json.dumps({
+            "ok": False,
+            "error": "codex_not_found",
+            "execution_mode": "non_pty",
+            "command": cmd[:1],
+        }, ensure_ascii=False)
+    except Exception as exc:
+        return json.dumps({
+            "ok": False,
+            "error": "subprocess_error",
+            "execution_mode": "non_pty",
+            "message": str(exc),
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "ok": completed.returncode == 0,
+        "error": None if completed.returncode == 0 else "codex_exec_failed",
+        "execution_mode": "non_pty",
+        "returncode": completed.returncode,
+        "timeout_seconds": timeout_seconds,
+        "working_directory": str(workdir),
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }, ensure_ascii=False)
+
+
+DELEGATE_TO_CODEX_SCHEMA: dict[str, Any] = {
+    "name": "delegate_to_codex",
+    "description": (
+        "Delegate code-writing work to the local Codex CLI via non-interactive `codex exec`. "
+        "Use this for product-code edits when Build Zeller has code_writes_require_codex enabled. "
+        "Returns structured subprocess evidence; verify changed files and tests separately."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {"type": "string", "description": "Self-contained Codex task brief."},
+            "working_directory": {"type": "string", "description": "Repository/workspace root for Codex."},
+            "context_files": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional files Codex should inspect first.",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": f"Timeout seconds, capped at {MAX_TIMEOUT_SECONDS}.",
+                "default": DEFAULT_TIMEOUT_SECONDS,
+            },
+            "sandbox": {
+                "type": "string",
+                "enum": ["read-only", "workspace-write", "danger-full-access"],
+                "default": "workspace-write",
+                "description": "Codex sandbox mode.",
+            },
+            "model": {"type": "string", "description": "Optional Codex model override."},
+        },
+        "required": ["task", "working_directory"],
+    },
+}
+
+
+def _handle_delegate_to_codex(args, **kw):
+    return delegate_to_codex_tool(
+        task=args.get("task", ""),
+        working_directory=args.get("working_directory", ""),
+        context_files=args.get("context_files"),
+        timeout=args.get("timeout"),
+        sandbox=args.get("sandbox", "workspace-write"),
+        model=args.get("model"),
+    )
+
+
+registry.register(
+    name="delegate_to_codex",
+    toolset="codex",
+    schema=DELEGATE_TO_CODEX_SCHEMA,
+    handler=_handle_delegate_to_codex,
+    emoji="🤖",
+    max_result_size_chars=100_000,
+)

--- a/tools/evidence_gate_tool.py
+++ b/tools/evidence_gate_tool.py
@@ -67,56 +67,75 @@ def _check_file_exists(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
     }
 
 
-def _check_command(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
-    command = str(check.get("command", ""))
-    expected = int(check.get("expected_exit_code", 0))
-    timeout = float(check.get("timeout", 60))
-    cwd_value = check.get("cwd")
-    cwd = _resolve_path(str(cwd_value), base_dir) if cwd_value else base_dir
-    if not command:
-        return {
-            "type": "command",
-            "name": check.get("name") or "command",
-            "passed": False,
-            "expected_exit_code": expected,
-            "message": "command is required",
-        }
+def _file_state(path: Path) -> dict[str, Any]:
+    exists = path.exists()
+    is_file = path.is_file() if exists else False
+    size = path.stat().st_size if is_file else None
+    mtime = path.stat().st_mtime if is_file else None
+    return {
+        "path": str(path),
+        "exists": exists,
+        "is_file": is_file,
+        "size": size,
+        "mtime": mtime,
+    }
+
+
+def _check_file_non_empty(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
+    path = _resolve_path(str(check.get("path", "")), base_dir)
+    state = _file_state(path)
+    passed = bool(state["is_file"] and (state["size"] or 0) > 0)
+    return {
+        "type": "file_non_empty",
+        "name": check.get("name") or str(check.get("path", "")),
+        "passed": passed,
+        **state,
+        "message": (
+            "file exists and is non-empty"
+            if passed
+            else "file is missing, not a file, or empty"
+        ),
+    }
+
+
+def _check_file_fresh(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
+    path = _resolve_path(str(check.get("path", "")), base_dir)
+    state = _file_state(path)
     try:
-        proc = subprocess.run(
-            command,
-            cwd=str(cwd),
-            shell=True,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
-        )
-        passed = proc.returncode == expected
-        return {
-            "type": "command",
-            "name": check.get("name") or command,
-            "passed": passed,
-            "command": command,
-            "cwd": str(cwd),
-            "expected_exit_code": expected,
-            "exit_code": proc.returncode,
-            "stdout": proc.stdout[-4000:],
-            "stderr": proc.stderr[-4000:],
-            "message": "expected exit code observed" if passed else "unexpected exit code",
-        }
-    except subprocess.TimeoutExpired as exc:
-        return {
-            "type": "command",
-            "name": check.get("name") or command,
-            "passed": False,
-            "command": command,
-            "cwd": str(cwd),
-            "expected_exit_code": expected,
-            "timeout": timeout,
-            "stdout": (exc.stdout or "")[-4000:] if isinstance(exc.stdout, str) else "",
-            "stderr": (exc.stderr or "")[-4000:] if isinstance(exc.stderr, str) else "",
-            "message": "command timed out",
-        }
+        max_age_seconds = float(check.get("max_age_seconds"))
+    except (TypeError, ValueError):
+        max_age_seconds = -1
+    now = datetime.now(timezone.utc).timestamp()
+    age_seconds = (now - state["mtime"]) if state["mtime"] is not None else None
+    passed = bool(
+        state["is_file"]
+        and (state["size"] or 0) > 0
+        and max_age_seconds >= 0
+        and age_seconds is not None
+        and age_seconds <= max_age_seconds
+    )
+    return {
+        "type": "file_fresh",
+        "name": check.get("name") or str(check.get("path", "")),
+        "passed": passed,
+        **state,
+        "max_age_seconds": max_age_seconds,
+        "age_seconds": age_seconds,
+        "message": (
+            "file exists, is non-empty, and is fresh"
+            if passed
+            else "file is missing, empty, or stale"
+        ),
+    }
+
+
+def _check_command_unsupported(check: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "command",
+        "name": check.get("name") or "command",
+        "passed": False,
+        "message": "unsupported check type: command checks are not executed",
+    }
 
 
 def _porcelain_path(line: str) -> str:
@@ -179,8 +198,12 @@ def _evaluate_check(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
     check_type = str(check.get("type", "")).strip()
     if check_type == "file_exists":
         return _check_file_exists(check, base_dir)
+    if check_type == "file_non_empty":
+        return _check_file_non_empty(check, base_dir)
+    if check_type == "file_fresh":
+        return _check_file_fresh(check, base_dir)
     if check_type == "command":
-        return _check_command(check, base_dir)
+        return _check_command_unsupported(check)
     if check_type == "git_clean":
         return _check_git_clean(check, base_dir)
     if check_type == "manual":
@@ -327,7 +350,7 @@ registry.register(
         "name": "evidence_gate",
         "description": (
             "Evaluate an evidence manifest and write RESULT.md only with a "
-            "status supported by file, command, git-clean, or manual checks."
+            "status supported by non-executing file, git-clean, or manual checks."
         ),
         "parameters": {
             "type": "object",

--- a/tools/evidence_gate_tool.py
+++ b/tools/evidence_gate_tool.py
@@ -1,0 +1,369 @@
+"""Evidence-gated result writer.
+
+This tool prevents agents from writing a completed RESULT.md unless a manifest
+contains checks that can be evaluated successfully.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry
+
+
+COMPLETED = "COMPLETED"
+FAILED = "FAILED"
+MANUAL = "MANUAL_VERIFICATION_REQUIRED"
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, Path):
+        return str(value)
+    return repr(value)
+
+
+def _resolve_path(value: str | None, base_dir: Path) -> Path:
+    path = Path(value or "")
+    if not path.is_absolute():
+        path = base_dir / path
+    return path
+
+
+def _default_log_path() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "logs" / "evidence-gate.log"
+    except Exception:
+        return Path.home() / ".hermes" / "evidence-gate.log"
+
+
+def log_evidence_gate_event(event: str, payload: dict[str, Any], log_path: str | None = None) -> Path:
+    path = Path(log_path) if log_path else _default_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        **payload,
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True, default=_json_default) + "\n")
+    return path
+
+
+def _check_file_exists(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
+    path = _resolve_path(str(check.get("path", "")), base_dir)
+    passed = path.exists()
+    return {
+        "type": "file_exists",
+        "name": check.get("name") or str(check.get("path", "")),
+        "passed": passed,
+        "path": str(path),
+        "message": "path exists" if passed else "path does not exist",
+    }
+
+
+def _check_command(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
+    command = str(check.get("command", ""))
+    expected = int(check.get("expected_exit_code", 0))
+    timeout = float(check.get("timeout", 60))
+    cwd_value = check.get("cwd")
+    cwd = _resolve_path(str(cwd_value), base_dir) if cwd_value else base_dir
+    if not command:
+        return {
+            "type": "command",
+            "name": check.get("name") or "command",
+            "passed": False,
+            "expected_exit_code": expected,
+            "message": "command is required",
+        }
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=str(cwd),
+            shell=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        passed = proc.returncode == expected
+        return {
+            "type": "command",
+            "name": check.get("name") or command,
+            "passed": passed,
+            "command": command,
+            "cwd": str(cwd),
+            "expected_exit_code": expected,
+            "exit_code": proc.returncode,
+            "stdout": proc.stdout[-4000:],
+            "stderr": proc.stderr[-4000:],
+            "message": "expected exit code observed" if passed else "unexpected exit code",
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "type": "command",
+            "name": check.get("name") or command,
+            "passed": False,
+            "command": command,
+            "cwd": str(cwd),
+            "expected_exit_code": expected,
+            "timeout": timeout,
+            "stdout": (exc.stdout or "")[-4000:] if isinstance(exc.stdout, str) else "",
+            "stderr": (exc.stderr or "")[-4000:] if isinstance(exc.stderr, str) else "",
+            "message": "command timed out",
+        }
+
+
+def _porcelain_path(line: str) -> str:
+    path = line[3:] if len(line) > 3 else ""
+    if " -> " in path:
+        path = path.rsplit(" -> ", 1)[1]
+    return path.strip().strip('"')
+
+
+def _check_git_clean(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
+    repo = _resolve_path(str(check.get("repo_path") or check.get("path") or "."), base_dir)
+    allowed_prefixes = [str(prefix) for prefix in check.get("allowed_prefixes", [])]
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {
+            "type": "git_clean",
+            "name": check.get("name") or str(repo),
+            "passed": False,
+            "repo_path": str(repo),
+            "exit_code": proc.returncode,
+            "stderr": proc.stderr[-4000:],
+            "message": "git status failed",
+        }
+    dirty = []
+    allowed = []
+    for line in proc.stdout.splitlines():
+        path = _porcelain_path(line)
+        if any(path == prefix or path.startswith(prefix.rstrip("/") + "/") for prefix in allowed_prefixes):
+            allowed.append(line)
+        else:
+            dirty.append(line)
+    passed = not dirty
+    return {
+        "type": "git_clean",
+        "name": check.get("name") or str(repo),
+        "passed": passed,
+        "repo_path": str(repo),
+        "allowed_prefixes": allowed_prefixes,
+        "dirty": dirty,
+        "allowed_dirty": allowed,
+        "message": "git tree clean" if passed else "git tree has unallowed changes",
+    }
+
+
+def _check_manual(check: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "manual",
+        "name": check.get("name") or "manual",
+        "passed": None,
+        "message": check.get("message") or "manual verification required",
+    }
+
+
+def _evaluate_check(check: dict[str, Any], base_dir: Path) -> dict[str, Any]:
+    check_type = str(check.get("type", "")).strip()
+    if check_type == "file_exists":
+        return _check_file_exists(check, base_dir)
+    if check_type == "command":
+        return _check_command(check, base_dir)
+    if check_type == "git_clean":
+        return _check_git_clean(check, base_dir)
+    if check_type == "manual":
+        return _check_manual(check)
+    return {
+        "type": check_type or "unknown",
+        "name": check.get("name") or check_type or "unknown",
+        "passed": False,
+        "message": f"unsupported check type: {check_type!r}",
+    }
+
+
+def _render_result_markdown(
+    final_status: str,
+    requested_status: str,
+    manifest_path: Path,
+    check_results: list[dict[str, Any]],
+    body: str,
+) -> str:
+    lines = [
+        "# Result",
+        "",
+        f"Status: {final_status}",
+        f"Requested status: {requested_status}",
+        f"Evidence manifest: {manifest_path}",
+        "",
+    ]
+    if body:
+        lines.extend([body.rstrip(), ""])
+    lines.extend(["## Evidence Checks", ""])
+    for result in check_results:
+        marker = "PASS" if result.get("passed") is True else "MANUAL" if result.get("passed") is None else "FAIL"
+        lines.append(f"- {marker} {result.get('type')}: {result.get('name')} - {result.get('message')}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def evidence_gate(
+    manifest_path: str,
+    requested_status: str | None = None,
+    result_path: str | None = None,
+    result_body: str | None = None,
+    log_path: str | None = None,
+    task_id: str | None = None,
+) -> str:
+    """Evaluate a JSON evidence manifest and write RESULT.md with gated status."""
+    manifest_file = Path(manifest_path).expanduser()
+    if not manifest_file.is_absolute():
+        manifest_file = Path.cwd() / manifest_file
+    manifest_file = manifest_file.resolve()
+    try:
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except Exception as exc:
+        result = {
+            "success": False,
+            "status": FAILED,
+            "requested_status": requested_status,
+            "manifest_path": str(manifest_file),
+            "error": f"could not load evidence manifest: {exc}",
+        }
+        if (requested_status or "").upper() == COMPLETED:
+            log_path_used = log_evidence_gate_event(
+                "evidence_gate_refused",
+                {**result, "reason": "manifest_load_failed", "task_id": task_id},
+                log_path,
+            )
+            result["log_path"] = str(log_path_used)
+        return json.dumps(result)
+
+    if not isinstance(manifest, dict):
+        return json.dumps({
+            "success": False,
+            "status": FAILED,
+            "requested_status": requested_status,
+            "manifest_path": str(manifest_file),
+            "error": "evidence manifest must be a JSON object",
+        })
+
+    base_dir = _resolve_path(str(manifest.get("base_dir", ".")), manifest_file.parent)
+    checks = manifest.get("checks", [])
+    if not isinstance(checks, list):
+        checks = []
+
+    requested = str(requested_status or manifest.get("requested_status") or COMPLETED)
+    output_path_value = result_path or manifest.get("result_path") or "RESULT.md"
+    output_path = _resolve_path(str(output_path_value), base_dir)
+    body = result_body if result_body is not None else str(manifest.get("result_body", ""))
+
+    check_results = [
+        _evaluate_check(check, base_dir)
+        for check in checks
+        if isinstance(check, dict)
+    ]
+    if not check_results:
+        check_results.append({
+            "type": "manifest",
+            "name": "evidence checks",
+            "passed": False,
+            "message": "at least one evidence check is required",
+        })
+    failures = [result for result in check_results if result.get("passed") is False]
+    manual = [result for result in check_results if result.get("passed") is None]
+    if failures:
+        final_status = FAILED
+    elif manual:
+        final_status = MANUAL
+    else:
+        final_status = requested
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        _render_result_markdown(final_status, requested, manifest_file, check_results, body),
+        encoding="utf-8",
+    )
+
+    response = {
+        "success": final_status == requested and not failures and not manual,
+        "status": final_status,
+        "requested_status": requested,
+        "manifest_path": str(manifest_file),
+        "result_path": str(output_path),
+        "checks": check_results,
+        "failure_count": len(failures),
+        "manual_count": len(manual),
+    }
+    if requested.upper() == COMPLETED and final_status.upper() != COMPLETED:
+        log_path_used = log_evidence_gate_event(
+            "evidence_gate_refused",
+            {
+                **response,
+                "reason": "completion_refused",
+                "task_id": task_id,
+            },
+            log_path,
+        )
+        response["log_path"] = str(log_path_used)
+    return json.dumps(response, default=_json_default)
+
+
+registry.register(
+    name="evidence_gate",
+    toolset="evidence_gate",
+    schema={
+        "name": "evidence_gate",
+        "description": (
+            "Evaluate an evidence manifest and write RESULT.md only with a "
+            "status supported by file, command, git-clean, or manual checks."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "manifest_path": {
+                    "type": "string",
+                    "description": "Path to the evidence manifest JSON.",
+                },
+                "requested_status": {
+                    "type": "string",
+                    "description": "Requested final status, for example COMPLETED.",
+                },
+                "result_path": {
+                    "type": "string",
+                    "description": "Optional RESULT.md output path overriding the manifest.",
+                },
+                "result_body": {
+                    "type": "string",
+                    "description": "Optional markdown body to include in RESULT.md.",
+                },
+                "log_path": {
+                    "type": "string",
+                    "description": "Optional evidence-gate refusal log path.",
+                },
+            },
+            "required": ["manifest_path"],
+        },
+    },
+    handler=lambda args, **kw: evidence_gate(
+        manifest_path=args.get("manifest_path", ""),
+        requested_status=args.get("requested_status"),
+        result_path=args.get("result_path"),
+        result_body=args.get("result_body"),
+        log_path=args.get("log_path"),
+        task_id=kw.get("task_id"),
+    ),
+    description="Evidence-gated RESULT.md writer",
+    emoji="",
+)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -147,21 +147,27 @@ def _is_blocked_device_path(path: str) -> bool:
     return False
 
 
-def _is_blocked_device(filepath: str) -> bool:
+def _is_blocked_device(filepath: str, task_id: str = "default") -> bool:
     """Return True if the path would hang the process (infinite output or blocking input).
 
     Check the literal path first so aliases like /dev/stdin are caught before
-    they resolve to terminal-specific paths. Then check the resolved path so a
-    workspace symlink to /dev/zero cannot bypass the guard.
+    they resolve to terminal-specific paths. Then check the task-cwd-resolved
+    path so a workspace symlink to /dev/zero cannot bypass the guard.
     """
     normalized = os.path.expanduser(filepath)
     if _is_blocked_device_path(normalized):
         return True
     try:
-        resolved = os.path.realpath(normalized)
+        task_resolved = str(_resolve_path_for_task(normalized, task_id))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if _is_blocked_device_path(task_resolved):
+        return True
+    try:
+        task_realpath = os.path.realpath(task_resolved)
     except (OSError, ValueError):
         return False
-    if resolved != normalized and _is_blocked_device_path(resolved):
+    if task_realpath != task_resolved and _is_blocked_device_path(task_realpath):
         return True
     return False
 
@@ -627,7 +633,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        if _is_blocked_device(path):
+        if _is_blocked_device(path, task_id):
             return json.dumps({
                 "error": (
                     f"Cannot read '{path}': this is a device file that would "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import threading
 from pathlib import Path
+from typing import Iterable
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
@@ -172,6 +173,94 @@ _SENSITIVE_PATH_PREFIXES = (
     "/private/etc/", "/private/var/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
+
+_PRODUCT_CODE_SOURCE_EXTENSIONS = frozenset({
+    ".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+    ".go", ".rs", ".java", ".kt", ".kts", ".swift", ".c", ".h",
+    ".cc", ".cpp", ".cxx", ".hpp", ".cs", ".php", ".rb", ".sh",
+    ".bash", ".zsh", ".fish", ".ps1", ".sql", ".html", ".css",
+    ".scss", ".vue", ".svelte",
+})
+
+_PRODUCT_CODE_MANIFEST_FILENAMES = frozenset({
+    "package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock",
+    "pyproject.toml", "poetry.lock", "go.mod", "go.sum",
+    "cargo.toml", "cargo.lock", "dockerfile", "containerfile",
+})
+
+_PRODUCT_CODE_MANIFEST_PATTERNS = frozenset({
+    "tsconfig*.json", "vite.config.*", "webpack.config.*", "next.config.*",
+    "requirements*.txt", "docker-compose*.yml", "docker-compose*.yaml",
+})
+
+_NON_PRODUCT_ARTIFACT_FILENAMES = frozenset({
+    "result.md", "soul.md", "codex.md", "config.yaml", "config.yml",
+    "evidence_manifest.json",
+})
+
+_NON_PRODUCT_ARTIFACT_PATTERNS = frozenset({
+    "*result.md", "*evidence_manifest*.json", "*.log", "*.md",
+})
+
+
+def _code_writes_require_codex_enabled() -> bool:
+    """Return true when native Hermes code writes should be refused.
+
+    Supports both a simple boolean and a future-extensible object:
+    ``code_writes_require_codex: true`` or
+    ``code_writes_require_codex: {enabled: true}``.
+    """
+    if os.environ.get("HERMES_CODEX_DELEGATE_ACTIVE") == "1":
+        return False
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return False
+    value = cfg.get("code_writes_require_codex") if isinstance(cfg, dict) else None
+    if isinstance(value, dict):
+        return bool(value.get("enabled", False))
+    return bool(value)
+
+
+def _is_code_write_path(filepath: str, task_id: str = "default") -> bool:
+    """Return True when *filepath* is product code for code-write delegation.
+
+    Product code includes source files and code-affecting manifests/configs
+    that change build, dependency, runtime, or container behavior. Reporting,
+    evidence, profile, and Markdown artifacts are deliberately excluded so the
+    guard can still write verification notes while product-code edits route
+    through Codex.
+    """
+    import fnmatch
+
+    try:
+        resolved = _resolve_path_for_task(filepath, task_id)
+    except Exception:
+        resolved = Path(os.path.expanduser(filepath))
+    name = resolved.name.lower()
+    if name in _NON_PRODUCT_ARTIFACT_FILENAMES:
+        return False
+    if any(fnmatch.fnmatchcase(name, pattern) for pattern in _NON_PRODUCT_ARTIFACT_PATTERNS):
+        return False
+    if name in _PRODUCT_CODE_MANIFEST_FILENAMES:
+        return True
+    if any(fnmatch.fnmatchcase(name, pattern) for pattern in _PRODUCT_CODE_MANIFEST_PATTERNS):
+        return True
+    return resolved.suffix.lower() in _PRODUCT_CODE_SOURCE_EXTENSIONS
+
+
+def _check_codex_code_write_guard(paths: Iterable[str], task_id: str = "default") -> str | None:
+    if not _code_writes_require_codex_enabled():
+        return None
+    blocked = [p for p in paths if p and _is_code_write_path(p, task_id)]
+    if not blocked:
+        return None
+    return (
+        "code_writes_require_codex is enabled; refusing native Hermes file edit "
+        f"for code path(s): {', '.join(blocked)}. Use delegate_to_codex for "
+        "product-code changes, then verify artifacts/tests separately."
+    )
 
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
@@ -894,6 +983,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    codex_guard_err = _check_codex_code_write_guard([path], task_id)
+    if codex_guard_err:
+        return tool_error(codex_guard_err)
     if not cross_profile:
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
@@ -987,6 +1079,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        codex_guard_err = _check_codex_code_write_guard([_p], task_id)
+        if codex_guard_err:
+            return tool_error(codex_guard_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,6 +52,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Evidence-gated completion/result writing
+    "evidence_gate",
     # Code execution + delegation
     "execute_code", "delegate_task", "delegate_to_codex",
     # Cronjob management
@@ -227,6 +229,12 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    "evidence_gate": {
+        "description": "Evidence-gated RESULT.md writing and completion refusal logging",
+        "tools": ["evidence_gate"],
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
@@ -358,7 +366,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task", "delegate_to_codex",
+            "execute_code", "delegate_task",
         ],
         "includes": []
     },
@@ -386,7 +394,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task", "delegate_to_codex",
+            "execute_code", "delegate_task",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "delegate_to_codex",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -240,6 +240,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "codex": {
+        "description": "Delegate code-writing work to the local Codex CLI via codex exec",
+        "tools": ["delegate_to_codex"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -352,7 +358,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_codex",
         ],
         "includes": []
     },
@@ -380,7 +386,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_to_codex",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary
- Add `evidence_gate` tool for manifest-driven, evidence-gated RESULT.md writing
- Add Clawpatch weekly evidence-gate script with verify-only refusal path
- Register evidence gate in core/toolsets
- Add focused behavioural tests for Build Zeller and Clawpatch refusal paths

## Verification
- `pytest tests/tools/test_evidence_gate_tool.py tests/scripts/test_clawpatch_weekly_evidence_gate.py tests/tools/test_code_write_guard.py tests/tools/test_codex_delegate_tool.py -q` -> 51 passed
- Phase C behavioural evidence: unsatisfiable Build Zeller criterion writes FAILED, Clawpatch missing-artifact path exits 1 and writes FAILED
- `delegate_to_codex` iterate loop evidence: failing pytest -> Codex edit -> pytest 2 passed

## Stacking note
This branch is stacked on the Phase B branch/commit. Merge Phase B first, then merge this PR. Until Phase B is merged, GitHub may show the Phase B commit in this comparison.

## Evidence status
All phases A/B/C verified by Sam + Jason; status: Migration COMPLETE.
