### PR TITLE
feat: add mission control dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17,6 +17,7 @@ import importlib.util
 import json
 import logging
 import os
+import platform
 import secrets
 import stat
 import subprocess
@@ -747,6 +748,117 @@ async def get_status():
         "active_sessions": active_sessions,
         "auth_required": auth_required,
         "auth_providers": auth_providers,
+    }
+
+
+def _run_short_command(args: List[str], cwd: Path | None = None) -> str | None:
+    """Run a quick local diagnostic command for dashboard health metadata."""
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _safe_path_stat(path: Path) -> Dict[str, Any]:
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "exists": True,
+            "is_dir": path.is_dir(),
+            "size": stat.st_size,
+            "mtime": stat.st_mtime,
+        }
+    except OSError:
+        return {
+            "path": str(path),
+            "exists": False,
+            "is_dir": False,
+            "size": None,
+            "mtime": None,
+        }
+
+
+@app.get("/api/system/health")
+async def get_system_health():
+    """Read-only local system/Hermes health summary for Mission Control.
+
+    Keep this endpoint diagnostic-only: no secrets, no destructive actions, no
+    broad process inventory. It reports only local runtime metadata needed by
+    the dashboard.
+    """
+    hermes_home = get_hermes_home()
+    state_db = hermes_home / "state.db"
+    sessions_dir = hermes_home / "sessions"
+    logs_dir = hermes_home / "logs"
+    skills_dir = hermes_home / "skills"
+    cron_dir = hermes_home / "cron"
+
+    git_branch = _run_short_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], PROJECT_ROOT)
+    git_commit = _run_short_command(["git", "rev-parse", "--short", "HEAD"], PROJECT_ROOT)
+    git_dirty = _run_short_command(["git", "status", "--porcelain"], PROJECT_ROOT)
+
+    status = await get_status()
+
+    error_tail: List[str] = []
+    try:
+        from hermes_cli.logs import _read_tail, LOG_FILES
+        error_log = logs_dir / LOG_FILES.get("errors", "errors.log")
+        if error_log.exists():
+            error_tail = _read_tail(error_log, 12)
+    except Exception:
+        error_tail = []
+
+    return {
+        "hermes": {
+            "version": __version__,
+            "release_date": __release_date__,
+            "home": str(hermes_home),
+            "config_path": str(get_config_path()),
+            "env_path": str(get_env_path()),
+            "project_root": str(PROJECT_ROOT),
+            "web_dist": str(WEB_DIST),
+        },
+        "runtime": {
+            "python": sys.version.split()[0],
+            "python_executable": sys.executable,
+            "platform": platform.platform(),
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "process_pid": os.getpid(),
+        },
+        "git": {
+            "branch": git_branch,
+            "commit": git_commit,
+            "dirty": bool(git_dirty),
+            "dirty_count": len(git_dirty.splitlines()) if git_dirty else 0,
+        },
+        "gateway": {
+            "running": status.get("gateway_running"),
+            "pid": status.get("gateway_pid"),
+            "state": status.get("gateway_state"),
+            "updated_at": status.get("gateway_updated_at"),
+            "exit_reason": status.get("gateway_exit_reason"),
+            "platform_count": len(status.get("gateway_platforms") or {}),
+        },
+        "paths": {
+            "state_db": _safe_path_stat(state_db),
+            "sessions_dir": _safe_path_stat(sessions_dir),
+            "logs_dir": _safe_path_stat(logs_dir),
+            "skills_dir": _safe_path_stat(skills_dir),
+            "cron_dir": _safe_path_stat(cron_dir),
+        },
+        "last_errors": error_tail,
     }
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import {
   Database,
   Download,
   Eye,
+  FileHeart,
   FileText,
   Globe,
   Heart,
@@ -44,6 +45,7 @@ import {
   Terminal,
   Users,
   Wrench,
+  Workflow,
   X,
   Zap,
 } from "lucide-react";
@@ -64,6 +66,9 @@ import type { SystemAction } from "@/contexts/system-actions-context";
 import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
+import OverviewPage from "@/pages/OverviewPage";
+import TasksPage from "@/pages/TasksPage";
+import SystemHealthPage from "@/pages/SystemHealthPage";
 import SessionsPage from "@/pages/SessionsPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
@@ -85,7 +90,7 @@ import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
 function RootRedirect() {
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to="/overview" replace />;
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -93,7 +98,7 @@ function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
     // Render nothing during the plugin-load window — a spinner here would just flash.
     return null;
   }
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to="/overview" replace />;
 }
 
 const CHAT_NAV_ITEM: NavItem = {
@@ -114,6 +119,8 @@ const CHAT_NAV_ITEM: NavItem = {
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
+  "/overview": OverviewPage,
+  "/tasks": TasksPage,
   "/sessions": SessionsPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
@@ -125,6 +132,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/config": ConfigPage,
   "/env": EnvPage,
   "/docs": DocsPage,
+  "/system": SystemHealthPage,
 };
 
 // Route placeholder for /chat.  The persistent ChatPage host (rendered
@@ -136,6 +144,18 @@ function ChatRouteSink() {
 }
 
 const BUILTIN_NAV_REST: NavItem[] = [
+  {
+    path: "/overview",
+    labelKey: "overview",
+    label: "Mission Control",
+    icon: Activity,
+  },
+  {
+    path: "/tasks",
+    labelKey: "tasks",
+    label: "Tasks",
+    icon: Workflow,
+  },
   {
     path: "/sessions",
     labelKey: "sessions",
@@ -167,6 +187,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     label: "Documentation",
     icon: BookOpen,
   },
+  { path: "/system", labelKey: "system", label: "System", icon: FileHeart },
 ];
 
 const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
@@ -187,11 +208,13 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Shield,
   Users,
   Wrench,
+  Workflow,
   Zap,
   Heart,
   Star,
   Code,
   Eye,
+  FileHeart,
 };
 
 function resolveIcon(name: string): ComponentType<{ className?: string }> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -194,6 +194,11 @@ export async function buildWsAuthParam(): Promise<[string, string]> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getSystemHealth: () => fetchJSON<SystemHealthResponse>("/api/system/health"),
+  getKanbanStats: () => fetchJSON<KanbanStatsResponse>("/api/plugins/kanban/stats"),
+  getKanbanBoard: () => fetchJSON<KanbanBoardResponse>("/api/plugins/kanban/board"),
+  getKanbanDiagnostics: () => fetchJSON<KanbanDiagnosticsResponse>("/api/plugins/kanban/diagnostics"),
+  getKanbanActiveWorkers: () => fetchJSON<KanbanActiveWorkersResponse>("/api/plugins/kanban/workers/active"),
   /**
    * Identity probe for the dashboard auth gate (Phase 7).
    *
@@ -577,6 +582,129 @@ export interface StatusResponse {
   latest_config_version: number;
   release_date: string;
   version: string;
+}
+
+export interface SystemPathStat {
+  path: string;
+  exists: boolean;
+  is_dir: boolean;
+  size: number | null;
+  mtime: number | null;
+}
+
+export interface SystemHealthResponse {
+  hermes: {
+    version: string;
+    release_date: string;
+    home: string;
+    config_path: string;
+    env_path: string;
+    project_root: string;
+    web_dist: string;
+  };
+  runtime: {
+    python: string;
+    python_executable: string;
+    platform: string;
+    system: string;
+    machine: string;
+    process_pid: number;
+  };
+  git: {
+    branch: string | null;
+    commit: string | null;
+    dirty: boolean;
+    dirty_count: number;
+  };
+  gateway: {
+    running: boolean;
+    pid: number | null;
+    state: string | null;
+    updated_at: string | null;
+    exit_reason: string | null;
+    platform_count: number;
+  };
+  paths: Record<string, SystemPathStat>;
+  last_errors: string[];
+}
+
+export interface KanbanStatsResponse {
+  by_status: Record<string, number>;
+  by_assignee: Record<string, Record<string, number>>;
+  oldest_ready_age_seconds: number | null;
+  now: number;
+}
+
+export interface KanbanTask {
+  id: string;
+  title: string;
+  body?: string | null;
+  status: string;
+  assignee?: string | null;
+  tenant?: string | null;
+  priority?: number | null;
+  created_at?: number | string | null;
+  updated_at?: number | string | null;
+  started_at?: number | string | null;
+  completed_at?: number | string | null;
+  latest_summary?: string | null;
+  comment_count?: number;
+  link_counts?: { parents: number; children: number };
+  progress?: { done: number; total: number } | null;
+  diagnostics?: unknown[];
+  warnings?: unknown;
+  age?: {
+    created_age_seconds?: number | null;
+    started_age_seconds?: number | null;
+    time_to_complete_seconds?: number | null;
+  };
+}
+
+export interface KanbanColumn {
+  name: string;
+  tasks: KanbanTask[];
+}
+
+export interface KanbanBoardResponse {
+  columns: KanbanColumn[];
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;
+  now: number;
+}
+
+export interface KanbanDiagnosticItem {
+  task_id: string;
+  task_title: string | null;
+  task_status: string | null;
+  task_assignee: string | null;
+  diagnostics: Array<Record<string, unknown>>;
+}
+
+export interface KanbanDiagnosticsResponse {
+  diagnostics: KanbanDiagnosticItem[];
+  count: number;
+}
+
+export interface KanbanWorker {
+  run_id: number;
+  task_id: string;
+  task_title: string;
+  task_status: string;
+  task_assignee: string | null;
+  profile: string | null;
+  worker_pid: number | null;
+  started_at: number | string | null;
+  claim_lock: string | null;
+  claim_expires: number | string | null;
+  last_heartbeat_at: number | string | null;
+  max_runtime_seconds: number | null;
+}
+
+export interface KanbanActiveWorkersResponse {
+  workers: KanbanWorker[];
+  count: number;
+  checked_at: number;
 }
 
 export interface SessionInfo {

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Activity,
+  BarChart3,
+  Clock,
+  Cpu,
+  FileText,
+  GitBranch,
+  KeyRound,
+  MessageSquare,
+  Package,
+  Puzzle,
+  Radar,
+  RefreshCw,
+  Search,
+  Settings,
+  Shield,
+  Terminal,
+  Users,
+  Zap,
+} from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { api } from "@/lib/api";
+import type {
+  AnalyticsResponse,
+  CronJob,
+  EnvVarInfo,
+  ModelInfoResponse,
+  PaginatedSessions,
+  ProfileInfo,
+  SkillInfo,
+  StatusResponse,
+  SystemHealthResponse,
+  KanbanStatsResponse,
+} from "@/lib/api";
+import { timeAgo } from "@/lib/utils";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+type LoadState = "loading" | "ready" | "error";
+
+interface OverviewData {
+  status: StatusResponse | null;
+  system: SystemHealthResponse | null;
+  kanban: KanbanStatsResponse | null;
+  sessions: PaginatedSessions | null;
+  analytics: AnalyticsResponse | null;
+  model: ModelInfoResponse | null;
+  cron: CronJob[] | null;
+  skills: SkillInfo[] | null;
+  profiles: ProfileInfo[] | null;
+  env: Record<string, EnvVarInfo> | null;
+  logs: string[];
+}
+
+const emptyData: OverviewData = {
+  status: null,
+  system: null,
+  kanban: null,
+  sessions: null,
+  analytics: null,
+  model: null,
+  cron: null,
+  skills: null,
+  profiles: null,
+  env: null,
+  logs: [],
+};
+
+function fmtNum(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "Unavailable";
+  return new Intl.NumberFormat().format(value);
+}
+
+function fmtCost(value: number | null | undefined): string {
+  if (!value) return "Unavailable";
+  return `$${value.toFixed(4)}`;
+}
+
+function StatusDot({ ok, warn = false }: { ok: boolean; warn?: boolean }) {
+  const color = ok ? "bg-success shadow-success/40" : warn ? "bg-warning shadow-warning/40" : "bg-destructive shadow-destructive/40";
+  return <span className={`inline-block h-2.5 w-2.5 rounded-full shadow-[0_0_14px] ${color}`} />;
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+  icon: typeof Activity;
+  tone?: "neutral" | "good" | "warn";
+}) {
+  const color = tone === "good" ? "text-success" : tone === "warn" ? "text-warning" : "text-primary";
+  return (
+    <Card className="group overflow-hidden border-primary/15 bg-[linear-gradient(145deg,color-mix(in_srgb,var(--midground-base)_8%,transparent),color-mix(in_srgb,var(--background-base)_88%,transparent))] shadow-[0_0_0_1px_rgba(255,230,203,0.03),0_18px_60px_rgba(0,0,0,0.22)] backdrop-blur">
+      <CardContent className="relative p-4">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="font-mono text-[11px] uppercase tracking-[0.22em] text-text-tertiary">{label}</div>
+            <div className="mt-2 text-2xl font-semibold text-text-primary">{value}</div>
+            {hint ? <div className="mt-1 text-xs text-text-secondary">{hint}</div> : null}
+          </div>
+          <div className="rounded border border-primary/20 bg-background/40 p-2">
+            <Icon className={`h-5 w-5 ${color}`} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SectionLink({ to, label, children, className = "" }: { to: string; label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <Card className={`border-primary/15 bg-surface/70 shadow-[inset_0_1px_0_rgba(255,230,203,0.06)] ${className}`}>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 pb-2">
+        <CardTitle className="font-mono text-xs uppercase tracking-[0.18em] text-text-secondary">{label}</CardTitle>
+        <Link className="font-mono text-[11px] uppercase tracking-[0.14em] text-primary hover:underline" to={to}>Open</Link>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function QuickLink({ to, icon: Icon, title, subtitle }: { to: string; icon: typeof Activity; title: string; subtitle: string }) {
+  return (
+    <Link className="group rounded-lg border border-primary/15 bg-surface/55 p-4 text-sm transition hover:border-primary/50 hover:bg-primary/5" to={to}>
+      <Icon className="mb-3 h-4 w-4 text-primary transition group-hover:scale-110" />
+      <div className="font-medium text-text-primary">{title}</div>
+      <div className="mt-1 text-xs text-text-tertiary">{subtitle}</div>
+    </Link>
+  );
+}
+
+export default function OverviewPage() {
+  const { setTitle, setAfterTitle } = usePageHeader();
+  const [data, setData] = useState<OverviewData>(emptyData);
+  const [state, setState] = useState<LoadState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setTitle("Mission Control");
+    setAfterTitle(<span className="text-xs text-text-tertiary">Live local Hermes observability — real data, read-only cockpit.</span>);
+    return () => {
+      setTitle(null);
+      setAfterTitle(null);
+    };
+  }, [setTitle, setAfterTitle]);
+
+  async function load() {
+    setState((prev) => (prev === "ready" ? "ready" : "loading"));
+    setError(null);
+    try {
+      const [status, system, kanban, sessions, analytics, model, cron, skills, profiles, env, logs] = await Promise.all([
+        api.getStatus().catch(() => null),
+        api.getSystemHealth().catch(() => null),
+        api.getKanbanStats().catch(() => null),
+        api.getSessions(8, 0).catch(() => null),
+        api.getAnalytics(30).catch(() => null),
+        api.getModelInfo().catch(() => null),
+        api.getCronJobs("all").catch(() => null),
+        api.getSkills().catch(() => null),
+        api.getProfiles().catch(() => null),
+        api.getEnvVars().catch(() => null),
+        api.getLogs({ file: "errors", lines: 8 }).then((r) => r.lines).catch(() => []),
+      ]);
+      setData({ status, system, kanban, sessions, analytics, model, cron, skills, profiles: profiles?.profiles ?? null, env, logs });
+      setUpdatedAt(new Date());
+      setState("ready");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setState("error");
+    }
+  }
+
+  useEffect(() => {
+    load();
+    const id = window.setInterval(load, 30000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const envSummary = useMemo(() => {
+    const values = Object.values(data.env ?? {});
+    return { total: values.length, set: values.filter((v) => v.is_set).length, missing: values.filter((v) => !v.is_set).length };
+  }, [data.env]);
+
+  const lastSession = data.sessions?.sessions?.[0];
+  const enabledCron = data.cron?.filter((j) => j.enabled).length ?? null;
+  const gatewayOk = Boolean(data.status?.gateway_running);
+  const dirtyGit = Boolean(data.system?.git.dirty);
+  const activeCron = enabledCron ?? 0;
+  const kanbanStatus = data.kanban?.by_status ?? null;
+  const kanbanTotal = kanbanStatus ? Object.values(kanbanStatus).reduce((sum, value) => sum + value, 0) : null;
+  const kanbanOpen = kanbanStatus
+    ? ["triage", "todo", "scheduled", "ready", "running", "blocked", "review"].reduce((sum, key) => sum + (kanbanStatus[key] ?? 0), 0)
+    : null;
+  const kanbanBlocked = kanbanStatus?.blocked ?? 0;
+  const kanbanRunning = kanbanStatus?.running ?? 0;
+  const assigneeCount = data.kanban ? Object.keys(data.kanban.by_assignee ?? {}).length : null;
+
+  return (
+    <div className="relative space-y-6 overflow-hidden rounded-xl border border-primary/10 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--midground-base)_10%,transparent),transparent_30%),linear-gradient(rgba(255,230,203,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,230,203,0.035)_1px,transparent_1px)] bg-[size:auto,28px_28px,28px_28px] p-1">
+      <div className="space-y-6 rounded-lg bg-background/40 p-3 md:p-5">
+        <div className="relative overflow-hidden rounded-xl border border-primary/20 bg-[linear-gradient(135deg,rgba(255,230,203,0.10),rgba(4,28,28,0.76)_42%,rgba(74,222,128,0.06))] p-5 shadow-[0_24px_90px_rgba(0,0,0,0.35)]">
+          <div className="absolute right-6 top-6 hidden h-28 w-28 rounded-full border border-primary/20 md:block" />
+          <div className="absolute right-10 top-10 hidden h-20 w-20 rounded-full border border-primary/10 md:block" />
+          <div className="relative flex flex-wrap items-start justify-between gap-5">
+            <div className="max-w-3xl">
+              <div className="mb-3 flex flex-wrap items-center gap-2 font-mono text-[11px] uppercase tracking-[0.22em] text-text-tertiary">
+                <span className="rounded-full border border-primary/20 bg-background/40 px-3 py-1">Localhost Control Plane</span>
+                <span className="rounded-full border border-success/30 bg-success/10 px-3 py-1 text-success">Real Data</span>
+                <span className="rounded-full border border-primary/20 bg-background/40 px-3 py-1">Read-only Overview</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <Radar className="h-8 w-8 text-primary" />
+                <h2 className="text-3xl font-semibold tracking-tight text-text-primary md:text-5xl">Hermes Mission Control</h2>
+              </div>
+              <p className="mt-3 max-w-2xl text-sm text-text-secondary md:text-base">
+                Tactical local cockpit for your active Hermes setup. No fake metrics, no secrets displayed, and missing integrations are labelled instead of invented. Proper little command deck, this.
+              </p>
+            </div>
+            <div className="min-w-56 rounded-lg border border-primary/15 bg-background/45 p-4 font-mono text-xs text-text-secondary">
+              <div className="mb-3 flex items-center justify-between text-text-primary"><span>LIVE STATUS</span><StatusDot ok={gatewayOk} warn={!gatewayOk} /></div>
+              <div className="space-y-2">
+                <div className="flex justify-between gap-4"><span>Gateway</span><span>{data.status?.gateway_state ?? (gatewayOk ? "running" : "stopped")}</span></div>
+                <div className="flex justify-between gap-4"><span>Sessions</span><span>{fmtNum(data.sessions?.total)}</span></div>
+                <div className="flex justify-between gap-4"><span>Cron</span><span>{data.cron ? `${activeCron}/${data.cron.length}` : "Unavailable"}</span></div>
+                <div className="flex justify-between gap-4"><span>Tasks</span><span>{kanbanOpen === null ? "Unavailable" : `${kanbanOpen} open`}</span></div>
+                <div className="flex justify-between gap-4"><span>Updated</span><span>{updatedAt ? updatedAt.toLocaleTimeString() : "—"}</span></div>
+              </div>
+              <Button className="mt-4 w-full" size="sm" onClick={load} disabled={state === "loading"}>
+                <RefreshCw className="mr-2 h-4 w-4" /> Refresh Scan
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {error ? <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div> : null}
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <StatCard label="Gateway" value={data.status?.gateway_state ?? (gatewayOk ? "running" : "stopped")} hint={data.status?.gateway_pid ? `PID ${data.status.gateway_pid}` : "Local/runtime status"} icon={Shield} tone={gatewayOk ? "good" : "warn"} />
+          <StatCard label="Sessions" value={fmtNum(data.sessions?.total)} hint={lastSession ? `Latest ${timeAgo(lastSession.last_active || lastSession.started_at)}` : "No recent session found"} icon={MessageSquare} />
+          <StatCard label="Tasks" value={kanbanOpen === null ? "Unavailable" : kanbanOpen} hint={kanbanTotal === null ? "Kanban plugin not wired" : `${kanbanRunning} running · ${kanbanBlocked} blocked · ${kanbanTotal} total`} icon={Puzzle} tone={kanbanBlocked > 0 ? "warn" : kanbanOpen ? "good" : "neutral"} />
+          <StatCard label="Cron jobs" value={data.cron ? `${enabledCron}/${data.cron.length}` : "Unavailable"} hint="enabled / total across profiles" icon={Clock} tone={activeCron > 0 ? "good" : "neutral"} />
+          <StatCard label="Secrets" value={data.env ? `${envSummary.set}/${envSummary.total}` : "Unavailable"} hint={data.env ? `${envSummary.missing} missing, values redacted` : "Presence only"} icon={KeyRound} tone={envSummary.missing ? "warn" : "good"} />
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-3">
+          <SectionLink to="/models" label="Model uplink">
+            <div className="space-y-3 text-sm">
+              <div className="flex items-center gap-2 text-text-primary"><Cpu className="h-4 w-4 text-primary" /> {data.model?.model || "Not configured"}</div>
+              <div className="grid grid-cols-2 gap-2 text-xs text-text-secondary">
+                <div className="rounded border border-border/50 bg-background/30 p-2">Provider<br /><span className="text-text-primary">{data.model?.provider || "Unavailable"}</span></div>
+                <div className="rounded border border-border/50 bg-background/30 p-2">Context<br /><span className="text-text-primary">{data.model?.effective_context_length ? fmtNum(data.model.effective_context_length) : "Unavailable"}</span></div>
+              </div>
+            </div>
+          </SectionLink>
+
+          <SectionLink to="/analytics" label="30-day telemetry">
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center gap-2"><BarChart3 className="h-4 w-4 text-primary" /> Sessions: {fmtNum(data.analytics?.totals.total_sessions)}</div>
+              <div>API calls: {fmtNum(data.analytics?.totals.total_api_calls)}</div>
+              <div>Estimated cost: {fmtCost(data.analytics?.totals.total_estimated_cost)}</div>
+            </div>
+          </SectionLink>
+
+          <SectionLink to="/system" label="System health">
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center gap-2"><Terminal className="h-4 w-4 text-primary" /> Python {data.system?.runtime.python ?? "Unavailable"}</div>
+              <div className="flex items-center gap-2"><GitBranch className="h-4 w-4 text-primary" /> {data.system?.git.branch ?? "git unavailable"} · {data.system?.git.commit ?? "—"}</div>
+              <div className="flex items-center gap-2 text-text-secondary"><StatusDot ok={!dirtyGit} warn={dirtyGit} /> {dirtyGit ? `${data.system?.git.dirty_count ?? 0} changed files` : "git clean"}</div>
+            </div>
+          </SectionLink>
+
+          <SectionLink to="/kanban" label="Kanban lanes">
+            <div className="space-y-3 text-sm">
+              {data.kanban ? (
+                <>
+                  <div className="grid grid-cols-3 gap-2 text-center font-mono text-xs">
+                    <div className="rounded border border-border/50 bg-background/30 p-2"><div className="text-lg text-text-primary">{kanbanOpen}</div><div className="text-text-tertiary">open</div></div>
+                    <div className="rounded border border-border/50 bg-background/30 p-2"><div className="text-lg text-text-primary">{kanbanRunning}</div><div className="text-text-tertiary">running</div></div>
+                    <div className="rounded border border-border/50 bg-background/30 p-2"><div className="text-lg text-text-primary">{kanbanBlocked}</div><div className="text-text-tertiary">blocked</div></div>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs text-text-secondary">
+                    {Object.entries(kanbanStatus ?? {}).slice(0, 8).map(([status, count]) => (
+                      <span key={status} className="rounded-full border border-primary/15 bg-background/30 px-2 py-1">{status}: {count}</span>
+                    ))}
+                  </div>
+                  <div className="text-xs text-text-tertiary">Assignees with tasks: {assigneeCount ?? 0}</div>
+                </>
+              ) : (
+                <div className="rounded border border-warning/20 bg-warning/5 p-3 text-sm text-text-secondary">Kanban plugin stats unavailable. Feature not yet wired or plugin route not mounted.</div>
+              )}
+            </div>
+          </SectionLink>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[1.25fr_0.75fr]">
+          <SectionLink to="/sessions" label="Mission feed — recent sessions">
+            <div className="space-y-3">
+              {(data.sessions?.sessions ?? []).slice(0, 6).map((s) => (
+                <Link to={`/sessions?session=${encodeURIComponent(s.id)}`} key={s.id} className="block rounded border border-border/60 bg-background/30 p-3 transition hover:border-primary/40 hover:bg-primary/5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="truncate text-sm font-medium text-text-primary">{s.title || s.id}</div>
+                    <Badge tone={s.is_active ? "success" : "secondary"}>{s.source || "unknown"}</Badge>
+                  </div>
+                  <div className="mt-1 truncate text-xs text-text-secondary">{s.preview || "No preview"}</div>
+                  <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+                    <span>{s.message_count} msgs</span><span>{s.tool_call_count} tools</span><span>{s.model || "model n/a"}</span><span>{timeAgo(s.last_active || s.started_at)}</span>
+                  </div>
+                </Link>
+              ))}
+              {data.sessions && data.sessions.sessions.length === 0 ? <div className="text-sm text-text-secondary">No sessions found.</div> : null}
+            </div>
+          </SectionLink>
+
+          <div className="space-y-4">
+            <SectionLink to="/skills" label="Crew loadout">
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center gap-2"><Package className="h-4 w-4 text-primary" /> Skills: {data.skills ? fmtNum(data.skills.length) : "Unavailable"}</div>
+                <div className="flex items-center gap-2"><Users className="h-4 w-4 text-primary" /> Profiles: {data.profiles ? fmtNum(data.profiles.length) : "Unavailable"}</div>
+                <div className="text-text-secondary">Default: {data.profiles?.find((p) => p.is_default)?.name ?? "default"}</div>
+              </div>
+            </SectionLink>
+
+            <SectionLink to="/logs" label="Fault monitor">
+              <div className="space-y-2">
+                {data.logs.length ? data.logs.slice(-4).map((line, idx) => (
+                  <pre key={idx} className="overflow-hidden text-ellipsis rounded border border-warning/20 bg-warning/5 p-2 text-xs text-text-secondary">{line}</pre>
+                )) : <div className="text-sm text-text-secondary">No recent error lines found.</div>}
+              </div>
+            </SectionLink>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <QuickLink to="/sessions" icon={Search} title="Search sessions" subtitle="Inspect real session store" />
+          <QuickLink to="/config" icon={Settings} title="Config" subtitle="Sanitized config view" />
+          <QuickLink to="/env" icon={KeyRound} title="Keys" subtitle="Presence only, redacted" />
+          <QuickLink to="/plugins" icon={Puzzle} title="Plugins / Kanban" subtitle="Installed dashboard tabs" />
+          <QuickLink to="/docs" icon={FileText} title="Docs" subtitle="Command references" />
+        </div>
+
+        <div className="rounded-lg border border-primary/15 bg-background/35 p-3 font-mono text-[11px] uppercase tracking-[0.16em] text-text-tertiary">
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+            <span className="flex items-center gap-2"><Zap className="h-3.5 w-3.5 text-primary" /> Local-first dashboard</span>
+            <span>Hermes home: {data.status?.hermes_home ?? data.system?.hermes.home ?? "Unavailable"}</span>
+            <span>Config: {data.status?.config_path ?? data.system?.hermes.config_path ?? "Unavailable"}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/SystemHealthPage.tsx
+++ b/web/src/pages/SystemHealthPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Cpu,
+  Database,
+  GitBranch,
+  HardDrive,
+  RefreshCw,
+  Server,
+  Shield,
+  Terminal,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { api, type SystemHealthResponse, type SystemPathStat } from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+function valueOrUnknown(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "Unavailable";
+  return String(value);
+}
+
+function bytes(value: number | null): string {
+  if (value === null) return "Unavailable";
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  if (value < 1024 * 1024 * 1024) return `${(value / 1024 / 1024).toFixed(1)} MB`;
+  return `${(value / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}
+
+function Field({ label, value }: { label: string; value: string | number | null | undefined }) {
+  return (
+    <div className="rounded border border-border/50 bg-background/30 p-3">
+      <div className="text-[11px] uppercase tracking-[0.16em] text-text-tertiary">{label}</div>
+      <div className="mt-1 break-all font-mono text-sm text-text-primary">{valueOrUnknown(value)}</div>
+    </div>
+  );
+}
+
+function PathRow({ name, stat }: { name: string; stat: SystemPathStat }) {
+  return (
+    <div className="rounded border border-border/60 bg-background/30 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="font-medium text-text-primary">{name}</div>
+        <Badge tone={stat.exists ? "success" : "secondary"}>{stat.exists ? "present" : "missing"}</Badge>
+      </div>
+      <div className="mt-1 break-all font-mono text-xs text-text-secondary">{stat.path}</div>
+      <div className="mt-2 text-xs text-text-tertiary">
+        {stat.is_dir ? "directory" : "file"} · {bytes(stat.size)}
+        {stat.mtime ? ` · ${new Date(stat.mtime * 1000).toLocaleString()}` : ""}
+      </div>
+    </div>
+  );
+}
+
+export default function SystemHealthPage() {
+  const { setTitle, setAfterTitle } = usePageHeader();
+  const [data, setData] = useState<SystemHealthResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setTitle("System / Health");
+    setAfterTitle(<span className="text-xs text-text-tertiary">Read-only local Hermes runtime diagnostics.</span>);
+    return () => {
+      setTitle(null);
+      setAfterTitle(null);
+    };
+  }, [setTitle, setAfterTitle]);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.getSystemHealth();
+      setData(result);
+      setUpdatedAt(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    const id = window.setInterval(load, 30000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const gatewayOk = Boolean(data?.gateway.running);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 p-4">
+        <div className="flex items-center gap-3">
+          {gatewayOk ? <CheckCircle2 className="h-5 w-5 text-success" /> : <AlertTriangle className="h-5 w-5 text-warning" />}
+          <div>
+            <div className="font-semibold text-text-primary">Local system health</div>
+            <div className="text-sm text-text-secondary">No secrets shown. No process inventory beyond Hermes dashboard/gateway metadata.</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {updatedAt ? <span className="text-xs text-text-tertiary">Updated {updatedAt.toLocaleTimeString()}</span> : null}
+          <Button size="sm" onClick={load} disabled={loading}>
+            <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+          </Button>
+        </div>
+      </div>
+
+      {error ? <div className="rounded border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div> : null}
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card className="border-border/60 bg-surface/70"><CardContent className="p-4"><Shield className="mb-3 h-5 w-5 text-primary" /><div className="text-xs uppercase tracking-[0.16em] text-text-tertiary">Gateway</div><div className="mt-2 text-xl font-semibold text-text-primary">{data?.gateway.state ?? (gatewayOk ? "running" : "stopped")}</div><div className="text-xs text-text-secondary">PID {valueOrUnknown(data?.gateway.pid)}</div></CardContent></Card>
+        <Card className="border-border/60 bg-surface/70"><CardContent className="p-4"><GitBranch className="mb-3 h-5 w-5 text-primary" /><div className="text-xs uppercase tracking-[0.16em] text-text-tertiary">Git</div><div className="mt-2 text-xl font-semibold text-text-primary">{valueOrUnknown(data?.git.branch)}</div><div className="text-xs text-text-secondary">{valueOrUnknown(data?.git.commit)} · {data?.git.dirty ? `${data.git.dirty_count} changed` : "clean"}</div></CardContent></Card>
+        <Card className="border-border/60 bg-surface/70"><CardContent className="p-4"><Cpu className="mb-3 h-5 w-5 text-primary" /><div className="text-xs uppercase tracking-[0.16em] text-text-tertiary">Runtime</div><div className="mt-2 text-xl font-semibold text-text-primary">Python {valueOrUnknown(data?.runtime.python)}</div><div className="text-xs text-text-secondary">{valueOrUnknown(data?.runtime.system)} {valueOrUnknown(data?.runtime.machine)}</div></CardContent></Card>
+        <Card className="border-border/60 bg-surface/70"><CardContent className="p-4"><Server className="mb-3 h-5 w-5 text-primary" /><div className="text-xs uppercase tracking-[0.16em] text-text-tertiary">Dashboard</div><div className="mt-2 text-xl font-semibold text-text-primary">PID {valueOrUnknown(data?.runtime.process_pid)}</div><div className="text-xs text-text-secondary">Hermes {valueOrUnknown(data?.hermes.version)}</div></CardContent></Card>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card className="border-border/60 bg-surface/70">
+          <CardHeader><CardTitle className="flex items-center gap-2 text-sm uppercase tracking-[0.14em]"><Terminal className="h-4 w-4 text-primary" /> Hermes runtime</CardTitle></CardHeader>
+          <CardContent className="grid gap-3">
+            <Field label="Hermes home" value={data?.hermes.home} />
+            <Field label="Config path" value={data?.hermes.config_path} />
+            <Field label="Env path" value={data?.hermes.env_path} />
+            <Field label="Project root" value={data?.hermes.project_root} />
+            <Field label="Web dist" value={data?.hermes.web_dist} />
+            <Field label="Python executable" value={data?.runtime.python_executable} />
+            <Field label="Platform" value={data?.runtime.platform} />
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60 bg-surface/70">
+          <CardHeader><CardTitle className="flex items-center gap-2 text-sm uppercase tracking-[0.14em]"><HardDrive className="h-4 w-4 text-primary" /> Local storage</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {data ? Object.entries(data.paths).map(([name, stat]) => <PathRow key={name} name={name.replace(/_/g, " ")} stat={stat} />) : null}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-border/60 bg-surface/70">
+        <CardHeader><CardTitle className="flex items-center gap-2 text-sm uppercase tracking-[0.14em]"><Database className="h-4 w-4 text-primary" /> Last error lines</CardTitle></CardHeader>
+        <CardContent className="space-y-2">
+          {data?.last_errors?.length ? data.last_errors.map((line, idx) => (
+            <pre key={idx} className="overflow-x-auto rounded border border-warning/20 bg-warning/5 p-2 text-xs text-text-secondary">{line}</pre>
+          )) : <div className="text-sm text-text-secondary">No recent error lines found.</div>}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { ExternalLink, Gauge, GitPullRequest, PlayCircle, Radar, RefreshCw, ShieldAlert, Users, Workflow } from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { api } from "@/lib/api";
+import type {
+  KanbanActiveWorkersResponse,
+  KanbanBoardResponse,
+  KanbanDiagnosticsResponse,
+  KanbanStatsResponse,
+  KanbanTask,
+} from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+const OPEN_STATUSES = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review"];
+const FOCUS_STATUSES = ["blocked", "running", "ready", "review", "scheduled"];
+
+type LoadState = "loading" | "ready" | "error";
+
+interface TaskMissionData {
+  stats: KanbanStatsResponse | null;
+  board: KanbanBoardResponse | null;
+  diagnostics: KanbanDiagnosticsResponse | null;
+  workers: KanbanActiveWorkersResponse | null;
+}
+
+const emptyData: TaskMissionData = {
+  stats: null,
+  board: null,
+  diagnostics: null,
+  workers: null,
+};
+
+function fmtAge(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined) return "—";
+  if (seconds < 60) return `${Math.max(0, Math.floor(seconds))}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+function StatTile({ label, value, hint, tone = "neutral" }: { label: string; value: string | number; hint?: string; tone?: "neutral" | "good" | "warn" }) {
+  const toneClass = tone === "good" ? "text-success" : tone === "warn" ? "text-warning" : "text-primary";
+  return (
+    <Card className="border-primary/15 bg-surface/65 shadow-[inset_0_1px_0_rgba(255,230,203,0.06)]">
+      <CardContent className="p-4">
+        <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-text-tertiary">{label}</div>
+        <div className={`mt-2 text-3xl font-semibold ${toneClass}`}>{value}</div>
+        {hint ? <div className="mt-1 text-xs text-text-secondary">{hint}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TaskRow({ task }: { task: KanbanTask }) {
+  const summary = task.latest_summary || task.body || "No summary yet.";
+  return (
+    <div className="rounded-lg border border-primary/10 bg-background/35 p-3 transition hover:border-primary/35">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <div className="font-medium text-text-primary">{task.title}</div>
+          <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.12em] text-text-tertiary">{task.id}</div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge tone="outline">{task.status}</Badge>
+          {task.assignee ? <Badge tone="secondary">{task.assignee}</Badge> : null}
+          {task.priority ? <Badge tone="outline">P{task.priority}</Badge> : null}
+        </div>
+      </div>
+      <p className="mt-2 line-clamp-2 text-sm text-text-secondary">{summary}</p>
+      <div className="mt-3 flex flex-wrap gap-3 text-xs text-text-tertiary">
+        <span>age {fmtAge(task.age?.created_age_seconds)}</span>
+        {task.comment_count ? <span>{task.comment_count} comments</span> : null}
+        {task.progress ? <span>{task.progress.done}/{task.progress.total} children done</span> : null}
+        {task.diagnostics?.length ? <span className="text-warning">{task.diagnostics.length} diagnostics</span> : null}
+      </div>
+    </div>
+  );
+}
+
+function Panel({ title, icon: Icon, children }: { title: string; icon: typeof Radar; children: React.ReactNode }) {
+  return (
+    <Card className="border-primary/15 bg-surface/70">
+      <CardHeader className="flex flex-row items-center gap-2 pb-2">
+        <Icon className="h-4 w-4 text-primary" />
+        <CardTitle className="font-mono text-xs uppercase tracking-[0.18em] text-text-secondary">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+export default function TasksPage() {
+  const { setTitle, setAfterTitle } = usePageHeader();
+  const [data, setData] = useState<TaskMissionData>(emptyData);
+  const [state, setState] = useState<LoadState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setTitle("Tasks Mission");
+    setAfterTitle(<span className="text-xs text-text-tertiary">Kanban command view — live board, workers, diagnostics, read-only controls.</span>);
+    return () => {
+      setTitle(null);
+      setAfterTitle(null);
+    };
+  }, [setTitle, setAfterTitle]);
+
+  async function load() {
+    setState((prev) => (prev === "ready" ? "ready" : "loading"));
+    setError(null);
+    try {
+      const [stats, board, diagnostics, workers] = await Promise.all([
+        api.getKanbanStats().catch(() => null),
+        api.getKanbanBoard().catch(() => null),
+        api.getKanbanDiagnostics().catch(() => null),
+        api.getKanbanActiveWorkers().catch(() => null),
+      ]);
+      setData({ stats, board, diagnostics, workers });
+      setUpdatedAt(new Date());
+      setState("ready");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setState("error");
+    }
+  }
+
+  useEffect(() => {
+    load();
+    const id = window.setInterval(load, 10000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const byStatus = data.stats?.by_status ?? {};
+  const total = Object.values(byStatus).reduce((sum, value) => sum + value, 0);
+  const open = OPEN_STATUSES.reduce((sum, key) => sum + (byStatus[key] ?? 0), 0);
+  const blocked = byStatus.blocked ?? 0;
+  const running = byStatus.running ?? 0;
+  const ready = byStatus.ready ?? 0;
+  const diagnosticsCount = data.diagnostics?.count ?? 0;
+  const workerCount = data.workers?.count ?? 0;
+  const allTasks = useMemo(() => data.board?.columns.flatMap((column) => column.tasks) ?? [], [data.board]);
+  const focusTasks = useMemo(
+    () => allTasks.filter((task) => FOCUS_STATUSES.includes(task.status)).slice(0, 12),
+    [allTasks],
+  );
+  const assignees = data.stats ? Object.keys(data.stats.by_assignee ?? {}) : [];
+
+  return (
+    <div className="relative space-y-6 overflow-hidden rounded-xl border border-primary/10 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--midground-base)_10%,transparent),transparent_30%),linear-gradient(rgba(255,230,203,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,230,203,0.035)_1px,transparent_1px)] bg-[size:auto,28px_28px,28px_28px] p-1">
+      <div className="space-y-6 rounded-lg bg-background/40 p-3 md:p-5">
+        <div className="relative overflow-hidden rounded-xl border border-primary/20 bg-[linear-gradient(135deg,rgba(255,230,203,0.09),rgba(4,28,28,0.78)_45%,rgba(74,222,128,0.06))] p-5 shadow-[0_24px_90px_rgba(0,0,0,0.35)]">
+          <div className="absolute right-6 top-6 hidden h-28 w-28 rounded-full border border-primary/20 md:block" />
+          <div className="absolute right-12 top-12 hidden h-16 w-16 rounded-full border border-success/20 md:block" />
+          <div className="relative flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <div className="mb-3 flex flex-wrap gap-2 font-mono text-[11px] uppercase tracking-[0.22em] text-text-tertiary">
+                <span className="rounded-full border border-primary/20 bg-background/40 px-3 py-1">Kanban Ops</span>
+                <span className="rounded-full border border-success/30 bg-success/10 px-3 py-1 text-success">Real Board Data</span>
+                <span className="rounded-full border border-warning/30 bg-warning/10 px-3 py-1 text-warning">Read-only</span>
+              </div>
+              <h2 className="text-3xl font-semibold tracking-tight text-text-primary">Tasks Mission Control</h2>
+              <p className="mt-2 max-w-2xl text-sm text-text-secondary">
+                Live cockpit for the Hermes Kanban work queue: lane pressure, active workers, diagnostics, and high-attention cards.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Link className="inline-flex items-center gap-2 rounded-md border border-primary/20 bg-background/45 px-3 py-2 text-sm text-primary hover:bg-primary/10" to="/kanban">
+                <ExternalLink className="h-4 w-4" /> Open full Kanban
+              </Link>
+              <Button size="sm" onClick={load} disabled={state === "loading"}>
+                <RefreshCw className={`mr-2 h-4 w-4 ${state === "loading" ? "animate-spin" : ""}`} /> Refresh
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {error ? <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div> : null}
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+          <StatTile label="Open" value={data.stats ? open : "Unavailable"} hint={`${total} non-archived total`} tone={open ? "good" : "neutral"} />
+          <StatTile label="Running" value={data.stats ? running : "Unavailable"} hint={`${workerCount} active workers`} tone={running ? "good" : "neutral"} />
+          <StatTile label="Ready" value={data.stats ? ready : "Unavailable"} hint={`oldest ${fmtAge(data.stats?.oldest_ready_age_seconds)}`} tone={ready ? "good" : "neutral"} />
+          <StatTile label="Blocked" value={data.stats ? blocked : "Unavailable"} hint="needs operator attention" tone={blocked ? "warn" : "neutral"} />
+          <StatTile label="Diagnostics" value={data.diagnostics ? diagnosticsCount : "Unavailable"} hint="active warnings/errors" tone={diagnosticsCount ? "warn" : "neutral"} />
+          <StatTile label="Assignees" value={data.stats ? assignees.length : "Unavailable"} hint="profiles with tasks" />
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[1.35fr_0.65fr]">
+          <Panel title="Lane pressure" icon={Gauge}>
+            {data.stats ? (
+              <div className="space-y-3">
+                {OPEN_STATUSES.map((status) => {
+                  const count = byStatus[status] ?? 0;
+                  const pct = open ? Math.round((count / open) * 100) : 0;
+                  return (
+                    <div key={status}>
+                      <div className="mb-1 flex justify-between text-xs text-text-secondary"><span>{status}</span><span>{count}</span></div>
+                      <div className="h-2 overflow-hidden rounded-full bg-background/60">
+                        <div className="h-full rounded-full bg-primary/70" style={{ width: `${pct}%` }} />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="rounded border border-warning/20 bg-warning/5 p-3 text-sm text-text-secondary">Kanban stats unavailable. Plugin API may not be mounted.</div>
+            )}
+          </Panel>
+
+          <Panel title="Active workers" icon={PlayCircle}>
+            {data.workers?.workers.length ? (
+              <div className="space-y-3">
+                {data.workers.workers.map((worker) => (
+                  <div key={worker.run_id} className="rounded border border-primary/10 bg-background/35 p-3 text-sm">
+                    <div className="font-medium text-text-primary">{worker.task_title}</div>
+                    <div className="mt-1 text-xs text-text-tertiary">PID {worker.worker_pid ?? "—"} · {worker.profile ?? "default"}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-text-secondary">No active workers right now.</div>
+            )}
+          </Panel>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[1fr_1fr]">
+          <Panel title="Attention queue" icon={ShieldAlert}>
+            {focusTasks.length ? (
+              <div className="space-y-3">
+                {focusTasks.map((task) => <TaskRow key={task.id} task={task} />)}
+              </div>
+            ) : (
+              <div className="rounded border border-primary/10 bg-background/35 p-4 text-sm text-text-secondary">No blocked/running/ready/review/scheduled tasks found.</div>
+            )}
+          </Panel>
+
+          <div className="space-y-4">
+            <Panel title="Diagnostics" icon={GitPullRequest}>
+              {data.diagnostics?.diagnostics.length ? (
+                <div className="space-y-3">
+                  {data.diagnostics.diagnostics.slice(0, 8).map((item) => (
+                    <div key={item.task_id} className="rounded border border-warning/20 bg-warning/5 p-3 text-sm">
+                      <div className="font-medium text-text-primary">{item.task_title ?? item.task_id}</div>
+                      <div className="mt-1 text-xs text-text-secondary">{item.task_status ?? "unknown"} · {item.task_assignee ?? "unassigned"} · {item.diagnostics.length} diagnostics</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-sm text-text-secondary">No active diagnostics.</div>
+              )}
+            </Panel>
+
+            <Panel title="Assignee loadout" icon={Users}>
+              {assignees.length ? (
+                <div className="space-y-2">
+                  {assignees.slice(0, 10).map((assignee) => {
+                    const counts = data.stats?.by_assignee[assignee] ?? {};
+                    const assignedTotal = Object.values(counts).reduce((sum, value) => sum + value, 0);
+                    return (
+                      <div key={assignee} className="flex items-center justify-between rounded border border-primary/10 bg-background/35 px-3 py-2 text-sm">
+                        <span className="text-text-primary">{assignee}</span>
+                        <span className="text-text-tertiary">{assignedTotal} tasks</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="text-sm text-text-secondary">No assignee load yet.</div>
+              )}
+            </Panel>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary/10 bg-surface/50 p-4 text-xs text-text-tertiary">
+          <div className="flex items-center gap-2"><Workflow className="h-4 w-4 text-primary" /> Full write controls stay inside the Kanban plugin page; this surface is intentionally read-only.</div>
+          <div>Updated: {updatedAt ? updatedAt.toLocaleTimeString() : "—"}</div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- adds a Mission Control overview page backed by live Hermes status/model/session/cron data
- adds a system health page for runtime, git, gateway, storage path, and recent error diagnostics
- adds a kanban tasks page with live board, worker, and diagnostics data

## Verification
- `venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -q -o 'addopts='` — 189 passed, 1 warning
- `cd web && npm run build` — passed
- `git diff --check origin/main...HEAD` — passed

## Notes
- rebased onto current `origin/main` from the older checkpoint branch
- resolved frontend API conflicts with the newer dashboard auth helpers
- normalized author/committer to `mglavinic86 <mglavinic86@users.noreply.github.com>`
