### PR TITLE
fix(session_search): exclude current session from FTS5 fetch window (#36238)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2464,6 +2464,7 @@ class SessionDB:
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
         role_filter: List[str] = None,
+        exclude_session_id: str = None,
         limit: int = 20,
         offset: int = 0,
         sort: str = None,
@@ -2488,6 +2489,9 @@ class SessionDB:
         The short-CJK LIKE fallback already orders by timestamp DESC and
         ignores ``sort``. The trigram CJK path honours ``sort`` like the main
         FTS5 path.
+
+        ``exclude_session_id``: when set, messages from this session id are
+        omitted from results across all query paths (FTS5, trigram, LIKE).
         """
         if not self._fts_enabled:
             return []
@@ -2536,6 +2540,10 @@ class SessionDB:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        if exclude_session_id:
+            where_clauses.append("m.session_id != ?")
+            params.append(exclude_session_id)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -2609,6 +2617,9 @@ class SessionDB:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if exclude_session_id:
+                    tri_where.append("m.session_id != ?")
+                    tri_params.append(exclude_session_id)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -2664,6 +2675,9 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if exclude_session_id:
+                    like_where.append("m.session_id != ?")
+                    like_params.append(exclude_session_id)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2782,6 +2782,46 @@ class TestExcludeSources:
         sources = [r["source"] for r in results]
         assert sources == ["cli"]
 
+    def test_search_messages_exclude_session_id_filters_match(self, db):
+        db.create_session("s_current", "cli")
+        db.append_message("s_current", "user", "uniqueneedle here in current")
+        db.create_session("s_other", "cli")
+        db.append_message("s_other", "user", "uniqueneedle here in other")
+        results = db.search_messages("uniqueneedle", exclude_session_id="s_current")
+        sids = [r["session_id"] for r in results]
+        assert "s_current" not in sids
+        assert "s_other" in sids
+
+    def test_search_messages_without_exclude_session_id_returns_all(self, db):
+        db.create_session("s_a", "cli")
+        db.append_message("s_a", "user", "uniqueneedle in a")
+        db.create_session("s_b", "cli")
+        db.append_message("s_b", "user", "uniqueneedle in b")
+        results = db.search_messages("uniqueneedle")
+        sids = {r["session_id"] for r in results}
+        assert sids == {"s_a", "s_b"}
+
+    def test_search_messages_exclude_session_id_cjk_trigram(self, db):
+        db.create_session("s_current", "cli")
+        db.append_message("s_current", "user", "记忆断裂在当前会话")
+        db.create_session("s_other", "cli")
+        db.append_message("s_other", "user", "记忆断裂在另一会话")
+        results = db.search_messages("记忆断裂", exclude_session_id="s_current")
+        sids = [r["session_id"] for r in results]
+        assert "s_current" not in sids
+        assert "s_other" in sids
+
+    def test_search_messages_exclude_session_id_cjk_like_fallback(self, db):
+        # 2-char CJK token routes to LIKE fallback path
+        db.create_session("s_current", "cli")
+        db.append_message("s_current", "user", "通信在当前")
+        db.create_session("s_other", "cli")
+        db.append_message("s_other", "user", "通信在另一")
+        results = db.search_messages("通信", exclude_session_id="s_current")
+        sids = [r["session_id"] for r in results]
+        assert "s_current" not in sids
+        assert "s_other" in sids
+
 
 class TestResolveSessionByNameOrId:
     """Tests for the main.py helper that resolves names or IDs."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -204,6 +204,32 @@ class TestDiscoveryShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+    def test_current_session_id_passed_to_search_messages(self, db, monkeypatch):
+        _seed_modpack_sessions(db)
+        captured = {}
+        original = db.search_messages
+
+        def spy(*args, **kwargs):
+            captured.update(kwargs)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(db, "search_messages", spy)
+        json.loads(session_search(query="modpack", db=db, current_session_id="s_newest"))
+        assert captured.get("exclude_session_id") == "s_newest"
+
+    def test_no_current_session_id_passes_none(self, db, monkeypatch):
+        _seed_modpack_sessions(db)
+        captured = {}
+        original = db.search_messages
+
+        def spy(*args, **kwargs):
+            captured.update(kwargs)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(db, "search_messages", spy)
+        json.loads(session_search(query="modpack", db=db))
+        assert captured.get("exclude_session_id") is None
+
 
 class TestDiscoverySort:
     def test_sort_newest_orders_by_recency(self, db):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -290,6 +290,7 @@ def _discover(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            exclude_session_id=current_session_id or None,
             limit=50,  # widen so dedup-by-lineage can find distinct sessions
             offset=0,
             sort=sort,


### PR DESCRIPTION
## Summary

Fixes #36238.

`session_search` discovery mode was losing historical matches because the current session's messages dominated the FTS5 fetch window. With `sort='newest'` the SQL is `ORDER BY m.timestamp DESC, rank`, so every match in the active session sorted first and consumed the 50-row `search_messages()` limit. The post-hoc lineage dedup inside `_discover()` correctly skipped the current session, but by then the window was exhausted and other matching sessions never appeared in `raw_results`.

The reporter's evidence (state.db with 82 sessions, query `llm_wiki`):

| Mode | Sessions returned |
|------|-------------------|
| `sort='newest', limit=50` | 2 (current + 1 other) |
| `sort=None, limit=50` | 6 (all matching) |
| `sort='newest', limit=200` | 6 (all matching) |

## Fix

- `hermes_state.py` — `SessionDB.search_messages` gains an `exclude_session_id: str = None` parameter. The filter `m.session_id != ?` is applied to **all three** query paths: the main FTS5 path, the trigram CJK path, and the short-CJK LIKE fallback. Docstring updated.
- `tools/session_search_tool.py` — `_discover()` now passes `current_session_id` as `exclude_session_id` to `db.search_messages`. The existing lineage dedup stays as a safety net (it still handles parent/child session resolution that pure id equality can't).

This aligns DISCOVERY mode with BROWSE mode, which already excludes the current session via `_list_recent_sessions`.

## Tests

- `tests/test_hermes_state.py` — 4 new tests covering the FTS5 path, trigram CJK path, short-CJK LIKE fallback, and the no-op default.
- `tests/tools/test_session_search.py` — 2 new tests verifying `_discover` threads `exclude_session_id` (and `None`) into `db.search_messages` correctly.

```
$ pytest tests/test_hermes_state.py tests/tools/test_session_search.py
21 passed
```

## Backward compatibility

- New parameter defaults to `None`; existing callers are unaffected.
- `sort=None` (BM25) behavior unchanged.
- Scroll and browse modes unchanged.

## Checklist

- [x] Tests added and passing
- [x] Minimal diff, no unrelated cleanups
- [x] Commit signed
