### PR TITLE
fix: enable native vision for kimi-coding provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -295,13 +295,12 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 # it must skip straight to the aggregator chain instead of returning a client
 # that will 404 on every vision request.
 #
-# kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
-# api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
-# describe as having no image_in capability. Vision lives on the separate
-# Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
+# kimi-coding / kimi-coding-cn: Kimi K2.6+ supports native multimodal
+# input through the /coding endpoint (Anthropic Messages wire). The old
+# restriction (no image_in) was accurate for pre-K2.6 models but is now
+# obsolete. Verified by user testing (2026-06-01).  See #17076.
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
-    "kimi-coding",
-    "kimi-coding-cn",
+    # Empty — kimi-coding supports vision as of K2.6.
 })
 
 # OpenRouter app attribution headers (base — always sent).
@@ -4036,13 +4035,10 @@ def resolve_vision_provider_client(
                     )
                     return _finalize(main_provider, sync_client, default_model)
             elif main_provider in _PROVIDERS_WITHOUT_VISION:
-                # Kimi Coding Plan's /coding endpoint (Anthropic Messages wire)
-                # does not accept image input — Kimi's own docs say "Current
-                # model does not support image input, switch to a model with
-                # image_in capability" and vision lives on the separate Kimi
-                # Platform (api.moonshot.ai). Skip the main provider and fall
-                # through to the aggregator chain instead of returning a
-                # client that will 404 on every vision request (#17076).
+                # This branch is now dead code — _PROVIDERS_WITHOUT_VISION is
+                # empty since Kimi K2.6+ supports native vision. Kept as a
+                # structural placeholder so the fallback-chain logic remains
+                # readable if a future provider needs blacklisting.
                 logger.debug(
                     "Vision auto-detect: skipping main provider %s (no "
                     "vision support) — falling through to aggregator chain",

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -513,6 +513,12 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
             return True
         return False
 
+    # Kimi (Kimi Code + Moonshot Open Platform) — K2.6+ supports native
+    # multimodal input via both Anthropic-compatible and OpenAI-compatible
+    # endpoints. Verified by user testing (2026-06-01).
+    if p in {"kimi-coding", "kimi-coding-cn", "kimi", "moonshot", "moonshot-cn"}:
+        return True
+
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result
     # multimodal support empirically.


### PR DESCRIPTION
## Summary

Kimi K2.6+ supports native multimodal input (text, image, video) through the /coding endpoint. The old restriction that blacklisted kimi-coding from vision tasks was accurate for pre-K2.6 models but is now obsolete.

## Changes

- **agent/auxiliary_client.py**: Remove kimi-coding and kimi-coding-cn from _PROVIDERS_WITHOUT_VISION
- **tools/vision_tools.py**: Add kimi-coding, kimi-coding-cn, kimi, moonshot, moonshot-cn to _supports_media_in_tool_results whitelist
- Update stale comments referencing #17076

## Impact

Before this fix, when a user sent an image while using kimi-coding as the main provider:
1. _PROVIDERS_WITHOUT_VISION forced the vision auxiliary to skip Kimi and fall through to OpenRouter/Nous
2. If no aggregator was configured, vision analysis failed with \"path included for retry\"
3. The model then tried workarounds (browser screenshot, PIL install) instead of using native vision

After this fix, images are attached directly to the main model context via the native vision fast path, just like Anthropic/OpenAI providers.

## Test Plan

- [x] Verified locally with kimi-k2.6 - images now attach natively without auxiliary LLM fallback