### PR TITLE
fix(cron): resolve BSM secrets by using load_hermes_dotenv in scheduler

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4785,3 +4785,77 @@ class TestMultiTargetDeliveryContinuesOnFailure:
         assert "a@example.com" in result
         assert "b@example.com" in result
         assert mock_pool.submit.call_count == 2
+
+
+class TestCronEnvLoaderUsesHermesDotenv:
+    """Regression: cron/scheduler.py must call load_hermes_dotenv (not bare
+    dotenv.load_dotenv) so that external secret sources such as Bitwarden
+    Secrets Manager are resolved for cron jobs.  Ref: #33465.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_runtime_provider(self):
+        fake_runtime = {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "source": "stub",
+            "requested_provider": None,
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ):
+            yield
+
+    def _make_job(self):
+        return {
+            "id": "env-loader-test",
+            "name": "env-loader",
+            "prompt": "hello",
+            "schedule": "*/5 * * * *",
+        }
+
+    def test_run_job_calls_load_hermes_dotenv(self, tmp_path):
+        """run_job must invoke load_hermes_dotenv so BSM secrets are resolved."""
+        import cron.scheduler as scheduler
+
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(
+            return_value={"final_response": "ok", "messages": []}
+        )
+        with patch.object(scheduler, "_hermes_home", tmp_path), \
+             patch.object(scheduler, "_resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv") as mock_load_env, \
+             patch("hermes_state.SessionDB", return_value=MagicMock()), \
+             patch("run_agent.AIAgent", return_value=agent):
+            scheduler.run_job(self._make_job())
+
+        assert mock_load_env.call_count >= 1
+        found_impl_call = any(
+            str(tmp_path) in str(call.kwargs.get("hermes_home", ""))
+            for call in mock_load_env.call_args_list
+        )
+        assert found_impl_call, (
+            f"No call with hermes_home pointing at tmp_path found. "
+            f"Calls: {mock_load_env.call_args_list}"
+        )
+
+    def test_load_hermes_dotenv_not_dotenv_load_dotenv(self, tmp_path):
+        """Ensure scheduler does NOT call bare dotenv.load_dotenv."""
+        import cron.scheduler as scheduler
+
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(
+            return_value={"final_response": "ok", "messages": []}
+        )
+        with patch.object(scheduler, "_hermes_home", tmp_path), \
+             patch.object(scheduler, "_resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("dotenv.load_dotenv") as mock_bare_dotenv, \
+             patch("hermes_state.SessionDB", return_value=MagicMock()), \
+             patch("run_agent.AIAgent", return_value=agent):
+            scheduler.run_job(self._make_job())
+
+        mock_bare_dotenv.assert_not_called()


### PR DESCRIPTION
## Summary

`cron/scheduler.py` used bare `dotenv.load_dotenv()` to re-read `.env` before each job run. This skipped `_apply_external_secret_sources()`, so any credential managed by Bitwarden Secrets Manager was left as a raw `.env` placeholder. Every cron job that needed a BSM-managed token (Discord bot token, provider API key, etc.) failed with HTTP 401 on startup.

Replace `dotenv.load_dotenv()` with the gateway's `load_hermes_dotenv()` which chains: `_load_dotenv_with_fallback` (encoding) → `_apply_external_secret_sources` (Bitwarden). The manual encoding-fallback try/except is no longer needed since `_load_dotenv_with_fallback` handles it internally.

Also update all 16 test mocks from `patch("dotenv.load_dotenv")` to `patch("hermes_cli.env_loader.load_hermes_dotenv")` and add a regression test class `TestCronEnvLoaderUsesHermesDotenv`.

## Root Cause

`_run_job_impl` at `cron/scheduler.py:1470`:
```python
from dotenv import load_dotenv
load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
```

This loads `.env` into `os.environ` but never calls `_apply_external_secret_sources()`. The gateway path uses `load_hermes_dotenv()` which does both. Cron jobs got the raw placeholder values (e.g. `${BWS:project:secret:version}`) instead of the resolved secrets.

## Fix

```python
from hermes_cli.env_loader import load_hermes_dotenv
load_hermes_dotenv(hermes_home=str(_get_hermes_home()))
```

## Test Plan

- `uv run --extra dev pytest tests/cron/test_scheduler.py -q -k "not test_all_token_case_insensitive"` — 129 passed
- New tests in `TestCronEnvLoaderUsesHermesDotenv` verify the correct function is called and the bare variant is not

Ref: #33465