### PR TITLE
fix(banner): honor display.show_update_banner config and surface docker upgrade command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5137,6 +5137,7 @@ class HermesCLI:
                 enabled_toolsets=self.enabled_toolsets,
                 session_id=self.session_id,
                 context_length=ctx_len,
+                show_update_banner=self.config.get("display", {}).get("show_update_banner", True),
             )
         
         # Tool discovery is intentionally deferred on the Termux bare prompt
@@ -8480,6 +8481,7 @@ class HermesCLI:
                         enabled_toolsets=self.enabled_toolsets,
                         session_id=self.session_id,
                         context_length=ctx_len,
+                        show_update_banner=self.config.get("display", {}).get("show_update_banner", True),
                     )
                 _cprint("  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n")
                 # Show a random tip on new session

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -480,7 +480,8 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                          enabled_toolsets: List[str] = None,
                          session_id: str = None,
                          get_toolset_for_tool=None,
-                         context_length: int = None):
+                         context_length: int = None,
+                         show_update_banner: bool = True):
     """Build and print a welcome banner with caduceus on left and info on right.
 
     Args:
@@ -682,42 +683,48 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     right_lines.append(f"[dim {dim}]{' · '.join(summary_parts)}[/]")
 
     # Update check — use prefetched result if available
-    try:
-        behind = get_update_result(timeout=0.5)
-        if behind is not None and behind != 0:
-            from hermes_cli.config import get_managed_update_command, recommended_update_command
-            if behind > 0:
-                commits_word = "commit" if behind == 1 else "commits"
-                right_lines.append(
-                    f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
-                    f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
-                )
-            else:
-                # UPDATE_AVAILABLE_NO_COUNT: nix-built hermes; we know an update
-                # exists but not by how much, and we don't know how the user
-                # installed it (nix run, profile, system flake, home-manager).
-                managed_cmd = get_managed_update_command()
-                line = "[bold yellow]⚠ update available[/]"
-                if managed_cmd:
-                    line += f"[dim yellow] — run [bold]{managed_cmd}[/bold][/]"
-                right_lines.append(line)
-    except Exception:
-        pass  # Never break the banner over an update check
+    if show_update_banner:
+        try:
+            behind = get_update_result(timeout=0.5)
+            if behind is not None and behind != 0:
+                from hermes_cli.config import get_managed_update_command, recommended_update_command
+                if behind > 0:
+                    commits_word = "commit" if behind == 1 else "commits"
+                    right_lines.append(
+                        f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
+                        f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
+                    )
+                else:
+                    # UPDATE_AVAILABLE_NO_COUNT: nix-built hermes; we know an update
+                    # exists but not by how much, and we don't know how the user
+                    # installed it (nix run, profile, system flake, home-manager).
+                    managed_cmd = get_managed_update_command()
+                    line = "[bold yellow]⚠ update available[/]"
+                    if managed_cmd:
+                        line += f"[dim yellow] — run [bold]{managed_cmd}[/bold][/]"
+                    else:
+                        fallback_cmd = recommended_update_command()
+                        if fallback_cmd and fallback_cmd.strip().lower() != "hermes update":
+                            line += f"[dim yellow] — run [bold]{fallback_cmd}[/bold] to update[/]"
+                    right_lines.append(line)
+        except Exception:
+            pass  # Never break the banner over an update check
 
     # Pip-install warning — `pip install hermes-agent` is not the supported
     # install path (it exists on PyPI for internal/CI reasons, not end users).
     # Such installs miss the git checkout + installer-managed deps, so updates,
     # self-update, and issue triage don't behave correctly. Warn, don't block.
-    try:
-        from hermes_cli.config import detect_install_method
-        if detect_install_method() == "pip":
-            right_lines.append(
-                "[bold yellow]⚠ pip install not officially supported[/]"
-                "[dim yellow] — exists for reasons other than user install; "
-                "expect instability and an inability to support issues[/]"
-            )
-    except Exception:
-        pass  # Never break the banner over the install-method check
+    if show_update_banner:
+        try:
+            from hermes_cli.config import detect_install_method
+            if detect_install_method() == "pip":
+                right_lines.append(
+                    "[bold yellow]⚠ pip install not officially supported[/]"
+                    "[dim yellow] — exists for reasons other than user install; "
+                    "expect instability and an inability to support issues[/]"
+                )
+        except Exception:
+            pass  # Never break the banner over the install-method check
 
     right_content = "\n".join(right_lines)
     layout_table.add_row(left_content, right_content)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1267,6 +1267,11 @@ DEFAULT_CONFIG = {
     
     "display": {
         "compact": False,
+        # When False, suppress the startup update-available banner entirely
+        # (the "commits behind" / "update available" / pip-install warning
+        # lines). Useful for docker / managed installs where the user can't
+        # act on the suggestion in-place.
+        "show_update_banner": True,
         "personality": "",
         "resume_display": "full",
         # Recap tuning for /resume and startup resume. The defaults match the

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -133,3 +133,64 @@ def test_build_welcome_banner_title_falls_back_when_no_tag():
     raw = buf.getvalue()
     assert "Hermes Agent v" in raw, "Version label missing from title"
     assert "\x1b]8;" not in raw, "OSC-8 hyperlink should not be emitted without a tag"
+
+
+def _render_banner(show_update_banner=True, update_result=None, install_method="git"):
+    """Helper: render a banner with controlled update-check + install-method state."""
+    import hermes_cli.banner as _banner
+    import hermes_cli.config as _config
+    import model_tools as _mt
+    import tools.mcp_tool as _mcp
+
+    with (
+        patch.object(_mt, "check_tool_availability", return_value=(["web"], [])),
+        patch.object(_banner, "get_available_skills", return_value={}),
+        patch.object(_banner, "get_update_result", return_value=update_result),
+        patch.object(_mcp, "get_mcp_status", return_value=[]),
+        patch.object(_config, "detect_install_method", return_value=install_method),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        _banner.build_welcome_banner(
+            console=console,
+            model="x",
+            cwd="/tmp",
+            session_id="abc123",
+            tools=[{"function": {"name": "read_file"}}],
+            get_toolset_for_tool=lambda n: "file",
+            show_update_banner=show_update_banner,
+        )
+    return console.export_text()
+
+
+def test_show_update_banner_false_suppresses_update_line():
+    """When show_update_banner=False, the update-available line is not rendered."""
+    output = _render_banner(
+        show_update_banner=False,
+        update_result=banner.UPDATE_AVAILABLE_NO_COUNT,
+        install_method="docker",
+    )
+    assert "update available" not in output
+    assert "commits behind" not in output
+    assert "pip install not officially supported" not in output
+
+
+def test_show_update_banner_true_renders_update_line():
+    """Default (True) still renders the update line."""
+    output = _render_banner(
+        show_update_banner=True,
+        update_result=banner.UPDATE_AVAILABLE_NO_COUNT,
+        install_method="docker",
+    )
+    assert "update available" in output
+
+
+def test_no_count_branch_docker_includes_pull_command():
+    """For docker installs, the no-count branch falls back to recommended_update_command()."""
+    import hermes_cli.config as _config
+    with patch.object(_config, "get_managed_update_command", return_value=None):
+        output = _render_banner(
+            show_update_banner=True,
+            update_result=banner.UPDATE_AVAILABLE_NO_COUNT,
+            install_method="docker",
+        )
+    assert "docker pull nousresearch/hermes-agent:latest" in output


### PR DESCRIPTION
## Summary

Fixes #36287.

The display.show_update_banner config key was silently ignored — it was never in DEFAULT_CONFIG and build_welcome_banner() did not check it, so there was no way to suppress the startup banner. Additionally, on Docker installs the UPDATE_AVAILABLE_NO_COUNT branch rendered a bare "update available" line with no actionable command (because get_managed_update_command() only returns a value for Homebrew / NixOS).

## Changes

- hermes_cli/config.py: add display.show_update_banner: True to DEFAULT_CONFIG with an explanatory comment.
- hermes_cli/banner.py: build_welcome_banner() now takes a show_update_banner: bool = True kwarg. When False, both the version-check block and the pip-install warning block are skipped entirely. In the UPDATE_AVAILABLE_NO_COUNT branch, when managed_cmd is None, fall back to recommended_update_command() so Docker / pip / uv-tool users get a useful command (the generic sentinel is filtered out).
- cli.py: both call sites of build_welcome_banner now read and forward the config value: show_update_banner=self.config.get("display", {}).get("show_update_banner", True).
- tests/hermes_cli/test_banner.py: 3 new tests:
  1. show_update_banner=False suppresses the line (with get_update_result mocked to return -1).
  2. Default (True) still renders it.
  3. No-count branch on Docker install (no managed_cmd) includes the docker pull command.

The new kwarg defaults to True, preserving existing behavior for all callers.

## Validation

python -m pytest tests/hermes_cli/test_banner.py tests/hermes_cli/test_pip_install_detection.py -q  ->  19 passed

Reviewed by codex: APPROVE, no issues found.
