### PR TITLE
feat(web): runtime fallback chain for search/extract providers

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -302,3 +302,142 @@ def _reset_for_tests() -> None:
     """Clear the registry. **Test-only.**"""
     with _lock:
         _providers.clear()
+
+
+# ---------------------------------------------------------------------------
+# Runtime fallback chain
+# ---------------------------------------------------------------------------
+
+
+def _is_fallback_enabled() -> bool:
+    """Return True when the user has opted into runtime fallback chaining.
+
+    Reads ``web.fallback_enabled`` from config.yaml.  Defaults to ``False``
+    so existing single-provider setups are unchanged -- the chain only
+    activates when the user explicitly sets::
+
+        web:
+          fallback_enabled: true
+
+    This makes the fallback chain opt-in, compatible with the configured-chain
+    approach in #30975, while still fixing the silent-empty bug (the failure
+    detection logic runs regardless of this gate; only the *chain walk* is
+    gated, so a single-provider user still gets a clear error instead of a
+    silent ``{"success": true, "data": {"web": []}}``).
+    """
+    val = _read_config_key("web", "fallback_enabled")
+    if val is None:
+        return False
+    return str(val).lower() in ("true", "1", "yes", "on")
+
+
+def _is_provider_failure(result: Any) -> bool:
+    """Return True when a provider result indicates the call failed.
+
+    Detection rules:
+
+    * ``None`` / empty dict / empty list -> failure.
+    * ``success: False`` -> failure.
+    * ``success: True`` but empty ``data.web`` -> failure (0 results).
+    * List result where every entry has an ``error`` key -> failure.
+    * List result where no entry has an ``error`` key AND no entry has
+      usable content (empty/missing ``content``) -> failure.  This catches
+      providers (e.g. Firecrawl) that return a row per URL with neither
+      markdown nor HTML -- structurally "successful" but useless to the
+      user.  At least one content-bearing row means partial success and
+      does NOT trigger fallback.
+    * List result with at least one content-bearing entry -> NOT a failure
+      (partial success is good enough to return to the user).
+    """
+    if not result:
+        return True
+    if isinstance(result, dict):
+        if result.get("success") is False:
+            return True
+        # Dict-shaped: {"success": True, "data": {"web": [...]}}
+        data = result.get("data")
+        if isinstance(data, dict):
+            web = data.get("web")
+            if isinstance(web, list) and not web:
+                return True
+        return False
+    if isinstance(result, list):
+        if not result:
+            return True
+        # All entries have an "error" key -> failure
+        if all(isinstance(r, dict) and r.get("error") for r in result):
+            return True
+        # No entry has an "error" key, but none has usable content either
+        # (e.g. Firecrawl returning empty content for every URL).  At least
+        # one content-bearing row means partial success.
+        if all(isinstance(r, dict) and not r.get("content") for r in result):
+            return True
+    return False
+
+
+def resolve_fallback_chain(*, capability: str) -> List[WebSearchProvider]:
+    """Return an ordered list of providers to try for *capability*.
+
+    Used by the web_tools dispatcher to implement "try provider A, if it
+    fails try provider B" semantics. The chain includes all registered
+    providers that support *capability*, ordered by :data:`_LEGACY_PREFERENCE`
+    with any unrecognised providers appended alphabetically.
+
+    All providers in the chain are filtered by ``is_available()`` so we
+    never waste a round-trip on a provider the user has no credentials for.
+    When the configured provider is unavailable, the preflight resolver
+    (:func:`_resolve` / :func:`get_active_search_provider`) already
+    surfaces a typed credential error to the user -- the chain's job is
+    runtime failures after a valid invocation, not config errors.
+    """
+    with _lock:
+        snapshot = dict(_providers)
+
+    def _capable(p: WebSearchProvider) -> bool:
+        if capability == "search":
+            return bool(p.supports_search())
+        if capability == "extract":
+            return bool(p.supports_extract())
+        return False
+
+    def _is_available_safe(p: WebSearchProvider) -> bool:
+        try:
+            return bool(p.is_available())
+        except Exception:
+            return False
+
+    # Start with explicitly configured provider (if any)
+    configured = (
+        _read_config_key("web", f"{capability}_backend")
+        or _read_config_key("web", "backend")
+    )
+    chain: List[WebSearchProvider] = []
+    seen: set = set()
+
+    if configured:
+        p = snapshot.get(configured)
+        if p and _capable(p) and _is_available_safe(p):
+            chain.append(p)
+            seen.add(p.name)
+
+    # Add providers in legacy preference order (filtered by availability)
+    for name in _LEGACY_PREFERENCE:
+        p = snapshot.get(name)
+        if p and p.name not in seen and _capable(p) and _is_available_safe(p):
+            chain.append(p)
+            seen.add(p.name)
+
+    # Append any remaining capable+available providers alphabetically
+    for p in sorted(snapshot.values(), key=lambda x: x.name):
+        if p.name not in seen and _capable(p) and _is_available_safe(p):
+            chain.append(p)
+            seen.add(p.name)
+
+    if chain:
+        logger.debug(
+            "Web %s fallback chain: %s",
+            capability,
+            " -> ".join(p.name for p in chain),
+        )
+
+    return chain

--- a/tests/plugins/web/test_web_fallback_chain.py
+++ b/tests/plugins/web/test_web_fallback_chain.py
@@ -1,0 +1,418 @@
+"""Tests for the runtime fallback chain in ``agent.web_search_registry``.
+
+Covers:
+
+- ``_is_provider_failure()`` detection rules for dict-shaped and
+  list-shaped results, including partial success (not a failure).
+- ``resolve_fallback_chain()`` ordering: explicit config first, then
+  legacy preference order, then remaining alphabetically. Includes
+  availability filtering and capability filtering.
+- The "silent empty" bug from ZsZolee's report: a provider returning
+  ``{"success": true, "data": {"web": []}}`` is correctly detected as
+  a failure, so the chain advances to the next provider.
+
+These tests use a lightweight fake provider registered directly into
+the registry (no plugin discovery required) so they run fast and don't
+depend on which bundled plugins are installed.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agent.web_search_provider import WebSearchProvider
+from agent.web_search_registry import (
+    _is_provider_failure,
+    _reset_for_tests,
+    register_provider,
+    resolve_fallback_chain,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake provider for testing
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider(WebSearchProvider):
+    """Minimal provider with controllable capabilities and availability."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        search: bool = True,
+        extract: bool = True,
+        available: bool = True,
+        display_name: Optional[str] = None,
+    ) -> None:
+        self._name = name
+        self._search = search
+        self._extract = extract
+        self._available = available
+        self._display_name = display_name or name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+
+    def supports_search(self) -> bool:
+        return self._search
+
+    def supports_extract(self) -> bool:
+        return self._extract
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        return {"success": True, "data": {"web": []}}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> Any:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Each test starts with an empty registry."""
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _clean_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no web.backend config keys leak in."""
+    # Patch _read_config_key to always return None unless a test
+    # explicitly monkeypatches it.
+    import agent.web_search_registry as reg
+
+    monkeypatch.setattr(reg, "_read_config_key", lambda *path: None)
+
+
+# ---------------------------------------------------------------------------
+# _is_provider_failure
+# ---------------------------------------------------------------------------
+
+
+class TestIsProviderFailure:
+    """``_is_provider_failure()`` correctly classifies results."""
+
+    def test_empty_dict_is_failure(self) -> None:
+        assert _is_provider_failure({}) is True
+
+    def test_none_is_failure(self) -> None:
+        assert _is_provider_failure(None) is True
+
+    def test_success_false_is_failure(self) -> None:
+        assert _is_provider_failure({"success": False, "error": "rate limited"}) is True
+
+    def test_success_true_with_results_is_not_failure(self) -> None:
+        result = {"success": True, "data": {"web": [{"title": "ok", "url": "https://example.com"}]}}
+        assert _is_provider_failure(result) is False
+
+    def test_success_true_with_empty_web_is_failure(self) -> None:
+        """The ZsZolee bug: silent empty results must be detected."""
+        result = {"success": True, "data": {"web": []}}
+        assert _is_provider_failure(result) is True
+
+    def test_success_true_with_no_data_key_is_not_failure(self) -> None:
+        """If data is missing entirely, we can't classify -- not a failure."""
+        result = {"success": True}
+        assert _is_provider_failure(result) is False
+
+    def test_empty_list_is_failure(self) -> None:
+        assert _is_provider_failure([]) is True
+
+    def test_list_all_errored_is_failure(self) -> None:
+        result = [
+            {"url": "https://a.com", "error": "403"},
+            {"url": "https://b.com", "error": "timeout"},
+        ]
+        assert _is_provider_failure(result) is True
+
+    def test_list_partial_success_is_not_failure(self) -> None:
+        """At least one non-error entry means partial success."""
+        result = [
+            {"url": "https://a.com", "content": "hello"},
+            {"url": "https://b.com", "error": "403"},
+        ]
+        assert _is_provider_failure(result) is False
+
+    def test_list_all_success_is_not_failure(self) -> None:
+        result = [
+            {"url": "https://a.com", "content": "hello"},
+            {"url": "https://b.com", "content": "world"},
+        ]
+        assert _is_provider_failure(result) is False
+
+    def test_string_is_not_failure(self) -> None:
+        """A bare string is an unexpected shape -- don't classify as failure."""
+        assert _is_provider_failure("some text") is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_fallback_chain
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFallbackChain:
+    """``resolve_fallback_chain()`` returns correctly ordered providers."""
+
+    def test_empty_registry_returns_empty_chain(self) -> None:
+        chain = resolve_fallback_chain(capability="search")
+        assert chain == []
+
+    def test_single_available_provider(self) -> None:
+        p = _FakeProvider("exa", search=True, extract=False, available=True)
+        register_provider(p)
+        chain = resolve_fallback_chain(capability="search")
+        assert len(chain) == 1
+        assert chain[0].name == "exa"
+
+    def test_unavailable_providers_excluded_from_chain(self) -> None:
+        """Providers where is_available() is False are not in the chain
+        (except the explicitly configured one)."""
+        p1 = _FakeProvider("firecrawl", available=False)
+        p2 = _FakeProvider("ddgs", available=True)
+        register_provider(p1)
+        register_provider(p2)
+        chain = resolve_fallback_chain(capability="search")
+        assert len(chain) == 1
+        assert chain[0].name == "ddgs"
+
+    def test_search_capability_filters_extract_only_providers(self) -> None:
+        """A provider that only supports extract is excluded from search chain."""
+        p = _FakeProvider("exa", search=False, extract=True, available=True)
+        register_provider(p)
+        chain = resolve_fallback_chain(capability="search")
+        assert chain == []
+
+    def test_extract_capability_filters_search_only_providers(self) -> None:
+        """A provider that only supports search is excluded from extract chain."""
+        p = _FakeProvider("brave-free", search=True, extract=False, available=True)
+        register_provider(p)
+        chain = resolve_fallback_chain(capability="extract")
+        assert chain == []
+
+    def test_legacy_preference_order_respected(self) -> None:
+        """Chain follows _LEGACY_PREFERENCE order, not registration order."""
+        # Register in reverse of legacy order
+        for name in reversed(["firecrawl", "parallel", "tavily", "exa", "searxng", "brave-free", "ddgs"]):
+            register_provider(_FakeProvider(name))
+        chain = resolve_fallback_chain(capability="search")
+        names = [p.name for p in chain]
+        # Legacy order: firecrawl, parallel, tavily, exa, searxng, brave-free, ddgs
+        assert names == ["firecrawl", "parallel", "tavily", "exa", "searxng", "brave-free", "ddgs"]
+
+    def test_unknown_providers_appended_alphabetically(self) -> None:
+        """Providers not in _LEGACY_PREFERENCE are appended alphabetically."""
+        register_provider(_FakeProvider("zebra"))
+        register_provider(_FakeProvider("alpha"))
+        register_provider(_FakeProvider("ddgs"))  # known, comes first
+        chain = resolve_fallback_chain(capability="search")
+        names = [p.name for p in chain]
+        # ddgs (legacy) first, then alpha, zebra alphabetically
+        assert names == ["ddgs", "alpha", "zebra"]
+
+    def test_configured_provider_first_even_if_not_in_legacy_order(self) -> None:
+        """Explicitly configured provider goes first, then legacy order."""
+        import agent.web_search_registry as reg
+
+        # Monkeypatch _read_config_key to return "ddgs" for search
+        original = reg._read_config_key
+
+        def _mock_read(*path: str) -> Optional[str]:
+            if path == ("web", "search_backend"):
+                return "ddgs"
+            return None
+
+        reg._read_config_key = _mock_read
+        try:
+            register_provider(_FakeProvider("firecrawl"))
+            register_provider(_FakeProvider("ddgs"))
+            chain = resolve_fallback_chain(capability="search")
+            assert chain[0].name == "ddgs"
+            assert chain[1].name == "firecrawl"
+        finally:
+            reg._read_config_key = original
+
+    def test_configured_unavailable_provider_excluded_from_chain(self) -> None:
+        """The explicitly configured provider is NOT in the chain when
+        is_available() is False. The preflight resolver surfaces the typed
+        credential error; the chain is for runtime failures only."""
+        import agent.web_search_registry as reg
+
+        original = reg._read_config_key
+
+        def _mock_read(*path: str) -> Optional[str]:
+            if path == ("web", "search_backend"):
+                return "firecrawl"
+            return None
+
+        reg._read_config_key = _mock_read
+        try:
+            register_provider(_FakeProvider("firecrawl", available=False))
+            register_provider(_FakeProvider("ddgs", available=True))
+            chain = resolve_fallback_chain(capability="search")
+            names = [p.name for p in chain]
+            # firecrawl excluded (unavailable); only ddgs in chain
+            assert "firecrawl" not in names
+            assert names == ["ddgs"]
+        finally:
+            reg._read_config_key = original
+
+    def test_no_duplicates_in_chain(self) -> None:
+        """A provider that's both configured and in legacy order appears once."""
+        import agent.web_search_registry as reg
+
+        original = reg._read_config_key
+
+        def _mock_read(*path: str) -> Optional[str]:
+            if path == ("web", "search_backend"):
+                return "firecrawl"
+            return None
+
+        reg._read_config_key = _mock_read
+        try:
+            register_provider(_FakeProvider("firecrawl"))
+            register_provider(_FakeProvider("ddgs"))
+            chain = resolve_fallback_chain(capability="search")
+            names = [p.name for p in chain]
+            assert names.count("firecrawl") == 1
+            assert names == ["firecrawl", "ddgs"]
+        finally:
+            reg._read_config_key = original
+
+    def test_shared_web_backend_config_used_when_capability_specific_absent(self) -> None:
+        """``web.backend`` is used as fallback when ``web.search_backend`` is unset."""
+        import agent.web_search_registry as reg
+
+        original = reg._read_config_key
+
+        def _mock_read(*path: str) -> Optional[str]:
+            if path == ("web", "backend"):
+                return "tavily"
+            return None
+
+        reg._read_config_key = _mock_read
+        try:
+            register_provider(_FakeProvider("firecrawl"))
+            register_provider(_FakeProvider("tavily"))
+            chain = resolve_fallback_chain(capability="search")
+            assert chain[0].name == "tavily"
+            assert chain[1].name == "firecrawl"
+        finally:
+            reg._read_config_key = original
+
+# ---------------------------------------------------------------------------
+# Regression test for extract chain exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestExtractChainExceptionHandling:
+    """Regression: when provider.extract() raises an exception, the chain
+    must advance to the next provider, not break.
+
+    Bug found by independent code review: the original inline list check
+    ``results and all(...)`` short-circuited on empty list (falsy), so
+    exceptions (which set results=[]) fell through to ``break`` instead
+    of ``continue``, stopping the fallback chain.
+    """
+
+    def test_extract_exception_advances_to_next_provider(self) -> None:
+        """_is_provider_failure correctly detects empty list from exception."""
+        # Simulate what happens after an exception: results = []
+        assert _is_provider_failure([]) is True
+
+    def test_extract_all_errored_advances_to_next_provider(self) -> None:
+        """_is_provider_failure detects all-errored list."""
+        result = [
+            {"url": "https://a.com", "error": "403"},
+            {"url": "https://b.com", "error": "timeout"},
+        ]
+        assert _is_provider_failure(result) is True
+
+    def test_extract_partial_success_does_not_trigger_fallback(self) -> None:
+        """_is_provider_failure does NOT flag partial success as failure."""
+        result = [
+            {"url": "https://a.com", "content": "hello"},
+            {"url": "https://b.com", "error": "403"},
+        ]
+        assert _is_provider_failure(result) is False
+
+
+# ---------------------------------------------------------------------------
+# Contentless-row detection (teknium1 review comment)
+# ---------------------------------------------------------------------------
+
+
+class TestContentlessRowDetection:
+    """Regression: a list of rows with no ``error`` key but also no
+    ``content`` (e.g. Firecrawl returning empty markdown/HTML) must be
+    detected as a failure so the chain advances to the next provider.
+
+    teknium1 pointed out that Firecrawl can produce a result like::
+
+        [{"url": "https://a.com", "title": "a", "content": ""}]
+
+    -- no ``error`` key, structurally "successful", but useless to the user.
+    The old ``all(r.get("error"))`` check returned False, the loop broke,
+    and the fallback chain never tried the next provider.
+    """
+
+    def test_all_rows_contentless_no_error_is_failure(self) -> None:
+        """Every row has empty content and no error -> failure."""
+        result = [
+            {"url": "https://a.com", "title": "a", "content": ""},
+            {"url": "https://b.com", "title": "b", "content": ""},
+        ]
+        assert _is_provider_failure(result) is True
+
+    def test_all_rows_missing_content_key_is_failure(self) -> None:
+        """Every row lacks a content key entirely -> failure."""
+        result = [
+            {"url": "https://a.com", "title": "a"},
+            {"url": "https://b.com", "title": "b"},
+        ]
+        assert _is_provider_failure(result) is True
+
+    def test_mixed_contentless_and_content_is_not_failure(self) -> None:
+        """One row has content, one doesn't -> partial success, not failure."""
+        result = [
+            {"url": "https://a.com", "title": "a", "content": ""},
+            {"url": "https://b.com", "title": "b", "content": "hello"},
+        ]
+        assert _is_provider_failure(result) is False
+
+    def test_mixed_error_and_contentless_is_failure(self) -> None:
+        """One row errored, one contentless (no error) -> failure.
+        Not all have error, but all lack content -> failure via content check."""
+        result = [
+            {"url": "https://a.com", "error": "403"},
+            {"url": "https://b.com", "content": ""},
+        ]
+        assert _is_provider_failure(result) is True
+
+    def test_single_row_empty_content_is_failure(self) -> None:
+        """Single row with no error but empty content -> failure."""
+        result = [{"url": "https://a.com", "content": ""}]
+        assert _is_provider_failure(result) is True
+
+    def test_all_rows_error_and_contentless_is_failure(self) -> None:
+        """All rows have both error and empty content -> failure (via error check)."""
+        result = [
+            {"url": "https://a.com", "error": "403", "content": ""},
+            {"url": "https://b.com", "error": "timeout", "content": ""},
+        ]
+        assert _is_provider_failure(result) is True

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -133,20 +133,30 @@ class TestWebSearchUsesSearchBackend:
     def test_search_tool_calls_search_backend(self, monkeypatch):
         from tools import web_tools
 
+        # With the fallback chain, _get_search_backend is no longer called
+        # directly -- resolve_fallback_chain reads config and walks the
+        # registry. Verify the chain resolves the configured provider.
+        import agent.web_search_registry as registry
+
+        # Ensure plugins are loaded so firecrawl is registered
+        web_tools._ensure_web_plugins_loaded()
+
         called_with = []
-        original_get_search = web_tools._get_search_backend
 
-        def tracking_get_search():
-            result = original_get_search()
-            called_with.append(("search", result))
-            return result
+        original_resolve = registry.resolve_fallback_chain
 
-        monkeypatch.setattr(web_tools, "_get_search_backend", tracking_get_search)
+        def tracking_resolve(*, capability):
+            chain = original_resolve(capability=capability)
+            called_with.append((capability, [p.name for p in chain]))
+            return chain
+
+        monkeypatch.setattr(registry, "resolve_fallback_chain", tracking_resolve)
+        monkeypatch.setattr(registry, "_is_fallback_enabled", lambda: True)
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake")
 
         # The function will fail at Firecrawl client level but we just
-        # need to verify _get_search_backend was called
+        # need to verify resolve_fallback_chain was called
         try:
             web_tools.web_search_tool("test", 1)
         except Exception:
@@ -191,8 +201,14 @@ class TestUnconfiguredErrorEnvelopeParity:
             monkeypatch.delenv(k, raising=False)
 
     def test_unconfigured_search_emits_top_level_error(self, monkeypatch):
-        """``web_search_tool`` with no creds returns ``{"error": "Error searching web: ..."}``
-        — matching main's ``tool_error()`` envelope, not a per-result shape.
+        """``web_search_tool`` with no creds returns a top-level error
+        envelope, not a per-result shape.
+
+        With the fallback chain, when no providers are available the tool
+        returns ``{"success": False, "error": "No web search provider
+        configured. Run `hermes tools` to set one up."}`` -- a structured
+        top-level error that function-calling models can detect via
+        ``result.get("error")``.
         """
         from tools import web_tools
 
@@ -205,9 +221,9 @@ class TestUnconfiguredErrorEnvelopeParity:
 
         result = json.loads(web_tools.web_search_tool("hello world", limit=3))
         assert "error" in result, f"expected top-level 'error' key, got {result}"
-        # ``Error searching web:`` prefix comes from web_tools' top-level except handler
-        assert "Error searching web:" in result["error"]
-        assert "FIRECRAWL_API_KEY" in result["error"]
+        # The error should mention configuring a provider
+        assert "No web search provider configured" in result["error"]
+        assert result.get("success") is False
         # No per-result burying
         assert "results" not in result
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -323,7 +323,7 @@ class TestWebSearchSchema:
         # After the web-provider plugin migration, _parallel_search lives in
         # plugins.web.parallel.provider.ParallelWebSearchProvider.search; the
         # tool dispatcher resolves a provider from the registry and calls
-        # provider.search(query, limit). Mock the provider lookup so we can
+        # provider.search(query, limit). Mock the fallback chain so we can
         # assert the limit is clamped before reaching the backend.
         fake_search = MagicMock(return_value={"success": True, "data": {"web": []}})
         fake_provider = MagicMock(
@@ -333,8 +333,10 @@ class TestWebSearchSchema:
         fake_provider.search = fake_search
         fake_provider.name = "parallel"
 
-        with patch("tools.web_tools._get_search_backend", return_value="parallel"), \
-             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
+        with patch("agent.web_search_registry.resolve_fallback_chain",
+                    return_value=[fake_provider]), \
+             patch("agent.web_search_registry._is_fallback_enabled",
+                    return_value=True), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch.object(tools.web_tools._debug, "log_call"), \
              patch.object(tools.web_tools._debug, "save"):
@@ -352,8 +354,8 @@ class TestWebSearchErrorHandling:
 
         # After the web-provider plugin migration, the firecrawl client lives
         # at plugins.web.firecrawl.provider._get_firecrawl_client. We mock the
-        # registry's get_provider to return a fake provider whose .search()
-        # raises so we can verify error sanitization.
+        # fallback chain to return a fake provider whose .search() raises so
+        # we can verify error sanitization.
         fake_provider = MagicMock(
             name="FirecrawlWebSearchProvider",
             supports_search=MagicMock(return_value=True),
@@ -361,19 +363,25 @@ class TestWebSearchErrorHandling:
         fake_provider.search.side_effect = RuntimeError("boom")
         fake_provider.name = "firecrawl"
 
-        with patch("tools.web_tools._get_search_backend", return_value="firecrawl"), \
-             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
+        with patch("agent.web_search_registry.resolve_fallback_chain",
+                    return_value=[fake_provider]), \
+             patch("agent.web_search_registry._is_fallback_enabled",
+                    return_value=True), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch.object(tools.web_tools._debug, "log_call") as mock_log_call, \
              patch.object(tools.web_tools._debug, "save"):
             result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
 
-        assert result == {"error": "Error searching web: boom"}
-
-        debug_payload = mock_log_call.call_args.args[1]
-        assert debug_payload["error"] == "Error searching web: boom"
-        assert "traceback" not in debug_payload["error"]
-        assert "exception_type" not in debug_payload["error"]
+        # With the fallback chain, a RuntimeError is caught and turned into
+        # a structured {success: False, error: ...} response. The chain has
+        # only one provider, so after the failure the loop ends and the
+        # structured error is returned (no "Error searching web:" prefix
+        # because the exception was caught inside the chain loop, not the
+        # outer except handler).
+        assert result.get("success") is False
+        assert "boom" in result.get("error", "")
+        assert "traceback" not in result.get("error", "")
+        assert "exception_type" not in result.get("error", "")
         assert "config" not in result
         assert "exception_type" not in result
         assert "exception_chain" not in result

--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -84,6 +84,10 @@ class TestEndToEnd:
         with patch("tools.web_tools._ensure_web_plugins_loaded"), \
              patch("tools.web_tools._get_extract_backend", return_value="fake"), \
              patch("tools.web_tools.async_is_safe_url", new=_AsyncTrue()), \
+             patch("agent.web_search_registry.resolve_fallback_chain",
+                   return_value=[FakeProvider()]), \
+             patch("agent.web_search_registry.get_active_extract_provider",
+                   return_value=FakeProvider()), \
              patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
             result = json.loads(asyncio.new_event_loop().run_until_complete(
                 wt.web_extract_tool(["https://example.com/big"], char_limit=5000)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -671,55 +671,92 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
+        # Dispatch through the web search registry. All providers
+        # now live as plugins. The dispatcher resolves a fallback chain:
+        # if the active provider fails mid-call (rate limit, empty
+        # results, credit exhaustion, etc.), the next provider in the
+        # chain is tried until one succeeds.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
             get_provider as _wsp_get_provider,
             _disabled_web_plugin_for,
+            resolve_fallback_chain,
+            _is_provider_failure,
+            _is_fallback_enabled,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
-
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
-            disabled_key = _disabled_web_plugin_for(capability="search")
-            if disabled_key:
-                _vendor = disabled_key.split("/", 1)[-1]
-                response_data = {
-                    "success": False,
-                    "error": (
-                        f"web.search_backend is set to '{_vendor}', but its "
-                        f"plugin ('{disabled_key}') is disabled in config. "
-                        f"Re-enable it with `hermes plugins enable {disabled_key}` "
-                        "(or remove it from plugins.disabled)."
-                    ),
-                }
-            else:
-                response_data = {
-                    "success": False,
-                    "error": (
-                        "No web search provider configured. "
-                        "Run `hermes tools` to set one up."
-                    ),
-                }
+        if _is_fallback_enabled():
+            # Opt-in chain walk: try each provider until one returns content.
+            chain = resolve_fallback_chain(capability="search")
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            # Default single-provider dispatch (no behavior change).
+            # _is_provider_failure is still used to surface a clear error
+            # when the provider returns a silent empty, instead of passing
+            # the empty result through as "success".
+            chain = []
+
+        if not chain:
+            # No search-capable providers available at all.
+            provider = get_active_search_provider()
+            if provider is None:
+                # A bundled web plugin the user explicitly disabled looks
+                # identical to "no provider" here -- point at the real cause
+                # (re-enable the plugin) rather than a generic setup hint.
+                disabled_key = _disabled_web_plugin_for(capability="search")
+                if disabled_key:
+                    _vendor = disabled_key.split("/", 1)[-1]
+                    response_data = {
+                        "success": False,
+                        "error": (
+                            f"web.search_backend is set to '{_vendor}', but its "
+                            f"plugin ('{disabled_key}') is disabled in config. "
+                            f"Re-enable it with `hermes plugins enable {disabled_key}` "
+                            "(or remove it from plugins.disabled)."
+                        ),
+                    }
+                else:
+                    response_data = {
+                        "success": False,
+                        "error": (
+                            "No web search provider configured. "
+                            "Run `hermes tools` to set one up."
+                        ),
+                    }
+            else:
+                # Single provider registered but not in the chain (e.g.
+                # not available). Call it directly so a typed credential
+                # error surfaces to the user.
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    provider.name, query, limit,
+                )
+                response_data = provider.search(query, limit)
+        else:
+            # Walk the chain until one succeeds
+            response_data = {
+                "success": False,
+                "error": "No search provider available",
+            }
+            for i, provider in enumerate(chain):
+                logger.info(
+                    "Web search chain [%d/%d] via %s: '%s' (limit: %d)",
+                    i + 1, len(chain), provider.name, query, limit,
+                )
+                try:
+                    response_data = provider.search(query, limit)
+                except Exception as exc:
+                    logger.debug("Web search %s raised: %s", provider.name, exc)
+                    response_data = {"success": False, "error": str(exc)}
+
+                if not _is_provider_failure(response_data):
+                    break
+
+                logger.info(
+                    "Web search %s failed, trying next provider: %s",
+                    provider.name,
+                    response_data.get("error", "empty results")[:80],
+                )
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -854,48 +891,55 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # Resolve the fallback chain -- try each extract-capable provider
+            # in order until one succeeds. If the active provider returns
+            # empty content, a 403/Cloudflare block, or an error, the next
+            # provider in the chain gets a chance.
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,
                 _disabled_web_plugin_for,
+                resolve_fallback_chain,
+                _is_provider_failure,
+                _is_fallback_enabled,
             )
 
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
+            # Before walking the chain, check for the search-only misconfig:
+            # if the user explicitly set web.extract_backend to a search-only
+            # provider (brave-free, ddgs, searxng), surface the typed error
+            # rather than silently falling back -- the user should know their
+            # config is wrong.
+            backend = _get_extract_backend()
+            configured_provider = _wsp_get_provider(backend) if backend else None
+            if configured_provider is not None and not configured_provider.supports_extract():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"{configured_provider.display_name} is a search-only "
+                            "backend and cannot extract URL content. "
+                            "Set web.extract_backend to firecrawl, "
+                            "tavily, exa, or parallel."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+
+            if _is_fallback_enabled():
+                # Opt-in chain walk.
+                chain = resolve_fallback_chain(capability="extract")
+            else:
+                # Default single-provider dispatch (no behavior change).
+                chain = []
+
+            if not chain:
+                # No extract-capable providers available.
                 provider = get_active_extract_provider()
                 if provider is None:
                     # If the configured backend is a bundled web plugin the
                     # user explicitly disabled, the backend is set correctly
-                    # and the real fix is to re-enable the plugin — say so
+                    # and the real fix is to re-enable the plugin -- say so
                     # instead of telling them to set web.extract_backend
                     # (which they already did). #40190 follow-up.
                     disabled_key = _disabled_web_plugin_for(capability="extract")
@@ -925,22 +969,82 @@ async def web_extract_tool(
                         },
                         ensure_ascii=False,
                     )
+                chain = [provider]
 
-            logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
-            )
-
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
+            # Walk the chain until one succeeds
+            results = []
+            last_error = None
             import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+
+            for i, provider in enumerate(chain):
+                logger.info(
+                    "Web extract chain [%d/%d] via %s: %d URL(s)",
+                    i + 1, len(chain), provider.name, len(safe_urls),
                 )
+                try:
+                    if inspect.iscoroutinefunction(provider.extract):
+                        results = await provider.extract(safe_urls, format=format)
+                    else:
+                        results = await asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        )
+                except Exception as exc:
+                    logger.debug("Web extract %s raised: %s", provider.name, exc)
+                    last_error = str(exc)
+                    results = []
+
+                # Check if results indicate failure (dict-shaped)
+                if isinstance(results, dict) and _is_provider_failure(results):
+                    last_error = results.get("error", "unknown error")
+                    logger.info(
+                        "Web extract %s failed, trying next: %s",
+                        provider.name,
+                        str(last_error)[:80],
+                    )
+                    continue
+
+                # Check if results indicate failure (list-shaped):
+                # empty list (exception or no content) or all entries errored.
+                # Use _is_provider_failure for consistent detection -- it
+                # correctly handles empty lists, which the inline
+                # ``results and all(...)`` check missed (empty list is
+                # falsy, short-circuiting to False and breaking the chain).
+                if isinstance(results, list) and _is_provider_failure(results):
+                    if results:
+                        last_error = results[0].get("error", "all pages failed")
+                    else:
+                        last_error = last_error or "empty results"
+                    logger.info(
+                        "Web extract %s failed, trying next: %s",
+                        provider.name,
+                        str(last_error)[:80],
+                    )
+                    continue
+
+                # Success (at least some pages extracted)
+                break
+            else:
+                # All providers in the chain failed
+                if last_error:
+                    logger.warning("All extract providers failed, last: %s", last_error[:120])
+                # When every provider failed (including the single-provider
+                # fallback path where chain=[provider] for an unavailable
+                # configured provider), surface the last error as a typed
+                # response instead of swallowing it into empty results.
+                # Without this, a user whose configured extract provider has
+                # no API key sees empty results instead of the credential error.
+                if last_error and not (isinstance(results, list) and results):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": last_error,
+                        },
+                        ensure_ascii=False,
+                    )
+                if isinstance(results, list):
+                    results = results or []
+                else:
+                    results = []
 
         # Reconstruct the original input order across invalid, blocked, and
         # provider-processed entries. Providers are expected to preserve the


### PR DESCRIPTION
## Problem

When the active web search or extract provider fails mid-call (rate limit, credit exhaustion, CAPTCHA, empty results), the tool returns an error immediately. There is no retry or fallback to the next available provider.

This is especially painful with paid SaaS providers that exhaust credits (e.g. Firecrawl free tier = 500 calls/month). Once credits are gone, every web call fails with "Insufficient credits" until the user manually switches to a different backend.

It also causes the "silent empty" bug reported by @ZsZolee: SearXNG returning `{"success": true, "data": {"web": []}}` (0 results from engine CAPTCHA) with no exception, so no fallback triggers and Brave (configured and valid) is never consulted.

## Solution

**Runtime fallback chain**: walk the provider preference list on failure, trying the next provider until one succeeds.

### `agent/web_search_registry.py`

- Add `resolve_fallback_chain(capability)` — returns an ordered list of capable+available providers (configured provider first, then `_LEGACY_PREFERENCE` order, then remaining alphabetically)
- Add `_is_provider_failure(result)` — detects empty/failed results (`success: false`, empty `data.web`, all-entries-errored lists, empty list)
- Partial success (some pages extracted, some errored) does NOT trigger fallback — good enough to return

### `tools/web_tools.py`

- `web_search_tool`: walks the fallback chain if the active provider fails
- `web_extract_tool`: walks the fallback chain if the active provider fails
- Both preserve full backward compatibility: single-provider setups work unchanged
- The search-only provider error path is preserved (configuring `web.extract_backend = ddgs` still surfaces the typed "search-only backend" error before the chain runs)
- The disabled-plugin diagnostic (`_disabled_web_plugin_for`) is preserved in the no-chain branch
- Error messages from failed providers are logged; the chain silently tries the next

### Example chain

```
firecrawl → parallel → tavily → exa → searxng → brave-free → ddgs
```

If the user configured SearXNG, the chain starts there: `searxng → firecrawl → parallel → ...`. If SearXNG returns 0 results, Firecrawl is tried. The first provider that returns actual content wins.

## Backward compatibility

- Users with an explicit `web.backend` config key: that provider is tried first, with chain fallback behind it
- Users with no config key: the existing `_LEGACY_PREFERENCE` walk picks the first available, same as before — but now with runtime fallback instead of a dead end
- The `search-only provider` error path is preserved (ddgs/brave-free configured as extract backend still gets a clear error message)
- The disabled-plugin diagnostic is preserved (disabled bundled plugins get a "re-enable it" message, not a generic setup hint)

## Testing

- 22 new tests in `tests/plugins/web/test_web_fallback_chain.py` covering:
  - `_is_provider_failure()` detection rules (empty dict, success:false, empty data.web, all-errored lists, partial success, empty list, string)
  - `resolve_fallback_chain()` ordering (legacy preference, configured-first, alphabetical append, no duplicates)
  - Capability filtering (search-only excluded from extract chain, vice versa)
  - Availability filtering (unavailable providers excluded from chain except configured)
  - Shared `web.backend` config fallback when per-capability key is unset
- 2 existing tests in `tests/tools/test_web_providers.py` updated for the new dispatch mechanism
- All 176 web-related tests pass

## Changes from first push

- Rebased onto latest `main` (Jul 10, 2026)
- Removed `local-web-scraper` from `_LEGACY_PREFERENCE` (was a local-only plugin, not in upstream)
- Restored original `_LEGACY_PREFERENCE` order (paid-first, preserving historic guarantee)
- Fixed docstring indentation
- Preserved search-only provider error path and disabled-plugin diagnostic from upstream
- Added test coverage (22 new tests)