### PR TITLE
fix(auxiliary): route minimax-oauth provider through dedicated helper

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1896,6 +1896,84 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
+def _build_minimax_oauth_aux_client(model: Optional[str]) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an auxiliary client for a MiniMax OAuth-authenticated session.
+
+    MiniMax's inference endpoint is Anthropic-compatible (the
+    ``/v1/messages`` wire format), but it's exposed under the OpenAI
+    ``/v1`` URL prefix and is reached via a short-lived bearer token
+    minted by MiniMax's device-code OAuth flow.  The persisted
+    ``access_token`` lives in ``auth.json`` under ``providers.minimax-oauth``
+    and is rotated every ~15 minutes by :func:`_refresh_minimax_oauth_state`.
+
+    We pass the *token provider callable* (not the raw string) as
+    ``api_key`` so that ``_wrap_if_needed`` -> ``build_anthropic_client``
+    installs a per-request bearer hook that re-reads the latest token from
+    ``auth.json`` on every outbound request.  Without that hook, the static
+    token captured at client construction would expire mid-session and the
+    user would see 401s on long-running auxiliary work
+    (compression, title_generation, curator, etc.).
+
+    Returns ``(None, None)`` when the user has not authenticated with
+    MiniMax OAuth (no entry in ``auth.json``, or the entry has no
+    ``access_token``).
+    """
+    try:
+        from hermes_cli.auth import build_minimax_oauth_token_provider
+    except ImportError:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but "
+            "hermes_cli.auth.build_minimax_oauth_token_provider is unavailable"
+        )
+        return None, None
+
+    # Probe auth state once to fail fast with a clear warning when the user
+    # isn't logged in.  build_minimax_oauth_token_provider() doesn't surface
+    # that case at construction time — it raises on the first invocation,
+    # which would land mid-request with a confusing traceback.
+    try:
+        from hermes_cli.auth import get_minimax_oauth_auth_status
+        status = get_minimax_oauth_auth_status()
+    except ImportError:
+        status = None
+    if status is not None and not status.get("logged_in", False):
+        return None, None
+
+    api_key = build_minimax_oauth_token_provider()
+    # The MiniMax OAuth base URL is stored in auth.json under
+    # ``inference_base_url`` (e.g. https://api.minimax.io/anthropic for
+    # the global region). We could read it from there, but for auxiliary
+    # tasks the Anthropic-compatible endpoint and the OpenAI SDK wrapper
+    # both work as long as we use the URL the OAuth state recorded at
+    # login time.  resolve_minimax_oauth_runtime_credentials is the
+    # authoritative source.
+    try:
+        from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+        creds = resolve_minimax_oauth_runtime_credentials()
+        base_url = creds.get("base_url", "").rstrip("/")
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but no MiniMax OAuth "
+            "token found in auth.json (run: hermes model -> MiniMax (OAuth)): %s",
+            exc,
+        )
+        return None, None
+
+    if not base_url:
+        logger.warning(
+            "Auxiliary client: minimax-oauth resolved but base_url is empty"
+        )
+        return None, None
+
+    logger.debug("Auxiliary client: MiniMax OAuth (model=%s base_url=%s)", model, base_url)
+    real_client = OpenAI(api_key=api_key, base_url=base_url)
+    # _wrap_if_needed in the caller detects the Anthropic-compatible
+    # endpoint (base_url ends in /anthropic or matches _ANTHROPIC_COMPAT_PROVIDERS)
+    # and swaps in the Anthropic transport automatically.
+    final_model = (model or "").strip() or creds.get("default_model", "MiniMax-M2.7-highspeed")
+    return real_client, final_model
+
+
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
@@ -3415,6 +3493,43 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── MiniMax OAuth (device-code flow) ─────────────────────────────
+    # Without this branch, a minimax-oauth main provider falls through to
+    # the generic ``oauth_minimax`` arm below (which currently only logs a
+    # warning and returns None). Auxiliary tasks configured with
+    # ``provider: minimax-oauth`` (compression, title_generation, etc.)
+    # would then raise the misleading
+    # "Provider 'minimax-oauth' is set in config.yaml but no API key was found"
+    # error, even though the user is logged in via ``hermes auth`` /
+    # ``hermes model -> MiniMax (OAuth)``.
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "MiniMax OAuth token found (run: hermes model -> MiniMax (OAuth))"
+            )
+            return None, None
+        # Note: the main agent path uses the Anthropic-Messages endpoint
+        # at https://api.minimax.io/anthropic/ for OAuth, but auxiliary
+        # tasks work fine over the OpenAI-compatible /v1/chat/completions
+        # route at the same host. We rewrite the base_url to the OpenAI
+        # path so the bare OpenAI client we built in the helper works
+        # without needing the Anthropic transport wrapper. The OAuth
+        # token provider is plumbed through ``OpenAI(api_key=callable)``
+        # which the SDK accepts and reads on every request — this is the
+        # same pattern the main chat path uses.
+        try:
+            _raw = str(getattr(client, "base_url", "") or "")
+            if _raw.endswith("/anthropic") or _raw.endswith("/anthropic/"):
+                _openai_base = _raw.rstrip("/").removesuffix("/anthropic") + "/v1"
+                client.base_url = _openai_base  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        final_model = _normalize_resolved_model(model or default, provider) or ""
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
@@ -3819,6 +3934,12 @@ def resolve_provider_client(
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)
         return None, None
+    elif pconfig.auth_type == "oauth_minimax":
+        # MiniMax uses its own auth_type (``oauth_minimax``) that isn't in the
+        # generic ``oauth_device_code``/``oauth_external`` set above. Route
+        # through the dedicated minimax-oauth helper so the token provider
+        # in auth.json is consulted.
+        return resolve_provider_client("minimax-oauth", model, async_mode)
 
     logger.warning("resolve_provider_client: unhandled auth_type %s for %s",
                    pconfig.auth_type, provider)

--- a/tests/agent/test_auxiliary_client_minimax_oauth.py
+++ b/tests/agent/test_auxiliary_client_minimax_oauth.py
@@ -1,0 +1,229 @@
+"""Regression test for the minimax-oauth auxiliary routing bug.
+
+Symptom: auxiliary tasks configured with ``provider: minimax-oauth`` (e.g.
+``auxiliary.title_generation.provider: minimax-oauth``) raised:
+
+    RuntimeError: Provider 'minimax-oauth' is set in config.yaml but no
+    API key was found. Set the MINIMAX-OAUTH_API_KEY environment variable,
+    or switch to a different provider with `hermes model`.
+
+Root cause: ``resolve_provider_client()`` in
+``agent/auxiliary_client.py`` had early branches for the ``nous``,
+``openai-codex``, and ``xai-oauth`` OAuth providers, but no branch for
+``minimax-oauth``.  Requests fell through to the generic
+``pconfig.auth_type in {"oauth_device_code", "oauth_external"}`` arm
+which doesn't list ``oauth_minimax``, and then to a final
+``unhandled auth_type oauth_minimax`` warning that returns ``(None, None)``.
+The caller then raised the misleading "no API key" error.
+
+These tests verify the fix:
+
+1. ``_build_minimax_oauth_aux_client`` returns a working client when
+   auth.json has a valid MiniMax OAuth token.
+2. ``_build_minimax_oauth_aux_client`` returns ``(None, None)`` when the
+   user is not logged in (no entry in auth.json).
+3. ``resolve_provider_client("minimax-oauth", ...)`` no longer falls
+   through to the misleading "no API key" path.
+4. The ``oauth_minimax`` auth_type routes through the dedicated branch
+   (defense in depth — the early branch above is the primary path).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _fake_auth_state(logged_in: bool = True) -> dict:
+    """Mimic the shape of ``get_minimax_oauth_auth_status()``."""
+    return {
+        "logged_in": logged_in,
+        "provider": "minimax-oauth",
+        "region": "global",
+    }
+
+
+def _fake_oauth_creds() -> dict:
+    """Mimic the shape of ``resolve_minimax_oauth_runtime_credentials()``."""
+    return {
+        "provider": "minimax-oauth",
+        "api_key": "fake-access-token-abc123",
+        "base_url": "https://api.minimax.io/anthropic",
+        "source": "oauth",
+    }
+
+
+# ── _build_minimax_oauth_aux_client: happy path ─────────────────────────────
+
+
+class TestBuildMinimaxOauthAuxClient:
+    """Verify _build_minimax_oauth_aux_client returns a working client."""
+
+    def _import(self):
+        from agent.auxiliary_client import _build_minimax_oauth_aux_client
+        return _build_minimax_oauth_aux_client
+
+    def test_returns_client_when_logged_in(self):
+        build = self._import()
+        with patch(
+            "hermes_cli.auth.get_minimax_oauth_auth_status",
+            return_value=_fake_auth_state(logged_in=True),
+        ), patch(
+            "hermes_cli.auth.build_minimax_oauth_token_provider",
+            return_value=lambda: "fresh-token",
+        ), patch(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            return_value=_fake_oauth_creds(),
+        ):
+            client, model = build("MiniMax-M3")
+
+        assert client is not None, "client must not be None when logged in"
+        assert model == "MiniMax-M3", f"expected caller-provided model, got {model!r}"
+
+    def test_returns_client_with_model_fallback(self):
+        """When no model is provided, falls back to a sensible default."""
+        build = self._import()
+        with patch(
+            "hermes_cli.auth.get_minimax_oauth_auth_status",
+            return_value=_fake_auth_state(logged_in=True),
+        ), patch(
+            "hermes_cli.auth.build_minimax_oauth_token_provider",
+            return_value=lambda: "fresh-token",
+        ), patch(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            return_value=_fake_oauth_creds(),
+        ):
+            client, model = build(None)
+
+        assert client is not None
+        assert model, "model must be non-empty even when caller passed None"
+
+    def test_returns_none_when_not_logged_in(self):
+        """When auth.json has no MiniMax entry, return (None, None) cleanly."""
+        build = self._import()
+        with patch(
+            "hermes_cli.auth.get_minimax_oauth_auth_status",
+            return_value=_fake_auth_state(logged_in=False),
+        ):
+            client, model = build("MiniMax-M3")
+
+        assert client is None
+        assert model is None
+
+    def test_returns_none_when_creds_resolution_raises(self):
+        """If resolve_minimax_oauth_runtime_credentials raises AuthError,
+        the helper must return (None, None) instead of propagating."""
+        from hermes_cli.auth import AuthError
+
+        build = self._import()
+        with patch(
+            "hermes_cli.auth.get_minimax_oauth_auth_status",
+            return_value=_fake_auth_state(logged_in=True),
+        ), patch(
+            "hermes_cli.auth.build_minimax_oauth_token_provider",
+            return_value=lambda: "token",
+        ), patch(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            side_effect=AuthError("not logged in", provider="minimax-oauth"),
+        ):
+            client, model = build("MiniMax-M3")
+
+        assert client is None
+        assert model is None
+
+
+# ── resolve_provider_client dispatch ───────────────────────────────────────
+
+
+class TestResolveProviderClientMinimaxOauth:
+    """Verify resolve_provider_client('minimax-oauth', ...) routes correctly.
+
+    Before the fix, this would fall through to the
+    ``unhandled auth_type oauth_minimax`` warning and return ``(None, None)``,
+    which the caller then translated into the misleading "no API key" error.
+    """
+
+    def test_dispatches_to_minimax_oauth_helper(self):
+        """The provider dispatch should reach the new branch instead of
+        falling through to the generic OAuth arm."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        fake_client = MagicMock(name="minimax_oauth_client")
+        with patch(
+            "agent.auxiliary_client._build_minimax_oauth_aux_client",
+            return_value=(fake_client, "MiniMax-M3"),
+        ) as mock_build:
+            client, model = resolve_provider_client("minimax-oauth", "MiniMax-M3")
+
+        mock_build.assert_called_once()
+        assert client is fake_client, "should return the client built by the helper"
+        assert model == "MiniMax-M3"
+
+    def test_returns_none_cleanly_when_helper_returns_none(self):
+        """When the helper returns (None, None) (user not logged in),
+        resolve_provider_client should also return (None, None) — *not*
+        raise the misleading "no API key" RuntimeError."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        with patch(
+            "agent.auxiliary_client._build_minimax_oauth_aux_client",
+            return_value=(None, None),
+        ):
+            client, model = resolve_provider_client("minimax-oauth", "MiniMax-M3")
+
+        assert client is None
+        assert model is None
+
+    def test_oauth_minimax_auth_type_branch_exists(self):
+        """Defense in depth: the auth_type dispatch in
+        resolve_provider_client should have an ``elif pconfig.auth_type
+        == 'oauth_minimax'`` arm.  Source-grep test — the branch is
+        short and unambiguous, and a future refactor is more likely to
+        preserve the semantic than to preserve a mockable surface."""
+        import inspect
+        from agent.auxiliary_client import resolve_provider_client
+
+        source = inspect.getsource(resolve_provider_client)
+        assert 'pconfig.auth_type == "oauth_minimax"' in source, (
+            "the oauth_minimax auth_type fallback has been removed or "
+            "refactored; verify the minimax-oauth dispatch still works"
+        )
+
+
+# ── regression: the original error message must no longer fire ──────────────
+
+
+class TestNoMisleadingApiKeyError:
+    """Before the fix, callers raised:
+
+        RuntimeError: Provider 'minimax-oauth' is set in config.yaml but
+        no API key was found. Set the MINIMAX-OAUTH_API_KEY environment
+        variable, or switch to a different provider with `hermes model`.
+
+    This regression test asserts that the error string is *not* raised
+    when the user is correctly authenticated with MiniMax OAuth.
+    """
+
+    def test_does_not_raise_api_key_error_when_logged_in(self):
+        from agent.auxiliary_client import resolve_provider_client
+
+        fake_client = MagicMock(name="minimax_oauth_client_no_error")
+        with patch(
+            "agent.auxiliary_client._build_minimax_oauth_aux_client",
+            return_value=(fake_client, "MiniMax-M3"),
+        ):
+            try:
+                client, model = resolve_provider_client("minimax-oauth", "MiniMax-M3")
+            except RuntimeError as exc:
+                msg = str(exc)
+                assert "MINIMAX-OAUTH_API_KEY" not in msg, (
+                    "regression: the misleading 'no API key' error is back"
+                )
+                raise
+
+        assert client is fake_client


### PR DESCRIPTION
## Problem

Users with MiniMax OAuth authentication (configured via `hermes model -> MiniMax (OAuth)`) cannot use it for auxiliary tasks (compression, title_generation, web_extract, etc.). Any `auxiliary.<task>.provider: minimax-oauth` config in `config.yaml` produces:

```
RuntimeError: Provider 'minimax-oauth' is set in config.yaml but no API key
was found. Set the MINIMAX-OAUTH_API_KEY environment variable, or switch
to a different provider with `hermes model`.
```

This is misleading: the user is correctly authenticated; the failure is in the dispatch.

## Root cause

`resolve_provider_client()` in `agent/auxiliary_client.py` has early branches for the other OAuth providers:

```
if provider == "nous": ...
if provider == "openai-codex": ...
if provider == "xai-oauth": ...
```

…but no branch for `minimax-oauth`. So requests fall through to the generic `pconfig.auth_type in {"oauth_device_code", "oauth_external"}` arm, which doesn't list `oauth_minimax` (the auth_type the MiniMax ProviderConfig uses). It hits the final `unhandled auth_type oauth_minimax` warning, returns `(None, None)`, and the caller raises the misleading error.

## Fix

1. **New helper `_build_minimax_oauth_aux_client()`** — plumbs the MiniMax OAuth token provider callable (`build_minimax_oauth_token_provider()`) into the OpenAI client so a fresh access token is minted per request (MiniMax issues short-lived tokens, ~15min TTL).
2. **New early branch in `resolve_provider_client()`** — parallel to the nous/openai-codex/xai-oauth branches, routes `provider='minimax-oauth'` to the new helper.
3. **Defensive `elif pconfig.auth_type == 'oauth_minimax'` arm** — belt-and-braces: if someone refactors out the early branch in the future, the auth_type fallback still works.
4. **OpenAI-compatible base_url rewrite** — MiniMax's `/anthropic` endpoint works over `/v1/chat/completions` too, so auxiliary tasks can use the bare OpenAI client (matching the existing `minimax` api-key path).

## Tests

8 new test cases in `tests/agent/test_auxiliary_client_minimax_oauth.py`:

- `test_returns_client_when_logged_in` — happy path
- `test_returns_client_with_model_fallback` — caller passes no model
- `test_returns_none_when_not_logged_in` — clean (None, None) when auth.json has no MiniMax entry
- `test_returns_none_when_creds_resolution_raises` — AuthError handled
- `test_dispatches_to_minimax_oauth_helper` — confirm early-branch routing
- `test_returns_none_cleanly_when_helper_returns_none` — no false-positive error
- `test_oauth_minimax_auth_type_branch_exists` — defensive source-grep on the auth_type fallback
- `test_does_not_raise_api_key_error_when_logged_in` — regression test for the original misleading error string

All 388 auxiliary/minimax tests pass; the 5 unrelated failures elsewhere in `tests/agent/` are pre-existing (verified by running on stashed/clean main).

## Live verification

```
$ python -c "from agent.auxiliary_client import resolve_provider_client, call_llm;               client, model = resolve_provider_client('minimax-oauth', 'MiniMax-M3');               r = call_llm(task='title_generation', messages=[...], max_tokens=200, temperature=0.3)"
client: OpenAI
base_url: https://api.minimax.io/v1/
model: MiniMax-M3
OK, response: ChatCompletion(id='066cb47be319db96ceb0134cb4f5689e', ...)
```

End-to-end call to MiniMax via the new auxiliary path returns a real ChatCompletion.

## Risk

- `auxiliary_client.py` is on the hot path for every auxiliary call (compression, web_extract, title_generation, curator, profile_describer, kanban_decomposer, triage_specifier, approval, mcp, skills_hub, vision). The new code is contained to one early branch and one helper function, both gated on `provider == 'minimax-oauth'`. The defensive auth_type arm only fires for the same provider.
- The `/anthropic` → `/v1` base_url rewrite is wrapped in a try/except so a non-matching base URL silently keeps the original (and would surface the same Anthropic 404 the user might have been seeing before).
- No new dependencies, no new env vars, no schema changes to auth.json.

## Checklist

- [x] Tested locally with live MiniMax OAuth
- [x] All existing auxiliary/minimax tests still pass
- [x] New regression tests cover the original error message
- [x] Defensive fallback for the auth_type dispatch