### PR TITLE
fix(file): avoid mutating dict caps during iteration

### DIFF
--- a/tests/tools/test_accretion_caps.py
+++ b/tests/tools/test_accretion_caps.py
@@ -78,6 +78,35 @@ class TestReadTrackerCaps:
         assert "/path/7" in task_data["read_timestamps"]
         assert "/path/0" not in task_data["read_timestamps"]
 
+    def test_dedup_hits_capped_oldest_first(self, monkeypatch):
+        """dedup_hits uses the same snapshot-before-pop cap path as dedup."""
+        from tools import file_tools as ft
+
+        monkeypatch.setattr(ft, "_DEDUP_CAP", 4)
+        task_data = {
+            "read_history": set(),
+            "dedup": {},
+            "dedup_hits": {f"/path/{i}": i for i in range(9)},
+            "read_timestamps": {},
+        }
+
+        ft._cap_read_tracker_data(task_data)
+
+        assert len(task_data["dedup_hits"]) == 4
+        assert "/path/8" in task_data["dedup_hits"]
+        assert "/path/5" in task_data["dedup_hits"]
+        assert "/path/0" not in task_data["dedup_hits"]
+
+    def test_file_state_dict_cap_trims_more_than_one_without_iterator_error(self):
+        """_cap_dict snapshots keys before mutation so multi-entry trims are safe."""
+        from tools import file_state
+
+        data = {f"/path/{i}": i for i in range(6)}
+
+        file_state._cap_dict(data, 3)
+
+        assert list(data) == ["/path/3", "/path/4", "/path/5"]
+
     def test_cap_is_idempotent_under_cap(self, monkeypatch):
         """When containers are under cap, _cap_read_tracker_data is a no-op."""
         from tools import file_tools as ft

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -282,13 +282,10 @@ def _cap_dict(d: dict, limit: int) -> None:
     over = len(d) - limit
     if over <= 0:
         return
-    # dict preserves insertion order (PY>=3.7) — pop the oldest keys.
-    it = iter(d)
-    for _ in range(over):
-        try:
-            d.pop(next(it))
-        except (StopIteration, KeyError):
-            break
+    # Snapshot keys before mutating.  Advancing an iterator after popping from
+    # the same dict raises ``RuntimeError: dictionary changed size``.
+    for key in list(d)[:over]:
+        d.pop(key, None)
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -398,29 +398,20 @@ def _cap_read_tracker_data(task_data: dict) -> None:
     dedup = task_data.get("dedup")
     if dedup is not None and len(dedup) > _DEDUP_CAP:
         excess = len(dedup) - _DEDUP_CAP
-        for _ in range(excess):
-            try:
-                dedup.pop(next(iter(dedup)))
-            except (StopIteration, KeyError):
-                break
+        for key in list(dedup)[:excess]:
+            dedup.pop(key, None)
 
     dedup_hits = task_data.get("dedup_hits")
     if dedup_hits is not None and len(dedup_hits) > _DEDUP_CAP:
         excess = len(dedup_hits) - _DEDUP_CAP
-        for _ in range(excess):
-            try:
-                dedup_hits.pop(next(iter(dedup_hits)))
-            except (StopIteration, KeyError):
-                break
+        for key in list(dedup_hits)[:excess]:
+            dedup_hits.pop(key, None)
 
     ts = task_data.get("read_timestamps")
     if ts is not None and len(ts) > _READ_TIMESTAMPS_CAP:
         excess = len(ts) - _READ_TIMESTAMPS_CAP
-        for _ in range(excess):
-            try:
-                ts.pop(next(iter(ts)))
-            except (StopIteration, KeyError):
-                break
+        for key in list(ts)[:excess]:
+            ts.pop(key, None)
 
 
 def _is_internal_file_status_text(content: str) -> bool:


### PR DESCRIPTION
## Summary
- fix dictionary cap helpers so they snapshot keys before trimming entries
- apply the same safe trim pattern to file read tracker dictionaries
- add regression coverage for multi-entry trimming and dedup_hits caps

Fixes #36643.

## Why
The cap helpers are used to keep long-running file/tool tracking data bounded. The previous pattern could keep an iterator over a dict while also popping from that dict, which can raise `RuntimeError: dictionary changed size during iteration` when more than one entry is trimmed.

## Test plan
- .venv/bin/python -m pytest tests/tools/test_accretion_caps.py -q
