### PR TITLE
fix(custom_providers): resolve per-model context_length for publisher/slug model ids

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1359,7 +1359,10 @@ def init_agent(
                 if _target and _cp_url == _target:
                     _cp_models = _cp_entry.get("models", {})
                     if isinstance(_cp_models, dict):
-                        _cp_model_cfg = _cp_models.get(agent.model, {})
+                        _cp_model_cfg = _cp_models.get(agent.model)
+                        if not isinstance(_cp_model_cfg, dict) and "/" in agent.model:
+                            # Mirror the helper's slug fallback (publisher/slug ids).
+                            _cp_model_cfg = _cp_models.get(agent.model.rsplit("/", 1)[1])
                         if isinstance(_cp_model_cfg, dict):
                             _cp_ctx = _cp_model_cfg.get("context_length")
                             if _cp_ctx is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9735,39 +9735,15 @@ class GatewayRunner:
         except Exception:
             pass
 
-        # Also check custom_providers for context_length when top-level model.context_length is not set
+        # Legacy entry-level override: top-level cp.model + cp.context_length
+        # (a distinct, documented schema from the per-model models: dict below).
         if config_context_length is None and data:
             try:
-                custom_providers = data.get("custom_providers", [])
-                if custom_providers:
-                    for cp in custom_providers:
-                        if not isinstance(cp, dict):
-                            continue
-                        cp_model = cp.get("model") or ""
-                        cp_models = cp.get("models") or {}
-                        # Match provider model to current model
-                        if cp_model and cp_model == model:
-                            raw_cp_ctx = cp.get("context_length")
-                            if raw_cp_ctx is not None:
-                                try:
-                                    config_context_length = int(raw_cp_ctx)
-                                    break
-                                except (TypeError, ValueError):
-                                    pass
-                        # Also check per-model context_length
-                        if isinstance(cp_models, dict):
-                            model_entry = cp_models.get(model)
-                            if isinstance(model_entry, dict):
-                                model_ctx = model_entry.get("context_length")
-                            else:
-                                model_ctx = model_entry
-                            if model_ctx is not None and isinstance(model_ctx, (int, float)):
-                                try:
-                                    config_context_length = int(model_ctx)
-                                    break
-                                except (TypeError, ValueError):
-                                    pass
-            except Exception:
+                for cp in data.get("custom_providers", []) or []:
+                    if isinstance(cp, dict) and cp.get("model") == model and cp.get("context_length") is not None:
+                        config_context_length = int(cp["context_length"])
+                        break
+            except (TypeError, ValueError):
                 pass
 
         # Resolve runtime credentials for probing
@@ -9778,6 +9754,17 @@ class GatewayRunner:
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        # Per-model custom_providers override via the shared slug-tolerant helper.
+        # Runs after runtime resolution so base_url is populated, and gates on it
+        # (the old inline loop matched by model name alone, ignoring base_url).
+        if config_context_length is None and base_url:
+            try:
+                from hermes_cli.config import get_custom_provider_context_length
+                if resolved := get_custom_provider_context_length(model=model, base_url=base_url, custom_providers=custom_provs):
+                    config_context_length = resolved
+            except Exception:
+                pass
 
         context_length = get_model_context_length(
             model,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8946,32 +8946,15 @@ class GatewayRunner:
                 except Exception:
                     pass
 
-                # Check custom_providers per-model context_length
-                # (same fallback as run_agent.py lines 1171-1189).
-                # Must run after runtime resolution so _hyg_base_url is set.
+                # Resolve per-model custom_providers context_length via the
+                # shared slug-tolerant helper (handles LM Studio publisher/slug
+                # ids). Must run after runtime resolution so _hyg_base_url is set.
                 if _hyg_config_context_length is None and _hyg_base_url:
                     try:
-                        try:
-                            from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
-                            _hyg_custom_providers = _gw_gcp(_hyg_data)
-                        except Exception:
-                            _hyg_custom_providers = _hyg_data.get("custom_providers")
-                            if not isinstance(_hyg_custom_providers, list):
-                                _hyg_custom_providers = []
-                        for _cp in _hyg_custom_providers:
-                            if not isinstance(_cp, dict):
-                                continue
-                            _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                            if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                _cp_models = _cp.get("models", {})
-                                if isinstance(_cp_models, dict):
-                                    _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                    if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
-                                        if _cp_ctx is not None:
-                                            _hyg_config_context_length = int(_cp_ctx)
-                                break
-                    except (TypeError, ValueError):
+                        from hermes_cli.config import get_custom_provider_context_length as _gw_gcpcl
+                        if resolved := _gw_gcpcl(model=_hyg_model, base_url=_hyg_base_url, config=_hyg_data):
+                            _hyg_config_context_length = resolved
+                    except Exception:
                         pass
             except Exception:
                 pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8547,6 +8547,7 @@ class GatewayRunner:
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_runtime = _resolve_runtime_agent_kwargs()
                 _msg_config_ctx = None
+                _msg_custom_providers = None
                 try:
                     _msg_cfg = _load_gateway_config()
                     _msg_model_cfg = _msg_cfg.get("model", {})
@@ -8554,6 +8555,9 @@ class GatewayRunner:
                         _msg_raw_ctx = _msg_model_cfg.get("context_length")
                         if _msg_raw_ctx is not None:
                             _msg_config_ctx = int(_msg_raw_ctx)
+                    if _msg_cfg:
+                        from hermes_cli.config import get_compatible_custom_providers
+                        _msg_custom_providers = get_compatible_custom_providers(_msg_cfg)
                 except Exception:
                     pass
                 _msg_ctx_len = get_model_context_length(
@@ -8561,6 +8565,7 @@ class GatewayRunner:
                     base_url=self._base_url or _msg_runtime.get("base_url") or "",
                     api_key=_msg_runtime.get("api_key") or "",
                     config_context_length=_msg_config_ctx,
+                    custom_providers=_msg_custom_providers,
                 )
                 _ctx_result = await preprocess_context_references_async(
                     message_text,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3720,6 +3720,12 @@ def get_custom_provider_context_length(
         if not isinstance(models, dict):
             continue
         model_cfg = models.get(model)
+        match = "exact"
+        if not isinstance(model_cfg, dict) and "/" in model:
+            # Slug fallback: LM Studio reports "publisher/slug" runtime ids but
+            # users key custom_providers by the bare slug. Exact match wins first.
+            model_cfg = models.get(model.rsplit("/", 1)[1])
+            match = "slug"
         if not isinstance(model_cfg, dict):
             continue
         raw_ctx = model_cfg.get("context_length")
@@ -3730,7 +3736,15 @@ def get_custom_provider_context_length(
         except (TypeError, ValueError):
             continue
         if ctx > 0:
+            logger.debug(
+                "custom_providers context_length resolved: model=%r base_url=%r ctx=%d (%s match)",
+                model, base_url, ctx, match,
+            )
             return ctx
+    logger.debug(
+        "custom_providers context_length miss: model=%r base_url=%r — falling back to probe/default",
+        model, base_url,
+    )
     return None
 
 

--- a/tests/gateway/test_context_expansion_custom_provider.py
+++ b/tests/gateway/test_context_expansion_custom_provider.py
@@ -1,0 +1,67 @@
+"""@context budget probe must honor custom_providers per-model context_length.
+
+The ``@file`` reference expansion sizes its injection budget from
+``get_model_context_length``.  For a slug-keyed custom-provider override
+(LM Studio's ``publisher/slug`` ids) the per-model context_length must reach
+that probe — otherwise the budget silently falls back to the default. Regression
+residual of PR #18844 (a).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+@pytest.mark.asyncio
+async def test_context_expansion_uses_custom_provider_slug_budget(monkeypatch):
+    import gateway.run as gateway_run
+
+    config = {
+        "model": {"default": "lmstudio/phi-4", "provider": "custom"},
+        "custom_providers": [
+            {
+                "name": "lmstudio",
+                "base_url": "http://localhost:1234/v1",
+                "models": {"phi-4": {"context_length": 1_048_576}},
+            }
+        ],
+    }
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "custom", "base_url": "http://localhost:1234/v1", "api_key": "x"},
+    )
+
+    captured = {}
+
+    async def fake_preprocess(message_text, *, cwd, context_length, allowed_root):
+        captured["context_length"] = context_length
+        return SimpleNamespace(blocked=False, expanded=False, message=message_text, warnings=[])
+
+    monkeypatch.setattr(
+        "agent.context_references.preprocess_context_references_async", fake_preprocess
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._model = "lmstudio/phi-4"
+    runner._base_url = "http://localhost:1234/v1"
+    runner.config = SimpleNamespace()
+    runner.adapters = {}
+    runner._session_key_for_source = lambda source: "agent:main:telegram:dm:1"
+
+    event = MessageEvent(
+        text="summarise @notes.md please",
+        source=SessionSource(platform=None, chat_id="1", chat_type="dm", user_id="9"),
+        message_id="1",
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event, source=event.source, history=[]
+    )
+
+    # Budget reflects the slug-keyed 1M override (step-0b), not the 256K default.
+    assert captured["context_length"] == 1_048_576

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -852,3 +852,106 @@ async def test_session_hygiene_default_hard_message_limit_does_not_fire_at_12_me
     assert FakeCompressAgent.last_instance is None, (
         "Compression should NOT fire at 12 messages with default hard_limit=400"
     )
+
+
+@pytest.mark.asyncio
+async def test_hygiene_threshold_uses_custom_provider_slug_context_length(monkeypatch, tmp_path):
+    """Hygiene resolves a slug-keyed custom_providers context_length.
+
+    LM Studio runs the model under the prefixed id ``lmstudio/phi-4`` while
+    the user keys ``custom_providers`` by the bare slug ``phi-4``.  The
+    configured 1M context must be threaded into ``get_model_context_length``
+    as ``config_context_length`` — not silently dropped to the 64K/256K
+    fallback (the 0.14.0 regression, #30178).
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    gateway_run = importlib.import_module("gateway.run")
+
+    config = {
+        "model": {
+            "default": "lmstudio/phi-4",
+            "provider": "custom",
+            "base_url": "http://localhost:1234/v1",
+        },
+        "compression": {"enabled": True},
+        "custom_providers": [
+            {
+                "name": "lmstudio",
+                "base_url": "http://localhost:1234/v1",
+                "models": {"phi-4": {"context_length": 1_048_576}},
+            }
+        ],
+    }
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config)
+
+    captured = {}
+
+    def fake_gmcl(model, **kwargs):
+        captured["model"] = model
+        captured["config_context_length"] = kwargs.get("config_context_length")
+        return 10_000_000  # huge → hygiene never fires; we only want the kwarg
+
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", fake_gmcl)
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: HygieneCaptureAdapter()}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._resolve_session_agent_runtime = lambda **_kw: (
+        "lmstudio/phi-4",
+        {"provider": "custom", "base_url": "http://localhost:1234/v1", "api_key": "x"},
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    await runner._handle_message(event)
+
+    assert captured["model"] == "lmstudio/phi-4"
+    assert captured["config_context_length"] == 1_048_576

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -107,3 +107,33 @@ class TestFormatSessionInfo:
             info = runner._format_session_info()
         assert "4K" in info
         assert "config" in info
+
+    def test_custom_provider_slug_context_length_labeled_config(self, runner, tmp_path):
+        """A slug-keyed custom_providers override must surface as '(config)'.
+
+        Runtime model is the prefixed 'lmstudio/phi-4'; the override is keyed
+        by the bare slug 'phi-4'.  The displayed number was already correct via
+        get_model_context_length's step-0b, but the source label wrongly read
+        '(detected)' until the inline /info lookup routed through the shared
+        slug-tolerant helper.
+        """
+        config_yaml = (
+            "model:\n"
+            "  default: lmstudio/phi-4\n"
+            "  provider: custom\n"
+            "  base_url: http://localhost:1234/v1\n"
+            "custom_providers:\n"
+            "  - name: lmstudio\n"
+            "    base_url: http://localhost:1234/v1\n"
+            "    models:\n"
+            "      phi-4:\n"
+            "        context_length: 1048576\n"
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path, config_yaml, "lmstudio/phi-4",
+            {"provider": "custom", "base_url": "http://localhost:1234/v1", "api_key": "k"},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info()
+        assert "1.0M" in info
+        assert "(config)" in info

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -167,16 +167,22 @@ class TestGetCustomProviderContextLength:
             == 99_999
         )
 
-    def test_slug_collision_first_dict_key_wins(self):
-        """Two config keys whose bare slugs collide: 'acme/m' and 'bigco/m'.
+    def test_slug_fallback_and_exact_match_precedence_with_prefixed_keys(self):
+        """Slug fallback for a lone bare key; exact match wins over slug.
 
-        When runtime is 'acme/m' and only bare-slug 'm' is in the config,
-        the slug fallback is 'm'. When two *different* prefixed keys share
-        the same slug and neither matches exactly, dict insertion order
-        governs which slug entry wins — and that is acceptable because
-        the user's config is self-contradictory (two publishers, same slug,
-        same endpoint — ambiguous by definition).  The function does not
-        detect or warn about this; it simply returns the first match.
+        Part 1: runtime 'acme/m' with only bare-slug 'm' configured resolves
+        via the slug fallback.  Part 2: when two prefixed keys ('acme/m',
+        'bigco/m') exist, each prefixed runtime id hits its own exact key and
+        the slug path is never taken — so the result is deterministic and does
+        NOT depend on dict insertion order.
+
+        Note on a genuine collision (two *different* prefixed keys, runtime id
+        matches neither exactly, both share a bare slug): the function returns
+        the first matching entry in dict-iteration order.  That case is
+        intentionally not asserted here — it is order-dependent by nature and
+        only arises from a self-contradictory config (two publishers, same
+        slug, same endpoint).  Asserting on it would bake a brittle
+        ordering expectation into the suite.
         """
         # Only one bare slug key — no ambiguity.
         custom_single = [
@@ -292,6 +298,26 @@ class TestGetCustomProviderContextLength:
                 "pub/model@q4_k_m", "http://localhost:1234/v1", custom
             )
             is None
+        )
+
+    def test_multi_slash_id_strips_only_last_segment(self):
+        """rsplit('/', 1)[1] takes the final segment of a multi-slash id.
+
+        For 'org/team/model' the slug fallback is the last segment 'model'.
+        LM Studio ids are single-slash 'publisher/slug', so this is an edge
+        case, but pinning it documents the well-defined rsplit behavior.
+        """
+        custom = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"model": {"context_length": 65_536}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "org/team/model", "http://localhost:1234/v1", custom
+            )
+            == 65_536
         )
 
     def test_ignores_non_dict_entries(self):

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -123,6 +123,177 @@ class TestGetCustomProviderContextLength:
         assert get_custom_provider_context_length("m", "http://x", None) is None
         assert get_custom_provider_context_length("m", "http://x", []) is None
 
+    # ------------------------------------------------------------------
+    # Slug-normalisation fallback (LM Studio "publisher/slug" runtime ids)
+    # ------------------------------------------------------------------
+
+    def test_slug_fallback_prefixed_runtime_matches_bare_config_key(self):
+        """Runtime model is 'lmstudio/phi-4'; config key is bare 'phi-4'.
+
+        This is the primary LM Studio scenario: probe_lmstudio_models returns
+        'publisher/slug' keys; users typically configure only the bare slug.
+        """
+        custom = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"phi-4": {"context_length": 131_072}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "lmstudio/phi-4", "http://localhost:1234/v1", custom
+            )
+            == 131_072
+        )
+
+    def test_exact_match_wins_over_slug_fallback(self):
+        """When the runtime id has a '/' AND appears as a literal key, exact
+        match must be returned without consulting the slug fallback.
+        """
+        custom = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {
+                    "pub/phi-4": {"context_length": 99_999},  # exact key
+                    "phi-4": {"context_length": 131_072},      # slug-only key
+                },
+            }
+        ]
+        # Exact match wins — returns the exact-key value, not the slug value.
+        assert (
+            get_custom_provider_context_length(
+                "pub/phi-4", "http://localhost:1234/v1", custom
+            )
+            == 99_999
+        )
+
+    def test_slug_collision_first_dict_key_wins(self):
+        """Two config keys whose bare slugs collide: 'acme/m' and 'bigco/m'.
+
+        When runtime is 'acme/m' and only bare-slug 'm' is in the config,
+        the slug fallback is 'm'. When two *different* prefixed keys share
+        the same slug and neither matches exactly, dict insertion order
+        governs which slug entry wins — and that is acceptable because
+        the user's config is self-contradictory (two publishers, same slug,
+        same endpoint — ambiguous by definition).  The function does not
+        detect or warn about this; it simply returns the first match.
+        """
+        # Only one bare slug key — no ambiguity.
+        custom_single = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"m": {"context_length": 8_192}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "acme/m", "http://localhost:1234/v1", custom_single
+            )
+            == 8_192
+        )
+
+        # Two prefixed keys, same bare slug 'm' — exact match on 'acme/m'
+        # returns the correct entry; 'bigco/m' is not reached.
+        custom_two_prefixed = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {
+                    "acme/m": {"context_length": 8_192},
+                    "bigco/m": {"context_length": 32_768},
+                },
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "acme/m", "http://localhost:1234/v1", custom_two_prefixed
+            )
+            == 8_192  # exact hit, not slug path
+        )
+        assert (
+            get_custom_provider_context_length(
+                "bigco/m", "http://localhost:1234/v1", custom_two_prefixed
+            )
+            == 32_768  # exact hit
+        )
+
+    def test_reverse_direction_not_handled(self):
+        """Bare runtime id 'm' does NOT match a config key 'pub/m'.
+
+        The fix is one-directional: runtime has '/', config key is bare slug.
+        The reverse (runtime bare, config key prefixed) is not a real scenario
+        because LM Studio always returns prefixed ids from its native API and
+        normalize_model_for_provider does not strip the publisher prefix for
+        the lmstudio provider.  Implementing the reverse would risk spurious
+        cross-publisher collisions and is explicitly out of scope.
+        """
+        custom = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"pub/m": {"context_length": 8_192}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "m", "http://localhost:1234/v1", custom
+            )
+            is None
+        )
+
+    def test_case_sensitive_slug_fallback(self):
+        """Slug fallback is case-sensitive, matching _model_id_matches precedent.
+
+        Config key 'Nemotron' does not match runtime 'nvidia/nemotron'.
+        Users must match case exactly, same as everywhere else in Hermes config.
+        """
+        custom = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"Nemotron": {"context_length": 131_072}},
+            }
+        ]
+        # Wrong case — must miss.
+        assert (
+            get_custom_provider_context_length(
+                "nvidia/nemotron", "http://localhost:1234/v1", custom
+            )
+            is None
+        )
+        # Correct case — must hit.
+        custom_correct = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"nemotron": {"context_length": 131_072}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "nvidia/nemotron", "http://localhost:1234/v1", custom_correct
+            )
+            == 131_072
+        )
+
+    def test_quant_suffix_in_slug_not_supported(self):
+        """Runtime id 'pub/model@q4_k_m' — slug fallback yields 'model@q4_k_m',
+        not 'model'.  Quant-suffix stripping is explicitly out of scope for this
+        fix.  LM Studio's native /api/v1/models returns plain 'publisher/slug'
+        keys with no '@' quant suffix (confirmed by probe_lmstudio_models which
+        uses raw.get('key') or raw.get('id')).  If a user manually writes a
+        quant-suffixed config key, they must match the full runtime id exactly.
+        """
+        custom = [
+            {
+                "base_url": "http://localhost:1234/v1",
+                "models": {"model": {"context_length": 32_768}},
+            }
+        ]
+        # Falls through to slug 'model@q4_k_m' — does not match bare 'model'.
+        assert (
+            get_custom_provider_context_length(
+                "pub/model@q4_k_m", "http://localhost:1234/v1", custom
+            )
+            is None
+        )
+
     def test_ignores_non_dict_entries(self):
         """Malformed entries must not crash the lookup."""
         custom = [

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -141,6 +141,56 @@ def test_no_warning_when_aux_context_sufficient(mock_get_client, mock_ctx_len):
     assert agent._compression_warning is None
 
 
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_resolves_slug_keyed_custom_provider_context(mock_get_client):
+    """Aux feasibility honors a slug-keyed custom_providers context_length.
+
+    The aux compression model runs under an LM Studio ``publisher/slug``
+    runtime id (``lmstudio/qwen3-coder-30b``) while ``custom_providers`` keys
+    the bare slug (``qwen3-coder-30b``). The shared slug-tolerant resolver must
+    surface the full 1M window through ``get_model_context_length`` step-0b, so
+    the feasibility check sees a context far above the threshold and does NOT
+    auto-lower it.
+
+    Regression guard for the slug path *through* compression: the other tests
+    in this file stub ``get_model_context_length`` and therefore cannot observe
+    a step-0b regression. Here it is deliberately NOT mocked — the resolver
+    chain is the unit under test. ``base_url`` is a localhost custom endpoint,
+    so step-0b short-circuits before any live probe (hermetic).
+
+    The 500K threshold is chosen ABOVE DEFAULT_FALLBACK_CONTEXT (256K, the
+    largest probe tier): only the slug-resolved 1M window can clear it, so the
+    assertions are genuinely RED if the slug fallback regresses (the resolver
+    would return None, resolution would fall through to the 256K default,
+    256K < 500K would trip the auto-lower warning).
+    """
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    # threshold = 500,000 — above every probe tier (max 256K)
+    agent.provider = "custom"
+    agent._custom_providers = [
+        {
+            "name": "lmstudio",
+            "base_url": "http://localhost:1234/v1",
+            "models": {"qwen3-coder-30b": {"context_length": 1_048_576}},
+        }
+    ]
+    mock_client = MagicMock()
+    mock_client.base_url = "http://localhost:1234/v1"
+    mock_client.api_key = "lm-studio"
+    # Prefixed runtime id ≠ bare "qwen3-coder-30b" config key → slug fallback.
+    mock_get_client.return_value = (mock_client, "lmstudio/qwen3-coder-30b")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    # 1,048,576 > 500,000 threshold → no warning, none stored, threshold kept.
+    assert messages == []
+    assert agent._compression_warning is None
+    assert agent.context_compressor.threshold_tokens == 500_000
+
+
 def test_feasibility_check_passes_live_main_runtime():
     """Compression feasibility should probe using the live session runtime."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -112,3 +112,30 @@ def test_custom_providers_valid_context_length():
         )
     for c in mock_logger.warning.call_args_list:
         assert "Invalid" not in str(c)
+
+
+def test_custom_providers_slug_keyed_invalid_context_length_warns():
+    """A slug-keyed invalid value still warns for a prefixed runtime id.
+
+    Runtime model is 'lmstudio/phi-4' but the config key is the bare slug
+    'phi-4'.  The warning lookup must mirror the helper's slug fallback,
+    otherwise an invalid value on a slug-keyed model is silently skipped.
+    """
+    custom_providers = [
+        {
+            "name": "lmstudio",
+            "base_url": "http://localhost:1234/v1",
+            "models": {"phi-4": {"context_length": "256K"}},
+        }
+    ]
+    with patch("run_agent.logger") as mock_logger:
+        _build_agent(
+            {"default": "lmstudio/phi-4", "provider": "custom",
+             "base_url": "http://localhost:1234/v1"},
+            custom_providers=custom_providers,
+            model="lmstudio/phi-4",
+        )
+    warning_calls = [c for c in mock_logger.warning.call_args_list
+                     if "Invalid" in str(c) and "256K" in str(c)]
+    assert len(warning_calls) == 1
+    assert "custom_providers" in str(warning_calls[0])


### PR DESCRIPTION
## Summary

LM Studio reports model ids as `publisher/slug` (e.g. `nvidia/nemotron-3-nano-4b`), but `custom_providers[].models:` is keyed by the bare slug (`nemotron-3-nano-4b`). `get_custom_provider_context_length` matched only the exact id, so per-model `context_length` was missed and the model fell back to the 256K default — mis-sizing compression and the `@context` budget (#30178, regressed in 0.14.0). Fix: try the exact key, then the bare slug, in that one resolver, and route the remaining inline lookups through it.

## Change

- `get_custom_provider_context_length` (`hermes_cli/config.py:3722-3748`): after an exact `models[model]` miss on an id containing `/`, retry `models[model.rsplit("/", 1)[1]]`. Case-sensitive; exact match wins; `ctx > 0` guard; debug logs tagged `exact`/`slug` plus a miss log.
- Session hygiene (`gateway/run.py:8957-8961`): replace the inline lookup loop (24 lines) with a call to the resolver.
- `/info` per-model (`gateway/run.py:9766-9772`): call the resolver; the match now requires `base_url` (the prior loop matched on model id alone).
- `/info` legacy entry-level (`gateway/run.py:9743-9750`): retained for the top-level `cp.model` + `context_length` schema.
- `@context` budget (`gateway/run.py:8550-8568`): pass `custom_providers` to `get_model_context_length`.
- Invalid-value warning (`agent/agent_init.py:1362-1365`): apply the same slug fallback so a non-integer `context_length` (e.g. `"256K"`) on a slug-keyed model still warns.
- Unchanged: compression code, `ContextCompressor.__init__`, and the `get_model_context_length` step-2 256K short-circuit.

## Resolution behavior

| runtime id | matching config key | result |
|---|---|---|
| `pub/m` | `pub/m` (exact) | exact value |
| `pub/m` | `m` (bare slug) | slug value |
| `pub/m` | only `Pub/m` / wrong case | miss → probe/default |
| `m` (no slash) | `pub/m` | miss (no reverse match) |
| `pub/m@q4` | `m` | miss (quant suffix not stripped) |

## Testing

`uv run --extra dev pytest -p no:randomly tests/hermes_cli/test_custom_provider_context_length.py tests/gateway/test_session_hygiene.py tests/gateway/test_session_info.py tests/gateway/test_context_expansion_custom_provider.py tests/run_agent/test_invalid_context_length_warning.py tests/run_agent/test_compression_feasibility.py` → **77 passed**. `ruff check` clean (the tree is not `ruff format`-managed).

- `test_custom_provider_context_length.py` (19): exact-wins, slug fallback, multi-slash, case sensitivity, quant-suffix and reverse-direction unsupported, trailing slash, non-positive, empty inputs.
- `test_session_hygiene.py`: slug-keyed `context_length` reaches `get_model_context_length` through `_handle_message`.
- `test_session_info.py`: `/info` shows `1.0M` and `(config)`.
- `test_context_expansion_custom_provider.py`: the `@context` budget uses the slug-resolved 1M through `_prepare_inbound_message_text`.
- `test_invalid_context_length_warning.py`: `"256K"` on a slug-keyed model warns through `_build_agent`.
- `test_compression_feasibility.py::test_feasibility_resolves_slug_keyed_custom_provider_context`: with `get_model_context_length` unmocked and a 500K threshold (above the 256K fallback tier), the feasibility check sees the slug-resolved 1M and does not lower the threshold; it fails if the slug fallback is removed.

Verification limit: exercised through config and the resolver chain, not against a live LM Studio endpoint.

## Note

The `/info` per-model lookup now requires a `base_url` match. For a single provider the result is identical; for multiple providers sharing a model id, a non-matching provider's `context_length` is no longer shown. The displayed number was already correct via `get_model_context_length` step-0b; this affects the `(detected)`→`(config)` source label.

## Related

- #18844 proposed the `@context` threading and the resolver-based hygiene lookup; both are implemented here (`gateway/run.py:8550-8568`, `:8957-8961`).
- #8785, #13807, #19539, #20608, #21919, #21947, #23779, #26548 report bare-keyed (non-slug) configs; those paths thread `custom_providers` into `get_model_context_length` as of `7becb19ea` and `b5bcffe16`. #21919 and #21947 describe the same case.
- #15563: the `resolve_display_context_length` half (`hermes_cli/model_switch.py`) is handled by `0dd373ec4`; the `get_model_context_length` step-2 short-circuit is unchanged here.
- #13540 and #25554 proposed the `custom_providers` threading now in `7becb19ea`/`b5bcffe16`. #26843 proposed passing `custom_providers` to `ContextCompressor.__init__`; that constructor uses an already-resolved `config_context_length` (step-0 returns before step-0b), so the window is resolved before construction.

Closes #30178
Refs #18844
