### PR TITLE
fix(agent): drop codex reasoning-only turns before anthropic fallback

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -62,6 +62,15 @@ def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
     return bool(memory_manager and memory_manager.has_tool(function_name))
 
 
+def _debug_request_suffix(api_mode: str | None) -> str:
+    """Return the request path suffix used in debug dump URLs."""
+    if api_mode == "codex_responses":
+        return "/responses"
+    if api_mode == "anthropic_messages":
+        return "/messages"
+    return "/chat/completions"
+
+
 def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
     """
     Convert internal message format to trajectory format for saving.
@@ -1100,7 +1109,7 @@ def dump_api_request_debug(
             "reason": reason,
             "request": {
                 "method": "POST",
-                "url": f"{agent.base_url.rstrip('/')}{'/responses' if agent.api_mode == 'codex_responses' else '/chat/completions'}",
+                "url": f"{agent.base_url.rstrip('/')}{_debug_request_suffix(agent.api_mode)}",
                 "headers": {
                     "Authorization": f"Bearer {agent._mask_api_key_for_logs(api_key)}",
                     "Content-Type": "application/json",

--- a/run_agent.py
+++ b/run_agent.py
@@ -3082,6 +3082,13 @@ class AIAgent:
         rd = msg.get("reasoning_details")
         if isinstance(rd, list) and rd:
             return True
+        # Codex Responses replay payload: encrypted reasoning items persisted
+        # for continuity. These should be treated as internal reasoning-only
+        # state (same drop behavior as reasoning/reasoning_details) when
+        # there is no visible assistant output.
+        cri = msg.get("codex_reasoning_items")
+        if isinstance(cri, list) and cri:
+            return True
         return False
 
     @staticmethod

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1811,6 +1811,33 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_uses_messages_url_for_anthropic(monkeypatch, tmp_path):
+    """Debug dumps should show /messages URL for anthropic_messages mode."""
+    import json
+    from types import SimpleNamespace
+    from agent.agent_runtime_helpers import dump_api_request_debug
+
+    agent = SimpleNamespace(
+        api_mode="anthropic_messages",
+        base_url="http://127.0.0.1:9208/v1",
+        logs_dir=tmp_path,
+        session_id="test-session",
+        client=SimpleNamespace(api_key="test-key"),
+        _mask_api_key_for_logs=lambda key: key,
+        _vprint=lambda *_args, **_kwargs: None,
+        log_prefix="",
+        verbose_logging=False,
+    )
+    dump_file = dump_api_request_debug(
+        agent,
+        {"model": "claude-sonnet-4-20250514", "messages": [{"role": "user", "content": "hi"}]},
+        reason="preflight",
+    )
+
+    payload = json.loads(dump_file.read_text())
+    assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/messages"
+
+
 # --- Reasoning-only response tests (fix for empty content retry loop) ---
 
 

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -104,6 +104,14 @@ class TestIsThinkingOnlyAssistant:
         }
         assert AIAgent._is_thinking_only_assistant(msg)
 
+    def test_codex_reasoning_items_list_form_detected(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "enc_blob"}],
+        }
+        assert AIAgent._is_thinking_only_assistant(msg)
+
     def test_user_message_never_thinking_only(self):
         assert not AIAgent._is_thinking_only_assistant({"role": "user", "content": ""})
 


### PR DESCRIPTION
## What does this PR do?

Fixes a fallback bug where Codex Responses reasoning-only assistant turns could survive sanitization and be sent to Anthropic as trailing assistant prefill (`"(empty)"`), which Anthropic rejects. It also corrects request debug dump URL labeling for native Anthropic mode.

## Related Issue

Fixes #29205

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py`: updated `AIAgent._is_thinking_only_assistant()` to treat non-empty `codex_reasoning_items` as reasoning-only payload when assistant content is empty and there are no tool calls.
- `agent/agent_runtime_helpers.py`: added API-mode-aware debug URL suffix mapping and switched dump URL generation to use it (`/responses`, `/messages`, or `/chat/completions`).
- `tests/run_agent/test_thinking_only_sanitizer.py`: added regression coverage proving Codex reasoning-item assistant turns are detected as thinking-only.
- `tests/run_agent/test_run_agent_codex_responses.py`: added regression coverage proving debug dumps use `/messages` for `anthropic_messages`.

## How to Test

1. Run targeted regressions:
   `pytest -q tests/run_agent/test_thinking_only_sanitizer.py tests/run_agent/test_run_agent_codex_responses.py -k "codex_reasoning_items_list_form_detected or uses_messages_url_for_anthropic"`
2. Run Windows portability guard:
   `python scripts/check-windows-footguns.py --all`
3. (Optional broad check) Run project suite wrapper:
   `scripts/run_tests.sh`

## What platforms tested on

- macOS (darwin-arm64) in this worktree/sandbox

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python scripts/check-windows-footguns.py --all` passed (`No Windows footguns found`).
- Targeted regression tests passed (`2 passed`).
- `scripts/run_tests.sh` was executed but showed unrelated pre-existing failures in this sandbox run (e.g. `tests/agent/lsp/test_client_e2e.py`, `tests/agent/test_anthropic_adapter.py`, `tests/agent/test_auxiliary_client.py`, `tests/agent/test_codex_ttfb_watchdog.py`, `tests/agent/test_save_url_image.py`, `tests/agent/test_compression_concurrent_fork.py`).

<!-- autocontrib:worker-id=issue-new-aeedf03c kind=pr-open -->