### PR TITLE
fix(desktop): don't render bare file paths as tool images (404)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback-model.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildToolView, type ToolPart } from './tool-fallback-model'
+
+const part = (overrides: Partial<ToolPart>): ToolPart => ({
+  args: {},
+  isError: false,
+  result: {},
+  toolCallId: 'call_1',
+  toolName: 'vision_analyze',
+  type: 'tool-call',
+  ...overrides
+})
+
+describe('buildToolView image handling', () => {
+  // vision_analyze reports the input image as a local path; an <img> pointed at
+  // a bare path resolves against the renderer origin and 404s, so we render the
+  // tool codicon instead of a broken image.
+  it('drops bare filesystem paths', () => {
+    expect(buildToolView(part({ args: { path: '/Users/me/shot.png' } }), '').imageUrl).toBe('')
+    expect(buildToolView(part({ result: { image_path: '/tmp/out.jpg' } }), '').imageUrl).toBe('')
+  })
+
+  it('keeps fetchable data URLs', () => {
+    const dataUrl = 'data:image/png;base64,AAAA'
+
+    expect(buildToolView(part({ result: { image_url: dataUrl } }), '').imageUrl).toBe(dataUrl)
+  })
+
+  it('keeps remote http(s) image URLs', () => {
+    const url = 'https://example.com/pic.webp'
+
+    expect(buildToolView(part({ result: { url } }), '').imageUrl).toBe(url)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool-fallback-model.ts
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback-model.ts
@@ -786,9 +786,14 @@ function toolImageUrl(args: Record<string, unknown>, result: Record<string, unkn
     return ''
   }
 
-  return candidate.toLowerCase().startsWith('data:image/') || /\.(png|jpe?g|gif|webp|bmp|svg)(\?|#|$)/i.test(candidate)
-    ? candidate
-    : ''
+  // Only inline-render images the renderer can actually fetch: data URLs or
+  // remote http(s). A bare filesystem path (e.g. vision_analyze's input image)
+  // resolves against the dev-server origin and 404s — fall back to the tool's
+  // codicon instead of a broken <img>.
+  const isDataImage = candidate.toLowerCase().startsWith('data:image/')
+  const isRemoteImage = /^https?:\/\//i.test(candidate) && /\.(png|jpe?g|gif|webp|bmp|svg)(\?|#|$)/i.test(candidate)
+
+  return isDataImage || isRemoteImage ? candidate : ''
 }
 
 function stripAnsi(value: string): string {


### PR DESCRIPTION
## Summary
- `vision_analyze` (and any tool reporting an image by local path) rendered a broken/404 image in its expanded tool block. `toolImageUrl` returned the bare filesystem path (e.g. `/Users/…/shot.png`) straight to `<img src>`, which the renderer resolves against the dev-server origin → 404.
- Restrict inline tool images to sources the renderer can actually fetch: `data:` URLs and remote `http(s)` image URLs. Bare paths now yield no `imageUrl`, so the row falls back to the tool's codicon (already shown in the header).
- Added focused regression tests via `buildToolView`.

## Test plan
- [x] `vitest run tool-fallback-model.test.ts` — 3 passed
- [x] eslint clean + `tsc -b`
- [ ] Trigger `vision_analyze` on a local image → tool block shows the codicon, no broken image