### PR TITLE
fix(agent): avoid custom keepalive transport for ChatGPT Codex SSE on Windows

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2936,6 +2936,11 @@ class AIAgent:
 
     @staticmethod
     def _build_keepalive_http_client(base_url: str = "") -> Any:
+        # On Windows, httpx's custom HTTPTransport + socket_options path can
+        # starve the ChatGPT Codex SSE stream until the SDK read timeout fires.
+        # Let the OpenAI SDK use its default transport for this endpoint.
+        if os.name == "nt" and base_url_host_matches(str(base_url or ""), "chatgpt.com"):
+            return None
         try:
             import httpx as _httpx
             import socket as _socket


### PR DESCRIPTION
## Summary

- Bypass the custom keepalive `httpx` client for ChatGPT Codex backend requests on native Windows.
- Let the OpenAI SDK use its default transport for `chatgpt.com` Codex requests on Windows.
- Keep the existing custom keepalive transport unchanged for all other hosts and non-Windows platforms.

## Why

Hermes currently builds an OpenAI client with a custom `httpx.Client(transport=httpx.HTTPTransport(socket_options=...))` so socket keepalives can be enabled. On native Windows, that custom transport path can make ChatGPT Codex SSE requests to `https://chatgpt.com/backend-api/codex` stall or fail with `APIConnectionError`. The same Codex account and model work when the OpenAI SDK is allowed to use its default transport.

This is a transport-level compatibility issue, not a user-specific configuration. It was observed with `openai-codex` / `gpt-5.5`, but the affected path is selected by OS and backend host before model-specific behavior, so the scope is the ChatGPT Codex backend on Windows.

## Scope and risk

The change is intentionally narrow:

- only applies when `os.name == "nt"`
- only applies when the configured base URL host matches `chatgpt.com`
- returns `None`, which is already the existing fallback behavior when the custom HTTP client cannot be created
- leaves Linux/macOS and all non-ChatGPT providers on the existing keepalive transport

The tradeoff is losing explicit socket keepalive options only for ChatGPT Codex requests on Windows, which is preferable to making the SSE stream unreliable on that platform.

## Validation

- `python -m py_compile run_agent.py`
- Manual Windows validation with `model.provider=openai-codex`, `model.default=gpt-5.5`, and `base_url=https://chatgpt.com/backend-api/codex`: Hermes no longer hits repeated `APIConnectionError` and returns a normal response.