### PR TITLE
fix(compressor): restore tail_token_budget on session reset

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -480,6 +480,7 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self.tail_token_budget = int(self.threshold_tokens * self.summary_target_ratio)
 
     def update_model(
         self,


### PR DESCRIPTION
Bug: `ContextCompressor.on_session_reset()` (called on `/new` or `/reset`) resets per-session state but did **not** restore `tail_token_budget`. If `update_model()` was called mid-session with a smaller context length (e.g. fallback to smaller model), the budget stayed shrunken after reset.

Fix: added `self.tail_token_budget = int(self.threshold_tokens * self.summary_target_ratio)` to `on_session_reset()`, matching the formula used in `__init__` and `update_model`.