### PR TITLE
fix(ddgs): add 30s wall-clock timeout to prevent indefinite search hangs

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -13,11 +13,19 @@ whether the package is importable; the plugin still registers either way so
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
+
+# Maximum wall-clock seconds for the entire ddgs search operation.
+# Individual HTTP requests already have their own timeout (DDGS default 5 s),
+# but when multiple engines chain slow requests the overall call can hang
+# indefinitely.  This cap prevents a single web search from blocking the
+# entire agent loop (issue #36776).
+_SEARCH_TIMEOUT_SECS = 30
 
 
 class DDGSWebSearchProvider(WebSearchProvider):
@@ -57,7 +65,12 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return False
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
-        """Execute a DuckDuckGo search and return normalized results."""
+        """Execute a DuckDuckGo search and return normalized results.
+
+        The synchronous ``ddgs`` library call is wrapped in a thread with a
+        hard wall-clock timeout so that a hung search cannot block the entire
+        agent loop indefinitely.
+        """
         try:
             from ddgs import DDGS  # type: ignore
         except ImportError:
@@ -70,21 +83,51 @@ class DDGSWebSearchProvider(WebSearchProvider):
         # in case the package ignores the hint.
         safe_limit = max(1, int(limit))
 
+        def _do_search() -> None:
+            """Run the actual ddgs query inside a thread, storing the result."""
+            try:
+                results: list[dict[str, Any]] = []
+                with DDGS() as client:
+                    for i, hit in enumerate(client.text(query, max_results=safe_limit)):
+                        if i >= safe_limit:
+                            break
+                        url = str(hit.get("href") or hit.get("url") or "")
+                        results.append(
+                            {
+                                "title": str(hit.get("title", "")),
+                                "url": url,
+                                "description": str(hit.get("body", "")),
+                                "position": i + 1,
+                            }
+                        )
+                _box["results"] = results
+            except Exception as exc:  # noqa: BLE001
+                _box["error"] = exc
+
+        # Run in a daemon thread so the caller can enforce a wall-clock
+        # timeout.  Daemon threads are abandoned on timeout — the ddgs
+        # library's own HTTP timeouts will eventually release resources.
+        _box: dict[str, Any] = {}
+        worker = threading.Thread(target=_do_search, daemon=True)
+
         try:
-            web_results = []
-            with DDGS() as client:
-                for i, hit in enumerate(client.text(query, max_results=safe_limit)):
-                    if i >= safe_limit:
-                        break
-                    url = str(hit.get("href") or hit.get("url") or "")
-                    web_results.append(
-                        {
-                            "title": str(hit.get("title", "")),
-                            "url": url,
-                            "description": str(hit.get("body", "")),
-                            "position": i + 1,
-                        }
-                    )
+            worker.start()
+            worker.join(timeout=_SEARCH_TIMEOUT_SECS)
+            if worker.is_alive():
+                logger.warning(
+                    "DDGS search timed out after %ds for query: %s",
+                    _SEARCH_TIMEOUT_SECS, query,
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"DuckDuckGo search timed out after {_SEARCH_TIMEOUT_SECS}s. "
+                        "Try a shorter query or switch to a faster search backend."
+                    ),
+                }
+            if "error" in _box:
+                raise _box["error"]
+            web_results = _box.get("results", [])
         except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
             logger.warning("DDGS search error: %s", exc)
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -155,6 +155,38 @@ class TestDDGSProviderSearch:
         assert result["success"] is True
         assert result["data"]["web"] == []
 
+    def test_search_timeout_returns_failure(self, monkeypatch):
+        """When the ddgs library hangs, the search must time out gracefully."""
+        import threading
+
+        _hang = threading.Event()  # never set → blocks forever
+
+        fake = types.ModuleType("ddgs")
+
+        class _HangingDDGS:
+            def __enter__(self):
+                return self
+            def __exit__(self, *_a):
+                return False
+            def text(self, query, max_results=5):
+                _hang.wait(timeout=999)  # blocks until timeout (never fires)
+                yield  # pragma: no cover
+
+        fake.DDGS = _HangingDDGS
+        monkeypatch.setitem(sys.modules, "ddgs", fake)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        # Use a very short timeout so the test finishes fast
+        monkeypatch.setattr(
+            "plugins.web.ddgs.provider._SEARCH_TIMEOUT_SECS", 0.5
+        )
+        result = DDGSWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "timed out" in result["error"].lower()
+
 
 # ---------------------------------------------------------------------------
 # Integration: _is_backend_available / _get_backend / check_web_api_key


### PR DESCRIPTION
## What does this PR do?

Adds a 30-second wall-clock timeout to the DuckDuckGo (`ddgs`) web search provider so that a hung search cannot block the entire agent loop indefinitely.

## Related Issue

Fixes #36776

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/ddgs/provider.py`: Wrap the synchronous `DDGS().text()` call in a daemon thread with a 30-second `join()` timeout. On timeout, return a clear error message instead of hanging. Exceptions from the search thread are captured and re-raised in the caller.
- `tests/tools/test_web_providers_ddgs.py`: Add `test_search_timeout_returns_failure` — uses a fake ddgs module whose `text()` blocks forever (via `threading.Event`), verifies the provider returns `success: False` with "timed out" in the error message.

## How to Test

1. Run the ddgs provider tests: `pytest tests/tools/test_web_providers_ddgs.py -v`
2. Run the broader web search plugin tests: `pytest tests/plugins/web/ -v`
3. Verify the timeout test completes in <2 seconds (uses a 0.5s monkeypatched timeout)
4. All 50 tests should pass with no regressions

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_web_providers_ddgs.py tests/plugins/web/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/web/ddgs/provider.py` (DDGSWebSearchProvider.search — callers: web_search_tool dispatch via registry)
- Blast radius: LOW — single plugin provider, no shared state changes
- Related patterns: Thread-based timeout for synchronous I/O is the standard approach when the underlying library doesn't support async or timeout parameters. The ddgs library's `DDGS(timeout=5)` only covers individual HTTP requests, not the overall multi-engine search loop.
