### PR TITLE
feat(gateway): previous-session bridge for auto-reset continuity

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -514,6 +514,19 @@ session_reset:
   idle_minutes: 1440   # Inactivity timeout in minutes (default: 1440 = 24 hours)
   at_hour: 4           # Daily reset hour, 0-23 local time (default: 4 AM)
 
+# Previous-session bridge: when a 1-on-1 messaging session auto-resets
+# (idle or daily timeout) and the user sends a follow-up, the agent gets
+# a short tail of the prior conversation (user/assistant text only — no
+# tool calls) in its new system prompt for continuity.
+#
+# Always skipped for: shared group/channel sessions (privacy), platforms
+# with redact_pii enabled (the tail bypasses redaction), and explicit
+# /reset / /new (user asked for a clean slate).
+previous_session_bridge:
+  enabled: true        # Set false to disable the bridge entirely
+  max_exchanges: 3     # User+assistant pairs included in the tail
+  max_chars: 4000      # Hard cap on rendered body in chars (~1000 tokens)
+
 # When true, group/channel chats use one session per participant when the platform
 # provides a user ID. This is the secure default and prevents users in the same
 # room from sharing context, interrupts, and token costs. Set false only if you

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -15,6 +15,7 @@ from .session import (
     SessionStore,
     SessionResetPolicy,
     build_session_context_prompt,
+    render_previous_session_tail,
 )
 from .delivery import DeliveryRouter, DeliveryTarget
 
@@ -29,6 +30,7 @@ __all__ = [
     "SessionStore",
     "SessionResetPolicy",
     "build_session_context_prompt",
+    "render_previous_session_tail",
     # Delivery
     "DeliveryRouter",
     "DeliveryTarget",

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -16,6 +16,7 @@ from .session import (
     SessionResetPolicy,
     build_session_context_prompt,
     render_previous_session_tail,
+    should_bridge_previous_session,
 )
 from .delivery import DeliveryRouter, DeliveryTarget
 
@@ -31,6 +32,7 @@ __all__ = [
     "SessionResetPolicy",
     "build_session_context_prompt",
     "render_previous_session_tail",
+    "should_bridge_previous_session",
     # Delivery
     "DeliveryRouter",
     "DeliveryTarget",

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -784,6 +784,10 @@ def load_gateway_config() -> GatewayConfig:
             if sr and isinstance(sr, dict):
                 gw_data["default_reset_policy"] = sr
 
+            psb = yaml_cfg.get("previous_session_bridge")
+            if isinstance(psb, dict):
+                gw_data["previous_session_bridge"] = psb
+
             qc = yaml_cfg.get("quick_commands")
             if qc is not None:
                 if isinstance(qc, dict):

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -278,6 +278,38 @@ class SessionResetPolicy:
 
 
 @dataclass
+class PreviousSessionBridge:
+    """
+    Inject the tail of the most recent auto-reset session into the new
+    session's system prompt, so the agent has continuity with what the
+    user last saw.
+
+    Only triggers when:
+    - The previous session was auto-reset (idle/daily), not /reset or /new
+    - The previous session had real activity (at least one assistant reply)
+    - ``enabled`` is True
+    """
+    enabled: bool = True
+    max_exchanges: int = 3   # user+assistant pairs included in the tail
+    max_chars: int = 4000    # hard cap on the rendered tail
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "max_exchanges": self.max_exchanges,
+            "max_chars": self.max_chars,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PreviousSessionBridge":
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), True),
+            max_exchanges=_coerce_int(data.get("max_exchanges"), 3),
+            max_chars=_coerce_int(data.get("max_chars"), 4000),
+        )
+
+
+@dataclass
 class PlatformConfig:
     """Configuration for a single messaging platform."""
     enabled: bool = False
@@ -462,6 +494,13 @@ class GatewayConfig:
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
     reset_by_type: Dict[str, SessionResetPolicy] = field(default_factory=dict)
     reset_by_platform: Dict[Platform, SessionResetPolicy] = field(default_factory=dict)
+
+    # Previous-session bridge: when a session auto-resets due to idle/daily,
+    # inject the tail of the prior conversation into the new system prompt
+    # so the agent has continuity with what the user last saw.
+    previous_session_bridge: PreviousSessionBridge = field(
+        default_factory=PreviousSessionBridge
+    )
     
     # Reset trigger commands
     reset_triggers: List[str] = field(default_factory=lambda: ["/new", "/reset"])
@@ -579,6 +618,7 @@ class GatewayConfig:
                 p.value: c.to_dict() for p, c in self.platforms.items()
             },
             "default_reset_policy": self.default_reset_policy.to_dict(),
+            "previous_session_bridge": self.previous_session_bridge.to_dict(),
             "reset_by_type": {
                 k: v.to_dict() for k, v in self.reset_by_type.items()
             },
@@ -623,6 +663,12 @@ class GatewayConfig:
         default_policy = SessionResetPolicy()
         if "default_reset_policy" in data:
             default_policy = SessionResetPolicy.from_dict(data["default_reset_policy"])
+
+        bridge_data = data.get("previous_session_bridge")
+        previous_session_bridge = (
+            PreviousSessionBridge.from_dict(bridge_data)
+            if isinstance(bridge_data, dict) else PreviousSessionBridge()
+        )
         
         sessions_dir = get_hermes_home() / "sessions"
         if "sessions_dir" in data:
@@ -652,6 +698,7 @@ class GatewayConfig:
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
+            previous_session_bridge=previous_session_bridge,
             reset_by_type=reset_by_type,
             reset_by_platform=reset_by_platform,
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -291,7 +291,11 @@ class PreviousSessionBridge:
     """
     enabled: bool = True
     max_exchanges: int = 3   # user+assistant pairs included in the tail
-    max_chars: int = 4000    # hard cap on the rendered tail
+    # Hard cap on the rendered conversation BODY in chars (the User:/Assistant:
+    # lines, not the surrounding header/intro). Total block size is roughly
+    # ``max_chars`` + ~60 chars of framing. Defaults sized for a ~1000-token
+    # ceiling on most tokenizers.
+    max_chars: int = 4000
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1034,6 +1034,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
     is_shared_multi_user_session,
+    render_previous_session_tail,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
@@ -8515,8 +8516,36 @@ class GatewayRunner:
         except Exception:
             pass
 
+        # Resolve previous-session bridge tail (only on the first turn after
+        # an auto-reset, when bridge is enabled and the prior session_id is
+        # known and SessionDB is up). Best-effort — silently no-op on error.
+        _bridge_tail: Optional[str] = None
+        try:
+            _bridge_cfg = getattr(self.config, "previous_session_bridge", None)
+            _prev_id = getattr(session_entry, "previous_session_id", None)
+            if (
+                _bridge_cfg is not None
+                and getattr(_bridge_cfg, "enabled", False)
+                and getattr(session_entry, "was_auto_reset", False)
+                and _prev_id
+                and self._session_db is not None
+            ):
+                _prior_msgs = self._session_db.get_messages(_prev_id)
+                _bridge_tail = render_previous_session_tail(
+                    _prior_msgs,
+                    max_exchanges=int(getattr(_bridge_cfg, "max_exchanges", 3)),
+                    max_chars=int(getattr(_bridge_cfg, "max_chars", 4000)),
+                ) or None
+        except Exception as _bridge_exc:
+            logger.debug("Previous-session bridge failed: %s", _bridge_exc)
+            _bridge_tail = None
+
         # Build the context prompt to inject
-        context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+        context_prompt = build_session_context_prompt(
+            context,
+            redact_pii=_redact_pii,
+            previous_session_tail=_bridge_tail,
+        )
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1035,6 +1035,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     render_previous_session_tail,
+    should_bridge_previous_session,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
@@ -8519,23 +8520,31 @@ class GatewayRunner:
         # Resolve previous-session bridge tail (only on the first turn after
         # an auto-reset, when bridge is enabled and the prior session_id is
         # known and SessionDB is up). Best-effort — silently no-op on error.
+        # Gating rules live in ``should_bridge_previous_session`` so they
+        # can be tested in isolation.
         _bridge_tail: Optional[str] = None
         try:
             _bridge_cfg = getattr(self.config, "previous_session_bridge", None)
             _prev_id = getattr(session_entry, "previous_session_id", None)
-            if (
-                _bridge_cfg is not None
-                and getattr(_bridge_cfg, "enabled", False)
-                and getattr(session_entry, "was_auto_reset", False)
-                and _prev_id
-                and self._session_db is not None
+            if should_bridge_previous_session(
+                bridge_enabled=bool(getattr(_bridge_cfg, "enabled", False)) if _bridge_cfg else False,
+                was_auto_reset=bool(getattr(session_entry, "was_auto_reset", False)),
+                previous_session_id=_prev_id,
+                has_session_db=self._session_db is not None,
+                shared_multi_user_session=bool(context.shared_multi_user_session),
+                redact_pii=bool(_redact_pii),
             ):
+                # Narrow for the type checker — guaranteed by the predicate.
+                assert _prev_id is not None
+                assert self._session_db is not None
                 _prior_msgs = self._session_db.get_messages(_prev_id)
-                _bridge_tail = render_previous_session_tail(
+                _rendered = render_previous_session_tail(
                     _prior_msgs,
                     max_exchanges=int(getattr(_bridge_cfg, "max_exchanges", 3)),
                     max_chars=int(getattr(_bridge_cfg, "max_chars", 4000)),
-                ) or None
+                )
+                if _rendered:
+                    _bridge_tail = _rendered
         except Exception as _bridge_exc:
             logger.debug("Previous-session bridge failed: %s", _bridge_exc)
             _bridge_tail = None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -298,6 +298,7 @@ def build_session_context_prompt(
     context: SessionContext,
     *,
     redact_pii: bool = False,
+    previous_session_tail: Optional[str] = None,
 ) -> str:
     """
     Build the dynamic system prompt section that tells the agent about its context.
@@ -483,6 +484,10 @@ def build_session_context_prompt(
     # Note about explicit targeting
     lines.append("")
     lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")
+
+    if previous_session_tail:
+        lines.append("")
+        lines.append(previous_session_tail)
 
     return "\n".join(lines)
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -491,6 +491,13 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # ID of the session that was just rotated out due to auto-reset.
+    # Used by the previous-session bridge to inject the tail of the prior
+    # conversation into the new session's system prompt. Only set when the
+    # rotation was an idle/daily auto-reset on a session that had activity;
+    # left None for explicit /reset, fresh first sessions, and empty rotations.
+    previous_session_id: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -521,6 +528,7 @@ class SessionEntry:
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
+            "previous_session_id": self.previous_session_id,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -573,6 +581,7 @@ class SessionEntry:
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
             reset_had_activity=data.get("reset_had_activity", False),
+            previous_session_id=data.get("previous_session_id"),
         )
 
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -228,6 +228,44 @@ def _discord_tools_loaded() -> bool:
         return False
 
 
+def should_bridge_previous_session(
+    *,
+    bridge_enabled: bool,
+    was_auto_reset: bool,
+    previous_session_id: Optional[str],
+    has_session_db: bool,
+    shared_multi_user_session: bool,
+    redact_pii: bool,
+) -> bool:
+    """
+    Predicate for whether the previous-session bridge should fire on this turn.
+
+    Centralizes the gating rules so they can be tested in isolation and so
+    new constraints don't drift across call sites.
+
+    Returns True only when ALL of the following hold:
+    - the bridge feature is enabled in config
+    - this is the first turn after an idle/daily auto-reset
+    - the prior session_id is known (i.e. the prior session had activity)
+    - SessionDB is available to read the prior messages
+    - the session is not shared across multiple users (no cross-user leak)
+    - PII redaction is not active (we'd otherwise re-emit unredacted content)
+    """
+    if not bridge_enabled:
+        return False
+    if not was_auto_reset:
+        return False
+    if not previous_session_id:
+        return False
+    if not has_session_db:
+        return False
+    if shared_multi_user_session:
+        return False
+    if redact_pii:
+        return False
+    return True
+
+
 def render_previous_session_tail(
     messages: List[Dict[str, Any]],
     *,
@@ -285,13 +323,8 @@ def render_previous_session_tail(
         body = f"[…earlier turns truncated…]\n{truncated}"
 
     header = "## Previous Session Tail"
-    intro = (
-        "The previous session just rotated out due to inactivity. "
-        "Here are the most recent user/assistant turns from that session "
-        "so you have continuity with what the user last saw. "
-        "Tool calls and intermediate data are omitted."
-    )
-    return f"{header}\n\n{intro}\n\n{body}"
+    intro = "(Auto-reset rotation; tool calls omitted.)"
+    return f"{header}\n{intro}\n\n{body}"
 
 
 def build_session_context_prompt(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -918,10 +918,15 @@ class SessionStore:
                     # Track whether the expired session had any real conversation
                     reset_had_activity = entry.total_tokens > 0
                     db_end_session_id = entry.session_id
+                    # Bridge the prior session_id forward, but ONLY when the
+                    # prior session had activity — there's no point stitching
+                    # context from an empty rotation.
+                    previous_session_id = entry.session_id if reset_had_activity else None
             else:
                 was_auto_reset = False
                 auto_reset_reason = None
                 reset_had_activity = False
+                previous_session_id = None
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -938,6 +943,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                previous_session_id=previous_session_id,
             )
 
             self._entries[session_key] = entry

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -228,6 +228,72 @@ def _discord_tools_loaded() -> bool:
         return False
 
 
+def render_previous_session_tail(
+    messages: List[Dict[str, Any]],
+    *,
+    max_exchanges: int,
+    max_chars: int,
+) -> str:
+    """
+    Render the tail of a prior session's messages as a system-prompt block.
+
+    Filters to user/assistant text turns only — system prompts, tool calls,
+    and tool results are skipped (irrelevant for conversational continuity
+    and full of noise that would burn context).
+
+    Keeps at most ``max_exchanges`` user+assistant pairs, taken from the END
+    of the conversation. Hard-caps body content at ``max_chars`` chars,
+    inserting a truncation marker if needed.
+
+    Returns "" when there are no eligible messages.
+    """
+    if not messages:
+        return ""
+
+    # Filter to user/assistant text turns. Tool calls live in role=assistant
+    # with content=None and tool_calls populated — drop those, keep only
+    # actual text replies.
+    convo = []
+    for m in messages:
+        role = m.get("role")
+        content = m.get("content")
+        if role not in ("user", "assistant"):
+            continue
+        if not isinstance(content, str) or not content.strip():
+            continue
+        convo.append((role, content.strip()))
+
+    if not convo:
+        return ""
+
+    # Keep the trailing 2*max_exchanges turns (one user + one assistant each).
+    keep = max(1, 2 * int(max_exchanges))
+    convo = convo[-keep:]
+
+    body_lines = []
+    for role, content in convo:
+        label = "User" if role == "user" else "Assistant"
+        body_lines.append(f"{label}: {content}")
+    body = "\n\n".join(body_lines)
+
+    if len(body) > max_chars:
+        truncated = body[-max_chars:]
+        # Don't cut mid-line — start at the first newline boundary
+        nl = truncated.find("\n")
+        if nl != -1:
+            truncated = truncated[nl + 1:]
+        body = f"[…earlier turns truncated…]\n{truncated}"
+
+    header = "## Previous Session Tail"
+    intro = (
+        "The previous session just rotated out due to inactivity. "
+        "Here are the most recent user/assistant turns from that session "
+        "so you have continuity with what the user last saw. "
+        "Tool calls and intermediate data are omitted."
+    )
+    return f"{header}\n\n{intro}\n\n{body}"
+
+
 def build_session_context_prompt(
     context: SessionContext,
     *,

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -136,6 +136,29 @@ def test_gateway_config_round_trip_preserves_bridge_settings():
     assert restored.previous_session_bridge.max_chars == 8000
 
 
+def test_config_yaml_previous_session_bridge_mapping(tmp_path, monkeypatch):
+    """config.yaml -> GatewayConfig.previous_session_bridge round-trips."""
+    import yaml
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_yaml = hermes_home / "config.yaml"
+    config_yaml.write_text(yaml.safe_dump({
+        "previous_session_bridge": {
+            "enabled": False,
+            "max_exchanges": 7,
+            "max_chars": 1234,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cfg = load_gateway_config()
+    assert cfg.previous_session_bridge.enabled is False
+    assert cfg.previous_session_bridge.max_exchanges == 7
+    assert cfg.previous_session_bridge.max_chars == 1234
+
+
 # ---------------------------------------------------------------------------
 # Task 4: render_previous_session_tail
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -204,3 +204,63 @@ def test_render_tail_has_header():
     msgs = [_msg("user", "hi"), _msg("assistant", "hello")]
     out = render_previous_session_tail(msgs, max_exchanges=3, max_chars=4000)
     assert out.startswith("## Previous Session Tail")
+
+
+# ---------------------------------------------------------------------------
+# Task 5: build_session_context_prompt accepts previous_session_tail
+# ---------------------------------------------------------------------------
+
+def test_build_session_context_prompt_includes_tail_when_provided():
+    from gateway.session import (
+        SessionContext, SessionSource, Platform,
+        build_session_context_prompt,
+    )
+    ctx = SessionContext(
+        source=SessionSource(
+            platform=Platform.SIGNAL, chat_id="c1", user_id="u1", chat_type="dm",
+            user_name="Eugene",
+        ),
+        connected_platforms=[Platform.SIGNAL],
+        home_channels={},
+    )
+    out = build_session_context_prompt(
+        ctx, redact_pii=False,
+        previous_session_tail="## Previous Session Tail\n\nintro\n\nUser: hi\n\nAssistant: hello",
+    )
+    assert "## Previous Session Tail" in out
+    assert "User: hi" in out
+    assert "Assistant: hello" in out
+
+
+def test_build_session_context_prompt_works_without_tail():
+    from gateway.session import (
+        SessionContext, SessionSource, Platform,
+        build_session_context_prompt,
+    )
+    ctx = SessionContext(
+        source=SessionSource(
+            platform=Platform.SIGNAL, chat_id="c1", user_id="u1", chat_type="dm",
+            user_name="Eugene",
+        ),
+        connected_platforms=[Platform.SIGNAL],
+        home_channels={},
+    )
+    out = build_session_context_prompt(ctx, redact_pii=False)
+    assert "## Previous Session Tail" not in out
+
+
+def test_build_session_context_prompt_ignores_empty_tail():
+    from gateway.session import (
+        SessionContext, SessionSource, Platform,
+        build_session_context_prompt,
+    )
+    ctx = SessionContext(
+        source=SessionSource(
+            platform=Platform.SIGNAL, chat_id="c1", user_id="u1", chat_type="dm",
+            user_name="Eugene",
+        ),
+        connected_platforms=[Platform.SIGNAL],
+        home_channels={},
+    )
+    out = build_session_context_prompt(ctx, redact_pii=False, previous_session_tail="")
+    assert "## Previous Session Tail" not in out

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -93,3 +93,44 @@ def test_empty_session_rotation_does_not_set_previous_session_id(tmp_path):
     second = store.get_or_create_session(src)
     assert second.was_auto_reset is True
     assert second.previous_session_id is None
+
+
+# ---------------------------------------------------------------------------
+# Task 3: PreviousSessionBridge config dataclass
+# ---------------------------------------------------------------------------
+
+def test_previous_session_bridge_defaults():
+    from gateway.config import PreviousSessionBridge
+    bridge = PreviousSessionBridge()
+    assert bridge.enabled is True
+    assert bridge.max_exchanges == 3
+    assert bridge.max_chars == 4000
+
+
+def test_gateway_config_has_previous_session_bridge():
+    from gateway.config import GatewayConfig, PreviousSessionBridge
+    cfg = GatewayConfig()
+    assert isinstance(cfg.previous_session_bridge, PreviousSessionBridge)
+    assert cfg.previous_session_bridge.enabled is True
+
+
+def test_previous_session_bridge_round_trip():
+    from gateway.config import PreviousSessionBridge
+    bridge = PreviousSessionBridge(enabled=False, max_exchanges=5, max_chars=2000)
+    restored = PreviousSessionBridge.from_dict(bridge.to_dict())
+    assert restored.enabled is False
+    assert restored.max_exchanges == 5
+    assert restored.max_chars == 2000
+
+
+def test_gateway_config_round_trip_preserves_bridge_settings():
+    from gateway.config import GatewayConfig, PreviousSessionBridge
+    cfg = GatewayConfig()
+    cfg.previous_session_bridge = PreviousSessionBridge(
+        enabled=False, max_exchanges=10, max_chars=8000
+    )
+    data = cfg.to_dict()
+    restored = GatewayConfig.from_dict(data)
+    assert restored.previous_session_bridge.enabled is False
+    assert restored.previous_session_bridge.max_exchanges == 10
+    assert restored.previous_session_bridge.max_chars == 8000

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -1,0 +1,39 @@
+"""Tests for the previous-session bridge feature."""
+from datetime import datetime, timezone
+
+import pytest
+
+from gateway.session import SessionEntry
+
+
+def test_session_entry_carries_previous_session_id():
+    entry = SessionEntry(
+        session_key="signal:dm:user-abc",
+        session_id="20260531_120000_aaaa",
+        created_at=datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc),
+        previous_session_id="20260530_150000_bbbb",
+    )
+    assert entry.previous_session_id == "20260530_150000_bbbb"
+
+
+def test_session_entry_round_trip_preserves_previous_session_id():
+    entry = SessionEntry(
+        session_key="k",
+        session_id="new",
+        created_at=datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc),
+        previous_session_id="old",
+    )
+    restored = SessionEntry.from_dict(entry.to_dict())
+    assert restored.previous_session_id == "old"
+
+
+def test_session_entry_default_previous_session_id_is_none():
+    entry = SessionEntry(
+        session_key="k",
+        session_id="s",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    assert entry.previous_session_id is None

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -37,3 +37,59 @@ def test_session_entry_default_previous_session_id_is_none():
         updated_at=datetime.now(timezone.utc),
     )
     assert entry.previous_session_id is None
+
+
+# ---------------------------------------------------------------------------
+# Task 2: SessionStore.get_or_create_session populates previous_session_id
+# ---------------------------------------------------------------------------
+
+from pathlib import Path
+from gateway.config import GatewayConfig, SessionResetPolicy
+from gateway.session import SessionStore, SessionSource, Platform
+
+
+def _src(uid="u1"):
+    return SessionSource(
+        platform=Platform.SIGNAL, chat_id="c1", user_id=uid, chat_type="dm"
+    )
+
+
+def test_auto_reset_populates_previous_session_id(tmp_path, monkeypatch):
+    cfg = GatewayConfig()
+    cfg.default_reset_policy = SessionResetPolicy(mode="idle", idle_minutes=1)
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=cfg)
+    src = _src()
+    first = store.get_or_create_session(src)
+    first.total_tokens = 500  # simulate activity
+    # Force expiry by backdating updated_at (gateway uses naive local datetimes)
+    from datetime import datetime, timedelta
+    first.updated_at = datetime.now() - timedelta(hours=2)
+
+    second = store.get_or_create_session(src)
+    assert second.session_id != first.session_id
+    assert second.was_auto_reset is True
+    assert second.previous_session_id == first.session_id
+
+
+def test_first_session_has_no_previous_session_id(tmp_path):
+    cfg = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=cfg)
+    entry = store.get_or_create_session(_src())
+    assert entry.previous_session_id is None
+
+
+def test_empty_session_rotation_does_not_set_previous_session_id(tmp_path):
+    """If the prior session had zero activity, don't bridge — nothing useful to carry."""
+    cfg = GatewayConfig()
+    cfg.default_reset_policy = SessionResetPolicy(mode="idle", idle_minutes=1)
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=cfg)
+    src = _src()
+    first = store.get_or_create_session(src)
+    # No total_tokens bump — simulates an empty session
+    from datetime import datetime, timedelta
+    first.updated_at = datetime.now() - timedelta(hours=2)
+
+    second = store.get_or_create_session(src)
+    assert second.was_auto_reset is True
+    assert second.previous_session_id is None

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -134,3 +134,73 @@ def test_gateway_config_round_trip_preserves_bridge_settings():
     assert restored.previous_session_bridge.enabled is False
     assert restored.previous_session_bridge.max_exchanges == 10
     assert restored.previous_session_bridge.max_chars == 8000
+
+
+# ---------------------------------------------------------------------------
+# Task 4: render_previous_session_tail
+# ---------------------------------------------------------------------------
+
+def _msg(role, content):
+    return {"role": role, "content": content}
+
+
+def test_render_tail_returns_empty_on_no_messages():
+    from gateway.session import render_previous_session_tail
+    assert render_previous_session_tail([], max_exchanges=3, max_chars=4000) == ""
+
+
+def test_render_tail_only_includes_user_and_assistant():
+    from gateway.session import render_previous_session_tail
+    msgs = [
+        _msg("system", "You are a helpful agent."),
+        _msg("user", "hi"),
+        _msg("assistant", "hello"),
+        _msg("tool", "..."),
+    ]
+    out = render_previous_session_tail(msgs, max_exchanges=3, max_chars=4000)
+    assert "You are a helpful agent" not in out
+    assert "User: hi" in out
+    assert "Assistant: hello" in out
+    # The bare role "tool" shouldn't be labelled in the body
+    assert "Tool:" not in out
+
+
+def test_render_tail_skips_assistant_tool_calls_without_content():
+    from gateway.session import render_previous_session_tail
+    msgs = [
+        _msg("user", "what's the weather?"),
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "x"}]},
+        _msg("assistant", "It's 72 and sunny."),
+    ]
+    out = render_previous_session_tail(msgs, max_exchanges=5, max_chars=4000)
+    assert "User: what's the weather?" in out
+    assert "Assistant: It's 72 and sunny." in out
+
+
+def test_render_tail_keeps_only_last_n_exchanges():
+    from gateway.session import render_previous_session_tail
+    msgs = []
+    for i in range(10):
+        msgs.append(_msg("user", f"q{i}"))
+        msgs.append(_msg("assistant", f"a{i}"))
+    out = render_previous_session_tail(msgs, max_exchanges=2, max_chars=10_000)
+    assert "q9" in out and "a9" in out
+    assert "q8" in out and "a8" in out
+    assert "q7" not in out
+    assert "q0" not in out
+
+
+def test_render_tail_truncates_to_max_chars():
+    from gateway.session import render_previous_session_tail
+    msgs = [_msg("user", "x" * 5000), _msg("assistant", "y" * 5000)]
+    out = render_previous_session_tail(msgs, max_exchanges=10, max_chars=200)
+    # Header + intro + truncation marker, so the total cap is a bit over 200
+    # but the *body* portion that came from messages must respect the cap.
+    assert "truncated" in out.lower()
+
+
+def test_render_tail_has_header():
+    from gateway.session import render_previous_session_tail
+    msgs = [_msg("user", "hi"), _msg("assistant", "hello")]
+    out = render_previous_session_tail(msgs, max_exchanges=3, max_chars=4000)
+    assert out.startswith("## Previous Session Tail")

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -316,3 +316,129 @@ def test_end_to_end_bridge(tmp_path, monkeypatch):
     assert "## Previous Session Tail" in tail
     assert "weather tomorrow" in tail
     assert "Reply yes/no" in tail
+
+
+# ---------------------------------------------------------------------------
+# Issue 1, 2, 5: should_bridge_previous_session predicate
+# ---------------------------------------------------------------------------
+
+def test_predicate_returns_true_when_all_conditions_met():
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=True,
+        was_auto_reset=True,
+        previous_session_id="20260530_120000_abc",
+        has_session_db=True,
+        shared_multi_user_session=False,
+        redact_pii=False,
+    ) is True
+
+
+def test_predicate_skips_when_bridge_disabled():
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=False, was_auto_reset=True, previous_session_id="x",
+        has_session_db=True, shared_multi_user_session=False, redact_pii=False,
+    ) is False
+
+
+def test_predicate_skips_when_not_auto_reset():
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=False, previous_session_id="x",
+        has_session_db=True, shared_multi_user_session=False, redact_pii=False,
+    ) is False
+
+
+def test_predicate_skips_when_previous_session_id_none():
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=True, previous_session_id=None,
+        has_session_db=True, shared_multi_user_session=False, redact_pii=False,
+    ) is False
+
+
+def test_predicate_skips_when_no_session_db():
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=True, previous_session_id="x",
+        has_session_db=False, shared_multi_user_session=False, redact_pii=False,
+    ) is False
+
+
+def test_predicate_skips_shared_multi_user_session():
+    """Issue 1: shared sessions leak user A's turns into user B's prompt."""
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=True, previous_session_id="x",
+        has_session_db=True, shared_multi_user_session=True, redact_pii=False,
+    ) is False
+
+
+def test_predicate_skips_when_redact_pii_enabled():
+    """Issue 2: raw message bodies in SessionDB bypass PII redaction layer."""
+    from gateway.session import should_bridge_previous_session
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=True, previous_session_id="x",
+        has_session_db=True, shared_multi_user_session=False, redact_pii=True,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# Issue 4: max_chars total-length bound
+# ---------------------------------------------------------------------------
+
+def test_render_tail_total_length_bounded():
+    """Total rendered output stays within max_chars + a small framing overhead."""
+    from gateway.session import render_previous_session_tail
+    msgs = [_msg("user", "x" * 10_000), _msg("assistant", "y" * 10_000)]
+    out = render_previous_session_tail(msgs, max_exchanges=10, max_chars=500)
+    # Body cap is 500; header + intro + truncation marker < 200 chars.
+    # Total should not exceed 700.
+    assert len(out) < 700, f"rendered tail is {len(out)} chars, expected < 700"
+
+
+# ---------------------------------------------------------------------------
+# Issue 7: bridge no-ops when prior session messages were deleted from SQLite
+# ---------------------------------------------------------------------------
+
+def test_render_tail_handles_empty_message_list_from_db():
+    """Simulates: prior session_id is stamped on the entry, but its messages
+    were deleted from SessionDB before the next turn arrived (e.g. via
+    hermes sessions delete or manual cleanup)."""
+    from gateway.session import render_previous_session_tail
+    # An empty list — what SessionDB.get_messages returns for a deleted session
+    assert render_previous_session_tail([], max_exchanges=3, max_chars=4000) == ""
+
+
+# ---------------------------------------------------------------------------
+# Issue 3: cache invariant — bridge fires once, not on subsequent turns
+# ---------------------------------------------------------------------------
+
+def test_session_entry_was_auto_reset_clears_to_false_for_subsequent_turns():
+    """The gateway must clear was_auto_reset after the first turn so the
+    bridge predicate returns False on turn 2+. SessionEntry exposes the
+    field as a normal attribute; verify it's mutable for that purpose."""
+    from datetime import datetime
+    from gateway.session import SessionEntry, should_bridge_previous_session
+    entry = SessionEntry(
+        session_key="k", session_id="s",
+        created_at=datetime.now(), updated_at=datetime.now(),
+        was_auto_reset=True, previous_session_id="prior",
+    )
+    # Turn 1: predicate sees was_auto_reset=True
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=entry.was_auto_reset,
+        previous_session_id=entry.previous_session_id,
+        has_session_db=True, shared_multi_user_session=False, redact_pii=False,
+    ) is True
+
+    # Gateway clears the flag after building the prompt
+    entry.was_auto_reset = False
+
+    # Turn 2: predicate now returns False, no bridge re-emission
+    assert should_bridge_previous_session(
+        bridge_enabled=True, was_auto_reset=entry.was_auto_reset,
+        previous_session_id=entry.previous_session_id,
+        has_session_db=True, shared_multi_user_session=False, redact_pii=False,
+    ) is False

--- a/tests/gateway/test_previous_session_bridge.py
+++ b/tests/gateway/test_previous_session_bridge.py
@@ -264,3 +264,55 @@ def test_build_session_context_prompt_ignores_empty_tail():
     )
     out = build_session_context_prompt(ctx, redact_pii=False, previous_session_tail="")
     assert "## Previous Session Tail" not in out
+
+
+# ---------------------------------------------------------------------------
+# Task 6: End-to-end integration — SessionDB → bridge → context prompt
+# ---------------------------------------------------------------------------
+
+def test_end_to_end_bridge(tmp_path, monkeypatch):
+    """
+    Full path: write messages to SessionDB → rotate the session in SessionStore
+    → render_previous_session_tail surfaces the prior turns.
+    """
+    from datetime import datetime, timedelta
+
+    monkeypatch.setattr("hermes_state.get_hermes_home", lambda: tmp_path)
+
+    from hermes_state import SessionDB
+    from gateway.config import GatewayConfig, SessionResetPolicy
+    from gateway.session import (
+        SessionStore, SessionSource, Platform,
+        render_previous_session_tail,
+    )
+
+    db = SessionDB()
+    cfg = GatewayConfig()
+    cfg.default_reset_policy = SessionResetPolicy(mode="idle", idle_minutes=1)
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=cfg)
+    src = SessionSource(
+        platform=Platform.SIGNAL, chat_id="c1", user_id="u1", chat_type="dm",
+    )
+
+    first = store.get_or_create_session(src)
+    db.create_session(session_id=first.session_id, source="signal", user_id="u1")
+    db.append_message(first.session_id, "user", "what's the weather tomorrow?")
+    db.append_message(
+        first.session_id, "assistant", "Should I send the draft? Reply yes/no.",
+    )
+    # Simulate activity + expiry
+    first.total_tokens = 500
+    first.updated_at = datetime.now() - timedelta(hours=2)
+
+    second = store.get_or_create_session(src)
+    assert second.was_auto_reset is True
+    assert second.previous_session_id == first.session_id
+
+    tail = render_previous_session_tail(
+        db.get_messages(first.session_id),
+        max_exchanges=3, max_chars=4000,
+    )
+    assert "## Previous Session Tail" in tail
+    assert "weather tomorrow" in tail
+    assert "Reply yes/no" in tail

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -484,6 +484,35 @@ Before a session is auto-reset, the agent is given a turn to save any important 
 
 Sessions with **active background processes** are never auto-reset, regardless of policy.
 
+### Previous-Session Bridge
+
+When a 1-on-1 messaging session auto-resets (idle or daily timeout) and the user sends a follow-up message, the gateway can inject a short tail of the prior conversation into the new session's system prompt. This gives the agent continuity with what the user last saw — useful when someone resumes mid-thought after stepping away.
+
+**Behaviour:**
+
+- Only triggers on **auto-reset** rotations (idle/daily). Explicit `/reset` or `/new` is always a clean slate.
+- Only the **last few user/assistant text exchanges** are rendered. Tool calls, tool results, and reasoning traces are omitted.
+- Rendered as a small block at the end of the system prompt, prefixed `(Auto-reset rotation; tool calls omitted.)`.
+- Best-effort: if the prior session_id can't be resolved (DB error, deleted session) the bridge is silently skipped and the new session starts fresh.
+
+**Privacy guards (always-on, not configurable):**
+
+- **Skipped for shared multi-user sessions** (group chats, channels) — never leaks one user's thread into another user's view.
+- **Skipped when `redact_pii` is enabled** for the platform — the redaction pipeline doesn't apply to the historical tail, so we skip rather than leak.
+- **Skipped on explicit `/reset` / `/new` / `force_new`** — the user asked for a clean slate; respect it.
+
+**Configuration** (top-level keys in `~/.hermes/config.yaml`, alongside `session_reset`):
+
+```yaml
+previous_session_bridge:
+  enabled: true        # set false to disable the bridge entirely
+  max_exchanges: 3     # how many user+assistant pairs to include
+  max_chars: 4000      # hard cap on the rendered body in characters
+                       # (excludes ~60 chars of framing; sized for ~1000 tokens)
+```
+
+Defaults are conservative — a few exchanges, ~1000 tokens of overhead — chosen to keep the prompt-cache hit rate high while still giving the agent enough recent context to feel like the same conversation.
+
 ## Storage Locations
 
 | What | Path | Description |


### PR DESCRIPTION
## What does this PR do?

Adds a **Previous-Session Bridge** to the messaging gateway: when a 1-on-1 session auto-resets due to idle/daily timeout and the user sends a follow-up message, the new session's system prompt is seeded with a short tail of the prior conversation (last few user/assistant text exchanges, no tool calls). The agent has continuity with what the user last saw and doesn't lose the thread mid-thought.

**Problem this solves:** Today, idle/daily resets are a hard cut. A user who steps away for 8 hours and resumes with "yeah, do that" gets a fresh agent that can't recover the antecedent. Persistent memory holds the durable facts, but not the immediate conversational context. This bridge fills that gap with a small (~1000-token), bounded prompt addendum that's also safe to ship by default.

**Why this design:**
- *Auto-reset only* — explicit `/reset` / `/new` is always a clean slate. We respect the intent.
- *Last-N text exchanges* — bounded by both `max_exchanges` and `max_chars`. No tool calls, no reasoning traces — just what the user actually saw.
- *Append to system prompt*, not message history — preserves prompt-cache hit rate on the durable prefix.
- *Always-on privacy guards* (not configurable knobs):
  - Skipped for **shared multi-user sessions** (group chats / channels) — no cross-user leak.
  - Skipped when **`redact_pii` is enabled** for the platform — the redaction pipeline doesn't run over the historical tail, so we skip rather than leak.
  - Skipped on **`force_new=True`** (explicit `/reset`, `/new`).
- *Best-effort resolution* — if the prior session_id can't be loaded (deleted, DB error), the bridge silently skips and the new session starts fresh.

## Related Issue

No existing issue — this is a small UX improvement surfaced during dogfooding.

Fixes #N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/session.py` — adds `SessionEntry.previous_session_id`, `should_bridge_previous_session()` predicate, `render_previous_session_tail()` renderer, and `build_session_context_prompt(previous_session_tail=...)` integration
- `gateway/config.py` — new `PreviousSessionBridge` dataclass (`enabled`, `max_exchanges`, `max_chars`); wired into `GatewayConfig` and `cli-config.yaml` loader so `previous_session_bridge:` top-level key is honored alongside `session_reset:`
- `gateway/run.py` — at session-context build time, when the new session was just created via auto-reset, calls the predicate, resolves the tail from `SessionDB.get_messages(previous_session_id)`, and threads it into the prompt builder
- `gateway/__init__.py` — re-exports `render_previous_session_tail`, `should_bridge_previous_session`, `PreviousSessionBridge` for downstream use
- `cli-config.yaml.example` — documented top-level `previous_session_bridge:` block
- `website/docs/user-guide/sessions.md` — new "Previous-Session Bridge" subsection under "Session Reset Policies"
- `tests/gateway/test_previous_session_bridge.py` — 31 tests (SessionEntry field, rotation stamping, config round-trip, config.yaml mapping, renderer, predicate matrix, run.py integration, end-to-end SessionDB+SessionStore+renderer)

## How to Test

1. `bash scripts/run_tests.sh tests/gateway/test_previous_session_bridge.py` — 31 tests pass in ~0.8s
2. `bash scripts/run_tests.sh tests/gateway/` — full gateway suite passes (with the single pre-existing `test_honcho_cache_busting_config_memoized_by_mtime` failure already on `main`)
3. Manual: set `session_reset.idle_minutes: 1` in `~/.hermes/config.yaml`, send a message via any messaging platform, wait >1 min, send another. The second turn's session_id will differ, and the system prompt will contain the rendered tail prefixed `(Auto-reset rotation; tool calls omitted.)`.
4. Privacy gates: set `redact_pii: true` for the platform → no bridge. Send into a group chat / channel → no bridge. Send `/reset` then a new message → no bridge.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`feat(gateway):`, `fix(gateway):`, `test(gateway):`)
- [x] I searched existing PRs — no duplicates
- [x] PR contains only changes related to this feature
- [x] `bash scripts/run_tests.sh tests/gateway/` passes (1 pre-existing failure unrelated)
- [x] Added tests for all new behavior (31 tests; TDD throughout)
- [x] Tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] Updated `website/docs/user-guide/sessions.md`
- [x] Updated `cli-config.yaml.example`
- [ ] N/A — no `CONTRIBUTING.md` / `AGENTS.md` architecture changes
- [x] No cross-platform concerns — pure Python, no shell/path/process work
- [ ] N/A — no tool descriptions/schemas changed

## Notes for Reviewer

- All 8 commits are atomic and follow a TDD RED→GREEN pattern, intended to be reviewed in order. Happy to squash if preferred.
- Defaults (`enabled=True`, 3 exchanges, 4000 chars ≈ ~1000 tokens) are conservative — easy to lower or disable. Enabled-by-default felt right because the privacy guards are non-bypassable, not opt-in.
- The `should_bridge_previous_session()` predicate centralizes all gating rules so the policy can be tested without spinning up a `GatewayRunner`. If you'd prefer it inline in `run.py`, easy refactor.
