### PR TITLE
chore(terminal-tool): remove duplicate 'import threading'

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -233,7 +233,6 @@ _sudo_password_cache_lock = threading.Lock()
 # own callback exactly like before. Gateway mode resolves approvals via
 # the per-session queue in tools.approval, not through these callbacks,
 # so it's unaffected.
-import threading
 _callback_tls = threading.local()
 
 


### PR DESCRIPTION
`threading` was already imported at line 43. The duplicate at line 236 was leftover from a refactor — Python caches module imports so it had no functional effect, but removing it keeps the codebase clean.