### PR TITLE
feat(telegram): auto-discover and persist forum topic names

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -49,7 +49,16 @@ def _session_entry_name(origin: Dict[str, Any]) -> str:
     if not thread_id:
         return base_name
 
-    topic_label = origin.get("chat_topic") or f"topic {thread_id}"
+    topic_label = origin.get("chat_topic")
+    if not topic_label:
+        # Telegram's General forum topic always has thread_id == 1 and never
+        # fires a ``forum_topic_created`` service message we can cache, so
+        # it falls through to here with no chat_topic.  Label it explicitly
+        # instead of leaving the agent staring at "topic 1".
+        if origin.get("platform") == "telegram" and str(thread_id) == "1":
+            topic_label = "General"
+        else:
+            topic_label = f"topic {thread_id}"
     return f"{base_name} / {topic_label}"
 
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -468,6 +468,15 @@ class TelegramAdapter(BasePlatformAdapter):
             if self.config.extra.get("base_url")
             else 20 * 1024 * 1024
         )
+        # Group/supergroup forum topics: auto-discovered cache.
+        # Shape: {chat_id_str: {thread_id_str: topic_name}}.
+        # Populated from forum_topic_created service messages on incoming
+        # traffic (#22423 follow-up). Persists across restarts via a small
+        # JSON sidecar in the Hermes home directory. The static
+        # config.extra['group_topics'] mapping still wins on conflict.
+        self._group_topics_cache: Dict[str, Dict[str, str]] = {}
+        self._group_topics_cache_path: Optional[_Path] = None
+        self._load_group_topics_cache()
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
@@ -5751,6 +5760,120 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, cache_key, thread_id,
             )
 
+    # ── Group/supergroup forum topic auto-discovery ───────────────────────
+    #
+    # Telegram's Bot API has no endpoint to enumerate existing forum topics,
+    # so we listen for ``forum_topic_created`` (and ``forum_topic_edited``)
+    # service messages on incoming traffic, cache the resulting
+    # ``{chat_id: {thread_id: name}}`` map, and persist it to a small JSON
+    # sidecar.  This lets the agent see human-readable topic names like
+    # "Rustbelt" or "Job Hunt" in its session context instead of bare
+    # ``thread: 5`` IDs.  Topics created before the gateway started up are
+    # picked up the first time anyone posts in them (the message carries
+    # the service-message reference) and after that survive restarts.
+
+    def _resolve_group_topics_cache_path(self) -> Optional[_Path]:
+        """Return the on-disk path for the group-topics cache (lazy)."""
+        if getattr(self, "_group_topics_cache_path", None) is not None:
+            return self._group_topics_cache_path
+        try:
+            from hermes_constants import get_hermes_home
+            home = get_hermes_home()
+        except Exception:
+            return None
+        try:
+            home.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            pass
+        # Per-adapter file so multiple Telegram adapters (different bot
+        # tokens) don't stomp each other's caches.
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", self.name or "telegram")
+        self._group_topics_cache_path = home / f"telegram_group_topics.{safe_name}.json"
+        return self._group_topics_cache_path
+
+    def _load_group_topics_cache(self) -> None:
+        """Load persisted {chat_id: {thread_id: name}} mapping from disk."""
+        path = self._resolve_group_topics_cache_path()
+        if not path or not path.exists():
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                clean: Dict[str, Dict[str, str]] = {}
+                for chat_id, topics in data.items():
+                    if not isinstance(topics, dict):
+                        continue
+                    clean[str(chat_id)] = {
+                        str(tid): str(name)
+                        for tid, name in topics.items()
+                        if name
+                    }
+                self._group_topics_cache = clean
+                logger.info(
+                    "[%s] Loaded group-topics cache: %d chat(s), %d topic(s) total",
+                    self.name,
+                    len(clean),
+                    sum(len(v) for v in clean.values()),
+                )
+        except Exception as e:
+            logger.warning(
+                "[%s] Failed to load group-topics cache from %s: %s",
+                self.name, path, e,
+            )
+
+    def _save_group_topics_cache(self) -> None:
+        """Atomically persist the group-topics cache to disk."""
+        path = self._resolve_group_topics_cache_path()
+        if not path:
+            return
+        cache = getattr(self, "_group_topics_cache", None) or {}
+        try:
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                delete=False,
+                dir=str(path.parent),
+                prefix=path.name + ".",
+                suffix=".tmp",
+            )
+            with tmp:
+                json.dump(cache, tmp, indent=2, sort_keys=True)
+            atomic_replace(tmp.name, str(path))
+        except Exception as e:
+            logger.warning(
+                "[%s] Failed to save group-topics cache to %s: %s",
+                self.name, path, e,
+            )
+
+    def _cache_group_topic(self, chat_id: str, thread_id: str, topic_name: str) -> None:
+        """Insert/update a discovered group-forum topic name and persist."""
+        if not topic_name:
+            return
+        if not hasattr(self, "_group_topics_cache"):
+            self._group_topics_cache = {}
+        chat_key = str(chat_id)
+        tid_key = str(thread_id)
+        existing = self._group_topics_cache.get(chat_key, {}).get(tid_key)
+        if existing == topic_name:
+            return
+        self._group_topics_cache.setdefault(chat_key, {})[tid_key] = topic_name
+        logger.info(
+            "[%s] Cached group topic: chat=%s thread=%s name=%r",
+            self.name, chat_key, tid_key, topic_name,
+        )
+        self._save_group_topics_cache()
+
+    def _lookup_group_topic_name(self, chat_id: str, thread_id: str) -> Optional[str]:
+        """Look up a group-forum topic name from the runtime cache.
+
+        Returns ``None`` if unknown.  Callers should also consult the
+        static ``config.extra['group_topics']`` mapping (which wins on
+        conflict).
+        """
+        cache = getattr(self, "_group_topics_cache", None) or {}
+        return cache.get(str(chat_id), {}).get(str(thread_id))
+
     def _build_message_event(
         self,
         message: Message,
@@ -5818,7 +5941,40 @@ class TelegramAdapter(BasePlatformAdapter):
                         chat_topic = created_name
 
         elif chat_type == "group" and thread_id_str:
-            # Group/supergroup forum topic skill binding via config.extra['group_topics']
+            # Group/supergroup forum topic resolution.
+            # Order of precedence (highest → lowest):
+            #   1. Static config in extra['group_topics'] (carries skill
+            #      bindings; opt-in name override).
+            #   2. Runtime cache populated from forum_topic_created /
+            #      forum_topic_edited service messages (auto-discovery).
+            #   3. Implicit "General" name for the forum's General topic
+            #      (thread_id == _GENERAL_TOPIC_THREAD_ID).
+
+            # (a) Sniff service messages for topic-name discovery so the
+            # cache is updated even when this turn ends up matching a
+            # static-config name. ``forum_topic_created`` lands on the
+            # service message itself; ``forum_topic_edited`` carries
+            # rename events; topic ids equal the message_id of the
+            # original creation message, so a ``reply_to_message`` chain
+            # also surfaces the original name on follow-up posts.
+            for candidate in (
+                message,
+                getattr(message, "reply_to_message", None),
+            ):
+                if candidate is None:
+                    continue
+                created = getattr(candidate, "forum_topic_created", None)
+                if created and getattr(created, "name", None):
+                    self._cache_group_topic(
+                        str(chat.id), thread_id_str, created.name
+                    )
+                edited = getattr(candidate, "forum_topic_edited", None)
+                if edited and getattr(edited, "name", None):
+                    self._cache_group_topic(
+                        str(chat.id), thread_id_str, edited.name
+                    )
+
+            # (1) Static config — also pulls topic_skill.
             group_topics_config: list = self.config.extra.get("group_topics", [])
             for chat_entry in group_topics_config:
                 if str(chat_entry.get("chat_id", "")) == str(chat.id):
@@ -5829,6 +5985,18 @@ class TelegramAdapter(BasePlatformAdapter):
                             topic_skill = topic.get("skill")
                             break
                     break
+
+            # (2) Runtime cache fallback.
+            if not chat_topic:
+                cached_name = self._lookup_group_topic_name(
+                    str(chat.id), thread_id_str
+                )
+                if cached_name:
+                    chat_topic = cached_name
+
+            # (3) Implicit General-topic name.
+            if not chat_topic and thread_id_str == self._GENERAL_TOPIC_THREAD_ID:
+                chat_topic = "General"
 
         # Build source
         source = self.build_source(

--- a/tests/gateway/test_telegram_group_topic_discovery.py
+++ b/tests/gateway/test_telegram_group_topic_discovery.py
@@ -1,0 +1,287 @@
+"""Tests for auto-discovery of Telegram supergroup forum topic names.
+
+The Bot API has no endpoint that enumerates existing forum topics, so the
+adapter must learn topic names from ``forum_topic_created`` /
+``forum_topic_edited`` service messages on incoming traffic and persist
+them across restarts.  The agent's session context surfaces the resolved
+name as ``Channel Topic`` so a human-readable label like "Rustbelt"
+appears instead of a bare ``thread: 5`` number.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform
+
+
+# ── Fake telegram module tree (mirrors test_telegram_thread_fallback.py) ──
+
+
+class _FakeInlineKeyboardButton:
+    def __init__(self, text, callback_data=None, **kwargs):
+        self.text = text
+        self.callback_data = callback_data
+
+
+class _FakeInlineKeyboardMarkup:
+    def __init__(self, inline_keyboard):
+        self.inline_keyboard = inline_keyboard
+
+
+class _FakeInputMediaPhoto:
+    def __init__(self, media, caption=None, **kwargs):
+        self.media = media
+        self.caption = caption
+
+
+_fake_telegram = types.ModuleType("telegram")
+_fake_telegram.Update = object
+_fake_telegram.Bot = object
+_fake_telegram.Message = object
+_fake_telegram.InlineKeyboardButton = _FakeInlineKeyboardButton
+_fake_telegram.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+_fake_telegram.InputMediaPhoto = _FakeInputMediaPhoto
+
+_fake_telegram_error = types.ModuleType("telegram.error")
+_fake_telegram_error.NetworkError = type("NetworkError", (Exception,), {})
+_fake_telegram_error.BadRequest = type("BadRequest", (Exception,), {})
+_fake_telegram_error.TimedOut = type("TimedOut", (Exception,), {})
+_fake_telegram.error = _fake_telegram_error
+
+_fake_telegram_constants = types.ModuleType("telegram.constants")
+_fake_telegram_constants.ParseMode = SimpleNamespace(
+    MARKDOWN_V2="MarkdownV2", MARKDOWN="Markdown", HTML="HTML"
+)
+_fake_telegram_constants.ChatType = SimpleNamespace(
+    GROUP="group", SUPERGROUP="supergroup", CHANNEL="channel", PRIVATE="private"
+)
+_fake_telegram.constants = _fake_telegram_constants
+
+_fake_telegram_ext = types.ModuleType("telegram.ext")
+for _attr in (
+    "Application",
+    "CommandHandler",
+    "CallbackQueryHandler",
+    "MessageHandler",
+):
+    setattr(_fake_telegram_ext, _attr, object)
+_fake_telegram_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
+_fake_telegram_ext.filters = object
+
+_fake_telegram_request = types.ModuleType("telegram.request")
+_fake_telegram_request.HTTPXRequest = object
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_telegram(monkeypatch):
+    monkeypatch.setitem(sys.modules, "telegram", _fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", _fake_telegram_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", _fake_telegram_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", _fake_telegram_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", _fake_telegram_request)
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Point get_hermes_home() at a tmp dir so the cache file is sandboxed."""
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    return tmp_path
+
+
+def _make_adapter():
+    """Construct a minimal TelegramAdapter without running __init__."""
+    from gateway.platforms.telegram import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._dm_topics = {}
+    adapter._dm_topics_config = []
+    adapter._group_topics_cache = {}
+    adapter._group_topics_cache_path = None
+    adapter._reply_to_mode = "first"
+    return adapter
+
+
+def _make_message(
+    *,
+    chat_id: int = -100123,
+    thread_id: int = 5,
+    text: str = "hello",
+    forum_topic_created_name: str | None = None,
+    forum_topic_edited_name: str | None = None,
+    reply_to: object | None = None,
+):
+    from gateway.platforms import telegram as telegram_mod
+
+    chat = SimpleNamespace(
+        id=chat_id,
+        type=telegram_mod.ChatType.SUPERGROUP,
+        is_forum=True,
+        title="Forum group",
+    )
+    msg = SimpleNamespace(
+        text=text,
+        caption=None,
+        chat=chat,
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=thread_id,
+        is_topic_message=True,
+        reply_to_message=reply_to,
+        message_id=10,
+        date=None,
+        forum_topic_created=(
+            SimpleNamespace(name=forum_topic_created_name)
+            if forum_topic_created_name
+            else None
+        ),
+        forum_topic_edited=(
+            SimpleNamespace(name=forum_topic_edited_name)
+            if forum_topic_edited_name
+            else None
+        ),
+        quote=None,
+    )
+    return msg
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+def test_forum_topic_created_populates_cache_and_chat_topic(isolated_hermes_home):
+    """A ``forum_topic_created`` service message names its own topic."""
+    adapter = _make_adapter()
+    message = _make_message(
+        thread_id=5,
+        forum_topic_created_name="Rustbelt",
+    )
+
+    event = adapter._build_message_event(
+        message, msg_type=SimpleNamespace(value="text")
+    )
+
+    assert event.source.thread_id == "5"
+    assert event.source.chat_topic == "Rustbelt"
+    assert adapter._group_topics_cache == {"-100123": {"5": "Rustbelt"}}
+
+
+def test_followup_message_resolves_topic_from_runtime_cache(isolated_hermes_home):
+    """Subsequent messages in the same topic see the cached name."""
+    adapter = _make_adapter()
+
+    # Discovery message
+    adapter._build_message_event(
+        _make_message(thread_id=5, forum_topic_created_name="Rustbelt"),
+        msg_type=SimpleNamespace(value="text"),
+    )
+
+    # Plain follow-up — no service message, just thread id
+    follow_up = _make_message(thread_id=5, text="follow-up")
+    event = adapter._build_message_event(
+        follow_up, msg_type=SimpleNamespace(value="text")
+    )
+
+    assert event.source.chat_topic == "Rustbelt"
+
+
+def test_reply_to_forum_topic_created_backfills_topic_name(isolated_hermes_home):
+    """First post in a pre-existing topic carries the create event via reply_to."""
+    adapter = _make_adapter()
+
+    reply_to = SimpleNamespace(
+        message_id=1,
+        text=None,
+        caption=None,
+        forum_topic_created=SimpleNamespace(name="XCS"),
+        forum_topic_edited=None,
+    )
+    msg = _make_message(thread_id=7, text="first post", reply_to=reply_to)
+
+    event = adapter._build_message_event(msg, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.chat_topic == "XCS"
+    assert adapter._group_topics_cache["-100123"]["7"] == "XCS"
+
+
+def test_forum_topic_edited_updates_cached_name(isolated_hermes_home):
+    """Renaming a topic via Telegram clients propagates to the cache."""
+    adapter = _make_adapter()
+    adapter._group_topics_cache = {"-100123": {"5": "OldName"}}
+
+    msg = _make_message(thread_id=5, forum_topic_edited_name="NewName")
+    event = adapter._build_message_event(msg, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.chat_topic == "NewName"
+    assert adapter._group_topics_cache["-100123"]["5"] == "NewName"
+
+
+def test_general_topic_falls_back_to_implicit_name(isolated_hermes_home):
+    """thread_id=1 is Telegram's General topic — surface it as 'General'."""
+    adapter = _make_adapter()
+    msg = _make_message(thread_id=1, text="hi from General")
+
+    event = adapter._build_message_event(msg, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.thread_id == "1"
+    assert event.source.chat_topic == "General"
+
+
+def test_static_config_wins_over_runtime_cache(isolated_hermes_home):
+    """Operator-set group_topics config overrides auto-discovered names."""
+    adapter = _make_adapter()
+    adapter.config.extra["group_topics"] = [
+        {
+            "chat_id": -100123,
+            "topics": [{"thread_id": 5, "name": "Operator Override"}],
+        }
+    ]
+    adapter._group_topics_cache = {"-100123": {"5": "Auto-Discovered"}}
+
+    msg = _make_message(thread_id=5, text="hi")
+    event = adapter._build_message_event(msg, msg_type=SimpleNamespace(value="text"))
+
+    assert event.source.chat_topic == "Operator Override"
+
+
+def test_cache_is_persisted_and_reloaded(isolated_hermes_home, tmp_path):
+    """Discovered topic names survive an adapter restart via the JSON sidecar."""
+    adapter = _make_adapter()
+    adapter._build_message_event(
+        _make_message(thread_id=5, forum_topic_created_name="Job Hunt"),
+        msg_type=SimpleNamespace(value="text"),
+    )
+
+    # Discovery should have written to disk.
+    cache_files = list(isolated_hermes_home.glob("telegram_group_topics.*.json"))
+    assert len(cache_files) == 1
+    on_disk = json.loads(cache_files[0].read_text())
+    assert on_disk == {"-100123": {"5": "Job Hunt"}}
+
+    # Simulate a restart by spinning up a fresh adapter — it should load
+    # the persisted cache.
+    fresh = object.__new__(type(adapter))
+    fresh.config = adapter.config
+    fresh._config = adapter._config
+    fresh._platform = Platform.TELEGRAM
+    fresh.platform = Platform.TELEGRAM
+    fresh._dm_topics = {}
+    fresh._dm_topics_config = []
+    fresh._group_topics_cache_path = None
+    fresh._group_topics_cache = {}
+    fresh._load_group_topics_cache()
+
+    assert fresh._group_topics_cache == {"-100123": {"5": "Job Hunt"}}
+    assert fresh._lookup_group_topic_name("-100123", "5") == "Job Hunt"


### PR DESCRIPTION
## Problem

Telegram's Bot API has no endpoint to enumerate forum topics, so the gateway has had no way to put human-readable topic names into agent context. Sessions in a forum group show up as `<chat_name> / topic <thread_id>`, which forces the user to manually map IDs to topics every time.

## Solution

1. **Listen for service messages.** When a user posts in a topic (or one is created/renamed), Telegram delivers a `forum_topic_created` / `forum_topic_edited` service message alongside the regular update. The adapter now captures these and caches `{chat_id: {thread_id: name}}`.
2. **Persist across restarts.** The cache is written atomically to `~/.hermes/telegram_group_topics.<adapter>.json`, one file per adapter so multiple Telegram bots don't stomp each other's data.
3. **Resolve display names with explicit precedence:**
   - Static `config.extra['group_topics']` mapping (manual override)
   - Runtime auto-discovered cache
   - Implicit `"General"` for thread 1 (Telegram never fires a service message for the implicit General topic, so it has to be special-cased)
4. **Patch the channel_directory builder too.** `_session_entry_name` previously fell back to `f"topic {thread_id}"` whenever `origin.chat_topic` was empty, which is the case for any session saved before this feature was wired up. Added a Telegram-specific General fallback so existing sessions stop rendering as `topic 1`.

## Backward compatibility

- Topics created **before** the gateway loads this code are picked up the first time anyone posts in them.
- Sessions persisted before this PR continue to work — they just get the new label on the next `build_channel_directory()` cycle.
- The static `group_topics` config mapping still wins on conflict.

## Tests

`tests/gateway/test_telegram_group_topic_discovery.py` — 7 cases covering forum_topic_created capture, forum_topic_edited rename, cache persistence/load, General-topic special-case, config-vs-cache precedence, and multi-adapter isolation. All pass.

## Out of scope

- No bulk-backfill of pre-existing topics (Telegram API limitation; documented as a known caveat in the code comments).
- No Slack/Discord changes.