### PR TITLE
fix(compression): anchor raw tail to active exchange

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1818,6 +1818,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         * If the transcript ends with that user message, also keep the
           immediately preceding assistant/tool group so short replies retain
           the question they answer.
+          Orphan tool results are summarized instead of protected raw, because
+          the sanitizer would otherwise remove them after compression.
         * If assistant/tool messages follow the most recent user message, keep
           that whole in-progress exchange.
         * Always align backward so assistant tool_calls and tool results are
@@ -1831,12 +1833,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         cut_idx = last_user_idx
         if last_user_idx == n - 1:
             prev_idx = last_user_idx - 1
+            prev_role = messages[prev_idx].get("role") if prev_idx >= 0 else None
             if (
                 prev_idx > head_end
-                and messages[prev_idx].get("role") in {"assistant", "tool"}
+                and prev_role in {"assistant", "tool"}
                 and _content_length_for_budget(messages[prev_idx].get("content")) <= _FALLBACK_SUMMARY_MAX_CHARS
             ):
-                cut_idx = prev_idx
+                # For a tool result, let boundary alignment inspect the whole
+                # tool run before the user.  If no parent assistant tool_call is
+                # found, the cut stays at the user so the orphan result is
+                # summarized rather than later stripped by _sanitize_tool_pairs.
+                cut_idx = last_user_idx if prev_role == "tool" else prev_idx
 
         cut_idx = self._align_boundary_backward(messages, cut_idx)
         return max(cut_idx, head_end + 1)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1805,6 +1805,42 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         return max(cut_idx, head_end + 1)
 
+    def _find_active_tail_cut(
+        self, messages: List[Dict[str, Any]], head_end: int,
+    ) -> int:
+        """Return the smallest safe raw tail that preserves the active turn.
+
+        The token-budget tail can keep a large slice of stale history raw.  In
+        topic-switch sessions that stale slice may sit between a recent
+        assistant question and the user's terse answer after compaction.  The
+        active-tail boundary instead anchors on the most recent user message:
+
+        * If the transcript ends with that user message, also keep the
+          immediately preceding assistant/tool group so short replies retain
+          the question they answer.
+        * If assistant/tool messages follow the most recent user message, keep
+          that whole in-progress exchange.
+        * Always align backward so assistant tool_calls and tool results are
+          not split across the summary/tail boundary.
+        """
+        n = len(messages)
+        last_user_idx = self._find_last_user_message_idx(messages, head_end)
+        if last_user_idx < 0:
+            return self._find_tail_cut_by_tokens(messages, head_end)
+
+        cut_idx = last_user_idx
+        if last_user_idx == n - 1:
+            prev_idx = last_user_idx - 1
+            if (
+                prev_idx > head_end
+                and messages[prev_idx].get("role") in {"assistant", "tool"}
+                and _content_length_for_budget(messages[prev_idx].get("content")) <= _FALLBACK_SUMMARY_MAX_CHARS
+            ):
+                cut_idx = prev_idx
+
+        cut_idx = self._align_boundary_backward(messages, cut_idx)
+        return max(cut_idx, head_end + 1)
+
     # ------------------------------------------------------------------
     # ContextEngine: manual /compress preflight
     # ------------------------------------------------------------------
@@ -1817,7 +1853,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         the protected head/tail.
         """
         compress_start = self._align_boundary_forward(messages, self._protect_head_size(messages))
-        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        compress_end = self._find_active_tail_cut(messages, compress_start)
         return compress_start < compress_end
 
     # ------------------------------------------------------------------
@@ -1885,8 +1921,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         compress_start = self._protect_head_size(messages)
         compress_start = self._align_boundary_forward(messages, compress_start)
 
-        # Use token-budget tail protection instead of fixed message count
-        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+        # Keep only the current active exchange as raw tail.  Older turns,
+        # including previously token-protected history, are summarized so stale
+        # topic context cannot appear between a recent question and answer.
+        compress_end = self._find_active_tail_cut(messages, compress_start)
 
         if compress_start >= compress_end:
             return messages

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1234,6 +1234,7 @@ class TestCompressWithClient:
             {"role": "assistant", "content": "msg 5"},
             {"role": "user", "content": "msg 6"},
             {"role": "assistant", "content": "msg 7"},
+            {"role": "user", "content": "msg 8"},
         ]
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             result = c.compress(msgs)
@@ -1363,7 +1364,7 @@ class TestCompressWithClient:
             c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=3)
 
         # Head: [system, user, assistant]  →  last head = assistant
-        # Tail: [user, assistant, user]    →  first tail = user
+        # Tail: [user, assistant]          →  first tail = user
         # summary_role="user" collides with tail, "assistant" collides with head → merge
         # NOTE: protect_first_n=2 preserves 2 non-system messages in addition to
         # the system prompt (always implicitly protected).
@@ -1377,6 +1378,7 @@ class TestCompressWithClient:
             {"role": "user", "content": "msg 6"},       # tail start
             {"role": "assistant", "content": "msg 7"},
             {"role": "user", "content": "msg 8"},
+            {"role": "assistant", "content": "msg 9"},
         ]
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             result = c.compress(msgs)
@@ -1388,8 +1390,8 @@ class TestCompressWithClient:
             if r1 in {"user", "assistant"} and r2 in {"user", "assistant"}:
                 assert r1 != r2, f"consecutive {r1} at indices {i-1},{i}"
 
-        # The summary text should be merged into the first tail message
-        first_tail = [m for m in result if "msg 6" in (m.get("content") or "")]
+        # The summary text should be merged into the first active-tail message.
+        first_tail = [m for m in result if "msg 8" in (m.get("content") or "")]
         assert len(first_tail) == 1
         assert "summary text" in first_tail[0]["content"]
 
@@ -1411,7 +1413,6 @@ class TestCompressWithClient:
             {"role": "user", "content": "msg 5"},
             {"role": "user", "content": [{"type": "text", "text": "msg 6"}]},
             {"role": "assistant", "content": "msg 7"},
-            {"role": "user", "content": "msg 8"},
         ]
 
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
@@ -1454,6 +1455,7 @@ class TestCompressWithClient:
             {"role": "assistant", "content": "msg 5"},   # tail start
             {"role": "user", "content": "msg 6"},
             {"role": "assistant", "content": "msg 7"},
+            {"role": "user", "content": "msg 8"},
         ]
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             result = c.compress(msgs)
@@ -1465,8 +1467,8 @@ class TestCompressWithClient:
             if r1 in {"user", "assistant"} and r2 in {"user", "assistant"}:
                 assert r1 != r2, f"consecutive {r1} at indices {i-1},{i}"
 
-        # The summary should be merged into the first tail message (assistant at index 5)
-        first_tail = [m for m in result if "msg 5" in (m.get("content") or "")]
+        # The summary should be merged into the first tail message (assistant at index 7)
+        first_tail = [m for m in result if "msg 7" in (m.get("content") or "")]
         assert len(first_tail) == 1
         assert "summary text" in first_tail[0]["content"]
 
@@ -1956,6 +1958,87 @@ class TestTokenBudgetTailProtection:
         cut = c._find_tail_cut_by_tokens(messages, head_end)
         assert isinstance(cut, int)
         assert 0 <= cut <= len(messages)
+
+    def test_latest_assistant_question_stays_adjacent_to_short_user_reply(self):
+        """Compression must not leave stale raw history between a question and
+        the user's terse answer to that question.
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=20,
+            )
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "start the session"},
+            {"role": "assistant", "content": "ready"},
+        ]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"old proxy debugging turn {i}"})
+            msgs.append({"role": "assistant", "content": f"old proxy response {i}"})
+        msgs.extend([
+            {
+                "role": "assistant",
+                "content": "Should I add Sina K-line and emweb financial APIs to the data-source config?",
+            },
+            {"role": "user", "content": "add them all"},
+        ])
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        contents = [m.get("content") for m in result]
+        question_idx = contents.index(
+            "Should I add Sina K-line and emweb financial APIs to the data-source config?"
+        )
+        reply_idx = contents.index("add them all")
+        assert reply_idx == question_idx + 1
+        assert not any(
+            isinstance(content, str) and content.startswith("old proxy")
+            for content in contents
+        )
+
+    def test_manual_preflight_uses_same_active_tail_boundary_as_compress(self):
+        """A huge token budget should not make /compress skip a transcript that
+        active-tail compression can still compact safely.
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=20,
+            )
+        c.tail_token_budget = 1_000_000
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "ready"},
+        ]
+        for i in range(12):
+            msgs.append({"role": "user", "content": f"middle user {i}"})
+            msgs.append({"role": "assistant", "content": f"middle assistant {i}"})
+        msgs.extend([
+            {"role": "assistant", "content": "latest clarifying question"},
+            {"role": "user", "content": "yes"},
+        ])
+
+        assert c.has_content_to_compress(msgs) is True
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+        assert len(result) < len(msgs)
 
     def test_generous_budget_protects_everything_floor_does_not_override(
         self, budget_compressor

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2005,6 +2005,86 @@ class TestTokenBudgetTailProtection:
             for content in contents
         )
 
+    def test_tool_result_before_latest_user_reply_stays_with_parent_call(self):
+        """When a user replies after a tool result, keep the full tool group raw."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=20,
+            )
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "start the session"},
+            {"role": "assistant", "content": "ready"},
+        ]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"old proxy debugging turn {i}"})
+            msgs.append({"role": "assistant", "content": f"old proxy response {i}"})
+        msgs.extend([
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_current",
+                    "type": "function",
+                    "function": {"name": "lookup_prices", "arguments": "{}"},
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_current",
+                "content": "fresh tool output: latest market data",
+            },
+            {"role": "user", "content": "use that result"},
+        ])
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        assert [m.get("role") for m in result[-3:]] == ["assistant", "tool", "user"]
+        assert result[-3]["tool_calls"][0]["id"] == "call_current"
+        assert result[-2]["tool_call_id"] == "call_current"
+        assert result[-2]["content"] == "fresh tool output: latest market data"
+        assert result[-1]["content"] == "use that result"
+
+    def test_orphan_tool_before_latest_user_is_summarized_not_tail_sanitized(self):
+        """Do not protect an orphan tool result that sanitizer will later drop."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=20,
+            )
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "start the session"},
+            {"role": "assistant", "content": "ready"},
+        ]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"old proxy debugging turn {i}"})
+            msgs.append({"role": "assistant", "content": f"old proxy response {i}"})
+        msgs.extend([
+            {
+                "role": "tool",
+                "tool_call_id": "orphan_current",
+                "content": "fresh orphan tool output",
+            },
+            {"role": "user", "content": "use that result"},
+        ])
+
+        head_end = c._align_boundary_forward(msgs, c._protect_head_size(msgs))
+
+        assert c._find_active_tail_cut(msgs, head_end) == len(msgs) - 1
+
     def test_manual_preflight_uses_same_active_tail_boundary_as_compress(self):
         """A huge token budget should not make /compress skip a transcript that
         active-tail compression can still compact safely.


### PR DESCRIPTION
## Summary

- Replace compression's large token-budget raw tail with an active-exchange tail boundary.
- Keep the latest user message active and, when the transcript ends with a short user reply, keep the immediately preceding assistant/tool message so terse replies retain the question they answer.
- Use the same active-tail boundary for `/compress` preflight and actual compression.
- Preserve existing token-budget helper behavior, summary-failure abort semantics, historical media stripping, and tool-pair sanitization.

## Root Cause

The previous token-budget tail could preserve many old raw turns. After compaction, stale topic history could appear between a recent question and a user's terse answer, causing the next model turn to attach the reply to the wrong topic.

## Testing

- `env UV_CACHE_DIR=/private/tmp/uv-cache-hermes uv run --extra dev ruff check agent/context_compressor.py tests/agent/test_context_compressor.py`
- `env UV_CACHE_DIR=/private/tmp/uv-cache-hermes uv run --extra dev pytest tests/agent/test_context_compressor.py -q`
- `env UV_CACHE_DIR=/private/tmp/uv-cache-hermes uv run --extra dev pytest tests/agent/test_compress_focus.py tests/cli/test_compress_focus.py tests/gateway/test_compress_focus.py tests/gateway/test_compress_command.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_413_compression.py tests/run_agent/test_compression_boundary.py tests/run_agent/test_compression_boundary_hook.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_trigger_excludes_reasoning.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compressor_historical_media.py -q`