### PR TITLE
fix(gateway): overlay profile config.yaml in _load_gateway_config (#36729)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1505,14 +1505,45 @@ def _teams_pipeline_plugin_enabled() -> bool:
     return "teams_pipeline" in enabled or "teams-pipeline" in enabled
 
 
+def _deep_merge_config(base: dict, overlay: dict) -> dict:
+    """Recursively merge ``overlay`` onto ``base`` (overlay wins for scalars/lists).
+
+    Used to layer a profile's ``config.yaml`` on top of the global one. Only
+    nested dicts are merged; lists and scalars from ``overlay`` replace the
+    corresponding ``base`` entry wholesale (matches the CLI's profile
+    semantics where ``disabled_toolsets`` is a list override, not append).
+    """
+    if not isinstance(overlay, dict):
+        return overlay if overlay is not None else base
+    if not isinstance(base, dict):
+        return dict(overlay)
+    out = dict(base)
+    for k, v in overlay.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge_config(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error.
 
     Uses the module-level ``_hermes_home`` (so tests that monkeypatch it
     still see their fixture) and shares the mtime-keyed raw-yaml cache
     from ``hermes_cli.config.read_raw_config`` when the paths match.
+
+    When the gateway is launched without ``HERMES_HOME`` redirected into a
+    profile directory (the common case for the WebUI / standalone gateway
+    processes), the sticky ``active_profile`` file and ``$HERMES_PROFILE``
+    env var are also honored: the profile\'s ``config.yaml`` is
+    deep-merged on top of the global config so profile-level
+    ``agent.disabled_toolsets`` (and other overrides) take effect for the
+    WebUI gateway too. See issue #36729.
     """
     config_path = _hermes_home / 'config.yaml'
+    base: dict = {}
+    used_fast_path = False
     try:
         from hermes_cli.config import get_config_path, read_raw_config
         # Fast path: if _hermes_home agrees with the canonical config
@@ -1520,18 +1551,80 @@ def _load_gateway_config() -> dict:
         # direct read (keeps test fixtures with a monkeypatched
         # _hermes_home working).
         if config_path == get_config_path():
-            return read_raw_config()
+            base = read_raw_config() or {}
+            used_fast_path = True
     except Exception:
         pass
 
+    if not used_fast_path:
+        try:
+            if config_path.exists():
+                import yaml
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    base = yaml.safe_load(f) or {}
+        except Exception:
+            logger.debug("Could not load gateway config from %s", config_path)
+            base = {}
+
+    # Profile-level overlay (#36729). Only when _hermes_home is NOT itself
+    # a profile directory — otherwise we\'d be re-loading the same file.
     try:
-        if config_path.exists():
-            import yaml
-            with open(config_path, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f) or {}
+        import os as _os
+        from hermes_cli.profiles import (
+            _get_default_hermes_home,
+            _get_profiles_root,
+            get_active_profile,
+            normalize_profile_name,
+            validate_profile_name,
+        )
+        default_home = _get_default_hermes_home().resolve()
+        try:
+            current_home = _hermes_home.resolve()
+        except Exception:
+            current_home = _hermes_home
+        # Skip overlay if we're already inside a profile dir; the loaded
+        # config IS the profile config in that case.
+        already_profile = False
+        try:
+            _get_profiles_root().resolve()
+            rel = current_home.relative_to(_get_profiles_root().resolve())
+            if len(rel.parts) >= 1:
+                already_profile = True
+        except Exception:
+            pass
+        if not already_profile and current_home == default_home:
+            profile_name = (_os.environ.get("HERMES_PROFILE") or "").strip()
+            if not profile_name:
+                try:
+                    profile_name = get_active_profile()
+                except Exception:
+                    profile_name = "default"
+            if profile_name and profile_name != "default":
+                canon = None
+                try:
+                    canon = normalize_profile_name(profile_name)
+                    validate_profile_name(canon)
+                except Exception:
+                    canon = None
+                if canon:
+                    overlay_path = _get_profiles_root() / canon / "config.yaml"
+                    if overlay_path.exists():
+                        try:
+                            import yaml
+                            with open(overlay_path, "r", encoding="utf-8") as f:
+                                overlay = yaml.safe_load(f) or {}
+                            if isinstance(overlay, dict) and overlay:
+                                base = _deep_merge_config(base, overlay)
+                        except Exception:
+                            logger.debug(
+                                "Could not merge profile config from %s",
+                                overlay_path,
+                            )
     except Exception:
-        logger.debug("Could not load gateway config from %s", config_path)
-    return {}
+        # Profile resolution must never break gateway config loading.
+        logger.debug("Profile overlay skipped due to unexpected error", exc_info=True)
+
+    return base
 
 
 def _load_gateway_runtime_config() -> dict:

--- a/tests/gateway/test_load_gateway_config_profile_overlay.py
+++ b/tests/gateway/test_load_gateway_config_profile_overlay.py
@@ -1,0 +1,121 @@
+"""Regression test for issue #36729.
+
+The WebUI / standalone gateway processes start without ``HERMES_HOME``
+being redirected into a profile directory. Before the fix,
+``_load_gateway_config()`` only loaded ``~/.hermes/config.yaml`` and
+silently ignored profile-level overrides like
+``agent.disabled_toolsets`` from ``~/.hermes/profiles/<name>/config.yaml``.
+This test verifies that the active profile's config is now deep-merged
+on top of the global one.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def fake_hermes_home(tmp_path, monkeypatch):
+    """Build a fake ~/.hermes layout and point HERMES_HOME at it."""
+    home = tmp_path / "hermes"
+    (home / "profiles" / "pm").mkdir(parents=True)
+    # Global config: disabled_toolsets is empty (matches issue reporter's setup).
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "agent": {"disabled_toolsets": [], "model": "global-model"},
+            "platforms": {"foo": True},
+        })
+    )
+    # Profile config defines disabled_toolsets that should win.
+    (home / "profiles" / "pm" / "config.yaml").write_text(
+        yaml.safe_dump({
+            "agent": {"disabled_toolsets": ["browser", "computer_use"]},
+        })
+    )
+    # Sticky active_profile pointer (no HERMES_PROFILE env in this test).
+    (home / "active_profile").write_text("pm\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    # Import / reload the relevant modules so the module-level
+    # ``_hermes_home`` picks up the fake HERMES_HOME.
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import hermes_cli.profiles as profiles
+    importlib.reload(profiles)
+    import gateway.run as gateway_run
+    importlib.reload(gateway_run)
+
+    # Also poke the module-level cached path the loader actually reads.
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+
+    return home, gateway_run
+
+
+def test_profile_disabled_toolsets_merged_into_gateway_config(fake_hermes_home):
+    _, gateway_run = fake_hermes_home
+    cfg = gateway_run._load_gateway_config()
+    assert isinstance(cfg, dict)
+    # Profile override wins for disabled_toolsets.
+    assert cfg["agent"]["disabled_toolsets"] == ["browser", "computer_use"]
+    # Other keys from the global config survive the deep-merge.
+    assert cfg["agent"]["model"] == "global-model"
+    assert cfg["platforms"]["foo"] is True
+
+
+def test_no_active_profile_falls_back_to_global(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"agent": {"disabled_toolsets": ["only_global"]}})
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import hermes_cli.profiles as profiles
+    importlib.reload(profiles)
+    import gateway.run as gateway_run
+    importlib.reload(gateway_run)
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+
+    cfg = gateway_run._load_gateway_config()
+    assert cfg["agent"]["disabled_toolsets"] == ["only_global"]
+
+
+def test_hermes_profile_env_overrides_active_profile_file(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    (home / "profiles" / "coder").mkdir(parents=True)
+    (home / "profiles" / "pm").mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"agent": {"disabled_toolsets": []}})
+    )
+    (home / "profiles" / "coder" / "config.yaml").write_text(
+        yaml.safe_dump({"agent": {"disabled_toolsets": ["from_coder"]}})
+    )
+    (home / "profiles" / "pm" / "config.yaml").write_text(
+        yaml.safe_dump({"agent": {"disabled_toolsets": ["from_pm"]}})
+    )
+    (home / "active_profile").write_text("pm\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "coder")
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import hermes_cli.profiles as profiles
+    importlib.reload(profiles)
+    import gateway.run as gateway_run
+    importlib.reload(gateway_run)
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+
+    cfg = gateway_run._load_gateway_config()
+    # HERMES_PROFILE env wins over the active_profile file.
+    assert cfg["agent"]["disabled_toolsets"] == ["from_coder"]


### PR DESCRIPTION
## Summary

Fixes #36729 — the WebUI gateway silently ignored profile-level `agent.disabled_toolsets` (and any other profile-level overrides) from `~/.hermes/profiles/<name>/config.yaml`.

## Root cause

`gateway/run.py::_load_gateway_config()` only loads `_hermes_home / 'config.yaml'`. The TUI/CLI gets away with this because `hermes_cli/main.py::_apply_profile_override()` rewrites `HERMES_HOME` to point at the profile directory **before** module imports, so `_hermes_home` already resolves to the profile config.

The standalone WebUI / gateway entry points never perform that rewrite, so `_hermes_home` stays at `~/.hermes` and the global `config.yaml` (with `disabled_toolsets: []`) is the only one read — even when an active profile defines a non-empty `disabled_toolsets`.

## Fix

`_load_gateway_config()` now:

1. Loads the global `~/.hermes/config.yaml` exactly as before (preserving the existing `read_raw_config` mtime-cache fast path).
2. Resolves the active profile from `$HERMES_PROFILE`, falling back to the sticky `~/.hermes/active_profile` file (same precedence used elsewhere).
3. If `_hermes_home` is **not** already inside `profiles/<name>/` (i.e. we're not in TUI profile mode) and an active profile is set, deep-merges `~/.hermes/profiles/<profile>/config.yaml` on top of the base config. Nested dicts merge recursively; lists/scalars from the profile replace the global value wholesale (this matches the issue reporter's expectation that profile `disabled_toolsets` *overrides* rather than appends).
4. Any failure during profile resolution is logged at `debug` level and swallowed — profile overlay can never break gateway startup.

A small `_deep_merge_config()` helper is added next to the loader.

## Tests

New `tests/gateway/test_load_gateway_config_profile_overlay.py` (3 cases):

- `test_profile_disabled_toolsets_merged_into_gateway_config` — profile overrides `disabled_toolsets` while global `agent.model` and `platforms.foo` survive the merge.
- `test_no_active_profile_falls_back_to_global` — no `active_profile` file ⇒ behavior unchanged.
- `test_hermes_profile_env_overrides_active_profile_file` — `$HERMES_PROFILE=coder` wins over `active_profile=pm`.

```
$ pytest tests/gateway/test_load_gateway_config_profile_overlay.py
3 passed in 0.56s
```

Adjacent regression sweep also green:

```
$ pytest tests/gateway/test_run_cleanup_progress.py \
         tests/gateway/test_api_server_toolset.py \
         tests/gateway/test_fast_command.py \
         tests/gateway/test_background_command.py \
         tests/gateway/test_teams_pipeline_runtime_wiring.py
49 passed in 7.55s
```

## Scope

- `gateway/run.py` — `_load_gateway_config()` + new `_deep_merge_config()` (~100 LOC, all in one function neighborhood).
- `tests/gateway/test_load_gateway_config_profile_overlay.py` — new test file.

No behavior change for users who don't use profiles, and no behavior change for the TUI (which already resolves `_hermes_home` to the profile directory itself).

Closes #36729.
