### PR TITLE
fix(cli): surface clean diagnostic on fatal dependency-install failure

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6509,6 +6509,41 @@ def _run_install_with_heartbeat(
         t.join(timeout=0.2)
 
 
+def _report_fatal_install_failure(cmd: list[str], exc: BaseException) -> None:
+    """Print a clean, actionable diagnostic when a base-deps install fails fatally.
+
+    The fatal install path previously relied on a distant outer handler that caught
+    only ``CalledProcessError`` and printed a content-free "returned non-zero exit
+    status 1" while the real build error sat unused in ``~/.hermes/logs/update.log``.
+    Non-``CalledProcessError`` failures (missing/unexecutable uv|pip binary, urlretrieve
+    errors, disk/permission) escaped to the default excepthook and rendered a noisy,
+    source-context-elided traceback on Python 3.13.
+
+    This helper echoes the tail of the already-persisted ``update.log`` (where the real
+    pip/build error streamed live) inline so the user sees the cause without opening a
+    file, points at the full log, and exits via ``SystemExit(1)`` — which propagates
+    cleanly through the existing outer handlers without dumping a wrapper traceback.
+    """
+    print()
+    print(f"\u2717 Update failed installing base dependencies (command: {' '.join(cmd)})")
+    print(f"  {type(exc).__name__}: {exc}")
+    try:
+        from hermes_constants import get_hermes_home
+
+        log_path = get_hermes_home() / "logs" / "update.log"
+        if log_path.is_file():
+            tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-30:]
+            if tail:
+                print(f"  \u2500\u2500 last {len(tail)} lines of {log_path} \u2500\u2500")
+                for line in tail:
+                    print(f"  \u2502 {line}")
+            print(f"  Full output: {log_path}")
+    except Exception:
+        pass
+    print("  Re-run `hermes update` after resolving the issue above.")
+    raise SystemExit(1)
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
@@ -6537,13 +6572,32 @@ def _install_python_dependencies_with_optional_fallback(
         return
     except subprocess.CalledProcessError:
         print(
-            "  ⚠ Optional extras failed, reinstalling base dependencies and retrying extras individually..."
+            "  \u26a0 Optional extras failed, reinstalling base dependencies and retrying extras individually..."
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        # Non-recoverable: a SubprocessError other than CalledProcessError
+        # (e.g. TimeoutExpired) or an OSError (missing/unexecutable uv|pip
+        # binary, urlretrieve on Termux, disk/permission) escapes the wrapper
+        # recoverable branch. Surface a clean diagnostic instead of leaking
+        # the noisy elided traceback that CPython 3.13 produces.
+        _report_fatal_install_failure(
+            install_cmd_prefix + ["install", "-e", ".[all]"], exc
         )
 
-    _run_install_with_heartbeat(
-        install_cmd_prefix + ["install", "-e", "."],
-        env=env,
-    )
+    try:
+        _run_install_with_heartbeat(
+            install_cmd_prefix + ["install", "-e", "."],
+            env=env,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        # Mandatory base install is fatal — unlike the .[all] branch above,
+        # there is no further fallback. The (SubprocessError, OSError) tuple
+        # covers every documented raise on the install path without
+        # enumerating failure modes, so future build tooling is handled
+        # with no code change.
+        _report_fatal_install_failure(
+            install_cmd_prefix + ["install", "-e", "."], exc
+        )
 
     failed_extras: list[str] = []
     installed_extras: list[str] = []

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -400,6 +400,167 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 
     out = capsys.readouterr().out
     assert "still installing dependencies" in out
+# ---------------------------------------------------------------------------
+# Fatal dependency-install failures surface a clean diagnostic (issue #36247)
+# ---------------------------------------------------------------------------
+
+import hermes_constants
+
+
+def _patch_update_log(monkeypatch, tmp_path, contents: str):
+    """Point ``hermes_constants.get_hermes_home`` at ``tmp_path`` and seed update.log."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "update.log").write_text(contents, encoding="utf-8")
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+
+
+def test_base_install_calledprocesserror_exits_clean_with_log_tail(
+    monkeypatch, tmp_path, capsys
+):
+    """Fatal base-deps CalledProcessError exits(1), echoes the log tail, no traceback."""
+    _patch_update_log(monkeypatch, tmp_path, "Building wheel for cffi\n  gcc: not found\n")
+    monkeypatch.setattr(
+        hermes_main, "_run_install_with_heartbeat",
+        lambda cmd, **kw: (_ for _ in ()).throw(CalledProcessError(1, cmd)),
+    )
+    monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda: [])
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._install_python_dependencies_with_optional_fallback(
+            ["/usr/bin/uv", "pip"]
+        )
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Update failed installing base dependencies" in out
+    assert "CalledProcessError" in out
+    assert "gcc" in out
+    assert "Full output:" in out
+    # No Python traceback should leak when SystemExit is the exit channel.
+    assert "Traceback" not in out
+    assert "...<N lines>..." not in out  # CPython 3.13 source-context elision
+
+
+def test_base_install_oserror_is_diagnosed_not_leaked(monkeypatch, tmp_path, capsys):
+    """Non-CalledProcessError (e.g. missing binary) is diagnosed identically."""
+    _patch_update_log(monkeypatch, tmp_path, "uv: command not found\n")
+    monkeypatch.setattr(
+        hermes_main, "_run_install_with_heartbeat",
+        lambda cmd, **kw: (_ for _ in ()).throw(FileNotFoundError(2, "nope", "uv")),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._install_python_dependencies_with_optional_fallback(
+            ["/usr/bin/uv", "pip"]
+        )
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Update failed installing base dependencies" in out
+    assert "FileNotFoundError" in out
+    assert "Traceback" not in out
+
+
+def test_recoverable_extras_failure_still_falls_back(monkeypatch, tmp_path):
+    """Regression guard: .[all] CalledProcessError still retries extras, no exit."""
+    calls = []
+
+    def fake_run_with_heartbeat(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == ".[all]":
+            raise CalledProcessError(returncode=1, cmd=cmd)
+
+    monkeypatch.setattr(
+        hermes_main, "_run_install_with_heartbeat", fake_run_with_heartbeat
+    )
+    monkeypatch.setattr(
+        hermes_main, "_load_installable_optional_extras", lambda: ["mcp"]
+    )
+
+    hermes_main._install_python_dependencies_with_optional_fallback(
+        ["/usr/bin/uv", "pip"]
+    )
+
+    assert calls == [
+        ["/usr/bin/uv", "pip", "install", "-e", ".[all]"],
+        ["/usr/bin/uv", "pip", "install", "-e", "."],
+        ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"],
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Current-flow regression — wrapper path + update.log cleanup after SystemExit
+# ---------------------------------------------------------------------------
+
+def test_fatal_install_cleans_up_update_log_after_systemexit(monkeypatch, tmp_path, capsys):
+    """Current-flow regression (teknium1 review, issue #36247).
+
+    Exercises the wrapper path end-to-end and confirms that after
+    ``SystemExit(1)`` is raised by ``_report_fatal_install_failure`` (via
+    ``_install_python_dependencies_with_optional_fallback`` → ``_run_install_with_heartbeat``
+    → fatal branch), the already-persisted ``update.log`` tail is still readable and echoed in
+    the diagnostic stdout. Guards two properties the original PR's per-site tests did not cover:
+
+      1. The wrapper path does not swallow the live-streamed log content when it raises SystemExit.
+      2. The diagnostic helper does not crash when ``update.log`` exists but was only partially
+         written (e.g. pip was killed mid-build) — the ``errors='replace'`` decode + ``splitlines()[-30:]``
+         slice must handle a short or truncated log without raising.
+    """
+    # Seed a short (unterminated) log emulating pip being killed mid-build.
+    _patch_update_log(monkeypatch, tmp_path, "Building cffi… killed mid-compile")
+
+    # First .[all] attempt fails with a non-recoverable OSError exercising the wrapper's fatal
+    # branch (not the recoverable CalledProcessError path).
+    monkeypatch.setattr(
+        hermes_main, "_run_install_with_heartbeat",
+        lambda cmd, **kw: (_ for _ in ()).throw(OSError("uv not executable")),
+    )
+    monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda: [])
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._install_python_dependencies_with_optional_fallback(
+            ["/usr/bin/uv", "pip"]
+        )
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    # The diagnostic must echo the truncated log's single line.
+    assert "last 1 lines of" in out
+    assert "killed mid-compile" in out
+    assert "OSError" in out
+    assert "Traceback" not in out
+
+
+def test_fatal_install_does_not_crash_when_update_log_absent(monkeypatch, tmp_path, capsys):
+    """No update.log present → helper skips tail echo and still exits cleanly.
+
+    Guards the bare ``log_path.is_file()`` branch: a fresh install (no prior
+    ``hermes update`` runs) will not have created ``~/.hermes/logs/update.log`` yet,
+    so the diagnostic must not raise when reading it.
+    """
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    # Note: tmp_path / "logs" / "update.log" is intentionally NOT created.
+    monkeypatch.setattr(
+        hermes_main, "_run_install_with_heartbeat",
+        lambda cmd, **kw: (_ for _ in ()).throw(PermissionError("disk full")),
+    )
+    monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda: [])
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._install_python_dependencies_with_optional_fallback(
+            ["/usr/bin/uv", "pip"]
+        )
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Update failed installing base dependencies" in out
+    assert "PermissionError" in out
+    # No log-tail section should appear when the log is absent.
+    assert "last" not in out
+    assert "Full output:" not in out
+    assert "Traceback" not in out
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Make `hermes update` surface a clean, actionable diagnostic when dependency installation fails fatally, instead of leaking a noisy Python traceback (source-context-elided on Python 3.13, the `...<N lines>...` form).

## Related Issue

Fixes #36247

## Type

- [x] Bug fix

## Root cause

The reporter's literal symptom — a truncated/elided traceback on a cffi build failure — is downstream of a structural gap, not a traceback-formatting problem. Two findings from tracing the update path on current `main`:

1. **The `...<N lines>...` is not hermes truncating anything.** It is CPython 3.13's `traceback.StackSummary.format_frame_summary` eliding the middle source lines of a multi-line statement frame (introduced in 3.13; absent on the repo-pinned 3.12). It is purely cosmetic display of the *wrapper* call frames and never hides the pip/build error itself, which streams to the terminal and is mirrored to `~/.hermes/logs/update.log`. So `--tb=long` (a pytest flag, not in this code path) would not help and is not implementable here.

2. **The real defect:** `_install_python_dependencies_with_optional_fallback` owns the recoverable-vs-fatal install decision but only instruments the *recoverable* branch (a bad optional extra → retry individually). The **fatal** base-deps install (`pip install -e .`) was unguarded, and the only backstop was a distant generic handler that (a) caught **only** `CalledProcessError` — so `OSError`/`FileNotFoundError`/`URLError` from a missing-binary or Termux `urlretrieve` path escaped to the default excepthook and produced the elided traceback — and (b) when it did catch, printed a content-free `returned non-zero exit status 1` while the actual error sat unused in `update.log`.

## Changes

- Add `_report_fatal_install_failure(cmd, exc)`: prints a clean banner naming the failed command, echoes the tail of `~/.hermes/logs/update.log` (where the real build error already streamed) inline so the user sees the cause without opening a file, points at the full log, and exits via `SystemExit(1)` — which propagates cleanly through the existing outer handlers without dumping a wrapper traceback.
- Wrap both fatal install sites in `_install_python_dependencies_with_optional_fallback` (the initial `.[group]` non-recoverable escape and the mandatory base-deps install) with `except (subprocess.SubprocessError, OSError)`. This one tuple covers every documented raise on the install path (`CalledProcessError`, `TimeoutExpired`, `URLError`, `FileNotFoundError`, `PermissionError`) **without enumerating failure modes**, so future build tooling is handled with no code change.
- The recoverable path (a `CalledProcessError` on `.[all]` → fall back to base + retry extras individually) is unchanged; a regression test guards it.

No change to `_run_install_with_heartbeat` — output keeps streaming live (no capture overhead on long Rust/C builds), and the diagnostic reads the already-persisted log post-hoc.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py
```

New tests in `tests/hermes_cli/test_update_autostash.py`:

- `test_base_install_calledprocesserror_exits_clean_with_log_tail` — fatal base-deps `CalledProcessError` exits 1, echoes the seeded `update.log` tail (asserts the real build error text appears), no traceback.
- `test_base_install_oserror_is_diagnosed_not_leaked` — a `FileNotFoundError` (missing `uv`) is diagnosed identically, proving the non-`CalledProcessError` coverage.
- `test_recoverable_extras_failure_still_falls_back` — regression guard: `.[all]` `CalledProcessError` still falls back to base + per-extra retry, does not exit.

Verified manually on Python 3.13.13 (the version that shows the elision): the fatal path now prints the clean banner + log tail + `Full output:` pointer and exits 1 with zero `Traceback`/`...<N lines>...` output.

## Checklist

- [x] Tests pass (`scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py` — 28 passed)
- [x] Added tests covering the fix
- [x] `ruff check` clean on touched files
- [x] PR contains only changes related to this fix
- [x] Tested platform: macOS (Python 3.13.13)
