### PR TITLE
fix(gateway): bypass WhatsApp batching for slash commands

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1213,6 +1213,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
         period before dispatching the combined message.
         """
         key = self._text_batch_key(event)
+        if event.is_command():
+            pending_task = self._pending_text_batch_tasks.pop(key, None)
+            if pending_task and not pending_task.done():
+                pending_task.cancel()
+            self._pending_text_batches.pop(key, None)
+            asyncio.create_task(self.handle_message(event))
+            return
+
         existing = self._pending_text_batches.get(key)
         chunk_len = len(event.text or "")
         if existing is None:

--- a/tests/gateway/test_whatsapp_text_batching.py
+++ b/tests/gateway/test_whatsapp_text_batching.py
@@ -105,3 +105,41 @@ def test_lone_message_dispatched_alone():
 
     asyncio.run(_drive())
     assert dispatched == ["solo"]
+
+
+def test_slash_command_bypasses_text_batch_delay():
+    """Control commands like /approve must not wait behind WhatsApp debounce."""
+    adapter = _make_adapter(text_batch_delay_seconds=5.0)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event.text)
+
+    adapter.handle_message = _capture
+
+    async def _drive():
+        adapter._enqueue_text_event(_event("/approve"))
+        await asyncio.sleep(0.05)
+
+    asyncio.run(_drive())
+    assert dispatched == ["/approve"]
+
+
+def test_slash_command_discards_pending_text_batch():
+    """A quick clarification followed by /approve must not merge into non-command text."""
+    adapter = _make_adapter(text_batch_delay_seconds=5.0)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event.text)
+
+    adapter.handle_message = _capture
+
+    async def _drive():
+        adapter._enqueue_text_event(_event("ok do it"))
+        adapter._enqueue_text_event(_event("/approve"))
+        await asyncio.sleep(0.05)
+
+    asyncio.run(_drive())
+    assert dispatched == ["/approve"]
+    assert adapter._pending_text_batches == {}


### PR DESCRIPTION
## Summary
- Bypass WhatsApp text-debounce batching for slash commands such as `/approve` and `/deny`.
- Clear any pending WhatsApp text batch before dispatching a slash command so `/approve` is not merged into prior normal text.
- Add regression coverage for immediate slash-command dispatch and pending-batch discard.

## Root cause
Recent WhatsApp text batching delayed every text event, including gateway control commands. If a user sent normal text and then `/approve` inside the debounce window, the adapter merged them into one non-command payload, so the approval handler never ran.

## Test Plan
- `python -m pytest tests/gateway/test_whatsapp_text_batching.py -q`
