### PR TITLE
fix(tests): save/restore HERMES_CRON_SESSION in approval test teardown

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -177,7 +177,7 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
         "conflicts (Telegram, Discord, and Slack only allow one active "
         "session per token)."
     )
-    print_info("Recommendation: stop the gateway first with 'hermes stop'.")
+    print_info("Recommendation: stop the gateway first with 'hermes gateway stop'.")
     print()
     if not auto_yes and not prompt_yes_no("Continue anyway?", default=False):
         print_info("Migration cancelled. Stop the gateway and try again.")

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1345,11 +1345,13 @@ class TestApprovalTimeoutIsNotConsent:
 
         self._saved_env = {
             k: os.environ.get(k)
-            for k in ("HERMES_GATEWAY_SESSION", "HERMES_YOLO_MODE",
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_YOLO_MODE",
                       "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
         }
         os.environ.pop("HERMES_YOLO_MODE", None)
         os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_CRON_SESSION", None)
         os.environ["HERMES_GATEWAY_SESSION"] = "1"
         os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
 


### PR DESCRIPTION
## Problem
When `HERMES_CRON_SESSION=1` leaks from the parent process (e.g. cron scheduler running before the test suite), two tests fail:

1. `TestApprovalTimeoutIsNotConsent::test_timeout_returns_approved_false_with_no_consent` — takes the cron-path instead of gateway-path because `_is_gateway_approval_context()` checks CRON_SESSION before GATEWAY_SESSION
2. `TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode` — `_cprint` output routing depends on whether a cron context is active

## Fix
Added `HERMES_CRON_SESSION` to the saved env vars in `TestApprovalTimeoutIsNotConsent.setup_method()`, and explicitly `.pop()` it to ensure a clean gateway test context.

## Testing
- `tests/tools/test_approval.py::TestApprovalTimeoutIsNotConsent` — 4/4 passing
- `tests/cli/test_resume_quiet_stderr.py` — 4/4 passing

This is a test-infrastructure fix that prevents environment-dependent test failures in CI or local runs when cron jobs are active.