### PR TITLE
fix(weixin): exempt slash commands from content-fingerprint dedup

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1449,7 +1449,7 @@ class WeixinAdapter(BasePlatformAdapter):
         # Secondary content-fingerprint dedup for text messages
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
-        if text:
+        if text and not text.startswith("/"):
             content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -890,7 +890,7 @@ class WeixinAdapter(BasePlatformAdapter):
         # Secondary content-fingerprint dedup: upstream re-sends identical text under new message_ids.
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
-        if text and self._dedup.is_duplicate(f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"):
+        if text and not text.startswith("/") and self._dedup.is_duplicate(f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"):
             logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
             return
         chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -545,6 +545,41 @@ class TestWeixinContentDedup:
         event = adapter.handle_message.await_args[0][0]
         assert event.text == "hello world"
 
+    def test_slash_commands_bypass_content_dedup(self):
+        """Slash commands with different message IDs bypass content dedup."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+        async def _drive():
+            await adapter._process_message({**base_msg, "message_id": "msg-1"})
+            await adapter._process_message({**base_msg, "message_id": "msg-2"})
+            await asyncio.sleep(0.2)
+        asyncio.run(_drive())
+        assert adapter.handle_message.await_count == 2
+        texts = [call.args[0].text for call in adapter.handle_message.await_args_list]
+        assert texts == ["/approve", "/approve"]
+
+    def test_slash_command_msg_id_dedup_still_applies(self):
+        """Message ID dedup still applies to slash commands."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+        async def _drive():
+            await adapter._process_message({**base_msg, "message_id": "same-id"})
+            await adapter._process_message({**base_msg, "message_id": "same-id"})
+        asyncio.run(_drive())
+        assert adapter.handle_message.await_count == 1
+
 
 class TestWeixinTextDebounce:
     """Text-debounce batching for rapid multi-message bursts (issue #35301).

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -597,6 +597,41 @@ class TestWeixinContentDedup:
         event = adapter.handle_message.await_args[0][0]
         assert event.text == "hello world"
 
+    def test_slash_commands_bypass_content_dedup(self):
+        """Slash commands with different message IDs bypass content dedup."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+        async def _drive():
+            await adapter._process_message({**base_msg, "message_id": "msg-1"})
+            await adapter._process_message({**base_msg, "message_id": "msg-2"})
+            await asyncio.sleep(0.2)
+        asyncio.run(_drive())
+        assert adapter.handle_message.await_count == 2
+        texts = [call.args[0].text for call in adapter.handle_message.await_args_list]
+        assert texts == ["/approve", "/approve"]
+
+    def test_slash_command_msg_id_dedup_still_applies(self):
+        """Message ID dedup still applies to slash commands."""
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": "/approve"}}],
+        }
+        async def _drive():
+            await adapter._process_message({**base_msg, "message_id": "same-id"})
+            await adapter._process_message({**base_msg, "message_id": "same-id"})
+        asyncio.run(_drive())
+        assert adapter.handle_message.await_count == 1
+
 
 class TestWeixinTextDebounce:
     """Text-debounce batching for rapid multi-message bursts (issue #35301).


### PR DESCRIPTION
## Problem

When a user sends the same slash command twice (e.g. `/approve`, `/deny`, `/retry`) via Weixin, the second message is silently dropped by the content-fingerprint deduplication logic at `gateway/platforms/weixin.py:1449-1456`.  Slash commands are intentionally repeatable — the user may need to send `/approve` again or `/retry` to re-run the last turn.

## Fix

Skip content-fingerprint dedup for messages starting with `/`:

```python
# Before
if text:
# After
if text and not text.startswith("/"):
```

Message-ID dedup (300s TTL) still handles iLink network retries, so no additional command-specific dedup mechanism is needed.

## Tests

- `test_slash_commands_bypass_content_dedup` — two `/approve` with different message IDs → both reach the handler
- `test_slash_command_msg_id_dedup_still_applies` — same message ID → deduped by message_id cache
- Existing `test_duplicate_content_with_different_message_ids_is_dropped` still passes (regular text dedup unchanged)

## Verification

- All 12 existing weixin gateway tests pass (unchanged behavior for regular text)