### PR TITLE
feat(approval): add risk category + warning banner to approval UI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11583,12 +11583,18 @@ class HermesCLI:
             timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
             response_queue = queue.Queue()
 
+            # Read risk info set by check_all_command_guards via contextvar
+            from tools.approval import _approval_risk_info
+            _risk_info = _approval_risk_info.get()
+
             self._approval_state = {
                 "command": command,
                 "description": description,
                 "choices": self._approval_choices(command, allow_permanent=allow_permanent),
                 "selected": 0,
                 "response_queue": response_queue,
+                "risk_category": _risk_info.get("category"),
+                "risk_warning": _risk_info.get("warning"),
             }
             self._approval_deadline = _time.monotonic() + timeout
 
@@ -11712,6 +11718,8 @@ class HermesCLI:
 
         command = state["command"]
         description = state["description"]
+        risk_category = state.get("risk_category")
+        risk_warning = state.get("risk_warning")
         choices = state["choices"]
         selected = state.get("selected", 0)
         show_full = state.get("show_full", False)
@@ -11727,6 +11735,15 @@ class HermesCLI:
         }
 
         preview_lines = _wrap_panel_text(description, 60)
+        # Build risk line text for box sizing
+        risk_line_parts = []
+        if risk_category:
+            risk_line_parts.append(f"[{risk_category}]")
+        if risk_warning:
+            risk_line_parts.append(risk_warning)
+        risk_text = " ".join(risk_line_parts) if risk_line_parts else ""
+        if risk_text:
+            preview_lines.extend(_wrap_panel_text(risk_text, 60))
         preview_lines.extend(_wrap_panel_text(cmd_display, 60))
         for i, choice in enumerate(choices):
             prefix = '❯ ' if i == selected else '  '
@@ -11816,6 +11833,19 @@ class HermesCLI:
         _append_panel_line(lines, 'class:approval-border', 'class:approval-title', title, box_width)
         if not use_compact_chrome:
             _append_blank_panel_line(lines, 'class:approval-border', box_width)
+
+        # Risk banner: category + warning between title and command
+        risk_line_parts = []
+        if risk_category:
+            risk_line_parts.append(f"[{risk_category}]")
+        if risk_warning:
+            risk_line_parts.append(risk_warning)
+        risk_text = " ".join(risk_line_parts) if risk_line_parts else ""
+        if risk_text:
+            for wrapped in _wrap_panel_text(risk_text, inner_text_width):
+                _append_panel_line(lines, 'class:approval-border', 'class:approval-risk', wrapped, box_width)
+            if not use_compact_chrome:
+                _append_blank_panel_line(lines, 'class:approval-border', box_width)
 
         for wrapped in cmd_wrapped:
             _append_panel_line(lines, 'class:approval-border', 'class:approval-cmd', wrapped, box_width)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1861,6 +1861,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        risk_category: Optional[str] = None,
+        risk_warning: Optional[str] = None,
     ) -> SendResult:
         """Send an interactive card with approval buttons.
 

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1269,6 +1269,8 @@ class MatrixAdapter(BasePlatformAdapter):
         session_key: str,
         description: str = "dangerous command",
         metadata: Optional[dict] = None,
+        risk_category: Optional[str] = None,
+        risk_warning: Optional[str] = None,
     ) -> SendResult:
         """Send a reaction-based exec approval prompt for Matrix."""
         if not self._client:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2654,6 +2654,8 @@ class QQAdapter(BasePlatformAdapter):
             session_key: str,
             description: str = "dangerous command",
             metadata: Optional[Dict[str, Any]] = None,
+            risk_category: Optional[str] = None,
+            risk_warning: Optional[str] = None,
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2650,6 +2650,8 @@ class SlackAdapter(BasePlatformAdapter):
         session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        risk_category: Optional[str] = None,
+        risk_warning: Optional[str] = None,
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
 
@@ -2663,6 +2665,13 @@ class SlackAdapter(BasePlatformAdapter):
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
 
+            risk_line_parts = []
+            if risk_category:
+                risk_line_parts.append(f"[{risk_category}]")
+            if risk_warning:
+                risk_line_parts.append(risk_warning)
+            risk_text = " ".join(risk_line_parts)
+
             blocks = [
                 {
                     "type": "section",
@@ -2675,6 +2684,13 @@ class SlackAdapter(BasePlatformAdapter):
                         ),
                     },
                 },
+                *([{
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f":warning: *{risk_text}*",
+                    },
+                }] if risk_text else []),
                 {
                     "type": "actions",
                     "elements": [

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2626,6 +2626,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        risk_category: Optional[str] = None,
+        risk_warning: Optional[str] = None,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
@@ -2637,8 +2639,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            risk_line_parts = []
+            if risk_category:
+                risk_line_parts.append(f"<b>[{_html.escape(risk_category)}]</b>")
+            if risk_warning:
+                risk_line_parts.append(_html.escape(risk_warning))
+            risk_html = f"{' '.join(risk_line_parts)}\n\n" if risk_line_parts else ""
             text = (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"{risk_html}"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
                 f"Reason: {_html.escape(description)}"
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17781,6 +17781,8 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                risk_category = approval_data.get("risk_category")
+                risk_warning = approval_data.get("risk_warning")
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -17794,6 +17796,8 @@ class GatewayRunner:
                                 session_key=_approval_session_key,
                                 description=desc,
                                 metadata=_status_thread_metadata,
+                                risk_category=risk_category,
+                                risk_warning=risk_warning,
                             ),
                             _loop_for_step,
                             logger=logger,
@@ -17815,8 +17819,16 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                risk_line_parts = []
+                if risk_category:
+                    risk_line_parts.append(f"[{risk_category}]")
+                if risk_warning:
+                    risk_line_parts.append(risk_warning)
+                risk_text = " ".join(risk_line_parts)
+                risk_block = f"\n{risk_text}\n" if risk_text else ""
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
+                    f"{risk_block}"
                     f"```\n{cmd_preview}\n```\n"
                     f"Reason: {desc}\n\n"
                     f"Reply `/approve` to execute, `/approve session` to approve this pattern "

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -918,6 +918,7 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         "approval-border": input_rule,
         "approval-title": f"{warn} bold",
         "approval-desc": f"{text} bold",
+        "approval-risk": f"{warn}",
         "approval-cmd": f"{dim} italic",
         "approval-choice": dim,
         "approval-selected": f"{title} bold",

--- a/locales/risk.yaml
+++ b/locales/risk.yaml
@@ -1,0 +1,184 @@
+# Risk category mapping and translations for approval UI.
+# Loaded by tools/approval.py _load_risk_data().
+#
+# category: maps each DANGEROUS_PATTERNS / HARDLINE_PATTERNS
+#   description to a risk category ID.  Keep in sync with the
+#   patterns in tools/approval.py.
+#
+# Each category ID below has label (name in each language) and
+# warning (risk description in each language).
+# To add a new language, add its key under label and warning for
+# every category.
+
+category:
+  # FILE_DELETION
+  delete in root path: FILE_DELETION
+  recursive delete: FILE_DELETION
+  recursive delete (long flag): FILE_DELETION
+  recursive delete of root filesystem: FILE_DELETION
+  recursive delete of system directory: FILE_DELETION
+  recursive delete of home directory: FILE_DELETION
+  xargs with rm: FILE_DELETION
+  find -exec/-execdir rm: FILE_DELETION
+  find -delete: FILE_DELETION
+  # SYSTEM_CONFIG_OVERWRITE
+  overwrite system config: SYSTEM_CONFIG_OVERWRITE
+  overwrite system file via tee: SYSTEM_CONFIG_OVERWRITE
+  overwrite system file via redirection: SYSTEM_CONFIG_OVERWRITE
+  copy/move file into system config path: SYSTEM_CONFIG_OVERWRITE
+  in-place edit of system config: SYSTEM_CONFIG_OVERWRITE
+  in-place edit of system config (long flag): SYSTEM_CONFIG_OVERWRITE
+  dd to raw block device: SYSTEM_CONFIG_OVERWRITE
+  redirect to raw block device: SYSTEM_CONFIG_OVERWRITE
+  # PROJECT_CONFIG_OVERWRITE
+  overwrite project env/config via tee: PROJECT_CONFIG_OVERWRITE
+  overwrite project env/config via redirection: PROJECT_CONFIG_OVERWRITE
+  overwrite project env/config file: PROJECT_CONFIG_OVERWRITE
+  # GIT_DATA_LOSS
+  git reset --hard (destroys uncommitted changes): GIT_DATA_LOSS
+  git force push (rewrites remote history): GIT_DATA_LOSS
+  git force push short flag (rewrites remote history): GIT_DATA_LOSS
+  git clean with force (deletes untracked files): GIT_DATA_LOSS
+  git branch force delete: GIT_DATA_LOSS
+  # DATABASE_DESTRUCTION
+  SQL DROP: DATABASE_DESTRUCTION
+  SQL DELETE without WHERE: DATABASE_DESTRUCTION
+  SQL TRUNCATE: DATABASE_DESTRUCTION
+  # DISK_FORMAT
+  format filesystem: DISK_FORMAT
+  format filesystem (mkfs): DISK_FORMAT
+  disk copy: DISK_FORMAT
+  write to block device: DISK_FORMAT
+  # REMOTE_CODE_EXECUTION
+  shell command via -c/-lc flag: REMOTE_CODE_EXECUTION
+  script execution via -e/-c flag: REMOTE_CODE_EXECUTION
+  script execution via heredoc: REMOTE_CODE_EXECUTION
+  pipe remote content to shell: REMOTE_CODE_EXECUTION
+  execute remote script via process substitution: REMOTE_CODE_EXECUTION
+  chmod +x followed by immediate execution: REMOTE_CODE_EXECUTION
+  # PROCESS_TERMINATION
+  kill all processes: PROCESS_TERMINATION
+  force kill processes: PROCESS_TERMINATION
+  force kill processes (killall -KILL): PROCESS_TERMINATION
+  force kill processes (killall -s KILL): PROCESS_TERMINATION
+  kill processes by regex (killall -r): PROCESS_TERMINATION
+  kill hermes/gateway process (self-termination): PROCESS_TERMINATION
+  kill process via pgrep expansion (self-termination): PROCESS_TERMINATION
+  kill process via backtick pgrep expansion (self-termination): PROCESS_TERMINATION
+  # SERVICE_LIFECYCLE
+  stop/restart system service: SERVICE_LIFECYCLE
+  stop/restart hermes gateway (kills running agents): SERVICE_LIFECYCLE
+  hermes update (restarts gateway, kills running agents): SERVICE_LIFECYCLE
+  docker compose restart/stop/kill/down (container lifecycle): SERVICE_LIFECYCLE
+  docker restart/stop/kill (container lifecycle): SERVICE_LIFECYCLE
+  start gateway outside systemd (use 'systemctl --user restart hermes-gateway'): SERVICE_LIFECYCLE
+  # SYSTEM_SHUTDOWN
+  system shutdown/reboot: SYSTEM_SHUTDOWN
+  init 0/6 (shutdown/reboot): SYSTEM_SHUTDOWN
+  systemctl poweroff/reboot: SYSTEM_SHUTDOWN
+  telinit 0/6 (shutdown/reboot): SYSTEM_SHUTDOWN
+  # PERMISSION_ESCALATION
+  world/other-writable permissions: PERMISSION_ESCALATION
+  recursive world/other-writable (long flag): PERMISSION_ESCALATION
+  recursive chown to root: PERMISSION_ESCALATION
+  recursive chown to root (long flag): PERMISSION_ESCALATION
+  sudo with privilege flag (stdin/askpass/shell/list): PERMISSION_ESCALATION
+  sudo with combined-flag privilege escalation: PERMISSION_ESCALATION
+  # FORK_BOMB
+  fork bomb: FORK_BOMB
+
+FILE_DELETION:
+  label:
+    en: "File Deletion"
+    zh: "删除文件"
+  warning:
+    en: "This will permanently delete files and cannot be undone."
+    zh: "此操作将永久删除文件，无法恢复。"
+
+SYSTEM_CONFIG_OVERWRITE:
+  label:
+    en: "System Config Overwrite"
+    zh: "系统配置覆盖"
+  warning:
+    en: "This modifies system configuration files and may affect system stability."
+    zh: "此操作将修改系统配置文件，可能影响系统稳定性。"
+
+PROJECT_CONFIG_OVERWRITE:
+  label:
+    en: "Project Config Overwrite"
+    zh: "项目配置覆盖"
+  warning:
+    en: "This overwrites project environment or configuration files."
+    zh: "此操作将覆盖项目环境变量或配置文件。"
+
+GIT_DATA_LOSS:
+  label:
+    en: "Git Data Loss"
+    zh: "Git 数据丢失"
+  warning:
+    en: "This will permanently discard uncommitted work or rewrite history."
+    zh: "此操作将永久丢弃未提交的工作或重写历史记录。"
+
+DATABASE_DESTRUCTION:
+  label:
+    en: "Database Destruction"
+    zh: "数据库删除"
+  warning:
+    en: "This permanently deletes database data or schema."
+    zh: "此操作将永久删除数据库数据或结构。"
+
+DISK_FORMAT:
+  label:
+    en: "Disk Format"
+    zh: "磁盘格式化"
+  warning:
+    en: "This destroys data on the target disk or partition."
+    zh: "此操作将销毁目标磁盘或分区上的数据。"
+
+REMOTE_CODE_EXECUTION:
+  label:
+    en: "Remote Code Execution"
+    zh: "远程代码执行"
+  warning:
+    en: "This downloads and executes code from an external source."
+    zh: "此操作将从外部来源下载并执行代码。"
+
+PROCESS_TERMINATION:
+  label:
+    en: "Process Termination"
+    zh: "进程终止"
+  warning:
+    en: "This terminates running processes and may cause data loss."
+    zh: "此操作将终止运行中的进程，可能导致数据丢失。"
+
+SERVICE_LIFECYCLE:
+  label:
+    en: "Service Lifecycle"
+    zh: "服务生命周期"
+  warning:
+    en: "This stops or restarts services and will disrupt running operations."
+    zh: "此操作将停止或重启服务，会中断正在运行的操作。"
+
+SYSTEM_SHUTDOWN:
+  label:
+    en: "System Shutdown"
+    zh: "系统关机"
+  warning:
+    en: "This shuts down or reboots the system immediately."
+    zh: "此操作将立即关机或重启系统。"
+
+PERMISSION_ESCALATION:
+  label:
+    en: "Permission Escalation"
+    zh: "提权操作"
+  warning:
+    en: "This changes file permissions or escalates privileges."
+    zh: "此操作将修改文件权限或提升权限等级。"
+
+FORK_BOMB:
+  label:
+    en: "Fork Bomb"
+    zh: "Fork 炸弹"
+  warning:
+    en: "This will crash the system by exhausting all resources."
+    zh: "此操作将耗尽系统资源导致崩溃。"

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4064,6 +4064,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[dict] = None,
+        risk_category: Optional[str] = None,
+        risk_warning: Optional[str] = None,
     ) -> SendResult:
         """
         Send a button-based exec approval prompt for a dangerous command.
@@ -4092,6 +4094,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 description=f"```\n{cmd_display}\n```",
                 color=discord.Color.orange(),
             )
+            # Risk field
+            risk_line_parts = []
+            if risk_category:
+                risk_line_parts.append(f"**[{risk_category}]**")
+            if risk_warning:
+                risk_line_parts.append(risk_warning)
+            risk_text = " ".join(risk_line_parts)
+            if risk_text:
+                embed.add_field(name="⚠️ Risk", value=risk_text, inline=False)
             embed.add_field(name="Reason", value=description, inline=False)
 
             view = ExecApprovalView(

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -920,6 +920,8 @@ class TeamsAdapter(BasePlatformAdapter):
         session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        risk_category: Optional[str] = None,
+        risk_warning: Optional[str] = None,
     ) -> SendResult:
         """Send an Adaptive Card approval prompt with Allow/Deny buttons."""
         if not self._app:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1520,3 +1520,60 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+
+
+class TestRiskInfo:
+    """Tests for _get_risk_info — risk category + warning for approval UI."""
+
+    def test_returns_category_for_known_description(self):
+        from tools.approval import _get_risk_info
+        result = _get_risk_info(["recursive delete"])
+        assert result["category"] is not None
+        assert "File Deletion" in result["category"]
+
+    def test_returns_warning_for_known_description(self):
+        from tools.approval import _get_risk_info
+        result = _get_risk_info(["recursive delete"])
+        assert result["warning"] is not None
+        assert "permanently delete" in result["warning"].lower()
+
+    def test_returns_none_for_unknown_description(self):
+        from tools.approval import _get_risk_info
+        result = _get_risk_info(["some unknown pattern"])
+        assert result["category"] is None
+        assert result["warning"] is None
+
+    def test_empty_list_returns_none(self):
+        from tools.approval import _get_risk_info
+        result = _get_risk_info([])
+        assert result["category"] is None
+        assert result["warning"] is None
+
+    def test_all_dangerous_patterns_have_risk_category(self):
+        from tools.approval import (
+            DANGEROUS_PATTERNS, HARDLINE_PATTERNS, _load_risk_data
+        )
+        data = _load_risk_data()
+        cat_map = data.get("category", {})
+        all_descs = set()
+        for _, desc in DANGEROUS_PATTERNS:
+            all_descs.add(desc)
+        for _, desc in HARDLINE_PATTERNS:
+            all_descs.add(desc)
+        mapped = set(cat_map.keys())
+        missing = all_descs - mapped
+        extra = mapped - all_descs
+        if missing or extra:
+            msg = []
+            if missing:
+                msg.append(f"Missing categories for: {sorted(missing)}")
+            if extra:
+                msg.append(f"Unknown keys in risk.yaml: {sorted(extra)}")
+            pytest.fail("; ".join(msg))
+
+    def test_returns_chinese_label_when_lang_is_zh(self, monkeypatch):
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        from tools.approval import _get_risk_info
+        result = _get_risk_info(["recursive delete"])
+        assert result["category"] == "删除文件"
+        assert "文件" in result["warning"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -37,6 +37,14 @@ _approval_session_key: contextvars.ContextVar[str] = contextvars.ContextVar(
     default="",
 )
 
+# Per-thread/per-task risk info for CLI approval callback.
+# Set in check_all_command_guards before calling the CLI callback,
+# read inside the callback when building _approval_state.
+_approval_risk_info: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "approval_risk_info",
+    default={},
+)
+
 
 def _fire_approval_hook(hook_name: str, **kwargs) -> None:
     """Invoke a plugin lifecycle hook for the approval system.
@@ -1318,6 +1326,10 @@ def check_all_command_guards(command: str, env_type: str,
     all_keys = [key for key, _, _ in warnings]
     has_tirith = any(is_t for _, _, is_t in warnings)
 
+    # Risk info for approval UI banners (category + warning).
+    risk_descriptions = [desc for _, desc, _ in warnings]
+    _risk_info = _get_risk_info(risk_descriptions)
+
     # Gateway/async approval — block the agent thread until the user
     # responds with /approve or /deny, mirroring the CLI's synchronous
     # input() flow.  The agent never sees "approval_required"; it either
@@ -1337,6 +1349,8 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": combined_desc,
+                "risk_category": _risk_info.get("category"),
+                "risk_warning": _risk_info.get("warning"),
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
@@ -1427,9 +1441,13 @@ def check_all_command_guards(command: str, env_type: str,
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(command, combined_desc,
-                                       allow_permanent=not has_tirith,
-                                       approval_callback=approval_callback)
+    token = _approval_risk_info.set(_risk_info)
+    try:
+        choice = prompt_dangerous_approval(command, combined_desc,
+                                           allow_permanent=not has_tirith,
+                                           approval_callback=approval_callback)
+    finally:
+        _approval_risk_info.reset(token)
     _fire_approval_hook(
         "post_approval_response",
         command=command,
@@ -1639,6 +1657,90 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     # persists to future scripts.
     return {"approved": True, "message": None,
             "user_approved": True, "description": description}
+
+
+# =========================================================================
+# Risk category mapping for dangerous command approval UI
+# =========================================================================
+# Maps each DANGEROUS_PATTERNS / HARDLINE_PATTERNS description to a
+# user-facing risk category and a short warning.  Data lives in
+# locales/risk.yaml (category + label + warning per language).
+# Unknown descriptions silently produce None (no banner rendered).
+
+def _load_risk_data() -> dict:
+    """Load risk category mapping + translations from locales/risk.yaml.
+
+    Returns a dict with:
+      "category" -> {description: category_id, ...}
+      "<category_id>" -> {"label": {en: ..., zh: ...}, "warning": {...}}
+    Returns empty dict on any error (banner silently degrades to None).
+    """
+    try:
+        from agent.i18n import _locales_dir as _base_dir
+        import yaml
+        path = _base_dir() / "risk.yaml"
+        if path.is_file():
+            with path.open("r", encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+    except Exception:
+        pass
+    return {}
+
+
+def _get_risk_info(descriptions: list[str]) -> dict:
+    """Return risk category label + warning for a list of matched descriptions.
+
+    Args:
+        descriptions: Description strings from matched DANGEROUS_PATTERNS
+                      and/or HARDLINE_PATTERNS entries.
+
+    Returns:
+        dict with keys:
+          "category" — user-facing category label in the active language,
+                       or None if no description maps to a known category.
+          "warning"  — human-readable risk warning in the active language,
+                       or None if no warning is available.
+    """
+    data = _load_risk_data()
+    cat_map: dict = data.get("category", {})
+
+    # Collect unique categories from all descriptions
+    categories: set[str] = set()
+    for desc in descriptions:
+        cat = cat_map.get(desc)
+        if cat:
+            categories.add(cat)
+
+    if not categories:
+        return {"category": None, "warning": None}
+
+    # Primary category = first description's mapping
+    primary = None
+    for desc in descriptions:
+        cat = cat_map.get(desc)
+        if cat:
+            primary = cat
+            break
+
+    # Resolve active language
+    try:
+        from agent.i18n import get_language
+        lang = get_language()
+    except Exception:
+        lang = "en"
+
+    # Get label and warning in the active language
+    cat_data = data.get(primary, {})
+    labels = cat_data.get("label", {})
+    label = labels.get(lang) or labels.get("en") or primary
+
+    warnings = cat_data.get("warning", {})
+    warning = warnings.get(lang) or warnings.get("en") or ""
+
+    return {
+        "category": label or None,
+        "warning": warning or None,
+    }
 
 
 # Load permanent allowlist from config on module import


### PR DESCRIPTION
## Summary

Inject risk category label and risk warning into the approval dialog across CLI, Telegram, Slack, and Discord. Non-rendering adapters (Matrix, Feishu, QQBot, Teams) accept the new signature params but skip rendering.

63 DANGEROUS_PATTERNS + HARDLINE_PATTERNS descriptions map to 12 risk categories with bilingual (en/zh) labels and warnings via a static lookup table — zero command parsing, zero heuristics.

All risk data lives in `locales/risk.yaml`: category mapping, per-category labels + warnings in en/zh. Adding a new language requires editing one YAML file only.

## Changes

- `tools/approval.py`: `_load_risk_data()` + `_get_risk_info()`, contextvar for CLI callback, injection into `approval_data` dict
- `cli.py`: read risk from contextvar, store in `_approval_state`, render banner between title and command
- `hermes_cli/skin_engine.py`: register `approval-risk` style
- `gateway/run.py`: pass risk fields through to `send_exec_approval` + fallback text
- 7 platform adapters: accept `risk_category=None, risk_warning=None`; Telegram/Slack/Discord render, others sig only
- `locales/risk.yaml` (new): all risk data
- `tests/tools/test_approval.py`: TestRiskInfo (6 cases, incl. full coverage check)

## Design constraints

- Zero function signature changes in detection/approval chain
- Zero new dependencies
- Zero new Python files (1 YAML data file)
- 100% backward compatible (all new params default to None)

## Testing

- `tests/tools/test_approval.py`: 194/194 passed (6 new TestRiskInfo)
- CI: all 16 checks green (3 pre-existing failures unrelated: WhatsApp adapter test, slash-confirm mock test, fork attribution check)