### PR TITLE
refactor: add LLM-native WhatsApp conversation routing

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -24,6 +24,11 @@ import re
 import shutil
 import signal
 import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -265,6 +270,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
         self._mention_patterns = self._compile_mention_patterns()
+        self._last_bot_reply_at_by_chat: Dict[str, float] = {}
+        self._last_bot_reply_text_by_chat: Dict[str, str] = {}
+        self._active_threads_path: Path = self._session_path / "active-threads.json"
+        self._recent_group_messages_by_chat: Dict[str, list[Dict[str, Any]]] = {}
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
         self._bridge_log: Optional[Path] = None
@@ -312,6 +321,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _whatsapp_respond_when_likely_directed(self) -> bool:
+        """Whether group messages may wake the bot via high-confidence intent heuristics."""
+        configured = self.config.extra.get("respond_when_likely_directed")
+        if configured is None:
+            configured = self.config.extra.get("likely_directed_response")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("WHATSAPP_RESPOND_WHEN_LIKELY_DIRECTED", "false").lower() in {"true", "1", "yes", "on"}
 
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
@@ -440,6 +460,583 @@ class WhatsAppAdapter(BasePlatformAdapter):
         body = str(data.get("body") or "")
         return any(pattern.search(body) for pattern in self._mention_patterns)
 
+    def _message_is_ambiguous_third_party_check(self, body: str) -> bool:
+        """Return True for group-chat "can you check if it/he/she/they..." ambiguity."""
+        normalized = re.sub(r"\s+", " ", str(body or "")).strip().lower()
+        return bool(re.match(
+            r"^(?:can|could|would)\s+you\s+(?:please\s+)?check\s+(?:if|whether)\s+(?:it|it['’]s|he|she|they|that|this|the\b)",
+            normalized,
+        ))
+
+    def _message_likely_directed_at_bot(self, data: Dict[str, Any]) -> bool:
+        """High-confidence wake heuristic for WhatsApp groups.
+
+        This is deliberately conservative. It is not free-response mode: normal
+        group chatter such as "any ideas?" or "can you come over later?" should
+        not wake the bot. It only accepts messages that look like assistant-style
+        requests, or messages addressed to obvious bot/AI names.
+        """
+        if not self._whatsapp_respond_when_likely_directed():
+            return False
+        body = re.sub(r"\s+", " ", str(data.get("body") or "")).strip()
+        if not body or body.startswith("/"):
+            return False
+        if self._message_is_ambiguous_third_party_check(body):
+            return False
+        lower = body.lower()
+
+        # Natural name/wake-word, separate from platform @mention metadata.
+        if re.search(r"\bhermes\b", lower):
+            return True
+
+        # Direct address to the bot as a role: "bot, ...", "AI can you ...".
+        if re.match(r"^(?:hey|hi|yo|ok(?:ay)?|please\s+)?(?:bot|ai|assistant)\b", lower):
+            return True
+
+        assistant_verbs = (
+            "look up", "lookup", "search", "google", "find", "summarize", "summarise", "summary", "recap",
+            "explain", "translate", "draft", "write", "make", "create", "generate",
+            "plan", "calculate", "compare", "recommend", "suggest", "remind", "remember",
+            "forget", "save", "note", "list", "turn this into", "help me", "help us",
+        )
+        verb_pattern = "|".join(re.escape(v) for v in assistant_verbs)
+
+        # "Can you check ..." is common human-to-human group phrasing. Only
+        # wake on it when the object is clearly a bot-owned feature or public
+        # object ID; ambiguous "check if/whether it/he/she/they..." should stay
+        # silent unless WhatBot was named/mentioned or recently replied.
+        check_feature_pattern = (
+            r"(?:reminders?|todo(?:\s+list)?s?|poll(?:\s+results?)?|memory|notes?|images?|media|"
+            r"TL-[A-Z0-9]{4,}|TI-[A-Z0-9]{4,}|N-[A-Z0-9]{4,}|M-[A-Z0-9]{4,}|I-[A-Z0-9]{4,}|gr-[A-Za-z0-9-]+)"
+        )
+        if re.match(rf"^(?:can|could|would)\s+you\s+(?:please\s+)?check\b.*\b{check_feature_pattern}\b", body, re.IGNORECASE):
+            return True
+
+        # High-confidence assistant request forms. Avoid broad "can you ..."
+        # unless the requested action is a typical bot/assistant task.
+        if re.match(rf"^(?:can|could|would)\s+you\s+(?:please\s+)?(?:{verb_pattern})\b", lower):
+            return True
+        if re.match(rf"^please\s+(?:{verb_pattern})\b", lower):
+            return True
+
+        return False
+
+    def _read_active_thread_store(self) -> Dict[str, Any]:
+        try:
+            path = getattr(self, "_active_threads_path", self._session_path / "active-threads.json")
+            if not path.exists():
+                return {"chats": {}}
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return {"chats": {}}
+            data.setdefault("chats", {})
+            return data
+        except (OSError, json.JSONDecodeError, TypeError):
+            return {"chats": {}}
+
+    def _write_active_thread_store(self, store: Dict[str, Any]) -> None:
+        try:
+            path = getattr(self, "_active_threads_path", self._session_path / "active-threads.json")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(store, indent=2, sort_keys=True), encoding="utf-8")
+            tmp.replace(path)
+        except OSError as exc:
+            logger.debug("whatsapp active-thread store write failed: %s", exc)
+
+    def _record_recent_group_message(self, data: Dict[str, Any]) -> None:
+        chat_id = str(data.get("chatId") or "")
+        body = re.sub(r"\s+", " ", str(data.get("body") or "")).strip()
+        if not chat_id or not chat_id.endswith("@g.us") or not body:
+            return
+        sender = self._safe_whatsapp_display_name(data.get("senderName")) or "someone"
+        entry = {
+            "at": time.time(),
+            "sender": sender,
+            "body": self._sanitize_whatsapp_visible_ids(body)[:1000],
+        }
+        recent = list(getattr(self, "_recent_group_messages_by_chat", {}).get(chat_id, []))
+        recent.append(entry)
+        recent = recent[-20:]
+        self._recent_group_messages_by_chat[chat_id] = recent
+        store = self._read_active_thread_store()
+        chat_state = store.setdefault("chats", {}).setdefault(chat_id, {})
+        chat_state["recent_messages"] = recent
+        self._write_active_thread_store(store)
+
+    def _recent_messages_for_chat(self, chat_id: str) -> list[Dict[str, Any]]:
+        recent = list(getattr(self, "_recent_group_messages_by_chat", {}).get(chat_id, []))
+        if recent:
+            return recent[-20:]
+        store = self._read_active_thread_store()
+        stored = store.get("chats", {}).get(chat_id, {}).get("recent_messages", [])
+        if isinstance(stored, list):
+            self._recent_group_messages_by_chat[chat_id] = stored[-20:]
+            return stored[-20:]
+        return []
+
+    @staticmethod
+    def _message_is_retroactive_bot_addressing_text(text: str) -> bool:
+        """Return True when a user is pointing WhatBot at a recent prior message."""
+        normalized = re.sub(r"\s+", " ", str(text or "")).strip().lower()
+        if not normalized:
+            return False
+        normalized = re.sub(r"^(?:what\s*bot|whatbot|hermes)[\s,.:;!-]*", "", normalized).strip()
+        return bool(re.search(
+            r"\b(?:"
+            r"(?:the\s+)?last\s+message\s+(?:was|is)\s+for\s+you|"
+            r"that\s+(?:was|is)\s+for\s+you|"
+            r"i\s+meant\s+you|"
+            r"forgot\s+to\s+(?:tag|mention)\s+you|"
+            r"forgot\s+to\s+(?:say\s+)?(?:what\s*bot|whatbot|hermes)|"
+            r"answer\s+(?:the\s+)?(?:above|previous\s+message)"
+            r")\b",
+            normalized,
+        ))
+
+    def _retroactive_target_recent_message(self, chat_id: str, current_body: str) -> Optional[Dict[str, Any]]:
+        """Find the nearest prior human-visible group message for retroactive addressing."""
+        current_clean = re.sub(r"\s+", " ", str(current_body or "")).strip()
+        recent = self._recent_messages_for_chat(chat_id)
+        candidates = recent[:-1] if recent and str(recent[-1].get("body") or "").strip() == current_clean else recent
+        for item in reversed(candidates):
+            body = re.sub(r"\s+", " ", str(item.get("body") or "")).strip()
+            if not body:
+                continue
+            if self._message_is_retroactive_bot_addressing_text(body):
+                continue
+            return item
+        return None
+
+    def _rewrite_retroactive_bot_addressing_body(self, chat_id: str, body: str) -> str:
+        """Inject the prior message when user says the previous message was for WhatBot."""
+        if not self._message_is_retroactive_bot_addressing_text(body):
+            return body
+        target = self._retroactive_target_recent_message(chat_id, body)
+        if not target:
+            return body
+        sender = str(target.get("sender") or "someone").strip() or "someone"
+        target_body = str(target.get("body") or "").strip()
+        return (
+            "[Conversational repair]\n"
+            f"The user is now directing this prior group message at WhatBot (from {sender}):\n"
+            f"{target_body}\n\n"
+            "[User repair message]\n"
+            f"{body}"
+        )
+
+    @staticmethod
+    def _infer_active_thread_type(text: str) -> str:
+        lower = str(text or "").lower()
+        if re.search(r"\b(remind|reminder)\b", lower):
+            return "reminder_creation"
+        if re.search(r"\b(plan|trip|event|bbq|party|dinner|lunch|breakfast)\b", lower):
+            return "plan_creation"
+        if re.search(r"\b(poll|vote|options?)\b", lower):
+            return "poll_creation"
+        if re.search(r"\b(todo|to-do|task|list)\b", lower):
+            return "todo_update"
+        if re.search(r"\b(prediction|predict|league|market)\b", lower):
+            return "prediction_game"
+        return "clarification"
+
+    def _record_bot_group_reply(self, chat_id: str, text: str) -> None:
+        chat_id = str(chat_id or "")
+        if not chat_id.endswith("@g.us"):
+            return
+        clean = re.sub(r"\s+", " ", str(text or "")).strip()
+        self._last_bot_reply_at_by_chat[chat_id] = time.monotonic()
+        self._last_bot_reply_text_by_chat[chat_id] = clean
+        if not self._bot_reply_looks_like_clarification(clean):
+            self._close_active_thread(chat_id)
+            return
+        recent = self._recent_messages_for_chat(chat_id)
+        joined_context = "\n".join(str(item.get("body") or "") for item in recent[-6:])
+        now = time.time()
+        thread = {
+            "thread_id": f"T-{uuid.uuid4().hex[:8].upper()}",
+            "thread_type": self._infer_active_thread_type(f"{joined_context}\n{clean}"),
+            "status": "awaiting_user_input",
+            "chat_id": chat_id,
+            "last_bot_reply": clean,
+            "created_at": now,
+            "updated_at": now,
+        }
+        store = self._read_active_thread_store()
+        chat_state = store.setdefault("chats", {}).setdefault(chat_id, {})
+        chat_state["active_thread"] = thread
+        chat_state["recent_messages"] = recent[-20:]
+        self._write_active_thread_store(store)
+
+    def _load_active_thread(self, chat_id: str) -> Optional[Dict[str, Any]]:
+        chat_id = str(chat_id or "")
+        store = self._read_active_thread_store()
+        chat_state = store.get("chats", {}).get(chat_id, {})
+        recent = chat_state.get("recent_messages")
+        if isinstance(recent, list):
+            self._recent_group_messages_by_chat[chat_id] = recent[-20:]
+        thread = chat_state.get("active_thread")
+        if not isinstance(thread, dict) or thread.get("status") != "awaiting_user_input":
+            return None
+        try:
+            window = float(self.config.extra.get("followup_response_window_seconds", 300))
+        except (TypeError, ValueError):
+            window = 300.0
+        updated_at = float(thread.get("updated_at") or thread.get("created_at") or 0)
+        if window <= 0 or not updated_at or (time.time() - updated_at) > window:
+            self._close_active_thread(chat_id)
+            return None
+        return thread
+
+    def _close_active_thread(self, chat_id: str) -> None:
+        chat_id = str(chat_id or "")
+        store = self._read_active_thread_store()
+        chat_state = store.setdefault("chats", {}).setdefault(chat_id, {})
+        if "active_thread" in chat_state:
+            chat_state.pop("active_thread", None)
+            self._write_active_thread_store(store)
+
+    def _message_is_followup_to_recent_bot_reply(self, data: Dict[str, Any]) -> bool:
+        """Wake on a short-window follow-up after the bot just spoke in the group.
+
+        Question-like follow-ups still use the cheap deterministic gate. If the
+        bot's previous message was itself a clarification question, a local
+        classifier may also wake on declarative answer-shaped replies such as
+        "breakfast in 30 days".
+        """
+        if not self._whatsapp_respond_when_likely_directed():
+            return False
+        chat_id = str(data.get("chatId") or "")
+        active_thread = self._load_active_thread(chat_id)
+        last_reply_at = self._last_bot_reply_at_by_chat.get(chat_id)
+        if not last_reply_at and not active_thread:
+            return False
+        try:
+            window = float(self.config.extra.get("followup_response_window_seconds", 300))
+        except (TypeError, ValueError):
+            window = 300.0
+        if last_reply_at and (window <= 0 or (time.monotonic() - last_reply_at) > window) and not active_thread:
+            return False
+
+        body = re.sub(r"\s+", " ", str(data.get("body") or "")).strip()
+        if not body or body.startswith("/"):
+            return False
+        if self._message_is_ambiguous_third_party_check(body):
+            return False
+        lower = body.lower()
+        last_bot_reply = self._last_bot_reply_text_by_chat.get(chat_id, "")
+        if active_thread and not last_bot_reply:
+            last_bot_reply = str(active_thread.get("last_bot_reply") or "")
+        if "?" in body:
+            return bool(active_thread or self._bot_reply_looks_like_clarification(last_bot_reply))
+        if re.match(
+            r"^(?:why|what|how|when|where|who|which|can|could|would|should|is|are|do|does|did|will)\b",
+            lower,
+        ):
+            return bool(active_thread or self._bot_reply_looks_like_clarification(last_bot_reply))
+
+        if last_bot_reply and (active_thread or self._bot_reply_looks_like_clarification(last_bot_reply)):
+            return self._classify_followup_with_local_model(
+                data,
+                last_bot_reply=last_bot_reply,
+                active_thread=active_thread,
+                recent_messages=self._recent_messages_for_chat(chat_id),
+            )
+        return False
+
+    @staticmethod
+    def _bot_reply_looks_like_clarification(text: str) -> bool:
+        clean = re.sub(r"\s+", " ", str(text or "")).strip()
+        if not clean or "?" not in clean:
+            return False
+        lower = clean.lower()
+        return bool(re.search(
+            r"\b(which|what|when|where|who|confirm|clarify|exact|date|time|meal|options?|should i|do you want)\b",
+            lower,
+        ))
+
+    def _classify_followup_with_local_model(
+        self,
+        data: Dict[str, Any],
+        *,
+        last_bot_reply: str,
+        active_thread: Optional[Dict[str, Any]] = None,
+        recent_messages: Optional[list[Dict[str, Any]]] = None,
+    ) -> bool:
+        """Use a local model to decide if a declarative message continues a bot thread.
+
+        This is intentionally scoped to pending bot clarification questions so it
+        does not turn WhatsApp groups into ambient free-response chats.
+        """
+        if not self.config.extra.get("local_followup_classifier", False):
+            return False
+        body = re.sub(r"\s+", " ", str(data.get("body") or "")).strip()
+        if not body:
+            return False
+        model = str(self.config.extra.get("local_followup_classifier_model") or "qwen3.6:35b")
+        base_url = str(self.config.extra.get("local_followup_classifier_base_url") or "http://localhost:11434").rstrip("/")
+        if not self._is_local_model_base_url(base_url) and not self.config.extra.get("allow_remote_followup_classifier", False):
+            logger.warning("whatsapp local followup classifier refused non-local base_url=%s", base_url)
+            return False
+        try:
+            timeout = float(self.config.extra.get("local_followup_classifier_timeout", 45))
+        except (TypeError, ValueError):
+            timeout = 45.0
+        recent_lines = []
+        for item in (recent_messages or [])[-8:]:
+            sender = str(item.get("sender") or "").strip()
+            body_line = str(item.get("body") or "").strip()
+            if body_line:
+                recent_lines.append(f"- {sender + ': ' if sender else ''}{body_line}")
+        thread_context = ""
+        if active_thread:
+            thread_context = (
+                "Active WhatBot thread:\n"
+                f"- id: {active_thread.get('thread_id', '')}\n"
+                f"- type: {active_thread.get('thread_type', 'clarification')}\n"
+                f"- status: {active_thread.get('status', '')}\n"
+            )
+        recent_context = "Recent group messages:\n" + "\n".join(recent_lines) + "\n" if recent_lines else ""
+        prompt = (
+            "You are a WhatsApp group wake-gate classifier for WhatBot. Decide whether the new message should wake WhatBot "
+            "because it answers or directly continues a visible active WhatBot thread. Do not wake for general group chatter, "
+            "topic similarity alone, or human-to-human replies. Return ONLY compact JSON with keys should_wake boolean, confidence number, and reason string.\n\n"
+            f"{thread_context}"
+            f"{recent_context}"
+            f"Previous WhatBot message: {last_bot_reply}\n"
+            f"New group message: {body}\n"
+        )
+        payload = {
+            "model": model,
+            "think": False,
+            "stream": False,
+            "messages": [{"role": "user", "content": prompt}],
+            "options": {"temperature": 0, "num_predict": 160},
+        }
+        req = urllib.request.Request(
+            f"{base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+            outer = json.loads(raw)
+            content = str((outer.get("message") or {}).get("content") or "").strip()
+            match = re.search(r"\{.*\}", content, re.DOTALL)
+            decision = json.loads(match.group(0) if match else content)
+            should_wake = bool(decision.get("should_wake"))
+            logger.info(
+                "whatsapp local followup classifier: chat=%s should_wake=%s reason=%s",
+                data.get("chatId"),
+                should_wake,
+                str(decision.get("reason") or "")[:160],
+            )
+            return should_wake
+        except (OSError, urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+            logger.warning("whatsapp local followup classifier failed: %s", exc)
+            return False
+
+    def _local_conversation_router_enabled(self) -> bool:
+        return bool(self.config.extra.get("local_conversation_router", False))
+
+    @staticmethod
+    def _is_local_model_base_url(base_url: str) -> bool:
+        try:
+            host = urllib.parse.urlparse(str(base_url or "")).hostname or ""
+        except ValueError:
+            return False
+        return host.lower() in {"localhost", "127.0.0.1", "::1"}
+
+    def _router_decision_cache_key(
+        self,
+        data: Dict[str, Any],
+        *,
+        recent_messages: list[Dict[str, Any]],
+        active_thread: Optional[Dict[str, Any]],
+        last_bot_reply: str,
+    ) -> str:
+        recent_signature = json.dumps(
+            [
+                {
+                    "sender": str(item.get("sender") or "")[:80],
+                    "body": str(item.get("body") or "")[:200],
+                }
+                for item in recent_messages[-10:]
+            ],
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        thread_signature = json.dumps(
+            {
+                "thread_id": (active_thread or {}).get("thread_id", ""),
+                "status": (active_thread or {}).get("status", ""),
+                "updated_at": (active_thread or {}).get("updated_at", ""),
+                "last_bot_reply": last_bot_reply[:300],
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        return "\x1f".join([
+            str(data.get("chatId") or ""),
+            str(data.get("messageId") or ""),
+            re.sub(r"\s+", " ", str(data.get("body") or "")).strip(),
+            recent_signature,
+            thread_signature,
+        ])
+
+    def _conversation_router_decision(self, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Return a local LLM routing decision for ambiguous WhatsApp group messages."""
+        if not self._local_conversation_router_enabled():
+            return None
+        chat_id = str(data.get("chatId") or "")
+        body = re.sub(r"\s+", " ", str(data.get("body") or "")).strip()
+        if not chat_id.endswith("@g.us") or not body or body.startswith("/"):
+            return None
+        active_thread = self._load_active_thread(chat_id)
+        last_bot_reply = self._last_bot_reply_text_by_chat.get(chat_id, "")
+        if active_thread and not last_bot_reply:
+            last_bot_reply = str(active_thread.get("last_bot_reply") or "")
+        recent_messages = self._recent_messages_for_chat(chat_id)
+        key = self._router_decision_cache_key(
+            data,
+            recent_messages=recent_messages,
+            active_thread=active_thread,
+            last_bot_reply=last_bot_reply,
+        )
+        cache = getattr(self, "_conversation_router_decision_cache", None)
+        if cache is None:
+            cache = {}
+            self._conversation_router_decision_cache = cache
+        if key in cache:
+            return cache[key]
+        decision = self._classify_group_message_with_local_router(
+            data,
+            recent_messages=recent_messages,
+            active_thread=active_thread,
+            last_bot_reply=last_bot_reply,
+        )
+        if isinstance(decision, dict):
+            decision["should_wake"] = bool(decision.get("should_wake"))
+            cache[key] = decision
+            return decision
+        return None
+
+    def _classify_group_message_with_local_router(
+        self,
+        data: Dict[str, Any],
+        *,
+        recent_messages: Optional[list[Dict[str, Any]]] = None,
+        active_thread: Optional[Dict[str, Any]] = None,
+        last_bot_reply: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Use local Ollama as a structured WhatsApp conversation router."""
+        model = str(self.config.extra.get("local_conversation_router_model") or "qwen3.6:35b")
+        base_url = str(self.config.extra.get("local_conversation_router_base_url") or "http://localhost:11434").rstrip("/")
+        if not self._is_local_model_base_url(base_url) and not self.config.extra.get("allow_remote_conversation_router", False):
+            logger.warning("whatsapp local conversation router refused non-local base_url=%s", base_url)
+            return None
+        try:
+            timeout = float(self.config.extra.get("local_conversation_router_timeout", 45))
+        except (TypeError, ValueError):
+            timeout = 45.0
+        body = re.sub(r"\s+", " ", str(data.get("body") or "")).strip()
+        recent_slice = (recent_messages or [])[-10:]
+        recent_lines = []
+        for idx, item in enumerate(recent_slice, start=-len(recent_slice)):
+            sender = str(item.get("sender") or "").strip()
+            line = str(item.get("body") or "").strip()
+            if line:
+                recent_lines.append(f"{idx}: {sender + ': ' if sender else ''}{line}")
+        thread_context = ""
+        if active_thread:
+            thread_context = (
+                "Active WhatBot thread:\n"
+                f"- type: {active_thread.get('thread_type', 'clarification')}\n"
+                f"- status: {active_thread.get('status', '')}\n"
+                f"- last_bot_reply: {active_thread.get('last_bot_reply', '')}\n"
+            )
+        prompt = (
+            "You are WhatBot's WhatsApp group conversation router. Decide whether the new group message should wake WhatBot, "
+            "what conversational role it has, and whether it points at a prior message. Be conservative: do not wake for ordinary "
+            "human-to-human chatter. Wake for clear bot addressing, repair phrases like 'that was for you', direct continuations of "
+            "visible active WhatBot threads, and assistant-style requests. Return ONLY compact JSON with keys: should_wake boolean, "
+            "addressing_type string, confidence number, reason string, optional target_message_index integer where -1 means nearest prior "
+            "recent message, and optional rewritten_user_intent string.\n\n"
+            f"{thread_context}"
+            "Recent group messages:\n" + "\n".join(recent_lines) + "\n"
+            f"Previous WhatBot message: {last_bot_reply}\n"
+            f"New group message: {body}\n"
+        )
+        payload = {
+            "model": model,
+            "think": False,
+            "stream": False,
+            "messages": [{"role": "user", "content": prompt}],
+            "options": {"temperature": 0, "num_predict": 220},
+        }
+        req = urllib.request.Request(
+            f"{base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+            outer = json.loads(raw)
+            content = str((outer.get("message") or {}).get("content") or "").strip()
+            match = re.search(r"\{.*\}", content, re.DOTALL)
+            decision = json.loads(match.group(0) if match else content)
+            if not isinstance(decision, dict):
+                return None
+            decision["should_wake"] = bool(decision.get("should_wake"))
+            logger.info(
+                "whatsapp local conversation router: chat=%s should_wake=%s type=%s reason=%s",
+                data.get("chatId"),
+                decision.get("should_wake"),
+                str(decision.get("addressing_type") or "")[:80],
+                str(decision.get("reason") or "")[:160],
+            )
+            return decision
+        except (OSError, urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+            logger.warning("whatsapp local conversation router failed: %s", exc)
+            return None
+
+    def _rewrite_group_message_body_with_router(self, chat_id: str, body: str, data: Dict[str, Any]) -> str:
+        decision = self._conversation_router_decision(data)
+        if not decision or not decision.get("should_wake"):
+            return body
+        addressing_type = str(decision.get("addressing_type") or "")
+        if addressing_type not in {"retroactive_repair", "prior_message_repair", "message_repair"}:
+            return body
+        recent = self._recent_messages_for_chat(chat_id)
+        current_clean = re.sub(r"\s+", " ", str(body or "")).strip()
+        candidates = recent[:-1] if recent and str(recent[-1].get("body") or "").strip() == current_clean else recent
+        target = None
+        target_index = decision.get("target_message_index")
+        if isinstance(target_index, int) and candidates:
+            try:
+                target = candidates[target_index]
+            except IndexError:
+                target = None
+        if target is None:
+            target = candidates[-1] if candidates else None
+        if not target:
+            return body
+        sender = str(target.get("sender") or "someone").strip() or "someone"
+        target_body = str(target.get("body") or "").strip()
+        intent = str(decision.get("rewritten_user_intent") or "Answer the prior group message as if it was addressed to WhatBot.").strip()
+        return (
+            "[Conversation router repair]\n"
+            f"Router decision: {intent}\n"
+            f"Prior group message now being directed at WhatBot (from {sender}):\n"
+            f"{target_body}\n\n"
+            "[User repair message]\n"
+            f"{body}"
+        )
+
     def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
         if not text:
             return text
@@ -450,6 +1047,38 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if bare_id:
                 cleaned = re.sub(rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned)
         return cleaned.strip() or text
+
+    @staticmethod
+    def _safe_whatsapp_display_name(value: Any) -> str:
+        """Return a one-line human display name suitable for agent-visible context."""
+        name = re.sub(r"\s+", " ", str(value or "")).strip()
+        if not name:
+            return ""
+        # Avoid leaking raw WhatsApp JIDs as user-facing names. The bridge only
+        # fills quotedSenderName when it has an observed pushName/contact label.
+        if "@" in name and ("whatsapp" in name.lower() or name.endswith("@lid") or name.endswith("@g.us")):
+            return ""
+        return name[:80]
+
+    @staticmethod
+    def _label_with_sender(label: str, sender_name: Any) -> str:
+        sender = WhatsAppAdapter._safe_whatsapp_display_name(sender_name)
+        if sender:
+            if label.endswith("]"):
+                return f"{label[:-1]} from {sender}]"
+            return f"{label} from {sender}"
+        return label
+
+    @staticmethod
+    def _sanitize_whatsapp_visible_ids(value: str) -> str:
+        """Hide raw WhatsApp/LID mention IDs from agent-visible quoted text."""
+        text = str(value or "")
+        # WhatsApp quoted text can contain bare Linked Identity ids rendered as
+        # @139904986148944. Those are not useful to the group and can prompt the
+        # model to repeat private-looking implementation IDs. If the bridge can
+        # resolve a human name it should already have replaced the mention; this
+        # is the safety fallback.
+        return re.sub(r"@\d{8,}(?=\b)", "@someone", text)
 
     def _should_process_message(self, data: Dict[str, Any]) -> bool:
         chat_id_raw = str(data.get("chatId") or "")
@@ -483,7 +1112,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return True
         if self._message_mentions_bot(data):
             return True
-        return self._message_matches_mention_patterns(data)
+        if self._message_matches_mention_patterns(data):
+            return True
+        router_decision = self._conversation_router_decision(data)
+        if router_decision is not None:
+            return bool(router_decision.get("should_wake"))
+        if self._message_is_retroactive_bot_addressing_text(body) and self._retroactive_target_recent_message(chat_id, body):
+            return True
+        if self._message_is_followup_to_recent_bot_reply(data):
+            return True
+        return self._message_likely_directed_at_bot(data)
     
     async def connect(self) -> bool:
         """
@@ -919,6 +1557,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 if len(chunks) > 1:
                     await asyncio.sleep(0.3)
 
+            if str(chat_id).endswith("@g.us"):
+                self._record_bot_group_reply(str(chat_id), formatted)
             return SendResult(
                 success=True,
                 message_id=last_message_id,
@@ -1155,8 +1795,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
-            if not self._should_process_message(data):
+            if data.get("isGroup") and not self._is_group_allowed(str(data.get("chatId") or "")):
                 return None
+            if data.get("isGroup"):
+                self._record_recent_group_message(data)
+            should_process = self._should_process_message(data)
 
             # Determine message type
             msg_type = MessageType.TEXT
@@ -1241,6 +1884,45 @@ class WhatsAppAdapter(BasePlatformAdapter):
             body = data.get("body", "")
             if data.get("isGroup"):
                 body = self._clean_bot_mention_text(body, data)
+                body = self._rewrite_group_message_body_with_router(str(data.get("chatId") or ""), body, data)
+                body = self._rewrite_retroactive_bot_addressing_body(str(data.get("chatId") or ""), body)
+
+            quoted_body = self._sanitize_whatsapp_visible_ids(str(data.get("quotedBody") or "").strip())
+            if quoted_body:
+                quoted_label = self._label_with_sender("[Quoted message]", data.get("quotedSenderName"))
+                if data.get("quotedHasMedia"):
+                    quoted_type = str(data.get("quotedType") or "media").replace("Message", "").strip() or "media"
+                    quoted_label = self._label_with_sender(f"[Quoted {quoted_type}]", data.get("quotedSenderName"))
+                user_label = self._label_with_sender("[User message]", data.get("senderName"))
+                user_body = body or "[no additional text]"
+                body = f"{quoted_label}\n{quoted_body}\n\n{user_label}\n{user_body}"
+
+            # Let plugins observe allowlisted group messages before the
+            # reply/wake gate drops ordinary chatter. This supports passive
+            # same-group archives while keeping response behavior conservative.
+            observed_event = MessageEvent(
+                text=body,
+                message_type=msg_type,
+                source=source,
+                raw_message=data,
+                message_id=data.get("messageId"),
+                media_urls=list(data.get("mediaUrls", []) or []),
+                media_types=[],
+            )
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "platform_message_observed",
+                    event=observed_event,
+                    will_process=should_process,
+                    adapter=self,
+                )
+            except Exception as hook_exc:
+                logger.debug("[%s] platform_message_observed hook failed: %s", self.name, hook_exc)
+
+            if not should_process:
+                return None
+
             MAX_TEXT_INJECT_BYTES = 100 * 1024
             if msg_type == MessageType.DOCUMENT and cached_urls:
                 for doc_path in cached_urls:

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,14 +1,20 @@
 import json
+import time
 from unittest.mock import AsyncMock
+
+import pytest
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
-                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
+                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
+                  respond_when_likely_directed=None, session_path=None):
     from gateway.platforms.whatsapp import WhatsAppAdapter
 
     extra = {}
+    if session_path is not None:
+        extra["session_path"] = str(session_path)
     if require_mention is not None:
         extra["require_mention"] = require_mention
     if mention_patterns is not None:
@@ -23,6 +29,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_policy"] = group_policy
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if respond_when_likely_directed is not None:
+        extra["respond_when_likely_directed"] = respond_when_likely_directed
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -33,6 +41,12 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter._group_policy = str(extra.get("group_policy", "open")).strip().lower()
     adapter._group_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_allow_from"))
     adapter._mention_patterns = adapter._compile_mention_patterns()
+    adapter._last_bot_reply_at_by_chat = {}
+    adapter._last_bot_reply_text_by_chat = {}
+    from pathlib import Path
+    adapter._session_path = Path(extra.get("session_path", "/tmp/whatsapp-test-session"))
+    adapter._active_threads_path = adapter._session_path / "active-threads.json"
+    adapter._recent_group_messages_by_chat = {}
     adapter._free_response_chats = adapter._whatsapp_free_response_chats()
     return adapter
 
@@ -61,6 +75,79 @@ def _dm_message(body="hello", **overrides):
     }
     data.update(overrides)
     return data
+
+
+@pytest.mark.asyncio
+async def test_quoted_message_body_is_included_in_processed_event(monkeypatch):
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bwhatbot\b"])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "WhatBot, what does this mean?",
+            messageId="reply-1",
+            senderId="111@s.whatsapp.net",
+            senderName="Alice",
+            hasQuotedMessage=True,
+            quotedBody="This is the attached earlier message",
+            quotedType="conversation",
+            quotedSenderName="Bob",
+        )
+    )
+
+    assert event is not None
+    assert event.text == (
+        "[Quoted message from Bob]\n"
+        "This is the attached earlier message\n\n"
+        "[User message from Alice]\n"
+        "WhatBot, what does this mean?"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quoted_media_caption_is_labeled_in_processed_event(monkeypatch):
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bwhatbot\b"])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "WhatBot, caption?",
+            messageId="reply-2",
+            senderId="111@s.whatsapp.net",
+            senderName="Alice",
+            hasQuotedMessage=True,
+            quotedBody="Photo caption from attached message",
+            quotedType="imageMessage",
+            quotedHasMedia=True,
+            quotedSenderName="Bob",
+        )
+    )
+
+    assert event is not None
+    assert event.text.startswith("[Quoted image from Bob]\nPhoto caption from attached message")
+
+
+@pytest.mark.asyncio
+async def test_quoted_body_does_not_expose_raw_whatsapp_lid_mentions(monkeypatch):
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bwhatbot\b"])
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "WhatBot, who wrote this?",
+            messageId="reply-3",
+            senderId="111@s.whatsapp.net",
+            senderName="Alice",
+            hasQuotedMessage=True,
+            quotedBody="Can you unsee it @139904986148944",
+            quotedType="conversation",
+            quotedSenderName="Bob",
+        )
+    )
+
+    assert event is not None
+    assert "139904986148944" not in event.text
+    assert "Can you unsee it @someone" in event.text
 
 
 # --- Existing tests (unchanged logic, updated helper) ---
@@ -96,6 +183,469 @@ def test_regex_mention_patterns_allow_custom_wake_words():
     assert adapter._should_process_message(_group_message("chompy status")) is True
     assert adapter._should_process_message(_group_message("   chompy help")) is True
     assert adapter._should_process_message(_group_message("hey chompy")) is False
+
+
+def test_whatsapp_can_wake_on_hermes_name_without_platform_tag():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bhermes\b"])
+
+    assert adapter._should_process_message(_group_message("Hermes, can you summarize this?")) is True
+    assert adapter._should_process_message(_group_message("hey hermes what do you think?")) is True
+
+
+def test_likely_directed_gate_accepts_high_confidence_assistant_requests():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+
+    assert adapter._should_process_message(_group_message("can you look up the restaurant opening hours?")) is True
+    assert adapter._should_process_message(_group_message("could you summarise the plan so far?")) is True
+    assert adapter._should_process_message(_group_message("please remember that dinner is at 7")) is True
+
+
+def test_likely_directed_gate_rejects_normal_group_chatter():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+
+    assert adapter._should_process_message(_group_message("any ideas?")) is False
+    assert adapter._should_process_message(_group_message("can you come over later?")) is False
+    assert adapter._should_process_message(_group_message("what do you think?")) is False
+
+
+def test_likely_directed_gate_rejects_ambiguous_can_you_check_without_bot_context():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+
+    assert adapter._should_process_message(_group_message("Can you check if it’s seen any messages from me")) is False
+    assert adapter._should_process_message(_group_message("could you check whether he got the invite?")) is False
+    assert adapter._should_process_message(_group_message("would you check if they are coming later?")) is False
+
+
+def test_likely_directed_gate_still_accepts_bot_specific_check_requests():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bwhat\s*bot\b", r"(?i)\bwhatbot\b"],
+        respond_when_likely_directed=True,
+    )
+
+    assert adapter._should_process_message(_group_message("WhatBot can you check if you have any reminders?")) is True
+    assert adapter._should_process_message(_group_message("can you check reminders?")) is True
+    assert adapter._should_process_message(_group_message("can you check todo list TL-AB12?")) is True
+
+
+def test_recent_bot_reply_wakes_on_followup_question():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic()
+    adapter._last_bot_reply_text_by_chat["120363001234567890@g.us"] = "What part of the fish anatomy should I explain?"
+
+    assert adapter._should_process_message(_group_message("Why don’t they have one heart for both gills?")) is True
+
+
+def test_recent_non_clarification_bot_reply_does_not_wake_on_question():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic()
+    adapter._last_bot_reply_text_by_chat["120363001234567890@g.us"] = "No active reminders right now."
+
+    assert adapter._should_process_message(_group_message("Why don’t they have one heart for both gills?")) is False
+
+
+def test_recent_bot_reply_followup_gate_stays_conservative():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic()
+
+    assert adapter._should_process_message(_group_message("haha fair enough")) is False
+
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic() - 301
+    assert adapter._should_process_message(_group_message("Why don’t they have one heart?")) is False
+
+
+def test_recent_bot_reply_does_not_wake_on_ambiguous_can_you_check_about_third_party():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic()
+    adapter._last_bot_reply_text_by_chat["120363001234567890@g.us"] = "Can you clarify?"
+
+    assert adapter._should_process_message(_group_message("Can you check if it’s seen any messages from me")) is False
+    assert adapter._should_process_message(_group_message("Can you check if you have any reminders?")) is True
+
+
+def test_local_followup_classifier_can_wake_declarative_answer_to_bot_question(monkeypatch):
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic() - 60
+    adapter._last_bot_reply_text_by_chat["120363001234567890@g.us"] = (
+        "Which meal, and what exact date/time in about a month should I set it for?"
+    )
+    calls = []
+
+    def fake_classifier(data, *, last_bot_reply, **kwargs):
+        calls.append((data["body"], last_bot_reply))
+        return True
+
+    monkeypatch.setattr(adapter, "_classify_followup_with_local_model", fake_classifier)
+
+    assert adapter._should_process_message(_group_message("let’s provisionally say breakfast in 30 days")) is True
+    assert calls == [(
+        "let’s provisionally say breakfast in 30 days",
+        "Which meal, and what exact date/time in about a month should I set it for?",
+    )]
+
+
+def test_local_followup_classifier_does_not_run_without_pending_bot_question(monkeypatch):
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    adapter._last_bot_reply_at_by_chat["120363001234567890@g.us"] = time.monotonic() - 60
+    adapter._last_bot_reply_text_by_chat["120363001234567890@g.us"] = "No active reminders right now."
+
+    def fail_classifier(*args, **kwargs):
+        raise AssertionError("classifier should not run without a bot clarification question")
+
+    monkeypatch.setattr(adapter, "_classify_followup_with_local_model", fail_classifier)
+
+    assert adapter._should_process_message(_group_message("breakfast in 30 days")) is False
+
+
+def test_active_thread_survives_adapter_restart_and_wakes_with_context(monkeypatch, tmp_path):
+    first = _make_adapter(require_mention=True, respond_when_likely_directed=True, session_path=tmp_path)
+    first._record_recent_group_message(_group_message("WhatBot remind Matt and me to have breakfast in about a month"))
+    first._record_bot_group_reply(
+        "120363001234567890@g.us",
+        "Which meal, and what exact date/time in about a month should I set it for?",
+    )
+
+    restarted = _make_adapter(require_mention=True, respond_when_likely_directed=True, session_path=tmp_path)
+    calls = []
+
+    def fake_classifier(data, *, last_bot_reply, active_thread=None, recent_messages=None):
+        calls.append({
+            "body": data["body"],
+            "last_bot_reply": last_bot_reply,
+            "active_thread": active_thread,
+            "recent_messages": recent_messages,
+        })
+        return True
+
+    monkeypatch.setattr(restarted, "_classify_followup_with_local_model", fake_classifier)
+
+    assert restarted._should_process_message(_group_message("let’s provisionally say breakfast in 30 days")) is True
+    assert calls[0]["last_bot_reply"] == "Which meal, and what exact date/time in about a month should I set it for?"
+    assert calls[0]["active_thread"]["status"] == "awaiting_user_input"
+    assert calls[0]["active_thread"]["thread_type"] == "reminder_creation"
+    assert any("remind Matt" in msg["body"] for msg in calls[0]["recent_messages"])
+
+
+def test_retroactive_bot_addressing_wakes_for_previous_group_message(tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        mention_patterns=[r"(?i)\bwhat\s*bot\b", r"(?i)\bwhatbot\b"],
+        session_path=tmp_path,
+    )
+    adapter._record_recent_group_message(_group_message(
+        "Summarise to Matt your new capabilities in terms of modes etc.",
+        senderName="Simon W",
+    ))
+    adapter._record_recent_group_message(_group_message(
+        "Whatbot the last message was for you",
+        senderName="Simon W",
+    ))
+
+    assert adapter._should_process_message(_group_message(
+        "Whatbot the last message was for you",
+        senderName="Simon W",
+    )) is True
+
+
+def test_llm_conversation_router_can_wake_and_rewrite_retroactive_addressing(monkeypatch, tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        session_path=tmp_path,
+    )
+    adapter.config.extra["local_conversation_router"] = True
+    adapter._record_recent_group_message(_group_message(
+        "Summarise to Matt your new capabilities in terms of modes etc.",
+        senderName="Simon W",
+    ))
+    calls = []
+
+    def fake_router(data, *, recent_messages=None, active_thread=None, last_bot_reply=""):
+        calls.append({"body": data["body"], "recent_messages": recent_messages, "active_thread": active_thread})
+        return {
+            "should_wake": True,
+            "addressing_type": "retroactive_repair",
+            "target_message_index": -1,
+            "rewritten_user_intent": "Answer the previous group message as if it was addressed to WhatBot.",
+            "reason": "user says the previous message was for the bot",
+            "confidence": 0.94,
+        }
+
+    monkeypatch.setattr(adapter, "_classify_group_message_with_local_router", fake_router)
+
+    data = _group_message("that was for you", senderName="Simon W")
+    assert adapter._should_process_message(data) is True
+    rewritten = adapter._rewrite_group_message_body_with_router("120363001234567890@g.us", data["body"], data)
+    assert "Conversation router repair" in rewritten
+    assert "Summarise to Matt your new capabilities" in rewritten
+    assert calls[0]["recent_messages"]
+
+
+def test_llm_conversation_router_uses_target_message_index(monkeypatch, tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        session_path=tmp_path,
+    )
+    adapter.config.extra["local_conversation_router"] = True
+    adapter._record_recent_group_message(_group_message("first candidate", senderName="Alice"))
+    adapter._record_recent_group_message(_group_message("second candidate", senderName="Bob"))
+
+    monkeypatch.setattr(adapter, "_classify_group_message_with_local_router", lambda *args, **kwargs: {
+        "should_wake": True,
+        "addressing_type": "retroactive_repair",
+        "target_message_index": -2,
+        "rewritten_user_intent": "Answer the earlier target message.",
+        "reason": "router selected the earlier prior message",
+        "confidence": 0.9,
+    })
+
+    data = _group_message("that earlier one was for you", senderName="Simon W")
+    rewritten = adapter._rewrite_group_message_body_with_router("120363001234567890@g.us", data["body"], data)
+
+    assert "first candidate" in rewritten
+    assert "second candidate" not in rewritten
+
+
+def test_recent_group_message_does_not_persist_raw_sender_id_when_name_missing():
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+
+    adapter._record_recent_group_message(_group_message("hello", senderName="", senderId="111@s.whatsapp.net"))
+
+    recent = adapter._recent_messages_for_chat("120363001234567890@g.us")
+    assert recent[-1]["sender"] == "someone"
+    assert "s.whatsapp.net" not in json.dumps(recent)
+
+
+def test_llm_conversation_router_cache_key_changes_with_recent_context(monkeypatch, tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        session_path=tmp_path,
+    )
+    adapter.config.extra["local_conversation_router"] = True
+    calls = []
+
+    def fake_router(data, *, recent_messages=None, active_thread=None, last_bot_reply=""):
+        calls.append([item.get("body") for item in (recent_messages or [])])
+        return {
+            "should_wake": len(calls) == 1,
+            "addressing_type": "human_chatter" if len(calls) > 1 else "retroactive_repair",
+            "reason": "context-sensitive decision",
+        }
+
+    monkeypatch.setattr(adapter, "_classify_group_message_with_local_router", fake_router)
+    data = _group_message("that was for you", messageId="same-message")
+    adapter._record_recent_group_message(_group_message("first context", senderName="Alice"))
+    first = adapter._conversation_router_decision(data)
+    adapter._record_recent_group_message(_group_message("different context", senderName="Bob"))
+    second = adapter._conversation_router_decision(data)
+
+    assert first is not None
+    assert second is not None
+    assert first["should_wake"] is True
+    assert second["should_wake"] is False
+    assert len(calls) == 2
+
+
+def test_local_router_refuses_non_local_base_url_without_explicit_opt_in(monkeypatch, tmp_path):
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True, session_path=tmp_path)
+    adapter.config.extra["local_conversation_router"] = True
+    adapter.config.extra["local_conversation_router_base_url"] = "https://example.com"
+
+    def fail_urlopen(*args, **kwargs):
+        raise AssertionError("non-local router URL should not be called")
+
+    monkeypatch.setattr("urllib.request.urlopen", fail_urlopen)
+
+    assert adapter._classify_group_message_with_local_router(_group_message("that was for you")) is None
+
+
+def test_llm_conversation_router_can_reject_ambiguous_group_chatter(monkeypatch, tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        session_path=tmp_path,
+    )
+    adapter.config.extra["local_conversation_router"] = True
+
+    monkeypatch.setattr(adapter, "_classify_group_message_with_local_router", lambda *args, **kwargs: {
+        "should_wake": False,
+        "addressing_type": "human_chatter",
+        "reason": "ordinary human-to-human message",
+        "confidence": 0.88,
+    })
+
+    assert adapter._should_process_message(_group_message("can you check if it saw me?")) is False
+
+
+def test_retroactive_bot_addressing_wakes_without_fresh_bot_mention(tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        mention_patterns=[r"(?i)\bwhat\s*bot\b", r"(?i)\bwhatbot\b"],
+        session_path=tmp_path,
+    )
+    adapter._record_recent_group_message(_group_message(
+        "Summarise to Matt your new capabilities in terms of modes etc.",
+        senderName="Simon W",
+    ))
+    adapter._record_recent_group_message(_group_message(
+        "the last message was for you",
+        senderName="Simon W",
+    ))
+
+    assert adapter._should_process_message(_group_message(
+        "the last message was for you",
+        senderName="Simon W",
+    )) is True
+
+
+@pytest.mark.asyncio
+async def test_retroactive_bot_addressing_injects_previous_message_into_event(monkeypatch, tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        respond_when_likely_directed=True,
+        mention_patterns=[r"(?i)\bwhat\s*bot\b", r"(?i)\bwhatbot\b"],
+        session_path=tmp_path,
+    )
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+
+    # First message is not directly addressed to the bot, but it is persisted
+    # in the recent group slice by the bridge before the wake gate runs.
+    first = await adapter._build_message_event(_group_message(
+        "Summarise to Matt your new capabilities in terms of modes etc.",
+        messageId="m1",
+        senderId="111@s.whatsapp.net",
+        senderName="Simon W",
+    ))
+    assert first is None
+
+    event = await adapter._build_message_event(_group_message(
+        "Whatbot the last message was for you",
+        messageId="m2",
+        senderId="111@s.whatsapp.net",
+        senderName="Simon W",
+    ))
+
+    assert event is not None
+    assert "The user is now directing this prior group message at WhatBot" in event.text
+    assert "Summarise to Matt your new capabilities" in event.text
+    assert "Whatbot the last message was for you" in event.text
+
+
+def test_non_clarification_bot_reply_closes_persisted_active_thread(tmp_path):
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True, session_path=tmp_path)
+    adapter._record_bot_group_reply(
+        "120363001234567890@g.us",
+        "Which meal, and what exact date/time in about a month should I set it for?",
+    )
+    assert adapter._load_active_thread("120363001234567890@g.us") is not None
+
+    adapter._record_bot_group_reply("120363001234567890@g.us", "Done — I set the reminder.")
+
+    assert adapter._load_active_thread("120363001234567890@g.us") is None
+
+
+def test_local_followup_classifier_prompt_includes_thread_and_recent_context(monkeypatch, tmp_path):
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True, session_path=tmp_path)
+    adapter.config.extra["local_followup_classifier"] = True
+    adapter.config.extra["local_followup_classifier_base_url"] = "http://localhost:11434"
+    adapter._record_recent_group_message(_group_message("WhatBot create a BBQ plan for Saturday", senderName="Simon"))
+    active_thread = {
+        "thread_id": "T-TEST",
+        "thread_type": "plan_creation",
+        "status": "awaiting_user_input",
+        "last_bot_reply": "What date should I put on the BBQ plan?",
+    }
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return False
+        def read(self):
+            return json.dumps({"message": {"content": json.dumps({"should_wake": True, "reason": "answers plan date", "confidence": 0.9})}}).encode()
+
+    def fake_urlopen(req, timeout):
+        captured["payload"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert adapter._classify_followup_with_local_model(
+        _group_message("second Saturday in June"),
+        last_bot_reply="What date should I put on the BBQ plan?",
+        active_thread=active_thread,
+        recent_messages=adapter._recent_group_messages_by_chat["120363001234567890@g.us"],
+    ) is True
+    prompt = captured["payload"]["messages"][0]["content"]
+    assert "Active WhatBot thread" in prompt
+    assert "plan_creation" in prompt
+    assert "Recent group messages" in prompt
+    assert "WhatBot create a BBQ plan" in prompt
+    assert captured["payload"]["think"] is False
+
+
+@pytest.mark.asyncio
+async def test_ignored_group_message_still_fires_observed_hook(monkeypatch):
+    adapter = _make_adapter(require_mention=True, respond_when_likely_directed=True)
+    calls = []
+
+    def fake_invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "ordinary group chatter",
+            messageId="casual-1",
+            senderId="111@s.whatsapp.net",
+            senderName="Alice",
+        )
+    )
+
+    assert event is None
+    observed = [kwargs for name, kwargs in calls if name == "platform_message_observed"]
+    assert len(observed) == 1
+    assert observed[0]["will_process"] is False
+    assert observed[0]["event"].text == "ordinary group chatter"
+
+
+@pytest.mark.asyncio
+async def test_unallowlisted_group_activation_request_is_not_observed_or_persisted(monkeypatch, tmp_path):
+    adapter = _make_adapter(
+        require_mention=True,
+        group_policy="allowlist",
+        group_allow_from=["allowed@g.us"],
+        session_path=tmp_path,
+    )
+    calls = []
+
+    def fake_invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "Hermes activate",
+            chatId="unknown@g.us",
+            chatName="Unknown Group",
+            messageId="activate-1",
+            senderId="111@s.whatsapp.net",
+            senderName="Alice",
+        )
+    )
+
+    assert event is None
+    assert [name for name, _kwargs in calls if name == "platform_message_observed"] == []
+    assert adapter._recent_messages_for_chat("unknown@g.us") == []
 
 
 def test_invalid_regex_patterns_are_ignored():


### PR DESCRIPTION
## Summary
- Add a local structured WhatsApp conversation router for wake/no-wake and retroactive repair decisions
- Keep conservative deterministic guardrails for mentions, blocked groups, follow-ups, and router fallback
- Add privacy protections: blocked groups return before observation/persistence, raw WhatsApp sender IDs are not persisted into router context, and non-local model URLs are refused unless explicitly opted in
- Cover router target selection, context-sensitive cache keys, local-only router URLs, and conservative follow-up behavior with tests

## Test Plan
- ./venv/bin/python -m pytest tests/gateway/test_whatsapp_group_gating.py -q → 54 passed
- ./venv/bin/python -m pytest tests/gateway/test_whatsapp*.py -q → 115 passed, 1 existing AsyncMock warning
- ./venv/bin/python -m pytest /Users/mac_studio/.hermes/profiles/whatsapp-groups/plugins/group-local-memory/test_group_local_memory.py /Users/mac_studio/.hermes/profiles/whatsapp-groups/plugins/group-self-improvement/test_group_self_improvement.py -q → 52 passed

## Review
- Independent pre-commit review passed after two rounds of fixes for privacy, cache, target-selection, and follow-up-gating issues.

## Notes
- This PR intentionally includes only the main-repo WhatsApp gateway routing change.
- Other unrelated local changes in the working tree were left out for separate review.
- Profile plugin changes live outside this repo and were backed up separately at /Users/mac_studio/.hermes/change-snapshots/whatbot-llm-routing-profile-plugins-20260601-114731