### PR TITLE
fix: clarify cron delivery error status

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -133,7 +133,11 @@ def cron_list(show_all: bool = False):
 
         delivery_err = job.get("last_delivery_error")
         if delivery_err:
-            print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
+            # Delivery is tracked separately from execution: a cron run can
+            # complete successfully while the platform send fails.  Say "Last
+            # delivery" so an old platform error is not mistaken for a current
+            # execution failure.
+            print(f"    {color('⚠ Last delivery failed:', Colors.YELLOW)} {delivery_err}")
 
         print()
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+from cron.jobs import create_job, get_job, list_jobs, mark_job_run
 from hermes_cli.cron import cron_command
 
 
@@ -111,3 +111,16 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_list_labels_delivery_failure_as_delivery_not_execution(self, tmp_cron_dir, capsys):
+        job = create_job(prompt="Report", schedule="every 1h", name="Report job")
+        mark_job_run(job["id"], success=True, delivery_error="telegram TLS failure")
+
+        cron_command(Namespace(cron_command="list", all=False))
+
+        out = capsys.readouterr().out
+        assert "Last run:" in out
+        assert "ok" in out
+        assert "Last delivery failed:" in out
+        assert "Delivery failed:" not in out
+        assert "telegram TLS failure" in out


### PR DESCRIPTION
## Summary
- clarify cron list wording so delivery failures are not mistaken for execution failures
- add CLI regression coverage for a successful run with a delivery error

## Verification
- ./venv/bin/python3 -m pytest tests/hermes_cli/test_cron.py tests/cron/test_jobs.py::TestMarkJobRun::test_delivery_error_cleared_on_success -q -o 'addopts='
- hermes cron list --all | grep -A12 'ad510105c212'
- hermes cron status