### PR TITLE
feat(mcp): add official registry metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ all = [
 
 [project.scripts]
 hermes = "hermes_cli.main:main"
-hermes-agent = "run_agent:main"
+hermes-agent = "hermes_cli.main:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nousresearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Bridge MCP clients to Hermes conversations, events, approvals, and messaging targets.",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp#running-hermes-as-an-mcp-server",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "version": "0.15.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent[mcp]",
+      "version": "0.15.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "com.github": {
+        "serverDisplayName": "Hermes Agent"
+      },
+      "com.nousresearch.hermes-agent": {
+        "tools": [
+          "conversations_list",
+          "conversation_get",
+          "messages_read",
+          "attachments_fetch",
+          "events_poll",
+          "events_wait",
+          "messages_send",
+          "channels_list",
+          "permissions_list_open",
+          "permissions_respond"
+        ],
+        "gateway_required_for_sends": true,
+        "stdio_only": true
+      }
+    }
+  }
+}

--- a/tests/test_mcp_registry_metadata.py
+++ b/tests/test_mcp_registry_metadata.py
@@ -1,0 +1,68 @@
+"""Tests for official MCP Registry metadata shipped with Hermes."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER_JSON = ROOT / "server.json"
+
+
+def _server_json() -> dict:
+    return json.loads(SERVER_JSON.read_text(encoding="utf-8"))
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_server_json_matches_mcp_registry_identity_and_package():
+    data = _server_json()
+    pyproject = _pyproject()
+    version = pyproject["project"]["version"]
+
+    assert data["$schema"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    assert data["name"] == "io.github.nousresearch/hermes-agent"
+    assert data["title"] == "Hermes Agent"
+    assert data["repository"] == {
+        "url": "https://github.com/NousResearch/hermes-agent",
+        "source": "github",
+        "id": "1024554267",
+    }
+    assert data["version"] == version
+
+    assert len(data["packages"]) == 1
+    package = data["packages"][0]
+    assert package["registryType"] == "pypi"
+    assert package["registryBaseUrl"] == "https://pypi.org"
+    assert package["identifier"] == "hermes-agent[mcp]"
+    assert package["version"] == version
+    assert package["runtimeHint"] == "uvx"
+    assert package["transport"] == {"type": "stdio"}
+    assert package["packageArguments"] == [
+        {"type": "positional", "value": "mcp"},
+        {"type": "positional", "value": "serve"},
+    ]
+
+
+def test_hermes_agent_console_script_can_launch_mcp_package_arguments():
+    """Registry clients may execute the PyPI package's matching binary.
+
+    Keep ``hermes-agent mcp serve`` equivalent to ``hermes mcp serve`` so the
+    root ``server.json`` packageArguments start the MCP server instead of the
+    legacy direct-agent runner.
+    """
+
+    scripts = _pyproject()["project"]["scripts"]
+    assert scripts["hermes"] == "hermes_cli.main:main"
+    assert scripts["hermes-agent"] == scripts["hermes"]
+
+
+def test_publisher_provided_meta_stays_within_official_registry_limit():
+    data = _server_json()
+    publisher_meta = data["_meta"]["io.modelcontextprotocol.registry/publisher-provided"]
+
+    encoded = json.dumps(publisher_meta, separators=(",", ":")).encode("utf-8")
+    assert len(encoded) <= 4096

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -658,6 +658,16 @@ hermes mcp serve
 
 This starts a stdio MCP server. The MCP client (not you) manages the process lifecycle.
 
+### Registry metadata
+
+Hermes ships a root-level [`server.json`](https://github.com/NousResearch/hermes-agent/blob/main/server.json) for MCP registries and clients that can install from registry metadata. The package entry uses the PyPI extra `hermes-agent[mcp]` and fixed package arguments (`mcp`, `serve`) so clients launch the MCP server directly instead of starting a normal Hermes chat session.
+
+If your client does not yet understand Python extras in registry metadata, install MCP support manually and use the explicit command configuration below:
+
+```bash
+pip install "hermes-agent[mcp]"
+```
+
 ### MCP client configuration
 
 Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:


### PR DESCRIPTION
## Summary
- add root `server.json` metadata for official MCP registry/client discovery
- pin the PyPI package entry to the repo version with `hermes-agent[mcp]`, stdio transport, and fixed `mcp serve` package arguments
- make the `hermes-agent` console script route through the main Hermes CLI so package-matching registry launchers can run `hermes-agent mcp serve`
- document registry metadata and the manual fallback for clients that do not parse PyPI extras
- add regression tests for registry metadata/version/script invariants

## Test Plan
- `python -m pytest tests/test_mcp_registry_metadata.py tests/test_project_metadata.py -q -o 'addopts='`
- validated `server.json` against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- `python -m hermes_cli.main mcp serve --help`

## Notes
- This is intentionally PR-sized registry metadata prep; external registry submission should happen after merge/release so the referenced PyPI version and repo metadata are stable.
