### PR TITLE
fix: prevent cron ticker from dying silently (#32612)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19056,21 +19056,36 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
     from hermes_cli.debug import _sweep_expired_pastes
+    from hermes_constants import get_hermes_home
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
 
+    _heartbeat_file = get_hermes_home() / "cron" / ".ticker-heartbeat"
+
+    def _write_heartbeat():
+        try:
+            _heartbeat_file.parent.mkdir(parents=True, exist_ok=True)
+            _heartbeat_file.write_text(str(time.time()), encoding="utf-8")
+        except Exception:
+            pass
+
     logger.info("Cron ticker started (interval=%ds)", interval)
+    _write_heartbeat()
     tick_count = 0
     while not stop_event.is_set():
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop)
-        except Exception as e:
-            logger.debug("Cron tick error: %s", e)
+        except BaseException as e:
+            if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                logger.info("Cron ticker stopping due to %s", type(e).__name__)
+                raise
+            logger.error("Cron tick error (tick %d): %s: %s", tick_count, type(e).__name__, e, exc_info=True)
 
         tick_count += 1
+        _write_heartbeat()
 
         if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
             try:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -8,6 +8,7 @@ pause/resume/run/remove, status, and tick.
 import json
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Iterable, List, Optional
 
@@ -155,6 +156,7 @@ def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
     from hermes_cli.gateway import find_gateway_pids
+    from hermes_constants import get_hermes_home
 
     print()
 
@@ -162,6 +164,51 @@ def cron_status():
     if pids:
         print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
         print(f"  PID: {', '.join(map(str, pids))}")
+
+        # Check ticker liveness via heartbeat file.
+        # The ticker writes a timestamp after every successful tick.
+        # If the file is missing or stale (> 2x interval + 60s grace),
+        # the ticker thread may have died silently.  (#32612)
+        heartbeat_file = get_hermes_home() / "cron" / ".ticker-heartbeat"
+        try:
+            if heartbeat_file.exists():
+                heartbeat_age = time.time() - float(
+                    heartbeat_file.read_text(encoding="utf-8").strip()
+                )
+                heartbeat_mins = int(heartbeat_age / 60)
+                heartbeat_secs = int(heartbeat_age % 60)
+                if heartbeat_age > 180:  # 2x 60s interval + 60s grace
+                    print(
+                        color(
+                            f"  ! Ticker heartbeat is stale ({heartbeat_mins}m {heartbeat_secs}s ago) "
+                            f"— cron jobs may NOT be firing!",
+                            Colors.YELLOW,
+                        )
+                    )
+                    print(
+                        color(
+                            "     The cron ticker thread may have died. "
+                            "Restart the gateway: hermes gateway restart",
+                            Colors.DIM,
+                        )
+                    )
+                else:
+                    print(
+                        color(
+                            f"  Ticker heartbeat: {heartbeat_secs}s ago",
+                            Colors.DIM,
+                        )
+                    )
+            else:
+                print(
+                    color(
+                        "  ! No ticker heartbeat yet — "
+                        "wait for the first tick or restart the gateway",
+                        Colors.YELLOW,
+                    )
+                )
+        except Exception:
+            pass  # best-effort; never fail cron status on a heartbeat I/O error
     else:
         print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
         print()


### PR DESCRIPTION
 ## Problem

  The cron ticker thread inside the gateway can die silently, leaving all
  scheduled jobs unexecuted for hours while `hermes cron status` falsely
  reports healthy. Three specific gaps cause this:

  1. **Errors logged at DEBUG level** — invisible at the default WARNING
     threshold. An unhandled exception in a tick is effectively silent.
  2. **Only `Exception` is caught** — `BaseException` subclasses
     (GeneratorExit, etc.) kill the daemon thread with zero log output.
  3. **No liveness tracking** — `hermes cron status` only checks whether
     the gateway PID exists; it has no way to know if the ticker thread
     is still running.

  Closes #32612

  ## Changes

  ### `gateway/run.py` — `_start_cron_ticker()`

  - Promote tick errors from `logger.debug` → `logger.error` with full
    traceback (`exc_info=True`), visible at default WARNING level.
  - Catch `BaseException` instead of just `Exception`. KeyboardInterrupt
    and SystemExit still propagate for clean shutdown; everything else is
    logged and the ticker loop survives so one bad tick doesn't
    permanently disable cron.
  - Write a liveness heartbeat file
    (`~/.hermes/cron/.ticker-heartbeat`) after every successful tick.
    Best-effort: I/O errors are swallowed so the heartbeat can never be
    the reason a tick fails.

  ### `hermes_cli/cron.py` — `cron_status()`

  - Read the ticker heartbeat file when the gateway is running.
  - Warn the operator if the heartbeat is stale (>180s = 2× interval +
    grace) or missing, with a clear instruction to restart the gateway.

  ## Verification

  - [x] `python3 -m py_compile` passes on both files
  - [x] Heartbeat path creation and readback tested
  - [x] `git diff` reviewed for unintended changes