### PR TITLE
docs: replace invalid config get examples

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/migrate-from-openclaw.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/migrate-from-openclaw.md
@@ -225,7 +225,7 @@ OpenClaw 配置中 token 和 API 密钥的值支持三种格式：
 
 5. **测试消息平台** — 若迁移了平台 token，重启 gateway：`systemctl --user restart hermes-gateway`
 
-6. **检查会话策略** — 验证 `hermes config get session_reset` 是否符合预期。
+6. **检查会话策略** — 运行 `hermes config show` 并确认 `session_reset` 设置符合预期。
 
 7. **重新配对 WhatsApp** — WhatsApp 使用二维码配对（Baileys），不支持 token 迁移。运行 `hermes whatsapp` 进行配对。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/work-with-skills.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/work-with-skills.md
@@ -161,8 +161,8 @@ metadata:
 # 对特定 skill 进行交互式配置
 hermes skills config gif-search
 
-# 查看所有 skill 配置
-hermes config get skills.config
+# 查看完整配置并定位 skill 配置
+hermes config show | grep -A20 '^skills:'
 ```
 
 ---

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuring-models.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuring-models.md
@@ -196,7 +196,7 @@ hermes model            # 交互式提供商 + 模型选择器（切换默认值
 
 `hermes model` 引导你选择提供商、完成认证（OAuth 流程会打开浏览器；API key 提供商会提示输入密钥），然后从该提供商的精选目录中选择具体模型。选择结果写入 `~/.hermes/config.yaml` 的 `model.provider` 和 `model.model` 字段。
 
-如需在不启动选择器的情况下列出提供商/模型，请使用仪表板或下方的 REST 端点。查看 CLI 当前实际使用的配置：`hermes config get model` 和 `hermes status`。
+如需在不启动选择器的情况下列出提供商/模型，请使用仪表板或下方的 REST 端点。查看 CLI 当前实际使用的配置：`hermes config show` 和 `hermes status`。
 
 ### 直接编辑配置文件
 


### PR DESCRIPTION
## Summary
- Replace stale `hermes config get ...` examples with valid `hermes config show` usage
- Update the remaining zh-Hans docs references so translated docs do not point users at a nonexistent subcommand

Fixes #30195

## Test Plan
- `hermes config --help`
- `hermes config show --help`
- `! git grep -n "hermes config get" -- '*.md'`
- `git diff --check`
