### PR TITLE
fix(build): upper-bound setuptools build requirement (#36620)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0,<83"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Adds an upper bound of `<83` to the setuptools build-system requirement in pyproject.toml, pinning the acceptable range to `setuptools>=61.0,<83`.

The bound is set at `<83` to align with the project's dev dependency pin of `setuptools==82.0.1`, ensuring the build and dev environments are consistent while still bounding the range as requested in the issue.