### PR TITLE
fix(cli): /sessions and /history show no visible output (#36815)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6336,50 +6336,58 @@ class HermesCLI:
 
         from hermes_cli.main import _relative_time
 
-        print()
+        # Route through _cprint, not plain print(): in the interactive CLI the
+        # command runs while prompt_toolkit owns the screen, so raw print()
+        # output is swallowed / redrawn over by the prompt (#36815). _cprint
+        # prints plain text above the prompt safely (no Rich markup parsing, so
+        # arbitrary session titles/previews can't break rendering).
+        _cprint("")
         if reason == "history":
-            print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
+            _cprint("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
         else:
-            print("  Recent sessions:")
-        print()
-        print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+            _cprint("  Recent sessions:")
+        _cprint("")
+        _cprint(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        _cprint(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
-        print()
-        print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
-        print("  Example: /resume 2")
-        print()
+            _cprint(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+        _cprint("")
+        _cprint("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
+        _cprint("  Example: /resume 2")
+        _cprint("")
         return True
 
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
             if not self._show_recent_sessions(reason="history"):
-                print("(._.) No conversation history yet.")
+                _cprint("(._.) No conversation history yet.")
             return
 
         preview_limit = 400
         visible_index = 0
         hidden_tool_messages = 0
 
+        # Use _cprint, not plain print(): inside the interactive CLI the prompt
+        # owns the screen and raw print() output is swallowed / overdrawn by the
+        # prompt refresh (#36815).
         def flush_tool_summary():
             nonlocal hidden_tool_messages
             if not hidden_tool_messages:
                 return
 
             noun = "message" if hidden_tool_messages == 1 else "messages"
-            print("\n  [Tools]")
-            print(f"    ({hidden_tool_messages} tool {noun} hidden)")
+            _cprint("\n  [Tools]")
+            _cprint(f"    ({hidden_tool_messages} tool {noun} hidden)")
             hidden_tool_messages = 0
 
-        print()
-        print("+" + "-" * 50 + "+")
-        print("|" + " " * 12 + "(^_^) Conversation History" + " " * 11 + "|")
-        print("+" + "-" * 50 + "+")
+        _cprint("")
+        _cprint("+" + "-" * 50 + "+")
+        _cprint("|" + " " * 12 + "(^_^) Conversation History" + " " * 11 + "|")
+        _cprint("+" + "-" * 50 + "+")
 
         for msg in self.conversation_history:
             role = msg.get("role", "unknown")
@@ -6398,13 +6406,13 @@ class HermesCLI:
             content_text = "" if content is None else str(content)
 
             if role == "user":
-                print(f"\n  [You #{visible_index}]")
-                print(
+                _cprint(f"\n  [You #{visible_index}]")
+                _cprint(
                     f"    {content_text[:preview_limit]}{'...' if len(content_text) > preview_limit else ''}"
                 )
                 continue
 
-            print(f"\n  [Hermes #{visible_index}]")
+            _cprint(f"\n  [Hermes #{visible_index}]")
             tool_calls = msg.get("tool_calls") or []
             if content_text:
                 preview = content_text[:preview_limit]
@@ -6417,10 +6425,10 @@ class HermesCLI:
             else:
                 preview = "(no text response)"
                 suffix = ""
-            print(f"    {preview}{suffix}")
+            _cprint(f"    {preview}{suffix}")
 
         flush_tool_summary()
-        print()
+        _cprint("")
     
     def _notify_session_boundary(self, event_type: str) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -3,10 +3,29 @@ that only manifest at runtime (not in mocked unit tests)."""
 
 import os
 import sys
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@contextmanager
+def _capture_cprint():
+    """Capture text routed through cli._cprint.
+
+    The history / recent-sessions views print through ``_cprint`` (the
+    prompt_toolkit-safe path) rather than the builtin ``print`` so the output
+    isn't swallowed / overdrawn by the live prompt (#36815). ``capsys`` does
+    not see prompt_toolkit's renderer, so tests assert on the captured lines.
+    """
+    lines: list[str] = []
+
+    def _record(text=""):
+        lines.append(str(text))
+
+    with patch("cli._cprint", side_effect=_record):
+        yield lines
 
 
 def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
@@ -276,8 +295,9 @@ class TestHistoryDisplay:
             {"role": "user", "content": "A" * 250},
         ]
 
-        cli.show_history()
-        output = capsys.readouterr().out
+        with _capture_cprint() as _lines:
+            cli.show_history()
+        output = "\n".join(_lines)
 
         assert "[You #1]" in output
         assert "[Hermes #2]" in output
@@ -309,8 +329,9 @@ class TestHistoryDisplay:
             },
         ]
 
-        cli.show_history()
-        output = capsys.readouterr().out
+        with _capture_cprint() as _lines:
+            cli.show_history()
+        output = "\n".join(_lines)
 
         assert "No messages in the current chat yet" in output
         assert "Checking Running Hermes Agent" in output
@@ -337,8 +358,9 @@ class TestHistoryDisplay:
             },
         ]
 
-        cli._handle_resume_command("/resume")
-        output = capsys.readouterr().out
+        with _capture_cprint() as _lines:
+            cli._handle_resume_command("/resume")
+        output = "\n".join(_lines)
 
         assert "Recent sessions" in output
         assert "Checking Running Hermes Agent" in output
@@ -394,8 +416,9 @@ class TestHistoryDisplay:
             },
         ]
 
-        cli._handle_resume_command("/resume")
-        output = capsys.readouterr().out
+        with _capture_cprint() as _lines:
+            cli._handle_resume_command("/resume")
+        output = "\n".join(_lines)
 
         assert long_title in output
         assert "20260401_201329_d85961" in output
@@ -422,8 +445,9 @@ class TestHistoryDisplay:
 
         # Drive it through the public dispatcher to also lock in the
         # process_command wiring, not just the handler in isolation.
-        cli.process_command("/sessions")
-        output = capsys.readouterr().out
+        with _capture_cprint() as _lines:
+            cli.process_command("/sessions")
+        output = "\n".join(_lines)
 
         assert "Unknown command" not in output
         assert "Recent sessions" in output
@@ -444,8 +468,9 @@ class TestHistoryDisplay:
             },
         ]
 
-        cli.process_command("/sessions list")
-        output = capsys.readouterr().out
+        with _capture_cprint() as _lines:
+            cli.process_command("/sessions list")
+        output = "\n".join(_lines)
 
         assert "Unknown command" not in output
         assert "Recent sessions" in output

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -20,15 +20,19 @@ def _make_cli():
 
 
 class TestCliResumeCommand:
-    def test_show_recent_sessions_includes_indexes_and_resume_hint(self, capsys):
+    def test_show_recent_sessions_includes_indexes_and_resume_hint(self):
         cli_obj = _make_cli()
         cli_obj._list_recent_sessions = MagicMock(return_value=[
             {"id": "sess_002", "title": "Coding", "preview": "build feature", "last_active": None},
             {"id": "sess_001", "title": "Research", "preview": "read docs", "last_active": None},
         ])
 
-        shown = cli_obj._show_recent_sessions(reason="resume")
-        output = capsys.readouterr().out
+        # _show_recent_sessions prints via _cprint (prompt_toolkit-safe), which
+        # capsys cannot observe — capture the routed lines instead (#36815).
+        _lines: list[str] = []
+        with patch("cli._cprint", side_effect=lambda text="": _lines.append(str(text))):
+            shown = cli_obj._show_recent_sessions(reason="resume")
+        output = "\n".join(_lines)
 
         assert shown is True
         assert "1" in output


### PR DESCRIPTION
## Summary

Fixes #36815. In the interactive CLI, `/sessions` and `/history` produced **no visible output** even though the session DB had data and the handlers ran correctly.

Root cause: `_show_recent_sessions()` and `show_history()` printed via the builtin `print()`. The command runs while prompt_toolkit owns the screen, so that output is swallowed / overdrawn by the prompt refresh. Every other slash command (e.g. `/title`, `/resume`) already prints through the module-level `_cprint`, which routes lines above the prompt via `run_in_terminal` and is safe from the background-thread race.

- Switched both methods to `_cprint`. `_cprint` prints plain text without Rich markup parsing, so arbitrary session titles/previews can't break rendering.
- Updated the regression tests: the history / recent-sessions output now goes through prompt_toolkit's renderer, which `capsys` cannot observe, so the tests capture the routed `_cprint` lines instead (matching the existing pattern in `test_cli_resume_command.py`).

## Test plan

- [x] `scripts/run_tests.sh tests/cli/test_cli_init.py tests/cli/test_cli_resume_command.py` — 53 tests green, including `/sessions`, `/sessions list`, `/resume` (no target), long-title rendering, and `show_history` numbering/tool-summary coverage.
- [x] `hermes sessions list` (non-interactive) remains unaffected — only the interactive print path changed.