### PR TITLE
fix: stabilize Windows gateway restart and status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3958,18 +3958,28 @@ class GatewayRunner:
                 _CREATE_NEW_PROCESS_GROUP = 0x00000200
                 _DETACHED_PROCESS = 0x00000008
                 _CREATE_NO_WINDOW = 0x08000000
+                env = os.environ.copy()
+                # The live gateway sets _HERMES_GATEWAY=1 so CLI lifecycle
+                # commands invoked *inside* an agent cannot kill their own host.
+                # This helper intentionally runs after the old gateway exits,
+                # so it must not inherit that self-targeting guard marker.
+                env.pop('_HERMES_GATEWAY', None)
                 subprocess.Popen(
                     cmd,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    env=env,
                     creationflags=_CREATE_NEW_PROCESS_GROUP | _DETACHED_PROCESS | _CREATE_NO_WINDOW,
                 )
                 """
             ).strip()
+            restart_env = os.environ.copy()
+            restart_env.pop("_HERMES_GATEWAY", None)
             subprocess.Popen(
                 [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                env=restart_env,
                 **windows_detach_popen_kwargs(),
             )
             return

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -29,6 +29,7 @@ Design notes
 from __future__ import annotations
 
 import ctypes
+import locale
 import os
 import re
 import shlex
@@ -97,6 +98,36 @@ def _quote_schtasks_arg(value: str) -> str:
 # schtasks.exe wrapper
 # ---------------------------------------------------------------------------
 
+def _decode_schtasks_output(data: bytes | str | None) -> str:
+    """Decode localized schtasks.exe output without crashing.
+
+    ``schtasks.exe`` emits localized Windows text using the process ANSI/OEM
+    code page on many systems.  Hermes may run with UTF-8-mode enabled, so
+    ``subprocess.run(..., text=True)`` can raise ``UnicodeDecodeError`` in its
+    reader thread before we get a CompletedProcess.  Capture bytes and decode
+    explicitly instead; if every likely codec fails, preserve diagnostics with
+    replacement characters rather than crashing gateway status/start/stop.
+    """
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return data
+    encodings = ["mbcs", locale.getpreferredencoding(False), "utf-8"]
+    seen: set[str] = set()
+    for encoding in encodings:
+        if not encoding:
+            continue
+        key = encoding.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            return data.decode(encoding)
+        except (LookupError, UnicodeDecodeError):
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
 def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
     """Run ``schtasks.exe`` with a hard timeout. Return (code, stdout, stderr).
 
@@ -111,14 +142,17 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
         proc = subprocess.run(
             [schtasks, *args],
             capture_output=True,
-            text=True,
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the
             # same pattern and the windows-subprocess-sigint-storm.md ref.
             creationflags=0x08000000,  # CREATE_NO_WINDOW
         )
-        return (proc.returncode, proc.stdout or "", proc.stderr or "")
+        return (
+            proc.returncode,
+            _decode_schtasks_output(proc.stdout),
+            _decode_schtasks_output(proc.stderr),
+        )
     except subprocess.TimeoutExpired:
         return (124, "", f"schtasks timed out after {_SCHTASKS_TIMEOUT_S}s")
     except OSError as e:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -182,6 +182,7 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     runner, _adapter = make_restart_runner()
     popen_calls = []
 
+    monkeypatch.setattr(gateway_run, "sys", __import__("types").SimpleNamespace(platform="linux", executable="python"))
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["/usr/bin/hermes"])
     monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
     monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/setsid" if cmd == "setsid" else None)
@@ -202,6 +203,36 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_windows_detached_restart_does_not_inherit_gateway_guard(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+
+    monkeypatch.setattr(gateway_run, "sys", __import__("types").SimpleNamespace(platform="win32", executable="python.exe"))
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    import hermes_cli._subprocess_compat as compat
+
+    monkeypatch.setattr(compat, "windows_detach_popen_kwargs", lambda: {})
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[:3] == [gateway_run.sys.executable, "-c", cmd[2]]
+    assert cmd[-2:] == ["gateway", "restart"]
+    assert kwargs["env"].get("_HERMES_GATEWAY") is None
+    assert "env.pop('_HERMES_GATEWAY', None)" in cmd[2]
 
 
 # ── Shutdown notification tests ──────────────────────────────────────

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -29,6 +29,36 @@ def test_schtasks_fallback_does_not_hide_unknown_errors():
     assert gateway_windows._should_fall_back(1, "ERROR: The system cannot find the file specified.") is False
 
 
+def test_exec_schtasks_decodes_localized_bytes_without_utf8_crash(monkeypatch):
+    """Localized schtasks output may be CP949/ANSI bytes while Hermes runs UTF-8 mode."""
+
+    class Proc:
+        returncode = 0
+        # Korean CP949 bytes that are invalid as UTF-8.
+        stdout = "작업 상태: 실행 중".encode("cp949")
+        stderr = b"\xbf"
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        assert kwargs["capture_output"] is True
+        assert "text" not in kwargs
+        return Proc()
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows.locale, "getpreferredencoding", lambda do_setlocale=False: "cp949")
+    monkeypatch.setattr(gateway_windows.shutil, "which", lambda name: "C:/Windows/System32/schtasks.exe")
+    monkeypatch.setattr(gateway_windows.subprocess, "run", fake_run)
+
+    code, stdout, stderr = gateway_windows._exec_schtasks(["/Query", "/TN", "Hermes_Gateway"])
+
+    assert code == 0
+    assert "작업 상태" in stdout
+    assert isinstance(stderr, str)
+    assert calls[0][0] == ["C:/Windows/System32/schtasks.exe", "/Query", "/TN", "Hermes_Gateway"]
+
+
 def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, tmp_path):
     """Avoid uv's venv pythonw launcher because it respawns console python.exe."""
 


### PR DESCRIPTION
## Summary
- Fix Windows gateway `/restart` when launched from a gateway process by ensuring detached restart helpers do not inherit `_HERMES_GATEWAY`.
- Keep the self-targeting lifecycle guard intact for real in-gateway `gateway stop/restart` calls.
- Fix `hermes gateway status` UnicodeDecodeError on localized Windows systems by capturing `schtasks.exe` output as bytes and decoding with Windows/local encodings before falling back safely.
- Add regression tests for both Windows gateway restart env handling and localized `schtasks` output decoding.

## Test Plan
- `python -m pytest -o addopts='' tests/hermes_cli/test_gateway_windows.py tests/gateway/test_restart_drain.py tests/hermes_cli/test_gateway_restart_loop.py -q`
- Manual: `hermes gateway status` on Windows now exits 0 and reports the running gateway without UnicodeDecodeError.
