### PR TITLE
fix(weixin): clear content dedup key after text-batch dispatch

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -70,6 +70,16 @@ class MessageDeduplicator:
                 self._seen = dict(newest)
         return False
 
+    def remove(self, key: str) -> None:
+        """Remove *key* from the seen cache so it can be accepted again.
+
+        Useful for lifecycle-aware dedup: mark a message as in-flight
+        with ``is_duplicate()``, then ``remove()`` the key once
+        processing completes so the same content is accepted on the
+        next send.
+        """
+        self._seen.pop(key, None)
+
     def clear(self):
         """Clear all tracked messages."""
         self._seen.clear()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1383,9 +1383,13 @@ class WeixinAdapter(BasePlatformAdapter):
         if message_id and self._dedup.is_duplicate(message_id):
             return
 
-        # Secondary content-fingerprint dedup for text messages
+        # Secondary content-fingerprint dedup for text messages.
+        # The key is stored on the event so it can be removed from the
+        # dedup cache after the message is dispatched, allowing the same
+        # text to be accepted again on the next send (issue #36750).
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
+        content_key: str = ""
         if text:
             content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
@@ -1435,6 +1439,9 @@ class WeixinAdapter(BasePlatformAdapter):
             media_types=media_types,
             timestamp=datetime.now(),
         )
+        # Attach content key for lifecycle-aware dedup removal after dispatch.
+        if content_key:
+            event._dedup_content_key = content_key  # type: ignore[attr-defined]
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
         if event.message_type == MessageType.TEXT:
             self._enqueue_text_event(event)
@@ -1515,6 +1522,11 @@ class WeixinAdapter(BasePlatformAdapter):
                 return
             await self.handle_message(event)
         finally:
+            # Lifecycle-aware dedup: remove the content fingerprint key
+            # so the same text is accepted again on the next send (#36750).
+            dedup_key = getattr(event, "_dedup_content_key", None)
+            if dedup_key:
+                self._dedup.remove(dedup_key)
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -896,6 +896,42 @@ class TestWeixinContentDedup:
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
 
+    def test_same_text_accepted_after_previous_processing_completes(self):
+        """Regression test for Issue #36750.
+
+        After the first message with text T has been dispatched (i.e. the
+        text-batch flush completed), sending the same text T again must be
+        accepted — the content dedup key is removed on dispatch so the TTL
+        cache does not suppress the follow-up.
+        """
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.05
+        adapter._text_batch_split_delay_seconds = 0.05
+
+        msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": { "text": "怎么样了"}}],
+        }
+
+        async def _drive():
+            # First send — should be accepted and dispatched.
+            await adapter._process_message({**msg, "message_id": "msg-1"})
+            await asyncio.sleep(0.2)  # wait for flush
+            assert adapter.handle_message.await_count == 1
+
+            # Second send with the same text but a different message_id.
+            # The content dedup key should have been removed after the
+            # first dispatch, so this must be accepted.
+            await adapter._process_message({**msg, "message_id": "msg-2"})
+            await asyncio.sleep(0.2)  # wait for flush
+
+        asyncio.run(_drive())
+
+        # Both messages should reach handle_message.
+        assert adapter.handle_message.await_count == 2
+
 
 class TestWeixinTextDebounce:
     """Text-debounce batching for rapid multi-message bursts (issue #35301).


### PR DESCRIPTION
## What does this PR do?

Clears the content fingerprint dedup key from `MessageDeduplicator` after the Weixin text-batch is dispatched, so the same text sent again after the previous turn completes is accepted instead of silently dropped.

## Related Issue

Fixes #36750

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/helpers.py`: Added `MessageDeduplicator.remove(key)` method to evict a single key from the TTL cache, enabling lifecycle-aware dedup patterns.
- `gateway/platforms/weixin.py`: Store the content dedup key on the event (`_dedup_content_key`) and remove it from the dedup cache in `_flush_text_batch`'s `finally` block after dispatch. In-flight dedup (same text arriving while the first is still queued) is unaffected.
- `tests/gateway/test_weixin.py`: Added `test_same_text_accepted_after_previous_processing_completes` regression test — sends the same text twice with a flush in between and asserts both reach `handle_message`.

## How to Test

1. Run `python3 -m pytest tests/gateway/test_weixin.py::TestWeixinContentDedup -v` — all 3 tests should pass.
2. Run `python3 -m pytest tests/gateway/test_weixin.py -x -q` — all 59 tests should pass.
3. Manual: with a Weixin/WeChat gateway configured, send "怎么样了", wait for the response, then send "怎么样了" again — the second message should be processed normally instead of being silently dropped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `MessageDeduplicator.remove()` (new method), `_flush_text_batch` (callers: 1, flows: text-batch dispatch)
- Blast radius: LOW — change is scoped to Weixin adapter's content dedup lifecycle; `MessageDeduplicator` is a shared helper but `remove()` is additive (no existing callers affected)
- Related patterns: `TextBatchAggregator` uses similar lifecycle pattern; other adapters using `MessageDeduplicator` (discord, slack, feishu) only use `is_duplicate()` and `clear()` — unaffected by `remove()` addition
