### PR TITLE
fix(config): ignore stale docker install-method stamp when .git exists (#35835)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -302,21 +302,42 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     so ``hermes update`` bailed with "doesn't apply inside the Docker
     container". Without that fallback such installs fall through to the
     ``.git``/pip checks and behave like any off-path install. See issue #34397.
+
+    Stale-stamp guard (issue #35835): when ``$HERMES_HOME`` is a shared
+    bind-mounted volume, the ``.install_method`` stamp from a prior
+    official-image run can persist after the user switches to a custom
+    container that installed Hermes via git or pip.  The published image
+    excludes ``.git`` via ``.dockerignore``, so a ``.git`` directory at
+    ``project_root`` is definitive proof the stamp is stale — we ignore
+    it, auto-correct the stamp to the real method, and let the update
+    path proceed normally.
     """
     stamp = get_hermes_home() / ".install_method"
+    # Resolve project_root once so the stale-stamp guard can use it.
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.resolve()
     try:
         method = stamp.read_text(encoding="utf-8").strip().lower()
         if method:
-            return method
+            # A "docker" stamp is only valid inside the published image,
+            # which excludes .git.  If .git exists, the stamp is stale
+            # — ignore it and fall through to the real detection below.
+            if method == "docker" and (project_root / ".git").is_dir():
+                pass  # stale stamp — fall through
+            else:
+                return method
     except OSError:
         pass
     managed = get_managed_system()
     if managed:
         return managed.lower().replace(" ", "-")
-    if project_root is None:
-        project_root = Path(__file__).parent.parent.resolve()
     if (project_root / ".git").is_dir():
+        # If we got here past a stale "docker" stamp, correct it for
+        # next time so the user doesn't hit this again.
+        stamp_install_method("git")
         return "git"
+    # Likewise, correct a stale "docker" stamp for pip installs.
+    stamp_install_method("pip")
     return "pip"
 
 

--- a/tests/hermes_cli/test_pip_install_detection.py
+++ b/tests/hermes_cli/test_pip_install_detection.py
@@ -40,12 +40,40 @@ def test_recommended_update_command_pip():
 
 
 def test_stamp_file_takes_precedence(tmp_path):
-    (tmp_path / ".git").mkdir()
+    """A valid stamp file takes precedence over .git detection.
+
+    When the stamp says 'docker' and there is no .git directory (matching
+    the published image which excludes .git via .dockerignore), the stamp
+    wins.  When .git *does* exist alongside a 'docker' stamp, the stamp
+    is stale (e.g. shared $HERMES_HOME volume from a prior official-image
+    run) — see test_stale_docker_stamp_with_git_falls_through.
+    """
+    # No .git dir → stamp is valid
     (tmp_path / ".install_method").write_text("docker\n")
     with patch("hermes_cli.config.get_managed_system", return_value=None), \
          patch("hermes_cli.config.get_hermes_home", return_value=tmp_path):
         from hermes_cli.config import detect_install_method
         assert detect_install_method(project_root=tmp_path) == "docker"
+
+
+def test_stale_docker_stamp_with_git_falls_through(tmp_path):
+    """A 'docker' stamp with .git present is stale → detect real method (#35835).
+
+    The published image excludes .git via .dockerignore.  When a user
+    shares $HERMES_HOME across installations and a 'docker' stamp from
+    a prior official-image run persists into a git-based custom
+    container, the stamp must be ignored so ``hermes update`` can
+    proceed with ``git pull`` instead of bailing with the docker-pull
+    message.
+    """
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".install_method").write_text("docker\n")
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=tmp_path):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=tmp_path) == "git"
+        # The stale stamp should be auto-corrected for next time.
+        assert (tmp_path / ".install_method").read_text().strip() == "git"
 
 
 def test_container_without_stamp_is_not_docker(tmp_path):


### PR DESCRIPTION
## Summary
When `detect_install_method()` reads a stale `.install_method` stamp from a shared `$HERMES_HOME` bin directory, it incorrectly reports 'docker' even when a `.git` directory proves this is a pip install. The fix checks for `.git` existence first before trusting the stamp.

## Test Plan
- [x] Regression tests pass
- [x] Fail-without-fix verified
- [x] One focused commit ahead of upstream/main

Fixes #35835