### PR TITLE
fix: include locales/ in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+locales = ["*.yaml"]
 plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
@@ -245,7 +246,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "locales", "locales.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Problem

The locales/ directory containing i18n translation catalogs was never included in the package distribution. When users install hermes-agent via pip, the agent.i18n.t() function cannot find the locale files and falls back to returning the raw key string.

This causes raw keys like gateway.model.switched, gateway.model.provider_label, gateway.status.header, etc. to appear in gateway messages on all messaging platforms (Telegram, Matrix, Discord, Slack, etc.).

## Root Cause

locales/ sits at the repo root but:
1. Has no __init__.py, so setuptools does not discover it as a package
2. Is not listed in [tool.setuptools.package-data]

Both conditions must be fixed for the directory to be included in the wheel.

## Fix

1. Add locales/__init__.py (empty) so setuptools discovers the directory
2. Add locales, locales.* to [tool.setuptools.packages.find] include list
3. Add locales = [*.yaml] to [tool.setuptools.package-data]

## Testing

pip install -e .
python -c "from agent.i18n import t; print(t('gateway.model.switched', model='test'))"
# Expected: Model switched to test

## Notes

- The locales/ directory already contains all 17 locale files (en, de, zh, ja, etc.)
- The i18n module caches catalogs in memory - a gateway restart is required after upgrading
- This is a packaging-only fix; no code logic changes