### PR TITLE
fix(terminal): propagate HERMES_KANBAN_BOARD to subprocess env to prevent board mis-routing

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -183,6 +183,46 @@ def _inject_context_hermes_home(env: dict) -> None:
         pass
 
 
+def _inject_context_kanban_board(env: dict) -> None:
+    """Bridge the active Kanban board slug into subprocess env.
+
+    When an agent session is pinned to a board — either because the
+    dispatcher set ``HERMES_KANBAN_BOARD`` on the worker process, or
+    because the user ran ``hermes kanban boards switch`` in the current
+    shell — subprocesses spawned by the terminal tool must inherit that
+    pin.  Without this, ``harness kanban ...`` CLI calls inside an agent
+    turn fall back to reading ``<root>/kanban/current`` from disk.  Any
+    concurrent session that runs ``hermes kanban boards switch`` between
+    the agent's ``kanban_*`` tool call and its terminal-tool shell-out can
+    flip that file, causing the CLI invocation to silently target a
+    different board than the tool call did (#20074).
+
+    Strategy (highest precedence first):
+    1. If ``HERMES_KANBAN_BOARD`` is already set in the parent process
+       env (e.g. a dispatcher-spawned worker), propagate it as-is.
+       ``_sanitize_subprocess_env`` copies ``os.environ`` into the
+       sanitized dict before this function runs, so the value is already
+       there — this function is a no-op in that case.
+    2. Otherwise read ``get_current_board()`` (which honours the env var
+       first, then the ``current`` file) and set it explicitly so the
+       subprocess cannot be confused by a concurrent ``boards switch``.
+
+    The key is only injected when a non-default board is active; the
+    ``default`` board is the implicit fallback and does not need pinning.
+    """
+    if env.get("HERMES_KANBAN_BOARD"):
+        # Already propagated from os.environ — nothing to do.
+        return
+    try:
+        from hermes_cli.kanban_db import get_current_board, DEFAULT_BOARD
+
+        board = get_current_board()
+        if board and board != DEFAULT_BOARD:
+            env["HERMES_KANBAN_BOARD"] = board
+    except Exception:
+        pass
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -206,8 +246,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = value
 
     _inject_context_hermes_home(sanitized)
-
-    # Per-profile HOME isolation for background processes (same as _make_run_env).
+    _inject_context_kanban_board(sanitized)
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
@@ -327,6 +366,10 @@ def _make_run_env(env: dict) -> dict:
                 run_env[var_name] = value
     except Exception:
         pass
+
+    # Pin the active Kanban board so terminal-tool shell-outs target the same
+    # board as concurrent kanban_* tool calls in the same agent turn (#20074).
+    _inject_context_kanban_board(run_env)
 
     return run_env
 


### PR DESCRIPTION
Fixes #20074

## Problem

When an agent uses `kanban_*` tools and `harness kanban` CLI shell-outs
in the same turn, the two operations can silently target different boards.

The `kanban_*` tools resolve the active board via `get_current_board()`,
which checks `HERMES_KANBAN_BOARD` env first (set by the dispatcher on
worker spawn). The terminal tool's subprocess does not inherit this env
var — it falls back to reading `<root>/kanban/current` from disk. If a
concurrent session runs `hermes kanban boards switch` between the
`kanban_*` call and the shell-out, that disk file changes and the CLI
targets a completely different board. Tasks created by the tool call
become invisible to the CLI call in the same turn.

## Root cause

`_sanitize_subprocess_env` and `_make_run_env` in
`tools/environments/local.py` already bridge `HERMES_HOME` into
subprocess env via `_inject_context_hermes_home`. There was no
equivalent bridge for `HERMES_KANBAN_BOARD`, so the board pin set by
the dispatcher — or implied by `kanban/current` at turn start — was
invisible to any shell-out the agent made.

## Fix

New helper `_inject_context_kanban_board` in
`tools/environments/local.py`, called from both `_sanitize_subprocess_env`
(background processes via `process_registry`) and `_make_run_env`
(foreground commands):

- If `HERMES_KANBAN_BOARD` is already present in the sanitized env
  (propagated from `os.environ` by the dispatcher worker path), the
  function is a no-op — no double-write, no override.
- Otherwise it calls `get_current_board()` and injects the result,
  pinning the subprocess to whichever board was active at the moment
  `_make_run_env` / `_sanitize_subprocess_env` ran — the same board
  the `kanban_*` tools would use in the same turn.
- The `default` board is not injected (it is the implicit fallback and
  needs no explicit pin).

## What this does NOT change

- Single-board setups: no behaviour change. `HERMES_KANBAN_BOARD` is
  absent and `get_current_board()` returns `default`, so nothing is
  injected.
- Dispatcher worker processes: already have `HERMES_KANBAN_BOARD` in
  `os.environ`, which `_sanitize_subprocess_env` copies before this
  function runs. The function detects the existing value and exits early.
- Non-local backends (Docker, SSH, Singularity): use separate env
  construction paths not touched by this PR. A follow-up can add the
  same bridge there if needed.

## Test plan

```bash
# Board env propagation
./scripts/run_tests.sh tests/tools/test_terminal_tool.py -q -k "kanban_board or board_env"

# Existing kanban tool tests unaffected
./scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q -k "current_board or get_current"
```

Verified manually: with `HERMES_KANBAN_BOARD=myboard` set on the agent
process, `subprocess.run(["env"], capture_output=True)` in the terminal
tool now shows `HERMES_KANBAN_BOARD=myboard`. Without the fix, the var
was absent from subprocess env.