### PR TITLE
fix(cli): propagate --provider override to auxiliary title generation (#36748)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12332,6 +12332,12 @@ class HermesCLI:
                     _title_failure_cb = getattr(
                         self.agent, "_emit_auxiliary_failure", None
                     ) if self.agent else None
+                    # Prefer the *effective* runtime the agent actually used
+                    # (e.g. when --provider names a custom provider whose
+                    # model/base_url differ from the CLI defaults) so title
+                    # generation targets the same backend as the main reply
+                    # rather than the global default (issue #36748).
+                    _agent = self.agent
                     maybe_auto_title(
                         self._session_db,
                         self.session_id,
@@ -12340,11 +12346,11 @@ class HermesCLI:
                         self.conversation_history,
                         failure_callback=_title_failure_cb,
                         main_runtime={
-                            "model": self.model,
-                            "provider": self.provider,
-                            "base_url": self.base_url,
-                            "api_key": self.api_key,
-                            "api_mode": self.api_mode,
+                            "model": getattr(_agent, "model", None) or self.model,
+                            "provider": getattr(_agent, "provider", None) or self.provider,
+                            "base_url": getattr(_agent, "base_url", None) or self.base_url,
+                            "api_key": getattr(_agent, "api_key", None) or self.api_key,
+                            "api_mode": getattr(_agent, "api_mode", None) or self.api_mode,
                         },
                     )
                 except Exception:

--- a/tests/test_cli_provider_override_aux_title_36748.py
+++ b/tests/test_cli_provider_override_aux_title_36748.py
@@ -1,0 +1,88 @@
+"""Regression test for #36748: CLI provider override propagates to aux title generation.
+
+The one-shot CLI path used to pass ``self.model``/``self.provider`` etc.
+unconditionally to ``maybe_auto_title``.  When a named custom provider was
+selected via ``--provider <custom>`` (e.g. an Ollama OpenAI-compatible
+endpoint), ``self.model`` could still hold the global default
+(``gpt-5.5``) while the agent actually used the custom provider's model.
+Title generation then routed against the global default and 404'd.
+
+Fix: prefer ``self.agent.{model,provider,base_url,api_key,api_mode}`` when
+the agent is set, falling back to the CLI defaults.
+"""
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def test_aux_title_main_runtime_prefers_agent_runtime(tmp_path, monkeypatch):
+    # Ensure repo on sys.path
+    repo = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if repo not in sys.path:
+        sys.path.insert(0, repo)
+
+    # Read cli.py and snip the relevant block so we don't have to bring up
+    # the whole HermesCLI constructor (heavy).  We assert the literal code
+    # path uses the agent's runtime when available.
+    cli_src = open(os.path.join(repo, "cli.py")).read()
+    # The dict construction must reference `_agent` (or `self.agent`)
+    # before falling back to `self`.
+    assert "getattr(_agent, \"model\"" in cli_src or "getattr(self.agent, \"model\"" in cli_src, \
+        "maybe_auto_title call must read effective model from the agent"
+    assert "getattr(_agent, \"provider\"" in cli_src or "getattr(self.agent, \"provider\"" in cli_src
+    assert "getattr(_agent, \"base_url\"" in cli_src or "getattr(self.agent, \"base_url\"" in cli_src
+    assert "getattr(_agent, \"api_key\"" in cli_src or "getattr(self.agent, \"api_key\"" in cli_src
+    assert "getattr(_agent, \"api_mode\"" in cli_src or "getattr(self.agent, \"api_mode\"" in cli_src
+
+
+def test_aux_title_main_runtime_construction_logic():
+    """Direct unit test of the precedence rule itself."""
+
+    class _Agent:
+        model = "qwen3.6:35b-mlx"
+        provider = "ollama-local"
+        base_url = "http://localhost:11434/v1"
+        api_key = "no-key-required"
+        api_mode = "chat_completions"
+
+    class _CLI:
+        model = "gpt-5.5"
+        provider = "openai-codex"
+        base_url = ""
+        api_key = ""
+        api_mode = "chat_completions"
+        agent = _Agent()
+
+    cli = _CLI()
+    _agent = cli.agent
+    main_runtime = {
+        "model": getattr(_agent, "model", None) or cli.model,
+        "provider": getattr(_agent, "provider", None) or cli.provider,
+        "base_url": getattr(_agent, "base_url", None) or cli.base_url,
+        "api_key": getattr(_agent, "api_key", None) or cli.api_key,
+        "api_mode": getattr(_agent, "api_mode", None) or cli.api_mode,
+    }
+    assert main_runtime["model"] == "qwen3.6:35b-mlx"
+    assert main_runtime["provider"] == "ollama-local"
+    assert main_runtime["base_url"] == "http://localhost:11434/v1"
+    assert main_runtime["api_key"] == "no-key-required"
+
+
+def test_aux_title_main_runtime_fallback_when_no_agent():
+    class _CLI:
+        model = "gpt-5.5"
+        provider = "openai-codex"
+        base_url = ""
+        api_key = ""
+        api_mode = "chat_completions"
+        agent = None
+
+    cli = _CLI()
+    _agent = cli.agent
+    main_runtime = {
+        "model": getattr(_agent, "model", None) or cli.model,
+        "provider": getattr(_agent, "provider", None) or cli.provider,
+    }
+    assert main_runtime["model"] == "gpt-5.5"
+    assert main_runtime["provider"] == "openai-codex"


### PR DESCRIPTION
## Summary

Fixes #36748 — when `hermes chat -q "..." --provider <named-custom-provider>` is used, the main response correctly routes to the custom provider but auxiliary title generation still hits the global default model (e.g. `gpt-5.5`), producing a user-visible `⚠ Auxiliary title generation failed: HTTP 404: model 'gpt-5.5' not found` warning at the end of an otherwise-successful one-shot session.

## Root cause

In `cli.py`, the one-shot path (`~line 12335`) calls `maybe_auto_title(...)` with `main_runtime` built unconditionally from `self.model` / `self.provider` / `self.base_url` / `self.api_key` / `self.api_mode`. By that point, the *agent* has already been constructed and run against the named custom provider's effective model/base_url/api_key, but the `HermesCLI` instance attributes still reflect the original global defaults — so auxiliary title generation re-resolves to the wrong backend.

## Fix

Prefer the live `self.agent.{model,provider,base_url,api_key,api_mode}` when the agent is set, falling back to the CLI defaults. Minimal surgical change at the existing call site; no signature changes to `maybe_auto_title`.

```python
_agent = self.agent
maybe_auto_title(
    ...,
    main_runtime={
        "model": getattr(_agent, "model", None) or self.model,
        "provider": getattr(_agent, "provider", None) or self.provider,
        "base_url": getattr(_agent, "base_url", None) or self.base_url,
        "api_key": getattr(_agent, "api_key", None) or self.api_key,
        "api_mode": getattr(_agent, "api_mode", None) or self.api_mode,
    },
)
```

## Tests

Added `tests/test_cli_provider_override_aux_title_36748.py`:

1. **Source pin** — asserts the call site reads from the agent first, so a future cleanup cannot silently re-introduce the regression.
2. **Precedence rule** — agent's runtime wins when present and differs from CLI defaults (mirrors the Ollama `qwen3.6:35b-mlx` scenario from the issue).
3. **Fallback** — CLI defaults are used when `self.agent` is `None`.

```
$ pytest tests/test_cli_provider_override_aux_title_36748.py -x -q
... 3 passed in 0.23s
```

## Scope

- `cli.py`: 11 lines changed (5 lookups now prefer `_agent`, plus 1 alias + 5 lines of comment).
- New regression test file.

No behaviour change for paths where `self.agent` is unset or where agent attributes are empty (falls through to CLI values).
