### PR TITLE
fix(web): close log_file after Popen in _spawn_hermes_action

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -696,6 +696,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         popen_kwargs["start_new_session"] = True
 
     proc = subprocess.Popen(cmd, **popen_kwargs)
+    log_file.close()  # child process has its own fd via dup2; parent can close
     _ACTION_PROCS[name] = proc
     return proc
 


### PR DESCRIPTION
The _spawn_hermes_action function in web_server.py opens a log file for writing via open() but never explicitly closes it. The child process inherits the fd via dup2, so the parent can safely close its reference immediately after Popen returns. This is inconsistent with _record_completed_action which uses a  block.