### PR TITLE
fix(gateway): skip systemd timing check for non-loaded units

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3991,7 +3991,7 @@ class GatewayRunner:
                 logger.warning(
                     "Stale systemd unit detected: %s has TimeoutStopSec=%.0fs but "
                     "drain_timeout=%.0fs (expected >=%.0fs). systemd may SIGKILL the "
-                    "gateway mid-drain. Run `hermes gateway service install --replace` "
+                    "gateway mid-drain. Run `hermes gateway install --replace` "
                     "to regenerate the unit, or shorten agent.restart_drain_timeout.",
                     _alignment.get("unit", "(unknown)"),
                     _alignment["timeout_stop_sec"],

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -363,16 +363,32 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
     # on which manager actually owns the unit.  Try user first since
     # that's the common case for hermes.
+    #
+    # Skip iterations where the unit isn't actually loaded in this manager
+    # -- `systemctl show` returns rc=0 and emits compiled-in defaults for
+    # nonexistent units (notably TimeoutStopUSec=1min 30s), which would
+    # produce a false-positive 'stale unit' warning when the gateway is
+    # deployed via a system-level unit but the user manager is reachable.
     timeout_us: Optional[int] = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name,
+                 "--property=LoadState",
+                 "--property=TimeoutStopUSec"],
                 capture_output=True, text=True, timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
+            continue
+        # Skip if the unit isn't actually loaded
+        load_state: Optional[str] = None
+        for line in result.stdout.splitlines():
+            if line.startswith("LoadState="):
+                load_state = line.split("=", 1)[1].strip()
+                break
+        if load_state and load_state != "loaded":
             continue
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
         for line in result.stdout.splitlines():


### PR DESCRIPTION
## What does this PR do?

Fixes false-positive 'stale systemd unit' warning when the gateway runs as a system-level unit but the user manager is reachable. The warning would appear even when the system unit has the correct TimeoutStopSec because `systemctl --user show` returns compiled-in defaults (90s) for nonexistent units.

## Related Issue

Fixes #36755

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/shutdown_forensics.py`: Add LoadState to systemctl query and skip iterations where LoadState != loaded
- `gateway/run.py`: Update warning message to reference correct CLI command

## How to Test

1. (Linux only) Deploy hermes-gateway as a system-level systemd unit with TimeoutStopSec=240s
2. Ensure the gateway user has a reachable user manager (e.g., XDG_RUNTIME_DIR set for rootless podman)
3. Start the gateway via systemctl
4. Verify no false-positive warning appears in the logs (previously would warn "stale unit" with 90s timeout)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (1 pre-existing flaky test failure unrelated to this change)
- [x] I've added tests for my changes (N/A - existing tests cover the function)
- [x] I've tested on my platform: macOS (no systemd - code path unchanged)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Linux-only function, no impact on Windows/macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.

- Analyzed: `gateway/shutdown_forensics.py:check_systemd_timing_alignment()` (callers: `gateway/run.py:check_systemd_timing_alignment()`)
- Blast radius: LOW — only affects Linux systems under systemd, function is defensive and never raises
- Related patterns: subprocess error handling, systemctl query parsing, systemd unit property retrieval