### PR TITLE
fix(ci): restore main test suite

### DIFF
--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -60,12 +60,14 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok) as mock_install, \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup") as mock_fixup, \
          patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
     mock_install.assert_called_once_with("/usr/bin/npm", root, capture_output=False)
+    mock_fixup.assert_called_once_with(desktop_dir)
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
     assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
@@ -85,6 +87,7 @@ def test_gui_forwards_desktop_environment_overrides(tmp_path, monkeypatch):
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
          pytest.raises(SystemExit):
         cli_main.cmd_gui(_ns(

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-31T03:27:32Z",
+  "updated_at": "2026-06-01T09:34:29Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -77,7 +77,7 @@
           "description": "recommended"
         },
         {
-          "id": "minimax/minimax-m2.7",
+          "id": "minimax/minimax-m3",
           "description": ""
         },
         {
@@ -178,7 +178,7 @@
           "id": "moonshotai/kimi-k2.6"
         },
         {
-          "id": "minimax/minimax-m2.7"
+          "id": "minimax/minimax-m3"
         },
         {
           "id": "z-ai/glm-5.1"


### PR DESCRIPTION
## Summary
- Update GUI launcher tests to account for the macOS relaunch fixup subprocess wrapper.
- Regenerate the committed model catalog so it matches the current provider model lists.

## Test Plan
- scripts/run_tests.sh tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_model_catalog.py