### PR TITLE
fix(packaging): tolerate missing optional data roots

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ REPO_ROOT = Path(__file__).parent.resolve()
 
 def _data_file_tree(root_name: str) -> list[tuple[str, list[str]]]:
     root = REPO_ROOT / root_name
+    if not root.exists():
+        return []
+
     grouped: defaultdict[str, list[str]] = defaultdict(list)
     for path in sorted(root.rglob("*")):
         if not path.is_file():

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+import importlib.util
 import tomllib
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +14,16 @@ find_packages = pytest.importorskip("setuptools", exc_type=ImportError).find_pac
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_setup_module():
+    spec = importlib.util.spec_from_file_location(
+        "hermes_setup_for_tests", REPO_ROOT / "setup.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    with patch("setuptools.setup"):
+        spec.loader.exec_module(module)
+    return module
 
 
 def _packages_find_include():
@@ -76,6 +88,13 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_setup_data_file_tree_tolerates_missing_roots(tmp_path, monkeypatch):
+    setup_module = _load_setup_module()
+    monkeypatch.setattr(setup_module, "REPO_ROOT", tmp_path)
+
+    assert setup_module._data_file_tree("optional-skills") == []
 
 
 def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():


### PR DESCRIPTION
## What does this PR do?

Fixes source install and metadata/build evaluation for minimal downstream
checkouts where optional bundled data directories are absent.

`setup.py` now treats a missing data-file root as empty instead of walking a
path that may not exist. This keeps optional directories such as
`optional-skills` optional for source distributions and packager checkouts.

## Related Issue

Fixes #36619

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `setup.py`: return an empty data-file list when `_data_file_tree()` receives a missing root.
- `tests/test_packaging_metadata.py`: add a regression test that imports `setup.py` with `setuptools.setup` mocked, redirects `REPO_ROOT` to a temporary directory, and verifies missing optional data roots produce no entries.

## How to Test

1. `scripts/run_tests.sh tests/test_packaging_metadata.py`
2. `uv run ruff check setup.py tests/test_packaging_metadata.py`
3. `python3 -m py_compile setup.py tests/test_packaging_metadata.py && git diff --check`
4. `python3 scripts/check-windows-footguns.py --diff origin/main`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not run locally; this repository's full suite is large. I ran the focused CI-style wrapper test for the changed packaging test file instead.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / local Conductor workspace

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

```text
$ scripts/run_tests.sh tests/test_packaging_metadata.py
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 0.3s (24 workers) ===

$ uv run ruff check setup.py tests/test_packaging_metadata.py
All checks passed!

$ python3 -m py_compile setup.py tests/test_packaging_metadata.py && git diff --check

$ python3 scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (2 file(s) scanned).
```
