### PR TITLE
fix: route OpenCode Zen Gemini through native client

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1282,7 +1282,13 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
-    if agent.provider == "gemini":
+    provider_id = str(getattr(agent, "provider", "") or "").strip().lower()
+    model_id = str(getattr(agent, "model", "") or "").strip().rsplit("/", 1)[-1].lower()
+    uses_gemini_native = provider_id == "gemini" or (
+        provider_id in {"opencode", "opencode-zen", "zen"}
+        and model_id.startswith("gemini-")
+    )
+    if uses_gemini_native:
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
         base_url = str(client_kwargs.get("base_url", "") or "")

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Iterator, List, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -39,9 +40,17 @@ def is_native_gemini_base_url(base_url: str) -> bool:
     normalized = str(base_url or "").strip().rstrip("/").lower()
     if not normalized:
         return False
-    if "generativelanguage.googleapis.com" not in normalized:
-        return False
-    return not normalized.endswith("/openai")
+    if "generativelanguage.googleapis.com" in normalized:
+        return not normalized.endswith("/openai")
+
+    parsed = urlparse(normalized)
+    if parsed.netloc == "opencode.ai" and parsed.path.rstrip("/") == "/zen/v1":
+        # OpenCode Zen exposes Gemini models through the native Google API
+        # shape (/models/<model>:generateContent) while other Zen families use
+        # OpenAI, Anthropic, or Responses-compatible endpoints.
+        return True
+
+    return False
 
 
 def probe_gemini_tier(

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -101,7 +101,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
-    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
+    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3.5-flash", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
     "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -19,6 +19,19 @@ class DummyResponse:
         return self._payload
 
 
+def test_native_base_url_detection_accepts_opencode_zen_google_endpoint():
+    from agent.gemini_native_adapter import is_native_gemini_base_url
+
+    assert is_native_gemini_base_url("https://opencode.ai/zen/v1")
+    assert is_native_gemini_base_url("https://opencode.ai/zen/v1/")
+
+
+def test_native_base_url_detection_rejects_opencode_go_openai_endpoint():
+    from agent.gemini_native_adapter import is_native_gemini_base_url
+
+    assert not is_native_gemini_base_url("https://opencode.ai/zen/go/v1")
+
+
 def test_build_native_request_preserves_thought_signature_on_tool_replay():
     from agent.gemini_native_adapter import build_gemini_request
 

--- a/tests/run_agent/test_opencode_zen_gemini_native_client.py
+++ b/tests/run_agent/test_opencode_zen_gemini_native_client.py
@@ -1,0 +1,56 @@
+"""Regression tests for OpenCode Zen Gemini-native routing."""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+ZEN_TEST_KEY = "zen-test-key"
+
+
+def _make_agent(model="gemini-3.5-flash"):
+    return AIAgent(
+        api_key=ZEN_TEST_KEY,
+        base_url="https://opencode.ai/zen/v1",
+        provider="opencode-zen",
+        model=model,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+@patch("run_agent.OpenAI")
+def test_opencode_zen_gemini_model_uses_native_gemini_client(mock_openai):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    agent = _make_agent()
+    mock_openai.reset_mock()
+
+    client = agent._create_openai_client(
+        {"api_key": ZEN_TEST_KEY, "base_url": "https://opencode.ai/zen/v1"},
+        reason="test",
+        shared=False,
+    )
+    try:
+        assert isinstance(client, GeminiNativeClient)
+        assert client.base_url == "https://opencode.ai/zen/v1"
+        assert client._headers()["x-goog-api-key"] == ZEN_TEST_KEY
+        mock_openai.assert_not_called()
+    finally:
+        client.close()
+
+
+@patch("run_agent.OpenAI")
+def test_opencode_zen_non_gemini_model_keeps_openai_transport(mock_openai):
+    agent = _make_agent(model="glm-5")
+    mock_openai.reset_mock()
+
+    client = agent._create_openai_client(
+        {"api_key": ZEN_TEST_KEY, "base_url": "https://opencode.ai/zen/v1"},
+        reason="test",
+        shared=False,
+    )
+
+    assert client is mock_openai.return_value
+    mock_openai.assert_called_once()


### PR DESCRIPTION
## Summary
- Route OpenCode Zen `gemini-*` models through the existing GeminiNativeClient instead of OpenAI chat completions.
- Recognize `https://opencode.ai/zen/v1` as a Gemini-native endpoint while keeping OpenCode Go on the OpenAI-compatible path.
- Add `gemini-3.5-flash` to OpenCode Zen setup suggestions.

## Test Plan
- `/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/agent/test_gemini_native_adapter.py tests/run_agent/test_opencode_zen_gemini_native_client.py -q`
- `/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/plugins/model_providers/test_opencode_go_profile.py tests/hermes_cli/test_opencode_go_flat_namespace.py tests/hermes_cli/test_opencode_go_in_model_list.py -q`
- No-fallback smoke test: `HERMES_HOME=/tmp/hermes-pr-opencode-zen-gemini hermes chat -Q -q 'Reply with exactly OK.'` returned `OK`.

## Notes
Verified the raw OpenCode Zen Gemini endpoint succeeds via `/zen/v1/models/gemini-3.5-flash:generateContent` with `x-goog-api-key`. The previous Hermes route hit `/chat/completions` and returned `No provider available`.
