### PR TITLE
feat(ha): add config-driven notification toggle for Home Assistant adapter

### DIFF
--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -86,6 +86,10 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._watch_all: bool = bool(extra.get("watch_all", False))
         self._cooldown_seconds: int = int(extra.get("cooldown_seconds", 30))
 
+        # Outbound notifications (persistent_notification.create). When false,
+        # send() becomes a silent no-op; inbound event listening is unaffected.
+        self._notifications_enabled: bool = bool(extra.get("notifications", True))
+
         # Cooldown tracking: entity_id -> last_event_timestamp
         self._last_event_time: Dict[str, float] = {}
 
@@ -131,6 +135,12 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._running = True
             logger.info("[%s] Connected to %s", self.name, self._hass_url)
+            if not self._notifications_enabled:
+                logger.info(
+                    "[%s] Outbound persistent notifications disabled "
+                    "(notifications=false in config)",
+                    self.name,
+                )
             return True
 
         except Exception as e:
@@ -395,6 +405,12 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         Uses the REST API instead of WebSocket to avoid a race condition
         with the event listener loop that reads from the same WS connection.
         """
+        # Honor the `notifications` config flag (default: true). When false,
+        # persistent_notification.create is skipped but inbound event listening
+        # continues unaffected — useful when interacting via another platform.
+        if not self._notifications_enabled:
+            logger.debug("[%s] notifications disabled — skip send()", self.name)
+            return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
         url = f"{self._hass_url}/api/services/persistent_notification/create"
         headers = {
             "Authorization": f"Bearer {self._hass_token}",

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -518,6 +518,27 @@ class TestSendViaRestApi:
         assert call_args[1]["json"]["message"] == "Test notification"
         assert "Bearer tok" in call_args[1]["headers"]["Authorization"]
 
+    def test_notifications_enabled_by_default(self):
+        # Default config keeps outbound notifications on.
+        adapter = _make_adapter()
+        assert adapter._notifications_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_send_silent_no_op_when_notifications_disabled(self):
+        # notifications=false -> send() returns success WITHOUT any HTTP POST.
+        adapter = _make_adapter(notifications=False)
+        assert adapter._notifications_enabled is False
+        mock_session = self._mock_aiohttp_session(200)
+
+        with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+            mock_aiohttp.ClientTimeout = lambda total: total
+
+            result = await adapter.send("ha_events", "Test notification")
+
+        assert result.success is True
+        mock_session.post.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_send_http_error(self):
         adapter = _make_adapter()

--- a/website/docs/user-guide/messaging/homeassistant.md
+++ b/website/docs/user-guide/messaging/homeassistant.md
@@ -158,6 +158,7 @@ platforms:
 | `watch_all` | `false` | Set to `true` to receive **all** state changes (not recommended for most setups) |
 | `ignore_entities` | *(none)* | Always ignore these entities (applied before domain/entity filters) |
 | `cooldown_seconds` | `30` | Minimum seconds between events for the same entity |
+| `notifications` | `true` | Set to `false` to stop the agent's outbound responses from creating HA persistent notifications (useful when you interact via Telegram or another platform). Inbound event listening is unaffected. |
 
 :::tip
 Start with a focused set of domains — `climate`, `binary_sensor`, and `alarm_control_panel` cover the most useful automations. Add more as needed. Use `ignore_entities` to suppress noisy sensors like CPU temperature or uptime counters.
@@ -179,6 +180,8 @@ State changes are formatted as human-readable messages based on domain:
 ### Agent Responses
 
 Outbound messages from the agent are delivered as **Home Assistant persistent notifications** (via `persistent_notification.create`). These appear in the HA notification panel with the title "Hermes Agent".
+
+Set `notifications: false` in the platform's `extra` config to disable this — `send()` becomes a silent no-op (returning success) so the agent stays reachable via other platforms like Telegram without generating notification noise in HA. Inbound event listening is unaffected.
 
 ### Connection Management
 


### PR DESCRIPTION
## Contribution: Config-driven notification toggle for Home Assistant adapter

### Problem
The `homeassistant` platform adapter calls `persistent_notification.create`
for every response, generating notification spam in HA. Users who interact
with Hermes via Telegram (or any non-HA platform) do not need Hermes responses
to appear as HA notifications.

### Solution
Add a `notifications` boolean in `platforms.homeassistant.extra` (default: `true`).
When set to `false`, `send()` becomes a silent no-op while inbound event listening
(WebSocket state_changed events) continues unaffected.

### Usage
```yaml
# ~/.hermes/config.yaml
platforms:
  homeassistant:
    extra:
      notifications: false  # disable persistent_notification.create
      watch_entities:
        - binary_sensor.motion_sensor
      cooldown_seconds: 60
```

### Implementation
- `__init__`: read `extra.get("notifications", True)` -> `self._notifications_enabled`
- `connect()`: log info when notifications are disabled
- `send()`: early return with `success=True` when notifications are off

### Files changed
- `plugins/platforms/homeassistant/adapter.py` — config read (`__init__`), startup log (`connect`), early-return guard (`send`)
- `tests/gateway/test_homeassistant.py` — no-POST/success test for the disabled path + default-enabled assertion
- `website/docs/user-guide/messaging/homeassistant.md` — document `extra.notifications`
