### PR TITLE
fix: avoid routing Feishu quoted replies into topics

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1092,15 +1092,29 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     return due
 
 
+def _reserve_job_output_file(job_output_dir: Path, timestamp: str) -> Path:
+    """Return a non-existing output path without removing prior runs."""
+    output_file = job_output_dir / f"{timestamp}.md"
+    if not output_file.exists():
+        return output_file
+
+    counter = 2
+    while True:
+        candidate = job_output_dir / f"{timestamp}-{counter}.md"
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
 def save_job_output(job_id: str, output: str):
-    """Save job output to file."""
+    """Save job output to a new file without overwriting existing output."""
     ensure_dirs()
     job_output_dir = _job_output_dir(job_id)
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
     
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
-    output_file = job_output_dir / f"{timestamp}.md"
+    output_file = _reserve_job_output_file(job_output_dir, timestamp)
     
     fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
     try:
@@ -1108,7 +1122,7 @@ def save_job_output(job_id: str, output: str):
             f.write(output)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, output_file)
+        os.link(tmp_path, output_file)
         _secure_file(output_file)
     except BaseException:
         try:
@@ -1116,6 +1130,8 @@ def save_job_output(job_id: str, output: str):
         except OSError:
             pass
         raise
+    else:
+        os.unlink(tmp_path)
     
     return output_file
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -828,6 +828,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
+                if plat == Platform.FEISHU and "quote_threading" in platform_cfg:
+                    bridged["quote_threading"] = platform_cfg["quote_threading"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -94,8 +94,6 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -76,6 +76,45 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     return metadata
 
 
+def _normalize_quote_threading(value) -> str:
+    mode = str(value or "never").strip().lower()
+    if mode in {"never", "group_only", "always"}:
+        return mode
+    logger.warning(
+        "Unknown quote_threading=%r; falling back to 'never'. Valid: never, group_only, always.",
+        value,
+    )
+    return "never"
+
+
+def _send_metadata_for_event(event, config_extra: dict | None = None) -> dict | None:
+    """Build platform metadata for a response to an inbound event."""
+    reply_anchor = _reply_anchor_for_event(event)
+    metadata = _thread_metadata_for_source(event.source, reply_anchor)
+    source = getattr(event, "source", None)
+    if _platform_name(getattr(source, "platform", None)) != "feishu":
+        return metadata
+
+    quote_threading = _normalize_quote_threading((config_extra or {}).get("quote_threading"))
+    if quote_threading == "never":
+        return metadata
+    if getattr(source, "thread_id", None):
+        return metadata
+
+    reply_to_message_id = getattr(event, "reply_to_message_id", None)
+    if not reply_to_message_id:
+        return metadata
+
+    chat_type = str(getattr(source, "chat_type", "") or "").lower()
+    if quote_threading == "group_only" and chat_type not in {"group", "channel", "thread"}:
+        return metadata
+
+    metadata = dict(metadata or {})
+    metadata["feishu_quote_threading"] = quote_threading
+    metadata["reply_to_message_id"] = str(reply_to_message_id)
+    return metadata
+
+
 def _reply_anchor_for_event(event) -> str | None:
     """Return reply_to id for platforms that need reply semantics.
 
@@ -3224,7 +3263,7 @@ class BasePlatformAdapter(ABC):
         current_guard = self._active_sessions.get(session_key)
         command_guard = asyncio.Event()
         self._active_sessions[session_key] = command_guard
-        thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        thread_meta = _send_metadata_for_event(event, self.config.extra)
 
         try:
             response = await self._message_handler(event)
@@ -3339,7 +3378,7 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
-                    _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                    _thread_meta = _send_metadata_for_event(event, self.config.extra)
                     response = await self._message_handler(event)
                     _text, _eph_ttl = self._unwrap_ephemeral(response)
                     if _text:
@@ -3387,9 +3426,7 @@ class BasePlatformAdapter(ABC):
                         self.name, session_key,
                     )
                     try:
-                        _thread_meta = _thread_metadata_for_source(
-                            event.source, _reply_anchor_for_event(event)
-                        )
+                        _thread_meta = _send_metadata_for_event(event, self.config.extra)
                         response = await self._message_handler(event)
                         _text, _eph_ttl = self._unwrap_ephemeral(response)
                         if _text:
@@ -3508,7 +3545,7 @@ class BasePlatformAdapter(ABC):
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
-        _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        _thread_metadata = _send_metadata_for_event(event, self.config.extra)
         _keep_typing_kwargs = {"metadata": _thread_metadata}
         try:
             _keep_typing_sig = inspect.signature(self._keep_typing)
@@ -3860,7 +3897,7 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                _thread_metadata = _send_metadata_for_event(event, self.config.extra)
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3037,7 +3037,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3037,7 +3037,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or None
+        thread_id = self._message_thread_context_id(message)
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
@@ -4001,13 +4001,28 @@ class FeishuAdapter(BasePlatformAdapter):
     # Inbound admission
     # =========================================================================
 
+    @staticmethod
+    def _message_thread_context_id(message: Any) -> Optional[str]:
+        """Return the stable Feishu topic/thread context for an inbound message."""
+        thread_id = getattr(message, "thread_id", None)
+        if thread_id:
+            return str(thread_id)
+        if getattr(message, "chat_type", "p2p") == "p2p":
+            return None
+        for attr in ("root_id", "parent_id", "upper_message_id"):
+            value = getattr(message, attr, None)
+            if value:
+                return str(value)
+        return None
+
     def _admit(self, sender: Any, message: Any) -> Optional[RejectReason]:
         sender_ids = _sender_identity(sender)
         self_ids = frozenset(v for v in (self._bot_open_id, self._bot_user_id) if v)
         is_bot = _is_bot_sender(sender)
         is_group = getattr(message, "chat_type", "p2p") != "p2p"
+        is_thread = bool(self._message_thread_context_id(message))
         chat_id = getattr(message, "chat_id", "") or ""
-        require_mention = is_group and self._require_mention_for(chat_id)
+        require_mention = is_group and not is_thread and self._require_mention_for(chat_id)
 
         # Defensive only — Feishu doesn't echo our outbound back as inbound,
         # and open_id is always populated on both sides.
@@ -4369,9 +4384,14 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
+        if metadata and metadata.get("feishu_quote_threading"):
+            effective_reply_to = metadata.get("reply_to_message_id") or effective_reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
-        reply_in_thread = bool((metadata or {}).get("thread_id"))
+        reply_in_thread = bool(
+            (metadata or {}).get("thread_id")
+            or (metadata or {}).get("feishu_quote_threading")
+        )
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1034,6 +1034,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _normalize_quote_threading,
     _reply_anchor_for_event,
     merge_pending_message_event,
 )
@@ -8794,6 +8795,7 @@ class GatewayRunner:
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
+                event_reply_to_message_id=getattr(event, "reply_to_message_id", None),
                 channel_prompt=event.channel_prompt,
             )
 
@@ -13828,6 +13830,44 @@ class GatewayRunner:
                 metadata["telegram_reply_to_message_id"] = str(anchor)
         return metadata
 
+    def _feishu_status_thread_metadata_for_source(
+        self,
+        source,
+        event_message_id: Optional[str] = None,
+        event_reply_to_message_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build metadata for Feishu status/interim sends to mirror final replies."""
+        metadata = self._thread_metadata_for_source(source, event_message_id)
+        platform_cfg = self.config.platforms.get(source.platform) if self.config else None
+        quote_threading = _normalize_quote_threading(
+            (getattr(platform_cfg, "extra", None) or {}).get("quote_threading")
+            if platform_cfg
+            else None
+        )
+        chat_type = str(getattr(source, "chat_type", "") or "").lower()
+        if (
+            quote_threading != "never"
+            and not getattr(source, "thread_id", None)
+            and event_reply_to_message_id
+            and (quote_threading == "always" or chat_type in {"group", "channel", "thread"})
+        ):
+            metadata = {
+                **(metadata or {}),
+                "feishu_quote_threading": quote_threading,
+                "reply_to_message_id": str(event_reply_to_message_id),
+            }
+        if getattr(source, "thread_id", None) and event_message_id:
+            # Feishu topics only keep messages inside the topic when they are
+            # sent via the reply API with reply_in_thread=true. Status/interim,
+            # approval, and stream-consumer paths usually only receive metadata,
+            # so carry the triggering message id as a Feishu-specific fallback.
+            metadata = {
+                **(metadata or {}),
+                "thread_id": getattr(source, "thread_id", None),
+                "reply_to_message_id": event_message_id,
+            }
+        return metadata
+
     @staticmethod
     def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
         """Return the platform-specific reply anchor for GatewayRunner sends."""
@@ -15892,6 +15932,7 @@ class GatewayRunner:
         run_generation: Optional[int] = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        event_reply_to_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
@@ -16525,15 +16566,12 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
-            # Feishu topics only keep messages inside the topic when they are
-            # sent via the reply API with reply_in_thread=true. Status/interim,
-            # approval, and stream-consumer paths usually only receive metadata,
-            # so carry the triggering message id as a Feishu-specific fallback.
-            _status_thread_metadata: Optional[Dict[str, Any]] = {
-                "thread_id": _progress_thread_id,
-                "reply_to_message_id": event_message_id,
-            }
+        if source.platform == Platform.FEISHU:
+            _status_thread_metadata = self._feishu_status_thread_metadata_for_source(
+                source,
+                event_message_id=event_message_id,
+                event_reply_to_message_id=event_reply_to_message_id,
+            )
         else:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -16,11 +16,19 @@ def make_sender(sender_type: str = "user", open_id: str = "ou_human",
 
 
 def make_message(message_id: str = "om_xxx", chat_type: str = "p2p",
-                 chat_id: str = "oc_1", mentions: Optional[list] = None) -> Any:
+                 chat_id: str = "oc_1", mentions: Optional[list] = None,
+                 thread_id: Optional[str] = None,
+                 root_id: Optional[str] = None,
+                 parent_id: Optional[str] = None,
+                 upper_message_id: Optional[str] = None) -> Any:
     return SimpleNamespace(
         message_id=message_id,
         chat_type=chat_type,
         chat_id=chat_id,
+        thread_id=thread_id,
+        root_id=root_id,
+        parent_id=parent_id,
+        upper_message_id=upper_message_id,
         mentions=mentions,
         content="",
         message_type="text",

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1951,6 +1951,47 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_text, "父消息内容")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_does_not_treat_quote_root_as_topic(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="引用消息内容")
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id="om_quoted_root",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"quote context"}',
+            message_id="om_quote_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_quote_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(event.reply_to_message_id, "om_quoted_root")
+        self.assertEqual(event.reply_to_text, "引用消息内容")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -77,6 +77,25 @@ class TestConfigEnvOverrides(unittest.TestCase):
 
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_feishu_quote_threading_bridged_from_yaml(self):
+        from gateway.config import Platform, load_gateway_config
+
+        with tempfile.TemporaryDirectory() as temp_home:
+            config_path = Path(temp_home) / "config.yaml"
+            config_path.write_text(
+                "feishu:\n"
+                "  quote_threading: group_only\n",
+                encoding="utf-8",
+            )
+            with patch.dict(os.environ, {"HERMES_HOME": temp_home}, clear=True):
+                config = load_gateway_config()
+
+        self.assertEqual(
+            config.platforms[Platform.FEISHU].extra.get("quote_threading"),
+            "group_only",
+        )
+
 
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):
@@ -1463,6 +1482,49 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.text, "/help test")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_uses_root_id_as_thread_context(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            chat_type="group",
+            thread_id=None,
+            root_id="om_topic_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"继续"}',
+            message_id="om_followup",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_followup",
+            )
+        )
+
+        adapter._dispatch_inbound_event.assert_awaited_once()
+        call_args = adapter._dispatch_inbound_event.await_args
+        assert call_args is not None
+        event = call_args.args[0]
+        self.assertEqual(event.source.thread_id, "om_topic_root")
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_text_file_injects_content(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -1991,6 +2053,140 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_message_id, "om_quoted_root")
         self.assertEqual(event.reply_to_text, "引用消息内容")
 
+    def test_send_metadata_defaults_to_quote_context_only_for_feishu_quote(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _send_metadata_for_event
+
+        event = SimpleNamespace(
+            source=SimpleNamespace(
+                platform=Platform.FEISHU,
+                chat_type="group",
+                thread_id=None,
+                message_id="om_current",
+            ),
+            message_id="om_current",
+            reply_to_message_id="om_quoted_root",
+        )
+
+        self.assertIsNone(_send_metadata_for_event(event, {}))
+
+    def test_send_metadata_enables_group_quote_threading_when_configured(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _send_metadata_for_event
+
+        event = SimpleNamespace(
+            source=SimpleNamespace(
+                platform=Platform.FEISHU,
+                chat_type="group",
+                thread_id=None,
+                message_id="om_current",
+            ),
+            message_id="om_current",
+            reply_to_message_id="om_quoted_root",
+        )
+
+        metadata = _send_metadata_for_event(event, {"quote_threading": "group_only"})
+
+        self.assertIsNotNone(metadata)
+        self.assertEqual(metadata["feishu_quote_threading"], "group_only")
+        self.assertEqual(metadata["reply_to_message_id"], "om_quoted_root")
+        self.assertNotIn("thread_id", metadata)
+
+    def test_status_metadata_enables_group_quote_threading_when_configured(self):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: PlatformConfig(
+                    enabled=True,
+                    extra={"quote_threading": "group_only"},
+                )
+            }
+        )
+        source = SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="group",
+            thread_id=None,
+            message_id="om_current",
+        )
+
+        metadata = runner._feishu_status_thread_metadata_for_source(
+            source,
+            event_message_id="om_current",
+            event_reply_to_message_id="om_quoted_root",
+        )
+
+        self.assertIsNotNone(metadata)
+        self.assertEqual(metadata["feishu_quote_threading"], "group_only")
+        self.assertEqual(metadata["reply_to_message_id"], "om_quoted_root")
+        self.assertNotIn("thread_id", metadata)
+
+    def test_status_metadata_group_only_does_not_thread_dm_quotes(self):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: PlatformConfig(
+                    enabled=True,
+                    extra={"quote_threading": "group_only"},
+                )
+            }
+        )
+        source = SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="dm",
+            thread_id=None,
+            message_id="om_current",
+        )
+
+        self.assertIsNone(
+            runner._feishu_status_thread_metadata_for_source(
+                source,
+                event_message_id="om_current",
+                event_reply_to_message_id="om_quoted_root",
+            )
+        )
+
+    def test_send_metadata_group_only_does_not_thread_dm_quotes(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _send_metadata_for_event
+
+        event = SimpleNamespace(
+            source=SimpleNamespace(
+                platform=Platform.FEISHU,
+                chat_type="dm",
+                thread_id=None,
+                message_id="om_current",
+            ),
+            message_id="om_current",
+            reply_to_message_id="om_quoted_root",
+        )
+
+        self.assertIsNone(_send_metadata_for_event(event, {"quote_threading": "group_only"}))
+
+    def test_send_metadata_preserves_existing_feishu_thread_metadata(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _send_metadata_for_event
+
+        event = SimpleNamespace(
+            source=SimpleNamespace(
+                platform=Platform.FEISHU,
+                chat_type="group",
+                thread_id="omt_existing",
+                message_id="om_current",
+            ),
+            message_id="om_current",
+            reply_to_message_id="om_quoted_root",
+        )
+
+        metadata = _send_metadata_for_event(event, {"quote_threading": "group_only"})
+
+        self.assertEqual(metadata, {"thread_id": "omt_existing"})
+
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
@@ -2069,6 +2265,46 @@ class TestAdapterBehavior(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertEqual(captured["request"].message_id, "om_trigger")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_metadata_reply_target_for_quote_threading(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="status update",
+                    reply_to="om_current",
+                    metadata={
+                        "feishu_quote_threading": "group_only",
+                        "reply_to_message_id": "om_quoted_root",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].message_id, "om_quoted_root")
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -333,6 +333,62 @@ _ADMIT_CASES = [
         _admit_case(
             adapter={
                 "bot_open_id": "ou_self",
+                "require_mention": True,
+                "group_policy": "open",
+            },
+            sender={"sender_type": "user", "open_id": "ou_human"},
+            message={"chat_type": "group"},
+            mentions_self=False,
+            expected="group_policy_rejected",
+        ),
+        id="require_mention_true:group_human_no_mention_rejected",
+    ),
+    pytest.param(
+        _admit_case(
+            adapter={
+                "bot_open_id": "ou_self",
+                "require_mention": True,
+                "group_policy": "open",
+            },
+            sender={"sender_type": "user", "open_id": "ou_human"},
+            message={"chat_type": "group", "thread_id": "omt_thread"},
+            mentions_self=False,
+            expected=None,
+        ),
+        id="require_mention_true:thread_human_no_mention_admitted",
+    ),
+    pytest.param(
+        _admit_case(
+            adapter={
+                "bot_open_id": "ou_self",
+                "require_mention": True,
+                "group_policy": "open",
+            },
+            sender={"sender_type": "user", "open_id": "ou_human"},
+            message={"chat_type": "group", "root_id": "om_topic_root"},
+            mentions_self=False,
+            expected=None,
+        ),
+        id="require_mention_true:root_thread_human_no_mention_admitted",
+    ),
+    pytest.param(
+        _admit_case(
+            adapter={
+                "bot_open_id": "ou_self",
+                "require_mention": True,
+                "group_policy": "open",
+            },
+            sender={"sender_type": "user", "open_id": "ou_human"},
+            message={"chat_type": "group", "upper_message_id": "om_topic_root"},
+            mentions_self=False,
+            expected=None,
+        ),
+        id="require_mention_true:upper_message_thread_human_no_mention_admitted",
+    ),
+    pytest.param(
+        _admit_case(
+            adapter={
+                "bot_open_id": "ou_self",
                 "require_mention": False,
                 "group_policy": "open",
             },

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -506,6 +506,21 @@ def test_base_gateway_replies_to_triggering_message_for_telegram_dm_topic():
     assert _reply_anchor_for_event(event) == "463"
 
 
+def test_base_gateway_replies_to_triggering_message_for_feishu_topic():
+    """Feishu topics should reply to the current message, not a quoted parent."""
+    event = SimpleNamespace(
+        message_id="om_current",
+        reply_to_message_id="om_quoted_parent",
+        source=SimpleNamespace(
+            platform=Platform.FEISHU,
+            chat_type="dm",
+            thread_id="omt_topic",
+        ),
+    )
+
+    assert _reply_anchor_for_event(event) == "om_current"
+
+
 @pytest.mark.asyncio
 async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegram_dm_topic(monkeypatch, tmp_path):
     """GatewayRunner's duplicate thread metadata must match the base helper."""


### PR DESCRIPTION
## Summary
- Stop Feishu quoted replies from being routed into topic/thread sessions by removing quoted-message root IDs from generic thread metadata.
- Keep Feishu thread routing based on explicit topic context rather than ordinary quote/reply context.
- Add regression coverage for Feishu quoted replies and Telegram thread fallback behavior.

## Test Plan
- python -m pytest tests/gateway/test_feishu.py tests/gateway/test_telegram_thread_fallback.py -q

## Notes
- Local working tree still has unrelated uncommitted package-lock changes in ui-tui/ and web/; they are not part of this PR.