### PR TITLE
Add desktop-only install mode

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -30,6 +30,17 @@ Add `--include-desktop` to the [one-line installer](../../README.md#quick-instal
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --include-desktop
 ```
 
+If this machine should only run the Desktop shell and connect to a Hermes
+backend running somewhere else, use desktop-only mode instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --desktop-only
+```
+
+Desktop-only mode builds the app but skips the local setup wizard and gateway
+setup. This is useful for a laptop that should control a server, VM, WSL
+instance, or Tailscale-accessible Hermes runtime.
+
 Already have the Hermes CLI? Just run:
 
 ```bash
@@ -37,6 +48,35 @@ hermes desktop
 ```
 
 It builds and launches the GUI against your existing install — same config, keys, sessions, and skills. On first launch Hermes walks you through picking a provider and model; nothing else to configure.
+
+On macOS, source-built desktop installs also create a user app shortcut at:
+
+```text
+~/Applications/Hermes.app
+```
+
+### Remote gateway
+
+Hermes Desktop can connect to a remote dashboard backend instead of starting a
+local runtime. On the backend machine, run:
+
+```bash
+hermes dashboard --tui --no-open --host 127.0.0.1 --port 9120 --insecure
+```
+
+Expose that port through your preferred private network or reverse proxy, then
+configure the Desktop app from **Settings → Gateway → Remote gateway**. Provide
+the base URL and the dashboard session token. Path prefixes are supported, so a
+URL such as `https://server.example.com/hermes` maps Desktop REST calls to
+`/hermes/api/...` and WebSocket calls to `/hermes/api/ws`.
+
+For scripted launches, set both environment variables before starting Desktop:
+
+```bash
+export HERMES_DESKTOP_REMOTE_URL="https://server.example.com/hermes"
+export HERMES_DESKTOP_REMOTE_TOKEN="<dashboard-session-token>"
+hermes desktop --skip-build
+```
 
 ### Prebuilt installers
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,6 +79,7 @@ STAGE_NAME=""
 JSON_OUTPUT=false
 NON_INTERACTIVE=false
 INCLUDE_DESKTOP=false
+DESKTOP_ONLY=false
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -132,6 +133,12 @@ while [[ $# -gt 0 ]]; do
             INCLUDE_DESKTOP=true
             shift
             ;;
+        --desktop-only|-DesktopOnly)
+            DESKTOP_ONLY=true
+            INCLUDE_DESKTOP=true
+            RUN_SETUP=false
+            shift
+            ;;
         --dir)
             INSTALL_DIR="$2"
             INSTALL_DIR_EXPLICIT=true
@@ -165,6 +172,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --json         Print a JSON result frame for --stage"
             echo "  --non-interactive  Skip stages that require user input"
             echo "  --include-desktop  Also build the desktop app (apps/desktop -> Hermes.app)"
+            echo "  --desktop-only  Build only the desktop app and skip local agent setup"
             echo "  --dir PATH     Installation directory"
             echo "                   default (non-root):  ~/.hermes/hermes-agent"
             echo "                   default (root, Linux): /usr/local/lib/hermes-agent"
@@ -2018,6 +2026,11 @@ run_setup_wizard() {
 }
 
 maybe_start_gateway() {
+    if [ "$DESKTOP_ONLY" = true ]; then
+        log_info "Skipping gateway setup (--desktop-only)"
+        return 0
+    fi
+
     # Check if any messaging platform tokens were configured
     ENV_FILE="$HERMES_HOME/.env"
     if [ ! -f "$ENV_FILE" ]; then
@@ -2389,6 +2402,16 @@ install_desktop() {
         return 1
     fi
     log_success "Desktop app built: $app"
+
+    if [ "$OS" = "macos" ]; then
+        local user_apps="$HOME/Applications"
+        mkdir -p "$user_apps"
+        ln -sfn "$app" "$user_apps/Hermes.app"
+        log_success "Desktop app shortcut created: $user_apps/Hermes.app"
+        log_info "Launch with: open \"$user_apps/Hermes.app\""
+    else
+        log_info "Launch with: hermes desktop --skip-build"
+    fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the
     # checkout stays clean for the next `hermes update`.


### PR DESCRIPTION
## Summary

- Adds `scripts/install.sh --desktop-only` for machines that should only build/run Hermes Desktop and connect to a remote Hermes backend.
- Skips the local setup wizard and gateway setup in desktop-only mode so a Mac laptop does not get forced through local provider configuration.
- Creates `~/Applications/Hermes.app` on macOS source-built desktop installs and prints a direct launch command.
- Documents remote gateway setup, path-prefixed remote URLs, and `HERMES_DESKTOP_REMOTE_URL` / `HERMES_DESKTOP_REMOTE_TOKEN` launch flow in the Desktop README.

## User problem

When using Hermes Desktop as a thin Mac shell for a Hermes runtime on another machine, the existing install path is awkward:

- `--include-desktop` builds the app, but also starts the local Hermes setup wizard.
- Users are asked to configure a local provider even though Desktop will connect to a remote backend.
- The built macOS app lives under `~/.hermes/hermes-agent/apps/desktop/release/...`, which is easy to miss because nothing appears in Applications.
- Remote gateway mode exists, but the setup path is spread across code/UI rather than documented as an install flow.

## Verification

- `bash -n scripts/install.sh`
- `scripts/install.sh --help` shows `--desktop-only`

## Notes

Draft PR. This intentionally keeps the change small: shell installer behavior plus Desktop README docs. It does not introduce a new remote provisioning protocol or change Desktop runtime behavior.
