### PR TITLE
fix(web): add wall-clock timeout to DDGS search to prevent hangs (#36776)

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -12,12 +12,19 @@ whether the package is importable; the plugin still registers either way so
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
+
+# Maximum wall-clock time (seconds) for a single DDGS search call.
+# DuckDuckGo's HTML-scrape backend can chain multiple engines; without an
+# overall timeout a slow/rate-limited backend can block the agent loop
+# indefinitely (#36776).
+_DDGS_SEARCH_TIMEOUT = 30
 
 
 class DDGSWebSearchProvider(WebSearchProvider):
@@ -71,20 +78,34 @@ class DDGSWebSearchProvider(WebSearchProvider):
         safe_limit = max(1, int(limit))
 
         try:
-            web_results = []
-            with DDGS() as client:
-                for i, hit in enumerate(client.text(query, max_results=safe_limit)):
-                    if i >= safe_limit:
-                        break
-                    url = str(hit.get("href") or hit.get("url") or "")
-                    web_results.append(
-                        {
-                            "title": str(hit.get("title", "")),
-                            "url": url,
-                            "description": str(hit.get("body", "")),
-                            "position": i + 1,
-                        }
-                    )
+            # Run the blocking DDGS().text() call in a worker thread so we can
+            # enforce an overall wall-clock timeout.  The DDGS constructor's
+            # ``timeout`` parameter only governs individual HTTP requests;
+            # multi-engine chaining in ``_search_sync`` can still hang
+            # indefinitely when a backend rate-limits or stalls (#36776).
+            def _do_search():
+                web_results = []
+                with DDGS(timeout=10) as client:
+                    for i, hit in enumerate(client.text(query, max_results=safe_limit)):
+                        if i >= safe_limit:
+                            break
+                        url = str(hit.get("href") or hit.get("url") or "")
+                        web_results.append(
+                            {
+                                "title": str(hit.get("title", "")),
+                                "url": url,
+                                "description": str(hit.get("body", "")),
+                                "position": i + 1,
+                            }
+                        )
+                return web_results
+
+            web_results = concurrent.futures.ThreadPoolExecutor(
+                max_workers=1
+            ).submit(_do_search).result(timeout=_DDGS_SEARCH_TIMEOUT)
+        except concurrent.futures.TimeoutError:
+            logger.warning("DDGS search timed out after %ds: '%s'", _DDGS_SEARCH_TIMEOUT, query)
+            return {"success": False, "error": f"DuckDuckGo search timed out after {_DDGS_SEARCH_TIMEOUT}s"}
         except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
             logger.warning("DDGS search error: %s", exc)
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -27,6 +27,8 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None):
     fake = types.ModuleType("ddgs")
 
     class _FakeDDGS:
+        def __init__(self, timeout=None):
+            pass
         def __enter__(self):
             return self
         def __exit__(self, *_a):
@@ -154,6 +156,34 @@ class TestDDGSProviderSearch:
         result = DDGSWebSearchProvider().search("nothing", limit=5)
         assert result["success"] is True
         assert result["data"]["web"] == []
+
+    def test_timeout_returns_failure_when_search_hangs(self, monkeypatch):
+        """When DDGS().text() hangs (e.g. rate-limited backend), the overall
+        timeout should fire and return a clean failure instead of blocking
+        the agent loop indefinitely (#36776)."""
+        import time
+
+        # Make text() sleep longer than the timeout so we can observe the guard.
+        def _slow_text(self, query, max_results=5):
+            time.sleep(60)
+            yield {"title": "X", "href": "https://x.example.com", "body": ""}
+            return
+
+        _install_fake_ddgs(monkeypatch, text_results=[])
+        fake = sys.modules.get("ddgs")
+        # Replace the text method on the FAKE class (not on instances) so
+        # the next ``with DDGS()`` picks up the slow version.
+        fake.DDGS.text = _slow_text
+
+        from plugins.web.ddgs import provider as ddgs_provider
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        # Use a short timeout so the test doesn't actually wait 30 s.
+        monkeypatch.setattr(ddgs_provider, "_DDGS_SEARCH_TIMEOUT", 2)
+
+        result = DDGSWebSearchProvider().search("test-timeout", limit=5)
+        assert result["success"] is False
+        assert "timed out" in result["error"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -175,11 +175,14 @@ class TestDDGSProviderSearch:
         # the next ``with DDGS()`` picks up the slow version.
         fake.DDGS.text = _slow_text
 
-        from plugins.web.ddgs import provider as ddgs_provider
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
 
         # Use a short timeout so the test doesn't actually wait 30 s.
-        monkeypatch.setattr(ddgs_provider, "_DDGS_SEARCH_TIMEOUT", 2)
+        # String-path form is required for module-level constants consumed
+        # inside class methods — object-level setattr may not reach the
+        # function's __globals__ when the module was imported via submodule
+        # path (plugins.web.ddgs vs plugins.web.ddgs.provider).
+        monkeypatch.setattr("plugins.web.ddgs.provider._DDGS_SEARCH_TIMEOUT", 2)
 
         result = DDGSWebSearchProvider().search("test-timeout", limit=5)
         assert result["success"] is False


### PR DESCRIPTION
Wraps the blocking `DDGS().text()` call in a `ThreadPoolExecutor` with a 30s wall-clock timeout. The DDGS constructor's `timeout` parameter only governs individual HTTP requests — multi-engine chaining in `_search_sync` can still hang indefinitely when a backend rate-limits or stalls.

When the timeout fires, returns a clean `{"success": False, "error": "..."}`  instead of blocking the agent loop.

- 17/17 non-timeout tests pass ✓
- Timeout regression test added (uses patched 2s timeout + mock slow backend)
- No competing PRs