### PR TITLE
fix: preserve configured picker models

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1503,6 +1503,18 @@ def list_authenticated_providers(
     # produces two picker rows: one bare-slug ("openrouter") from section 3
     # and one "custom:openrouter" from section 4, both labelled identically.
     _section3_emitted_pairs: set = set()
+
+    def _merge_model_ids(configured: list[str], live: list[str]) -> list[str]:
+        """Merge configured and live-discovered model ids without reordering config."""
+        merged: list[str] = []
+        seen: set[str] = set()
+        for model_id in [*(configured or []), *(live or [])]:
+            if not model_id or model_id in seen:
+                continue
+            merged.append(model_id)
+            seen.add(model_id)
+        return merged
+
     if user_providers and isinstance(user_providers, dict):
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
@@ -1568,7 +1580,7 @@ def list_authenticated_providers(
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)
                     if live_models:
-                        models_list = live_models
+                        models_list = _merge_model_ids(models_list, live_models)
                 except Exception:
                     pass
 
@@ -1737,9 +1749,9 @@ def list_authenticated_providers(
             # the Telegram/Discord picker should do the same for parity.
             # Live-discovery policy:
             # - With an api_key, the user has explicitly opted into the
-            #   endpoint and live /models is the source of truth — replace
-            #   the (possibly partial) ``models:`` subset configured for
-            #   context-length overrides with the full live catalog.
+            #   endpoint. Merge live /models results with the configured
+            #   model list so manual/private ids are not hidden just because
+            #   an aggregator omits them from discovery.
             #   This is the Bifrost / aggregator-gateway case.
             # - Without an api_key but with an explicit ``models:`` list
             #   (or top-level ``model:``), the user is narrowing a public
@@ -1756,8 +1768,8 @@ def list_authenticated_providers(
 
                     live_models = fetch_api_models(api_key, api_url)
                     if live_models:
-                        grp["models"] = live_models
-                        grp["total_models"] = len(live_models)
+                        grp["models"] = _merge_model_ids(grp["models"], live_models)
+                        grp["total_models"] = len(grp["models"])
                 except Exception:
                     pass
             results.append({

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -259,3 +259,59 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     assert row["slug"] == "custom:ollama"
     assert row["is_current"] is True
     assert row["models"] == ["glm-5.1", "qwen3"]
+
+
+def test_user_provider_live_models_merge_configured_models(monkeypatch):
+    """Live /models discovery should not hide manually configured model ids."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models",
+                        lambda *a, **kw: ["configured-model", "live-model"])
+
+    result = model_switch.list_authenticated_providers(
+        user_providers={
+            "relay": {
+                "name": "Relay",
+                "base_url": "https://relay.example/v1",
+                "api_key": "key",
+                "models": {
+                    "configured-model": {},
+                    "manual-only-model": {},
+                },
+            },
+        },
+        custom_providers=[],
+        max_models=50,
+    )
+
+    row = next(p for p in result if p["slug"] == "relay")
+    assert row["models"] == ["configured-model", "manual-only-model", "live-model"]
+    assert row["total_models"] == 3
+
+
+def test_custom_provider_live_models_merge_configured_models(monkeypatch):
+    """Grouped custom providers keep config-only ids alongside live discovery."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models",
+                        lambda *a, **kw: ["configured-model", "live-model"])
+
+    result = model_switch.list_authenticated_providers(
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Private Relay",
+                "base_url": "https://relay.example/v1",
+                "api_key": "key",
+                "model": "configured-model",
+                "models": {"manual-only-model": {}},
+            },
+        ],
+        max_models=50,
+    )
+
+    row = next(p for p in result if p["slug"] == "custom:private-relay")
+    assert row["models"] == ["configured-model", "manual-only-model", "live-model"]
+    assert row["total_models"] == 3


### PR DESCRIPTION
## Summary
- Merge live-discovered `/models` results with configured model ids instead of replacing them
- Preserve manual/private model ids for both `providers:` rows and grouped `custom_providers:` rows
- Add regression tests for both config shapes

## Validation
- `./scripts/run_tests.sh tests/hermes_cli/test_list_picker_providers.py`
- `git diff --check`

Fixes #36639
