### PR TITLE
fix: skip OpenAI rebuild for anthropic clients

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3010,6 +3010,14 @@ class AIAgent:
             )
 
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
+        if getattr(self, "api_mode", "") == "anthropic_messages":
+            logger.info(
+                "Skipping shared OpenAI client rebuild for anthropic_messages (%s) %s",
+                reason,
+                self._client_log_context(),
+            )
+            return True
+
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5441,6 +5441,20 @@ class TestStreamingApiCall:
         assert resp.id.startswith("stream-")
         assert len(resp.id) > len("stream-")
 
+    def test_replace_primary_openai_client_noops_for_anthropic_messages(self):
+        """Native Anthropic/Bedrock paths do not need an OpenAI client rebuild."""
+        agent = AIAgent.__new__(AIAgent)
+        setattr(agent, "api_mode", "anthropic_messages")
+        setattr(agent, "client", None)
+        setattr(agent, "_client_kwargs", {})
+        agent._client_log_context = MagicMock(return_value="provider=bedrock")
+        agent._create_openai_client = MagicMock(
+            side_effect=AssertionError("should not build OpenAI client")
+        )
+
+        assert agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup") is True
+        agent._create_openai_client.assert_not_called()
+
     def test_empty_choices_chunk_skipped(self, agent):
         empty_chunk = SimpleNamespace(model="gpt-4", choices=[])
         chunks = [


### PR DESCRIPTION
## Summary
- Skip shared OpenAI client rebuilds for native `anthropic_messages` clients
- Add regression coverage so Bedrock/Anthropic native paths do not try to create an OpenAI client during stale-stream cleanup

## Validation
- `./scripts/run_tests.sh tests/run_agent/test_run_agent.py`
- `git diff --check`

Fixes #36693
