### PR TITLE
feat(stt): add StepFun StepAudio 2.5 ASR provider

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -821,6 +821,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "stepfun":
+            if get_env_value("STEPFUN_API_KEY"):
+                return "stepfun"
+            logger.warning(
+                "STT provider 'stepfun' configured but STEPFUN_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider): local > groq > openai > xai > elevenlabs -
@@ -1606,6 +1614,132 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.error("ElevenLabs STT transcription failed: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"ElevenLabs STT transcription failed: {e}"}
 
+# ---------------------------------------------------------------------------
+# Provider: StepFun (StepAudio 2.5 ASR)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_stepfun(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using StepFun StepAudio 2.5 ASR API.
+
+    Uses ``POST /v1/audio/asr/sse`` with SSE streaming response.
+    Requires ``STEPFUN_API_KEY`` environment variable.
+    """
+    api_key = get_env_value("STEPFUN_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "STEPFUN_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    stepfun_cfg = stt_config.get("stepfun", {})
+    base_url = str(
+        stepfun_cfg.get("base_url")
+        or get_env_value("STEPFUN_BASE_URL")
+        or "https://api.stepfun.ai/v1"
+    ).strip().rstrip("/")
+    if "step_plan" in base_url:
+        base_url = "https://api.stepfun.ai/v1"
+    language = str(
+        stepfun_cfg.get("language")
+        or os.getenv("HERMES_LOCAL_STT_LANGUAGE")
+        or "ko"
+    ).strip()
+
+    audio_path = Path(file_path)
+    if audio_path.suffix.lower() == ".ogg":
+        audio_format = {"type": "ogg", "codec": "opus"}
+    else:
+        audio_format = {"type": "mp3", "codec": "mp3"}
+
+    payload = {
+        "audio": {
+            "data": _encode_audio_base64(file_path),
+            "input": {
+                "transcription": {
+                    "model": model_name,
+                    "language": language,
+                    "enable_itn": True,
+                },
+                "format": audio_format,
+            },
+        }
+    }
+
+    try:
+        import json
+        import urllib.request
+        import urllib.error
+
+        req = urllib.request.Request(
+            f"{base_url}/audio/asr/sse",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+            },
+            method="POST",
+        )
+
+        transcript_parts = []
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            for raw_line in resp:
+                try:
+                    line = raw_line.decode("utf-8").strip()
+                except UnicodeDecodeError:
+                    continue
+                if not line.startswith("data:"):
+                    continue
+                data_str = line[5:].strip()
+                if data_str == "[DONE]":
+                    break
+                try:
+                    event = json.loads(data_str)
+                    event_type = event.get("type", "")
+                    if event_type == "transcript.text.delta":
+                        transcript_parts.append(event.get("delta", ""))
+                    elif event_type == "transcript.text.done":
+                        break
+                except Exception:
+                    continue
+
+        transcript = "".join(transcript_parts).strip()
+
+        if not transcript:
+            return {"success": False, "transcript": "", "error": "StepFun ASR returned empty transcript"}
+
+        logger.info(
+            "Transcribed %s via StepFun ASR (lang=%s, model=%s, %d chars)",
+            audio_path.name,
+            language,
+            model_name,
+            len(transcript),
+        )
+
+        return {"success": True, "transcript": transcript, "provider": "stepfun"}
+
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:300]
+        except Exception:
+            detail = str(e)
+        return {"success": False, "transcript": "", "error": f"StepFun ASR API error (HTTP {e.code}): {detail}"}
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("StepFun ASR transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"StepFun ASR transcription failed: {e}"}
+
+
+def _encode_audio_base64(file_path: str) -> str:
+    """Read an audio file and return base64-encoded bytes as a string."""
+    import base64
+
+    with open(file_path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -1684,6 +1818,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         elevenlabs_cfg = stt_config.get("elevenlabs", {})
         model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
         return _transcribe_elevenlabs(file_path, model_name)
+
+    if provider == "stepfun":
+        stepfun_cfg = stt_config.get("stepfun", {})
+        model_name = model or stepfun_cfg.get("model", "stepaudio-2.5-asr")
+        return _transcribe_stepfun(file_path, model_name)
 
     # User-declared command-type provider
     # (``stt.providers.<name>: type: command``). Fires after the built-in


### PR DESCRIPTION
    Title:

    feat(stt): add StepFun StepAudio 2.5 ASR provider

    Description:

    markdown
    Adds native stepfun STT provider to tools/transcription_tools.py, supporting StepFun's StepAudio 2.5 ASR API via POST /v1/audio/asr/sse.

    What

    - New provider branch in _get_provider() — activates when stt.provider: stepfun is set in config.yaml and STEPFUN_API_KEY is available.
    - New _transcribe_stepfun() implementation using stdlib urllib + SSE streaming parser (no new dependencies).
    - New dispatcher branch in transcribe_audio() with configurable model default (stepaudio-2.5-asr).
    - New _encode_audio_base64() helper.

    Config

    yaml
    stt:
      provider: stepfun stepfun: model: stepaudio-2.5-asr
        language: ko   # optional, defaults to ko

    Environment: STEPFUN_API_KEY (required), STEPFUN_BASE_URL (optional, defaults to https://api.stepfun.ai/v1).

    Design decisions

    - Follows existing provider pattern: mirrors _transcribe_xai / _transcribe_openai structure — env check in _get_provider(), dedicated transcribe* function, dispatcher branch with model fallback.
    - No new dependencies: uses stdlib urllib, json, base64 only.
    - URL safety: if STEPFUN_BASE_URL contains step_plan, it's rewritten to /v1 before calling /audio/asr/sse (audio endpoints return 404 under /step_plan/v1).
    - Format inference: .ogg → ogg/opus, all other supported formats → mp3/mp3.
    - Language resolution: stt.stepfun.language → HERMES_LOCAL_STT_LANGUAGE env var → "ko".
    - Credential resolution: uses get_env_value() (not os.getenv()) so keys in ~/.hermes/.env are found correctly.

    Testing

    - Existing tests/tools/test_transcription_tools.py: 95/95 passed — no regressions.
    - Discord voice end-to-end test: transcription works correctly with stt.provider: stepfun in production config.

    Notes

    - This is a additive change — no existing providers or code paths were modified.
    - StepFun is not included in the auto-detect fallback chain; users must set stt.provider: stepfun explicitly.

## What does this PR do?

Adds StepFun StepAudio 2.5 ASR as a first-class STT provider in transcription_tools.py.
Changes are purely additive — no existing providers, command-provider STT registry, or plugin dispatch were touched. Follows the same pattern as the existing xAI/OpenAI/Mistral providers.
    
    Tested: 95/95 existing unit tests pass. Discord voice end-to-end verified with STEPFUN_API_KEY in .env.

## Related Issue

Closes #36768

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [v] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Adds StepFun StepAudio 2.5 ASR as a first-class STT provider in transcription_tools.py.
Changes are purely additive — no existing providers, command-provider STT registry, or plugin dispatch were touched. Follows the same pattern as the existing xAI/OpenAI/Mistral providers.

## How to Test

    - Existing tests/tools/test_transcription_tools.py: 95/95 passed — no regressions.
    - Discord voice end-to-end test: transcription works correctly with stt.provider: stepfun in production config.

## Checklist

    - This is a additive change — no existing providers or code paths were modified.
    - StepFun is not included in the auto-detect fallback chain; users must set stt.provider: stepfun explicitly.

### Code

- [v] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [v] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [v] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [v] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [v] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [v] I've tested on my platform: Ubuntu 24.04, macOS 15.7.7

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [v] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

## Screenshots / Logs
agent.log
2026-06-01 20:58:16,049 INFO [20260531_223951_e2648aed] tools.transcription_tools: Transcribed vc_listen_m7pgg5fm.wav via StepFun ASR (lang=ko, model=stepaudio-2.5-asr, 21 chars)
2026-06-01 20:58:16,051 INFO hermes_plugins.discord_platform.adapter: Voice input from user 232886068045807616: hello this is a test.
2026-06-01 20:58:16,572 INFO gateway.run: inbound message: platform=discord user=232886068045807616 chat=1501212616360722465 msg='hello this is a test.'

