### PR TITLE
Fix auto compression for tool-heavy sessions

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -547,6 +547,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._last_compression_failure_code = None
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
         self.last_real_prompt_tokens = 0
         self.last_compression_rough_tokens = 0
@@ -661,6 +662,7 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
+        self._last_compression_failure_code: Optional[str] = None
         self._summary_failure_cooldown_until: float = 0.0
         self._last_summary_error: Optional[str] = None
         # When summary generation fails and a static fallback is inserted,
@@ -737,14 +739,22 @@ class ContextCompressor(ContextEngine):
             return False
         # Anti-thrashing: back off if recent compressions were ineffective
         if self._ineffective_compression_count >= 2:
+            self._last_compress_aborted = True
+            self._last_compression_failure_code = "compression_exhausted"
+            self._last_summary_error = (
+                "compression exhausted: repeated compression attempts did not "
+                "materially reduce the context"
+            )
             if not self.quiet_mode:
                 logger.warning(
-                    "Compression skipped — last %d compressions saved <10%% each. "
+                    "Compression exhausted — last %d compressions saved <10%% each. "
+                    "Blocking this turn instead of retrying until context overflow. "
                     "Consider /new to start a fresh session, or /compress <topic> "
                     "for focused compression.",
                     self._ineffective_compression_count,
                 )
             return False
+        self._last_compression_failure_code = None
         return True
 
     # ------------------------------------------------------------------
@@ -855,11 +865,10 @@ class ContextCompressor(ContextEngine):
             else:
                 content_hashes[h] = (i, msg.get("tool_call_id", "?"))
 
-        # Pass 2: Replace old tool results with informative summaries
-        for i in range(prune_boundary):
+        def _summarize_tool_message(i: int) -> bool:
             msg = result[i]
             if msg.get("role") != "tool":
-                continue
+                return False
             content = msg.get("content", "")
             # Multimodal content (base64 screenshots etc.): strip the image
             # payload — keep a lightweight text placeholder in its place.
@@ -869,26 +878,43 @@ class ContextCompressor(ContextEngine):
                 stripped = _strip_image_parts_from_parts(content)
                 if stripped is not None:
                     result[i] = {**msg, "content": stripped}
-                    pruned += 1
-                continue
+                    return True
+                return False
             if isinstance(content, dict) and content.get("_multimodal"):
                 summary = content.get("text_summary") or "[screenshot removed to save context]"
                 result[i] = {**msg, "content": f"[screenshot removed] {summary[:200]}"}
-                pruned += 1
-                continue
+                return True
             if not isinstance(content, str):
-                continue
+                return False
             if not content or content == _PRUNED_TOOL_PLACEHOLDER:
-                continue
+                return False
             # Skip already-deduplicated or previously-summarized results
             if content.startswith("[Duplicate tool output"):
-                continue
+                return False
             # Only prune if the content is substantial (>200 chars)
             if len(content) > 200:
                 call_id = msg.get("tool_call_id", "")
                 tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
                 summary = _summarize_tool_result(tool_name, tool_args, content)
                 result[i] = {**msg, "content": summary}
+                return True
+            return False
+
+        # Pass 2: Replace old tool results with informative summaries
+        for i in range(prune_boundary):
+            if _summarize_tool_message(i):
+                pruned += 1
+
+        # Pass 2b: long single-turn tool chains can put completed tool
+        # results inside the protected tail, including the current final
+        # message before the next LLM call. A role="tool" message is already
+        # completed; still-running tools have no result row to summarize.
+        # Keep provider-legal tool pairing and demote only the raw body.
+        for i in range(prune_boundary, len(result)):
+            msg = result[i]
+            if msg.get("role") != "tool":
+                continue
+            if _summarize_tool_message(i):
                 pruned += 1
 
         # Pass 3: Truncate large tool_call arguments in assistant messages
@@ -1691,7 +1717,9 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     ) -> int:
         """Return the index of the last user-role message at or after *head_end*, or -1."""
         for i in range(len(messages) - 1, head_end - 1, -1):
-            if messages[i].get("role") == "user":
+            if messages[i].get("role") == "user" and not self._is_context_summary_content(
+                messages[i].get("content")
+            ):
                 return i
         return -1
 
@@ -1854,6 +1882,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_compression_failure_code = None
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
@@ -2062,8 +2091,16 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_compression_savings_pct = savings_pct
         if savings_pct < 10:
             self._ineffective_compression_count += 1
+            if self._ineffective_compression_count >= 2:
+                self._last_compress_aborted = True
+                self._last_compression_failure_code = "compression_exhausted"
+                self._last_summary_error = (
+                    "compression exhausted: repeated compression attempts did not "
+                    "materially reduce the context"
+                )
         else:
             self._ineffective_compression_count = 0
+            self._last_compression_failure_code = None
 
         if not self.quiet_mode:
             logger.info(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -108,6 +108,48 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     )
 
 
+def _compression_exhausted_result_if_needed(
+    agent: Any,
+    messages: list,
+    conversation_history: Optional[list],
+    api_call_count: int,
+    prompt_tokens: int,
+) -> Optional[dict]:
+    """Build a terminal compression-exhausted result when no safe progress remains."""
+    compressor = getattr(agent, "context_compressor", None)
+    threshold = int(getattr(compressor, "threshold_tokens", 0) or 0)
+    if threshold <= 0 or int(prompt_tokens or 0) < threshold:
+        return None
+    if getattr(compressor, "_last_compression_failure_code", None) != "compression_exhausted":
+        return None
+
+    flush = getattr(agent, "_flush_status_buffer", None)
+    if callable(flush):
+        flush()
+    err = (
+        getattr(compressor, "_last_summary_error", None)
+        or "Context compression exhausted."
+    )
+    logger.error(
+        "%sPreflight compression exhausted: ~%s tokens still >= %s threshold",
+        getattr(agent, "log_prefix", "") or "",
+        f"{int(prompt_tokens or 0):,}",
+        f"{threshold:,}",
+    )
+    persist = getattr(agent, "_persist_session", None)
+    if callable(persist):
+        persist(messages, conversation_history)
+    return {
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": err,
+        "partial": True,
+        "failed": True,
+        "compression_exhausted": True,
+    }
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -658,6 +700,20 @@ def run_conversation(
                     task_id=effective_task_id,
                 )
                 if len(messages) >= _orig_len:
+                    _preflight_tokens = estimate_request_tokens_rough(
+                        messages,
+                        system_prompt=active_system_prompt or "",
+                        tools=agent.tools or None,
+                    )
+                    _exhausted_result = _compression_exhausted_result_if_needed(
+                        agent,
+                        messages,
+                        conversation_history,
+                        api_call_count,
+                        _preflight_tokens,
+                    )
+                    if _exhausted_result is not None:
+                        return _exhausted_result
                     break  # Cannot compress further
                 # Compression created a new session — clear the history
                 # reference so _flush_messages_to_session_db writes ALL
@@ -682,6 +738,15 @@ def run_conversation(
                     tools=agent.tools or None,
                 )
                 if not _compressor.should_compress(_preflight_tokens):
+                    _exhausted_result = _compression_exhausted_result_if_needed(
+                        agent,
+                        messages,
+                        conversation_history,
+                        api_call_count,
+                        _preflight_tokens,
+                    )
+                    if _exhausted_result is not None:
+                        return _exhausted_result
                     break  # Under threshold or anti-thrash guard stopped it
 
     # Plugin hook: pre_llm_call

--- a/tests/test_auto_compression_tool_heavy_tail.py
+++ b/tests/test_auto_compression_tool_heavy_tail.py
@@ -1,0 +1,186 @@
+"""Regression tests for tool-heavy auto-compression tails."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent.conversation_loop import _compression_exhausted_result_if_needed
+from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+
+
+def _compressor() -> ContextCompressor:
+    c = ContextCompressor(
+        model="test-model",
+        config_context_length=200_000,
+        protect_first_n=1,
+        protect_last_n=20,
+        summary_target_ratio=0.10,
+        quiet_mode=True,
+    )
+    c.threshold_tokens = 10_000
+    c.tail_token_budget = 400
+    c.max_summary_tokens = 2_000
+    return c
+
+
+def _tool_pair(i: int, *, size: int = 8_000) -> list[dict]:
+    call_id = f"call_{i}"
+    return [
+        {
+            "role": "assistant",
+            "content": f"Progress checkpoint {i}: inspecting tool output.",
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": f'{{"path":"/tmp/file_{i}.txt"}}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": f"file_{i}.txt\n" + ("raw tool output\n" * size),
+        },
+    ]
+
+
+def test_tool_heavy_tail_demotes_completed_tool_results_to_evidence(monkeypatch):
+    c = _compressor()
+    monkeypatch.setattr(c, "_generate_summary", lambda turns, focus_topic=None: SUMMARY_PREFIX + "summary")
+
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Inspect many files and keep me posted."},
+    ]
+    for i in range(12):
+        messages.extend(_tool_pair(i, size=900))
+    messages.append(
+        {
+            "role": "assistant",
+            "content": "I have inspected the files and am preparing the final answer.",
+        }
+    )
+
+    compressed = c.compress(messages, current_tokens=80_000)
+
+    tool_messages = [m for m in compressed if m.get("role") == "tool"]
+    assert tool_messages
+    assert all(len(str(m.get("content") or "")) < 1_000 for m in tool_messages)
+    assert any(
+        "preparing the final answer" in str(m.get("content") or "")
+        for m in compressed
+        if m.get("role") == "assistant"
+    )
+
+
+def test_tail_completed_tool_result_without_later_assistant_is_summarized(monkeypatch):
+    c = _compressor()
+    monkeypatch.setattr(c, "_generate_summary", lambda turns, focus_topic=None: SUMMARY_PREFIX + "summary")
+
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Read the large file, then answer."},
+    ]
+    for i in range(4):
+        messages.extend(_tool_pair(i, size=200))
+    messages.extend([
+        {
+            "role": "assistant",
+            "content": "I will inspect the file now.",
+            "tool_calls": [
+                {
+                    "id": "call_final",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"/tmp/final.txt"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_final",
+            "content": "final.txt\n" + ("large raw result\n" * 1_000),
+        },
+    ])
+
+    compressed = c.compress(messages, current_tokens=80_000)
+
+    final_tool = compressed[-1]
+    assert final_tool["role"] == "tool"
+    assert final_tool["tool_call_id"] == "call_final"
+    assert "[read_file] read /tmp/final.txt" in final_tool["content"]
+    assert "large raw result" not in final_tool["content"]
+    assert any(
+        m.get("role") == "assistant"
+        and any(tc.get("id") == "call_final" for tc in m.get("tool_calls", []))
+        for m in compressed
+    )
+
+
+def test_reference_only_context_marker_is_not_latest_user_tail_anchor():
+    c = _compressor()
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Real current task."},
+        {"role": "assistant", "content": "Working on it."},
+        {"role": "user", "content": SUMMARY_PREFIX + "\n## Active Task\nOld compacted task."},
+        {"role": "assistant", "content": "Continuing from real task."},
+    ]
+
+    assert c._find_last_user_message_idx(messages, head_end=1) == 1
+
+
+def test_repeated_ineffective_compression_marks_exhausted_before_retry():
+    c = _compressor()
+    c._ineffective_compression_count = 2
+
+    assert c.should_compress(c.threshold_tokens + 1) is False
+    assert c._last_compress_aborted is True
+    assert c._last_compression_failure_code == "compression_exhausted"
+
+
+def test_noop_preflight_compression_result_returns_compression_exhausted():
+    persisted = []
+    agent = SimpleNamespace(
+        log_prefix="",
+        context_compressor=SimpleNamespace(
+            threshold_tokens=10_000,
+            _last_compression_failure_code="compression_exhausted",
+            _last_summary_error="compression exhausted: no material reduction",
+        ),
+        _flush_status_buffer=lambda: None,
+        _persist_session=lambda messages, history: persisted.append((messages, history)),
+    )
+    messages = [{"role": "user", "content": "still too large"}]
+
+    result = _compression_exhausted_result_if_needed(
+        agent,
+        messages,
+        conversation_history=["previous"],
+        api_call_count=2,
+        prompt_tokens=12_000,
+    )
+
+    assert result is not None
+    assert result["failed"] is True
+    assert result["partial"] is True
+    assert result["compression_exhausted"] is True
+    assert result["messages"] == messages
+    assert persisted == [(messages, ["previous"])]
+
+
+def test_noop_preflight_compression_branch_checks_exhausted_before_break():
+    src = Path("agent/conversation_loop.py").read_text(encoding="utf-8")
+    noop_idx = src.find("if len(messages) >= _orig_len:")
+    exhausted_idx = src.find("_compression_exhausted_result_if_needed", noop_idx)
+    break_idx = src.find("break  # Cannot compress further", noop_idx)
+
+    assert noop_idx != -1
+    assert exhausted_idx != -1
+    assert break_idx != -1
+    assert noop_idx < exhausted_idx < break_idx


### PR DESCRIPTION
## Summary

Long single-turn, tool-heavy sessions could repeatedly auto-compress without materially reducing context. Completed tool results in the protected tail could remain large, internal context-compaction markers could be treated like real user anchors, and repeated no-op compression could continue until the provider rejected the oversized context.

This PR makes auto compression fail explicitly when it is exhausted and demotes completed tool results to concise evidence summaries, including completed tool results at the current tail before the next LLM call.

## Changes

- Demotes completed `tool` result bodies to concise evidence summaries even when they sit in the current protected tail.
- Keeps provider-legal assistant/tool pairing while replacing only completed raw tool bodies.
- Skips context-compaction reference markers when finding the latest real user tail anchor.
- Tracks repeated ineffective compression attempts and marks them as `compression_exhausted`.
- Returns an explicit failed/partial/compression_exhausted result during preflight when compression leaves messages/tokens effectively unchanged.
- Adds regression tests for tool-heavy tail summarization, marker-anchor handling, ineffective compression exhaustion, and preflight no-op exhaustion.

## Verification

- `python -m pytest tests/test_auto_compression_tool_heavy_tail.py tests/run_agent/test_1630_context_overflow_loop.py tests/run_agent/test_compression_trigger_excludes_reasoning.py tests/test_ctx_halving_fix.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_compression_boundary.py -q`
- `git diff --check`

## Related

- Related to NousResearch/hermes-agent#36624.
- Companion WebUI issue: nesquena/hermes-webui#3315.
- Companion WebUI PR: nesquena/hermes-webui#3316.

## Risks / Follow-ups

- The branch is currently behind upstream `main` by one commit; no rebase was performed before publishing to avoid changing the already-validated branch state.
- Tool result summarization is intentionally limited to completed `role=tool` messages; running tools have no result row to summarize.

## Model Used

AI-assisted implementation with OpenAI GPT-5 Codex in a local coding workflow. The assistant inspected repository code, wrote regression tests, implemented the fix, and ran the verification commands above.
