### PR TITLE
fix(web): return 400 for invalid env var key in DELETE /api/env

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1237,6 +1237,8 @@ async def remove_env_var(body: EnvVarDelete):
         return {"ok": True, "key": body.key}
     except HTTPException:
         raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     except Exception:
         _log.exception("DELETE /api/env failed")
         raise HTTPException(status_code=500, detail="Internal server error")


### PR DESCRIPTION
The DELETE /api/env endpoint calls remove_env_value() which raises ValueError for invalid or denylisted key names. Previously this fell through to the generic Exception handler and returned HTTP 500, misleading the user into thinking the server broke when the actual problem is an invalid key name. Adding an explicit except ValueError handler returns HTTP 400 with the actual error message.