### PR TITLE
fix(mcp): poller now processes sessions-index-only changes (#36647)

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -356,9 +356,7 @@ class EventBridge:
         except OSError:
             sj_mtime = 0.0
 
-        if sj_mtime != self._sessions_json_mtime:
-            self._sessions_json_mtime = sj_mtime
-            self._cached_sessions_index = _load_sessions_index()
+        sessions_changed = sj_mtime != self._sessions_json_mtime
 
         # Check if state.db has changed
         try:
@@ -372,8 +370,14 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        db_changed = db_mtime != self._state_db_mtime
+
+        if not sessions_changed and not db_changed:
             return  # Nothing changed since last poll — skip entirely
+
+        if sessions_changed:
+            self._sessions_json_mtime = sj_mtime
+            self._cached_sessions_index = _load_sessions_index()
 
         self._state_db_mtime = db_mtime
         entries = self._cached_sessions_index

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1236,3 +1236,88 @@ class TestEventBridgePollE2E:
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL
         assert POLL_INTERVAL == 0.2
+
+    def test_poll_processes_sessions_index_only_changes(self, tmp_path, monkeypatch):
+        """Regression for #36647: when sessions.json changes but state.db does not,
+        the poller must NOT early-return — it must refresh the cached sessions
+        index and pick up new sessions on the next tick.
+        """
+        import mcp_serve
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        session_a = "20260329_150000_idxA"
+        session_b = "20260329_150500_idxB"
+        db_path = tmp_path / "state.db"
+
+        # Initial sessions.json — only session A is known.
+        sessions_data = {
+            "agent:main:telegram:dm:idxA": {
+                "session_key": "agent:main:telegram:dm:idxA",
+                "session_id": session_a,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:05",
+                "origin": {"platform": "telegram", "chat_id": "idxA"},
+            },
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+
+        # Pre-seed BOTH sessions' messages in the DB so a single state.db write
+        # is enough — we can hold state.db mtime constant for the rest of the test.
+        _create_test_db(db_path, session_a, [
+            {"role": "user", "content": "from A", "timestamp": "2026-03-29T15:00:01"},
+        ])
+        # Append session B's row to the same DB.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_b, "user", "from B", "2026-03-29T15:05:01"),
+        )
+        conn.commit()
+        conn.close()
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        db = TestDB()
+        bridge = mcp_serve.EventBridge()
+
+        # First poll — sees only session A.
+        bridge._poll_once(db)
+        r1 = bridge.poll_events(after_cursor=0)
+        contents_1 = [e["content"] for e in r1["events"]]
+        assert contents_1 == ["from A"], contents_1
+
+        # Freeze state.db mtime: capture and re-pin after sessions.json write.
+        db_mtime_before = db_path.stat().st_mtime
+
+        # Add session B to sessions.json (rewrite triggers an mtime change on the
+        # index file). state.db is NOT touched.
+        sessions_data["agent:main:telegram:dm:idxB"] = {
+            "session_key": "agent:main:telegram:dm:idxB",
+            "session_id": session_b,
+            "platform": "telegram",
+            "updated_at": "2026-03-29T15:05:05",
+            "origin": {"platform": "telegram", "chat_id": "idxB"},
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+        # Ensure state.db mtime is unchanged from the first poll.
+        os.utime(db_path, (db_mtime_before, db_mtime_before))
+
+        # Second poll — must refresh sessions index and emit session B's message.
+        bridge._poll_once(db)
+        r2 = bridge.poll_events(after_cursor=r1["next_cursor"])
+        contents_2 = [e["content"] for e in r2["events"]]
+        assert "from B" in contents_2, (
+            f"Sessions-index-only change was skipped (bug #36647). Got: {contents_2}"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a latent early-return bug in the MCP server EventBridge._poll_once poller. The method was updating self._sessions_json_mtime immediately upon detecting a change to sessions.json, then later reading that just-overwritten value as part of the nothing-changed-since-last-poll comparison. The second comparison was therefore always true, so when sessions.json changed but state.db did not (e.g. a new session was registered but no new messages had landed yet), the poller falsely concluded that nothing had changed and skipped emitting events for the refreshed index until the next state.db write happened to coincide.

The fix computes sessions_changed and db_changed BEFORE mutating either cached mtime, returns early only when both are false, and only then updates the cached mtimes and refreshes _cached_sessions_index.

## Related Issue

Fixes #36647

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- mcp_serve.py: restructure EventBridge._poll_once so the early-return short-circuit is evaluated against the previous cached mtimes, not the freshly-written ones. Cache invalidation order is now: compute then check then mutate.
- tests/test_mcp_serve.py: add test_poll_processes_sessions_index_only_changes regression test that holds state.db mtime constant while sessions.json grows by one session, then asserts the new session pre-seeded message is emitted on the next poll. This test fails against the old code path and passes against the fix.

## How to Test

1. source .venv/bin/activate
2. pytest tests/test_mcp_serve.py -x -q -k poll
   - All 13 poll-related tests pass, including the new regression test.
3. Conceptual reproduction (mirrored by the new test): seed state.db with two sessions messages but list only session A in sessions.json. Poll once: session A is emitted. Append session B to sessions.json without touching state.db. Poll again. Before the fix: nothing emitted (early-return triggered against the freshly-updated mtime). After the fix: session B message is emitted.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(mcp): ...)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run the targeted suite (pytest tests/test_mcp_serve.py -k poll): 13 passed
- [x] I have added a regression test for the fix
- [x] I have tested on my platform: macOS

### Documentation and Housekeeping

- [x] No documentation update required, internal poller behavior, no public surface change (N/A)
- [x] No config keys changed (N/A)
- [x] No architecture or workflow change (N/A)
- [x] Pure Python stdlib mtime semantics; no cross-platform concern beyond the existing implementation
