### PR TITLE
fix(agent): defer preflight compression when awaiting real usage after compaction (#36718)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -708,6 +708,13 @@ class ContextCompressor(ContextEngine):
         """
         if rough_tokens < self.threshold_tokens:
             return False
+        # After compression, ``last_real_prompt_tokens`` still holds the
+        # pre-compression value (which was above threshold — that's why
+        # compression fired).  Without this check the stale value defeats
+        # deferral and preflight compression fires a second time before
+        # a real API response has returned fresh token counts.  (#36718)
+        if self.awaiting_real_usage_after_compression:
+            return True
         if self.last_real_prompt_tokens <= 0:
             return False
         if self.last_real_prompt_tokens >= self.threshold_tokens:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -586,6 +586,7 @@ def compress_context(
     agent.context_compressor.last_compression_rough_tokens = _compressed_est
     agent.context_compressor.last_prompt_tokens = -1
     agent.context_compressor.last_completion_tokens = 0
+    agent.context_compressor.last_real_prompt_tokens = 0  # reset so defer check doesn't see stale pre-compression value (#36718)
     agent.context_compressor.awaiting_real_usage_after_compression = True
 
     # Clear the file-read dedup cache.  After compression the original

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -82,6 +82,27 @@ class TestPreflightDeferral:
 
         assert compressor.should_defer_preflight_to_real_usage(93_000) is False
 
+    def test_defers_after_compression_awaiting_real_usage(self, compressor):
+        """Regression: after compression, stale last_real_prompt_tokens
+        (above threshold) should not defeat preflight deferral.  (#36718)"""
+        compressor.threshold_tokens = 85_000
+        # Simulate post-compression state: real prompt was high (why
+        # compression fired), but we haven't received a real API response yet.
+        compressor.last_real_prompt_tokens = 90_000  # stale, above threshold
+        compressor.awaiting_real_usage_after_compression = True
+
+        # Rough estimate is above threshold, but we should defer because
+        # we don't trust the stale last_real_prompt_tokens after compression.
+        assert compressor.should_defer_preflight_to_real_usage(90_000) is True
+
+    def test_does_not_defer_after_compression_when_below_threshold(self, compressor):
+        """Even when awaiting_real_usage, rough estimate below threshold
+        means no compression needed — don't defer (no-op)."""
+        compressor.threshold_tokens = 85_000
+        compressor.awaiting_real_usage_after_compression = True
+
+        assert compressor.should_defer_preflight_to_real_usage(40_000) is False
+
 
 
 class TestCompress:


### PR DESCRIPTION
Fixes a P1 bug where context compression triggers repeatedly after a fresh compact because `last_prompt_tokens=-1` is not updated to a real value until the next API response returns fresh token counts, and the pre-compression `last_real_prompt_tokens` value (above threshold) defeats the deferral check.

Two changes:
1. **Early return in `should_defer_preflight_to_real_usage`** when `awaiting_real_usage_after_compression` is True — skips the stale `last_real_prompt_tokens` check entirely
2. **Reset `last_real_prompt_tokens=0`** after compression in `compress_context()` as defense-in-depth

Two focused regression tests with fail-without-fix proof. 93/93 tests in the file pass.