### PR TITLE
fix(agent): prevent base_url kwarg leak in vision fallback path (#35876)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2974,8 +2974,8 @@ def _resolve_single_provider(
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 


### PR DESCRIPTION
## Summary
`_resolve_single_provider()` passes `base_url=` to `resolve_provider_client()` when falling back from vision to non-vision provider, causing the fallback client to inherit the wrong base_url. Fix strips the kwarg when the fallback provider doesn't use it.

## Test Plan
- [x] Regression tests pass
- [x] Fail-without-fix verified
- [x] One focused commit ahead of upstream/main

Fixes #35876