### PR TITLE
fix(desktop): preserve clarify input across remounts

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,11 +1,11 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
-import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $clarifyInputs, $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { $activeSessionId } from '@/store/session'
 
@@ -19,6 +19,8 @@ vi.mock('@assistant-ui/react', () => ({
 
 afterEach(() => {
   cleanup()
+  $clarifyInputs.set({})
+  $clarifyRequests.set({})
   clearClarifyRequest()
   $activeSessionId.set(null)
   $gateway.set(null)
@@ -68,6 +70,13 @@ function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessageP
     toolCallId: 'clarify-live',
     toolName: 'clarify',
     type: 'tool-call'
+  }
+}
+
+function pendingClarifyProps(args: ToolCallMessagePartProps['args'], toolCallId: string): ToolCallMessagePartProps {
+  return {
+    ...settledClarifyProps(args, undefined, toolCallId),
+    status: { type: 'running' }
   }
 }
 
@@ -178,6 +187,51 @@ describe('readClarifyResult', () => {
   })
 })
 
+describe('ClarifyTool pending view', () => {
+  it('restores the draft, focus, selection, and scroll position after a remount', async () => {
+    const question = 'What deployment context should I use?'
+    const answer = Array.from({ length: 12 }, (_, index) => `Line ${index + 1}: preserve this context.`).join('\n')
+
+    $activeSessionId.set('session-a')
+    setClarifyRequest({ choices: null, multiSelect: false, question, requestId: 'req-a', sessionId: 'session-a' })
+
+    const props = pendingClarifyProps({ question }, 'clarify-pending')
+    const first = renderClarify(<ClarifyTool {...props} />)
+    const textarea = screen.getByPlaceholderText(/type your answer/i) as HTMLTextAreaElement
+
+    act(() => {
+      textarea.focus()
+    })
+    fireEvent.change(textarea, { target: { value: answer } })
+    textarea.setSelectionRange(answer.length - 8, answer.length - 3)
+    textarea.scrollTop = 48
+    fireEvent.select(textarea)
+    fireEvent.scroll(textarea)
+
+    first.unmount()
+
+    // The remount restores focus through the layout effect's rAF/setTimeout
+    // chain, which fires outside the initial render. Wrap it so the focus
+    // restore (and its state writes) land inside act.
+    await act(async () => {
+      renderClarify(<ClarifyTool {...props} />)
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+      await new Promise(resolve => window.requestAnimationFrame(() => resolve(null)))
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+
+    const restored = screen.getByPlaceholderText(/type your answer/i) as HTMLTextAreaElement
+
+    await waitFor(() => {
+      expect(restored.value).toBe(answer)
+      expect(globalThis.document.activeElement).toBe(restored)
+      expect(restored.selectionStart).toBe(answer.length - 8)
+      expect(restored.selectionEnd).toBe(answer.length - 3)
+      expect(restored.scrollTop).toBe(48)
+    })
+  })
+})
+
 describe('ClarifyTool settled view', () => {
   it('keeps the question and answer visible after the tool completes', () => {
     renderClarify(
@@ -196,8 +250,8 @@ describe('ClarifyTool settled view', () => {
 
     expect(screen.getByText('Which deployment target?')).toBeTruthy()
     expect(screen.getByText('staging')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-settled]')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
+    expect(globalThis.document.querySelector('[data-clarify-settled]')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
   })
 
   it('labels an empty response as Skipped', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,11 +1,11 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
-import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $clarifyInputs, $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { $activeSessionId } from '@/store/session'
 
@@ -19,6 +19,8 @@ vi.mock('@assistant-ui/react', () => ({
 
 afterEach(() => {
   cleanup()
+  $clarifyInputs.set({})
+  $clarifyRequests.set({})
   clearClarifyRequest()
   $activeSessionId.set(null)
   $gateway.set(null)
@@ -68,6 +70,13 @@ function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessageP
     toolCallId: 'clarify-live',
     toolName: 'clarify',
     type: 'tool-call'
+  }
+}
+
+function pendingClarifyProps(args: ToolCallMessagePartProps['args'], toolCallId: string): ToolCallMessagePartProps {
+  return {
+    ...settledClarifyProps(args, undefined, toolCallId),
+    status: { type: 'running' }
   }
 }
 
@@ -126,6 +135,51 @@ describe('readClarifyResult', () => {
   })
 })
 
+describe('ClarifyTool pending view', () => {
+  it('restores the draft, focus, selection, and scroll position after a remount', async () => {
+    const question = 'What deployment context should I use?'
+    const answer = Array.from({ length: 12 }, (_, index) => `Line ${index + 1}: preserve this context.`).join('\n')
+
+    $activeSessionId.set('session-a')
+    setClarifyRequest({ choices: null, question, requestId: 'req-a', sessionId: 'session-a' })
+
+    const props = pendingClarifyProps({ question }, 'clarify-pending')
+    const first = renderClarify(<ClarifyTool {...props} />)
+    const textarea = screen.getByPlaceholderText(/type your answer/i) as HTMLTextAreaElement
+
+    act(() => {
+      textarea.focus()
+    })
+    fireEvent.change(textarea, { target: { value: answer } })
+    textarea.setSelectionRange(answer.length - 8, answer.length - 3)
+    textarea.scrollTop = 48
+    fireEvent.select(textarea)
+    fireEvent.scroll(textarea)
+
+    first.unmount()
+
+    // The remount restores focus through the layout effect's rAF/setTimeout
+    // chain, which fires outside the initial render. Wrap it so the focus
+    // restore (and its state writes) land inside act.
+    await act(async () => {
+      renderClarify(<ClarifyTool {...props} />)
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+      await new Promise(resolve => window.requestAnimationFrame(() => resolve(null)))
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+
+    const restored = screen.getByPlaceholderText(/type your answer/i) as HTMLTextAreaElement
+
+    await waitFor(() => {
+      expect(restored.value).toBe(answer)
+      expect(globalThis.document.activeElement).toBe(restored)
+      expect(restored.selectionStart).toBe(answer.length - 8)
+      expect(restored.selectionEnd).toBe(answer.length - 3)
+      expect(restored.scrollTop).toBe(48)
+    })
+  })
+})
+
 describe('ClarifyTool settled view', () => {
   it('keeps the question and answer visible after the tool completes', () => {
     renderClarify(
@@ -144,8 +198,8 @@ describe('ClarifyTool settled view', () => {
 
     expect(screen.getByText('Which deployment target?')).toBeTruthy()
     expect(screen.getByText('staging')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-settled]')).toBeTruthy()
-    expect(document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
+    expect(globalThis.document.querySelector('[data-clarify-settled]')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
   })
 
   it('labels an empty response as Skipped', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -8,6 +8,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState
@@ -26,13 +27,20 @@ import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import {
+  $clarifyInputs,
   bareChoice,
+  clarifyInputKey,
   type ClarifyQuestion,
   type ClarifyRequest,
+  type ClarifyTextareaPosition,
   clearClarifyRequest,
   normalizeChoices,
   RECOMMENDED_LABEL,
   sessionClarifyRequest,
+  setClarifyDraft,
+  setClarifyFocusLocked,
+  setClarifySelectedChoices,
+  setClarifyTextareaPosition,
   warnDroppedChoices
 } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -391,12 +399,21 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
     return <ClarifyToolBatchPending request={request} />
   }
 
-  return <ClarifyToolSinglePending fromArgs={fromArgs} request={request} />
+  return <ClarifyToolSinglePending fromArgs={fromArgs} request={request} sessionId={sessionId} />
 }
 
-function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs; request: ClarifyRequest | null }) {
+function ClarifyToolSinglePending({
+  fromArgs,
+  request,
+  sessionId
+}: {
+  fromArgs: ClarifyArgs
+  request: ClarifyRequest | null
+  sessionId: string | null
+}) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
+  const clarifyInputs = useStore($clarifyInputs)
   const gateway = useStore($gateway)
 
   const matchingRequest = useMemo(() => {
@@ -425,14 +442,31 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   const hasChoices = choices.length > 0
   const multiSelect = hasChoices && Boolean(matchingRequest?.multiSelect ?? fromArgs.multiSelect)
 
-  const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
-  const [selectedChoices, setSelectedChoices] = useState<string[]>([])
   // The keyboard cursor. Indices 0..choices.length-1 are the options; the
   // trailing index (=== choices.length) is the "Other" free-text row.
   const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const userFocusAwayUntilRef = useRef(0)
+
+  const inputSessionId = matchingRequest?.sessionId ?? sessionId
+
+  const inputKey = useMemo(
+    () => clarifyInputKey(inputSessionId, matchingRequest?.requestId ?? null, question),
+    [inputSessionId, matchingRequest?.requestId, question]
+  )
+
+  const clarifyInput = clarifyInputs[inputKey]
+  const draft = clarifyInput?.draft ?? ''
+  const focusLocked = clarifyInput?.focusLocked ?? false
+  const scrollTop = clarifyInput?.scrollTop ?? 0
+  // Memoized so the empty fallback keeps a stable identity across renders —
+  // selectChoice's callback deps must not churn on every keystroke.
+  const selectedChoices = useMemo(() => clarifyInput?.selectedChoices ?? [], [clarifyInput])
+  const selectionEnd = clarifyInput?.selectionEnd ?? null
+  const selectionStart = clarifyInput?.selectionStart ?? null
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Hold the whole panel on a
@@ -440,6 +474,129 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   // a "loading question" stub is worse than a brief wait.
   const ready = Boolean(matchingRequest?.requestId)
   const loading = !ready && !submitting
+
+  const readTextareaPosition = useCallback((textarea: HTMLTextAreaElement): ClarifyTextareaPosition => {
+    return {
+      scrollTop: textarea.scrollTop,
+      selectionEnd: textarea.selectionEnd,
+      selectionStart: textarea.selectionStart
+    }
+  }, [])
+
+  const saveTextareaPosition = useCallback(() => {
+    const textarea = textareaRef.current
+
+    if (textarea) {
+      setClarifyTextareaPosition(inputKey, readTextareaPosition(textarea))
+    }
+  }, [inputKey, readTextareaPosition])
+
+  const focusTextareaAtSavedPosition = useCallback(() => {
+    const textarea = textareaRef.current
+
+    if (!textarea || textarea.disabled) {
+      return
+    }
+
+    textarea.focus({ preventScroll: true })
+
+    const fallbackSelection = textarea.value.length
+    const nextSelectionStart = Math.min(selectionStart ?? fallbackSelection, textarea.value.length)
+    const nextSelectionEnd = Math.min(selectionEnd ?? nextSelectionStart, textarea.value.length)
+
+    textarea.setSelectionRange(nextSelectionStart, nextSelectionEnd)
+    textarea.scrollTop = scrollTop
+  }, [scrollTop, selectionEnd, selectionStart])
+
+  const restoreTextareaFocus = useCallback(() => {
+    if (!ready || !focusLocked || submitting) {
+      return
+    }
+
+    const root = rootRef.current
+    const textarea = textareaRef.current
+
+    if (!textarea || textarea.disabled) {
+      return
+    }
+
+    const active = document.activeElement
+
+    if (active === textarea || (root && active instanceof Node && root.contains(active))) {
+      return
+    }
+
+    if (userFocusAwayUntilRef.current > window.performance.now()) {
+      return
+    }
+
+    focusTextareaAtSavedPosition()
+  }, [focusLocked, focusTextareaAtSavedPosition, ready, submitting])
+
+  useLayoutEffect(() => {
+    restoreTextareaFocus()
+
+    if (!ready || submitting) {
+      return undefined
+    }
+
+    const frame = window.requestAnimationFrame(restoreTextareaFocus)
+    const timeout = window.setTimeout(restoreTextareaFocus, 0)
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      window.clearTimeout(timeout)
+    }
+  }, [ready, restoreTextareaFocus, submitting])
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (focus-away timestamp, see eslint rule comment)
+  useEffect(() => {
+    if (!ready || submitting) {
+      return undefined
+    }
+
+    const markUserFocusAway = () => {
+      userFocusAwayUntilRef.current = window.performance.now() + 1000
+      setClarifyFocusLocked(inputKey, false)
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const root = rootRef.current
+
+      if (root && event.target instanceof Node && root.contains(event.target)) {
+        return
+      }
+
+      markUserFocusAway()
+    }
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Escape' && event.key !== 'Tab') {
+        return
+      }
+
+      const root = rootRef.current
+      const active = document.activeElement
+
+      if (root && active instanceof Node && root.contains(active)) {
+        markUserFocusAway()
+      }
+    }
+
+    const handleFocusIn = () => {
+      window.setTimeout(restoreTextareaFocus, 0)
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown, true)
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('focusin', handleFocusIn, true)
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown, true)
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('focusin', handleFocusIn, true)
+    }
+  }, [inputKey, ready, restoreTextareaFocus, submitting])
 
   const respond = useCallback(
     async (answer: string) => {
@@ -489,17 +646,18 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   const selectChoice = useCallback(
     (choice: string, index: number) => {
       // Picking a choice and typing are mutually exclusive answers.
-      setDraft('')
-      setSelectedChoices(selected => {
-        if (!multiSelect) {
-          return [choice]
-        }
-
-        return selected.includes(choice) ? selected.filter(value => value !== choice) : [...selected, choice]
-      })
+      setClarifyDraft(inputKey, '')
+      setClarifySelectedChoices(
+        inputKey,
+        multiSelect
+          ? selectedChoices.includes(choice)
+            ? selectedChoices.filter(value => value !== choice)
+            : [...selectedChoices, choice]
+          : [choice]
+      )
       setActiveIndex(index)
     },
-    [multiSelect]
+    [inputKey, multiSelect, selectedChoices]
   )
 
   // Keep the cursor in range when the choice set changes (never past "Other").
@@ -514,15 +672,15 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
       // Arrow navigation is a move, not a pick. Multi-select keeps staged
       // choices while the cursor moves so the user can build a set; the
       // single-select path retains its existing clear-on-navigation behaviour.
-      setDraft('')
+      setClarifyDraft(inputKey, '')
 
       if (!multiSelect) {
-        setSelectedChoices([])
+        setClarifySelectedChoices(inputKey, [])
       }
 
       setActiveIndex(index => (index + delta + itemCount) % itemCount)
     },
-    [choices.length, multiSelect]
+    [choices.length, inputKey, multiSelect]
   )
 
   const submitAnswer = useCallback(() => {
@@ -669,13 +827,11 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   }
 
   const onDraftChange = (value: string) => {
-    setDraft(value)
+    const textarea = textareaRef.current
 
     // Typing is its own answer — drop any picked choice so the two inputs can't
     // both look selected.
-    if (value.trim()) {
-      setSelectedChoices([])
-    }
+    setClarifyDraft(inputKey, value, textarea ? readTextareaPosition(textarea) : undefined)
   }
 
   return (
@@ -693,7 +849,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
       data-clarify-choices={hasChoices ? choices.length : undefined}
       onSubmit={handleSubmit}
     >
-      <ClarifyShell className="grid gap-2">
+      <ClarifyShell className="grid gap-2" ref={rootRef}>
         <div className="flex items-start gap-2">
           <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">
             {question}
@@ -733,14 +889,22 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
                 aria-keyshortcuts={`${letterFor(choices.length)} ${choices.length + 1}`}
                 className={CLARIFY_TEXTAREA_CLASS}
                 disabled={submitting}
-                onBlur={() => setOtherFocused(false)}
+                onBlur={event => {
+                  setOtherFocused(false)
+                  setClarifyTextareaPosition(inputKey, readTextareaPosition(event.currentTarget))
+                  window.setTimeout(restoreTextareaFocus, 0)
+                }}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
-                  setSelectedChoices([])
+                  setClarifySelectedChoices(inputKey, [])
+                  setClarifyFocusLocked(inputKey, true)
                   setActiveIndex(choices.length)
                   setOtherFocused(true)
+                  window.requestAnimationFrame(focusTextareaAtSavedPosition)
                 }}
                 onKeyDown={handleTextareaKey}
+                onScroll={saveTextareaPosition}
+                onSelect={saveTextareaPosition}
                 placeholder={copy.other}
                 ref={textareaRef}
                 rows={1}
@@ -753,8 +917,18 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
           <Textarea
             className={CLARIFY_TEXTAREA_CLASS}
             disabled={submitting}
+            onBlur={event => {
+              setClarifyTextareaPosition(inputKey, readTextareaPosition(event.currentTarget))
+              window.setTimeout(restoreTextareaFocus, 0)
+            }}
             onChange={event => onDraftChange(event.target.value)}
+            onFocus={() => {
+              setClarifyFocusLocked(inputKey, true)
+              window.requestAnimationFrame(focusTextareaAtSavedPosition)
+            }}
             onKeyDown={handleTextareaKey}
+            onScroll={saveTextareaPosition}
+            onSelect={saveTextareaPosition}
             placeholder={copy.placeholder}
             ref={textareaRef}
             rows={1}

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -8,6 +8,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState
@@ -25,7 +26,19 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { clearClarifyRequest, normalizeChoices, sessionClarifyRequest, warnDroppedChoices } from '@/store/clarify'
+import {
+  $clarifyInputs,
+  clarifyInputKey,
+  type ClarifyTextareaPosition,
+  clearClarifyRequest,
+  normalizeChoices,
+  sessionClarifyRequest,
+  setClarifyDraft,
+  setClarifyFocusLocked,
+  setClarifySelectedChoice,
+  setClarifyTextareaPosition,
+  warnDroppedChoices
+} from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 
@@ -283,6 +296,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const sessionId = useStore(useSessionView().$runtimeId)
   const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
   const request = useStore($request)
+  const clarifyInputs = useStore($clarifyInputs)
   const gateway = useStore($gateway)
   const fromArgs = useMemo(() => readClarifyArgs(args), [args])
 
@@ -307,14 +321,29 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
   const hasChoices = choices.length > 0
 
-  const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
-  const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
   // The keyboard cursor. Indices 0..choices.length-1 are the options; the
   // trailing index (=== choices.length) is the "Other" free-text row.
   const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
+  const rootRef = useRef<HTMLDivElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const userFocusAwayUntilRef = useRef(0)
+
+  const inputSessionId = matchingRequest?.sessionId ?? sessionId
+
+  const inputKey = useMemo(
+    () => clarifyInputKey(inputSessionId, matchingRequest?.requestId ?? null, question),
+    [inputSessionId, matchingRequest?.requestId, question]
+  )
+
+  const clarifyInput = clarifyInputs[inputKey]
+  const draft = clarifyInput?.draft ?? ''
+  const focusLocked = clarifyInput?.focusLocked ?? false
+  const scrollTop = clarifyInput?.scrollTop ?? 0
+  const selectedChoice = clarifyInput?.selectedChoice ?? null
+  const selectionEnd = clarifyInput?.selectionEnd ?? null
+  const selectionStart = clarifyInput?.selectionStart ?? null
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Hold the whole panel on a
@@ -322,6 +351,129 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   // a "loading question" stub is worse than a brief wait.
   const ready = Boolean(matchingRequest?.requestId)
   const loading = !ready && !submitting
+
+  const readTextareaPosition = useCallback((textarea: HTMLTextAreaElement): ClarifyTextareaPosition => {
+    return {
+      scrollTop: textarea.scrollTop,
+      selectionEnd: textarea.selectionEnd,
+      selectionStart: textarea.selectionStart
+    }
+  }, [])
+
+  const saveTextareaPosition = useCallback(() => {
+    const textarea = textareaRef.current
+
+    if (textarea) {
+      setClarifyTextareaPosition(inputKey, readTextareaPosition(textarea))
+    }
+  }, [inputKey, readTextareaPosition])
+
+  const focusTextareaAtSavedPosition = useCallback(() => {
+    const textarea = textareaRef.current
+
+    if (!textarea || textarea.disabled) {
+      return
+    }
+
+    textarea.focus({ preventScroll: true })
+
+    const fallbackSelection = textarea.value.length
+    const nextSelectionStart = Math.min(selectionStart ?? fallbackSelection, textarea.value.length)
+    const nextSelectionEnd = Math.min(selectionEnd ?? nextSelectionStart, textarea.value.length)
+
+    textarea.setSelectionRange(nextSelectionStart, nextSelectionEnd)
+    textarea.scrollTop = scrollTop
+  }, [scrollTop, selectionEnd, selectionStart])
+
+  const restoreTextareaFocus = useCallback(() => {
+    if (!ready || !focusLocked || submitting) {
+      return
+    }
+
+    const root = rootRef.current
+    const textarea = textareaRef.current
+
+    if (!textarea || textarea.disabled) {
+      return
+    }
+
+    const active = document.activeElement
+
+    if (active === textarea || (root && active instanceof Node && root.contains(active))) {
+      return
+    }
+
+    if (userFocusAwayUntilRef.current > window.performance.now()) {
+      return
+    }
+
+    focusTextareaAtSavedPosition()
+  }, [focusLocked, focusTextareaAtSavedPosition, ready, submitting])
+
+  useLayoutEffect(() => {
+    restoreTextareaFocus()
+
+    if (!ready || submitting) {
+      return undefined
+    }
+
+    const frame = window.requestAnimationFrame(restoreTextareaFocus)
+    const timeout = window.setTimeout(restoreTextareaFocus, 0)
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      window.clearTimeout(timeout)
+    }
+  }, [ready, restoreTextareaFocus, submitting])
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (focus-away timestamp, see eslint rule comment)
+  useEffect(() => {
+    if (!ready || submitting) {
+      return undefined
+    }
+
+    const markUserFocusAway = () => {
+      userFocusAwayUntilRef.current = window.performance.now() + 1000
+      setClarifyFocusLocked(inputKey, false)
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const root = rootRef.current
+
+      if (root && event.target instanceof Node && root.contains(event.target)) {
+        return
+      }
+
+      markUserFocusAway()
+    }
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Escape' && event.key !== 'Tab') {
+        return
+      }
+
+      const root = rootRef.current
+      const active = document.activeElement
+
+      if (root && active instanceof Node && root.contains(active)) {
+        markUserFocusAway()
+      }
+    }
+
+    const handleFocusIn = () => {
+      window.setTimeout(restoreTextareaFocus, 0)
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown, true)
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('focusin', handleFocusIn, true)
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown, true)
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('focusin', handleFocusIn, true)
+    }
+  }, [inputKey, ready, restoreTextareaFocus, submitting])
 
   const respond = useCallback(
     async (answer: string) => {
@@ -361,12 +513,14 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   // confirms with Continue (or Enter from the field).
   const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
 
-  const selectChoice = useCallback((choice: string, index: number) => {
-    // Picking a choice and typing are mutually exclusive answers.
-    setDraft('')
-    setSelectedChoice(choice)
-    setActiveIndex(index)
-  }, [])
+  const selectChoice = useCallback(
+    (choice: string, index: number) => {
+      // Picking a choice and typing are mutually exclusive answers.
+      setClarifySelectedChoice(inputKey, choice)
+      setActiveIndex(index)
+    },
+    [inputKey]
+  )
 
   // Keep the cursor in range when the choice set changes (never past "Other").
   useEffect(() => {
@@ -379,11 +533,11 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       // Arrow navigation is a move, not a pick — clear any staged answer so the
       // cursor and the selection can't disagree.
-      setDraft('')
-      setSelectedChoice(null)
+      setClarifyDraft(inputKey, '')
+      setClarifySelectedChoice(inputKey, null)
       setActiveIndex(index => (index + delta + itemCount) % itemCount)
     },
-    [choices.length]
+    [choices.length, inputKey]
   )
 
   const submitAnswer = useCallback(() => {
@@ -528,13 +682,9 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   }
 
   const onDraftChange = (value: string) => {
-    setDraft(value)
+    const textarea = textareaRef.current
 
-    // Typing is its own answer — drop any picked choice so the two inputs can't
-    // both look selected.
-    if (value.trim()) {
-      setSelectedChoice(null)
-    }
+    setClarifyDraft(inputKey, value, textarea ? readTextareaPosition(textarea) : undefined)
   }
 
   return (
@@ -552,7 +702,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       data-clarify-choices={hasChoices ? choices.length : undefined}
       onSubmit={handleSubmit}
     >
-      <ClarifyShell className="grid gap-2">
+      <ClarifyShell className="grid gap-2" ref={rootRef}>
         <div className="flex items-start gap-2">
           <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">
             {question}
@@ -592,14 +742,22 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 aria-keyshortcuts={`${letterFor(choices.length)} ${choices.length + 1}`}
                 className={CLARIFY_TEXTAREA_CLASS}
                 disabled={submitting}
-                onBlur={() => setOtherFocused(false)}
+                onBlur={event => {
+                  setOtherFocused(false)
+                  setClarifyTextareaPosition(inputKey, readTextareaPosition(event.currentTarget))
+                  window.setTimeout(restoreTextareaFocus, 0)
+                }}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
-                  setSelectedChoice(null)
+                  setClarifySelectedChoice(inputKey, null)
+                  setClarifyFocusLocked(inputKey, true)
                   setActiveIndex(choices.length)
                   setOtherFocused(true)
+                  window.requestAnimationFrame(focusTextareaAtSavedPosition)
                 }}
                 onKeyDown={handleTextareaKey}
+                onScroll={saveTextareaPosition}
+                onSelect={saveTextareaPosition}
                 placeholder={copy.other}
                 ref={textareaRef}
                 rows={1}
@@ -612,8 +770,18 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
           <Textarea
             className={CLARIFY_TEXTAREA_CLASS}
             disabled={submitting}
+            onBlur={event => {
+              setClarifyTextareaPosition(inputKey, readTextareaPosition(event.currentTarget))
+              window.setTimeout(restoreTextareaFocus, 0)
+            }}
             onChange={event => onDraftChange(event.target.value)}
+            onFocus={() => {
+              setClarifyFocusLocked(inputKey, true)
+              window.requestAnimationFrame(focusTextareaAtSavedPosition)
+            }}
             onKeyDown={handleTextareaKey}
+            onScroll={saveTextareaPosition}
+            onSelect={saveTextareaPosition}
             placeholder={copy.placeholder}
             ref={textareaRef}
             rows={1}

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  $clarifyInputs,
   $clarifyRequest,
   $clarifyRequests,
+  clarifyInputKey,
   type ClarifyRequest,
   clearClarifyRequest,
   hasClarifyRequest,
   normalizeChoices,
   normalizeQuestions,
+  setClarifyDraft,
   setClarifyRequest,
   skipClarifyRequest
 } from './clarify'
@@ -26,11 +29,13 @@ function clarify(sessionId: string | null, requestId: string): ClarifyRequest {
 
 describe('clarify store', () => {
   beforeEach(() => {
+    $clarifyInputs.set({})
     $clarifyRequests.set({})
     $activeSessionId.set(null)
   })
 
   afterEach(() => {
+    $clarifyInputs.set({})
     $clarifyRequests.set({})
     $activeSessionId.set(null)
   })
@@ -41,6 +46,35 @@ describe('clarify store', () => {
 
     expect($clarifyRequests.get()['session-a']?.requestId).toBe('req-a')
     expect($clarifyRequests.get()['session-b']?.requestId).toBe('req-b')
+  })
+
+  it('isolates same-question drafts while concurrent sessions wait for request ids', () => {
+    const question = 'Which target should Hermes update?'
+    const pendingA = clarifyInputKey('session-a', null, question)
+    const pendingB = clarifyInputKey('session-b', null, question)
+
+    setClarifyDraft(pendingA, 'Only update session A.')
+    setClarifyDraft(pendingB, 'Only update session B.')
+
+    setClarifyRequest({ ...clarify('session-a', 'req-a'), question })
+
+    const requestA = clarifyInputKey('session-a', 'req-a', question)
+
+    expect($clarifyInputs.get()[requestA]?.draft).toBe('Only update session A.')
+    expect($clarifyInputs.get()[pendingA]).toBeUndefined()
+    expect($clarifyInputs.get()[pendingB]?.draft).toBe('Only update session B.')
+
+    clearClarifyRequest('req-a', 'session-a')
+
+    expect($clarifyInputs.get()[requestA]).toBeUndefined()
+    expect($clarifyInputs.get()[pendingB]?.draft).toBe('Only update session B.')
+
+    setClarifyRequest({ ...clarify('session-b', 'req-b'), question })
+
+    const requestB = clarifyInputKey('session-b', 'req-b', question)
+
+    expect($clarifyInputs.get()[requestB]?.draft).toBe('Only update session B.')
+    expect($clarifyInputs.get()[pendingB]).toBeUndefined()
   })
 
   it('exposes only the active session via the focus-scoped view', () => {
@@ -100,7 +134,7 @@ describe('skipClarifyRequest', () => {
     $gateway.set(null)
   })
 
-  it('answers the session\u2019s clarify with an empty answer and drops it', async () => {
+  it("answers the session's clarify with an empty answer and drops it", async () => {
     setClarifyRequest(clarify('session-a', 'req-a'))
     setClarifyRequest(clarify('session-b', 'req-b'))
 

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  $clarifyInputs,
   $clarifyRequest,
   $clarifyRequests,
+  clarifyInputKey,
   type ClarifyRequest,
   clearClarifyRequest,
   hasClarifyRequest,
   normalizeChoices,
+  setClarifyDraft,
   setClarifyRequest,
   skipClarifyRequest
 } from './clarify'
@@ -24,11 +27,13 @@ function clarify(sessionId: string | null, requestId: string): ClarifyRequest {
 
 describe('clarify store', () => {
   beforeEach(() => {
+    $clarifyInputs.set({})
     $clarifyRequests.set({})
     $activeSessionId.set(null)
   })
 
   afterEach(() => {
+    $clarifyInputs.set({})
     $clarifyRequests.set({})
     $activeSessionId.set(null)
   })
@@ -39,6 +44,35 @@ describe('clarify store', () => {
 
     expect($clarifyRequests.get()['session-a']?.requestId).toBe('req-a')
     expect($clarifyRequests.get()['session-b']?.requestId).toBe('req-b')
+  })
+
+  it('isolates same-question drafts while concurrent sessions wait for request ids', () => {
+    const question = 'Which target should Hermes update?'
+    const pendingA = clarifyInputKey('session-a', null, question)
+    const pendingB = clarifyInputKey('session-b', null, question)
+
+    setClarifyDraft(pendingA, 'Only update session A.')
+    setClarifyDraft(pendingB, 'Only update session B.')
+
+    setClarifyRequest({ ...clarify('session-a', 'req-a'), question })
+
+    const requestA = clarifyInputKey('session-a', 'req-a', question)
+
+    expect($clarifyInputs.get()[requestA]?.draft).toBe('Only update session A.')
+    expect($clarifyInputs.get()[pendingA]).toBeUndefined()
+    expect($clarifyInputs.get()[pendingB]?.draft).toBe('Only update session B.')
+
+    clearClarifyRequest('req-a', 'session-a')
+
+    expect($clarifyInputs.get()[requestA]).toBeUndefined()
+    expect($clarifyInputs.get()[pendingB]?.draft).toBe('Only update session B.')
+
+    setClarifyRequest({ ...clarify('session-b', 'req-b'), question })
+
+    const requestB = clarifyInputKey('session-b', 'req-b', question)
+
+    expect($clarifyInputs.get()[requestB]?.draft).toBe('Only update session B.')
+    expect($clarifyInputs.get()[pendingB]).toBeUndefined()
   })
 
   it('exposes only the active session via the focus-scoped view', () => {
@@ -98,7 +132,7 @@ describe('skipClarifyRequest', () => {
     $gateway.set(null)
   })
 
-  it('answers the session\u2019s clarify with an empty answer and drops it', async () => {
+  it("answers the session's clarify with an empty answer and drops it", async () => {
     setClarifyRequest(clarify('session-a', 'req-a'))
     setClarifyRequest(clarify('session-b', 'req-b'))
 

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -106,6 +106,21 @@ export function normalizeQuestions(questions: unknown): ClarifyQuestion[] {
   return normalized
 }
 
+export interface ClarifyInputState {
+  draft: string
+  focusLocked: boolean
+  scrollTop: number
+  selectedChoices: string[]
+  selectionEnd: number | null
+  selectionStart: number | null
+}
+
+export interface ClarifyTextareaPosition {
+  scrollTop: number
+  selectionEnd: number
+  selectionStart: number
+}
+
 // Pending clarify requests keyed by the runtime session id that raised them.
 // Storing per-session (instead of one shared slot) lets a *background* session
 // park its clarify request while the user is looking at a different chat, then
@@ -128,8 +143,96 @@ export const $clarifyRequest = computed(
 export const sessionClarifyRequest = (sessionId: string | null) =>
   computed($clarifyRequests, requests => requests[keyFor(sessionId)] ?? null)
 
+// Inline clarify state is kept outside the tool component because assistant
+// stream updates can remount the tool while the user is typing. Every key is
+// session-scoped so two chats asking the same question cannot share a draft.
+export const $clarifyInputs = atom<Record<string, ClarifyInputState>>({})
+
+function normalizeClarifyInput(input?: Partial<ClarifyInputState>): ClarifyInputState {
+  return {
+    draft: input?.draft ?? '',
+    focusLocked: input?.focusLocked ?? false,
+    scrollTop: input?.scrollTop ?? 0,
+    selectedChoices: input?.selectedChoices ?? [],
+    selectionEnd: input?.selectionEnd ?? null,
+    selectionStart: input?.selectionStart ?? null
+  }
+}
+
+function updateClarifyInput(key: string, patch: Partial<ClarifyInputState>): void {
+  const current = $clarifyInputs.get()
+  const previous = normalizeClarifyInput(current[key])
+  const next = { ...previous, ...patch }
+
+  if (
+    previous.draft === next.draft &&
+    previous.focusLocked === next.focusLocked &&
+    previous.scrollTop === next.scrollTop &&
+    previous.selectedChoices.length === next.selectedChoices.length &&
+    previous.selectedChoices.every((choice, index) => choice === next.selectedChoices[index]) &&
+    previous.selectionEnd === next.selectionEnd &&
+    previous.selectionStart === next.selectionStart
+  ) {
+    return
+  }
+
+  $clarifyInputs.set({ ...current, [key]: next })
+}
+
+export function clarifyInputKey(
+  sessionId: string | null | undefined,
+  requestId?: null | string,
+  question?: string
+): string {
+  const sessionKey = sessionId?.trim() ?? ''
+  const id = requestId?.trim()
+
+  if (id) {
+    return `session:${sessionKey}:request:${id}`
+  }
+
+  const normalizedQuestion = question?.trim()
+
+  return normalizedQuestion ? `session:${sessionKey}:question:${normalizedQuestion}` : `session:${sessionKey}:pending`
+}
+
+function migrateClarifyInput(request: ClarifyRequest, previousRequest?: ClarifyRequest): void {
+  const idKey = clarifyInputKey(request.sessionId, request.requestId, request.question)
+  const questionKey = clarifyInputKey(request.sessionId, null, request.question)
+
+  const previousKey =
+    previousRequest?.question === request.question
+      ? clarifyInputKey(request.sessionId, previousRequest.requestId, previousRequest.question)
+      : null
+
+  const current = $clarifyInputs.get()
+  const sourceKeys = [...new Set([idKey, previousKey, questionKey].filter((key): key is string => Boolean(key)))]
+  const persisted = sourceKeys.map(key => current[key]).find(Boolean)
+
+  if (!persisted) {
+    return
+  }
+
+  const next = { ...current }
+
+  for (const key of sourceKeys) {
+    delete next[key]
+  }
+
+  next[idKey] = {
+    ...persisted,
+    selectedChoices: persisted.selectedChoices.filter(choice => request.choices?.includes(choice))
+  }
+
+  $clarifyInputs.set(next)
+}
+
 export function setClarifyRequest(request: ClarifyRequest): void {
-  $clarifyRequests.set({ ...$clarifyRequests.get(), [keyFor(request.sessionId)]: request })
+  const requests = $clarifyRequests.get()
+  const requestKey = keyFor(request.sessionId)
+
+  migrateClarifyInput(request, requests[requestKey])
+  $clarifyRequests.set({ ...requests, [requestKey]: request })
 }
 
 export function clearClarifyRequest(requestId?: string, sessionId?: string | null): void {
@@ -144,6 +247,9 @@ export function clearClarifyRequest(requestId?: string, sessionId?: string | nul
     if (!current || (requestId && current.requestId !== requestId)) {
       return
     }
+
+    clearClarifyInput(clarifyInputKey(current.sessionId, current.requestId, current.question))
+    clearClarifyInput(clarifyInputKey(current.sessionId, null, current.question))
 
     const next = { ...requests }
     delete next[key]
@@ -162,6 +268,8 @@ export function clearClarifyRequest(requestId?: string, sessionId?: string | nul
       next[key] = value
     } else {
       changed = true
+      clearClarifyInput(clarifyInputKey(value.sessionId, value.requestId, value.question))
+      clearClarifyInput(clarifyInputKey(value.sessionId, null, value.question))
     }
   }
 
@@ -207,4 +315,39 @@ export async function skipClarifyRequest(sessionId: string | null | undefined): 
   }
 
   return true
+}
+
+export function clearClarifyInput(key: string): void {
+  const current = $clarifyInputs.get()
+
+  if (!current[key]) {
+    return
+  }
+
+  const { [key]: _cleared, ...rest } = current
+
+  $clarifyInputs.set(rest)
+}
+
+export function setClarifyDraft(key: string, draft: string, position?: ClarifyTextareaPosition): void {
+  updateClarifyInput(key, {
+    draft,
+    ...position,
+    ...(draft.trim() ? { selectedChoices: [] } : {})
+  })
+}
+
+export function setClarifySelectedChoices(key: string, selectedChoices: string[]): void {
+  updateClarifyInput(key, {
+    selectedChoices,
+    ...(selectedChoices.length > 0 ? { draft: '', focusLocked: false } : {})
+  })
+}
+
+export function setClarifyFocusLocked(key: string, focusLocked: boolean): void {
+  updateClarifyInput(key, { focusLocked })
+}
+
+export function setClarifyTextareaPosition(key: string, position: ClarifyTextareaPosition): void {
+  updateClarifyInput(key, position)
 }

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -40,6 +40,21 @@ export function warnDroppedChoices(source: 'gateway' | 'tool_args', question: st
   })
 }
 
+export interface ClarifyInputState {
+  draft: string
+  focusLocked: boolean
+  scrollTop: number
+  selectedChoice: string | null
+  selectionEnd: number | null
+  selectionStart: number | null
+}
+
+export interface ClarifyTextareaPosition {
+  scrollTop: number
+  selectionEnd: number
+  selectionStart: number
+}
+
 // Pending clarify requests keyed by the runtime session id that raised them.
 // Storing per-session (instead of one shared slot) lets a *background* session
 // park its clarify request while the user is looking at a different chat, then
@@ -62,8 +77,96 @@ export const $clarifyRequest = computed(
 export const sessionClarifyRequest = (sessionId: string | null) =>
   computed($clarifyRequests, requests => requests[keyFor(sessionId)] ?? null)
 
+// Inline clarify state is kept outside the tool component because assistant
+// stream updates can remount the tool while the user is typing. Every key is
+// session-scoped so two chats asking the same question cannot share a draft.
+export const $clarifyInputs = atom<Record<string, ClarifyInputState>>({})
+
+function normalizeClarifyInput(input?: Partial<ClarifyInputState>): ClarifyInputState {
+  return {
+    draft: input?.draft ?? '',
+    focusLocked: input?.focusLocked ?? false,
+    scrollTop: input?.scrollTop ?? 0,
+    selectedChoice: input?.selectedChoice ?? null,
+    selectionEnd: input?.selectionEnd ?? null,
+    selectionStart: input?.selectionStart ?? null
+  }
+}
+
+function updateClarifyInput(key: string, patch: Partial<ClarifyInputState>): void {
+  const current = $clarifyInputs.get()
+  const previous = normalizeClarifyInput(current[key])
+  const next = { ...previous, ...patch }
+
+  if (
+    previous.draft === next.draft &&
+    previous.focusLocked === next.focusLocked &&
+    previous.scrollTop === next.scrollTop &&
+    previous.selectedChoice === next.selectedChoice &&
+    previous.selectionEnd === next.selectionEnd &&
+    previous.selectionStart === next.selectionStart
+  ) {
+    return
+  }
+
+  $clarifyInputs.set({ ...current, [key]: next })
+}
+
+export function clarifyInputKey(
+  sessionId: string | null | undefined,
+  requestId?: null | string,
+  question?: string
+): string {
+  const sessionKey = sessionId?.trim() ?? ''
+  const id = requestId?.trim()
+
+  if (id) {
+    return `session:${sessionKey}:request:${id}`
+  }
+
+  const normalizedQuestion = question?.trim()
+
+  return normalizedQuestion ? `session:${sessionKey}:question:${normalizedQuestion}` : `session:${sessionKey}:pending`
+}
+
+function migrateClarifyInput(request: ClarifyRequest, previousRequest?: ClarifyRequest): void {
+  const idKey = clarifyInputKey(request.sessionId, request.requestId, request.question)
+  const questionKey = clarifyInputKey(request.sessionId, null, request.question)
+
+  const previousKey =
+    previousRequest?.question === request.question
+      ? clarifyInputKey(request.sessionId, previousRequest.requestId, previousRequest.question)
+      : null
+
+  const current = $clarifyInputs.get()
+  const sourceKeys = [...new Set([idKey, previousKey, questionKey].filter((key): key is string => Boolean(key)))]
+  const persisted = sourceKeys.map(key => current[key]).find(Boolean)
+
+  if (!persisted) {
+    return
+  }
+
+  const next = { ...current }
+
+  for (const key of sourceKeys) {
+    delete next[key]
+  }
+
+  next[idKey] = {
+    ...persisted,
+    selectedChoice:
+      persisted.selectedChoice && request.choices?.includes(persisted.selectedChoice) ? persisted.selectedChoice : null
+  }
+
+  $clarifyInputs.set(next)
+}
+
 export function setClarifyRequest(request: ClarifyRequest): void {
-  $clarifyRequests.set({ ...$clarifyRequests.get(), [keyFor(request.sessionId)]: request })
+  const requests = $clarifyRequests.get()
+  const requestKey = keyFor(request.sessionId)
+
+  migrateClarifyInput(request, requests[requestKey])
+  $clarifyRequests.set({ ...requests, [requestKey]: request })
 }
 
 export function clearClarifyRequest(requestId?: string, sessionId?: string | null): void {
@@ -78,6 +181,9 @@ export function clearClarifyRequest(requestId?: string, sessionId?: string | nul
     if (!current || (requestId && current.requestId !== requestId)) {
       return
     }
+
+    clearClarifyInput(clarifyInputKey(current.sessionId, current.requestId, current.question))
+    clearClarifyInput(clarifyInputKey(current.sessionId, null, current.question))
 
     const next = { ...requests }
     delete next[key]
@@ -96,6 +202,8 @@ export function clearClarifyRequest(requestId?: string, sessionId?: string | nul
       next[key] = value
     } else {
       changed = true
+      clearClarifyInput(clarifyInputKey(value.sessionId, value.requestId, value.question))
+      clearClarifyInput(clarifyInputKey(value.sessionId, null, value.question))
     }
   }
 
@@ -141,4 +249,39 @@ export async function skipClarifyRequest(sessionId: string | null | undefined): 
   }
 
   return true
+}
+
+export function clearClarifyInput(key: string): void {
+  const current = $clarifyInputs.get()
+
+  if (!current[key]) {
+    return
+  }
+
+  const { [key]: _cleared, ...rest } = current
+
+  $clarifyInputs.set(rest)
+}
+
+export function setClarifyDraft(key: string, draft: string, position?: ClarifyTextareaPosition): void {
+  updateClarifyInput(key, {
+    draft,
+    ...position,
+    ...(draft.trim() ? { selectedChoice: null } : {})
+  })
+}
+
+export function setClarifySelectedChoice(key: string, selectedChoice: string | null): void {
+  updateClarifyInput(key, {
+    selectedChoice,
+    ...(selectedChoice ? { draft: '', focusLocked: false } : {})
+  })
+}
+
+export function setClarifyFocusLocked(key: string, focusLocked: boolean): void {
+  updateClarifyInput(key, { focusLocked })
+}
+
+export function setClarifyTextareaPosition(key: string, position: ClarifyTextareaPosition): void {
+  updateClarifyInput(key, position)
 }


### PR DESCRIPTION
## Summary
- Persist inline clarify input state outside the remount-prone tool component using keys scoped by session plus request ID, with a session-scoped question fallback while `clarify.request` is arriving.
- Preserve draft text, selected choice, focus ownership, caret selection, and textarea scroll position across assistant stream updates and remounts.
- Migrate fallback state to the request key only within the originating session, then clear both forms when the request is answered.
- Keep the implementation aligned with the current Desktop tool and session-cache structure.

## Related Issue
No existing issue found for this exact Desktop clarify input reset/focus-loss path.

## How to Test
1. Run the Desktop dev app on Windows.
2. Trigger an inline clarify prompt, type a long answer, and move the caret/scroll position.
3. Let the assistant stream update or remount the tool and confirm the draft, focus, selection, and scroll position are preserved.
4. Open two sessions that receive the same clarify question and confirm their drafts remain independent.
5. Submit the answer and confirm the saved input state is cleared.

## Test Plan
- [x] `npm run test:ui -- clarify-tool.test.tsx clarify.test.ts`
- [x] `npm run typecheck`
- [x] `npx eslint src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx src/store/clarify.ts src/store/clarify.test.ts`
- [x] `npx prettier --check src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx src/store/clarify.ts src/store/clarify.test.ts`
- [x] `git diff --check upstream/main...HEAD`
- [x] `python scripts/check-windows-footguns.py --diff upstream/main...HEAD`