### PR TITLE
fix(gateway): emit clear error when no provider credentials are configured

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4339,6 +4339,28 @@ class GatewayRunner:
         enabled_platform_count = 0
         startup_nonretryable_errors: list[str] = []
         startup_retryable_errors: list[str] = []
+
+        # Pre-flight provider credential check (#36277): detect missing
+        # API keys early and emit a clear, actionable error instead of
+        # silently running (and failing on every message).
+        _provider_ok = False
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            _rt = resolve_runtime_provider()
+            _provider_ok = bool((_rt or {}).get("api_key", "").strip())
+        except Exception as _pe:
+            logger.debug("Provider pre-flight check failed: %s", _pe)
+        if not _provider_ok:
+            _msg = (
+                "No valid model provider credentials detected. "
+                "Set an API key (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY) "
+                "in ~/.hermes/.env or run 'hermes setup' before starting "
+                "the gateway."
+            )
+            # Print to stderr so it's visible even when log level swallows
+            # the logger.warning below (e.g. Docker stdout-only capture).
+            print(f"ERROR: {_msg}", file=sys.stderr)
+            logger.warning(_msg)
         
         # Initialize and connect each configured platform
         for platform, platform_config in self.config.platforms.items():


### PR DESCRIPTION
## Problem

When the gateway starts without a valid model provider (no API key configured), it either:
- Exits silently with no error message, or  
- Runs but fails on every message with no actionable diagnostic

In Docker deployments, `curl http://localhost:<port>` returns `Connection reset by peer` with no explanation. Operators have no way to know why the gateway isn't working.

The startup path has per-platform "not configured" warnings for Telegram/Discord/etc., but **no top-level check for LLM provider credentials**.

## Fix

Added a pre-flight provider credential check at the start of `GatewayRunner.start()`:

1. Calls `resolve_runtime_provider()` to probe for available credentials
2. If no `api_key` is found, prints a **prominent `ERROR:` to stderr** and logs a `WARNING`
3. The message is actionable: tells the operator to set an API key or run `hermes setup`
4. Gateway continues running (so cron jobs still work) but the operator gets a clear diagnostic

The stderr print ensures visibility even when:
- Docker captures stdout only
- Log level is set above WARNING
- systemd journal shows stderr separately

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| No API key + Docker | Silent exit / "Connection reset" | `ERROR: No valid model provider credentials detected...` |
| No API key + systemd | Silent failure in journal | Clear WARNING in journal + stderr |
| No API key + cron-only | Works silently | Works with warning (expected) |

Fixes #36277