### PR TITLE
fix(auxiliary): use post-override base_url for endpoint detection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3728,7 +3728,16 @@ def resolve_provider_client(
         # Anthropic-wire endpoints (Kimi Coding Plan api.kimi.com/coding,
         # /anthropic-suffixed gateways) so named providers like kimi-coding
         # land on the right transport without needing per-provider branches.
-        client = _wrap_if_needed(client, final_model, raw_base_url, api_key)
+        # Pass ``base_url`` (post-override) rather than ``raw_base_url`` so
+        # the Anthropic-detect heuristic respects the user's explicit
+        # endpoint. Otherwise a user who routes the ``minimax`` provider
+        # through their own OpenAI-compatible gateway (e.g.
+        # api.minimax.chat/v1) gets falsely detected as Anthropic-wire
+        # and wrapped in AnthropicAuxiliaryClient → 401 invalid_api_key
+        # (their key is not valid on the registry's hardcoded
+        # api.minimax.io/anthropic). Same trap for any provider with a
+        # hardcoded /anthropic inference URL.
+        client = _wrap_if_needed(client, final_model, base_url, api_key)
 
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/tests/agent/test_auxiliary_url_override_anthropic_detect.py
+++ b/tests/agent/test_auxiliary_url_override_anthropic_detect.py
@@ -1,0 +1,93 @@
+"""Regression: auxiliary client Anthropic-detect must respect user base_url override.
+
+The bug: ``resolve_provider_client`` built the OpenAI client with the user's
+``explicit_base_url`` (e.g. ``https://api.minimax.chat/v1``) but then passed
+the *raw* registry URL (e.g. ``https://api.minimax.io/anthropic``) to
+``_wrap_if_needed``. ``_endpoint_speaks_anthropic_messages`` saw the
+``/anthropic`` suffix and wrapped the client in ``AnthropicAuxiliaryClient``,
+which then hit a real Anthropic endpoint with the user's key and 401'd.
+
+The fix: pass the post-override ``base_url`` to ``_wrap_if_needed`` so the
+Anthropic heuristic sees what the user actually configured.
+
+If you re-introduce this regression, a user who routes the ``minimax``
+provider through their own OpenAI-compatible gateway will get
+``HTTP 401: invalid api key`` from the auxiliary tasks.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from agent.auxiliary_client import resolve_provider_client
+
+
+def test_user_base_url_override_skips_anthropic_wrap():
+    """A user-supplied OpenAI-compatible base_url must NOT trigger the
+    Anthropic wire wrap, even when the provider registry's raw URL is the
+    /anthropic endpoint (minimax, minimax-cn, etc.)."""
+    client, resolved = resolve_provider_client(
+        provider="minimax",
+        model="MiniMax-M3",
+        explicit_base_url="https://api.minimax.chat/v1",
+        explicit_api_key="dummy-key-for-shape-test",
+        api_mode=None,  # the original buggy path; # type: ignore[arg-type]
+    )
+    assert client is not None
+    assert resolved == "MiniMax-M3"
+    assert type(client).__name__ == "OpenAI", (
+        f"Expected plain OpenAI client (user base_url is OpenAI-compatible), "
+        f"got {type(client).__name__} — the Anthropic detect heuristic "
+        f"leaked the registry's hardcoded /anthropic URL into the wrap "
+        f"decision (regression of url-override-anthropic-detect bug)."
+    )
+    # The actual base_url on the constructed client should be the user's URL,
+    # not the registry's hardcoded /anthropic URL.
+    actual = str(getattr(client, "base_url", "") or "")
+    assert actual.startswith("https://api.minimax.chat"), (
+        f"client.base_url leaked: got {actual!r}, expected to start with "
+        f"'https://api.minimax.chat'"
+    )
+
+
+def test_user_explicit_anthropic_url_still_wraps_with_explicit_mode():
+    """If the user genuinely wants the Anthropic wire transport, they
+    declare it with ``api_mode='anthropic_messages'`` and the wrap MUST
+    happen. The fix should not break this path."""
+    client, resolved = resolve_provider_client(
+        provider="minimax",
+        model="MiniMax-M3",
+        explicit_base_url="https://api.minimax.io/anthropic",
+        explicit_api_key="dummy-key-for-shape-test",
+        api_mode="anthropic_messages",
+    )
+    assert client is not None
+    # Should be wrapped in AnthropicAuxiliaryClient (the wire adapter)
+    assert type(client).__name__ in ("AnthropicAuxiliaryClient",), (
+        f"Expected AnthropicAuxiliaryClient for api_mode=anthropic_messages, "
+        f"got {type(client).__name__}"
+    )
+
+
+def test_explicit_anthropic_url_without_mode_uses_openai_shape():
+    """A URL ending in ``/anthropic`` gets normalized to ``/v1`` by
+    ``_to_openai_base_url`` (the OpenAI SDK needs ``/v1``). With no
+    ``api_mode`` override, the client is plain OpenAI — to actually
+    use the Anthropic wire, the user must set ``api_mode=anthropic_messages``.
+    This documents the contract so a future refactor doesn't silently
+    re-introduce the wrapping heuristic on /anthropic URLs."""
+    client, resolved = resolve_provider_client(
+        provider="minimax",
+        model="MiniMax-M3",
+        explicit_base_url="https://api.minimax.io/anthropic",
+        explicit_api_key="dummy-key-for-shape-test",
+        api_mode=None,  # type: ignore[arg-type]
+    )
+    assert client is not None
+    assert type(client).__name__ == "OpenAI"
+    actual = str(getattr(client, "base_url", "") or "")
+    assert actual.endswith("/v1/") or actual.endswith("/v1"), (
+        f"_to_openai_base_url should have normalised /anthropic -> /v1, "
+        f"got {actual!r}"
+    )


### PR DESCRIPTION
## Summary

`resolve_provider_client()` in `agent/auxiliary_client.py` used the **raw** provider-registry `base_url` when deciding whether to wrap the client as Anthropic-compatible. When a user overrode the `base_url` to an OpenAI-compatible endpoint (e.g. via `custom_providers` or a non-Anthropic proxy), the detector still saw the registry's hard-coded `/anthropic` suffix and forced the request through the Anthropic SDK, which then hit the real Anthropic endpoint with the user's key and returned `401 invalid api key`.

**Fix:** use the **post-override** `base_url` for endpoint-speak detection, so the wrapping decision follows the URL the request will actually hit. `api_mode='anthropic_messages'` remains an explicit opt-in.

## Reproduction

MiniMax auxiliary tasks (`title_generation`, `context_summary`, `memory_writer`, etc.) returned:

```
⚠ Auxiliary title generation failed: HTTP 401: invalid api key (2049)
```

Root cause: the provider registry hard-codes `minimax -> https://api.minimax.io/anthropic`. Even when the user supplied their own `base_url` pointing to a different provider, the detector saw the registry's `/anthropic` suffix and forced the request through `AnthropicAuxiliaryClient`.

## Changes

- `agent/auxiliary_client.py` — use post-override `base_url` in `_wrap_if_needed` / `_endpoint_speaks_anthropic_messages` (1 line: `raw_base_url` -> `base_url`).
- `tests/agent/test_auxiliary_url_override_anthropic_detect.py` — new regression test, 3 cases:
  1. user-override to non-Anthropic URL keeps OpenAI client (the bug)
  2. explicit `api_mode=anthropic_messages` still routes to Anthropic
  3. OpenAI path normalises `/anthropic` suffix to `/v1`

## Verification

- `uv run pytest tests/agent/test_auxiliary_url_override_anthropic_detect.py -v` -> 3/3 pass
- `uv run pytest tests/agent/test_auxiliary_named_custom_providers.py -v` -> 29/29 pass
- Pre-existing 12 failures in the full `tests/agent/` suite were verified to be a test-isolation bug unrelated to this change (azure_foundry pollutes named_custom state; reproducing on stashed working tree confirmed it pre-dates this commit).

## Test plan for reviewers

```bash
# 1. New regression test
uv run pytest tests/agent/test_auxiliary_url_override_anthropic_detect.py -v

# 2. Related test groups
uv run pytest tests/agent/test_auxiliary_named_custom_providers.py -v
uv run pytest tests/agent/test_auxiliary_client_azure_foundry.py -v
```

## Workaround for affected users (pre-merge)

Add `api_mode: chat_completions` to the relevant provider block in `~/.hermes/config.yaml`. This is a band-aid; the source fix is the proper resolution.
