### PR TITLE
fix(whatsapp): resolve LID aliases on modern platforms/ session layout

### DIFF
--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # full-width digits / Unicode word chars can't sneak through.
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_dir
 
 
 def normalize_whatsapp_identifier(value: str) -> str:
@@ -82,7 +82,7 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
     if not normalized:
         return set()
 
-    session_dir = get_hermes_home() / "whatsapp" / "session"
+    session_dir = get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
     resolved: Set[str] = set()
     queue = [normalized]
 

--- a/tests/gateway/test_whatsapp_identity.py
+++ b/tests/gateway/test_whatsapp_identity.py
@@ -1,0 +1,37 @@
+"""Tests for gateway.whatsapp_identity alias resolution path."""
+
+import json
+
+from gateway.whatsapp_identity import expand_whatsapp_aliases
+
+
+def test_aliases_resolve_on_modern_platforms_layout(tmp_path, monkeypatch):
+    tmp_home = tmp_path / "hermes-home"
+    mapping_dir = tmp_home / "platforms" / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True, exist_ok=True)
+    (mapping_dir / "lid-mapping-999999999999999.json").write_text(
+        json.dumps("15551234567@s.whatsapp.net"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+    assert expand_whatsapp_aliases("999999999999999@lid") == {
+        "999999999999999",
+        "15551234567",
+    }
+
+
+def test_aliases_resolve_on_legacy_layout(tmp_path, monkeypatch):
+    tmp_home = tmp_path / "hermes-home"
+    mapping_dir = tmp_home / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True, exist_ok=True)
+    (mapping_dir / "lid-mapping-999999999999999.json").write_text(
+        json.dumps("15551234567@s.whatsapp.net"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+    assert expand_whatsapp_aliases("999999999999999@lid") == {
+        "999999999999999",
+        "15551234567",
+    }


### PR DESCRIPTION
## What does this PR do?

`expand_whatsapp_aliases` in `gateway/whatsapp_identity.py` reads the bridge's `lid-mapping-*.json` files to collapse a WhatsApp LID to its phone alias, but it hardcodes the session directory:

```python
session_dir = get_hermes_home() / "whatsapp" / "session"
```

The WhatsApp adapter writes those files — and points the bridge at them via `--session` — through the consolidated-layout helper instead:

```python
get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
```

`get_hermes_dir(new, old)` returns the legacy path only when it already exists on disk, otherwise the new `platforms/...` path. So on any install without a legacy `whatsapp/session` directory the bridge writes mappings to `platforms/whatsapp/session` while the resolver looks in `whatsapp/session` — empty/nonexistent. The resolver finds no mappings, returns the bare LID, the allowlist check misses, and the inbound message is silently dropped. The module docstring's "single source of truth … so the two paths can never drift apart" is contradicted by this line.

This routes the resolver through the same `get_hermes_dir(...)` call the adapter uses, so the read and write paths stay in lockstep on both the modern and legacy layouts and can't drift again.

Same root-cause-not-symptom approach as #35859 (merged): one minimal in-style change at the divergence point, no new bookkeeping, plus a regression test that fails on the old path and passes on the fixed one.

## Related Issue

Fixes #36664

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/whatsapp_identity.py` — `expand_whatsapp_aliases`: resolve `session_dir` via `get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")` (the adapter's helper) instead of the hardcoded `get_hermes_home() / "whatsapp" / "session"`.
- `tests/gateway/test_whatsapp_identity.py` — resolution test on both the modern `platforms/whatsapp/session` and legacy `whatsapp/session` layouts.

## How to Test

```
pytest tests/gateway/test_whatsapp_identity.py -q
```

The modern-layout test fails on `main` (`expand_whatsapp_aliases("<lid>@lid")` returns `{"<lid>"}` only) and passes with this change (returns `{"<lid>", "<phone>"}`). Broader suite green:

```
pytest tests/gateway/test_whatsapp_identity.py tests/gateway/test_session.py \
  tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_pairing.py -q
# 149 passed
```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] Tests pass
- [x] I've added tests for my changes
- [x] Tested on macOS 26.4, Python 3.11.15

### Documentation & Housekeeping

- [x] N/A — behavior fix, no config/doc/schema changes.
