### PR TITLE
chore(attribution): map polnikale for PR #35717

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1413,6 +1413,7 @@ AUTHOR_MAP = {
     "takis312@hotmail.com": "ErnestHysa",  # PRs #32636/#32708 (MCP asyncio.sleep + O(n^2) watcher drain)
     "me@simontaggart.com": "SiTaggart",  # PR #35583 (docker_forward_env empty-secret .env fallback)
     "2663402852@qq.com": "x1am1",  # PR #35098 (chown root-owned top-level HERMES_HOME state files)
+    "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
 }
 
 


### PR DESCRIPTION
Adds `nicsequenzy@gmail.com` → `polnikale` to `AUTHOR_MAP` in `scripts/release.py`.

The `check-attribution` CI gate blocks #35717 (the Playwright `headless_shell` browser discovery fix) because the contributor's commit email isn't mapped yet. This backfills the mapping so #35717 can pass attribution and merge.

Pure data addition — no logic change.