### PR TITLE
fix(browser): add --remote-allow-origins to CDP launch args

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -127,6 +127,10 @@ def chrome_debug_data_dir() -> str:
 def _chrome_debug_args(port: int) -> list[str]:
     return [
         f"--remote-debugging-port={port}",
+        # Chrome 115+ rejects cross-origin CDP WebSocket handshakes by default,
+        # causing "Chrome exited early without writing DevToolsActivePort".
+        # Allow all origins for the local debug port so Hermes can attach.
+        "--remote-allow-origins=*",
         f"--user-data-dir={chrome_debug_data_dir()}",
         "--no-first-run",
         "--no-default-browser-check",


### PR DESCRIPTION
## Problem

On Windows with Chrome 115+, the built-in CDP browser (`/browser connect`)
fails to start with:

```
Chrome exited early (exit code: 0) without writing DevToolsActivePort
```

Hermes launches Chrome with a remote debugging port, then tries to attach
over the CDP WebSocket — but Chrome 115+ rejects cross-origin WebSocket
handshakes by default, returning `403 Forbidden`:

```
Rejected an incoming WebSocket connection from the http://127.0.0.1:9222 origin.
Use the command line flag --remote-allow-origins to allow connections from this origin.
```

So Hermes cannot connect to the Chrome instance it launched itself, and the
whole built-in browser path is unusable on affected setups.

## Fix

Add `--remote-allow-origins=*` to `_chrome_debug_args()` in
`hermes_cli/browser_connect.py`, so the local debug port accepts Hermes's
WebSocket connection.

## Verification

- Without the flag: manual Chrome launch + `websocket.create_connection`
  → `403 Forbidden` (handshake rejected).
- With the flag: CDP WebSocket connects cleanly; `Page.enable`,
  `Runtime.evaluate`, `Page.captureScreenshot` all work; verified by
  navigating an internal SPA, reading the rendered DOM, and capturing a
  screenshot.

## Scope / Notes

- Affects all Windows users on Chrome 115+ using the built-in CDP browser.
- The macOS branch in the same file (the `open -a "Google Chrome" --args ...`
  command) is missing the same flag and likely needs it too, but I only have
  a Windows box to verify on — flagging for a maintainer with a Mac.
- `--remote-allow-origins=*` is scoped to the local debug port only; this
  matches the default behavior of Playwright/Selenium-launched Chrome.
