### PR TITLE
fix(feishu): render markdown tables via post payloads

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -155,7 +155,6 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -4308,12 +4307,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Feishu post-type 'md' elements render markdown formatting, including
+        # tables, so table content should follow the same post path as other
+        # markdown-rich replies.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            return "post", _build_markdown_post_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2579,6 +2579,48 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_post_for_markdown_tables(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_markdown_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "| 列1 | 列2 |\n| --- | --- |\n| A | B |"
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=content,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["zh_cn"]["content"], [[{"tag": "md", "text": content}]])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- send outbound Markdown tables through Feishu `post` payloads instead of plain `text`
- preserve the existing fallback to plain text when Feishu rejects an invalid `post` payload
- add a focused regression test covering Markdown table sends

## Problem
Feishu outbound messages that contained Markdown tables were being sent as plain text, so the client displayed the raw table syntax instead of rendering the table.

## Root Cause
`_build_outbound_payload()` treated Markdown tables as a special case and forced them down the `text` path, bypassing the existing Markdown `post` payload builder used for other Markdown-rich content.

## Why this change makes sense now
Feishu clients previously had issues rendering Markdown tables, which is why table-shaped content was forced to plain text. Based on current client behavior, Markdown tables now render correctly through `post` payloads, so they should follow the same path as other supported Markdown content.

## Implementation
- route `_MARKDOWN_TABLE_RE` matches to `_build_markdown_post_payload(...)`
- keep the existing `post -> text` fallback behavior unchanged when the Feishu API rejects invalid post content
- add a regression test to verify that Markdown table messages are sent as `post`

## Testing
- added a regression test in `tests/gateway/test_feishu.py` for outbound Markdown table messages

## Notes
- this change only affects outbound payload selection for Markdown tables
- plain text fallback behavior remains intact as a safety net