### PR TITLE
fix(qqbot): allow DM approval button callbacks

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1086,7 +1086,11 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # Gateway sessions use the generic chat_type "dm" for direct/private
+        # messages.  QQ's INTERACTION_CREATE payload uses the platform scene
+        # name "c2c" for the same conversation.  Older QQ approval keyboards
+        # also embedded "c2c" directly, so accept both spellings here.
+        if chat_type in {"dm", "c2c"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1568,6 +1568,33 @@ class TestDefaultInteractionDispatch:
                 "id": "i",
                 "chat_type": 2,
                 "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-42:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_approval_click_accepts_legacy_c2c_session_key(self):
+        """Pre-fix QQ keyboards may still contain c2c; keep them valid."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
                 "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once"}},
             })
             await adapter._default_interaction_dispatch(event)


### PR DESCRIPTION
## Summary
Fixes QQ Bot command approval button callbacks for direct messages.

Gateway sessions use the generic `dm` chat type for direct/private conversations, while QQ platform events call the same scene `c2c`. The QQ approval interaction authorization logic only accepted `c2c`, so valid DM approval button clicks were rejected as unauthorized even when the operator openid matched the session chat id.

Observed log example:

```text
Rejected unauthorized approval click for session agent:main:qqbot:dm:<openid> (operator=<same-openid>)
```

This change accepts both `dm` and `c2c` for QQ private-message approval authorization, while preserving the existing operator equality check.

## Test Plan
- `venv/bin/python -m pytest tests/gateway/test_qqbot.py -q -o 'addopts='`
- Result: `160 passed, 4 warnings`
