### PR TITLE
fix(agent): use _USAGE_LIMIT_PATTERNS for quota-exhaustion fallback trigger

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -35,7 +35,7 @@ from hermes_cli.timeouts import get_provider_request_timeout
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
-from agent.error_classifier import FailoverReason
+from agent.error_classifier import FailoverReason, _USAGE_LIMIT_PATTERNS
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -621,11 +621,11 @@ def recover_with_credential_pool(
         if error_context:
             context_reason = str(error_context.get("reason") or "").lower()
             context_message = str(error_context.get("message") or "").lower()
+            haystack = context_reason + " " + context_message
             usage_limit_reached = (
                 "usage_limit_reached" in context_reason
                 or "gousagelimit" in context_reason
-                or "usage limit reached" in context_message
-                or "usage limit has been reached" in context_message
+                or any(p in haystack for p in _USAGE_LIMIT_PATTERNS)
             )
         if not has_retried_429 and not usage_limit_reached:
             return False, True


### PR DESCRIPTION
## Summary

- `recover_with_credential_pool` used a hardcoded set of strings to detect quota exhaustion that was inconsistent with `_USAGE_LIMIT_PATTERNS` in `error_classifier.py`
- Kimi's `"monthly usage limit"` message was not matched, so the `fallback_model` chain was never triggered when Kimi quota was exhausted — the error was surfaced directly to the user instead
- Replace the two ad-hoc strings with the shared `_USAGE_LIMIT_PATTERNS` list so classifier and fallback trigger stay in sync

## Test plan

- [ ] All 184 agent tests pass (`tests/agent/`)
- [ ] Kimi `"monthly usage limit"` message now matches `_USAGE_LIMIT_PATTERNS` and triggers fallback
- [ ] Normal rate-limit 429s (no quota phrase) continue to classify as retryable — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)