### PR TITLE
fix(bedrock): guard temperature/top_p for Opus 4.7/4.8 on Converse API (#36151)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -900,11 +900,18 @@ def build_converse_kwargs(
     if system_prompt:
         kwargs["system"] = system_prompt
 
-    if temperature is not None:
-        kwargs["inferenceConfig"]["temperature"] = temperature
+    # Opus 4.7/4.8 reject any non-default sampling parameters (temperature,
+    # top_p, top_k) with a 400 ValidationException.  The Anthropic-native
+    # adapter already guards this via _forbids_sampling_params(); apply the
+    # same guard to the Bedrock Converse path so Bedrock+Opus users don't
+    # get a 400 on every call.
+    from agent.anthropic_adapter import _forbids_sampling_params
+    if not _forbids_sampling_params(model):
+        if temperature is not None:
+            kwargs["inferenceConfig"]["temperature"] = temperature
 
-    if top_p is not None:
-        kwargs["inferenceConfig"]["topP"] = top_p
+        if top_p is not None:
+            kwargs["inferenceConfig"]["topP"] = top_p
 
     if stop_sequences:
         kwargs["inferenceConfig"]["stopSequences"] = stop_sequences

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -605,6 +605,52 @@ class TestBuildConverseKwargs:
         assert kwargs["inferenceConfig"]["temperature"] == 0.7
         assert kwargs["inferenceConfig"]["topP"] == 0.9
 
+    def test_opus4_7_strips_temperature_and_top_p(self):
+        """Opus 4.7 rejects non-default sampling params → Bedrock adapter must omit them."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7, top_p=0.9,
+        )
+        assert "temperature" not in kwargs["inferenceConfig"]
+        assert "topP" not in kwargs["inferenceConfig"]
+
+    def test_opus4_8_strips_temperature_and_top_p(self):
+        """Opus 4.8 extends the same rejection pattern → Bedrock adapter must omit."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-8",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7, top_p=0.9,
+        )
+        assert "temperature" not in kwargs["inferenceConfig"]
+        assert "topP" not in kwargs["inferenceConfig"]
+
+    def test_sonnet_keeps_temperature_and_top_p(self):
+        """Non-Opus models (e.g., Sonnet) must still receive sampling params."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7, top_p=0.9,
+        )
+        assert kwargs["inferenceConfig"]["temperature"] == 0.7
+        assert kwargs["inferenceConfig"]["topP"] == 0.9
+
+    def test_opus_strips_temperature_but_keeps_stop_sequences(self):
+        """Stop sequences are not sampling params and must always be forwarded."""
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-8",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7, top_p=0.9,
+            stop_sequences=["END"],
+        )
+        assert "temperature" not in kwargs["inferenceConfig"]
+        assert "topP" not in kwargs["inferenceConfig"]
+        assert kwargs["inferenceConfig"]["stopSequences"] == ["END"]
+
     def test_includes_guardrail_config(self):
         from agent.bedrock_adapter import build_converse_kwargs
         guardrail = {


### PR DESCRIPTION
## Summary
Opus 4.7 and 4.8 reject non-default temperature/top_p with 400 ValidationException on Bedrock Converse API. Applies the same `_forbids_sampling_params()` guard already used by the Anthropic-native adapter.

## Test Plan
- [x] Regression tests pass
- [x] Fail-without-fix verified
- [x] One focused commit ahead of upstream/main

Fixes #36151