### PR TITLE
fix(cron): avoid mkdir during script validation

### DIFF
--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -396,6 +396,17 @@ class TestScriptPathContainment:
 class TestCronjobToolScriptValidation:
     """Test API-boundary validation of cron script paths in cronjob_tools."""
 
+    def test_validate_relative_script_does_not_create_scripts_dir(self, tmp_path, monkeypatch):
+        """Validation must not mutate HERMES_HOME before a create/update succeeds."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from tools.cronjob_tools import _validate_cron_script_path
+
+        assert _validate_cron_script_path("monitor.py") is None
+        assert not (hermes_home / "scripts").exists()
+
     def test_create_with_absolute_script_rejected(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -367,7 +367,6 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     from tools.path_security import validate_within_dir
 
     scripts_dir = get_hermes_home() / "scripts"
-    scripts_dir.mkdir(parents=True, exist_ok=True)
     containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
     if containment_error:
         return (


### PR DESCRIPTION
## Summary
- stop cron script path validation from creating the scripts directory as a side effect
- keep validation focused on rejecting unsafe paths and containment escapes
- add regression coverage that validation leaves HERMES_HOME unchanged

Fixes #36642.

## Why
The validation helper should not mutate `HERMES_HOME` before the cron create/update operation has actually succeeded. Creating `~/.hermes/scripts` during validation can leave filesystem side effects even when later validation or job creation fails.

## Test plan
- .venv/bin/python -m pytest tests/cron/test_cron_script.py::TestCronjobToolScriptValidation -q
