### PR TITLE
fix(completion): replace 'ls' with glob-based listing in generated scripts

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -105,7 +105,7 @@ _hermes_profiles() {{
     local profiles_dir="$HOME/.hermes/profiles"
     local profiles="default"
     if [ -d "$profiles_dir" ]; then
-        profiles="$profiles $(ls "$profiles_dir" 2>/dev/null)"
+        for f in "$profiles_dir"/*/; do [ -d "$f" ] && profiles="$profiles $(basename "$f")"; done
     fi
     echo "$profiles"
 }}
@@ -206,7 +206,7 @@ _hermes_profiles() {{
     local -a profiles
     profiles=(default)
     if [[ -d "$HOME/.hermes/profiles" ]]; then
-        profiles+=("${{(@f)$(ls $HOME/.hermes/profiles 2>/dev/null)}}")
+        for f in $HOME/.hermes/profiles/*(N/); do profiles+=("${f:t}"); done
     fi
     _describe 'profile' profiles
 }}
@@ -260,7 +260,9 @@ def generate_fish(parser: argparse.ArgumentParser) -> str:
         "function __hermes_profiles",
         "    echo default",
         "    if test -d $HOME/.hermes/profiles",
-        "        ls $HOME/.hermes/profiles 2>/dev/null",
+        "        for d in $HOME/.hermes/profiles/*/
+            basename $d
+        end",
         "    end",
         "end",
         "",


### PR DESCRIPTION
The generated bash, zsh, and fish completion scripts used `ls` to list profile directories in `_hermes_profiles()`. `ls` output is not safe for programmatic consumption — filenames with spaces, newlines, or special characters would produce broken completions.

Replaced with safe alternatives:
- **bash**: glob loop with `basename`
- **zsh**: zsh glob qualifier `*(N/)` + `:t` modifier
- **fish**: `for` loop with `basename`

This is a correctness fix for edge cases (profile names with spaces).