### PR TITLE
fix(tui): update ctx.sid on session.info to handle compression fork

### DIFF
--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -389,12 +389,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
-        patchUiState(state => ({
-          ...state,
-          info,
-          status: state.status === 'starting agent…' ? 'ready' : state.status,
-          usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
-        }))
+        patchUiState(state => {
+          const sidChanged = info.session_id && info.session_id !== state.sid
+          return {
+            ...state,
+            info,
+            sid: sidChanged ? info.session_id : state.sid,
+            status: state.status === 'starting agent…' ? 'ready' : state.status,
+            usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
+          }
+        })
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
 


### PR DESCRIPTION
## What does this PR do?

Updates the TUI's `ctx.sid` when `session.info` event carries a new `session_id`, which happens after `/compress` triggers a session fork. Previously, the handler only updated `info`, `status`, and `usage` without syncing `sid`, causing subsequent RPC calls to target the closed parent session.

## Related Issue

Fixes #36777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/createGatewayEventHandler.ts`: Added `sidChanged` detection in `session.info` handler to update `state.sid` when `info.session_id` differs from current sid.

## How to Test

1. Start a TUI session with enough messages to trigger auto-compression (or manually run `/compress`)
2. Compression completes, session ID rotates in SessionDB
3. Verify TUI display shows compressed history (not blank)
4. Verify `/resume` shows the correct session_id in banner
5. Verify RPC calls (`/image`, `/model`, etc.) target the new session

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A for TS fix)
- [x] I've added tests for my changes (N/A for TS handler logic fix)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `ui-tui/src/app/createGatewayEventHandler.ts` (callers: 0, local handler in event loop)
- Blast radius: LOW (single handler, no downstream side effects)
- Related patterns: session.info handler pattern across tui_gateway/