### PR TITLE
fix(agent): trigger fallback on quota-exhaustion 429s (e.g. Kimi monthly limit)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -35,7 +35,7 @@ from hermes_cli.timeouts import get_provider_request_timeout
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
-from agent.error_classifier import FailoverReason
+from agent.error_classifier import FailoverReason, _USAGE_LIMIT_PATTERNS
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -621,11 +621,11 @@ def recover_with_credential_pool(
         if error_context:
             context_reason = str(error_context.get("reason") or "").lower()
             context_message = str(error_context.get("message") or "").lower()
+            haystack = context_reason + " " + context_message
             usage_limit_reached = (
                 "usage_limit_reached" in context_reason
                 or "gousagelimit" in context_reason
-                or "usage limit reached" in context_message
-                or "usage limit has been reached" in context_message
+                or any(p in haystack for p in _USAGE_LIMIT_PATTERNS)
             )
         if not has_retried_429 and not usage_limit_reached:
             return False, True

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -822,7 +822,36 @@ def _classify_by_status(
         )
 
     if status_code == 429:
-        # Already checked long_context_tier above; this is a normal rate limit
+        # Already checked long_context_tier above.
+        # Some providers return monthly/cycle quota exhaustion as 429 (e.g.
+        # Kimi "monthly usage limit").  Disambiguate the same way as 402:
+        # if the message carries a billing or permanent-quota-exhaustion
+        # signal with no transient "try again / resets at / wait" qualifier,
+        # classify as billing (non-retryable) so we don't burn retries on a
+        # quota that won't recover until the next billing cycle.
+        if any(p in error_msg for p in _BILLING_PATTERNS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
+        # Only check usage-limit patterns when the message does NOT already
+        # carry an explicit rate-limit signal (e.g. "rate limit exceeded").
+        # _USAGE_LIMIT_PATTERNS includes broad tokens like "limit exceeded"
+        # that overlap with normal transient 429 messages; _RATE_LIMIT_PATTERNS
+        # takes priority so those stay retryable.
+        has_rate_limit_signal = any(p in error_msg for p in _RATE_LIMIT_PATTERNS)
+        has_usage_limit = not has_rate_limit_signal and any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+        if has_usage_limit:
+            has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
+            if not has_transient_signal:
+                return result_fn(
+                    FailoverReason.billing,
+                    retryable=False,
+                    should_rotate_credential=True,
+                    should_fallback=True,
+                )
         return result_fn(
             FailoverReason.rate_limit,
             retryable=True,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -324,6 +324,56 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_rotate_credential is True
 
+    def test_429_kimi_monthly_usage_limit_is_billing(self):
+        """Kimi returns HTTP 429 for monthly quota exhaustion — must not retry.
+
+        Real error: "You've reached kimi monthly usage limit for this billing
+        cycle. Your quota will be refreshed in the next cycle."
+        'usage limit' matches _USAGE_LIMIT_PATTERNS; 'refreshed in the next
+        cycle' is NOT in _USAGE_LIMIT_TRANSIENT_SIGNALS → billing, non-retryable.
+        """
+        msg = (
+            "You've reached kimi monthly usage limit for this billing cycle. "
+            "Your quota will be refreshed in the next cycle. Upgrade to get more."
+        )
+        e = MockAPIError(msg, status_code=429)
+        result = classify_api_error(e, provider="kimi")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_429_with_transient_usage_limit_is_rate_limit(self):
+        """429 carrying 'usage limit' + 'try again' is a transient quota → rate_limit."""
+        e = MockAPIError(
+            "usage limit exceeded, try again in 60 seconds",
+            status_code=429,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_with_billing_pattern_is_billing(self):
+        """429 carrying an explicit billing phrase (e.g. 'insufficient credits') → billing."""
+        e = MockAPIError("insufficient credits", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_429_plain_no_message_is_rate_limit(self):
+        """Plain 429 with no billing/usage signal stays rate_limit (regression guard)."""
+        e = MockAPIError("Too Many Requests", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_429_quota_with_reset_window_is_rate_limit(self):
+        """429 + 'quota' + 'resets at' → transient, stays rate_limit."""
+        e = MockAPIError("quota exceeded, resets at midnight UTC", status_code=429)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     # ── Server errors ──
 
     def test_500_server_error(self):


### PR DESCRIPTION
## Problem

HTTP 429 responses carrying a permanent quota-exhaustion message (e.g. Kimi's "monthly usage limit") were not triggering the `fallback_model` chain. Two separate gaps caused this:

1. `error_classifier.py`: 429 was unconditionally classified as `rate_limit` (retryable), burning 3 retry attempts with backoff before giving up — even though a monthly billing-cycle limit won't recover within any retry window.

2. `agent_runtime_helpers.py`: `recover_with_credential_pool` used hardcoded strings that didn't cover Kimi's "monthly usage limit" phrasing, so `fallback_model` was never triggered.

Fixes #36276.

## Fix

**Part 1 — `error_classifier.py`**: Apply `_BILLING_PATTERNS` + `_USAGE_LIMIT_PATTERNS` / transient-signal disambiguation to the 429 branch (same as 402/400/no-status paths). Plain 429s with no quota phrase remain `rate_limit` retryable — no regression.

**Part 2 — `agent_runtime_helpers.py`**: Replace two ad-hoc hardcoded strings with the shared `_USAGE_LIMIT_PATTERNS` list so fallback trigger stays in sync with the classifier.

## Test plan

- [x] All 184 agent tests pass (`tests/agent/`)
- [x] Kimi "monthly usage limit" 429 now classifies as `billing` and triggers `fallback_model`
- [x] Normal rate-limit 429s remain retryable — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)