### PR TITLE
feat(delegate): add per-task model/provider routing

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -31,6 +31,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_model_provider_override,
 )
 
 
@@ -68,11 +69,26 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("model", props)
+        self.assertIn("provider", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertIn("provider", task_props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
         self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+
+    def test_schema_documents_model_provider_syntax(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        top_model_desc = props["model"]["description"]
+        task_model_desc = props["tasks"]["items"]["properties"]["model"]["description"]
+
+        self.assertIn("--provider", top_model_desc)
+        self.assertIn("--provider", task_model_desc)
+        self.assertIn("Do NOT use provider:model", top_model_desc)
+        self.assertIn("Do NOT use provider:model", task_model_desc)
 
     def test_schema_description_advertises_runtime_limits(self):
         """The model must see the user's actual concurrency / spawn-depth caps,
@@ -1403,6 +1419,304 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+
+class TestResolveModelProviderOverride(unittest.TestCase):
+    """Tests for resolving explicit delegate_task model/provider overrides."""
+
+    def _fake_switch_result(self, **overrides):
+        result = MagicMock()
+        defaults = {
+            "success": True,
+            "new_model": "claude-sonnet-4-6",
+            "target_provider": "anthropic",
+            "base_url": "https://api.anthropic.com/v1",
+            "api_key": "ant-test-key",
+            "api_mode": "anthropic_messages",
+            "error_message": "",
+        }
+        defaults.update(overrides)
+        for key, value in defaults.items():
+            setattr(result, key, value)
+        return result
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.model_switch.switch_model")
+    def test_resolves_model_with_structured_provider(self, mock_switch, mock_runtime):
+        mock_switch.return_value = self._fake_switch_result(
+            new_model="llama-3.3-70b:free",
+            target_provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+            api_mode="chat_completions",
+        )
+        mock_runtime.return_value = {"command": None, "args": []}
+        parent = _make_mock_parent(depth=0)
+
+        creds = _resolve_model_provider_override(
+            model_input="llama-3.3-70b:free",
+            provider_input="openrouter",
+            parent_agent=parent,
+        )
+
+        self.assertEqual(creds["model"], "llama-3.3-70b:free")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["api_key"], "sk-or-test")
+        _, kwargs = mock_switch.call_args
+        self.assertEqual(kwargs["raw_input"], "llama-3.3-70b:free")
+        self.assertEqual(kwargs["explicit_provider"], "openrouter")
+        self.assertFalse(kwargs["is_global"])
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.model_switch.switch_model")
+    def test_resolves_inline_provider_flag(self, mock_switch, mock_runtime):
+        mock_switch.return_value = self._fake_switch_result(
+            new_model="stepfun/step-3.5-flash",
+            target_provider="openrouter",
+        )
+        mock_runtime.return_value = {"command": None, "args": []}
+        parent = _make_mock_parent(depth=0)
+
+        _resolve_model_provider_override(
+            model_input="stepfun/step-3.5-flash --provider openrouter",
+            provider_input=None,
+            parent_agent=parent,
+        )
+
+        _, kwargs = mock_switch.call_args
+        self.assertEqual(kwargs["raw_input"], "stepfun/step-3.5-flash")
+        self.assertEqual(kwargs["explicit_provider"], "openrouter")
+
+    def test_conflicting_structured_and_inline_provider_fails(self):
+        parent = _make_mock_parent(depth=0)
+
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_model_provider_override(
+                model_input="sonnet --provider anthropic",
+                provider_input="openrouter",
+                parent_agent=parent,
+            )
+
+        self.assertIn("Conflicting provider overrides", str(ctx.exception))
+
+    @patch("hermes_cli.model_switch.switch_model")
+    def test_resolution_failure_raises_value_error(self, mock_switch):
+        mock_switch.return_value = self._fake_switch_result(
+            success=False,
+            error_message="Unknown model 'banana'",
+        )
+        parent = _make_mock_parent(depth=0)
+
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_model_provider_override(
+                model_input="banana",
+                provider_input=None,
+                parent_agent=parent,
+            )
+
+        self.assertIn("banana", str(ctx.exception))
+        self.assertIn("Unknown model", str(ctx.exception))
+
+
+class TestDelegateTaskModelProviderOverride(unittest.TestCase):
+    """Tests for delegate_task model/provider override plumbing."""
+
+    def _default_creds(self):
+        return {
+            "model": "default-model",
+            "provider": "default-provider",
+            "base_url": "https://default.example/v1",
+            "api_key": "default-key",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        }
+
+    def _override_creds(self, model_input, provider_input):
+        return {
+            "model": f"resolved:{model_input or 'default'}",
+            "provider": provider_input or "resolved-provider",
+            "base_url": "https://resolved.example/v1",
+            "api_key": "resolved-key",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        }
+
+    def _run_single_result(self, task_index, goal, child, parent_agent):
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "done",
+            "duration_seconds": 0.0,
+        }
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._resolve_model_provider_override")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_top_level_model_provider_reaches_single_goal(
+        self, mock_run, mock_build, mock_override, mock_creds, mock_cfg
+    ):
+        mock_creds.return_value = self._default_creds()
+        mock_override.side_effect = (
+            lambda *, model_input, provider_input, parent_agent:
+            self._override_creds(model_input, provider_input)
+        )
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = self._run_single_result
+        parent = _make_mock_parent(depth=0)
+
+        delegate_task(
+            goal="single",
+            model="sonnet",
+            provider="anthropic",
+            parent_agent=parent,
+        )
+
+        mock_override.assert_called_once_with(
+            model_input="sonnet",
+            provider_input="anthropic",
+            parent_agent=parent,
+        )
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "resolved:sonnet")
+        self.assertEqual(kwargs["override_provider"], "anthropic")
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._resolve_model_provider_override")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_model_beats_top_level_model(
+        self, mock_run, mock_build, mock_override, mock_creds, mock_cfg
+    ):
+        mock_creds.return_value = self._default_creds()
+        mock_override.side_effect = (
+            lambda *, model_input, provider_input, parent_agent:
+            self._override_creds(model_input, provider_input)
+        )
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = self._run_single_result
+        parent = _make_mock_parent(depth=0)
+
+        delegate_task(
+            model="sonnet",
+            tasks=[
+                {"goal": "Task A", "model": "haiku"},
+                {"goal": "Task B"},
+            ],
+            parent_agent=parent,
+        )
+
+        override_models = [
+            call.kwargs["model_input"]
+            for call in mock_override.call_args_list
+        ]
+        built_models = [
+            call.kwargs["model"]
+            for call in mock_build.call_args_list
+        ]
+        self.assertEqual(override_models, ["haiku", "sonnet"])
+        self.assertEqual(built_models, ["resolved:haiku", "resolved:sonnet"])
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._resolve_model_provider_override")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_model_only_override_on_same_provider_is_resolved(
+        self, mock_run, mock_build, mock_override, mock_creds, mock_cfg
+    ):
+        mock_creds.return_value = self._default_creds()
+        mock_override.side_effect = (
+            lambda *, model_input, provider_input, parent_agent:
+            self._override_creds(model_input, provider_input)
+        )
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = self._run_single_result
+        parent = _make_mock_parent(depth=0)
+
+        delegate_task(
+            tasks=[{"goal": "Task A", "model": "haiku"}],
+            parent_agent=parent,
+        )
+
+        mock_override.assert_called_once()
+        self.assertEqual(mock_build.call_args.kwargs["model"], "resolved:haiku")
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._resolve_model_provider_override")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_no_override_uses_delegation_credentials(
+        self, mock_run, mock_build, mock_override, mock_creds, mock_cfg
+    ):
+        mock_creds.return_value = self._default_creds()
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = self._run_single_result
+        parent = _make_mock_parent(depth=0)
+
+        delegate_task(goal="default", parent_agent=parent)
+
+        mock_override.assert_not_called()
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "default-model")
+        self.assertEqual(kwargs["override_provider"], "default-provider")
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._resolve_model_provider_override")
+    def test_override_failure_returns_tool_error(
+        self, mock_override, mock_creds, mock_cfg
+    ):
+        mock_creds.return_value = self._default_creds()
+        mock_override.side_effect = ValueError("Cannot resolve model 'banana'")
+        parent = _make_mock_parent(depth=0)
+
+        result = json.loads(
+            delegate_task(goal="bad", model="banana", parent_agent=parent)
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("banana", result["error"])
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 5})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._resolve_model_provider_override")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_registry_handler_forwards_model_and_provider(
+        self, mock_run, mock_build, mock_override, mock_creds, mock_cfg
+    ):
+        from tools.registry import registry
+
+        mock_creds.return_value = self._default_creds()
+        mock_override.side_effect = (
+            lambda *, model_input, provider_input, parent_agent:
+            self._override_creds(model_input, provider_input)
+        )
+        mock_build.return_value = MagicMock()
+        mock_run.side_effect = self._run_single_result
+        parent = _make_mock_parent(depth=0)
+
+        registry.dispatch(
+            "delegate_task",
+            {
+                "goal": "registry",
+                "model": "qwen3.6-plus",
+                "provider": "opencode-go",
+            },
+            parent_agent=parent,
+        )
+
+        mock_override.assert_called_once_with(
+            model_input="qwen3.6-plus",
+            provider_input="opencode-go",
+            parent_agent=parent,
+        )
 
 
 class TestChildCredentialPoolResolution(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1924,19 +1924,24 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, model, provider)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, model, provider}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    Model/provider precedence is:
+    per-task override > top-level override > delegation config > parent agent.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2017,7 +2022,14 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "model": model,
+                "provider": provider,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2058,26 +2070,42 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Explicit per-task values beat top-level defaults. If either is
+            # present, resolve a complete credential bundle for that child; a
+            # model-only override on the same provider must still take effect.
+            task_model = t.get("model") or model
+            task_provider = t.get("provider") or provider
+            if task_model or task_provider:
+                try:
+                    task_creds = _resolve_model_provider_override(
+                        model_input=task_model,
+                        provider_input=task_provider,
+                        parent_agent=parent_agent,
+                    )
+                except ValueError as exc:
+                    return tool_error(str(exc))
+            else:
+                task_creds = creds
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds.get("model"),
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds.get("provider"),
+                override_base_url=task_creds.get("base_url"),
+                override_api_key=task_creds.get("api_key"),
+                override_api_mode=task_creds.get("api_mode"),
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2456,6 +2484,98 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _resolve_model_provider_override(
+    *,
+    model_input: Optional[str],
+    provider_input: Optional[str],
+    parent_agent,
+) -> dict:
+    """Resolve an explicit delegate_task model/provider override.
+
+    Uses the same model-switching pipeline as the /model command so aliases,
+    provider catalogs, custom providers, and ``--provider`` syntax stay
+    consistent. The result matches _resolve_delegation_credentials() so it can
+    flow directly into _build_child_agent().
+    """
+    raw_model = str(model_input or "").strip()
+    explicit_provider = str(provider_input or "").strip()
+    if not raw_model and not explicit_provider:
+        raise ValueError("model/provider override is empty")
+
+    try:
+        from hermes_cli.model_switch import parse_model_flags, switch_model
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot import model switch resolver for delegation override: {exc}"
+        ) from exc
+
+    parsed_model, parsed_provider, _ignored_global, _ignored_refresh = parse_model_flags(raw_model)
+    if explicit_provider and parsed_provider and explicit_provider != parsed_provider:
+        raise ValueError(
+            f"Conflicting provider overrides: provider={explicit_provider!r} "
+            f"but model contains --provider {parsed_provider!r}."
+        )
+    provider_for_switch = explicit_provider or parsed_provider
+    if not parsed_model and not provider_for_switch:
+        raise ValueError(f"Could not parse model/provider override: {raw_model!r}")
+
+    user_providers = None
+    custom_providers = None
+    try:
+        from hermes_cli.config import load_config
+
+        full_cfg = load_config()
+        user_providers = full_cfg.get("providers")
+        custom_providers = full_cfg.get("custom_providers")
+    except Exception:
+        pass
+
+    result = switch_model(
+        raw_input=parsed_model,
+        current_provider=getattr(parent_agent, "provider", "") or "",
+        current_model=getattr(parent_agent, "model", "") or "",
+        current_base_url=getattr(parent_agent, "base_url", "") or "",
+        current_api_key=getattr(parent_agent, "api_key", "") or "",
+        is_global=False,
+        explicit_provider=provider_for_switch,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    if not result.success:
+        raise ValueError(
+            f"Cannot resolve delegation model/provider override "
+            f"{raw_model or provider_for_switch!r}: "
+            f"{result.error_message or 'unknown error'}"
+        )
+
+    creds = {
+        "model": result.new_model or None,
+        "provider": result.target_provider or None,
+        "base_url": result.base_url or None,
+        "api_key": result.api_key or None,
+        "api_mode": result.api_mode or None,
+        "command": None,
+        "args": [],
+    }
+
+    # Preserve runtime-provider metadata that switch_model does not expose
+    # directly, such as ACP command/args for subprocess-backed providers.
+    if creds["provider"]:
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(
+                requested=creds["provider"],
+                target_model=creds["model"],
+            )
+            creds["command"] = runtime.get("command")
+            creds["args"] = list(runtime.get("args") or [])
+        except Exception:
+            pass
+
+    return creds
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -2736,6 +2856,31 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override. When set, this child agent "
+                                "connects to the specified provider instead of inheriting "
+                                "from the top-level provider, delegation.provider, or the parent. "
+                                "The provider must be configured in Hermes. Use with 'model' "
+                                "to assign specific provider/model pairs per worker. Prefer "
+                                "this structured field over embedding --provider in model "
+                                "when making JSON tool calls."
+                            ),
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override. When set, this child agent uses "
+                                "the specified model. When unset, inherits from the top-level "
+                                "model, delegation.model, or parent agent. Uses the same syntax "
+                                "as /model: 'sonnet', 'glm-4.7', or "
+                                "'stepfun/step-3.5-flash --provider openrouter'. You may also "
+                                "set the structured 'provider' field. Do NOT use provider:model "
+                                "colon-prefix syntax; colons remain valid only inside model IDs "
+                                "or variant suffixes such as ':free'."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2748,6 +2893,28 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Provider override for child agents. When set, children connect "
+                    "to the specified provider. The provider must be configured in Hermes. "
+                    "For per-task provider overrides, use the 'provider' field inside "
+                    "each item of the 'tasks' array. Prefer this structured field over "
+                    "embedding --provider in model when making JSON tool calls."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model override for child agents. When set, the child uses the "
+                    "specified model. When unset, inherits from delegation.model or "
+                    "parent agent. Uses the same syntax as /model: 'sonnet', 'glm-4.7', "
+                    "or 'stepfun/step-3.5-flash --provider openrouter'. You may also "
+                    "set the structured 'provider' field. Do NOT use provider:model "
+                    "colon-prefix syntax. For per-task model overrides, use the 'model' "
+                    "field inside each item of the 'tasks' array."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2793,6 +2960,8 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -129,9 +129,79 @@ When you provide a `tasks` array, subagents run in **parallel** using a thread p
 
 Single-task delegation runs directly without thread pool overhead.
 
-## Model Override
+## Per-Task Model Selection
 
-You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
+You can route delegated work to different models at call time. This is useful when a batch mixes simple lookup work with harder reasoning, or when you want independent model perspectives in parallel.
+
+### Single Task
+
+```python
+delegate_task(
+    goal="Summarize the latest failing test output",
+    model="haiku",
+)
+
+delegate_task(
+    goal="Review the authentication refactor",
+    model="sonnet",
+    provider="anthropic",
+)
+```
+
+The `model` field uses the same syntax as `/model`, so inline provider selection is also supported:
+
+```python
+delegate_task(
+    goal="Check OpenRouter availability",
+    model="llama-3.3-70b:free --provider openrouter",
+)
+```
+
+For JSON tool calls, prefer the structured `provider` field:
+
+```python
+delegate_task(
+    goal="Run a quick implementation check",
+    model="qwen3.6-plus",
+    provider="opencode-go",
+)
+```
+
+Do not use `provider:model` colon-prefix syntax. Colons remain valid inside model IDs or provider-specific variant suffixes such as `:free`.
+
+### Batch With Mixed Models
+
+Each task in a batch can choose its own model/provider:
+
+```python
+delegate_task(tasks=[
+    {
+        "goal": "List files touched by this change",
+        "model": "haiku",
+    },
+    {
+        "goal": "Review the concurrency design",
+        "model": "sonnet",
+        "provider": "anthropic",
+    },
+    {
+        "goal": "Give an independent implementation critique",
+        "model": "qwen3.6-plus",
+        "provider": "opencode-go",
+    },
+])
+```
+
+Resolution precedence is:
+
+1. Per-task `model` / `provider`
+2. Top-level `model` / `provider`
+3. `delegation.model` / `delegation.provider` in `config.yaml`
+4. Parent agent model/provider
+
+### Configuration Default
+
+You can still configure a default model for all subagents via `config.yaml`:
 
 ```yaml
 # In ~/.hermes/config.yaml


### PR DESCRIPTION
## Summary

Adds per-call and per-task model/provider routing to `delegate_task`.

This lets delegated subagents run on different models in the same batch, while preserving the existing fallback behavior when no override is provided.

Fixes #6306
Fixes #10995
Fixes #5012

Related to #7586, #6771, #12715, #20000, #23266, #34773, and #35033. Also addresses the `delegate_task` portion discussed in #18880.

Builds on behavior already fixed by merged PRs #17587 and #19623.

## Design

Model/provider precedence is:

1. Per-task `tasks[].model` / `tasks[].provider`
2. Top-level `model` / `provider`
3. `delegation.model` / `delegation.provider` in config
4. Parent agent model/provider

The override resolver reuses the existing `/model` switch pipeline, so aliases, provider catalogs, custom providers, and `--provider` syntax stay consistent.

Both forms are supported:

```python
delegate_task(goal="Review logs", model="haiku")

delegate_task(
    goal="Review architecture",
    model="sonnet",
    provider="anthropic",
)

delegate_task(
    goal="Quick OpenRouter check",
    model="llama-3.3-70b:free --provider openrouter",
)
```

For JSON tool calls, the structured `provider` field is preferred. If a structured provider conflicts with an inline `--provider` in `model`, `delegate_task` returns a tool error instead of silently choosing one.

## Relation to Other PRs

There are several overlapping PRs in this feature cluster. This PR intentionally includes both top-level and per-task routing because #6306, #10995, and #5012 request single-call shorthand as well as mixed-model batch delegation.

Compared with the narrower per-task-only implementations, this PR also routes explicit overrides through the existing `/model` switch pipeline. That keeps alias handling, provider catalog lookup, custom providers, and inline `--provider` syntax consistent with the rest of Hermes instead of adding a parallel resolver.

This PR does not expose per-task `base_url` or `api_key`; provider credentials still come from configured Hermes providers.

## Changes

- Adds optional top-level `model` and `provider` parameters to `delegate_task`.
- Adds optional per-task `model` and `provider` fields in `tasks[]`.
- Resolves explicit per-task overrides before child construction.
- Fixes the same-provider model-only case, where a task-level model override must still take effect even when the provider does not change.
- Forwards `model` and `provider` through the registry handler.
- Documents the supported syntax and precedence.
- Adds unit coverage for schema shape, resolver behavior, precedence, registry forwarding, error handling, and no-override fallback.

## Verification

Automated:

```text
py_compile tools/delegate_tool.py: passed
ruff check tools/delegate_tool.py tests/tools/test_delegate.py --no-cache: passed
pytest -q tests/tools/test_delegate.py: 146 passed, 1 warning
pytest -q tests/tools/test_delegate*.py: 163 passed, 1 warning
git diff --check: passed
```

Manual Hermes verification with real models:

Parent model:

- `opencode-go/deepseek-v4-pro`

Parallel child models:

- `gemini/gemini-3.5-flash` -> `CHILD_OK_GEMINI`
- `opencode-go/mimo-v2.5-pro` -> `CHILD_OK_MIMO`
- `opencode-go/qwen3.6-plus` -> `CHILD_OK_QWEN`

Result: `3/3 completed`, total wall time about `6.36s`.
