### PR TITLE
feat(security): make trusted private-IP hosts configurable via security.trusted_private_hosts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -306,6 +306,16 @@ terminal:
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds
 #   tirith_fail_open: true      # Allow commands if tirith unavailable
+#
+#   # Bypass private-IP blocking for specific domains.  Useful when
+#   # transparent proxies (Clash TUN, Surge) cause external domains to
+#   # resolve to private/benchmark-range IPs (198.18.0.0/15, 100.64.0.0/10).
+#   # Each entry is an exact hostname; only HTTPS URLs are exempted.
+#   # Prefer this over allow_private_urls to keep SSRF protection for
+#   # other domains.  (See also: _TRUSTED_PRIVATE_IP_HOSTS in url_safety.py)
+#   # trusted_private_hosts:
+#   #   - github.com
+#   #   - api.github.com
 
 # =============================================================================
 # Browser Tool Configuration

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -21,6 +21,11 @@ Limitations (documented, not fixable at pre-flight level):
     each redirect target in vision_tools, gateway platform adapters, and
     media cache helpers. Web tools use third-party SDKs (Firecrawl/Tavily)
     where redirect handling is on their servers.
+
+    For a targeted approach, add domains to
+    ``security.trusted_private_hosts`` (a list of hostnames) in
+    config.yaml.  Trusted hosts may resolve to private/benchmark-range
+    IPs over HTTPS without opening all private IPs globally.
 """
 
 import ipaddress
@@ -68,11 +73,48 @@ _ALWAYS_BLOCKED_NETWORKS = (
 )
 
 # Exact HTTPS hostnames allowed to resolve to private/benchmark-space IPs.
-# This is intentionally narrow: QQ media downloads can legitimately resolve
-# to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
+# Users behind transparent proxies (Clash TUN, Surge, etc.) see external
+# domains resolve to 198.18.0.0/15 (RFC 2544) or 100.64.0.0/10 (CGNAT).
+# Add trusted domains to ``security.trusted_private_hosts`` in config.yaml.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
 })
+
+# Cached merged set of hardcoded + configured trusted hosts.
+_trusted_config_resolved = False
+_cached_trusted_hosts: frozenset = frozenset()
+
+
+def _get_trusted_private_hosts() -> frozenset:
+    """Return the merged set of trusted hosts (hardcoded + config).
+
+    Reads ``security.trusted_private_hosts`` from config.yaml and
+    merges with the hardcoded ``_TRUSTED_PRIVATE_IP_HOSTS`` set.
+    Result is cached for the process lifetime.
+    """
+    global _trusted_config_resolved, _cached_trusted_hosts
+    if _trusted_config_resolved:
+        return _cached_trusted_hosts
+
+    _trusted_config_resolved = True
+    result = set(_TRUSTED_PRIVATE_IP_HOSTS)
+
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        sec = cfg.get("security", {})
+        if isinstance(sec, dict):
+            configured = sec.get("trusted_private_hosts", [])
+            if isinstance(configured, list):
+                for host in configured:
+                    if isinstance(host, str) and host.strip():
+                        result.add(host.strip().lower())
+    except Exception:
+        pass
+
+    _cached_trusted_hosts = frozenset(result)
+    return _cached_trusted_hosts
 
 # 100.64.0.0/10 (CGNAT / Shared Address Space, RFC 6598) is NOT covered by
 # ipaddress.is_private — it returns False for both is_private and is_global.
@@ -144,6 +186,13 @@ def _reset_allow_private_cache() -> None:
     global _allow_private_resolved, _cached_allow_private
     _allow_private_resolved = False
     _cached_allow_private = False
+
+
+def _reset_trusted_private_cache() -> None:
+    """Reset the cached trusted hosts — only for tests."""
+    global _trusted_config_resolved, _cached_trusted_hosts
+    _trusted_config_resolved = False
+    _cached_trusted_hosts = frozenset()
 
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -266,7 +315,9 @@ def is_always_blocked_url(url: str) -> bool:
 
 def _allows_private_ip_resolution(hostname: str, scheme: str) -> bool:
     """Return True when a trusted HTTPS hostname may bypass IP-class blocking."""
-    return scheme == "https" and hostname in _TRUSTED_PRIVATE_IP_HOSTS
+    if scheme != "https":
+        return False
+    return hostname in _get_trusted_private_hosts()
 
 
 def is_safe_url(url: str) -> bool:


### PR DESCRIPTION
## What does this PR do?

Users behind transparent proxies (Clash TUN, Surge, etc.) see all external
domains resolve to RFC 2544 (198.18.0.0/15) or CGNAT (100.64.0.0/10)
addresses, causing `web_extract` / `web_search` / `browser_*` to
false-positive block **every** URL with
"Blocked: URL targets a private or internal network address".

The existing `_TRUSTED_PRIVATE_IP_HOSTS` mechanism already allows specific
hosts (e.g. `multimedia.nt.qq.com.cn` for QQ media) to bypass the IP-class
check, but the set is hardcoded.  This PR makes it user-configurable.

## Related Issue

Fixes #19992
Related to #6511, #3777

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/url_safety.py`: Add `_get_trusted_private_hosts()` to merge
  hardcoded hosts with `security.trusted_private_hosts` from config.yaml.
  Result is cached for the process lifetime.
- Add `_reset_trusted_private_cache()` for test isolation.
- Update module docstring and inline comments.
- `cli-config.yaml.example`: Add commented example in the security section.

## How to Test

1. Configure a Clash TUN proxy with fake-ip mode (198.18.0.0/15)
2. Without the config key: `web_extract` of github.com returns "Blocked: private"
3. Add to config.yaml:
   ```yaml
   security:
     trusted_private_hosts:
       - github.com
   ```
4. Restart gateway — `web_extract` of github.com now succeeds
5. Unrelated private IPs remain blocked (SSRF protection intact)

## Checklist

### Code

- [x] Commit messages follow Conventional Commits
- [x] PR contains only changes related to this feature
- [x] `pytest tests/tools/test_url_safety.py -q` — 112 passed
- [x] Tested on: macOS 26.5, Python 3.11

### Documentation & Housekeeping

- [x] Updated docstrings and module-level docs
- [x] Updated `cli-config.yaml.example` with new config key
- [x] Considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] Updated tool descriptions/schemas — N/A (no tool behavior change)