### PR TITLE
fix(agent): stale-stream watchdog rebuilds wrong client for Bedrock/Anthropic

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2361,7 +2361,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                if getattr(agent, "api_mode", None) == "anthropic_messages":
+                    agent._anthropic_client.close()
+                    agent._rebuild_anthropic_client()
+                else:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
             except Exception:
                 pass
             # Reset the timer so we don't kill repeatedly while


### PR DESCRIPTION
## Fixes #36693

When the stale-stream watchdog fires for a Bedrock or Anthropic provider (`api_mode=anthropic_messages`), it unconditionally called `_replace_primary_openai_client()`, which tries to create an OpenAI client that doesn't exist for these providers. This logged a misleading warning:

```
WARNING: Failed to rebuild shared OpenAI client (stale_stream_pool_cleanup)
  error=The api_key client option must be set ... OPENAI_API_KEY
```

The conversation was **not actually broken** — the rebuild attempt was dead-code — but the log was confusing and noisy for Bedrock users.

## Fix

Mirror the pattern already used in the interrupt handler (~line 2374 in the same file) which correctly branches on `api_mode`:
- `anthropic_messages`: close + rebuild the Anthropic client
- other modes: rebuild the OpenAI client (existing behavior)

## Changes

`agent/chat_completion_helpers.py` — 1 file, +5/-1 lines

Fixes #36693