### PR TITLE
fix(web-tools): include 'xai' in check_web_api_key backend list

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1367,11 +1367,11 @@ async def web_crawl_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
     )
 
 


### PR DESCRIPTION
check_web_api_key() lists known backends but was missing `xai`. Users with `web.backend: xai` configured would see the web search tool show as unavailable even when their X.AI API key is set.

This is a 2-line fix: added `"xai"` to both the configured-backend check and the fallback scan list.