### PR TITLE
fix(gateway): replace os.execvp("sleep", ...) with signal.pause()

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5877,15 +5877,18 @@ def _maybe_redirect_run_to_s6_supervision(args) -> bool:
         file=sys.stderr,
         flush=True,
     )
-    # Block until the container is signalled. The supervised gateway's
-    # lifetime is independent of this process — s6-supervise restarts
-    # it on crash, and we don't want the container to exit when the
-    # gateway flaps. `sleep infinity` matches the static main-hermes
-    # service's pattern (see docker/s6-rc.d/main-hermes/run): the CMD
-    # process is a no-op heartbeat that keeps /init alive until
-    # `docker stop` sends SIGTERM, at which point /init runs stage 3
-    # shutdown (which tears down the supervised gateway cleanly).
-    os.execvp("sleep", ["sleep", "infinity"])
+    # Block until SIGTERM/SIGINT. The supervised gateway's lifetime is
+    # independent of this process — s6-supervise restarts it on crash,
+    # and we keep the CMD process alive as a no-op heartbeat so /init
+    # doesn't start stage-3 shutdown.  `signal.pause()` replaces the
+    # earlier os.execvp("sleep", …) which broke when the Python
+    # process's PATH didn't contain a directory with `sleep` on it
+    # (issue #36208).  Register a SIGTERM handler so the container
+    # exits cleanly on `docker stop` with the conventional signal
+    # exit code (128 + signum).
+    signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(128 + signum))
+    while True:
+        signal.pause()
 
 
 def _gateway_command_inner(args):


### PR DESCRIPTION
Fixes #36208

Replaces `os.execvp("sleep", ["sleep", "infinity"])` in
`_maybe_redirect_run_to_s6_supervision()` with a Python-native
`signal.pause()` loop, which blocks until a signal is received
without depending on an external binary or PATH resolution.

The `sleep infinity` pattern worked under the old tini entrypoint
but broke in the new s6-overlay container image when the Python
process PATH did not contain a directory with `sleep` on it,
causing `FileNotFoundError: [Errno 2] No such file or directory`
on container boot.

`signal.pause()` is:
- Zero-dependency (stdlib only)
- Signal-safe (unblocks instantly on SIGTERM/SIGINT)
- Portable across all Unix platforms
- CPU-free while blocked

A SIGTERM handler is also registered so `docker stop` exits
with the conventional signal exit code (128 + SIGTERM = 143),
matching the behaviour of `exec sleep infinity`.