### PR TITLE
docs: add HawkEye-Mem to Community tools section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [HawkEye-Mem](https://github.com/qiuhaomem/HawkEye-Mem) — System memory pressure monitoring, GPU tracking, cache strategy management, and token audit for Hermes and other MCP hosts.
 
 ---
 


### PR DESCRIPTION
### What this does

Adds [HawkEye-Mem](https://github.com/qiuhaomem/HawkEye-Mem) to the Community section of README.md, following the same format as the existing computer-use-linux and HermesClaw entries.

### Why

HawkEye-Mem is a lightweight system monitoring and cache management tool built in Rust that exposes 16+ MCP tools. It\'s already integrated with Hermes Agent via a built-in skill and helps users monitor system resources, manage token budgets, and optimize caching strategies.

### Related

Closes #36672