### PR TITLE
fix(bedrock): preserve reasoning signature on Converse interleaved-thinking replay

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -550,6 +550,13 @@ def convert_messages_to_converse(
 
         if role == "assistant":
             content_blocks = []
+            # Replay signed reasoning first: Bedrock signs each thinking block
+            # and rejects it if the text/signature are modified or dropped on a
+            # multi-turn replay. reasoning_details carries the verbatim
+            # reasoningText payload captured in normalize_converse_response.
+            for detail in (msg.get("reasoning_details") or []):
+                if isinstance(detail, dict) and isinstance(detail.get("reasoningText"), dict):
+                    content_blocks.append({"reasoningContent": detail})
             # Convert text content
             if isinstance(content, str) and content.strip():
                 content_blocks.append({"text": content})
@@ -626,6 +633,19 @@ def _converse_stop_reason_to_openai(stop_reason: str) -> str:
     return mapping.get(stop_reason, "stop")
 
 
+def _build_reasoning_detail(text: str, signature: Optional[str]) -> Dict:
+    """Replay-ready Converse ``reasoningContent`` payload (text + signature).
+
+    Carried through ``reasoning_details`` so the signed thinking block can be
+    re-emitted unmodified on the next turn — Bedrock rejects reasoning replayed
+    without its original signature.
+    """
+    inner: Dict[str, Any] = {"text": text}
+    if signature:
+        inner["signature"] = signature
+    return {"reasoningText": inner}
+
+
 def normalize_converse_response(response: Dict) -> SimpleNamespace:
     """Convert a Bedrock Converse API response to an OpenAI-compatible object.
 
@@ -645,6 +665,7 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
 
     text_parts = []
     reasoning_parts = []
+    reasoning_details = []
     tool_calls = []
 
     for block in content_blocks:
@@ -652,10 +673,14 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
             text_parts.append(block["text"])
         elif "reasoningContent" in block:
             reasoning = block["reasoningContent"]
-            if isinstance(reasoning, dict):
-                thinking_text = reasoning.get("text", "")
+            rt = reasoning.get("reasoningText") if isinstance(reasoning, dict) else None
+            if isinstance(rt, dict):
+                thinking_text = rt.get("text", "")
+                signature = rt.get("signature")
                 if thinking_text:
                     reasoning_parts.append(str(thinking_text))
+                if thinking_text or signature:
+                    reasoning_details.append(_build_reasoning_detail(thinking_text, signature))
         elif "toolUse" in block:
             tu = block["toolUse"]
             tool_calls.append(SimpleNamespace(
@@ -673,6 +698,7 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
         reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
+        reasoning_details=reasoning_details or None,
     )
 
     # Build usage stats
@@ -754,6 +780,7 @@ def stream_converse_with_callbacks(
     """
     text_parts: List[str] = []
     reasoning_parts: List[str] = []
+    reasoning_signature: Optional[str] = None
     tool_calls: List[SimpleNamespace] = []
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
@@ -799,6 +826,9 @@ def stream_converse_with_callbacks(
                 reasoning = delta["reasoningContent"]
                 if isinstance(reasoning, dict):
                     thinking_text = reasoning.get("text", "")
+                    signature = reasoning.get("signature")
+                    if signature:
+                        reasoning_signature = signature
                     if thinking_text:
                         reasoning_parts.append(str(thinking_text))
                         if on_reasoning_delta:
@@ -837,11 +867,16 @@ def stream_converse_with_callbacks(
     if current_text_buffer:
         text_parts.append("".join(current_text_buffer))
 
+    reasoning_text = "\n\n".join(reasoning_parts) if reasoning_parts else None
     msg = SimpleNamespace(
         role="assistant",
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
-        reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
+        reasoning_content=reasoning_text,
+        reasoning_details=(
+            [_build_reasoning_detail(reasoning_text or "", reasoning_signature)]
+            if (reasoning_text or reasoning_signature) else None
+        ),
     )
 
     usage = SimpleNamespace(

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -107,12 +107,18 @@ class BedrockTransport(ProviderTransport):
 
         reasoning = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
 
+        provider_data = {}
+        reasoning_details = getattr(msg, "reasoning_details", None)
+        if reasoning_details:
+            provider_data["reasoning_details"] = reasoning_details
+
         return NormalizedResponse(
             content=msg.content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,
             usage=usage,
+            provider_data=provider_data or None,
         )
 
     def validate_response(self, response: Any) -> bool:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1007,6 +1007,65 @@ class TestStreamConverseWithCallbacks:
 
 
 # ---------------------------------------------------------------------------
+# Interleaved thinking signature round-trip (Bedrock analog of #35975)
+# ---------------------------------------------------------------------------
+
+class TestReasoningSignatureRoundTrip:
+    """Signed reasoning must survive normalize -> reasoning_details -> replay.
+
+    Bedrock signs each thinking block and rejects it on a multi-turn replay if
+    the text/signature are dropped or reordered relative to the tool_use it was
+    signed against.
+    """
+
+    def test_normalize_reads_nested_reasoning_text_and_signature(self):
+        from agent.bedrock_adapter import normalize_converse_response
+        # Real Converse schema: reasoningContent.reasoningText.{text,signature}.
+        raw = {
+            "output": {"message": {"role": "assistant", "content": [
+                {"reasoningContent": {"reasoningText": {
+                    "text": "Check the config first.", "signature": "sig-xyz"}}},
+                {"toolUse": {"toolUseId": "tu_1", "name": "read_file",
+                             "input": {"path": "config.py"}}},
+            ]}},
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+        }
+        msg = normalize_converse_response(raw).choices[0].message
+        assert msg.reasoning_content == "Check the config first."
+        assert msg.reasoning_details == [
+            {"reasoningText": {"text": "Check the config first.", "signature": "sig-xyz"}}
+        ]
+
+    def test_replay_reemits_signed_reasoning_before_tool_use(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_details": [
+                    {"reasoningText": {"text": "Check the config first.", "signature": "sig-xyz"}}
+                ],
+                "tool_calls": [{
+                    "id": "tu_1", "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "config.py"}'},
+                }],
+            },
+        ]
+        _system, converse = convert_messages_to_converse(messages)
+        assistant = next(m for m in converse if m["role"] == "assistant")
+        blocks = assistant["content"]
+        # Signed reasoning is replayed verbatim, in order, ahead of the tool_use.
+        assert blocks[0] == {"reasoningContent": {"reasoningText": {
+            "text": "Check the config first.", "signature": "sig-xyz"}}}
+        assert any("toolUse" in b for b in blocks)
+        reasoning_idx = next(i for i, b in enumerate(blocks) if "reasoningContent" in b)
+        tool_idx = next(i for i, b in enumerate(blocks) if "toolUse" in b)
+        assert reasoning_idx < tool_idx
+
+
+# ---------------------------------------------------------------------------
 # Guardrail config in build_converse_kwargs
 # ---------------------------------------------------------------------------
 

--- a/tests/agent/transports/test_bedrock_transport.py
+++ b/tests/agent/transports/test_bedrock_transport.py
@@ -147,7 +147,8 @@ class TestBedrockNormalize:
                 "message": {
                     "role": "assistant",
                     "content": [
-                        {"reasoningContent": {"text": "Let me think..."}},
+                        {"reasoningContent": {"reasoningText": {
+                            "text": "Let me think...", "signature": "sig-abc"}}},
                         {"text": "Answer."},
                     ],
                 }
@@ -158,6 +159,9 @@ class TestBedrockNormalize:
         nr = transport.normalize_response(raw)
         assert nr.reasoning == "Let me think..."
         assert nr.content == "Answer."
+        # Signature is preserved for verbatim multi-turn replay.
+        details = (nr.provider_data or {}).get("reasoning_details")
+        assert details == [{"reasoningText": {"text": "Let me think...", "signature": "sig-abc"}}]
 
     def test_already_normalized_response(self, transport):
         """Test normalize_response handles already-normalized SimpleNamespace (from dispatch site)."""


### PR DESCRIPTION
## What does this PR do?

Fixes the AWS Bedrock (Converse API) analog of #35975 / #35586: signed Claude extended-thinking blocks were not round-tripped, so multi-turn agentic turns with interleaved thinking + tool_use silently lost their reasoning (and replaying reasoning without its original signature is rejected by Bedrock).

**Root cause (three defects).**

1. **Wrong schema key.** `normalize_converse_response` read `reasoningContent.text`, but the Converse schema nests it at `reasoningContent.reasoningText.{text, signature}` (botocore `ReasoningContentBlock` / `ReasoningTextBlock`). On a real Bedrock response `reasoning.get("text")` is always `""`, so nothing was captured. The fix in 8d363f8d5 (#20366/#21202) only passed because its fixture used a flattened shape that does not match AWS.
2. **Signature dropped.** `reasoningText.signature` was never read. AWS requires it on replay: *"include the text and its signature unmodified."*
3. **Replay never reconstructs `reasoningContent`.** `convert_messages_to_converse` rebuilt assistant turns as `[text][toolUse]` only.

**Fix.** Read `reasoningText.{text, signature}`, carry it verbatim through the existing `reasoning_details` channel (same mechanism `AnthropicTransport` uses — no new state column), and re-emit the `reasoningContent` block ahead of `tool_use` on replay. Streaming deltas (flat shape) now also retain the signature.

## How was it tested?

- New `TestReasoningSignatureRoundTrip` (normalize → `reasoning_details` → replay, asserting order + signature). **Fails on `main`** (`reasoning is None`), passes here.
- Corrected the `test_raw_reasoning_content_response` fixture to the real nested schema; added a `provider_data["reasoning_details"]` assertion.
- `tests/agent/test_bedrock_adapter.py` + `tests/agent/transports/`: 435 passed, 0 regressions.

Closes #36260. Native-endpoint counterpart: #35586. Builds on the reasoningContent work in 8d363f8d5.