### PR TITLE
fix: stop mislabeling generic gateway zombie reaping as Kanban worker activity

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6045,15 +6045,26 @@ class GatewayRunner:
             try:
                 # Reap zombie children before per-board work so a board DB
                 # failure cannot block cleanup of unrelated workers.
+                #
+                # NOTE: reap_worker_zombies() calls os.waitpid(-1, WNOHANG),
+                # which reaps EVERY zombie child of the gateway process — not
+                # only Kanban task workers. The reaper intentionally stays
+                # decoupled from board state so a board DB failure can't block
+                # cleanup. Because of that, these PIDs may belong to any
+                # gateway child (cron-spawned scripts, terminal-tool
+                # subprocesses, watchers, etc.), so we log under a neutral
+                # "gateway" label rather than attributing them to Kanban.
+                # Mislabeling them as Kanban workers produces a false "Kanban
+                # tasks are running" signal even when the board is empty.
                 pids = await asyncio.to_thread(_kb.reap_worker_zombies)
                 if pids:
-                    logger.info(
-                        "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
+                    logger.debug(
+                        "gateway: reaped %d orphaned child process(es), pids=%s",
                         len(pids),
                         pids,
                     )
             except Exception:
-                logger.exception("kanban dispatcher: zombie reaper failed")
+                logger.exception("gateway: orphaned-child reaper failed")
 
             try:
                 if auto_decompose_enabled:


### PR DESCRIPTION
# Misleading log: `kanban dispatcher: reaped N zombie worker(s)` fires for ALL gateway children, not just Kanban workers

## Summary

The gateway's embedded Kanban dispatcher logs `kanban dispatcher: reaped N zombie worker(s), pids=[...]` for **any** zombie child of the gateway process — not only Kanban task workers. The reaper calls `os.waitpid(-1, os.WNOHANG)`, which reaps every direct child of the process. On a gateway that spawns non-Kanban subprocesses (cron-spawned scripts, terminal-tool children, watcher processes, etc.), these unrelated PIDs get logged under the Kanban label, even when **no Kanban tasks exist and the board is empty**.

## Impact

Operationally alarming false signal. On a deployment where the gateway runs an unrelated workload that spawns short-lived children (in our case a trading agent: copy-trader, order/fill watchers, keychain reads), the log shows a steady stream of:

```
kanban dispatcher: reaped 1 zombie worker(s), pids=[43920]
```

…around the clock, despite the Kanban board having **0 tasks, 0 runs, 0 events**. This reads as "autonomous Kanban workers are running" when nothing of the sort is happening. For an operator auditing what their agent is doing — especially anything touching money or external side effects — this triggers a full investigation to rule out rogue task execution. The label actively points in the wrong direction.

## Root cause

`gateway/run.py` (~L6044–6056):

```python
while self._running:
    try:
        # Reap zombie children before per-board work so a board DB
        # failure cannot block cleanup of unrelated workers.
        pids = await asyncio.to_thread(_kb.reap_worker_zombies)
        if pids:
            logger.info(
                "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
                len(pids),
                pids,
            )
```

`reap_worker_zombies()` in `hermes_cli/kanban_db.py` (~L4830):

```python
def reap_worker_zombies() -> "list[int]":
    ...
    while True:
        try:
            pid, status = os.waitpid(-1, os.WNOHANG)   # reaps ANY child, not just kanban
        except ChildProcessError:
            break
        if pid == 0:
            break
        _record_worker_exit(pid, status)
        reaped.append(pid)
    return reaped
```

`os.waitpid(-1, ...)` is process-wide. The reaper is a generic orphan-reaper that happens to live inside the Kanban dispatcher loop (intentionally — the comment notes it must run even if a board DB read fails). But the **log message** attributes every reaped PID to Kanban, which is incorrect for any child the dispatcher didn't spawn.

## Suggested fixes (any one)

1. **Neutral label.** Change the message to reflect what it actually does, e.g. `gateway: reaped N orphaned child process(es), pids=[...]` — since the reaper is genuinely process-wide cleanup, not Kanban-specific.
2. **Attribute only known Kanban workers.** Cross-reference reaped PIDs against `worker_pid` values the dispatcher actually spawned (the `tasks.worker_pid` column / dispatcher's own spawn registry) and only log those under the Kanban label; log the rest at `debug` under a neutral label (or not at all).
3. **Demote to debug.** If the PID isn't a tracked Kanban worker, `logger.debug` instead of `logger.info` so it doesn't surface in normal operation.

Option 2 is the most correct; option 1 is the cheapest and removes the false signal.

## Repro

1. Run the gateway with the Kanban dispatcher embedded (default) and an **empty** board.
2. From the same gateway process tree, spawn any short-lived child (e.g. a cron job that shells out, or a terminal-tool subprocess).
3. Observe `kanban dispatcher: reaped N zombie worker(s)` in the gateway log despite zero Kanban tasks.

## Environment

- Hermes Agent, gateway with embedded Kanban dispatcher (`interval=60.0s`)
- macOS (POSIX `os.waitpid` path)
- Observed on a gateway whose host workload spawns frequent non-Kanban children
