### PR TITLE
docs: document profile no-skills flag

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -199,7 +199,7 @@ patterns: `skill_view(name="hermes-agent", file_path="references/webhooks.md")`.
 
 ```
 hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
+hermes profile create NAME  Create (--clone, --clone-all, --clone-from, --no-skills)
 hermes profile use NAME     Set sticky default
 hermes profile delete NAME  Delete a profile
 hermes profile show NAME    Show details

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -216,7 +216,7 @@ patterns: `skill_view(name="hermes-agent", file_path="references/webhooks.md")`.
 
 ```
 hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
+hermes profile create NAME  Create (--clone, --clone-all, --clone-from, --no-skills)
 hermes profile use NAME     Set sticky default
 hermes profile delete NAME  Delete a profile
 hermes profile show NAME    Show details

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -209,7 +209,7 @@ hermes webhook test NAME    Send a test POST
 
 ```
 hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
+hermes profile create NAME  Create (--clone, --clone-all, --clone-from, --no-skills)
 hermes profile use NAME     Set sticky default
 hermes profile delete NAME  Delete a profile
 hermes profile show NAME    Show details


### PR DESCRIPTION
## Summary
- Add `--no-skills` to the bundled Hermes Agent skill command reference
- Update generated bundled-skill docs and zh-Hans docs to match
- Correct the documented opt-out marker from `.no-skills` to the actual `.no-bundled-skills`

Fixes #26446

## Test Plan
- `! git grep -n "\\.no-skills" -- '*.md'`
- `git grep -n "profile create NAME  Create (--clone, --clone-all, --clone-from)" -- '*.md'` returns no stale exact references
- `git diff --check`
