### PR TITLE
fix(web-server): return 400 for invalid env var names instead of 500

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1223,6 +1223,8 @@ async def set_env_var(body: EnvVarUpdate):
     try:
         save_env_value(body.key, body.value)
         return {"ok": True, "key": body.key}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         _log.exception("PUT /api/env failed")
         raise HTTPException(status_code=500, detail="Internal server error")


### PR DESCRIPTION
The `PUT /api/env` endpoint calls `save_env_value()` which raises `ValueError` for invalid env var names (e.g. empty key, invalid characters). The catch-all `except Exception` returned HTTP 500, making validation errors appear as internal server errors.

Fix: catch `ValueError` before the generic handler and return HTTP 400 with the specific validation error message.