### PR TITLE
fix(tui): sync ctx.sid on session.info after compression fork (#36777)

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1113,4 +1113,40 @@ describe('createGatewayEventHandler', () => {
       vi.useRealTimers()
     }
   })
+
+  it('updates sid on session.info when ev.session_id changes (compression fork)', () => {
+    const appended: Msg[] = []
+    patchUiState({ sid: 'old-sid' })
+
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: { usage: { input: 1, output: 2 } },
+      session_id: 'new-sid',
+      type: 'session.info'
+    } as any)
+
+    expect(getUiState().sid).toBe('new-sid')
+  })
+
+  it('keeps sid unchanged on session.info when session_id matches or is absent', () => {
+    const appended: Msg[] = []
+    patchUiState({ sid: 'same-sid' })
+
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: {},
+      session_id: 'same-sid',
+      type: 'session.info'
+    } as any)
+    expect(getUiState().sid).toBe('same-sid')
+
+    onEvent({
+      payload: {},
+      type: 'session.info'
+    } as any)
+    expect(getUiState().sid).toBe('same-sid')
+  })
+
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -370,7 +370,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   return (ev: GatewayEvent) => {
     const sid = getUiState().sid
 
-    if (ev.session_id && sid && ev.session_id !== sid && !ev.type.startsWith('gateway.')) {
+    if (
+      ev.session_id &&
+      sid &&
+      ev.session_id !== sid &&
+      !ev.type.startsWith('gateway.') &&
+      ev.type !== 'session.info'
+    ) {
       return
     }
 
@@ -388,13 +394,18 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       case 'session.info': {
         const info = ev.payload
+        const incomingSid = ev.session_id
 
-        patchUiState(state => ({
-          ...state,
-          info,
-          status: state.status === 'starting agent…' ? 'ready' : state.status,
-          usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
-        }))
+        patchUiState(state => {
+          const sidChanged = Boolean(incomingSid) && incomingSid !== state.sid
+          return {
+            ...state,
+            info,
+            sid: sidChanged ? (incomingSid as string) : state.sid,
+            status: state.status === 'starting agent…' ? 'ready' : state.status,
+            usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
+          }
+        })
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
 


### PR DESCRIPTION
## Summary

Fixes #36777. After `/compress` forks the TUI session (ends parent, creates continuation), the gateway emits `session.info` with the new `session_id` — but the TUI handler was dropping the update on the floor, leaving `ctx.sid` pointing at the closed parent session. All subsequent RPCs (message submission, `/image`, `/model`, etc.) then targeted the dead session.

## Root cause

Two interlocking bugs in `ui-tui/src/app/createGatewayEventHandler.ts`:

1. **Guard discarded the event.** The top-level guard early-returned any event whose `ev.session_id` differed from `state.sid` (except `gateway.*`). The post-compression `session.info` — which by definition carries a *different* sid — was silently discarded before any case ran.
2. **Handler ignored sid.** Even with the event delivered, the `session.info` case only patched `info` / `status` / `usage` — never `sid`.

The gateway side (`tui_gateway/server.py::_sync_session_key_after_compress`, `_emit("session.info", new_sid, ...)`) is correct; the bug was purely on the TS receiver.

## Fix

- Allow `session.info` past the sid mismatch guard so the compression-fork event reaches the handler.
- In the `session.info` case, read `ev.session_id` (set by the gateway `_emit` envelope) and update `state.sid` when it differs.

```ts
case 'session.info': {
  const info = ev.payload
  const incomingSid = ev.session_id
  patchUiState(state => {
    const sidChanged = Boolean(incomingSid) && incomingSid !== state.sid
    return {
      ...state,
      info,
      sid: sidChanged ? (incomingSid as string) : state.sid,
      status: state.status === 'starting agent…' ? 'ready' : state.status,
      usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
    }
  })
  ...
}
```

## Testing

- Added two vitest cases in `ui-tui/src/__tests__/createGatewayEventHandler.test.ts`:
  - updates `sid` when `ev.session_id` differs (compression fork)
  - leaves `sid` unchanged when it matches or is absent
- `npx vitest run src/__tests__/createGatewayEventHandler.test.ts` → **52/52 pass**
- `npx tsc --noEmit` → no new errors in touched files

## Notes

- Issue reporter's suggested fix read `info.session_id` from the payload, but the gateway puts `session_id` on the event envelope (`_emit` line `params = {"type": event, "session_id": sid}`), not in the payload dict — so this PR uses `ev.session_id`, which is the source of truth and is what the existing guard also reads.
- Scope is intentionally minimal: only the handler + tests; no refactors.
