### PR TITLE
fix(gateway): create Telegram DM topics from root prompts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2393,19 +2393,64 @@ class GatewayRunner:
     def _telegram_topic_root_lobby_message(self) -> str:
         return (
             "This main chat is reserved for system commands.\n\n"
-            "To start a new Hermes chat, open the All Messages topic at the top "
-            "of this bot interface and send any message there. Telegram will "
-            "create a new topic for that message; each topic works as an "
-            "independent Hermes session."
+            "I tried to create a new Hermes topic for that prompt but couldn't. "
+            "Use Telegram's new-topic/+ button in this bot interface, then send "
+            "your message inside that topic. Each topic works as an independent "
+            "Hermes session."
         )
 
     def _telegram_topic_root_new_message(self) -> str:
         return (
-            "To start a new parallel Hermes chat, open the All Messages topic "
-            "at the top of this bot interface and send any message there. "
-            "Telegram will create a new topic for it.\n\n"
+            "To start a new parallel Hermes chat, send a normal prompt in the "
+            "main/All Messages view and Hermes will create a new topic for it.\n\n"
             "Each topic is an independent Hermes session. Use /new inside an "
             "existing topic only if you want to replace that topic's current session."
+        )
+
+    async def _telegram_topic_source_for_root_prompt(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+    ) -> Optional[SessionSource]:
+        """Create a fresh Telegram DM topic for a root-lobby prompt.
+
+        Telegram's "All Messages" view in bot DMs is not delivered to bots as a
+        special create-topic event: the Bot API sees an ordinary private-chat
+        message with no ``message_thread_id`` (or sometimes General/``1``).
+        If we reject that as the root lobby, users have no message-driven way to
+        start the new parallel session that our own guidance promises.  Treat a
+        non-command root prompt as a request for a new lane: create the forum
+        topic via Bot API, rewrite the event source to that new thread, then let
+        the normal agent path create/bind the session.
+        """
+        if not self._is_telegram_topic_root_lobby(source):
+            return None
+        if event.get_command():
+            return None
+        adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
+        create_topic = getattr(adapter, "_create_dm_topic", None) if adapter is not None else None
+        if not callable(create_topic) or not source.chat_id:
+            return None
+        raw_title = (event.text or "").strip() or "Hermes Chat"
+        title = self._sanitize_telegram_topic_title(raw_title)
+        try:
+            thread_id = await create_topic(int(source.chat_id), title)
+        except Exception:
+            logger.debug("Failed to create Telegram topic for root prompt", exc_info=True)
+            return None
+        if not thread_id:
+            return None
+        logger.info(
+            "telegram topic lobby prompt: created topic chat=%s user=%s thread=%s title=%r",
+            source.chat_id,
+            source.user_id,
+            thread_id,
+            title,
+        )
+        return dataclasses.replace(
+            source,
+            thread_id=str(thread_id),
+            chat_topic=title,
         )
 
     def _telegram_topic_new_header(self, source: SessionSource) -> Optional[str]:
@@ -2413,9 +2458,9 @@ class GatewayRunner:
             return None
         return (
             "Started a new Hermes session in this topic.\n\n"
-            "Tip: for parallel work, open All Messages and send a message there "
-            "to create a separate topic instead of using /new here. /new replaces "
-            "the session attached to the current topic."
+            "Tip: for parallel work, send a normal prompt in the main/All "
+            "Messages view to create a separate topic instead of using /new "
+            "here. /new replaces the session attached to the current topic."
         )
 
     def _record_telegram_topic_binding(
@@ -8283,11 +8328,17 @@ class GatewayRunner:
         # execution of a dangerous command.
 
         if self._is_telegram_topic_root_lobby(source):
-            # Debounce the lobby reminder so a user who forgets about
-            # topic mode and fires ten prompts doesn't get ten copies.
-            if self._should_send_telegram_lobby_reminder(source):
-                return self._telegram_topic_root_lobby_message()
-            return None
+            topic_source = await self._telegram_topic_source_for_root_prompt(event, source)
+            if topic_source is not None:
+                source = topic_source
+                event = dataclasses.replace(event, source=source)
+                _quick_key = self._session_key_for_source(source)
+            else:
+                # Debounce the lobby reminder so a user who forgets about
+                # topic mode and fires ten prompts doesn't get ten copies.
+                if self._should_send_telegram_lobby_reminder(source):
+                    return self._telegram_topic_root_lobby_message()
+                return None
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
@@ -13064,7 +13115,10 @@ class GatewayRunner:
             send_result = await adapter.send(
                 source.chat_id,
                 "System topic for Hermes commands and status.",
-                metadata={"thread_id": str(thread_id)},
+                metadata={
+                    "thread_id": str(thread_id),
+                    "telegram_dm_topic_created_for_send": True,
+                },
             )
             message_id = getattr(send_result, "message_id", None)
         except Exception:
@@ -13292,8 +13346,8 @@ class GatewayRunner:
             "How it works:\n"
             "1. Run /topic once in this DM — Hermes checks BotFather Threads\n"
             "   Settings are enabled and flips on multi-session mode.\n"
-            "2. Tap All Messages at the top of the bot and send any message.\n"
-            "   Telegram creates a new topic for that message; each topic is\n"
+            "2. Send a normal prompt in the main/All Messages view.\n"
+            "   Hermes creates a new topic for that message; each topic is\n"
             "   an independent Hermes session (fresh history, fresh context).\n"
             "3. The root DM becomes a system lobby — send /topic, /status,\n"
             "   /help, /usage there. Normal prompts go in a topic.\n"
@@ -13386,6 +13440,15 @@ class GatewayRunner:
                     await self._send_telegram_topic_setup_image(source)
                 return t("gateway.topic.topics_user_disallowed")
 
+        was_enabled = False
+        try:
+            was_enabled = self._session_db.is_telegram_topic_mode_enabled(
+                chat_id=str(source.chat_id),
+                user_id=str(source.user_id),
+            )
+        except Exception:
+            logger.debug("Failed to read existing Telegram topic mode before /topic", exc_info=True)
+
         try:
             self._session_db.enable_telegram_topic_mode(
                 chat_id=str(source.chat_id),
@@ -13397,7 +13460,7 @@ class GatewayRunner:
             logger.exception("Failed to enable Telegram topic mode")
             return t("gateway.topic.enable_failed", error=exc)
 
-        if not source.thread_id:
+        if not source.thread_id and not was_enabled:
             await self._ensure_telegram_system_topic(source)
 
         if source.thread_id:
@@ -13430,9 +13493,8 @@ class GatewayRunner:
         lines = [
             "Telegram multi-session topics are enabled.",
             "",
-            "To create a new Hermes chat, open All Messages at the top of this "
-            "bot interface and send any message there. Telegram will create a "
-            "new topic for it.",
+            "To create a new Hermes chat, send a normal prompt in the main/All "
+            "Messages view. Hermes will create a new topic for it.",
             "",
         ]
         try:
@@ -13458,7 +13520,7 @@ class GatewayRunner:
             lines.extend([
                 "",
                 "To restore one:",
-                "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
+                "1. Create or open a topic. To create a new one, send a normal prompt in the main/All Messages view.",
                 "2. Send /topic <session-id> inside that topic.",
                 f"Example: Send /topic {sessions[0].get('id')} inside a topic.",
             ])
@@ -13467,7 +13529,7 @@ class GatewayRunner:
                 "No previous unlinked Telegram sessions found.",
                 "",
                 "To restore a previous session later:",
-                "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
+                "1. Create or open a topic. To create a new one, send a normal prompt in the main/All Messages view.",
                 "2. Send /topic <session-id> inside that topic.",
             ])
         return "\n".join(lines)

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -158,7 +158,7 @@ def _make_runner(session_db=None):
 
 
 @pytest.mark.asyncio
-async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_mode_enabled(monkeypatch):
+async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_creation_unavailable(monkeypatch):
     import gateway.run as gateway_run
 
     runner = _make_runner()
@@ -174,7 +174,7 @@ async def test_root_telegram_dm_prompt_is_system_lobby_when_topic_mode_enabled(m
     result = await runner._handle_message(_make_event("hello from root"))
 
     assert "main chat is reserved for system commands" in result
-    assert "All Messages" in result
+    assert "new-topic/+ button" in result
     runner._run_agent.assert_not_called()
     runner.session_store.get_or_create_session.assert_not_called()
 
@@ -195,12 +195,38 @@ async def test_root_telegram_dm_new_shows_create_topic_instruction(monkeypatch):
 
     result = await runner._handle_message(_make_event("/new"))
 
-    assert "create a new topic" in result
-    assert "All Messages" in result
+    assert "send a normal prompt" in result
+    assert "Hermes will create a new topic" in result
     assert "Use /new inside" in result
     runner._run_agent.assert_not_called()
     runner.session_store.reset_session.assert_not_called()
     runner.session_store.get_or_create_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_root_telegram_dm_prompt_creates_topic_and_runs_agent(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner.adapters[Platform.TELEGRAM]._create_dm_topic.return_value = 555
+    runner._handle_message_with_agent = AsyncMock(return_value="agent response")
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("research os cursor movement"))
+
+    assert result == "agent response"
+    runner.adapters[Platform.TELEGRAM]._create_dm_topic.assert_awaited_once()
+    create_args = runner.adapters[Platform.TELEGRAM]._create_dm_topic.await_args.args
+    assert create_args[0] == 208214988
+    assert "research os cursor movement" in create_args[1]
+    runner._handle_message_with_agent.assert_awaited_once()
+    _, routed_source, quick_key, _run_generation = runner._handle_message_with_agent.await_args.args
+    assert routed_source.thread_id == "555"
+    assert quick_key.endswith(":555")
 
 
 @pytest.mark.asyncio
@@ -561,6 +587,28 @@ async def test_topic_root_command_explicitly_migrates_and_enables_topic_mode(tmp
 
 
 @pytest.mark.asyncio
+async def test_topic_root_status_does_not_create_duplicate_system_topic(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    runner = _make_runner(session_db=session_db)
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("root /topic status must not enter the agent loop")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/topic"))
+
+    assert "Telegram multi-session topics are enabled" in result
+    runner.adapters[Platform.TELEGRAM]._create_dm_topic.assert_not_awaited()
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_topic_root_command_lists_unlinked_sessions_for_restore(tmp_path, monkeypatch):
     import gateway.run as gateway_run
 
@@ -823,7 +871,10 @@ async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkey
     adapter.send.assert_awaited_once_with(
         "208214988",
         "System topic for Hermes commands and status.",
-        metadata={"thread_id": "4242"},
+        metadata={
+            "thread_id": "4242",
+            "telegram_dm_topic_created_for_send": True,
+        },
     )
     bot.pin_chat_message.assert_awaited_once_with(
         chat_id=208214988,

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -664,7 +664,7 @@ Topics created outside of the config (e.g., by manually calling the Telegram API
 
 ## Multi-session DM mode (`/topic`)
 
-A ChatGPT-style multi-session DM — one bot, many parallel conversations. Unlike the operator-curated `extra.dm_topics` above, this mode is **user-driven**: no config, no pre-declared topic names. The end user flips it on with `/topic`, then taps the Telegram **+** button to create as many topics as they want, each one a fully independent Hermes session.
+A ChatGPT-style multi-session DM — one bot, many parallel conversations. Unlike the operator-curated `extra.dm_topics` above, this mode is **user-driven**: no config, no pre-declared topic names. The end user flips it on with `/topic`, then sends a normal prompt from the Telegram main/**All Messages** view; Hermes creates a fresh topic for that prompt and treats it as an independent session. Users can also use Telegram's new-topic/**+** button when their client exposes it.
 
 ### `/topic` subcommands
 
@@ -716,14 +716,16 @@ Hermes will:
 3. Create and pin a **System** topic for status/commands (best-effort)
 4. Reply with a list of previous unlinked Telegram sessions the user can restore
 
-After activation, the **root DM is a lobby**: normal prompts are rejected with guidance pointing at **All Messages**. System commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root.
+After activation, slash commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root/main view. A non-command prompt sent from the main/**All Messages** view starts a fresh topic automatically; if Hermes cannot create the topic (for example, BotFather thread settings changed), it falls back to guidance for creating a topic manually.
 
 ### Creating a new topic (end-user flow)
 
 1. Open the bot DM in Telegram
-2. Tap **All Messages** at the top of the bot interface, then send any message
-3. Telegram creates a new topic for that message
+2. From the main/**All Messages** view, send the first normal prompt for the new chat
+3. Hermes calls Telegram `createForumTopic`, creates a new topic for that prompt, and routes the prompt into that topic
 4. Hermes responds inside that topic — the topic is now a standalone session
+
+If your Telegram client exposes a new-topic/**+** button in the bot interface, you can also create/open a topic manually and send the first prompt there.
 
 Every topic gets its own conversation history, model state, tool execution, and session ID. The isolation key is `agent:main:telegram:dm:{chat_id}:{thread_id}` — identical to the config-driven DM topics isolation.
 
@@ -745,7 +747,7 @@ When this flag is on, Hermes still generates an internal session title (used by 
 
 ### `/new` inside a topic
 
-Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, creating another topic (via **All Messages**) is usually what you want.
+Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, sending a new prompt from the main/**All Messages** view is usually what you want.
 
 ### Restoring a previous session
 


### PR DESCRIPTION
Fix Telegram DM `/topic` mode so a normal prompt sent in the root/main "All Messages" view automatically creates a fresh Telegram topic via `createForumTopic` and routes the prompt into that new session lane.

**Problem:** The Bot API delivers messages from the "All Messages" view as ordinary private-chat messages with no `message_thread_id`. Previously Hermes would reject these as the root lobby, making the documented "send a message in All Messages to start a new session" flow impossible.

**Changes:**
- When a non-command message arrives at the root lobby, call `createForumTopic` to create a new topic, rewrite the event source to that thread, and route the session normally
- Update the lobby fallback message to explain using the Telegram + button when topic creation fails
- Update `_telegram_topic_root_new_message` guidance to match the new auto-create flow
- Avoid duplicate managed System topics on repeated `/topic` status calls
- Route the System topic intro message with created-topic metadata

## Test plan

```bash
pytest tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_delivery.py -q
```
