### PR TITLE
fix(claw-migrate): don't crash on inaccessible workspace path (#36831)

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -346,6 +346,30 @@ def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Op
     return None
 
 
+def _safe_is_dir(path: Path) -> bool:
+    """Like ``Path.is_dir()`` but never raises.
+
+    ``pathlib.Path.is_dir()`` only swallows ENOENT/ENOTDIR/EBADF/ELOOP — a
+    ``PermissionError`` (EACCES) is re-raised. A non-root user running
+    ``hermes claw migrate`` whose ``openclaw.json`` carries a stale absolute
+    workspace path under ``/root/`` (left over from a root install) would
+    otherwise crash the whole preview (#36831). Treat any inaccessible path
+    as "not a usable directory" instead.
+    """
+    try:
+        return os.path.isdir(path)
+    except OSError:
+        return False
+
+
+def _safe_exists(path: Path) -> bool:
+    """Like ``Path.exists()`` but never raises (see ``_safe_is_dir``)."""
+    try:
+        return os.path.exists(path)
+    except OSError:
+        return False
+
+
 def load_yaml_file(path: Path) -> Dict[str, Any]:
     if yaml is None or not path.exists():
         return {}
@@ -755,10 +779,16 @@ class Migrator:
         oc_config = self.load_openclaw_config()
         ws = (oc_config.get("agents", {}).get("defaults", {}).get("workspace") or "").strip()
         if ws:
-            ws_path = Path(ws).expanduser().resolve()
+            try:
+                ws_path = Path(ws).expanduser().resolve()
+            except OSError:
+                ws_path = None
             # Only use it if it exists and is outside the source_root tree
             # (otherwise the standard relative-path logic already covers it).
-            if ws_path.is_dir():
+            # _safe_is_dir tolerates a stale/inaccessible path in openclaw.json
+            # (e.g. a /root/ workspace from a prior root install) so a non-root
+            # migration doesn't crash on PermissionError (#36831).
+            if ws_path is not None and _safe_is_dir(ws_path):
                 try:
                     ws_path.relative_to(self.source_root)
                 except ValueError:
@@ -839,7 +869,7 @@ class Migrator:
     def source_candidate(self, *relative_paths: str) -> Optional[Path]:
         for rel in relative_paths:
             candidate = self.source_root / rel
-            if candidate.exists():
+            if _safe_exists(candidate):
                 return candidate
             # OpenClaw renamed workspace/ to workspace-main/ (and workspace-{agentId}
             # for multi-agent).  Try the new path as a fallback.
@@ -847,12 +877,12 @@ class Migrator:
                 suffix = rel[len("workspace/"):]
                 for variant in ("workspace-main", "workspace-assistant"):
                     alt = self.source_root / variant / suffix
-                    if alt.exists():
+                    if _safe_exists(alt):
                         return alt
             elif rel.startswith("workspace.default/"):
                 suffix = rel[len("workspace.default/"):]
                 alt = self.source_root / "workspace-main" / suffix
-                if alt.exists():
+                if _safe_exists(alt):
                     return alt
 
         # Final fallback: check the configured workspace directory from
@@ -867,7 +897,7 @@ class Migrator:
                     if rel.startswith(prefix):
                         suffix = rel[len(prefix):]
                         alt = self._custom_workspace / suffix
-                        if alt.exists():
+                        if _safe_exists(alt):
                             return alt
                         break
 

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -280,6 +280,56 @@ def test_migrator_records_preset_in_report(tmp_path: Path):
     assert report["selection"]["skill_conflict_mode"] == "skip"
 
 
+def test_migrator_survives_permission_denied_workspace_path(tmp_path: Path, monkeypatch):
+    """A non-root migration must not crash when openclaw.json carries a stale
+    absolute workspace path the user can't access (e.g. /root/.openclaw/workspace
+    left over from a prior root install) — #36831."""
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir()
+    target.mkdir()
+
+    stale_ws = "/root/.openclaw/workspace"
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": stale_ws}}}),
+        encoding="utf-8",
+    )
+    # A real file inside the source workspace so there's something to preview.
+    (source / "workspace").mkdir()
+    (source / "workspace" / "SOUL.md").write_text("# Soul\n\nhi\n", encoding="utf-8")
+
+    # Deny stat() on the stale path the way an unreadable /root/ would. This
+    # faithfully reproduces the original crash: pathlib's Path.is_dir() calls
+    # os.stat() and re-raises EACCES (only os.path.isdir swallows it).
+    real_stat = mod.os.stat
+
+    def fake_stat(path, *a, **kw):
+        p = str(path)
+        if p == stale_ws or p.startswith(stale_ws + "/"):
+            raise PermissionError(13, "Permission denied")
+        return real_stat(path, *a, **kw)
+
+    monkeypatch.setattr(mod.os, "stat", fake_stat)
+
+    # Construction + preview must not raise PermissionError.
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options={"soul"},
+    )
+    report = migrator.migrate()
+
+    # The inaccessible workspace is ignored rather than crashing the run.
+    assert migrator._custom_workspace is None
+    assert isinstance(report, dict)
+
+
 def test_source_candidate_finds_files_in_custom_workspace(tmp_path: Path):
     """When agents.defaults.workspace points outside ~/.openclaw, files should
     be discovered there as a fallback."""


### PR DESCRIPTION
## Summary

Fixes #36831. A non-root user running `hermes claw migrate` aborted with:

```
✗ Migration preview failed: [Errno 13] Permission denied: '/root/.openclaw/workspace'
```

even though they passed a valid source (`/home/dylan/.openclaw`).

Root cause: the `Migrator` reads `agents.defaults.workspace` from the user's `openclaw.json` to locate a custom workspace dir. When that value is a stale absolute path under `/root/` (left over from a prior root install), the constructor called pathlib's `Path.is_dir()`. Unlike `os.path.isdir`, `pathlib.Path.is_dir()` only swallows ENOENT/ENOTDIR/EBADF/ELOOP — a `PermissionError` (EACCES) is **re-raised**, killing the whole preview before anything is migrated.

- Added `_safe_is_dir` / `_safe_exists` helpers (`os.path`-based, never raise).
- Used them when resolving the custom workspace and in `source_candidate()`, plus wrapped the `Path(...).resolve()` of the configured workspace in a guard. A stale/inaccessible workspace path is now ignored instead of crashing — migration proceeds from the explicitly-provided source.

## Test plan

- [x] `scripts/run_tests.sh tests/skills/test_openclaw_migration.py` — 42 tests green, including a new `test_migrator_survives_permission_denied_workspace_path` that denies `stat()` on a `/root/` workspace path (faithfully reproducing the EACCES re-raise) and asserts the preview ignores it.