### PR TITLE
feat(diagnostics): preserve local validation tracebacks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -26,7 +26,9 @@ import copy
 import json
 import logging
 import re
+import ssl
 import time
+import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -39,6 +41,19 @@ from agent.error_classifier import FailoverReason
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
+
+
+def should_capture_local_validation_traceback(error: BaseException) -> bool:
+    """Return True when a local validation failure needs traceback context."""
+    return (
+        isinstance(error, (ValueError, TypeError))
+        and not isinstance(error, (UnicodeEncodeError, json.JSONDecodeError, ssl.SSLError))
+        and not (
+            isinstance(error, TypeError)
+            and "nonetype" in str(error).lower()
+            and "not iterable" in str(error).lower()
+        )
+    )
 
 
 def _ra():
@@ -1100,6 +1115,10 @@ def dump_api_request_debug(
                 "type": type(error).__name__,
                 "message": str(error),
             }
+            if should_capture_local_validation_traceback(error):
+                error_info["traceback"] = traceback.format_exception(
+                    type(error), error, error.__traceback__,
+                )
             for attr_name in ("status_code", "request_id", "code", "param", "type"):
                 attr_value = getattr(error, attr_name, None)
                 if attr_value is not None:
@@ -2345,6 +2364,7 @@ __all__ = [
     "restore_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",
+    "should_capture_local_validation_traceback",
     "anthropic_prompt_cache_policy",
     "create_openai_client",
     "switch_model",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.agent_runtime_helpers import should_capture_local_validation_traceback
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
@@ -2603,6 +2604,7 @@ def run_conversation(
                     error_type,
                     agent._client_log_context(),
                     _error_summary,
+                    exc_info=should_capture_local_validation_traceback(api_error),
                 )
 
                 _provider = getattr(agent, "provider", "unknown")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1811,6 +1811,51 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_includes_local_validation_traceback(monkeypatch, tmp_path):
+    """Local TypeError/ValueError dumps should preserve the failing call site."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.logs_dir = tmp_path
+
+    def _raise_adapter_type_error():
+        raise TypeError("adapter response shape broke")
+
+    try:
+        _raise_adapter_type_error()
+    except TypeError as exc:
+        dump_file = agent._dump_api_request_debug(
+            _codex_request_kwargs(),
+            reason="non_retryable_client_error",
+            error=exc,
+        )
+
+    payload = json.loads(dump_file.read_text())
+    traceback_lines = payload["error"]["traceback"]
+    assert payload["error"]["type"] == "TypeError"
+    assert any("_raise_adapter_type_error" in line for line in traceback_lines)
+    assert any("adapter response shape broke" in line for line in traceback_lines)
+
+
+def test_dump_api_request_debug_skips_retryable_decode_traceback(monkeypatch, tmp_path):
+    """JSON decode failures stay compact because they remain retryable transport errors."""
+    import json
+
+    agent = _build_agent(monkeypatch)
+    agent.logs_dir = tmp_path
+    error = json.JSONDecodeError("bad json", "<html>", 0)
+
+    dump_file = agent._dump_api_request_debug(
+        _codex_request_kwargs(),
+        reason="retryable_error",
+        error=error,
+    )
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["error"]["type"] == "JSONDecodeError"
+    assert "traceback" not in payload["error"]
+
+
 # --- Reasoning-only response tests (fix for empty content retry loop) ---
 
 


### PR DESCRIPTION
Adds traceback context for local validation failures so adapter-side `TypeError` / `ValueError` bugs leave enough information in both logs and request dumps to debug the failing call site.

The helper keeps retryable transport-style failures compact, including `JSONDecodeError`, `UnicodeEncodeError`, TLS errors, and the retryable `NoneType is not iterable` provider-shape case.

Closes #36752

Checked with:
- `python -m ruff check agent/agent_runtime_helpers.py agent/conversation_loop.py tests/run_agent/test_run_agent_codex_responses.py`
- `python -m pytest --timeout-method=thread tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_includes_local_validation_traceback tests/run_agent/test_run_agent_codex_responses.py::test_dump_api_request_debug_skips_retryable_decode_traceback -q`