### PR TITLE
fix: skip private shell function bodies in init_session snapshot

### DIFF
--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -268,3 +268,110 @@ class TestSnapshotEndToEnd:
         assert str(fake_n_bin) in output
         # bashrc short-circuited on the interactive guard — its export never ran
         assert "FROM_BASHRC=bashrc-should-not-appear" not in output
+
+
+class TestSnapshotSkipUnderscoreFunctions:
+    """Regression test for issue where ``_``-prefixed functions defined in
+    the user's shell init files leaked their bodies into the snapshot
+    file as top-level bash statements, producing ``local: can only be used
+    in a function`` errors and ``exit 127`` on every subsequent command.
+
+    The previous filter ``declare -f | grep -vE '^_[^_]'`` only matched
+    the function header line, so the body (including ``local``, ``export``,
+    closing brace) was kept verbatim and re-sourced at top level.  The fix
+    enumerates function names with ``compgen -A function`` and emits each
+    public function's full body via ``declare -f "$name"``, so the body
+    is never re-parsed.
+    """
+
+    def test_snapshot_excludes_underscore_function_body(
+        self, tmp_path, monkeypatch
+    ):
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(
+            "_helper() {\n"
+            "  local foo=1\n"
+            "  export MARKER_LEAK=$foo\n"
+            "}\n"
+            "keepme() {\n"
+            "  local bar=2\n"
+            "  echo 'keepme-ran: '$bar\n"
+            "}\n"
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            env.init_session()
+            try:
+                # The snapshot file should be re-sourceable bash.
+                import subprocess
+                check = subprocess.run(
+                    ["bash", "-n", env._snapshot_path],
+                    capture_output=True,
+                    text=True,
+                )
+                snap_text = open(env._snapshot_path).read()
+            finally:
+                env.cleanup()
+
+        assert check.returncode == 0, (
+            f"snapshot is not valid bash; stderr={check.stderr!r}\n"
+            f"snapshot contents:\n{snap_text}"
+        )
+        # The private function body must NOT appear at top level.
+        # The public function name should still be present.
+        assert "local foo=1" not in snap_text, (
+            f"private function body leaked into snapshot:\n{snap_text}"
+        )
+        assert "keepme ()" in snap_text, (
+            f"public function should still be captured:\n{snap_text}"
+        )
+
+    def test_execute_works_when_bashrc_defines_underscore_functions(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end regression: with a bashrc full of _-prefixed helpers,
+        a downstream ``echo`` should still return its actual output, not
+        the empty / exit 127 we used to see on every call.
+        """
+        bashrc = tmp_path / ".bashrc"
+        bashrc.write_text(
+            "_cc_inject_minimax() {\n"
+            "  local m=\"${1:-default-model}\"\n"
+            "  export ANTHROPIC_BASE_URL='https://example.invalid'\n"
+            "}\n"
+            "_load_minimax_key_for_claude() {\n"
+            "  local _mm_key=\"$HOME/.config/cc-profiles/minimax.key\"\n"
+            "  if [[ -f \"$_mm_key\" ]]; then\n"
+            "    export MINIMAX_API_KEY='***'\n"
+            "  fi\n"
+            "}\n"
+            "_private_helper() {\n"
+            "  local inner=42\n"
+            "  echo 'should-never-print: '$inner\n"
+            "}\n"
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        with patch(
+            "tools.environments.local._read_terminal_shell_init_config",
+            return_value=([], True),
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+            try:
+                result = env.execute("echo TERMINAL_TOOL_WORKS")
+            finally:
+                env.cleanup()
+
+        assert result.get("returncode") == 0, (
+            f"execute returned non-zero: {result!r}"
+        )
+        assert "TERMINAL_TOOL_WORKS" in result.get("output", ""), (
+            f"expected stdout to contain echo output, got: {result!r}"
+        )
+        # The private function body must not have leaked into stdout.
+        assert "should-never-print" not in result.get("output", "")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -339,9 +339,27 @@ class BaseEnvironment(ABC):
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
         _quoted_cwd = shlex.quote(self.cwd)
+        # Skip private (_-prefixed) shell functions entirely, including the
+        # body lines, so the snapshot is always re-sourceable. The previous
+        # `declare -f | grep -vE '^_[^_]'` only matched the function header
+        # line, so the body lines (containing `local`, `export`, closing
+        # brace) leaked through and were re-sourced as top-level bash
+        # statements, producing "local: can only be used in a function"
+        # errors and `exit 127` on every subsequent command.
+        #
+        # The fix enumerates function names with `compgen -A function` (one
+        # name per line, portable across bash 3.2/4.x/5.x, unlike `declare
+        # -F` whose output format changed between versions), filters out
+        # the private ones, then emits each public function's full body via
+        # `declare -f "$name"`. We never try to parse function body text,
+        # so the result is robust to all `declare -f` output formatting
+        # variants (compact, indented, with/without trailing spaces).
         bootstrap = (
             f"export -p > {self._snapshot_path}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
+            f"while IFS= read -r _name; do "
+            f"[[ \"$_name\" =~ ^_[^_] ]] && continue; "
+            f"declare -f \"$_name\"; "
+            f"done < <(compgen -A function) >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"
             f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
             f"echo 'set +e' >> {self._snapshot_path}\n"


### PR DESCRIPTION
## Summary

Fix `terminal_tool` returning `exit_code=127` and empty output on every call when the user's shell init files (`~/.bashrc`, `~/.zshrc`) define `_`-prefixed shell functions.

## Root cause

`BaseEnvironment.init_session()` captured the login shell's function table with:

```python
f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
```

The `grep -vE '^_[^_]'` only matched the function **header line** (e.g. `_helper ()`), not the body. So when the user had `_helper() { local foo=1; ... }` in their bashrc, the snapshot file ended up with:

```
_helper () 
{ 
    local foo=1
    export MARKER_LEAK=$foo
}
```

That's a top-level `{ ... local foo=1 ... }` block. When sourced on every subsequent command, bash barfs:

```
line N: local: can only be used in a function
```

and the wrapper's `__hermes_ec=$?` / `exit $__hermes_ec` propagates that as the command's exit code. Because the `local` parse error happens before the `eval 'echo HI'` line, **no stdout** is produced and `returncode=127` (`command not found`) is what every call reports. From the agent's perspective, the terminal tool is completely dead — every `terminal()` call returns the same empty error envelope regardless of the actual command.

## Fix

Enumerate function names with `compgen -A function` (one name per line, portable across bash 3.2/4.x/5.x — `declare -F` output format changed between versions), filter out the private `_`-prefixed ones, then emit each public function's full body via `declare -f "$name"`. We never try to parse the function body text, so the result is robust to all `declare -f` output formatting variants (compact, indented, with/without trailing spaces):

```bash
while IFS= read -r _name; do
  [[ "$_name" =~ ^_[^_] ]] && continue
  declare -f "$_name"
done < <(compgen -A function) >> "$SNAP"
```

## Tests

Two regression tests in `tests/tools/test_local_shell_init.py::TestSnapshotSkipUnderscoreFunctions`:

- **`test_snapshot_excludes_underscore_function_body`** — populates a fake `~/.bashrc` with both a `_helper()` and a public `keepme()` (both containing `local`), runs `init_session()`, then verifies:
  - `bash -n` parses the snapshot without errors
  - `local foo=1` does not appear at top level
  - `keepme ()` is still present in the snapshot
- **`test_execute_works_when_bashrc_defines_underscore_functions`** — same setup with a realistic `_cc_inject_minimax`-style function, then verifies `env.execute("echo TERMINAL_TOOL_WORKS")` returns `returncode=0` and the expected stdout. (This is the user-visible regression — the symptom they reported was "every terminal call returns empty + exit 127".)

## Test results

```
$ python3 -m pytest tests/tools/test_local_shell_init.py -v
============================== 16 passed in 3.69s ==============================
```

All 14 pre-existing tests in the file still pass; the 2 new tests pass.

## Reproduction

The bug requires:
- A `~/.bashrc` (or `~/.zshrc`, `~/.profile`) defining at least one `_`-prefixed function
- That function containing `local` (or any other construct that errors at top level: `return`, `${VAR:?msg}`, etc.)

The fix is upstream-friendly: no API changes, no config changes, no behavior changes for users without private functions in their init files.