### PR TITLE
fix: snapshot dict cap evictions

### DIFF
--- a/tests/tools/test_accretion_caps.py
+++ b/tests/tools/test_accretion_caps.py
@@ -62,6 +62,21 @@ class TestReadTrackerCaps:
         assert ("/p0", 0, 500) not in task_data["dedup"]
         assert ("/p14", 0, 500) not in task_data["dedup"]
 
+    def test_dedup_hits_capped_oldest_first(self, monkeypatch):
+        """dedup_hits dict is bounded; oldest entries evicted first."""
+        from tools import file_tools as ft
+
+        monkeypatch.setattr(ft, "_DEDUP_CAP", 3)
+        task_data = {
+            "read_history": set(),
+            "dedup": {},
+            "dedup_hits": {f"key-{i}": i for i in range(8)},
+            "read_timestamps": {},
+        }
+        ft._cap_read_tracker_data(task_data)
+        assert len(task_data["dedup_hits"]) == 3
+        assert list(task_data["dedup_hits"]) == ["key-5", "key-6", "key-7"]
+
     def test_read_timestamps_capped_oldest_first(self, monkeypatch):
         """read_timestamps dict is bounded; oldest entries evicted first."""
         from tools import file_tools as ft
@@ -107,6 +122,15 @@ class TestReadTrackerCaps:
         ft._cap_read_tracker_data({})  # no containers at all
         ft._cap_read_tracker_data({"read_history": None})
         ft._cap_read_tracker_data({"dedup": None})
+
+    def test_file_state_cap_dict_trims_multiple_entries_without_runtime_error(self):
+        """file_state dict caps snapshot keys before popping multiple entries."""
+        from tools import file_state
+
+        data = {i: i for i in range(5)}
+        file_state._cap_dict(data, 2)
+
+        assert list(data) == [3, 4]
 
     def test_live_cap_applied_after_read_add(self, tmp_path, monkeypatch):
         """Live read_file path enforces caps."""

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -283,12 +283,8 @@ def _cap_dict(d: dict, limit: int) -> None:
     if over <= 0:
         return
     # dict preserves insertion order (PY>=3.7) — pop the oldest keys.
-    it = iter(d)
-    for _ in range(over):
-        try:
-            d.pop(next(it))
-        except (StopIteration, KeyError):
-            break
+    for key in list(d)[:over]:
+        d.pop(key, None)
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -429,29 +429,20 @@ def _cap_read_tracker_data(task_data: dict) -> None:
     dedup = task_data.get("dedup")
     if dedup is not None and len(dedup) > _DEDUP_CAP:
         excess = len(dedup) - _DEDUP_CAP
-        for _ in range(excess):
-            try:
-                dedup.pop(next(iter(dedup)))
-            except (StopIteration, KeyError):
-                break
+        for key in list(dedup)[:excess]:
+            dedup.pop(key, None)
 
     dedup_hits = task_data.get("dedup_hits")
     if dedup_hits is not None and len(dedup_hits) > _DEDUP_CAP:
         excess = len(dedup_hits) - _DEDUP_CAP
-        for _ in range(excess):
-            try:
-                dedup_hits.pop(next(iter(dedup_hits)))
-            except (StopIteration, KeyError):
-                break
+        for key in list(dedup_hits)[:excess]:
+            dedup_hits.pop(key, None)
 
     ts = task_data.get("read_timestamps")
     if ts is not None and len(ts) > _READ_TIMESTAMPS_CAP:
         excess = len(ts) - _READ_TIMESTAMPS_CAP
-        for _ in range(excess):
-            try:
-                ts.pop(next(iter(ts)))
-            except (StopIteration, KeyError):
-                break
+        for key in list(ts)[:excess]:
+            ts.pop(key, None)
 
 
 def _is_internal_file_status_text(content: str) -> bool:


### PR DESCRIPTION
## Summary
- Snapshot dict keys before trimming file-state/read-tracker cap dictionaries
- Cover `dedup_hits` eviction and the `file_state._cap_dict` multi-pop path

## Validation
- `./scripts/run_tests.sh tests/tools/test_accretion_caps.py`
- `git diff --check`

Fixes #36643
