### PR TITLE
fix(agent): recover unescaped quotes/braces in tool-call args

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -182,6 +182,89 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+# Tools whose arguments end in a single free-form text field that routinely
+# carries the double-quotes and braces of real source code (``write_file``
+# content, ``patch`` replacement text).  Weak/local models frequently emit
+# this field WITHOUT escaping the inner quotes — e.g.
+#   {"path": "a.py", "content": "env.get("KEY", "default")"}
+# — producing JSON that none of the structural repair passes can fix: an
+# unescaped ``"`` is 0x22 so the control-char escaper skips it, and
+# brace-counting can't help when the break is *inside* a string.  For these
+# tools (and only these) we can recover the dropped content from schema
+# knowledge — see :func:`_recover_unescaped_tail_string`.  Keyed by tool
+# name → the candidate tail field(s), tried in order.
+_TAIL_TEXT_FIELDS: dict[str, tuple[str, ...]] = {
+    "write_file": ("content",),
+    "patch": ("new_string", "patch"),
+}
+
+# The value's true closing quote is always within the last handful of quote
+# characters (only a few clean trailing fields like ``cross_profile`` /
+# ``replace_all`` can follow it).  Trying just the rightmost N keeps recovery
+# O(N · len) instead of O(quotes · len) on large file payloads.
+_MAX_TAIL_QUOTE_CANDIDATES = 64
+
+
+def _recover_unescaped_tail_string(raw: str, tool_name: str) -> str | None:
+    """Recover a tool call whose only defect is unescaped quotes/braces inside
+    a known free-text tail field (e.g. ``write_file.content``).
+
+    Returns canonical JSON on a confident recovery, or ``None`` to mean "not
+    recoverable — let the caller fall back to ``{}``".
+
+    The recovery is *self-validating*: for each candidate closing quote we
+    re-escape the suspect span with ``json.dumps``, splice it back between the
+    untouched clean prefix and suffix, and keep the candidate only if it
+    re-parses as strict JSON with the target field present.  Among the valid
+    candidates we pick the one yielding the MOST keys: over-grabbing a trailing
+    field (e.g. ``"path"``) collapses it into the string and strictly *drops*
+    a key, so max-keys reliably recovers the intended split whether the messy
+    field is last or has clean fields after it.  Ties break toward the longest
+    content.  This preserves the invariant that we never silently substitute a
+    value we aren't certain about — anything ambiguous yields ``None``.
+    """
+    fields = _TAIL_TEXT_FIELDS.get(tool_name)
+    if not fields:
+        return None
+
+    # Require exactly one whitelisted field to be present: zero means the
+    # arguments aren't the shape we recover, more than one is ambiguous.
+    located = []
+    for field in fields:
+        m = re.search(r'"' + re.escape(field) + r'"\s*:\s*"', raw)
+        if m is not None:
+            located.append((field, m))
+    if len(located) != 1:
+        return None
+    field, match = located[0]
+
+    # ``prefix`` is everything up to (not including) the value's opening quote;
+    # ``tail`` is the raw value plus any trailing structured fields and ``}``.
+    prefix = raw[: match.end() - 1]
+    tail = raw[match.end():]
+
+    quote_positions = [i for i, ch in enumerate(tail) if ch == '"']
+    best_score: tuple[int, int] | None = None
+    best_obj: dict | None = None
+    for q in quote_positions[-_MAX_TAIL_QUOTE_CANDIDATES:]:
+        value = tail[:q]
+        suffix = tail[q + 1:]
+        candidate = prefix + json.dumps(value) + suffix
+        try:
+            obj = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not (isinstance(obj, dict) and obj.get(field) == value):
+            continue
+        score = (len(obj), q)  # most keys wins; ties → longest content
+        if best_score is None or score > best_score:
+            best_score, best_obj = score, obj
+
+    if best_obj is not None:
+        return json.dumps(best_obj, separators=(",", ":"))
+    return None
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -268,6 +351,24 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             return escaped
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
+
+    # Repair pass 5: schema-aware recovery of unescaped quotes/braces inside a
+    # known free-text tail field (e.g. ``write_file.content``).  This is the
+    # ONE malformation the structural passes above cannot touch — weak models
+    # routinely emit code like ``env.get("KEY", "default")`` or ``f"x {y}"``
+    # straight into the content field without escaping the inner quotes, and
+    # an unescaped ``"`` is invisible to both brace-counting and the
+    # control-char escaper.  Without this, the whole call collapsed to ``{}``
+    # and the model was told it dropped ``content`` — a confusing re-emit loop
+    # on exactly the tool where it hurts most.  Recovery is self-validating
+    # and whitelisted; see :func:`_recover_unescaped_tail_string`.
+    recovered = _recover_unescaped_tail_string(raw_stripped, tool_name)
+    if recovered is not None:
+        logger.warning(
+            "Recovered unescaped tail-string tool_call arguments for %s: %s → %s",
+            tool_name, raw_stripped[:80], recovered[:80],
+        )
+        return recovered
 
     # Last resort: replace with empty object so the API request doesn't
     # crash the entire session.
@@ -435,6 +536,7 @@ __all__ = [
     "_sanitize_structure_surrogates",
     "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings",
+    "_recover_unescaped_tail_string",
     "_repair_tool_call_arguments",
     "_strip_non_ascii",
     "_sanitize_messages_non_ascii",

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -3,6 +3,7 @@
 import json
 
 from run_agent import _repair_tool_call_arguments
+from agent.message_sanitization import _recover_unescaped_tail_string
 
 
 class TestRepairToolCallArguments:
@@ -139,4 +140,112 @@ class TestRepairToolCallArguments:
         result = _repair_tool_call_arguments(raw, "t")
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
+
+
+class TestUnescapedTailStringRecovery:
+    """Stage 5: schema-aware recovery of unescaped quotes/braces inside a
+    known free-text tail field (write_file.content, patch.new_string).
+
+    This is the failure class no structural pass can fix: an unescaped ``"``
+    is 0x22, invisible to brace-counting and the control-char escaper.  The
+    recovery is whitelisted and self-validating — it must never silently
+    substitute a value we aren't certain about.
+    """
+
+    # -- the core symptom: Python code with unescaped inner quotes --
+
+    def test_dict_access_with_unescaped_quotes(self):
+        """env.get("KEY", "default") — quotes break JSON, content must survive."""
+        raw = '{"path": "/tmp/a.py", "content": "env.get("KEY", "default")"}'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["path"] == "/tmp/a.py"
+        assert parsed["content"] == 'env.get("KEY", "default")'
+
+    def test_fstring_with_braces_and_quotes(self):
+        """f"Bearer {token}" — the braces (and the value) must be preserved."""
+        raw = '{"path": "/tmp/a.py", "content": "f"Bearer {token}""}'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["content"] == 'f"Bearer {token}"'
+
+    def test_mixed_quotes_and_braces(self):
+        raw = '{"path": "/tmp/a.py", "content": "d = {1: 2}; x = obj["k"]"}'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["content"] == 'd = {1: 2}; x = obj["k"]'
+
+    # -- the trailing-field hazard: greedy split must not over-grab --
+
+    def test_trailing_clean_field_after_content(self):
+        """A clean field after the messy content must NOT be swallowed into it."""
+        raw = ('{"path": "/tmp/a.py", "content": "env.get("KEY")", '
+               '"cross_profile": false}')
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["content"] == 'env.get("KEY")'
+        assert parsed["cross_profile"] is False
+
+    def test_content_first_field(self):
+        """Recovery works when the messy field is first in the object."""
+        raw = '{"content": "print("hi")", "path": "/tmp/a.py"}'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["content"] == 'print("hi")'
+        assert parsed["path"] == "/tmp/a.py"
+
+    # -- patch.new_string is also whitelisted --
+
+    def test_patch_new_string_recovery(self):
+        raw = ('{"path": "/tmp/a.py", "old_string": "x = 1", '
+               '"new_string": "x = env.get("K")"}')
+        result = _repair_tool_call_arguments(raw, "patch")
+        parsed = json.loads(result)
+        assert parsed["new_string"] == 'x = env.get("K")'
+        assert parsed["old_string"] == "x = 1"
+
+    # -- SAFETY: must fall back to {} rather than mis-recover --
+
+    def test_non_whitelisted_tool_does_not_recover(self):
+        """Same malformation on a tool with no free-text tail field → {}.
+
+        We must not invent a recovery for tools whose args aren't this shape.
+        """
+        raw = '{"command": "echo "hi""}'
+        assert _repair_tool_call_arguments(raw, "terminal") == "{}"
+
+    def test_leading_field_also_broken_falls_back(self):
+        """If a NON-tail field is also quote-broken, the reparse can't validate
+        and we must fall back to {} rather than guess."""
+        raw = '{"path": "/tmp/a".py", "content": "env.get("K")"}'
+        assert _repair_tool_call_arguments(raw, "write_file") == "{}"
+
+    def test_unknown_tool_name_falls_back(self):
+        raw = '{"content": "env.get("K")"}'
+        assert _repair_tool_call_arguments(raw, "?") == "{}"
+
+    # -- regression: well-formed content with braces is untouched --
+
+    def test_valid_braces_pass_through_unchanged(self):
+        """Properly-escaped braces are valid JSON and never reach recovery."""
+        raw = '{"path": "/tmp/a.py", "content": "f\\"Bearer {token}\\""}'
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["content"] == 'f"Bearer {token}"'
+
+    # -- direct helper-level checks --
+
+    def test_helper_returns_none_for_unknown_tool(self):
+        raw = '{"content": "env.get("K")"}'
+        assert _recover_unescaped_tail_string(raw, "terminal") is None
+
+    def test_helper_returns_none_when_field_absent(self):
+        raw = '{"path": "/tmp/a.py"}'
+        assert _recover_unescaped_tail_string(raw, "write_file") is None
+
+    def test_helper_recovers_canonical_json(self):
+        raw = '{"path": "/tmp/a.py", "content": "env.get("K")"}'
+        recovered = _recover_unescaped_tail_string(raw, "write_file")
+        assert recovered is not None
+        assert json.loads(recovered)["content"] == 'env.get("K")'
 


### PR DESCRIPTION
## What

Adds a final, schema-aware repair pass to `_repair_tool_call_arguments`
(`agent/message_sanitization.py`) that recovers a tool call's free-text tail
field when the only defect is **unescaped inner double-quotes** — e.g.

```json
{"path": "a.py", "content": "env.get("KEY", "default")"}
```

## Why

Weak/local models routinely emit quote-dense source code into
`write_file.content` (or `patch.new_string`) without escaping the inner quotes.
That's invalid JSON, and none of the existing structural repair passes can fix
it: an unescaped `"` is `0x22`, so the control-char escaper skips it, and
brace-counting can't help when the break is *inside* a string. The whole call
therefore collapsed to `{}`, and the model was told it dropped `content` — a
confusing re-emit loop on exactly the tool where it hurts most.

> Note: curly braces were never the cause. They're valid inside JSON strings and
> pass through `json.loads` untouched. The real trigger is the unescaped quotes
> that accompany quote-dense code; the brace symptom was a red herring.

## How it's safe

The recovery is deliberately conservative — its invariant is *never silently
substitute a value we aren't certain about*:

- **Whitelisted** to tools with a single free-text tail field
  (`write_file.content`, `patch.new_string` / `patch`).
- **Self-validating**: for each candidate closing quote it re-escapes the
  suspect span via `json.dumps`, splices it back between the untouched clean
  prefix/suffix, and accepts the candidate only if the result re-parses as
  strict JSON with the target field present.
- **Most-keys disambiguation**: over-grabbing a trailing field (e.g. `path`,
  `cross_profile`) collapses it into the string and strictly *drops* a key, so
  preferring the max-key split reliably recovers the intended boundary whether
  the messy field is last or has clean fields after it.
- **Ambiguous → `{}`**: anything that can't be validated falls back to the
  existing behavior.

It runs as the last pass, after all existing structural repairs, so
well-formed and structurally-repairable arguments never reach it — **no
behavior change for any existing case**.

## Scope

Benefits non-grammar-constrained backends only; grammar-constrained decoding
(already attempted for llama.cpp in `conversation_loop.py`) prevents the
malformation upstream. This is the net for when the grammar has to be stripped.

## Tests

13 new tests in `tests/run_agent/test_repair_tool_call_arguments.py` (34 total
in the file pass), covering: recovery of dict-access / f-string / mixed
quote+brace content, the trailing-field over-grab hazard, content-first field
ordering, `patch.new_string`, and the non-whitelisted / ambiguous / unknown-tool
fallbacks. Adjacent suites (`test_streaming_tool_call_repair`,
`test_tool_call_args_sanitizer`, `test_file_operations_edge_cases`) remain green.
