### PR TITLE
fix(minimax): drop stale ≤204,800 cache entries for MiniMax-M3

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1128,6 +1128,18 @@ def _model_name_suggests_kimi(model: str) -> bool:
     return lower.startswith("kimi") or "moonshot" in lower
 
 
+def _model_name_suggests_minimax_m3(model: str) -> bool:
+    """Return True if the model name looks like MiniMax M3.
+
+    Catches ``MiniMax-M3``, ``minimax/minimax-m3``, and similar variants
+    across surfaces (native MiniMax-M3, OpenRouter/Nous minimax/minimax-m3).
+    Used as a guard against stale cache entries seeded by pre-catalog builds
+    that resolved M3 via the generic ``minimax`` catch-all (204,800) before
+    the ``minimax-m3`` (1M) entry existed in DEFAULT_CONTEXT_LENGTHS.
+    """
+    return "minimax-m3" in model.lower()
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length."""
     import httpx
@@ -1535,6 +1547,19 @@ def get_model_context_length(
             elif cached <= 32768 and _model_name_suggests_kimi(model):
                 logger.info(
                     "Dropping stale Kimi cache entry %s@%s -> %s (OpenRouter underreport); "
+                    "re-resolving via hardcoded defaults",
+                    model, base_url, f"{cached:,}",
+                )
+                _invalidate_cached_context_length(model, base_url)
+            # Invalidate stale ≤204,800 cache entries for MiniMax-M3.  Pre-catalog
+            # builds resolved M3 via the generic ``minimax`` catch-all (204,800)
+            # and persisted it before the ``minimax-m3`` (1M) entry existed; that
+            # stale value would otherwise stick forever here at step 1.  M3 is 1M,
+            # so any sub-256K cached value for an M3 slug is a leftover — drop it
+            # and fall through to the hardcoded default.
+            elif cached <= 204_800 and _model_name_suggests_minimax_m3(model):
+                logger.info(
+                    "Dropping stale MiniMax-M3 cache entry %s@%s -> %s (pre-catalog value); "
                     "re-resolving via hardcoded defaults",
                     model, base_url, f"{cached:,}",
                 )

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -4,8 +4,9 @@ from unittest.mock import patch
 
 
 class TestMinimaxContextLengths:
-    """Verify context length entries match official docs (204,800 for all models).
+    """Verify context length entries match official docs.
 
+    M2.x series is 204,800; M3 is 1M (max output 512K).
     Source: https://platform.minimax.io/docs/api-reference/text-anthropic-api
     """
 
@@ -15,10 +16,73 @@ class TestMinimaxContextLengths:
 
     def test_minimax_models_resolve_via_prefix(self):
         from agent.model_metadata import get_model_context_length
-        # All MiniMax models should resolve to 204,800 via the "minimax" prefix
+        # M2.x models resolve to 204,800 via the "minimax" catch-all
         for model in ("MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"):
             ctx = get_model_context_length(model, "")
             assert ctx == 204_800, f"{model} expected 204800, got {ctx}"
+
+    def test_minimax_m3_resolves_to_1m(self):
+        from agent.model_metadata import get_model_context_length
+        # M3 must beat the generic "minimax" catch-all (204,800) and resolve to
+        # a 1M-class context. The exact value depends on the source: our
+        # hardcoded catalog says 1,000,000; the OpenRouter catalog reports
+        # 1,048,576 (1024²). Either is correct — assert "≥ 1M, not 204,800".
+        for model in ("MiniMax-M3", "minimax/minimax-m3", "minimax-m3"):
+            ctx = get_model_context_length(model, "")
+            assert ctx >= 1_000_000, f"{model} expected 1M-class, got {ctx}"
+
+
+class TestMinimaxM3StaleCacheGuard:
+    """Pre-catalog builds resolved M3 via the generic 'minimax' catch-all
+    (204,800) and persisted it before the 'minimax-m3' (1M) catalog entry
+    existed.  The step-1 cache guard must drop that stale value and re-resolve
+    to 1M, while leaving correct M2.x entries (204,800) untouched.
+    """
+
+    def test_suggests_minimax_m3(self):
+        from agent.model_metadata import _model_name_suggests_minimax_m3
+        assert _model_name_suggests_minimax_m3("MiniMax-M3")
+        assert _model_name_suggests_minimax_m3("minimax/minimax-m3")
+        assert not _model_name_suggests_minimax_m3("MiniMax-M2.7")
+        assert not _model_name_suggests_minimax_m3("MiniMax-M2.5")
+
+    def test_stale_m3_cache_dropped_and_reresolves_to_1m(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.minimaxi.com/anthropic"
+        mm.save_context_length("MiniMax-M3", base, 204_800)
+        ctx = mm.get_model_context_length(
+            "MiniMax-M3", base_url=base, api_key="", provider="minimax-cn"
+        )
+        assert ctx == 1_000_000
+
+    def test_correct_m3_cache_preserved(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.minimaxi.com/anthropic"
+        mm.save_context_length("MiniMax-M3", base, 1_000_000)
+        ctx = mm.get_model_context_length(
+            "MiniMax-M3", base_url=base, api_key="", provider="minimax-cn"
+        )
+        assert ctx == 1_000_000
+
+    def test_m2_cache_not_clobbered(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.minimaxi.com/anthropic"
+        # 204,800 is the CORRECT value for M2.x — guard must not touch it.
+        for slug in ("MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1"):
+            mm.save_context_length(slug, base, 204_800)
+            ctx = mm.get_model_context_length(
+                slug, base_url=base, api_key="", provider="minimax-cn"
+            )
+            assert ctx == 204_800, f"{slug} should stay 204800, got {ctx}"
 
 
 


### PR DESCRIPTION
## Summary
MiniMax-M3 users on a stale context-length cache no longer see 204K — the cached value is dropped and re-resolved to its real 1M context.

Root cause: pre-catalog builds resolved M3 via the generic `minimax` catch-all (204,800) and persisted it. Step 1 of `get_model_context_length` returns a cached `MiniMax-M3@<base_url>` entry directly, before reaching the `minimax-m3` (1M) catalog entry — so anyone who first probed M3 on an older build stuck at 204K forever (reported via Telegram `/new` showing `Context: 204K tokens (detected)` on the minimax coding plan, cn).

## Changes
- `agent/model_metadata.py`: add `_model_name_suggests_minimax_m3()` + a step-1 cache-invalidation branch mirroring the existing Kimi/Codex guards — drop cached entries `<= 204,800` for M3 slugs and re-resolve.
- `tests/agent/test_minimax_provider.py`: M3→1M resolution test + stale-cache guard tests (drop stale, preserve correct 1M, leave M2.x 204,800 untouched).

## Validation
| Scenario | Before | After |
|---|---|---|
| M3, stale 204,800 cache | 204,800 | 1,000,000 |
| M3, correct 1M cache | 1,000,000 | 1,000,000 |
| M2.x, 204,800 cache (correct) | 204,800 | 204,800 |

`tests/agent/test_minimax_provider.py`: 47 passed. Related context-length/cache tests: 263 passed.

## Infographic

![minimax-m3-stale-cache-guard](https://v3b.fal.media/files/b/0a9c88f0/A2Py5dtBduGuogLrAPiAc_ExuMxYip.png)
