### PR TITLE
fix(claw): correct 'hermes stop' to 'hermes gateway stop' in migrate recommendation

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -177,7 +177,7 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
         "conflicts (Telegram, Discord, and Slack only allow one active "
         "session per token)."
     )
-    print_info("Recommendation: stop the gateway first with 'hermes stop'.")
+    print_info("Recommendation: stop the gateway first with 'hermes gateway stop'.")
     print()
     if not auto_yes and not prompt_yes_no("Continue anyway?", default=False):
         print_info("Migration cancelled. Stop the gateway and try again.")


### PR DESCRIPTION
Fixes #36771

## Problem
`hermes claw migrate` prints:
```
Recommendation: stop the gateway first with 'hermes stop'.
```
But `hermes stop` is not a valid command. The correct command is `hermes gateway stop`.

## Fix
Changed the text on line 180 of `hermes_cli/claw.py`.

## Testing
- [x] Visual inspection of the changed string
- [x] `hermes gateway stop` is a valid command (confirmed via `hermes --help`)

Closes #36771