### PR TITLE
fix(ci): clear two pre-existing test failures (stale model catalog + GUI test mock)

### DIFF
--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -60,6 +60,7 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok) as mock_install, \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
@@ -85,6 +86,7 @@ def test_gui_forwards_desktop_environment_overrides(tmp_path, monkeypatch):
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
          pytest.raises(SystemExit):
         cli_main.cmd_gui(_ns(

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-31T03:27:32Z",
+  "updated_at": "2026-06-01T08:20:18Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -77,7 +77,7 @@
           "description": "recommended"
         },
         {
-          "id": "minimax/minimax-m2.7",
+          "id": "minimax/minimax-m3",
           "description": ""
         },
         {
@@ -178,7 +178,7 @@
           "id": "moonshotai/kimi-k2.6"
         },
         {
-          "id": "minimax/minimax-m2.7"
+          "id": "minimax/minimax-m3"
         },
         {
           "id": "z-ai/glm-5.1"


### PR DESCRIPTION
## Summary
Clears two unrelated pre-existing test failures on `main` so the test matrix goes green. Neither was introduced by this PR — both reproduce on a clean `origin/main` checkout.

## Changes
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`. The committed manifest had drifted from `_PROVIDER_MODELS` — `minimax/minimax-m2.7` was renamed to `minimax/minimax-m3` in the source list without regenerating the JSON, breaking `test_model_catalog.py::test_in_repo_lists_match_manifest`.
- `tests/hermes_cli/test_gui_command.py`: mock out `_desktop_macos_relaunchable_fixup` in the two `platform="darwin"` GUI tests. The fixup makes two extra `subprocess.run` calls (`xattr` + `codesign`) before launch; the tests' 2-element `subprocess.run` side_effect (pack + launch) got drained by the fixup → `StopIteration`. Production code is correct; the test fixtures were stale.

## Validation
| | Before | After |
|---|---|---|
| `test_gui_command.py` + `test_model_catalog.py` | 3 failed | 36 passed |

## Infographic
![ci-green-two-stale-tests](https://v3b.fal.media/files/b/0a9c8684/wuF0csyGnpLcvw8QpjNKX_KWttGSml.png)
