### PR TITLE
fix(gateway): avoid classifying all 2-member Matrix rooms as DMs

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2517,20 +2517,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _is_dm_room(self, room_id: str) -> bool:
         """Check if a room is a DM."""
-        if self._dm_rooms.get(room_id, False):
-            return True
-        # Fallback: check member count via state store.
-        state_store = (
-            getattr(self._client, "state_store", None) if self._client else None
-        )
-        if state_store:
-            try:
-                members = await state_store.get_members(room_id)
-                if members and len(members) == 2:
-                    return True
-            except Exception:
-                pass
-        return False
+        return self._dm_rooms.get(room_id, False)
 
     async def _refresh_dm_cache(self) -> None:
         """Refresh the DM room cache from m.direct account data."""

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -364,6 +364,51 @@ async def test_require_mention_dm_always_responds(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_two_member_non_dm_still_requires_mention(monkeypatch):
+    """A two-member room not marked in m.direct is treated as group chat."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "true")
+    monkeypatch.setenv("MATRIX_DM_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._client = SimpleNamespace(
+        state_store=SimpleNamespace(
+            get_members=AsyncMock(return_value=["@alice:example.org", "@hermes:example.org"])
+        )
+    )
+    adapter._dm_rooms.clear()
+    event = _make_event("hello without mention")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_two_member_non_dm_uses_group_auto_thread(monkeypatch):
+    """Two-member non-DM rooms should use MATRIX_AUTO_THREAD behavior."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "true")
+    monkeypatch.setenv("MATRIX_DM_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._client = SimpleNamespace(
+        state_store=SimpleNamespace(
+            get_members=AsyncMock(return_value=["@alice:example.org", "@hermes:example.org"])
+        )
+    )
+    adapter._dm_rooms.clear()
+    event = _make_event("@hermes:example.org please reply", event_id="$msg1")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.source.thread_id == "$msg1"
+    assert "$msg1" in adapter._threads
+
+
+@pytest.mark.asyncio
 async def test_dm_strips_full_mxid(monkeypatch):
     """DMs strip the full MXID from body when require_mention is on (default)."""
     monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix room classification so 2-member group rooms are no longer treated as DMs just because they have two members. This restores `MATRIX_REQUIRE_MENTION` behavior and group auto-threading in small non-DM rooms.

## Related Issue

Fixes #24114

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/matrix.py`: removed the member-count fallback in `_is_dm_room`; DM detection now trusts only the `m.direct` cache (`_dm_rooms`).
- `tests/gateway/test_matrix_mention.py`: added regressions proving that two-member rooms not marked as DM still require mentions and use group `MATRIX_AUTO_THREAD` behavior.

## How to Test

1. Run: `pytest tests/gateway/test_matrix_mention.py -q`
2. Verify new coverage:
   - `test_two_member_non_dm_still_requires_mention`
   - `test_two_member_non_dm_uses_group_auto_thread`
3. Confirm both tests pass and validate non-DM handling in 2-member rooms.

## What platforms tested on

- macOS (darwin-arm64), Python 3.11 local worktree

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest tests/gateway/test_matrix_mention.py -q` → `54 passed in 2.16s`
- `scripts/run_tests.sh` was started but reported unrelated existing failures in `tests/agent/lsp/test_client_e2e.py` and `tests/agent/test_anthropic_adapter.py` during parallel execution, outside Matrix gateway changes.
- `python scripts/check-windows-footguns.py` returned informational output (`No staged files to scan ...`) for this local run.

<!-- autocontrib:worker-id=issue-new-0837c355 kind=pr-open -->