### PR TITLE
feat(vertex): add Google Vertex AI provider for Gemini models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4507,6 +4507,52 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    elif pconfig.auth_type == "gcp_sdk":
+        # Google Vertex AI — standard OpenAI-compatible endpoint with OAuth2
+        # token authentication. Much simpler than Bedrock: no custom SDK or
+        # message translation. We just build an OpenAI client pointed at the
+        # Vertex endpoint with a fresh OAuth2 token.
+        try:
+            from agent.vertex_adapter import (
+                _resolve_vertex_token,
+                get_vertex_base_url,
+                has_vertex_credentials,
+            )
+        except ImportError:
+            logger.warning("resolve_provider_client: vertex requested but "
+                           "google-auth not installed")
+            return None, None
+
+        if not has_vertex_credentials():
+            logger.debug("resolve_provider_client: vertex requested but "
+                         "no GCP credentials found")
+            return None, None
+
+        base_url = get_vertex_base_url()
+        if not base_url:
+            logger.warning("resolve_provider_client: vertex requested but "
+                           "could not determine project ID")
+            return None, None
+
+        token = _resolve_vertex_token()
+        if not token:
+            logger.warning("resolve_provider_client: vertex requested but "
+                           "could not obtain OAuth2 token")
+            return None, None
+
+        default_model = "google/gemini-3-flash-preview"
+        final_model = _normalize_resolved_model(model or default_model, provider)
+        try:
+            from openai import OpenAI
+            client = OpenAI(api_key=token, base_url=base_url)
+        except Exception as exc:
+            logger.warning("resolve_provider_client: cannot create Vertex "
+                           "client: %s", exc)
+            return None, None
+        logger.debug("resolve_provider_client: vertex (%s)", final_model)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
         # OAuth providers — route through their specific try functions
         if provider == "nous":

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -426,6 +426,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "portal.qwen.ai": "qwen-oauth",
     "openrouter.ai": "openrouter",
     "generativelanguage.googleapis.com": "gemini",
+    "aiplatform.googleapis.com": "vertex",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -118,6 +118,37 @@ def resolve_vertex_auth_source() -> Optional[str]:
 # Token management (lazy google-auth import)
 # ---------------------------------------------------------------------------
 
+# Module-level cache for google-auth once imported — allows tests to mock
+# via agent.vertex_adapter._ga_service_account, etc.
+_ga_auth = None
+_ga_transport = None
+_ga_service_account = None
+
+
+def _import_google_auth() -> bool:
+    """Import google-auth modules once. Returns True on success.
+
+    Stores references at module scope so tests can mock them via
+    ``agent.vertex_adapter._ga_service_account`` etc.
+    """
+    global _ga_auth, _ga_transport, _ga_service_account
+    if _ga_auth is not None:
+        return True
+    try:
+        import google.auth as _a
+        import google.auth.transport.requests as _t
+        from google.oauth2 import service_account as _sa
+
+        _ga_auth = _a
+        _ga_transport = _t
+        _ga_service_account = _sa
+        return True
+    except ImportError:
+        logger.warning(
+            "google-auth not installed. Install with: pip install google-auth"
+        )
+        return False
+
 
 def _resolve_vertex_token() -> Optional[str]:
     """Return a valid OAuth2 access token for Vertex AI.
@@ -129,30 +160,23 @@ def _resolve_vertex_token() -> Optional[str]:
     if _token_cache and _token_cache.get("expires_at", 0) - now > 60:
         return _token_cache["token"]
 
-    try:
-        import google.auth
-        import google.auth.transport.requests
-        from google.oauth2 import service_account
-    except ImportError:
-        logger.warning(
-            "google-auth not installed. Install with: pip install google-auth"
-        )
+    if not _import_google_auth():
         return None
 
     credentials_path = _resolve_credentials_path()
 
     try:
         if credentials_path:
-            creds = service_account.Credentials.from_service_account_file(
+            creds = _ga_service_account.Credentials.from_service_account_file(
                 credentials_path,
                 scopes=["https://www.googleapis.com/auth/cloud-platform"],
             )
         else:
-            creds, _ = google.auth.default(
+            creds, _ = _ga_auth.default(
                 scopes=["https://www.googleapis.com/auth/cloud-platform"]
             )
 
-        auth_req = google.auth.transport.requests.Request()
+        auth_req = _ga_transport.Request()
         creds.refresh(auth_req)
 
         _token_cache["token"] = creds.token

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -1,0 +1,183 @@
+"""Vertex AI (Google Cloud) adapter for Hermes Agent.
+
+Provides credential resolution and OAuth2 token management for Vertex AI's
+OpenAI-compatible endpoint. This allows Hermes to use Gemini models via
+Google Cloud with enterprise-grade rate limits and GCP billing credits.
+
+Credential resolution priority:
+  1. VERTEX_CREDENTIALS_PATH env var — explicit path to service account JSON
+  2. GOOGLE_APPLICATION_CREDENTIALS env var — standard GCP ADC path
+  3. gcloud ADC (application default credentials) — auto-detected
+
+Project ID resolution priority:
+  1. VERTEX_PROJECT_ID env var
+  2. GOOGLE_CLOUD_PROJECT env var
+  3. project_id embedded in the service account JSON
+
+Region defaults to "global" (required for Gemini 3.x previews; us-central1
+silently breaks them). Override with VERTEX_REGION.
+
+Architecture follows the same pattern as ``agent/bedrock_adapter.py``:
+  - All Vertex-specific logic isolated here.
+  - Simple detection functions for auth flows (no heavy imports at startup).
+  - OAuth2 token caching with refresh-on-expiry.
+  - Standard OpenAI-compatible chat/completions — no custom SDK or message
+    translation needed.
+
+Requires: ``google-auth`` (optional — only needed when using Vertex provider).
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Cached token with expiry — refreshed lazily by _resolve_vertex_token()
+_token_cache: dict = {}
+
+
+# ---------------------------------------------------------------------------
+# Detection functions (fast, no heavy imports, no API calls)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_credentials_path() -> Optional[str]:
+    """Return the path to a service account JSON file, or None."""
+    for env_var in ("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS"):
+        path = os.environ.get(env_var, "").strip()
+        if path and os.path.exists(path):
+            return path
+    return None
+
+
+def _resolve_project_id_from_sa(path: str) -> Optional[str]:
+    """Read project_id from a service account JSON file."""
+    try:
+        with open(path, "r") as f:
+            sa = json.load(f)
+        return sa.get("project_id")
+    except (OSError, json.JSONDecodeError, KeyError):
+        return None
+
+
+def _resolve_project_id() -> Optional[str]:
+    """Resolve the GCP project ID for Vertex AI.
+
+    Priority: VERTEX_PROJECT_ID > GOOGLE_CLOUD_PROJECT > SA JSON project_id.
+    """
+    for env_var in ("VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"):
+        pid = os.environ.get(env_var, "").strip()
+        if pid:
+            return pid
+
+    creds_path = _resolve_credentials_path()
+    if creds_path:
+        pid = _resolve_project_id_from_sa(creds_path)
+        if pid:
+            return pid
+
+    return None
+
+
+def resolve_vertex_region() -> str:
+    """Return the Vertex AI region, defaulting to 'global'."""
+    return os.environ.get("VERTEX_REGION", "global").strip() or "global"
+
+
+def has_vertex_credentials() -> bool:
+    """Return True if Vertex AI credentials are configured.
+
+    Checks for a service account JSON at a known path or explicit project ID.
+    Does NOT try to load google-auth or make network calls — this is a fast
+    startup check used for provider auto-detection.
+    """
+    if _resolve_credentials_path():
+        return True
+    if _resolve_project_id():
+        return True
+    return False
+
+
+def resolve_vertex_auth_source() -> Optional[str]:
+    """Return a human-readable auth source label, or None."""
+    if os.environ.get("VERTEX_CREDENTIALS_PATH", "").strip():
+        return "VERTEX_CREDENTIALS_PATH"
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip():
+        return "GOOGLE_APPLICATION_CREDENTIALS"
+    if os.environ.get("VERTEX_PROJECT_ID", "").strip():
+        return "VERTEX_PROJECT_ID"
+    if os.environ.get("GOOGLE_CLOUD_PROJECT", "").strip():
+        return "GOOGLE_CLOUD_PROJECT"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Token management (lazy google-auth import)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_vertex_token() -> Optional[str]:
+    """Return a valid OAuth2 access token for Vertex AI.
+
+    Uses service account JSON if available, otherwise falls back to gcloud ADC.
+    Tokens are cached and refreshed only when within 60 seconds of expiry.
+    """
+    now = time.time()
+    if _token_cache and _token_cache.get("expires_at", 0) - now > 60:
+        return _token_cache["token"]
+
+    try:
+        import google.auth
+        import google.auth.transport.requests
+        from google.oauth2 import service_account
+    except ImportError:
+        logger.warning(
+            "google-auth not installed. Install with: pip install google-auth"
+        )
+        return None
+
+    credentials_path = _resolve_credentials_path()
+
+    try:
+        if credentials_path:
+            creds = service_account.Credentials.from_service_account_file(
+                credentials_path,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+        else:
+            creds, _ = google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"]
+            )
+
+        auth_req = google.auth.transport.requests.Request()
+        creds.refresh(auth_req)
+
+        _token_cache["token"] = creds.token
+        # 55 min buffer (tokens are valid for 60 min)
+        _token_cache["expires_at"] = now + 3300
+        return creds.token
+
+    except Exception as e:
+        logger.warning("Failed to resolve Vertex AI credentials: %s", e)
+        return None
+
+
+def get_vertex_base_url(
+    project_id: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Optional[str]:
+    """Build the Vertex AI OpenAI-compatible base URL.
+
+    Returns None if no project ID can be resolved.
+    """
+    pid = project_id or _resolve_project_id()
+    if not pid:
+        return None
+    reg = region or resolve_vertex_region()
+    return (
+        f"https://aiplatform.googleapis.com/v1/projects/{pid}"
+        f"/locations/{reg}/endpoints/openapi"
+    )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -427,6 +427,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
+    "vertex": ProviderConfig(
+        id="vertex",
+        name="Google Vertex AI",
+        auth_type="gcp_sdk",
+        inference_base_url="",  # Computed from project_id + region at runtime
+        api_key_env_vars=(),   # OAuth2 token — not a static API key
+        base_url_env_var="VERTEX_BASE_URL",
+    ),
     "azure-foundry": ProviderConfig(
         id="azure-foundry",
         name="Azure Foundry",
@@ -1580,6 +1588,7 @@ def resolve_provider(
         "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",
         "tencent-cloud": "tencent-tokenhub", "tencentmaas": "tencent-tokenhub",
         "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
+        "vertex-ai": "vertex", "google-vertex": "vertex", "gcp-vertex": "vertex", "google-vertex-ai": "vertex",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
@@ -1725,6 +1734,15 @@ def resolve_provider(
             return "bedrock"
     except ImportError:
         pass  # boto3 not installed — skip Bedrock auto-detection
+
+    # Google Vertex AI — detect via service account JSON or explicit project ID.
+    # Mirrors Bedrock auto-detection: no API key needed, credential chain handles auth.
+    try:
+        from agent.vertex_adapter import has_vertex_credentials
+        if has_vertex_credentials():
+            return "vertex"
+    except ImportError:
+        pass  # google-auth not installed — skip Vertex auto-detection
 
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
@@ -6245,6 +6263,13 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
             return {"logged_in": has_aws_credentials(), "provider": target}
         except ImportError:
             return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
+    # GCP SDK providers (Vertex AI) — check via service account / project ID
+    if pconfig and pconfig.auth_type == "gcp_sdk":
+        try:
+            from agent.vertex_adapter import has_vertex_credentials
+            return {"logged_in": has_vertex_credentials(), "provider": target}
+        except ImportError:
+            return {"logged_in": False, "provider": target, "error": "google-auth not installed"}
     return {"logged_in": False}
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3109,6 +3109,8 @@ def select_provider_and_model(args=None):
         _model_flow_stepfun(config, current_model)
     elif selected_provider == "bedrock":
         _model_flow_bedrock(config, current_model)
+    elif selected_provider == "vertex":
+        _model_flow_vertex(config, current_model)
     elif selected_provider == "azure-foundry":
         _model_flow_azure_foundry(config, current_model)
     elif selected_provider in {
@@ -4082,6 +4084,546 @@ def _stepfun_base_url_for_region(region: str) -> str:
 
 
 
+
+def _model_flow_vertex(config, current_model=""):
+    """Google Vertex AI provider flow.
+
+    Credentials come from a service account JSON file or gcloud ADC —
+    no API key prompt. Region defaults to 'global' (required for Gemini
+    3.x previews). Models are shown from the curated Vertex catalog.
+    """
+    from hermes_cli.auth import (
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    # 1. Credential status — display only, no prompt needed
+    creds_path = (
+        os.environ.get("VERTEX_CREDENTIALS_PATH", "").strip()
+        or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+    )
+    if creds_path:
+        short = creds_path if len(creds_path) <= 40 else f"...{creds_path[-37:]}"
+        print(f"  Credentials: {short} \u2713")
+    else:
+        print("  Credentials: Application Default Credentials (ADC)")
+        print("  (Set VERTEX_CREDENTIALS_PATH or GOOGLE_APPLICATION_CREDENTIALS")
+        print("   to a service account JSON file, or run")
+        print("   `gcloud auth application-default login`.)")
+    print()
+
+    # 2. Region override (optional)
+    from agent.vertex_adapter import resolve_vertex_region
+    current_region = resolve_vertex_region()
+    try:
+        region_input = input(f"  Region [{current_region}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    region = region_input or current_region
+    if region != current_region:
+        from hermes_cli.config import save_env_value
+        save_env_value("VERTEX_REGION", region)
+        print(f"  Region saved: {region}")
+        print()
+
+    # 3. Model selection from curated catalog
+    model_list = _PROVIDER_MODELS.get("vertex", [])
+    if not model_list:
+        model_list = [
+            "google/gemini-3.1-flash-lite-preview",
+            "google/gemini-3.5-flash",
+            "google/gemini-2.5-pro",
+        ]
+
+    selected = _prompt_model_selection(model_list, current_model)
+    if not selected:
+        print("  No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = "vertex"
+    model.pop("base_url", None)
+    model.pop("api_mode", None)
+    save_config(cfg)
+    deactivate_provider()
+    print(f"  Default model set to: {selected} (via Google Vertex AI, {region})")
+
+
+def _model_flow_bedrock(config, current_model=""):
+    """AWS Bedrock provider: verify credentials, pick region, discover models.
+
+    Uses the native Converse API via boto3 — not the OpenAI-compatible endpoint.
+    Auth is handled by the AWS SDK default credential chain (env vars, profile,
+    instance role), so no API key prompt is needed.
+    """
+    from hermes_cli.auth import (
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    # 1. Check for AWS credentials
+    try:
+        from agent.bedrock_adapter import (
+            has_aws_credentials,
+            resolve_aws_auth_env_var,
+            resolve_bedrock_region,
+            discover_bedrock_models,
+        )
+    except ImportError:
+        print("  ✗ boto3 is not installed. Install it with:")
+        print("    pip install boto3")
+        print()
+        return
+
+    if not has_aws_credentials():
+        print("  ⚠ No AWS credentials detected via environment variables.")
+        print("  Bedrock will use boto3's default credential chain (IMDS, SSO, etc.)")
+        print()
+
+    auth_var = resolve_aws_auth_env_var()
+    if auth_var:
+        print(f"  AWS credentials: {auth_var} ✓")
+    else:
+        print("  AWS credentials: boto3 default chain (instance role / SSO)")
+    print()
+
+    # 2. Region selection
+    current_region = resolve_bedrock_region()
+    try:
+        region_input = input(f"  AWS Region [{current_region}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    region = region_input or current_region
+
+    # 2b. Authentication mode
+    print("  Choose authentication method:")
+    print()
+    print("    1. IAM credential chain (recommended)")
+    print("       Works with EC2 instance roles, SSO, env vars, aws configure")
+    print("    2. Bedrock API Key")
+    print("       Enter your Bedrock API Key directly — also supports")
+    print("       team scenarios where an admin distributes keys")
+    print()
+    try:
+        auth_choice = input("  Choice [1]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+
+    if auth_choice == "2":
+        _model_flow_bedrock_api_key(config, region, current_model)
+        return
+
+    # 3. Model discovery — try live API first, fall back to static list
+    print(f"  Discovering models in {region}...")
+    live_models = discover_bedrock_models(region)
+
+    if live_models:
+        _EXCLUDE_PREFIXES = (
+            "stability.",
+            "cohere.embed",
+            "twelvelabs.",
+            "us.stability.",
+            "us.cohere.embed",
+            "us.twelvelabs.",
+            "global.cohere.embed",
+            "global.twelvelabs.",
+        )
+        _EXCLUDE_SUBSTRINGS = ("safeguard", "voxtral", "palmyra-vision")
+        filtered = []
+        for m in live_models:
+            mid = m["id"]
+            if any(mid.startswith(p) for p in _EXCLUDE_PREFIXES):
+                continue
+            if any(s in mid.lower() for s in _EXCLUDE_SUBSTRINGS):
+                continue
+            filtered.append(m)
+
+        # Deduplicate: prefer inference profiles (us.*, global.*) over bare
+        # foundation model IDs.
+        profile_base_ids = set()
+        for m in filtered:
+            mid = m["id"]
+            if mid.startswith(("us.", "global.")):
+                base = mid.split(".", 1)[1] if "." in mid[3:] else mid
+                profile_base_ids.add(base)
+
+        deduped = []
+        for m in filtered:
+            mid = m["id"]
+            if not mid.startswith(("us.", "global.")) and mid in profile_base_ids:
+                continue
+            deduped.append(m)
+
+        _RECOMMENDED = [
+            "us.anthropic.claude-sonnet-4-6",
+            "us.anthropic.claude-opus-4-6",
+            "us.anthropic.claude-haiku-4-5",
+            "us.amazon.nova-pro",
+            "us.amazon.nova-lite",
+            "us.amazon.nova-micro",
+            "deepseek.v3",
+            "us.meta.llama4-maverick",
+            "us.meta.llama4-scout",
+        ]
+
+        def _sort_key(m):
+            mid = m["id"]
+            for i, rec in enumerate(_RECOMMENDED):
+                if mid.startswith(rec):
+                    return (0, i, mid)
+            if mid.startswith("global."):
+                return (1, 0, mid)
+            return (2, 0, mid)
+
+        deduped.sort(key=_sort_key)
+        model_list = [m["id"] for m in deduped]
+        print(
+            f"  Found {len(model_list)} text model(s) (filtered from {len(live_models)} total)"
+        )
+    else:
+        model_list = _PROVIDER_MODELS.get("bedrock", [])
+        if model_list:
+            print(
+                f"  Using {len(model_list)} curated models (live discovery unavailable)"
+            )
+        else:
+            print(
+                "  No models found. Check IAM permissions for bedrock:ListFoundationModels."
+            )
+            return
+
+    # 4. Model selection
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("  Model ID: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "bedrock"
+        model["base_url"] = f"https://bedrock-runtime.{region}.amazonaws.com"
+        model.pop("api_mode", None)  # bedrock_converse is auto-detected
+
+        bedrock_cfg = cfg.get("bedrock", {})
+        if not isinstance(bedrock_cfg, dict):
+            bedrock_cfg = {}
+        bedrock_cfg["region"] = region
+        cfg["bedrock"] = bedrock_cfg
+
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
+    else:
+        print("  No change.")
+
+
+def _model_flow_api_key_provider(config, provider_id, current_model=""):
+    """Generic flow for API-key providers (z.ai, MiniMax, OpenCode, etc.)."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_config,
+    )
+    from hermes_cli.models import (
+        _PROVIDER_MODELS,
+        fetch_api_models,
+        opencode_model_api_mode,
+        normalize_opencode_model_id,
+    )
+
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
+    base_url_env = pconfig.base_url_env_var or ""
+
+    # Check / prompt for API key
+    existing_key = ""
+    for ev in pconfig.api_key_env_vars:
+        existing_key = get_env_value(ev) or os.getenv(ev, "")
+        if existing_key:
+            break
+
+    existing_key, abort = _prompt_api_key(
+        pconfig, existing_key, provider_id=provider_id
+    )
+    if abort:
+        return
+
+    # Gemini free-tier gate: free-tier daily quotas (<= 250 RPD for Flash)
+    # are exhausted in a handful of agent turns, so refuse to wire up the
+    # provider with a free-tier key. Probe is best-effort; network or auth
+    # errors fall through without blocking.
+    if provider_id == "gemini" and existing_key:
+        try:
+            from agent.gemini_native_adapter import probe_gemini_tier
+        except Exception:
+            probe_gemini_tier = None
+        if probe_gemini_tier is not None:
+            print("  Checking Gemini API tier...")
+            probe_base = (
+                (get_env_value(base_url_env) if base_url_env else "")
+                or os.getenv(base_url_env or "", "")
+                or pconfig.inference_base_url
+            )
+            tier = probe_gemini_tier(existing_key, probe_base)
+            if tier == "free":
+                print()
+                print(
+                    "❌ This Google API key is on the free tier "
+                    "(<= 250 requests/day for gemini-2.5-flash)."
+                )
+                print(
+                    "   Hermes typically makes 3-10 API calls per user turn "
+                    "(tool iterations + auxiliary tasks),"
+                )
+                print(
+                    "   so the free tier is exhausted after a handful of "
+                    "messages and cannot sustain"
+                )
+                print("   an agent session.")
+                print()
+                print(
+                    "   To use Gemini with Hermes, enable billing on your "
+                    "Google Cloud project and regenerate"
+                )
+                print(
+                    "   the key in a billing-enabled project: "
+                    "https://aistudio.google.com/apikey"
+                )
+                print()
+                print(
+                    "   Alternatives with workable free usage: DeepSeek, "
+                    "OpenRouter (free models), Groq, Nous."
+                )
+                print()
+                print("Not saving Gemini as the default provider.")
+                return
+            if tier == "paid":
+                print("  Tier check: paid ✓")
+            else:
+                # "unknown" -- network issue, auth problem, unexpected response.
+                # Don't block; the runtime 429 handler will surface free-tier
+                # guidance if the key turns out to be free tier.
+                print("  Tier check: could not verify (proceeding anyway).")
+            print()
+
+    # Optional base URL override.
+    # Precedence: env var → config.yaml model.base_url → registry default.
+    # Reading config.yaml prevents silently overwriting a saved remote URL
+    # (e.g. a remote LM Studio endpoint) with localhost when the user just
+    # presses Enter at the prompt below.
+    current_base = ""
+    if base_url_env:
+        current_base = get_env_value(base_url_env) or os.getenv(base_url_env, "")
+    if not current_base:
+        try:
+            _m = load_config().get("model") or {}
+            if str(_m.get("provider") or "").strip().lower() == provider_id:
+                current_base = str(_m.get("base_url") or "").strip()
+        except Exception:
+            pass
+    effective_base = current_base or pconfig.inference_base_url
+
+    try:
+        override = input(f"Base URL [{effective_base}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        override = ""
+    if override and base_url_env:
+        if not override.startswith(("http://", "https://")):
+            print(
+                "  Invalid URL — must start with http:// or https://. Keeping current value."
+            )
+        else:
+            save_env_value(base_url_env, override)
+            effective_base = override
+
+    # Model selection — resolution order:
+    #   1. models.dev registry (cached, filtered for agentic/tool-capable models)
+    #   2. Curated static fallback list (offline insurance)
+    #   3. Live /models endpoint probe (small providers without models.dev data)
+    #
+    # LM Studio: live /api/v1/models probe (no models.dev catalog).
+    # Ollama Cloud: merged discovery (live API + models.dev + disk cache).
+    if provider_id == "lmstudio":
+        from hermes_cli.auth import AuthError
+        from hermes_cli.models import fetch_lmstudio_models
+
+        api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
+        try:
+            model_list = fetch_lmstudio_models(
+                api_key=api_key_for_probe, base_url=effective_base
+            )
+        except AuthError as exc:
+            print(f"  LM Studio rejected the request: {exc}")
+            print("  Set LM_API_KEY (or update it) to match the server's bearer token.")
+            model_list = []
+        if model_list:
+            print(f"  Found {len(model_list)} model(s) from LM Studio")
+    elif provider_id == "ollama-cloud":
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
+        # During setup, force a live refresh so the picker reflects newly
+        # released models (e.g. deepseek v4 flash, kimi k2.6) the moment
+        # the user enters their key — not an hour later when the disk
+        # cache TTL expires.
+        model_list = fetch_ollama_cloud_models(
+            api_key=api_key_for_probe,
+            base_url=effective_base,
+            force_refresh=True,
+        )
+        if model_list:
+            print(f"  Found {len(model_list)} model(s) from Ollama Cloud")
+    elif provider_id == "novita":
+        from hermes_cli.models import fetch_api_models
+
+        api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
+        curated = _PROVIDER_MODELS.get(provider_id, [])
+        live_models = fetch_api_models(api_key_for_probe, effective_base)
+        if live_models:
+            model_list = live_models
+            print(f"  Found {len(model_list)} model(s) from {pconfig.name} API")
+        else:
+            mdev_models: list = []
+            try:
+                from agent.models_dev import list_agentic_models
+
+                mdev_models = list_agentic_models(provider_id)
+            except Exception:
+                pass
+            if mdev_models:
+                seen = {m.lower() for m in mdev_models}
+                model_list = list(mdev_models)
+                for m in curated:
+                    if m.lower() not in seen:
+                        model_list.append(m)
+                        seen.add(m.lower())
+                print(f"  Found {len(model_list)} model(s) from models.dev registry")
+            else:
+                model_list = curated
+                if model_list:
+                    print(
+                        f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'
+                    )
+    else:
+        curated = _PROVIDER_MODELS.get(provider_id, [])
+
+        # Try models.dev first — returns tool-capable models, filtered for noise
+        mdev_models: list = []
+        try:
+            from agent.models_dev import list_agentic_models
+
+            mdev_models = list_agentic_models(provider_id)
+        except Exception:
+            pass
+
+        if mdev_models:
+            # Merge models.dev with curated list so newly added models
+            # (not yet in models.dev) still appear in the picker.
+            if curated:
+                seen = {m.lower() for m in mdev_models}
+                merged = list(mdev_models)
+                for m in curated:
+                    if m.lower() not in seen:
+                        merged.append(m)
+                        seen.add(m.lower())
+                model_list = merged
+            else:
+                model_list = mdev_models
+            print(f"  Found {len(model_list)} model(s) from models.dev registry")
+        elif curated and len(curated) >= 8:
+            # Curated list is substantial — use it directly, skip live probe
+            model_list = curated
+            print(
+                f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'
+            )
+        else:
+            api_key_for_probe = existing_key or (
+                get_env_value(key_env) if key_env else ""
+            )
+            live_models = fetch_api_models(api_key_for_probe, effective_base)
+            if live_models and len(live_models) >= len(curated):
+                model_list = live_models
+                print(f"  Found {len(model_list)} model(s) from {pconfig.name} API")
+            else:
+                model_list = curated
+                if model_list:
+                    print(
+                        f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'
+                    )
+            # else: no defaults either, will fall through to raw input
+
+    if provider_id in {"opencode-zen", "opencode-go"}:
+        model_list = [
+            normalize_opencode_model_id(provider_id, mid) for mid in model_list
+        ]
+        current_model = normalize_opencode_model_id(provider_id, current_model)
+        model_list = list(dict.fromkeys(mid for mid in model_list if mid))
+
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        if provider_id in {"opencode-zen", "opencode-go"}:
+            selected = normalize_opencode_model_id(provider_id, selected)
+
+        _save_model_choice(selected)
+
+        # Update config with provider, base URL, and provider-specific API mode
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = provider_id
+        model["base_url"] = effective_base
+        if provider_id in {"opencode-zen", "opencode-go"}:
+            model["api_mode"] = opencode_model_api_mode(provider_id, selected)
+        else:
+            model.pop("api_mode", None)
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"Default model set to: {selected} (via {pconfig.name})")
+    else:
+        print("No change.")
 
 
 def _run_anthropic_oauth_flow(save_env_value):

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -393,6 +393,15 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     if provider in _AGGREGATOR_PROVIDERS:
         return _prepend_vendor(name)
 
+    # --- Vertex AI: OpenAI-compatible endpoint requires ``google/`` prefix ---
+    # Users can type bare ``gemini-3.5-flash`` and it auto-resolves to
+    # ``google/gemini-3.5-flash``, mirroring how aggregators prepend their
+    # own vendor slugs. Already-prefixed names pass through unchanged.
+    if provider == "vertex":
+        if name.startswith("google/"):
+            return name
+        return f"google/{name}"
+
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.
     #     Their /v1/models API returns bare IDs only (no vendor prefix), and
     #     the inference endpoint rejects vendor-prefixed names with HTTP 401

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -451,6 +451,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
     ],
+    # Google Vertex AI — models available via the OpenAI-compatible ChatCompletions API.
+    # Includes GA models (2.0, 2.5) and preview models (3.x) for maximum flexibility.
+    "vertex": [
+        "google/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-pro-preview",
+        "google/gemini-3-pro-preview",
+        "google/gemini-3.5-flash",
+        "google/gemini-2.5-pro",
+        "google/gemini-2.5-flash",
+        "google/gemini-2.5-flash-lite",
+        "google/gemini-2.0-flash-001",
+        "google/gemini-2.0-flash-lite-001",
+    ],
     # Alibaba DashScope Coding platform (coding-intl) — default endpoint.
     # Supports Qwen models + third-party providers (GLM, Kimi, MiniMax).
     # Users with classic DashScope keys should override DASHSCOPE_BASE_URL
@@ -1048,6 +1061,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (Curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (Open models subscription)"),
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
+    ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini models, GCP Service Account JSON or gcloud ADC)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
 ]

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -81,6 +81,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://portal.qwen.ai/v1",
         base_url_env_var="HERMES_QWEN_BASE_URL",
     ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        extra_env_vars=("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS"),
+        base_url_env_var="VERTEX_BASE_URL",
+    ),
     "lmstudio": HermesOverlay(
         transport="openai_chat",
         auth_type="api_key",
@@ -310,6 +316,9 @@ ALIASES: Dict[str, str] = {
     "alibaba-coding": "alibaba-coding-plan",
     "alibaba_coding_plan": "alibaba-coding-plan",
 
+    # google-vertex
+    "vertex-ai": "vertex",
+    "google-vertex": "vertex",
     # huggingface
     "hf": "huggingface",
     "hugging-face": "huggingface",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1895,6 +1895,63 @@ def resolve_runtime_provider(
             runtime["guardrail_config"] = guardrail_config
         return runtime
 
+    # Google Vertex AI (GCP SDK) — service account or gcloud ADC auth
+    if provider == "vertex":
+        from agent.vertex_adapter import (
+            _resolve_vertex_token,
+            get_vertex_base_url,
+            resolve_vertex_region,
+            resolve_vertex_auth_source,
+            has_vertex_credentials,
+        )
+        is_explicit = requested_provider in {
+            "vertex", "vertex-ai", "google-vertex", "gcp-vertex", "google-vertex-ai",
+        }
+        if not is_explicit and not has_vertex_credentials():
+            raise AuthError(
+                "No GCP credentials found for Vertex AI. Configure one of:\n"
+                "  - GOOGLE_APPLICATION_CREDENTIALS (service account JSON)\n"
+                "  - VERTEX_CREDENTIALS_PATH (explicit path to SA JSON)\n"
+                "  - gcloud auth application-default login\n"
+                "Or set VERTEX_PROJECT_ID + run 'gcloud auth application-default login'.",
+                code="no_gcp_credentials",
+            )
+        # Read vertex-specific config from config.yaml
+        _vertex_cfg = load_config().get("vertex", {})
+        region = resolve_vertex_region()
+        _cfg_region = (_vertex_cfg.get("region") or "").strip()
+        if _cfg_region:
+            region = _cfg_region
+        base_url = get_vertex_base_url(region=region)
+        if not base_url:
+            raise AuthError(
+                "Could not determine Vertex AI project ID. "
+                "Set VERTEX_PROJECT_ID in ~/.hermes/.env, or ensure your "
+                "service account JSON contains a project_id.",
+                code="no_vertex_project_id",
+            )
+        auth_source = resolve_vertex_auth_source() or "gcp-sdk"
+        # Token is resolved at runtime via _resolve_vertex_token() which has
+        # 55-min token caching. The transport layer calls this on each API
+        # request so the token is always fresh.
+        api_key = _resolve_vertex_token()
+        if not api_key:
+            raise AuthError(
+                "Failed to obtain OAuth2 token for Vertex AI. "
+                "Check that your service account JSON is valid and "
+                "the Vertex AI API is enabled on your GCP project.",
+                code="vertex_token_failed",
+            )
+        return {
+            "provider": "vertex",
+            "api_mode": "chat_completions",
+            "base_url": base_url,
+            "api_key": api_key,
+            "source": auth_source,
+            "region": region,
+            "requested_provider": requested_provider,
+        }
+
     # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -93,6 +93,12 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-3.1-pro-preview", "gemini-3-pro-preview",
         "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
     ],
+    "vertex": [
+        "gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview", "gemini-3.5-flash",
+        "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+        "gemini-2.0-flash-001", "gemini-2.0-flash-lite-001",
+    ],
     "zai": ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],

--- a/run_agent.py
+++ b/run_agent.py
@@ -4909,7 +4909,7 @@ class AIAgent:
         if (getattr(self, "provider", "") or "").lower() in {
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",
-            "zai", "bedrock",
+            "zai", "bedrock", "vertex",
             "xiaomi",
         }:
             return True
@@ -4924,6 +4924,8 @@ class AIAgent:
             # AWS Bedrock runtime endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
             or "bedrock-runtime." in base
+            # Google Vertex AI endpoints — same defense-in-depth.
+            or "aiplatform.googleapis.com" in base
         )
 
     def _is_qwen_portal(self) -> bool:

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -1,0 +1,468 @@
+"""Tests for the Google Vertex AI adapter.
+
+Covers:
+  - Credential path detection from environment variables
+  - Project ID resolution (env vars + SA JSON)
+  - Auth source labeling
+  - Region resolution
+  - Token caching and refresh
+  - Base URL construction
+  - Edge cases: missing files, corrupt JSON, missing keys
+
+Mirrors tests/agent/test_bedrock_adapter.py pattern.
+"""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Credential path detection
+# ---------------------------------------------------------------------------
+
+class TestResolveCredentialsPath:
+    """Test service account JSON path detection."""
+
+    def test_prefers_vertex_credentials_path(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_credentials_path
+
+        sa_path = "/tmp/fake-sa.json"
+        # Create a real file so os.path.exists returns True
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write('{"project_id": "test"}')
+            sa_path = f.name
+
+        monkeypatch.setenv("VERTEX_CREDENTIALS_PATH", sa_path)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/other/path.json")
+
+        result = _resolve_credentials_path()
+        assert result == sa_path
+        os.unlink(sa_path)
+
+    def test_falls_back_to_application_default_credentials(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_credentials_path
+
+        sa_path = "/tmp/fake-gac.json"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write('{"project_id": "test"}')
+            sa_path = f.name
+
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", sa_path)
+
+        result = _resolve_credentials_path()
+        assert result == sa_path
+        os.unlink(sa_path)
+
+    def test_returns_none_when_file_does_not_exist(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_credentials_path
+
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/sa.json")
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert _resolve_credentials_path() is None
+
+    def test_returns_none_when_no_env_vars_set(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_credentials_path
+
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+        assert _resolve_credentials_path() is None
+
+    def test_ignores_whitespace_only_values(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_credentials_path
+
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "   ")
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert _resolve_credentials_path() is None
+
+
+# ---------------------------------------------------------------------------
+# Project ID resolution from SA JSON
+# ---------------------------------------------------------------------------
+
+class TestResolveProjectIdFromSA:
+    """Test reading project_id from a service account JSON file."""
+
+    def test_reads_project_id(self):
+        from agent.vertex_adapter import _resolve_project_id_from_sa
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"project_id": "my-gcp-project-123"}, f)
+            path = f.name
+
+        result = _resolve_project_id_from_sa(path)
+        assert result == "my-gcp-project-123"
+        os.unlink(path)
+
+    def test_returns_none_when_key_missing(self):
+        from agent.vertex_adapter import _resolve_project_id_from_sa
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"client_email": "sa@project.iam.gserviceaccount.com"}, f)
+            path = f.name
+
+        result = _resolve_project_id_from_sa(path)
+        assert result is None
+        os.unlink(path)
+
+    def test_returns_none_on_corrupt_json(self):
+        from agent.vertex_adapter import _resolve_project_id_from_sa
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not valid json {{{")
+            path = f.name
+
+        result = _resolve_project_id_from_sa(path)
+        assert result is None
+        os.unlink(path)
+
+    def test_returns_none_on_missing_file(self):
+        from agent.vertex_adapter import _resolve_project_id_from_sa
+
+        assert _resolve_project_id_from_sa("/nonexistent/sa.json") is None
+
+
+# ---------------------------------------------------------------------------
+# Project ID resolution (priority chain)
+# ---------------------------------------------------------------------------
+
+class TestResolveProjectId:
+    """Test project ID priority: VERTEX_PROJECT_ID > GOOGLE_CLOUD_PROJECT > SA JSON."""
+
+    def test_prefers_vertex_project_id(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_project_id
+
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "vertex-pid")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "cloud-pid")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert _resolve_project_id() == "vertex-pid"
+
+    def test_falls_back_to_google_cloud_project(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_project_id
+
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "cloud-pid")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert _resolve_project_id() == "cloud-pid"
+
+    def test_falls_back_to_sa_json(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_project_id
+
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"project_id": "sa-pid"}, f)
+            sa_path = f.name
+
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", sa_path)
+
+        result = _resolve_project_id()
+        assert result == "sa-pid"
+        os.unlink(sa_path)
+
+    def test_returns_none_when_nothing_configured(self, monkeypatch):
+        from agent.vertex_adapter import _resolve_project_id
+
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert _resolve_project_id() is None
+
+
+# ---------------------------------------------------------------------------
+# Region resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveVertexRegion:
+    """Test Vertex AI region resolution."""
+
+    def test_returns_global_by_default(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_region
+
+        monkeypatch.delenv("VERTEX_REGION", raising=False)
+        assert resolve_vertex_region() == "global"
+
+    def test_respects_vertex_region_env(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_region
+
+        monkeypatch.setenv("VERTEX_REGION", "us-central1")
+        assert resolve_vertex_region() == "us-central1"
+
+    def test_falls_back_to_global_for_whitespace(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_region
+
+        monkeypatch.setenv("VERTEX_REGION", "   ")
+        assert resolve_vertex_region() == "global"
+
+
+# ---------------------------------------------------------------------------
+# Credential detection
+# ---------------------------------------------------------------------------
+
+class TestHasVertexCredentials:
+    """Test credential detection for auto-detection flow."""
+
+    def test_true_when_sa_json_exists(self, monkeypatch):
+        from agent.vertex_adapter import has_vertex_credentials
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write('{"project_id": "test"}')
+            sa_path = f.name
+
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", sa_path)
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+
+        assert has_vertex_credentials() is True
+        os.unlink(sa_path)
+
+    def test_true_when_project_id_set(self, monkeypatch):
+        from agent.vertex_adapter import has_vertex_credentials
+
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "my-project")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert has_vertex_credentials() is True
+
+    def test_false_when_nothing_configured(self, monkeypatch):
+        from agent.vertex_adapter import has_vertex_credentials
+
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert has_vertex_credentials() is False
+
+
+# ---------------------------------------------------------------------------
+# Auth source labeling
+# ---------------------------------------------------------------------------
+
+class TestResolveVertexAuthSource:
+    """Test human-readable auth source labels."""
+
+    def test_labels_vertex_credentials_path(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_auth_source
+
+        monkeypatch.setenv("VERTEX_CREDENTIALS_PATH", "/path/to/sa.json")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+        assert resolve_vertex_auth_source() == "VERTEX_CREDENTIALS_PATH"
+
+    def test_labels_application_default_credentials(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_auth_source
+
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/sa.json")
+
+        assert resolve_vertex_auth_source() == "GOOGLE_APPLICATION_CREDENTIALS"
+
+    def test_labels_vertex_project_id(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_auth_source
+
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "my-project")
+
+        assert resolve_vertex_auth_source() == "VERTEX_PROJECT_ID"
+
+    def test_labels_cloud_project(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_auth_source
+
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+
+        assert resolve_vertex_auth_source() == "GOOGLE_CLOUD_PROJECT"
+
+    def test_returns_none_when_nothing_set(self, monkeypatch):
+        from agent.vertex_adapter import resolve_vertex_auth_source
+
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+
+        assert resolve_vertex_auth_source() is None
+
+
+# ---------------------------------------------------------------------------
+# Token caching
+# ---------------------------------------------------------------------------
+
+class TestResolveVertexToken:
+    """Test OAuth2 token resolution with caching behavior."""
+
+    def test_returns_cached_token_when_fresh(self):
+        import time
+        from agent.vertex_adapter import _token_cache, _resolve_vertex_token
+
+        # Prime the cache with a fake token
+        _token_cache.clear()
+        _token_cache["token"] = "cached-token"
+        _token_cache["expires_at"] = time.time() + 3600
+
+        # Mock the actual credential fetching to ensure it's NOT called
+        with patch("agent.vertex_adapter._resolve_credentials_path",
+                   return_value=None):
+            result = _resolve_vertex_token()
+            assert result == "cached-token"
+
+    def test_refreshes_when_cache_stale(self):
+        import time
+        from agent.vertex_adapter import (
+            _token_cache, _resolve_vertex_token,
+        )
+
+        # Set an expired cache
+        _token_cache.clear()
+        _token_cache["token"] = "old-token"
+        _token_cache["expires_at"] = time.time() - 3600
+
+        # Prime the module-scoped google-auth refs so _import_google_auth()
+        # succeeds without actually importing google.auth.
+        # Route through service_account path by providing a SA JSON path.
+        mock_creds = MagicMock()
+        mock_creds.token = "fresh-token"
+
+        mock_sa = MagicMock()
+        mock_sa.Credentials.from_service_account_file = MagicMock(
+            return_value=mock_creds,
+        )
+        mock_transport = MagicMock()
+
+        with patch(
+            "agent.vertex_adapter._ga_service_account", mock_sa,
+        ), patch(
+            "agent.vertex_adapter._ga_transport", mock_transport,
+        ), patch(
+            "agent.vertex_adapter._ga_auth", MagicMock(),
+        ), patch(
+            "agent.vertex_adapter._resolve_credentials_path",
+            return_value="/fake/sa.json",
+        ):
+            result = _resolve_vertex_token()
+            assert result == "fresh-token"
+
+    def test_returns_none_when_google_auth_not_installed(self, monkeypatch):
+        from agent.vertex_adapter import _token_cache, _resolve_vertex_token
+
+        _token_cache.clear()
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        # Remove google from sys.modules so the import fails
+        with patch.dict("sys.modules", {
+            "google": None, "google.auth": None,
+            "google.oauth2": None,
+        }):
+            result = _resolve_vertex_token()
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Base URL construction
+# ---------------------------------------------------------------------------
+
+class TestGetVertexBaseUrl:
+    """Test Vertex AI OpenAI-compatible base URL construction."""
+
+    def test_builds_url_with_explicit_params(self, monkeypatch):
+        from agent.vertex_adapter import get_vertex_base_url
+
+        monkeypatch.delenv("VERTEX_REGION", raising=False)
+
+        url = get_vertex_base_url(
+            project_id="my-project",
+            region="us-central1",
+        )
+        assert url == (
+            "https://aiplatform.googleapis.com/v1/projects/my-project"
+            "/locations/us-central1/endpoints/openapi"
+        )
+
+    def test_defaults_to_global_region(self, monkeypatch):
+        from agent.vertex_adapter import get_vertex_base_url
+
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "my-project")
+        monkeypatch.delenv("VERTEX_REGION", raising=False)
+
+        url = get_vertex_base_url()
+        assert "locations/global/endpoints/openapi" in url
+
+    def test_returns_none_when_no_project_id(self, monkeypatch):
+        from agent.vertex_adapter import get_vertex_base_url
+
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        assert get_vertex_base_url() is None
+
+    def test_respects_vertex_region_env(self, monkeypatch):
+        from agent.vertex_adapter import get_vertex_base_url
+
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "my-project")
+        monkeypatch.setenv("VERTEX_REGION", "europe-west4")
+
+        url = get_vertex_base_url()
+        assert "locations/europe-west4/endpoints/openapi" in url
+
+
+# ---------------------------------------------------------------------------
+# Integration: full resolution chain
+# ---------------------------------------------------------------------------
+
+class TestVertexAdapterIntegration:
+    """End-to-end resolution without live API calls."""
+
+    def test_full_chain_with_sa_json(self, monkeypatch):
+        """When GOOGLE_APPLICATION_CREDENTIALS points to a valid SA JSON,
+        the full resolution chain should produce a project_id, region,
+        auth source label, and credential detection without errors."""
+        from agent.vertex_adapter import (
+            has_vertex_credentials,
+            resolve_vertex_auth_source,
+            _resolve_project_id,
+            resolve_vertex_region,
+            get_vertex_base_url,
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({
+                "project_id": "test-project-123",
+                "client_email": "sa@test-project-123.iam.gserviceaccount.com",
+            }, f)
+            sa_path = f.name
+
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", sa_path)
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("VERTEX_REGION", raising=False)
+
+        assert has_vertex_credentials() is True
+        assert resolve_vertex_auth_source() == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert _resolve_project_id() == "test-project-123"
+        assert resolve_vertex_region() == "global"
+
+        url = get_vertex_base_url()
+        assert "test-project-123" in url
+        assert "global" in url
+
+        os.unlink(sa_path)

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -1,0 +1,101 @@
+"""Tests for Vertex AI provider registration and resolution in auth.py.
+
+Mirrors tests/hermes_cli/test_gmi_provider.py pattern.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider, get_auth_status
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    """Clear provider env vars to prevent leakage."""
+    for key in (
+        "OPENROUTER_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY",
+        "VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_APPLICATION_CREDENTIALS", "VERTEX_CREDENTIALS_PATH",
+        "VERTEX_BASE_URL", "VERTEX_REGION",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestVertexProviderRegistration:
+    """Test that vertex is registered in PROVIDER_REGISTRY."""
+
+    def test_vertex_in_registry(self):
+        assert "vertex" in PROVIDER_REGISTRY
+
+    def test_vertex_config_auth_type(self):
+        config = PROVIDER_REGISTRY["vertex"]
+        assert config.auth_type == "gcp_sdk"
+
+    def test_vertex_config_name(self):
+        config = PROVIDER_REGISTRY["vertex"]
+        assert config.name == "Google Vertex AI"
+
+    def test_vertex_config_no_api_key_env_vars(self):
+        config = PROVIDER_REGISTRY["vertex"]
+        assert config.api_key_env_vars == ()
+
+    def test_vertex_config_base_url_env_var(self):
+        config = PROVIDER_REGISTRY["vertex"]
+        assert config.base_url_env_var == "VERTEX_BASE_URL"
+
+
+class TestVertexAliases:
+    """Test provider alias resolution."""
+
+    @pytest.mark.parametrize("alias", [
+        "vertex-ai", "google-vertex", "gcp-vertex", "google-vertex-ai",
+    ])
+    def test_alias_resolves_to_vertex(self, alias, monkeypatch):
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "test-project")
+        assert resolve_provider(alias) == "vertex"
+
+    def test_canonical_name_resolves(self, monkeypatch):
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "test-project")
+        assert resolve_provider("vertex") == "vertex"
+
+
+class TestVertexAuthStatus:
+    """Test get_auth_status for vertex provider."""
+
+    def test_vertex_has_credentials(self, monkeypatch):
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "test-project")
+        status = get_auth_status("vertex")
+        assert status["logged_in"] is True
+        assert status["provider"] == "vertex"
+
+    def test_vertex_no_credentials(self, monkeypatch):
+        monkeypatch.delenv("VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+
+        status = get_auth_status("vertex")
+        assert status["logged_in"] is False
+        assert status["provider"] == "vertex"
+
+    def test_vertex_auth_status_import_error_fallback(self, monkeypatch):
+        """When vertex_adapter can't be imported, auth_status returns
+        logged_in=False with an error message."""
+        monkeypatch.setenv("VERTEX_PROJECT_ID", "test-project")
+
+        with patch.dict("sys.modules", {
+            "agent.vertex_adapter": None,
+        }):
+            status = get_auth_status("vertex")
+            assert status["logged_in"] is False
+            assert "error" in status


### PR DESCRIPTION
## What does this PR do?

Adds Google Vertex AI as a first-class inference provider for Gemini models. Users with GCP free credits ($300) or enterprise billing can now use Hermes with Vertex AI instead of being stuck with the Google AI Studio free tier.

Mirrors the existing Bedrock provider pattern — `aws_sdk` → `gcp_sdk` auth type. Uses the standard OpenAI-compatible chat/completions endpoint (no custom SDK or message translation needed).

## Related Issue

Fixes #13484

Related: #8427 (stale PR for same feature, this is a clean rewrite against current main), #4375 (Vertex Express via custom provider workaround)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

### Production code
- **NEW** `agent/vertex_adapter.py` (189 lines) — credential detection via SA JSON or gcloud ADC, module-scoped lazy google-auth import for testability, OAuth2 token refresh with 55-min caching, base URL construction from project_id+region
- `hermes_cli/auth.py` (+25 lines) — ProviderConfig registration with `auth_type="gcp_sdk"`, aliases (`vertex-ai`, `google-vertex`, `gcp-vertex`), provider auto-detection, auth_status handler
- `hermes_cli/runtime_provider.py` (+57 lines) — vertex runtime resolution block with proper AuthError messages and config.yaml `vertex.region` support
- `agent/auxiliary_client.py` (+46 lines) — vertex handler in `resolve_provider_client` using standard `OpenAI()` client
- `run_agent.py` (+4/-1 lines) — vertex added to safe_providers + `aiplatform.googleapis.com` URL defense-in-depth
- `agent/model_metadata.py` (+1 line) — `aiplatform.googleapis.com` hostname mapping

### Tests (45 new tests, all passing)
- **NEW** `tests/agent/test_vertex_adapter.py` (32 tests) — credential path detection, project ID resolution from SA JSON and env vars, region resolution, auth source labeling, token caching/refresh behavior, base URL construction, full chain integration test
- **NEW** `tests/hermes_cli/test_vertex_provider.py` (13 tests) — provider registration, alias resolution (parametrized: vertex-ai, google-vertex, gcp-vertex, google-vertex-ai), auth_status reporting (credentials present, absent, import error fallback)

## How to Test

1. Set up a GCP service account with Vertex AI User + Service Usage Consumer roles
2. Set `GOOGLE_APPLICATION_CREDENTIALS` and `VERTEX_PROJECT_ID` in `~/.hermes/.env`
3. Run `hermes model` → select Vertex AI → pick a Gemini model
4. Send a test message — verify it routes through Vertex
5. Run `uv run python -m pytest tests/agent/test_vertex_adapter.py tests/hermes_cli/test_vertex_provider.py -v` (45/45 pass)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite: 27,281 tests across full `scripts/run_tests.sh` run — 99 pre-existing failures (kanban workers, ACP adapters, GMI provider `OpenAI` UnboundLocalError) confirmed present on main before our changes. Zero new failures.
- [x] I've added tests for my changes: 45 new tests covering vertex_adapter + provider registration
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon) — live end-to-end with SA JSON auth confirmed working

### Documentation & Housekeeping

- [x] I've updated relevant documentation — provider appears in picker automatically via PROVIDER_REGISTRY, model_metadata maps aiplatform hostname
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new required config keys; `vertex.region` in config.yaml is optional)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `google-auth` is pure Python, cross-platform. Lazy imports keep startup fast for non-Vertex users.

## Notes

- Requires `pip install google-auth` (not added to [all] extras — follows Bedrock pattern of lazy dependency with `_import_google_auth()`)
- OAuth2 tokens expire after 60 min; cached with 55-min refresh window. Module-scoped `_ga_*` globals allow tests to mock without importing google-auth
- Region defaults to `global` (required for Gemini 3.x previews; us-central1 silently breaks them)
- This PR does NOT add native Gemini SDK transport — uses OpenAI-compatible endpoint exclusively