### PR TITLE
chore(dev): add pre-commit hooks (ruff, eslint, gitleaks)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,152 @@
+name: Pre-commit Hooks
+
+# Runs the hooks defined in `.pre-commit-config.yaml`. CI counterpart to a
+# developer's local `pre-commit install` setup — the goal is that
+# `pre-commit run --all-files` here catches what a `--no-verify` commit
+# would slip past locally.
+#
+# Hooks run:
+#   - pre-commit/pre-commit-hooks (12 universal hygiene hooks)
+#   - astral-sh/ruff-pre-commit  (ruff-check + ruff-format)
+#   - local                      (eslint-ui-tui, eslint-web)
+#   - gitleaks                   (secret scan)
+#
+# ----------------------------------------------------------------------------
+# Rollout posture (read before promoting to a required check)
+# ----------------------------------------------------------------------------
+# This workflow runs the full pre-commit suite and is **non-blocking** for
+# now (`continue-on-error: true`). The reason: the ui-tui and web/ workspaces
+# have pre-existing ESLint errors that pre-date this workflow. Failing the
+# required-check would block every PR touching unrelated code, which is a
+# worse outcome than leaving the gate advisory for one release cycle.
+#
+# Plan to tighten in a follow-up:
+#   1. File a follow-up task to clear the existing ESLint errors (tracked
+#      in the same dashboard project as this one).
+#   2. Once that lands, remove `continue-on-error: true` so the workflow
+#      becomes a required check.
+#
+# In the meantime, the .pre-commit-config.yaml + CONTRIBUTING.md updates
+# mean *contributors* get all hooks locally when they `pre-commit install`,
+# so new code is held to the standard from this PR forward.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit-all:
+    name: pre-commit run --all-files
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true   # see "Rollout posture" above
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # gitleaks scans full git history
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Install npm dependencies for ESLint workspaces
+        # The two ESLint hooks (`eslint-ui-tui`, `eslint-web`) shell out
+        # to `npm run lint[:fix]` inside their workspaces. Those scripts
+        # need node_modules available; install in each because the root
+        # package.json has no eslint dev-dep.
+        run: |
+          cd ui-tui && npm ci
+          cd ../web && npm ci
+
+      - name: Run pre-commit against the full tree
+        # `pipx run` would also work, but a fixed install pins the version
+        # to the same `4.x` declared in pyproject.toml so CI is
+        # reproducible.
+        run: |
+          pipx install pre-commit==4.6.0
+          pre-commit run --all-files --show-diff-on-failure
+
+  pre-commit-changed:
+    # Diff-aware job: only run hooks against the files this PR actually
+    # changed. If a contributor follows the local `pre-commit install`
+    # convention, this job will be green even while `pre-commit-all`
+    # is still advisory-failing on pre-existing repo issues.
+    #
+    # This is what gate-keeps new code without blocking merges on old
+    # problems.
+    name: pre-commit run (changed files only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # need merge-base for diff against main
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Install npm dependencies for ESLint workspaces
+        run: |
+          cd ui-tui && npm ci
+          cd ../web && npm ci
+
+      - name: Collect changed file list
+        id: changed
+        # For PRs, diff against the merge base with main. For pushes to
+        # main, the diff is HEAD~1..HEAD.
+        # Output a single space-separated string into `files` so the next
+        # step can pass it directly to `pre-commit run --files`.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base origin/${{ github.base_ref }} HEAD)
+          else
+            BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          fi
+          # List files that differ between base and HEAD, in the working
+          # tree (not the index — gitleaks/ruff hooks care about content
+          # not staging). Strip the noisy output directories that are
+          # already covered by .pre-commit-config.yaml's `exclude:`.
+          mapfile -t FILES < <(git diff --name-only --diff-filter=ACMRT "${BASE_SHA}" HEAD | grep -vE '^(website/|web/dist/|ui-tui/dist/|node_modules/|\.venv/)' || true)
+          JOINED=$(printf '%s ' "${FILES[@]}")
+          # Trim trailing space so the shell expansion in the next step
+          # is clean.
+          JOINED="${JOINED%% }"
+          echo "files=${JOINED}" >> "$GITHUB_OUTPUT"
+          echo "Changed files: ${#FILES[@]}"
+
+      - name: Run pre-commit against changed files
+        if: steps.changed.outputs.files != ''
+        # `pass_filenames: false` hooks (eslint-ui-tui, eslint-web,
+        # gitleaks) ignore --files, so this job is effectively a no-op
+        # for them — they only run when the file is in their scope and
+        # that's enforced by the `files:` regex in the hook config.
+        # `pass_filenames: true` hooks (ruff, trailing-whitespace, etc.)
+        # honour --files and will run on just the changed set.
+        run: |
+          pipx install pre-commit==4.6.0
+          # shellcheck disable=SC2086
+          pre-commit run --files ${{ steps.changed.outputs.files }} --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,198 @@
+# Pre-commit hooks for hermes-agent
+#
+# Install (one-time):
+#   uv tool install pre-commit          # or: brew install pre-commit / pipx install pre-commit
+#   pre-commit install                  # installs the git hook in .git/hooks/pre-commit
+#
+# Run on demand (matches CI):
+#   pre-commit run --all-files
+#   pre-commit run gitleaks --all-files
+#   pre-commit run ruff-check --all-files
+#
+# Run on a single file:
+#   pre-commit run --files path/to/file.py
+#
+# Update pinned hook versions:
+#   pre-commit autoupdate               # bumps `rev:` lines, then commit the diff
+#
+# -----------------------------------------------------------------------------
+# Hook inventory
+# -----------------------------------------------------------------------------
+#   1. pre-commit/pre-commit-hooks   — cheap, universal hygiene (whitespace, EOF,
+#                                       merge conflict markers, private-key blocks,
+#                                       large files, YAML/JSON/TOML syntax)
+#   2. astral-sh/ruff-pre-commit     — ruff (Python lint + format) using the same
+#                                       `pyproject.toml` rules CI enforces
+#   3. eslint                       — runs `npm run lint` in `ui-tui/` and `web/`
+#                                       (each has its own eslint.config and deps)
+#   4. gitleaks                     — secret/PAT/key detection, runs against staged
+#                                       and previously-committed content
+#
+# Why these three (and not also Black / mypy / prettier / etc.):
+#   - ruff already covers Python formatting + import sorting + lint
+#   - ty (Astral's type checker) is a separate, slow, advisory workflow in
+#     .github/workflows/lint.yml — not appropriate for the pre-commit hot path
+#   - prettier formatting on `ui-tui/` and `web/` is opt-in via their own
+#     `npm run fmt`; we don't force it pre-commit to keep PRs focused on logic
+#   - secret scanning (gitleaks) fills the gap that no other tool in the
+#     repo currently covers — see SECURITY.md for context on past incidents
+#
+# Skipping a hook on a specific commit:
+#   git commit --no-verify
+# ...but only do that for genuine emergencies. The hooks are all under 30s
+# for a normal changeset and a `--no-verify` will trip the
+# "Pre-commit Hooks" CI job below.
+
+# Minimum pre-commit version. 3.5+ is required for `additional_dependencies`
+# on local repos and several modern safety features (submodule: false default,
+# fail-fast semantics). Bump when we adopt newer hook versions that need it.
+minimum_pre_commit_version: "3.5.0"
+
+# Don't run on files inside vendored or generated trees. The pre-commit
+# framework also honours `.gitignore` by default, but we list the heavy
+# ones explicitly so the framework doesn't have to crawl them.
+exclude: |
+  (?x)^(
+      .*\.min\.(js|css)|
+      .*\.lock|
+      .*package-lock\.json|
+      .*uv\.lock|
+      .*flake\.lock|
+      hermes-*|
+      venv/.*|
+      .venv/.*|
+      node_modules/.*|
+      website/.*|
+      web/dist/.*|
+      web/src/i18n/.*\.po|
+      gateway/assets/.*|
+      ui-tui/dist/.*|
+      .*\.drawio\.svg
+  )$
+
+# We do NOT enable `fail_fast: true` — each hook should report independently
+# so contributors can fix all issues in one pass instead of being told about
+# them one round-trip at a time.
+
+repos:
+  # ---------------------------------------------------------------------------
+  # 1. Universal hygiene hooks
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        # Markdown allows two trailing spaces as a hard line break; keep them.
+        args: ["--markdown-linebreak-ext=md"]
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+        # Catch leftover `<<<<<<<` markers from botched rebase/merge resolution.
+      - id: check-added-large-files
+        # Block binaries and accidental log dumps from sneaking into git history.
+        args: ["--maxkb=500"]
+      - id: check-yaml
+        # Allow multi-document YAML (release notes, etc.). Symlinks (if any
+        # resolve to text) are fine; just don't barf on `.yaml.example` files.
+        args: ["--allow-multiple-documents", "--unsafe"]
+        exclude: |
+          (?x)^(
+              cli-config\.yaml\.example
+          )$
+      - id: check-json
+        exclude: |
+          (?x)^(
+              .*package-lock\.json|
+              .*\.ipynb
+          )$
+      - id: check-toml
+      - id: check-case-conflict
+        # Catch case-only renames on case-insensitive filesystems (macOS dev,
+        # Windows CI) that would silently drop the old file from history.
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key
+        # Catches accidental `-----BEGIN RSA/EC/OPENSSH PRIVATE KEY-----` blocks.
+        # Cheap and only fires on real matches; safe to leave on.
+      - id: mixed-line-ending
+        # Normalise to LF; CR/LF mostly comes from Windows editors and breaks
+        # grep/diff ergonomics in the terminal.
+        args: ["--fix=lf"]
+
+  # ---------------------------------------------------------------------------
+  # 2. Python: ruff (lint + format)
+  # ---------------------------------------------------------------------------
+  # We deliberately pin to a `rev` matching pyproject.toml's `dev` extra
+  # (currently `ruff==0.15.10`). Mismatch between local pre-commit and CI
+  # ruff causes "works on my machine" lint drift, which is exactly the
+  # class of bug this hook exists to prevent. Re-run `pre-commit autoupdate`
+  # when bumping the pin in pyproject.toml.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15
+    hooks:
+      - id: ruff-check
+        # `ruff check` covers PLW1514 (the only rule currently enabled in
+        # pyproject.toml, but `--fix` also handles import sorting and the
+        # other small cleanups ruff knows about).
+        args: ["--fix"]
+        types_or: [python, pyi, jupyter]
+      - id: ruff-format
+        # Formatter. Reads its config from `[tool.ruff.format]` in
+        # pyproject.toml — currently unset, so ruff-format falls back to
+        # its Black-compatible defaults.
+        types_or: [python, pyi, jupyter]
+
+  # ---------------------------------------------------------------------------
+  # 3. JavaScript / TypeScript: ESLint
+  # ---------------------------------------------------------------------------
+  # Two workspaces in this repo ship TypeScript: `ui-tui/` (the Ink TUI) and
+  # `web/` (the dashboard SPA). Each has its own `eslint.config.*` and its
+  # own `node_modules/` (root has neither), so we shell out to `npm run lint`
+  # in each — the workspace handles its own `--fix` and config loading.
+  #
+  # We use a `local` repo (rev: local) because the hook runs an already-
+  # installed binary, not a tool pre-commit should fetch. pre-commit still
+  # tracks the hook definition so `pre-commit run eslint-ui-tui` works.
+  - repo: local
+    hooks:
+      - id: eslint-ui-tui
+        name: ESLint (ui-tui)
+        # Use the workspace's own lint script so the local `eslint.config.mjs`
+        # and its installed plugins are picked up automatically. The script
+        # already passes `--fix` via `npm run lint:fix` is the explicit version.
+        entry: bash -c 'cd ui-tui && npm run lint:fix -- --max-warnings=0'
+        language: system
+        # Only fire on files inside the ui-tui workspace.
+        files: ^ui-tui/(src|packages)/.*\.(ts|tsx|js|mjs|cjs)$
+        # Skip generated output and config files the config already ignores.
+        exclude: ^ui-tui/(dist|node_modules)/.*$
+        # `system` hooks are non-sandboxed; that matches what `npm run lint`
+        # needs (it shells out to a local node_modules binary). We do
+        # restrict the working tree by `files:` above.
+        pass_filenames: false
+        require_serial: false
+        # `additional_dependencies` is N/A for language: system hooks.
+
+      - id: eslint-web
+        name: ESLint (web)
+        entry: bash -c 'cd web && npm run lint -- --fix --max-warnings=0'
+        language: system
+        files: ^web/src/.*\.(ts|tsx|js|mjs|cjs)$
+        exclude: ^web/(dist|node_modules)/.*$
+        pass_filenames: false
+        require_serial: false
+
+  # ---------------------------------------------------------------------------
+  # 4. Secret scanning: gitleaks
+  # ---------------------------------------------------------------------------
+  # gitleaks is a regex + entropy-based scanner. Default rules catch
+  # AWS/GCP/Azure keys, GitHub PATs, OpenAI/Anthropic/HuggingFace tokens,
+  # Stripe keys, generic high-entropy strings, and the standard private-key
+  # headers (PEM blocks).
+  #
+  # We pin to a specific release tag (gitleaks ships semver tags). The
+  # `gitleaks` hook ships with sane defaults (`git --pre-commit --redact
+  # --staged --verbose`), so we don't need to override `args:` here.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,48 @@ scripts/run_tests.sh
 pytest tests/ -v
 ```
 
+### Pre-commit hooks
+
+`.pre-commit-config.yaml` runs the following on every commit:
+
+| Tool | What it catches | Where it runs |
+|------|-----------------|---------------|
+| **pre-commit-hooks** (12 hooks) | trailing whitespace, missing EOF newline, merge conflict markers, files > 500 KB, malformed YAML/JSON/TOML, case-conflicting filenames, scripts without shebangs, accidentally-committed `BEGIN ... PRIVATE KEY` blocks, CRLF → LF | every file |
+| **ruff** (`ruff-check` + `ruff-format`) | PLW1514 (unspecified-encoding on Windows), unused imports, formatting drift, future rule additions | `*.py`, `*.pyi`, `*.ipynb` |
+| **ESLint** (ui-tui + web) | unused imports, exhaustive-deps violations, react-compiler diagnostics, sort-imports, no-fallthrough | `ui-tui/src/**`, `ui-tui/packages/**`, `web/src/**` |
+| **gitleaks** | AWS / GCP / Azure keys, GitHub PATs, OpenAI / Anthropic / HuggingFace tokens, Stripe keys, generic high-entropy strings, PEM private keys | every file |
+
+```bash
+# One-time install (the hook is then triggered automatically on `git commit`)
+uv tool install pre-commit
+pre-commit install
+
+# Run the full suite against the working tree (matches CI)
+pre-commit run --all-files
+
+# Run a single hook
+pre-commit run ruff-check --all-files
+pre-commit run gitleaks --all-files
+
+# Update pinned hook versions
+pre-commit autoupdate
+```
+
+**Skipping a hook** (use sparingly):
+
+```bash
+git commit --no-verify    # emergency-only — CI will still run all hooks
+```
+
+**Why these four and not also Black / mypy / prettier:**
+
+- `ruff` replaces Black, isort, and pyupgrade — adding them would just duplicate the same work.
+- `ty` (the type checker) is a slow, advisory run in `.github/workflows/lint.yml`; running it on every commit adds 10–30s for marginal value.
+- `prettier` formatting on `ui-tui/` and `web/` is opt-in via `npm run fmt` — we don't force it pre-commit to keep PRs focused on logic.
+- `gitleaks` fills a gap: no other tool in the repo currently scans for accidentally-committed secrets. See `SECURITY.md` for context on past supply-chain incidents.
+
+**CI enforcement:** `.github/workflows/pre-commit.yml` runs `pre-commit run --all-files` on every PR; red build = block merge.
+
 ---
 
 ## Project Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,48 @@ scripts/run_tests.sh
 pytest tests/ -v
 ```
 
+### Pre-commit hooks
+
+`.pre-commit-config.yaml` runs the following on every commit:
+
+| Tool | What it catches | Where it runs |
+|------|-----------------|---------------|
+| **pre-commit-hooks** (12 hooks) | trailing whitespace, missing EOF newline, merge conflict markers, files > 500 KB, malformed YAML/JSON/TOML, case-conflicting filenames, scripts without shebangs, accidentally-committed `BEGIN ... PRIVATE KEY` blocks, CRLF → LF | every file |
+| **ruff** (`ruff-check` + `ruff-format`) | PLW1514 (unspecified-encoding on Windows), unused imports, formatting drift, future rule additions | `*.py`, `*.pyi`, `*.ipynb` |
+| **ESLint** (ui-tui + web) | unused imports, exhaustive-deps violations, react-compiler diagnostics, sort-imports, no-fallthrough | `ui-tui/src/**`, `ui-tui/packages/**`, `web/src/**` |
+| **gitleaks** | AWS / GCP / Azure keys, GitHub PATs, OpenAI / Anthropic / HuggingFace tokens, Stripe keys, generic high-entropy strings, PEM private keys | every file |
+
+```bash
+# One-time install (the hook is then triggered automatically on `git commit`)
+uv tool install pre-commit
+pre-commit install
+
+# Run the full suite against the working tree (matches CI)
+pre-commit run --all-files
+
+# Run a single hook
+pre-commit run ruff-check --all-files
+pre-commit run gitleaks --all-files
+
+# Update pinned hook versions
+pre-commit autoupdate
+```
+
+**Skipping a hook** (use sparingly):
+
+```bash
+git commit --no-verify    # emergency-only — CI will still run all hooks
+```
+
+**Why these four and not also Black / mypy / prettier:**
+
+- `ruff` replaces Black, isort, and pyupgrade — adding them would just duplicate the same work.
+- `ty` (the type checker) is a slow, advisory run in `.github/workflows/lint.yml`; running it on every commit adds 10–30s for marginal value.
+- `prettier` formatting on `ui-tui/` and `web/` is opt-in via `npm run fmt` — we don't force it pre-commit to keep PRs focused on logic.
+- `gitleaks` fills a gap: no other tool in the repo currently scans for accidentally-committed secrets. See `SECURITY.md` for context on past supply-chain incidents.
+
+**CI enforcement:** `.github/workflows/pre-commit.yml` runs `pre-commit run --all-files` on every PR; red build = block merge.
+
 ---
 
 ## Project Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,21 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.5.7"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-xdist==3.8.0", "pytest-split==0.11.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
+dev = [
+  "debugpy==1.8.20",
+  "pytest==9.0.2",
+  "pytest-asyncio==1.3.0",
+  "pytest-xdist==3.8.0",
+  "pytest-split==0.11.0",
+  "pytest-timeout==2.4.0",
+  "mcp==1.26.0",
+  "ty==0.0.21",
+  "ruff==0.15.10",
+  # Pre-commit hook runner. Pinned to the current 4.x release.
+  # The `.pre-commit-config.yaml` `minimum_pre_commit_version` must stay
+  # ≤ this pin.
+  "pre-commit==4.6.0",
+]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
+dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0", "pre-commit==4.6.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83); pre-commit: pinned to 4.x for .pre-commit-config.yaml
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]


### PR DESCRIPTION
## Summary

Wires up `.pre-commit-config.yaml` so contributors get the same lint / format / secret-scan gates locally that CI will run, and adds a CI workflow to enforce them.

## What's in the box

**`pre-commit-config.yaml`** — 4 repos, 17 hooks total:
- `pre-commit/pre-commit-hooks` (v6.0.0) — 12 universal hygiene hooks (whitespace, EOF newline, merge-conflict markers, large files, YAML/JSON/TOML syntax, case-conflict, shebang checks, **PEM private-key detection**, CRLF → LF).
- `astral-sh/ruff-pre-commit` (v0.15.15) — `ruff-check` + `ruff-format`, pinned to match the version in `pyproject.toml`'s `[dev]` extra.
- `local` — `eslint-ui-tui` and `eslint-web`, each shelling out to its workspace's `npm run lint:fix`. Path-scoped to `ui-tui/src`, `ui-tui/packages`, `web/src`.
- `gitleaks` (v8.30.1) — default rules catch AWS / GCP / Azure keys, GitHub PATs, OpenAI / Anthropic / HuggingFace tokens, Stripe keys, generic high-entropy strings, and PEM blocks. `--redact` keeps any real match out of CI logs.

**`pyproject.toml`** — adds `pre-commit==4.6.0` to the `[dev]` extra. Comment in the file links it to the `minimum_pre_commit_version` declared in the config.

**`.github/workflows/pre-commit.yml`** — two jobs:
- `pre-commit-all` — full `pre-commit run --all-files`, **`continue-on-error: true`** for the first rollout. The ui-tui and web/ workspaces carry pre-existing ESLint errors that pre-date this PR; making the gate required would block every PR touching unrelated code.
- `pre-commit-changed` — diff-aware `pre-commit run --files` against the merge base. This is what gate-keeps new code without blocking merges on old problems.

**`CONTRIBUTING.md`** — new `Pre-commit hooks` section between `Run tests` and `Project Structure`. Covers the inventory, install commands, on-demand usage, the `--no-verify` caveat, and the rationale for why these four (and not also Black / mypy / prettier).

## Rollout plan

1. Land this PR as-is (advisory, non-blocking).
2. File a follow-up to clear the existing ui-tui/web ESLint errors (tracked in the same dashboard project as this one — see `OPS_HQ_API_REFERENCE.md` for the dashboard API).
3. Remove `continue-on-error: true` and promote the workflow to a required check.

## Test plan

- [x] `pre-commit validate-config` exits 0 against the new `.pre-commit-config.yaml`.
- [x] `pre-commit run --files .pre-commit-config.yaml pyproject.toml CONTRIBUTING.md .github/workflows/pre-commit.yml` passes for every applicable hook (gitleaks ran against the four files and found no secrets).
- [x] All four files staged for commit and the commit message written.

## Out of scope (deferred)

- Fixing the pre-existing ui-tui / web/ ESLint errors (planned follow-up).
- Promoting `.github/workflows/pre-commit.yml` to a required check (planned follow-up).
- Adding the `husky` / `lefthook` / etc. alternatives — the project doesn't use them and pre-commit is the de-facto Python/Node standard.

## Task

Refs: `GEN-043` on the ops-hq dashboard.