### PR TITLE
fix(compression): retry feasibility check on transient failure instead of permanent skip

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -288,11 +288,9 @@ def compress_context(
     # The check itself sets ``agent._compression_warning`` so the
     # status-callback replay machinery still emits the warning to the user
     # the first time it would matter.
-    if not getattr(agent, "_compression_feasibility_checked", True):
-        try:
-            check_compression_model_feasibility(agent)
-        finally:
-            agent._compression_feasibility_checked = True
+    if not getattr(agent, "_compression_feasibility_checked", False):
+        check_compression_model_feasibility(agent)
+        agent._compression_feasibility_checked = True
 
     _pre_msg_count = len(messages)
     logger.info(


### PR DESCRIPTION
The lazy compression feasibility check in `conversation_compression.py` uses a `try/finally` that sets `_compression_feasibility_checked = True` unconditionally. If `check_compression_model_feasibility()` raises an exception (network blip, provider 503, transient DB lock), the flag is set to `True` and the check is **never retried** for the rest of the session.

Also fixed the `getattr` default from `True` to `False`: if the attribute is somehow missing from the agent object, the check should run rather than skip it.