### PR TITLE
feat(tui): add Cursor-style prompt modes

### DIFF
--- a/ui-tui/src/__tests__/modePrompt.test.ts
+++ b/ui-tui/src/__tests__/modePrompt.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $activeModeId, $agentModes, cycleActiveMode, DEFAULT_AGENT_MODES, NO_MODE_ID } from '../app/modeStore.js'
+import { applyModePrompt } from '../app/useSubmission.js'
+
+describe('applyModePrompt', () => {
+  afterEach(() => {
+    $agentModes.set(DEFAULT_AGENT_MODES)
+    $activeModeId.set(NO_MODE_ID)
+  })
+
+  it('does not inject instructions for hidden/no-mode entries', () => {
+    $agentModes.set([
+      {
+        color: '#D7D7D7',
+        description: 'No mode',
+        hidden: true,
+        id: NO_MODE_ID,
+        label: 'No Mode',
+        prompt: 'should not inject'
+      }
+    ])
+    $activeModeId.set(NO_MODE_ID)
+
+    expect(applyModePrompt('hello')).toBe('hello')
+  })
+
+  it('escapes mode names before inserting them into the wrapper attribute', () => {
+    $agentModes.set([
+      {
+        color: '#111111',
+        id: 'review',
+        label: 'Review "<Mode>"',
+        description: 'review mode',
+        prompt: 'review carefully'
+      }
+    ])
+    $activeModeId.set('review')
+
+    expect(applyModePrompt('hello')).toBe(
+      '<mode_instructions name="Review &quot;&lt;Mode&gt;&quot;">\nreview carefully\n</mode_instructions>\n\nhello'
+    )
+  })
+
+  it('cycles through visible modes and no-mode, skipping hidden custom modes', () => {
+    $agentModes.set([
+      {
+        color: '#D7D7D7',
+        description: 'No mode',
+        hidden: true,
+        id: NO_MODE_ID,
+        label: 'No Mode'
+      },
+      {
+        color: '#111111',
+        description: 'Hidden mode',
+        hidden: true,
+        id: 'hidden-review',
+        label: 'Hidden Review'
+      },
+      {
+        color: '#222222',
+        description: 'Visible mode',
+        id: 'review',
+        label: 'Review'
+      }
+    ])
+    $activeModeId.set(NO_MODE_ID)
+
+    expect(cycleActiveMode().id).toBe('review')
+    expect(cycleActiveMode().id).toBe(NO_MODE_ID)
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -1,15 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { NO_MODE_ID } from '../app/modeStore.js'
 import { $uiState, resetUiState } from '../app/uiStore.js'
 import {
   applyDisplay,
   hydrateFullConfig,
   normalizeBusyInputMode,
   normalizeIndicatorStyle,
+  normalizeModes,
   normalizeMouseTracking,
   normalizeStatusBar
 } from '../app/useConfigSync.js'
-import type { ParsedVoiceRecordKey } from '../lib/platform.js'
 
 describe('applyDisplay', () => {
   beforeEach(() => {
@@ -268,6 +269,42 @@ describe('normalizeIndicatorStyle', () => {
     expect(normalizeIndicatorStyle('')).toBe('kaomoji')
     expect(normalizeIndicatorStyle('sparkle')).toBe('kaomoji')
     expect(normalizeIndicatorStyle(42)).toBe('kaomoji')
+  })
+})
+
+describe('normalizeModes', () => {
+  it('strips prompts from hidden and no-mode entries', () => {
+    const modes = normalizeModes([
+      {
+        color: '#D7D7D7',
+        hidden: true,
+        id: NO_MODE_ID,
+        label: 'No Mode',
+        prompt: 'should not inject'
+      },
+      {
+        color: '#111111',
+        hidden: true,
+        id: 'quiet',
+        label: 'Quiet',
+        prompt: 'should not inject either'
+      }
+    ])
+
+    expect(modes).toEqual([
+      expect.objectContaining({ hidden: true, id: NO_MODE_ID, prompt: undefined }),
+      expect.objectContaining({ hidden: true, id: 'quiet', prompt: undefined })
+    ])
+  })
+
+  it('drops duplicate IDs so mode cycling is deterministic', () => {
+    const modes = normalizeModes([
+      { color: '#111111', id: 'review', label: 'Review', prompt: 'first' },
+      { color: '#222222', id: 'review', label: 'Duplicate', prompt: 'second' }
+    ])
+
+    expect(modes.map(mode => mode.id)).toEqual([NO_MODE_ID, 'review'])
+    expect(modes.find(mode => mode.id === 'review')?.label).toBe('Review')
   })
 })
 

--- a/ui-tui/src/app/modeStore.ts
+++ b/ui-tui/src/app/modeStore.ts
@@ -1,0 +1,72 @@
+import { atom } from 'nanostores'
+
+export interface AgentMode {
+  color: string
+  description: string
+  hidden?: boolean
+  id: string
+  label: string
+  prompt?: string
+}
+
+export const NO_MODE_ID = 'none'
+
+export const NO_MODE: AgentMode = {
+  color: '#D7D7D7',
+  description: 'No mode prompt instructions.',
+  hidden: true,
+  id: NO_MODE_ID,
+  label: 'No Mode'
+}
+
+export const DEFAULT_AGENT_MODES: AgentMode[] = [
+  NO_MODE,
+  {
+    color: '#9A7BC8',
+    description: 'Cursor-style Multi-Task mode: parallelize independent work through subagents.',
+    id: 'multitask',
+    label: 'Multi-Task',
+    prompt: 'Multi-Task Mode: HARD REQUIREMENT — preserve the main agent context window by using delegate_task subagents early, not as an optional last resort. For any codebase/research task that is likely to need more than 2 tool calls, touch more than 1 file, or benefit from inspection plus implementation/review, the parent agent should normally make delegate_task its first tool call. Use one batched delegate_task(tasks=[...]) call with up to 3 independent tasks whenever workstreams can run in parallel. Keep the parent as the lightweight orchestrator: retain the user goal, constraints, final decisions, edits that need direct ownership, and final verification in the main thread; send bulky repo inspection, research, implementation attempts, test failure analysis, and review passes to subagents. Each subagent prompt must be self-contained: include the exact goal, relevant paths/files/errors, constraints, allowed toolsets, expected output shape, and ask for concise findings plus verifiable handles such as files changed, commands run, test output, URLs, or IDs. If delegate_task is unavailable or the task is truly tiny/single-step, briefly say why you are not delegating; otherwise do not proceed manually before delegating. Do not delegate secrets, permission prompts, user-interactive choices, destructive/external side effects, or anything the parent cannot verify. After subagents return, synthesize only the useful results, verify important claims yourself with tools before reporting success, and avoid pasting large child transcripts into the main context.'
+  },
+  {
+    color: '#D6B56D',
+    description: 'Cursor-style Plan mode: research and propose an approach before building.',
+    id: 'plan',
+    label: 'Plan',
+    prompt: 'Plan Mode: design the approach before coding or changing state. Ask concise clarifying questions when requirements are ambiguous, inspect enough context to understand scope, and produce a clear reviewable plan before execution.'
+  },
+  {
+    color: '#7FAF8A',
+    description: 'Cursor-style Ask mode: read-only explanation and exploration.',
+    id: 'ask',
+    label: 'Ask',
+    prompt: 'Ask Mode: answer and explore without making edits or external changes unless the user explicitly asks to switch into execution. Use read-only inspection and explain clearly. Ask a concise clarifying question when missing context materially changes the answer.'
+  },
+  {
+    color: '#B86B6B',
+    description: 'Cursor-style Debug mode: runtime evidence, root cause, fix, verify.',
+    id: 'debug',
+    label: 'Debug',
+    prompt: 'Debug Mode: use a systematic debugging loop. Reproduce or inspect the failure, gather runtime evidence, isolate root cause, make the smallest safe fix, and verify with real tool output. Do not paper over errors or report success without verification.'
+  }
+]
+
+export const $activeModeId = atom<string>(NO_MODE_ID)
+export const $agentModes = atom<AgentMode[]>(DEFAULT_AGENT_MODES)
+
+const cycleableModes = () => $agentModes.get().filter(mode => !mode.hidden || mode.id === NO_MODE_ID)
+
+const modeById = (id: string) => $agentModes.get().find(mode => mode.id === id)
+
+export const getActiveMode = () => modeById($activeModeId.get()) ?? NO_MODE
+
+export const cycleActiveMode = (): AgentMode => {
+  const modes = cycleableModes()
+  const current = $activeModeId.get()
+  const index = Math.max(0, modes.findIndex(mode => mode.id === current))
+  const next = modes[(index + 1) % modes.length] ?? NO_MODE
+
+  $activeModeId.set(next.id)
+
+  return next
+}

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -22,6 +22,7 @@ import {
   type IndicatorStyle,
   type StatusBarMode
 } from './interfaces.js'
+import { $agentModes, type AgentMode, DEFAULT_AGENT_MODES, NO_MODE, NO_MODE_ID } from './modeStore.js'
 import { turnController } from './turnController.js'
 import { patchUiState } from './uiStore.js'
 
@@ -66,6 +67,48 @@ export const normalizeIndicatorStyle = (raw: unknown): IndicatorStyle => {
   const v = raw.trim().toLowerCase() as IndicatorStyle
 
   return INDICATOR_STYLE_SET.has(v) ? v : DEFAULT_INDICATOR_STYLE
+}
+
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i
+
+export const normalizeModes = (raw: unknown): AgentMode[] => {
+  if (!Array.isArray(raw)) {
+    return DEFAULT_AGENT_MODES
+  }
+
+  const seen = new Set<string>()
+
+  const modes = raw.flatMap((item): AgentMode[] => {
+    if (!item || typeof item !== 'object') {
+      return []
+    }
+
+    const rec = item as Record<string, unknown>
+    const id = typeof rec.id === 'string' ? rec.id.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-') : ''
+    const label = typeof rec.label === 'string' ? rec.label.trim() : id
+    const color = typeof rec.color === 'string' && HEX_COLOR_RE.test(rec.color.trim()) ? rec.color.trim() : ''
+    const description = typeof rec.description === 'string' ? rec.description.trim() : ''
+    const promptText = typeof rec.prompt === 'string' ? rec.prompt.trim() : undefined
+    const hidden = rec.hidden === true || id === NO_MODE_ID
+
+    if (!id || !label || !color || seen.has(id)) {
+      return []
+    }
+
+    seen.add(id)
+
+    return [{ color, description, hidden, id, label, prompt: hidden ? undefined : promptText }]
+  })
+
+  if (!modes.length) {
+    return DEFAULT_AGENT_MODES
+  }
+
+  if (modes.some(mode => mode.id === NO_MODE_ID)) {
+    return modes
+  }
+
+  return [NO_MODE, ...modes]
 }
 
 const FALSEY_MOUSE = new Set(['0', 'false', 'no', 'off'])
@@ -143,24 +186,46 @@ const _voiceRecordKeyFromConfig = (cfg: ConfigFullResponse | null): ParsedVoiceR
 }
 
 const _pasteCollapseLinesFromConfig = (cfg: ConfigFullResponse | null): number => {
-  if (!cfg?.config) return 5
+  if (!cfg?.config) {
+    return 5
+  }
+
   const raw = cfg.config.paste_collapse_threshold
-  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return Math.round(raw)
+
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+    return Math.round(raw)
+  }
+
   if (typeof raw === 'string') {
     const n = parseInt(raw, 10)
-    if (Number.isFinite(n) && n >= 0) return n
+
+    if (Number.isFinite(n) && n >= 0) {
+      return n
+    }
   }
+
   return 5
 }
 
 const _pasteCollapseCharsFromConfig = (cfg: ConfigFullResponse | null): number => {
-  if (!cfg?.config) return 2000
+  if (!cfg?.config) {
+    return 2000
+  }
+
   const raw = cfg.config.paste_collapse_char_threshold
-  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return Math.round(raw)
+
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+    return Math.round(raw)
+  }
+
   if (typeof raw === 'string') {
     const n = parseInt(raw, 10)
-    if (Number.isFinite(n) && n >= 0) return n
+
+    if (Number.isFinite(n) && n >= 0) {
+      return n
+    }
   }
+
   return 2000
 }
 
@@ -190,6 +255,7 @@ export const applyDisplay = (
   const d = cfg?.config?.display ?? {}
 
   setBell(!!d.bell_on_complete)
+  $agentModes.set(normalizeModes(d.modes))
 
   // Only push the voice record key when the RPC actually returned a
   // config payload. ``quietRpc()`` collapses failures to ``null``; if we

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -5,7 +5,6 @@ import { useEffect, useRef } from 'react'
 import { TYPING_IDLE_MS } from '../config/timing.js'
 import type {
   ApprovalRespondResponse,
-  ConfigSetResponse,
   SecretRespondResponse,
   SudoRespondResponse,
   VoiceRecordResponse
@@ -16,6 +15,7 @@ import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 
 import { getInputSelection } from './inputSelectionStore.js'
 import type { InputHandlerContext, InputHandlerResult } from './interfaces.js'
+import { cycleActiveMode } from './modeStore.js'
 import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
@@ -524,27 +524,11 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
-    // shift-tab flips yolo without spending a turn (claude-code parity)
+    // Shift+Tab cycles prompt modes without spending a turn.
     if (key.shift && key.tab && !cState.completions.length) {
-      if (!live.sid) {
-        return void actions.sys('yolo needs an active session')
-      }
+      cycleActiveMode()
 
-      // gateway.rpc swallows errors with its own sys() message and resolves to null,
-      // so we only speak when it came back with a real shape. null = rpc already spoke.
-      return void gateway.rpc<ConfigSetResponse>('config.set', { key: 'yolo', session_id: live.sid }).then(r => {
-        if (r?.value === '1') {
-          return actions.sys('yolo on')
-        }
-
-        if (r?.value === '0') {
-          return actions.sys('yolo off')
-        }
-
-        if (r) {
-          actions.sys('failed to toggle yolo')
-        }
-      })
+      return
     }
 
     if (key.tab && cState.completions.length) {

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -16,6 +16,7 @@ import { PASTE_SNIPPET_RE } from '../protocol/paste.js'
 import type { Msg } from '../types.js'
 
 import type { ComposerActions, ComposerRefs, ComposerState, PasteSnippet } from './interfaces.js'
+import { getActiveMode } from './modeStore.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
@@ -23,6 +24,20 @@ const DOUBLE_ENTER_MS = 450
 const SESSION_BUSY_RE = /session busy|waiting for model response/i
 
 const isSessionBusyError = (e: unknown) => e instanceof Error && SESSION_BUSY_RE.test(e.message)
+
+const escapeModeName = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+export const applyModePrompt = (text: string): string => {
+  const mode = getActiveMode()
+  const prompt = mode.prompt?.trim()
+
+  if (mode.hidden || !prompt) {
+    return text
+  }
+
+  return `<mode_instructions name="${escapeModeName(mode.label)}">\n${prompt}\n</mode_instructions>\n\n${text}`
+}
 
 const expandSnips = (snips: PasteSnippet[]) => {
   const byLabel = new Map<string, string[]>()
@@ -109,10 +124,10 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
         gw.request<PromptSubmitResponse>('prompt.submit', { session_id: sid, text: submitText }).catch((e: Error) => {
           if (isSessionBusyError(e)) {
-            composerActions.enqueue(submitText)
+            composerActions.enqueue(displayText)
             patchUiState({ busy: true, status: 'queued for next turn' })
 
-            return sys(`queued: "${submitText.slice(0, 50)}${submitText.length > 50 ? '…' : ''}"`)
+            return sys(`queued: "${displayText.slice(0, 50)}${displayText.length > 50 ? '…' : ''}"`)
           }
 
           sys(`error: ${e.message}`)
@@ -132,7 +147,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
       gw.request<InputDetectDropResponse>('input.detect_drop', { session_id: sid, text })
         .then(r => {
           if (!r?.matched) {
-            return startSubmit(text, expand(text), showUserMessage)
+            return startSubmit(text, applyModePrompt(expand(text)), showUserMessage)
           }
 
           if (r.is_image) {
@@ -141,9 +156,9 @@ export function useSubmission(opts: UseSubmissionOptions) {
             turnController.pushActivity(`detected file: ${r.name}`)
           }
 
-          startSubmit(r.text || text, expand(r.text || text), showUserMessage)
+          startSubmit(r.text || text, applyModePrompt(expand(r.text || text)), showUserMessage)
         })
-        .catch(() => startSubmit(text, expand(text), showUserMessage))
+        .catch(() => startSubmit(text, applyModePrompt(expand(text)), showUserMessage))
     },
     [appendMessage, composerActions, composerState.pasteSnips, gw, maybeGoodVibes, setLastUserMsg, sys]
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -4,6 +4,7 @@ import { Fragment, memo, useMemo, useRef } from 'react'
 
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
+import { $activeModeId, $agentModes } from '../app/modeStore.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
@@ -167,6 +168,9 @@ const ComposerPane = memo(function ComposerPane({
   status
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'status'>) {
   const ui = useStore($uiState)
+  const modeId = useStore($activeModeId)
+  const modes = useStore($agentModes)
+  const mode = modes.find(item => item.id === modeId) ?? modes[0]
   const isBlocked = useStore($isBlocked)
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
   const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
@@ -252,8 +256,8 @@ const ComposerPane = memo(function ComposerPane({
           cols={composer.cols}
           compIdx={composer.compIdx}
           completions={composer.completions}
-          onActiveSessionSelect={actions.activateLiveSession}
           onActiveSessionClose={actions.closeLiveSession}
+          onActiveSessionSelect={actions.activateLiveSession}
           onModelSelect={actions.onModelSelect}
           onNewLiveSession={actions.newLiveSession}
           onNewPromptSession={actions.newPromptSession}
@@ -317,6 +321,14 @@ const ComposerPane = memo(function ComposerPane({
           </>
         )}
       </Box>
+
+      {mode && !mode.hidden ? (
+        <Text color={mode.color} wrap="truncate-end">
+          {mode.label} (shift+tab to cycle)
+        </Text>
+      ) : (
+        <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag} />
+      )}
 
       {!composer.empty && !ui.sid && <Text color={ui.theme.color.muted}>⚕ {ui.status}</Text>}
 

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -22,6 +22,7 @@ export const HOTKEYS: [string, string][] = [
   [action + '+L', 'redraw / repaint'],
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],
+  ['Shift+Tab', 'cycle prompt mode'],
   ['↑/↓', 'completions / queue edit / history'],
   ['Ctrl+X', 'open live session switcher (deletes queued message while editing)'],
   [action + '+A/E', 'home / end of line'],

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -57,6 +57,7 @@ export interface ConfigDisplayConfig {
   details_mode?: string
   inline_diffs?: boolean
   mouse_tracking?: boolean | null | number | string
+  modes?: unknown
   sections?: Record<string, string>
   show_cost?: boolean
   show_reasoning?: boolean

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -90,6 +90,7 @@ Keybindings match the [Classic CLI](cli.md#keybindings) exactly. The only behavi
 - **`/terminal-setup`** installs local VS Code / Cursor / Windsurf terminal bindings for better `Cmd+Enter` and undo/redo parity on macOS.
 - **Slash autocompletion** opens as a floating panel with descriptions, not an inline dropdown.
 - **`Ctrl+X`** opens the live session switcher. When a queued message is highlighted (sent while the agent was still running), it still deletes that queued message instead. **`Esc`** cancels editing and unhighlights without deleting.
+- **`Shift+Tab`** cycles prompt modes. No Mode is blank; active modes appear as a colored chip like `Plan (shift+tab to cycle)` and can add mode-specific instructions to the next agent turn.
 - **`Ctrl+G` / `Ctrl+X Ctrl+E`** — open the current input buffer in `$EDITOR` for multi-line / long-prompt composition; save-and-exit sends the contents back as the prompt.
 
 ## Slash commands
@@ -222,6 +223,32 @@ display:
                              #   buttons — adds 1002 for terminal-side drag selection
                              #   all     — adds 1003 for hover (scrollbar paginate-on-hover,
                              #             link mouseenter, etc.)
+  modes:                     # optional: custom TUI mode chips shown in the prompt area
+    - id: none
+      label: No Mode
+      color: "#D7D7D7"
+      hidden: true           # shows nothing and injects no prompt
+      description: No extra mode instructions
+    - id: multitask
+      label: Multi-Task
+      color: "#9A7BC8"
+      description: Preserves parent context by delegating separable workstreams
+      prompt: "Hard requirement: preserve the main context window by making delegate_task the first tool call for any non-trivial codebase/research task. Use the parent as orchestrator, delegate bulky independent repo inspection/research/implementation/review to self-contained subagent tasks, synthesize concise results, and verify important claims in the parent before reporting success. If delegation is unavailable or the task is truly tiny, briefly say why."
+    - id: plan
+      label: Plan
+      color: "#D6B56D"
+      description: Research and propose an approach before building
+      prompt: "Design the approach before coding or changing state. Ask concise clarifying questions when requirements are ambiguous."
+    - id: ask
+      label: Ask
+      color: "#7FAF8A"
+      description: Read-only explanation and exploration
+      prompt: "Answer and explore without making edits or external changes unless explicitly asked to switch into execution."
+    - id: debug
+      label: Debug
+      color: "#B86B6B"
+      description: Runtime evidence, root cause, fix, verify
+      prompt: "Reproduce or inspect the failure, isolate root cause, make the smallest safe fix, and verify."
 ```
 
 Runtime toggles:


### PR DESCRIPTION
## Summary
- Add TUI prompt modes with Shift+Tab cycling and a bottom prompt-row mode chip
- Inject hidden per-mode instructions into submitted prompts while keeping the visible user message clean
- Support configurable `display.modes` entries and document the config shape
- Add regression coverage for mode normalization, prompt injection, hidden modes, duplicate IDs, and mode cycling

## Test Plan
- `npx eslint src/app/modeStore.ts src/app/useConfigSync.ts src/app/useInputHandlers.ts src/app/useSubmission.ts src/components/appLayout.tsx src/content/hotkeys.ts src/gatewayTypes.ts src/__tests__/useConfigSync.test.ts src/__tests__/modePrompt.test.ts`
  - 0 errors; 2 existing react-compiler warnings in touched files
- `npm run test -- src/__tests__/useConfigSync.test.ts src/__tests__/modePrompt.test.ts`
  - 39 passed
- `npm run build`
  - succeeded
- `git diff --check`
  - clean

## Review Notes
- Prompt mode instructions are prompt-level overlays, not separate sessions/context windows.
- Hidden/no-mode entries do not inject prompts.
- Busy/race queue fallback stores the raw user-visible prompt to avoid leaking or double-injecting mode wrappers.
