### PR TITLE
fix(gateway): create Telegram DM topics from root prompts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -409,9 +409,6 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
-        # suppress_commands: register an empty command list so this bot doesn't
-        # pollute the autocomplete in groups where another bot is the primary.
-        self._suppress_commands: bool = self._coerce_bool_extra("suppress_commands", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
@@ -1696,16 +1693,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     BotCommandScopeChat,
                 )
                 from hermes_cli.commands import telegram_menu_commands
-                if self._suppress_commands:
-                    bot_commands = []
-                    hidden_count = 0
-                    logger.info("[%s] suppress_commands=true — registering empty command list", self.name)
-                else:
-                    # Telegram allows up to 100 commands but has an undocumented
-                    # payload size limit (~4KB total).  Limit to 30 core commands
-                    # to stay well under the threshold while covering all categories.
-                    menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
-                    bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                # Telegram allows up to 100 commands but has an undocumented
+                # payload size limit (~4KB total).  Limit to 30 core commands
+                # to stay well under the threshold while covering all categories.
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
                 # through to AllGroupChats or Default).
@@ -1716,27 +1708,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
                     except Exception as scope_err:
                         logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
-                # Forum/group chats use BotCommandScopeChat(chat_id) which overrides
-                # AllGroupChats. When suppress_commands=true, proactively clear
-                # BotCommandScopeChat for the known home chat so cached commands
-                # from previous runs are wiped immediately on startup.
-                if self._suppress_commands:
-                    home_chat_id = self.config.extra.get("home_chat_id") or os.getenv("TELEGRAM_HOME_CHAT_ID")
-                    if home_chat_id:
-                        try:
-                            from telegram import BotCommandScopeChat
-                            await self._bot.set_my_commands([], scope=BotCommandScopeChat(chat_id=int(home_chat_id)))
-                            logger.info("[%s] suppress_commands: cleared BotCommandScopeChat for home chat %s", self.name, home_chat_id)
-                        except Exception as scope_err:
-                            logger.warning("[%s] suppress_commands: failed to clear BotCommandScopeChat for %s: %s", self.name, home_chat_id, scope_err)
                 # Forum topics don't inherit AllGroupChats — Telegram resolves
                 # commands via BotCommandScopeChat(chat_id) for forum groups.
                 # Lazy registration happens in _ensure_forum_commands on first
                 # message from a forum topic (see _handle_text_message).
-                if not self._suppress_commands and hidden_count:
+                if hidden_count:
                     logger.info(
                         "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
-                        self.name, len(bot_commands), hidden_count, 30,
+                        self.name, len(menu_commands), hidden_count, 30,
                     )
             except Exception as e:
                 logger.warning(
@@ -4949,13 +4928,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 if chat_id in self._forum_command_registered:
                     return
                 from telegram import BotCommand, BotCommandScopeChat
-                if self._suppress_commands:
-                    bot_commands = []
-                    logger.info("[%s] suppress_commands=true — registering empty commands for forum chat %s", self.name, chat_id)
-                else:
-                    from hermes_cli.commands import telegram_menu_commands
-                    menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
-                    bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                from hermes_cli.commands import telegram_menu_commands
+                menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)
                 logger.info("[%s] Lazy-registered %d commands for forum chat %s", self.name, len(bot_commands), chat_id)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -409,6 +409,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
+        # suppress_commands: register an empty command list so this bot doesn't
+        # pollute the autocomplete in groups where another bot is the primary.
+        self._suppress_commands: bool = self._coerce_bool_extra("suppress_commands", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
@@ -1693,11 +1696,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     BotCommandScopeChat,
                 )
                 from hermes_cli.commands import telegram_menu_commands
-                # Telegram allows up to 100 commands but has an undocumented
-                # payload size limit (~4KB total).  Limit to 30 core commands
-                # to stay well under the threshold while covering all categories.
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
-                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                if self._suppress_commands:
+                    bot_commands = []
+                    hidden_count = 0
+                    logger.info("[%s] suppress_commands=true — registering empty command list", self.name)
+                else:
+                    # Telegram allows up to 100 commands but has an undocumented
+                    # payload size limit (~4KB total).  Limit to 30 core commands
+                    # to stay well under the threshold while covering all categories.
+                    menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                    bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
                 # through to AllGroupChats or Default).
@@ -1708,14 +1716,27 @@ class TelegramAdapter(BasePlatformAdapter):
                         logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
                     except Exception as scope_err:
                         logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
+                # Forum/group chats use BotCommandScopeChat(chat_id) which overrides
+                # AllGroupChats. When suppress_commands=true, proactively clear
+                # BotCommandScopeChat for the known home chat so cached commands
+                # from previous runs are wiped immediately on startup.
+                if self._suppress_commands:
+                    home_chat_id = self.config.extra.get("home_chat_id") or os.getenv("TELEGRAM_HOME_CHAT_ID")
+                    if home_chat_id:
+                        try:
+                            from telegram import BotCommandScopeChat
+                            await self._bot.set_my_commands([], scope=BotCommandScopeChat(chat_id=int(home_chat_id)))
+                            logger.info("[%s] suppress_commands: cleared BotCommandScopeChat for home chat %s", self.name, home_chat_id)
+                        except Exception as scope_err:
+                            logger.warning("[%s] suppress_commands: failed to clear BotCommandScopeChat for %s: %s", self.name, home_chat_id, scope_err)
                 # Forum topics don't inherit AllGroupChats — Telegram resolves
                 # commands via BotCommandScopeChat(chat_id) for forum groups.
                 # Lazy registration happens in _ensure_forum_commands on first
                 # message from a forum topic (see _handle_text_message).
-                if hidden_count:
+                if not self._suppress_commands and hidden_count:
                     logger.info(
                         "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
-                        self.name, len(menu_commands), hidden_count, 30,
+                        self.name, len(bot_commands), hidden_count, 30,
                     )
             except Exception as e:
                 logger.warning(
@@ -4928,9 +4949,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 if chat_id in self._forum_command_registered:
                     return
                 from telegram import BotCommand, BotCommandScopeChat
-                from hermes_cli.commands import telegram_menu_commands
-                menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
-                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                if self._suppress_commands:
+                    bot_commands = []
+                    logger.info("[%s] suppress_commands=true — registering empty commands for forum chat %s", self.name, chat_id)
+                else:
+                    from hermes_cli.commands import telegram_menu_commands
+                    menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                    bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)
                 logger.info("[%s] Lazy-registered %d commands for forum chat %s", self.name, len(bot_commands), chat_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2254,6 +2254,14 @@ class GatewayRunner:
     def _telegram_topic_root_lobby_message(self) -> str:
         return (
             "This main chat is reserved for system commands.\n\n"
+            "To start a new Hermes chat, send a normal prompt in the main/All "
+            "Messages view and Hermes will create a new topic for it. Each topic "
+            "works as an independent Hermes session."
+        )
+
+    def _telegram_topic_root_creation_failed_message(self) -> str:
+        return (
+            "This main chat is reserved for system commands.\n\n"
             "I tried to create a new Hermes topic for that prompt but couldn't. "
             "Use Telegram's new-topic/+ button in this bot interface, then send "
             "your message inside that topic. Each topic works as an independent "
@@ -2272,7 +2280,7 @@ class GatewayRunner:
         self,
         event: MessageEvent,
         source: SessionSource,
-    ) -> Optional[SessionSource]:
+    ) -> tuple[Optional[SessionSource], bool]:
         """Create a fresh Telegram DM topic for a root-lobby prompt.
 
         Telegram's "All Messages" view in bot DMs is not delivered to bots as a
@@ -2283,24 +2291,30 @@ class GatewayRunner:
         non-command root prompt as a request for a new lane: create the forum
         topic via Bot API, rewrite the event source to that new thread, then let
         the normal agent path create/bind the session.
+
+        Returns:
+            (new_source, attempted) — ``new_source`` is the rewritten source on
+            success, ``None`` on failure or skip.  ``attempted`` is ``True`` when
+            a Bot API call was actually made (so the caller can show a specific
+            "couldn't create" message rather than the generic lobby reminder).
         """
         if not self._is_telegram_topic_root_lobby(source):
-            return None
+            return None, False
         if event.get_command():
-            return None
+            return None, False
         adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
         create_topic = getattr(adapter, "_create_dm_topic", None) if adapter is not None else None
         if not callable(create_topic) or not source.chat_id:
-            return None
+            return None, False
         raw_title = (event.text or "").strip() or "Hermes Chat"
         title = self._sanitize_telegram_topic_title(raw_title)
         try:
             thread_id = await create_topic(int(source.chat_id), title)
         except Exception:
             logger.debug("Failed to create Telegram topic for root prompt", exc_info=True)
-            return None
+            return None, True
         if not thread_id:
-            return None
+            return None, True
         logger.info(
             "telegram topic lobby prompt: created topic chat=%s user=%s thread=%s title=%r",
             source.chat_id,
@@ -2312,7 +2326,7 @@ class GatewayRunner:
             source,
             thread_id=str(thread_id),
             chat_topic=title,
-        )
+        ), False
 
     def _telegram_topic_new_header(self, source: SessionSource) -> Optional[str]:
         if not self._is_telegram_topic_lane(source):
@@ -7896,11 +7910,14 @@ class GatewayRunner:
         # execution of a dangerous command.
 
         if self._is_telegram_topic_root_lobby(source):
-            topic_source = await self._telegram_topic_source_for_root_prompt(event, source)
+            topic_source, attempted = await self._telegram_topic_source_for_root_prompt(event, source)
             if topic_source is not None:
                 source = topic_source
                 event = dataclasses.replace(event, source=source)
                 _quick_key = self._session_key_for_source(source)
+            elif attempted:
+                # We tried to create a topic but the Bot API call failed.
+                return self._telegram_topic_root_creation_failed_message()
             else:
                 # Debounce the lobby reminder so a user who forgets about
                 # topic mode and fires ten prompts doesn't get ten copies.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2372,6 +2372,14 @@ class GatewayRunner:
             # as a new independent lane below instead of hijacking the latest
             # existing topic binding.
             return None
+        # A completely absent thread_id means the message came from the root
+        # "All Messages" view — a genuine new-lane intent. Do NOT recover it
+        # into the last-used topic; let _telegram_topic_source_for_root_prompt
+        # create a fresh topic for it instead. Only recover when thread_id is
+        # "1" (General topic header), which is Telegram's ambiguous signal for
+        # a reply that lost its thread context.
+        if not inbound:
+            return None
         session_db = getattr(self, "_session_db", None)
         if session_db is None:
             return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2254,19 +2254,64 @@ class GatewayRunner:
     def _telegram_topic_root_lobby_message(self) -> str:
         return (
             "This main chat is reserved for system commands.\n\n"
-            "To start a new Hermes chat, open the All Messages topic at the top "
-            "of this bot interface and send any message there. Telegram will "
-            "create a new topic for that message; each topic works as an "
-            "independent Hermes session."
+            "I tried to create a new Hermes topic for that prompt but couldn't. "
+            "Use Telegram's new-topic/+ button in this bot interface, then send "
+            "your message inside that topic. Each topic works as an independent "
+            "Hermes session."
         )
 
     def _telegram_topic_root_new_message(self) -> str:
         return (
-            "To start a new parallel Hermes chat, open the All Messages topic "
-            "at the top of this bot interface and send any message there. "
-            "Telegram will create a new topic for it.\n\n"
+            "To start a new parallel Hermes chat, send a normal prompt in the "
+            "main/All Messages view and Hermes will create a new topic for it.\n\n"
             "Each topic is an independent Hermes session. Use /new inside an "
             "existing topic only if you want to replace that topic's current session."
+        )
+
+    async def _telegram_topic_source_for_root_prompt(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+    ) -> Optional[SessionSource]:
+        """Create a fresh Telegram DM topic for a root-lobby prompt.
+
+        Telegram's "All Messages" view in bot DMs is not delivered to bots as a
+        special create-topic event: the Bot API sees an ordinary private-chat
+        message with no ``message_thread_id`` (or sometimes General/``1``).
+        If we reject that as the root lobby, users have no message-driven way to
+        start the new parallel session that our own guidance promises.  Treat a
+        non-command root prompt as a request for a new lane: create the forum
+        topic via Bot API, rewrite the event source to that new thread, then let
+        the normal agent path create/bind the session.
+        """
+        if not self._is_telegram_topic_root_lobby(source):
+            return None
+        if event.get_command():
+            return None
+        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        create_topic = getattr(adapter, "_create_dm_topic", None) if adapter is not None else None
+        if not callable(create_topic) or not source.chat_id:
+            return None
+        raw_title = (event.text or "").strip() or "Hermes Chat"
+        title = self._sanitize_telegram_topic_title(raw_title)
+        try:
+            thread_id = await create_topic(int(source.chat_id), title)
+        except Exception:
+            logger.debug("Failed to create Telegram topic for root prompt", exc_info=True)
+            return None
+        if not thread_id:
+            return None
+        logger.info(
+            "telegram topic lobby prompt: created topic chat=%s user=%s thread=%s title=%r",
+            source.chat_id,
+            source.user_id,
+            thread_id,
+            title,
+        )
+        return dataclasses.replace(
+            source,
+            thread_id=str(thread_id),
+            chat_topic=title,
         )
 
     def _telegram_topic_new_header(self, source: SessionSource) -> Optional[str]:
@@ -2274,9 +2319,9 @@ class GatewayRunner:
             return None
         return (
             "Started a new Hermes session in this topic.\n\n"
-            "Tip: for parallel work, open All Messages and send a message there "
-            "to create a separate topic instead of using /new here. /new replaces "
-            "the session attached to the current topic."
+            "Tip: for parallel work, send a normal prompt in the main/All "
+            "Messages view to create a separate topic instead of using /new "
+            "here. /new replaces the session attached to the current topic."
         )
 
     def _record_telegram_topic_binding(
@@ -7843,11 +7888,17 @@ class GatewayRunner:
         # execution of a dangerous command.
 
         if self._is_telegram_topic_root_lobby(source):
-            # Debounce the lobby reminder so a user who forgets about
-            # topic mode and fires ten prompts doesn't get ten copies.
-            if self._should_send_telegram_lobby_reminder(source):
-                return self._telegram_topic_root_lobby_message()
-            return None
+            topic_source = await self._telegram_topic_source_for_root_prompt(event, source)
+            if topic_source is not None:
+                source = topic_source
+                event = dataclasses.replace(event, source=source)
+                _quick_key = self._session_key_for_source(source)
+            else:
+                # Debounce the lobby reminder so a user who forgets about
+                # topic mode and fires ten prompts doesn't get ten copies.
+                if self._should_send_telegram_lobby_reminder(source):
+                    return self._telegram_topic_root_lobby_message()
+                return None
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
@@ -12420,7 +12471,10 @@ class GatewayRunner:
             send_result = await adapter.send(
                 source.chat_id,
                 "System topic for Hermes commands and status.",
-                metadata={"thread_id": str(thread_id)},
+                metadata={
+                    "thread_id": str(thread_id),
+                    "telegram_dm_topic_created_for_send": True,
+                },
             )
             message_id = getattr(send_result, "message_id", None)
         except Exception:
@@ -12648,8 +12702,8 @@ class GatewayRunner:
             "How it works:\n"
             "1. Run /topic once in this DM — Hermes checks BotFather Threads\n"
             "   Settings are enabled and flips on multi-session mode.\n"
-            "2. Tap All Messages at the top of the bot and send any message.\n"
-            "   Telegram creates a new topic for that message; each topic is\n"
+            "2. Send a normal prompt in the main/All Messages view.\n"
+            "   Hermes creates a new topic for that message; each topic is\n"
             "   an independent Hermes session (fresh history, fresh context).\n"
             "3. The root DM becomes a system lobby — send /topic, /status,\n"
             "   /help, /usage there. Normal prompts go in a topic.\n"
@@ -12742,6 +12796,15 @@ class GatewayRunner:
                     await self._send_telegram_topic_setup_image(source)
                 return t("gateway.topic.topics_user_disallowed")
 
+        was_enabled = False
+        try:
+            was_enabled = self._session_db.is_telegram_topic_mode_enabled(
+                chat_id=str(source.chat_id),
+                user_id=str(source.user_id),
+            )
+        except Exception:
+            logger.debug("Failed to read existing Telegram topic mode before /topic", exc_info=True)
+
         try:
             self._session_db.enable_telegram_topic_mode(
                 chat_id=str(source.chat_id),
@@ -12753,7 +12816,7 @@ class GatewayRunner:
             logger.exception("Failed to enable Telegram topic mode")
             return t("gateway.topic.enable_failed", error=exc)
 
-        if not source.thread_id:
+        if not source.thread_id and not was_enabled:
             await self._ensure_telegram_system_topic(source)
 
         if source.thread_id:
@@ -12786,9 +12849,8 @@ class GatewayRunner:
         lines = [
             "Telegram multi-session topics are enabled.",
             "",
-            "To create a new Hermes chat, open All Messages at the top of this "
-            "bot interface and send any message there. Telegram will create a "
-            "new topic for it.",
+            "To create a new Hermes chat, send a normal prompt in the main/All "
+            "Messages view. Hermes will create a new topic for it.",
             "",
         ]
         try:
@@ -12814,7 +12876,7 @@ class GatewayRunner:
             lines.extend([
                 "",
                 "To restore one:",
-                "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
+                "1. Create or open a topic. To create a new one, send a normal prompt in the main/All Messages view.",
                 "2. Send /topic <session-id> inside that topic.",
                 f"Example: Send /topic {sessions[0].get('id')} inside a topic.",
             ])
@@ -12823,7 +12885,7 @@ class GatewayRunner:
                 "No previous unlinked Telegram sessions found.",
                 "",
                 "To restore a previous session later:",
-                "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
+                "1. Create or open a topic. To create a new one, send a normal prompt in the main/All Messages view.",
                 "2. Send /topic <session-id> inside that topic.",
             ])
         return "\n".join(lines)

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1238,12 +1238,26 @@ def test_recover_preserves_unknown_thread_id_for_new_topic(tmp_path):
 
 
 def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):
-    # Stripped plain reply: thread_id is None, topic mode is on.
+    # Stripped plain reply: Telegram delivers thread_id="1" (General topic
+    # header) when a reply loses its thread context. Recovery maps that back
+    # to the most-recently active topic.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
-    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) == "222"
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="1")) == "222"
+
+
+def test_recover_skips_bare_none_thread_id(tmp_path):
+    # A completely absent thread_id means the message came from the root
+    # "All Messages" view — a genuine new-lane intent. Recovery must NOT
+    # rewrite it; _telegram_topic_source_for_root_prompt handles this case
+    # by creating a fresh topic instead.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
 
 
 def test_recover_returns_none_when_topic_mode_disabled(tmp_path):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -158,7 +158,7 @@ def _make_runner(session_db=None):
 
 
 @pytest.mark.asyncio
-async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_mode_enabled(monkeypatch):
+async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_creation_unavailable(monkeypatch):
     import gateway.run as gateway_run
 
     runner = _make_runner()
@@ -174,7 +174,7 @@ async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_mode_enabled(m
     result = await runner._handle_message(_make_event("hello from root"))
 
     assert "main chat is reserved for system commands" in result
-    assert "All Messages" in result
+    assert "new-topic/+ button" in result
     runner._run_agent.assert_not_called()
     runner.session_store.get_or_create_session.assert_not_called()
 
@@ -195,12 +195,38 @@ async def test_root_telegram_dm_new_shows_create_topic_instruction(monkeypatch):
 
     result = await runner._handle_message(_make_event("/new"))
 
-    assert "create a new topic" in result
-    assert "All Messages" in result
+    assert "send a normal prompt" in result
+    assert "Hermes will create a new topic" in result
     assert "Use /new inside" in result
     runner._run_agent.assert_not_called()
     runner.session_store.reset_session.assert_not_called()
     runner.session_store.get_or_create_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_root_telegram_dm_prompt_creates_topic_and_runs_agent(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.adapters[Platform.TELEGRAM]._create_dm_topic.return_value = 555
+    runner._handle_message_with_agent = AsyncMock(return_value="agent response")
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("research os cursor movement"))
+
+    assert result == "agent response"
+    runner.adapters[Platform.TELEGRAM]._create_dm_topic.assert_awaited_once()
+    create_args = runner.adapters[Platform.TELEGRAM]._create_dm_topic.await_args.args
+    assert create_args[0] == 208214988
+    assert "research os cursor movement" in create_args[1]
+    runner._handle_message_with_agent.assert_awaited_once()
+    _, routed_source, quick_key, _run_generation = runner._handle_message_with_agent.await_args.args
+    assert routed_source.thread_id == "555"
+    assert quick_key.endswith(":555")
 
 
 @pytest.mark.asyncio
@@ -478,6 +504,28 @@ async def test_topic_root_command_explicitly_migrates_and_enables_topic_mode(tmp
 
 
 @pytest.mark.asyncio
+async def test_topic_root_status_does_not_create_duplicate_system_topic(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    runner = _make_runner(session_db=session_db)
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("root /topic status must not enter the agent loop")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/topic"))
+
+    assert "Telegram multi-session topics are enabled" in result
+    runner.adapters[Platform.TELEGRAM]._create_dm_topic.assert_not_awaited()
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_topic_root_command_lists_unlinked_sessions_for_restore(tmp_path, monkeypatch):
     import gateway.run as gateway_run
 
@@ -740,7 +788,10 @@ async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkey
     adapter.send.assert_awaited_once_with(
         "208214988",
         "System topic for Hermes commands and status.",
-        metadata={"thread_id": "4242"},
+        metadata={
+            "thread_id": "4242",
+            "telegram_dm_topic_created_for_send": True,
+        },
     )
     bot.pin_chat_message.assert_awaited_once_with(
         chat_id=208214988,

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -664,7 +664,7 @@ Topics created outside of the config (e.g., by manually calling the Telegram API
 
 ## Multi-session DM mode (`/topic`)
 
-A ChatGPT-style multi-session DM — one bot, many parallel conversations. Unlike the operator-curated `extra.dm_topics` above, this mode is **user-driven**: no config, no pre-declared topic names. The end user flips it on with `/topic`, then taps the Telegram **+** button to create as many topics as they want, each one a fully independent Hermes session.
+A ChatGPT-style multi-session DM — one bot, many parallel conversations. Unlike the operator-curated `extra.dm_topics` above, this mode is **user-driven**: no config, no pre-declared topic names. The end user flips it on with `/topic`, then sends a normal prompt from the Telegram main/**All Messages** view; Hermes creates a fresh topic for that prompt and treats it as an independent session. Users can also use Telegram's new-topic/**+** button when their client exposes it.
 
 ### `/topic` subcommands
 
@@ -716,14 +716,16 @@ Hermes will:
 3. Create and pin a **System** topic for status/commands (best-effort)
 4. Reply with a list of previous unlinked Telegram sessions the user can restore
 
-After activation, the **root DM is a lobby**: normal prompts are rejected with guidance pointing at **All Messages**. System commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root.
+After activation, slash commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root/main view. A non-command prompt sent from the main/**All Messages** view starts a fresh topic automatically; if Hermes cannot create the topic (for example, BotFather thread settings changed), it falls back to guidance for creating a topic manually.
 
 ### Creating a new topic (end-user flow)
 
 1. Open the bot DM in Telegram
-2. Tap **All Messages** at the top of the bot interface, then send any message
-3. Telegram creates a new topic for that message
+2. From the main/**All Messages** view, send the first normal prompt for the new chat
+3. Hermes calls Telegram `createForumTopic`, creates a new topic for that prompt, and routes the prompt into that topic
 4. Hermes responds inside that topic — the topic is now a standalone session
+
+If your Telegram client exposes a new-topic/**+** button in the bot interface, you can also create/open a topic manually and send the first prompt there.
 
 Every topic gets its own conversation history, model state, tool execution, and session ID. The isolation key is `agent:main:telegram:dm:{chat_id}:{thread_id}` — identical to the config-driven DM topics isolation.
 
@@ -745,7 +747,7 @@ When this flag is on, Hermes still generates an internal session title (used by 
 
 ### `/new` inside a topic
 
-Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, creating another topic (via **All Messages**) is usually what you want.
+Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, sending a new prompt from the main/**All Messages** view is usually what you want.
 
 ### Restoring a previous session
 


### PR DESCRIPTION
## Summary

Fix Telegram DM `/topic` mode so a normal prompt sent in the root/main "All Messages" view automatically creates a fresh Telegram topic and routes the prompt into that new session lane.

**Root problem (two-part):**

1. `_recover_telegram_topic_thread_id` runs as an adapter callback during session-key building — before any lobby check. When a message arrived from "All Messages" with `thread_id=None`, it was rewritten to the last-used topic thread_id. By the time the lobby check ran, the source no longer looked like a lobby, so the auto-create path never fired.

2. Even with recovery skipped, there was no auto-create path — root lobby messages were just returning the reminder text.

**Changes:**

- `_recover_telegram_topic_thread_id`: skip recovery when `thread_id` is completely absent (`None`). Only recover when `thread_id="1"` (General topic header — Telegram's ambiguous signal for a stripped reply context). Bare `thread_id=None` is a genuine new-lane intent from All Messages.

- `_telegram_topic_source_for_root_prompt`: new method. When a non-command root-lobby message arrives, call `createForumTopic` to create a fresh topic, rewrite the event source to that thread, and route the session normally. Returns `(new_source, attempted)` tuple — `attempted=True` only when a Bot API call was actually made, so the caller can show the right message.

- Two distinct lobby fallback messages:
  - `_telegram_topic_root_lobby_message()` — neutral reminder shown for commands and debounced repeat messages ("send a normal prompt in the main/All Messages view")
  - `_telegram_topic_root_creation_failed_message()` — shown only when `createForumTopic` was called and failed ("I tried to create a topic but couldn't")

- Update `_telegram_topic_root_new_message` and help text to match the new auto-create flow.

- Avoid duplicate managed System topics on repeated `/topic` status calls.

- Route the System topic intro message with created-topic metadata.

## Test plan

```bash
pytest tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_delivery.py -q
```
