### PR TITLE
fix(file-state): snapshot keys before mutating in _cap_dict

### DIFF
--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -283,5 +283,39 @@ class FileToolsIntegrationTests(unittest.TestCase):
         self.assertNotIn("error", w)
 
 
+class TestCapDict(unittest.TestCase):
+    """Regression tests for ``file_state._cap_dict``."""
+
+    def test_cap_dict_trims_to_limit(self):
+        """_cap_dict removes excess entries, keeping newest."""
+        d = {f"k{i}": i for i in range(20)}
+        file_state._cap_dict(d, 5)
+        self.assertEqual(len(d), 5)
+        # Newest keys (inserted last) survive.
+        self.assertIn("k19", d)
+        self.assertIn("k15", d)
+        # Oldest keys are evicted.
+        self.assertNotIn("k0", d)
+        self.assertNotIn("k14", d)
+
+    def test_cap_dict_noop_under_limit(self):
+        """_cap_dict is a no-op when dict is already within limit."""
+        d = {f"k{i}": i for i in range(3)}
+        before = dict(d)
+        file_state._cap_dict(d, 10)
+        self.assertEqual(d, before)
+
+    def test_cap_dict_empty(self):
+        """_cap_dict handles empty dict."""
+        file_state._cap_dict({}, 5)
+
+    def test_cap_dict_exact_limit(self):
+        """_cap_dict is a no-op when dict size equals limit."""
+        d = {f"k{i}": i for i in range(5)}
+        before = dict(d)
+        file_state._cap_dict(d, 5)
+        self.assertEqual(d, before)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -283,12 +283,10 @@ def _cap_dict(d: dict, limit: int) -> None:
     if over <= 0:
         return
     # dict preserves insertion order (PY>=3.7) — pop the oldest keys.
-    it = iter(d)
-    for _ in range(over):
-        try:
-            d.pop(next(it))
-        except (StopIteration, KeyError):
-            break
+    # Snapshot keys first; mutating a dict while iterating it raises
+    # ``RuntimeError: dictionary changed size during iteration``.
+    for key in list(d)[:over]:
+        d.pop(key, None)
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────


### PR DESCRIPTION
## What does this PR do?

Fixes a `RuntimeError: dictionary changed size during iteration` in `_cap_dict()` that prevents the file-state dictionary cap from trimming excess entries. The function created a single iterator then mutated the dict during iteration — on the second pop, Python raises `RuntimeError`, leaving the dict over-sized.

## Related Issue

Fixes #36643

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_state.py`: Replace single-iterator pattern with `list(d)[:over]` key snapshot before popping, matching the safe pattern already used in `file_tools._cap_read_tracker_data()`
- `tests/tools/test_file_state_registry.py`: Add `TestCapDict` regression class with 4 tests covering trim-to-limit, no-op under limit, empty dict, and exact limit

## How to Test

1. Run `python -m pytest tests/tools/test_file_state_registry.py::TestCapDict -v` — all 4 tests pass
2. Run `python -m pytest tests/tools/test_accretion_caps.py -v` — all 9 existing tests still pass
3. Verify the fix manually: `python -c "from tools.file_state import _cap_dict; d = {f'k{i}': i for i in range(20)}; _cap_dict(d, 5); assert len(d) == 5"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_file_state_registry.py tests/tools/test_accretion_caps.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/file_state.py:_cap_dict` (callers: 3 in file_state.py)
- Blast radius: LOW — `_cap_dict` is only called within `file_state.py` for `_last_writer` and `_reads` dictionaries
- Related patterns: `file_tools._cap_read_tracker_data()` uses the safe `next(iter(d))` pattern (new iterator per call); this PR aligns `_cap_dict` with that approach
