### PR TITLE
feat(media): add cheap audio model controls

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -71,9 +71,11 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'context.engine': ['compressor', 'default', 'custom'],
   'delegation.reasoning_effort': ['', 'minimal', 'low', 'medium', 'high', 'xhigh'],
   'memory.provider': ['', 'builtin', 'honcho'],
+  'stt.openai.model': ['gpt-audio-mini', 'whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe'],
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
-  'tts.openai.voice': ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer']
+  'tts.openai.voice': ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer', 'ash', 'ballad', 'coral', 'sage', 'verse', 'cedar'],
+  'tts.gemini.voice': ['Kore', 'Puck', 'Charon', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr']
 }
 
 export const FIELD_LABELS: Record<string, string> = {
@@ -113,6 +115,8 @@ export const FIELD_LABELS: Record<string, string> = {
   'stt.provider': 'Speech-To-Text Provider',
   'stt.local.model': 'Local Transcription Model',
   'stt.local.language': 'Transcription Language',
+  'stt.openai.model': 'OpenAI STT Model',
+  'stt.openai.prompt': 'OpenAI STT Prompt',
   'stt.elevenlabs.model_id': 'ElevenLabs STT Model',
   'stt.elevenlabs.language_code': 'ElevenLabs Language',
   'stt.elevenlabs.tag_audio_events': 'Tag Audio Events',
@@ -121,6 +125,10 @@ export const FIELD_LABELS: Record<string, string> = {
   'tts.edge.voice': 'Edge Voice',
   'tts.openai.model': 'OpenAI TTS Model',
   'tts.openai.voice': 'OpenAI Voice',
+  'tts.openai.instructions': 'OpenAI Voice Instructions',
+  'tts.gemini.model': 'Gemini TTS Model',
+  'tts.gemini.voice': 'Gemini Voice',
+  'tts.gemini.style': 'Gemini Voice Style',
   'tts.elevenlabs.voice_id': 'ElevenLabs Voice',
   'tts.elevenlabs.model_id': 'ElevenLabs Model',
   'memory.memory_enabled': 'Persistent Memory',

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -816,7 +816,7 @@ platform_toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe)
+# Providers: local (free, faster-whisper) | groq (free tier) | openai (quality/cheap audio models) | mistral (Voxtral Transcribe)
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
@@ -825,7 +825,8 @@ stt:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo
     # language: ""             # auto-detect; set to "en", "es", "fr", etc. to force
   openai:
-    model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+    model: "gpt-audio-mini"     # gpt-audio-mini | whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+    # prompt: ""                # optional transcription style/context hint
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1438,7 +1438,8 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
-            # Voices: alloy, echo, fable, onyx, nova, shimmer
+            "instructions": "",  # Optional speaking style prompt passed to OpenAI TTS
+            # Voices: alloy, echo, fable, onyx, nova, shimmer, ash, ballad, coral, sage, verse, cedar
         },
         "xai": {
             "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices
@@ -1449,6 +1450,11 @@ DEFAULT_CONFIG = {
         "mistral": {
             "model": "voxtral-mini-tts-2603",
             "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
+        },
+        "gemini": {
+            "model": "gemini-3.1-flash-tts-preview",
+            "voice": "Kore",
+            "style": "",  # Optional style prompt prepended to Gemini TTS input
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
@@ -1479,7 +1485,8 @@ DEFAULT_CONFIG = {
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "openai": {
-            "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+            "model": "gpt-audio-mini",  # gpt-audio-mini, whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+            "prompt": "",  # Optional transcription style/context hint (OpenAI only)
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
@@ -1490,6 +1497,11 @@ DEFAULT_CONFIG = {
             "tag_audio_events": False,
             "diarize": False,
         },
+    },
+
+    # Cross-provider prompt overrides for media helpers.
+    "prompt": {
+        "audio_transcription": "",  # Optional STT style/context hint; provider-specific settings may override
     },
 
     "voice": {

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -368,6 +368,26 @@ class TestTranscribeOpenAIExtended:
         assert "Permission denied" in result["error"]
         mock_client.close.assert_called_once()
 
+    def test_gpt_audio_mini_uses_json_response_and_prompt(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = {"text": "olá"}
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._resolve_audio_transcription_prompt", return_value="pt-BR, preserve names"), \
+             patch("openai.OpenAI", return_value=mock_client):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(sample_wav, "gpt-audio-mini")
+
+        assert result["success"] is True
+        assert result["transcript"] == "olá"
+        kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-audio-mini"
+        assert kwargs["response_format"] == "json"
+        assert kwargs["prompt"] == "pt-BR, preserve names"
+        mock_client.close.assert_called_once()
+
 
 class TestTranscribeLocalCommand:
     def test_auto_detects_local_whisper_binary(self, monkeypatch):

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -163,6 +163,18 @@ class TestGenerateGeminiTts:
         endpoint = mock_post.call_args[0][0]
         assert "gemini-2.5-pro-preview-tts" in endpoint
 
+    def test_default_style_prepended_to_text(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"default_style": "Fale em português brasileiro, natural."}}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Oi", str(tmp_path / "test.wav"), config)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["contents"][0]["parts"][0]["text"] == "Fale em português brasileiro, natural.\n\nOi"
+
     def test_response_modality_is_audio(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import _generate_gemini_tts
 

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -113,6 +113,12 @@ class TestOpenaiTtsSpeed:
         kwargs = create.call_args[1]
         assert kwargs["speed"] == 4.0
 
+    def test_provider_instructions_are_passed(self, tmp_path, monkeypatch):
+        """tts.openai.instructions/default_instructions controls expressive voice style."""
+        create = self._run({"openai": {"instructions": "Brazilian Portuguese, warm and concise"}}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["instructions"] == "Brazilian Portuguese, warm and concise"
+
 
 # ---------------------------------------------------------------------------
 # MiniMax TTS (t2a_v2 endpoint: nested voice_setting/audio_setting,

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -86,7 +86,7 @@ _HAS_MISTRAL = _safe_find_spec("mistralai")
 DEFAULT_PROVIDER = "local"
 DEFAULT_LOCAL_MODEL = "base"
 DEFAULT_LOCAL_STT_LANGUAGE = "en"
-DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
+DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "gpt-audio-mini")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
 DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
@@ -104,7 +104,7 @@ LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 
 # Known model sets for auto-correction
-OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
+OPENAI_MODELS = {"whisper-1", "gpt-audio-mini", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
 
 # Singleton for the local model — loaded once, reused across calls
@@ -124,6 +124,44 @@ def _load_stt_config() -> dict:
         return load_config().get("stt", {})
     except Exception:
         return {}
+
+
+def _load_full_config() -> dict:
+    """Load full Hermes config for cross-cutting audio prompt controls."""
+    try:
+        from hermes_cli.config import load_config
+        return load_config()
+    except Exception:
+        return {}
+
+
+def _resolve_audio_transcription_prompt(stt_config: Optional[dict] = None) -> Optional[str]:
+    """Return the configured OpenAI STT prompt/style hint, if any.
+
+    Supports both the Omni-compatible global shape:
+
+        prompt.audio_transcription: "..."
+
+    and provider-local overrides:
+
+        stt.openai.prompt: "..."
+        stt.openai.audio_transcription_prompt: "..."
+    """
+    stt = stt_config if stt_config is not None else _load_stt_config()
+    openai_cfg = stt.get("openai", {}) if isinstance(stt.get("openai"), dict) else {}
+    for value in (
+        openai_cfg.get("prompt"),
+        openai_cfg.get("audio_transcription_prompt"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    full = _load_full_config()
+    prompt_cfg = full.get("prompt", {}) if isinstance(full.get("prompt"), dict) else {}
+    value = prompt_cfg.get("audio_transcription")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
 
 
 def is_stt_enabled(stt_config: Optional[dict] = None) -> bool:
@@ -1342,11 +1380,15 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
         client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
-                transcription = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=audio_file,
-                    response_format="text" if model_name == "whisper-1" else "json",
-                )
+                create_kwargs = {
+                    "model": model_name,
+                    "file": audio_file,
+                    "response_format": "text" if model_name == "whisper-1" else "json",
+                }
+                prompt = _resolve_audio_transcription_prompt()
+                if prompt:
+                    create_kwargs["prompt"] = prompt
+                transcription = client.audio.transcriptions.create(**create_kwargs)
 
             transcript_text = _extract_transcript_text(transcription)
             logger.info("Transcribed %s via OpenAI API (%s, %d chars)",

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -171,6 +171,7 @@ DEFAULT_ELEVENLABS_VOICE_ID = "pNInz6obpgDQGcFmaJgB"  # Adam
 DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
+DEFAULT_OPENAI_INSTRUCTIONS = ""
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
@@ -187,8 +188,9 @@ DEFAULT_XAI_SAMPLE_RATE = 24000
 DEFAULT_XAI_BIT_RATE = 128000
 DEFAULT_XAI_AUTO_SPEECH_TAGS = False
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
-DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
+DEFAULT_GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
+DEFAULT_GEMINI_TTS_STYLE = ""
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
@@ -994,6 +996,11 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     oai_config = tts_config.get("openai", {})
     model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
+    instructions = str(
+        oai_config.get("instructions")
+        or oai_config.get("default_instructions")
+        or DEFAULT_OPENAI_INSTRUCTIONS
+    ).strip()
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
@@ -1013,6 +1020,8 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             "response_format": response_format,
             "extra_headers": {"x-idempotency-key": str(uuid.uuid4())},
         }
+        if instructions:
+            create_kwargs["instructions"] = instructions
         if speed != 1.0:
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
@@ -1419,6 +1428,12 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     gemini_config = tts_config.get("gemini", {})
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+    style = str(
+        gemini_config.get("style")
+        or gemini_config.get("default_style")
+        or DEFAULT_GEMINI_TTS_STYLE
+    ).strip()
+    prompt_text = f"{style}\n\n{text}" if style else text
     base_url = str(
         gemini_config.get("base_url")
         or get_env_value("GEMINI_BASE_URL")
@@ -1426,7 +1441,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     ).strip().rstrip("/")
 
     payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": text}]}],
+        "contents": [{"parts": [{"text": prompt_text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
             "speechConfig": {


### PR DESCRIPTION
## What

Ports the cheap/expressive audio family controls we dogfooded in Omni into Hermes:

- Default OpenAI STT model moves from `whisper-1` to `gpt-audio-mini`
- `gpt-audio-mini` is recognized as a valid OpenAI STT model
- OpenAI STT accepts an optional prompt/context hint via:
  - `stt.openai.prompt`
  - `stt.openai.audio_transcription_prompt`
  - `prompt.audio_transcription`
- OpenAI TTS accepts `tts.openai.instructions` / `default_instructions`
- Gemini TTS default moves to `gemini-3.1-flash-tts-preview`
- Gemini TTS accepts `tts.gemini.style` / `default_style`, prepended to the synthesis prompt
- Desktop settings expose the new OpenAI STT model and newer OpenAI/Gemini voice knobs
- Config/example docs are updated

## Why

The newer small audio models are cheaper and better suited for always-on chat/voice infra than the older defaults. This gives users the same sort of prompt/style optimization controls we added in Omni without requiring custom provider wrappers.

## Validation

- `uv run --with pytest --with pytest-asyncio python -m pytest tests/tools/test_transcription_tools.py tests/tools/test_tts_speed.py tests/tools/test_tts_gemini.py -q -o 'addopts='`
  - `144 passed in 5.88s`
- `python3 -m py_compile tools/transcription_tools.py tools/tts_tool.py hermes_cli/config.py`
- `git diff --check`
- Import/default smoke via `uv run python` confirmed:
  - `DEFAULT_CONFIG['stt']['openai']['model'] == 'gpt-audio-mini'`
  - `DEFAULT_CONFIG['tts']['openai']['model'] == 'gpt-4o-mini-tts'`
  - `DEFAULT_CONFIG['tts']['gemini']['model'] == 'gemini-3.1-flash-tts-preview'`
