### PR TITLE
feat(docker): add HERMES_S6_EXEC_WRAPPER hook for secret brokers

### DIFF
--- a/docker/s6-rc.d/dashboard/run
+++ b/docker/s6-rc.d/dashboard/run
@@ -47,9 +47,11 @@ case "${HERMES_DASHBOARD_INSECURE:-}" in
     1|true|TRUE|True|yes|YES|Yes) insecure="--insecure" ;;
 esac
 
-# Skip the drop when already non-root.
-# shellcheck disable=SC2086  # word-splitting of $insecure is intentional
-[ "$(id -u)" = 0 ] || exec hermes dashboard --host "$dash_host" --port "$dash_port" --no-open $insecure
-# shellcheck disable=SC2086  # word-splitting of $insecure is intentional
-exec s6-setuidgid hermes hermes dashboard \
+# Optional exec prefix for secret-broker integrations; see
+# HERMES_S6_EXEC_WRAPPER in docs/operations/secret-brokers.md.
+# Word-split intentionally; unset/empty is a no-op.
+# shellcheck disable=SC2086
+[ "$(id -u)" = 0 ] || exec ${HERMES_S6_EXEC_WRAPPER:-} hermes dashboard --host "$dash_host" --port "$dash_port" --no-open $insecure
+# shellcheck disable=SC2086
+exec ${HERMES_S6_EXEC_WRAPPER:-} s6-setuidgid hermes hermes dashboard \
     --host "$dash_host" --port "$dash_port" --no-open $insecure

--- a/docs/operations/secret-brokers.md
+++ b/docs/operations/secret-brokers.md
@@ -1,0 +1,76 @@
+# Secret broker integration (`HERMES_S6_EXEC_WRAPPER`)
+
+When running the official `hermes-agent` container, the dashboard and
+profile-gateway processes run as **s6-supervised services**, not as
+children of whatever the container CMD evaluates to. s6 launches each
+supervised service from `/run/service/<svc>/run` independently of the
+entrypoint, so any environment variables added by wrapping the CMD
+— for example `agent-vault run -- hermes gateway run`,
+`vault agent exec -- …`, `sops exec-env …`, or `doppler run --` —
+**are not inherited** by the supervised worker, and therefore not by
+any subprocess the worker forks (slash workers, MCP clients, …).
+
+The consequence: brokers that work by setting `HTTPS_PROXY` /
+`REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` on the child process don't
+get to intercept outbound HTTPS from the dashboard or gateway. Any
+provider key still stored as a placeholder (e.g. the literal string
+`__OPENROUTER_API_KEY__`) leaks verbatim to the LLM provider →
+HTTP 401.
+
+## The hook
+
+Set `HERMES_S6_EXEC_WRAPPER` in the container environment. Every
+s6-supervised hermes service (`dashboard`, `gateway-<profile>`)
+prepends this string to its final `exec` line, putting the broker
+**inside** the supervised slot:
+
+```yaml
+# docker-compose.yml
+services:
+  hermes:
+    image: nousresearch/hermes-agent:main
+    environment:
+      HERMES_S6_EXEC_WRAPPER: "agent-vault run --"
+    # CMD stays as the default — no wrapping needed at the container
+    # entrypoint, because the wrapper now applies per-service.
+```
+
+Properties:
+
+- **Word-split intentionally.** Multi-token prefixes
+  (`agent-vault run --`, `vault agent exec --`) work as written.
+- **Unset / empty is a no-op.** Existing deployments see no change.
+- **Applies to all supervised hermes services**: `dashboard` and every
+  `gateway-<profile>` registered via the dynamic service manager.
+- **`main-hermes` is unaffected.** It is a no-op `sleep infinity`
+  slot (see `docker/s6-rc.d/main-hermes/run`); the container CMD
+  remains the place to wrap the foreground process.
+
+## Examples
+
+Infisical agent-vault:
+
+```yaml
+environment:
+  HERMES_S6_EXEC_WRAPPER: "/opt/agent-vault/agent-vault run --"
+```
+
+HashiCorp Vault Agent:
+
+```yaml
+environment:
+  HERMES_S6_EXEC_WRAPPER: "vault agent exec -config=/etc/vault/agent.hcl --"
+```
+
+Doppler:
+
+```yaml
+environment:
+  HERMES_S6_EXEC_WRAPPER: "doppler run --"
+```
+
+## Compatibility
+
+The hook is purely additive: scripts expand `${HERMES_S6_EXEC_WRAPPER:-}`,
+so the variable being unset reproduces the previous (unwrapped) exec
+line byte-for-byte. No existing deployment needs to set it.

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -618,10 +618,16 @@ class S6ServiceManager:
             gateway_cmd = "hermes gateway run"
         else:
             gateway_cmd = f"hermes -p {shlex.quote(profile)} gateway run"
+        # Optional exec prefix for secret-broker integrations; see
+        # HERMES_S6_EXEC_WRAPPER in docs/operations/secret-brokers.md.
+        # Word-split intentionally; unset/empty is a no-op.
+        wrapper = "${HERMES_S6_EXEC_WRAPPER:-}"
         # Skip the drop when already non-root (setgroups() lacks CAP_SETGID →
         # s6 boot-loop).
-        lines.append(f'[ "$(id -u)" = 0 ] || exec {gateway_cmd}')
-        lines.append(f"exec s6-setuidgid hermes {gateway_cmd}")
+        lines.append("# shellcheck disable=SC2086")
+        lines.append(f'[ "$(id -u)" = 0 ] || exec {wrapper} {gateway_cmd}')
+        lines.append("# shellcheck disable=SC2086")
+        lines.append(f"exec {wrapper} s6-setuidgid hermes {gateway_cmd}")
         return "\n".join(lines) + "\n"
 
     @staticmethod

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -588,7 +588,31 @@ def test_render_run_script_resets_home_before_exec() -> None:
     run_text = S6ServiceManager._render_run_script("coder", {})
 
     assert "export HOME=/opt/data" in run_text
-    assert "exec s6-setuidgid hermes hermes -p coder gateway run" in run_text
+    assert (
+        "exec ${HERMES_S6_EXEC_WRAPPER:-} s6-setuidgid hermes "
+        "hermes -p coder gateway run"
+    ) in run_text
+
+
+def test_render_run_script_emits_exec_wrapper_hook() -> None:
+    # Both exec paths (root → drop, and already-unprivileged) must
+    # expand ${HERMES_S6_EXEC_WRAPPER:-} so secret-broker prefixes
+    # (agent-vault run --, vault agent exec --, …) cover the
+    # supervised worker. Unset/empty = no-op (additive contract).
+    run_text = S6ServiceManager._render_run_script("coder", {})
+    assert (
+        "exec ${HERMES_S6_EXEC_WRAPPER:-} s6-setuidgid hermes "
+        "hermes -p coder gateway run"
+    ) in run_text
+    assert (
+        "exec ${HERMES_S6_EXEC_WRAPPER:-} hermes -p coder gateway run"
+    ) in run_text
+
+    default_run = S6ServiceManager._render_run_script("default", {})
+    assert (
+        "exec ${HERMES_S6_EXEC_WRAPPER:-} s6-setuidgid hermes "
+        "hermes gateway run"
+    ) in default_run
 
 
 def test_s6_register_rejects_invalid_profile_name(s6_scandir) -> None:


### PR DESCRIPTION
s6-supervised hermes services (`dashboard`, `gateway-<profile>`) are
launched from `/run/service/<svc>/run` by s6-svscan, independently of
the container entrypoint. Any env that operators inject by wrapping
the container CMD — `agent-vault run -- hermes gateway run`,
`vault agent exec -- …`, `sops exec-env …`, `doppler run --` — is
inherited only by whatever the CMD itself evaluates to, NOT by the
supervised workers or anything they fork.

For secret brokers that work by setting `HTTPS_PROXY` /
`REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` on the child process so they
can MITM outbound HTTPS and substitute placeholder values (e.g.
`__OPENROUTER_API_KEY__`) with real secrets at the wire, this is a
correctness bug: the dashboard and gateway workers never see the
proxy, placeholders leak verbatim to the LLM provider, and the
provider returns HTTP 401. Today operators can only work around this
by bind-mounting a patched copy of each `run` script over the image,
which is brittle (re-syncs on every upstream change to the s6 layout)
and unhelpful for dynamically-registered profile gateways whose
scripts are rendered at runtime by `S6ServiceManager`.

This change adds a single contract: `HERMES_S6_EXEC_WRAPPER`. Every
supervised hermes service prepends `${HERMES_S6_EXEC_WRAPPER:-}` to
its final `exec` line, so the broker runs INSIDE the supervised slot
and its env-injection covers the worker and everything it forks.
Word-splitting is intentional so multi-token prefixes
(`agent-vault run --`) work; unset/empty reproduces the previous
exec line byte-for-byte (purely additive — zero impact on existing
deployments).

Scope:
- `docker/s6-rc.d/dashboard/run`: emit `${HERMES_S6_EXEC_WRAPPER:-}`
  in both exec paths (privileged → s6-setuidgid drop, and the
  already-unprivileged shortcut).
- `hermes_cli/service_manager.py::_render_run_script`: same hook in
  the dynamically-rendered profile-gateway template, covering
  `gateway-default` and every `gateway-<profile>` registered at
  runtime.
- `main-hermes` is intentionally untouched: it is a `sleep infinity`
  no-op slot; the container CMD remains the place to wrap the
  foreground process.
- New doc `docs/operations/secret-brokers.md` with rationale and
  worked examples (Infisical agent-vault, HashiCorp Vault Agent,
  Doppler).
- Extends `test_render_run_script_resets_home_before_exec` and adds
  `test_render_run_script_emits_exec_wrapper_hook` asserting both
  exec paths and the default-profile spelling.

Tested:
- Smoke-rendered both `coder` and `default` profile scripts and
  diffed against the unset-wrapper baseline: identical except for
  the literal `${HERMES_S6_EXEC_WRAPPER:-} ` prefix on the exec
  lines, which collapses to empty when the var is unset.
- In a downstream stack (Infisical agent-vault) the dashboard's
  spawned slash-worker now inherits HTTPS_PROXY and OAuth-token
  substitution succeeds; without this change the same slash-worker
  emits placeholder secrets and the LLM provider returns 401.
- Platforms: built and exercised on Linux/x86_64 (Docker Engine
  27.x). The change is shell + Python only; no platform-specific
  surface area.
