### PR TITLE
fix(claw): tolerate unreadable workspace path in openclaw.json (#36831)

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -755,10 +755,22 @@ class Migrator:
         oc_config = self.load_openclaw_config()
         ws = (oc_config.get("agents", {}).get("defaults", {}).get("workspace") or "").strip()
         if ws:
-            ws_path = Path(ws).expanduser().resolve()
-            # Only use it if it exists and is outside the source_root tree
-            # (otherwise the standard relative-path logic already covers it).
-            if ws_path.is_dir():
+            # The configured workspace path may be unreadable by the current
+            # user — common when openclaw.json was written by an earlier root
+            # install (workspace=/root/.openclaw/workspace) and the user is
+            # now migrating as a non-root account.  pathlib's stat-based
+            # methods (resolve / is_dir / exists) raise PermissionError on
+            # EACCES rather than returning False, which previously aborted
+            # the entire migration preview.  Treat any OS error here as
+            # "workspace unusable, skip custom override and fall back to
+            # the standard relative-path logic." See issue #36831.
+            try:
+                ws_path = Path(ws).expanduser().resolve()
+                ws_is_dir = ws_path.is_dir()
+            except OSError:
+                ws_path = None
+                ws_is_dir = False
+            if ws_path is not None and ws_is_dir:
                 try:
                     ws_path.relative_to(self.source_root)
                 except ValueError:

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -1107,3 +1107,179 @@ def test_migrate_model_config_no_catalog_leaves_value_alone(tmp_path: Path):
         {"agents": {"defaults": {"model": "some-model-id"}}},
     )
     assert _extract_model(parsed) == "some-model-id"
+
+
+# ── Permission-denied resilience (issue #36831) ─────────────────────
+#
+# When openclaw.json was written by an earlier root install, it can point
+# agents.defaults.workspace at a path the current (non-root) user cannot
+# stat — e.g. /root/.openclaw/workspace.  pathlib's stat-based methods
+# (resolve / is_dir / exists) raise PermissionError on EACCES rather
+# than returning False, which previously aborted the entire
+# `hermes claw migrate` preview with:
+#     ✗ Migration preview failed: [Errno 13] Permission denied: '/root/.openclaw/workspace'
+#
+# Treat any OSError while probing the configured workspace as
+# "unusable, fall back to standard relative-path lookup."
+
+def _make_migrator(source_root: Path, target_root: Path):
+    mod = load_module()
+    return mod, mod.Migrator(
+        source_root=source_root,
+        target_root=target_root,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options=set(),
+        preset_name="full",
+        skill_conflict_mode="skip",
+    )
+
+
+def test_migrator_init_tolerates_unreadable_workspace_from_openclaw_config(tmp_path, monkeypatch):
+    """openclaw.json points at an unreadable workspace (EACCES) — must not raise."""
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": "/root/.openclaw/workspace"}}}),
+        encoding="utf-8",
+    )
+
+    mod = load_module()
+
+    real_resolve = Path.resolve
+
+    def fake_resolve(self, *args, **kwargs):
+        # Only the workspace path is unreadable; everything else resolves normally.
+        if str(self).endswith("/root/.openclaw/workspace"):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    # Must not raise — previously raised PermissionError aborting `claw migrate`.
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options=set(),
+        preset_name="full",
+        skill_conflict_mode="skip",
+    )
+    # Unreadable workspace must not be adopted as the custom override.
+    assert migrator._custom_workspace is None
+
+
+def test_migrator_init_tolerates_unreadable_workspace_on_is_dir(tmp_path, monkeypatch):
+    """resolve() succeeds, is_dir() raises PermissionError — must not raise."""
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": "/root/.openclaw/workspace"}}}),
+        encoding="utf-8",
+    )
+
+    mod = load_module()
+
+    real_is_dir = Path.is_dir
+
+    def fake_is_dir(self):
+        if "/root/.openclaw/workspace" in str(self):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", fake_is_dir)
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options=set(),
+        preset_name="full",
+        skill_conflict_mode="skip",
+    )
+    assert migrator._custom_workspace is None
+
+
+def test_migrator_init_skips_workspace_when_path_missing(tmp_path):
+    """Workspace path is set but does not exist — must not adopt as custom."""
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": str(tmp_path / "does-not-exist")}}}),
+        encoding="utf-8",
+    )
+    _mod, migrator = _make_migrator(source, target)
+    assert migrator._custom_workspace is None
+
+
+def test_migrator_init_adopts_external_workspace_when_readable(tmp_path):
+    """Happy path regression guard — readable external workspace IS adopted."""
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    external = tmp_path / "clawd-workspace"
+    external.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": str(external)}}}),
+        encoding="utf-8",
+    )
+    _mod, migrator = _make_migrator(source, target)
+    assert migrator._custom_workspace == external.resolve()
+
+
+def test_migrate_preview_completes_when_workspace_is_unreadable(tmp_path, monkeypatch):
+    """End-to-end: migrate() returns a normal report even when the configured
+    workspace is unreadable — equivalent to the failing user scenario in #36831
+    where `hermes claw migrate` died with 'Migration preview failed'."""
+    source = tmp_path / ".openclaw"
+    source.mkdir()
+    target = tmp_path / ".hermes"
+    target.mkdir()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": "/root/.openclaw/workspace"}}}),
+        encoding="utf-8",
+    )
+
+    mod = load_module()
+    real_resolve = Path.resolve
+
+    def fake_resolve(self, *args, **kwargs):
+        if str(self).endswith("/root/.openclaw/workspace"):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options=set(),
+        preset_name="full",
+        skill_conflict_mode="skip",
+    )
+    report = migrator.migrate()
+    assert isinstance(report, dict)
+    assert "summary" in report


### PR DESCRIPTION
## Why

`hermes claw migrate` aborts on any host where `openclaw.json` was written
by an earlier root install (or a different user) and the current account
cannot stat the configured workspace path:

```
$ hermes claw migrate
...
✗ Migration preview failed: [Errno 13] Permission denied: '/root/.openclaw/workspace'
```

This is the exact symptom reported in #36831 on a Raspberry Pi running
Debian 13 as user `dylan`, where `agents.defaults.workspace` had been
recorded as `/root/.openclaw/workspace` from a prior `sudo` invocation.
The user's own `~/.openclaw/` is perfectly readable, but the migration
never gets a chance to look at it.

## What

In `Migrator.__init__`, the workspace probe was:

```python
ws_path = Path(ws).expanduser().resolve()
if ws_path.is_dir():
    ...
```

Both `Path.resolve()` and `Path.is_dir()` raise `PermissionError` on
EACCES rather than returning False. (`pathlib._ignore_error` only
swallows `ENOENT` / `ENOTDIR` / `EBADF` / `ELOOP` — by design.) So the
single bad side path took down the whole preview before any of the
user's actual data was inspected.

Fix is a one-block change in `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`:
wrap the `resolve()` + `is_dir()` probe in `try/except OSError`. If the
configured workspace can't be stat'd, leave `_custom_workspace=None`
and fall back to the standard `source_candidate()` relative-path lookup
against `--source`. The user's accessible files migrate normally; the
unreadable side path is just ignored.

`OSError` covers `PermissionError`, `FileNotFoundError` (race), and any
filesystem oddity the prober might hit on weird mounts — same defensive
posture the surrounding code already takes with `load_yaml_file()` /
`parse_env_file()`.

## Behaviour-change footprint

- Before: any unreadable `agents.defaults.workspace` → entire `claw migrate`
  preview aborts with `PermissionError` traceback.
- After: same unreadable path → workspace probe quietly declines, custom
  workspace stays `None`, migration uses the standard source-tree lookup.
- Readable workspaces are adopted as `_custom_workspace` exactly as
  before. No change to the `source_candidate()` fallback path that
  reads it. No change to any other code path.

## Test coverage

Added in `tests/skills/test_openclaw_migration.py`:

| Test | Asserts |
|---|---|
| `test_migrator_init_tolerates_unreadable_workspace_from_openclaw_config` | `PermissionError` from `Path.resolve()` is caught; `Migrator()` constructs without raising; `_custom_workspace is None` |
| `test_migrator_init_tolerates_unreadable_workspace_on_is_dir` | `PermissionError` from `Path.is_dir()` is caught; `Migrator()` constructs; `_custom_workspace is None` |
| `test_migrator_init_skips_workspace_when_path_missing` | Pre-existing happy path: configured path that simply doesn't exist is still skipped (regression guard for the original logic) |
| `test_migrator_init_adopts_external_workspace_when_readable` | Pre-existing happy path: readable external workspace IS adopted as `_custom_workspace` (regression guard that this PR doesn't disable the original feature) |
| `test_migrate_preview_completes_when_workspace_is_unreadable` | End-to-end: `migrator.migrate()` returns a normal report dict under simulated EACCES — equivalent to the failing `hermes claw migrate` scenario in the issue |

Full `tests/skills/` suite: **200 passed, 0 failed** on this branch
(baseline `upstream/main` also clean — no new failures introduced).

Reproduced the original bug locally by reverting the fix and running the
new end-to-end test: it fails with the same `PermissionError: [Errno 13]
Permission denied: '/root/.openclaw/workspace'` traceback the issue
reports. With the fix applied, it returns a normal report.

## Out of scope (deliberately)

- The cosmetic "side-effect of older root install" remediation (e.g.
  warning the user that an unreadable workspace was found in
  `openclaw.json` so they can re-`chown` it) — could be a follow-up if
  desired, but the immediate priority was unblocking the migration
  itself. Silent fallback matches the file's existing posture for
  unreadable optional sources.
- Other `pathlib.Path` call sites in the migrator that could in theory
  also encounter EACCES (e.g. the `source_candidate()` fallbacks
  themselves). None of those were implicated in the issue trace and
  changing them would expand the diff well beyond the reported bug.
- `hermes_cli/setup.py` has its own `Migration preview failed:` branch
  (line 2635) wrapping the same `Migrator()` call. Its `except Exception`
  already keeps `setup` going past this case; the user-visible bug only
  manifested on `hermes claw migrate`. No setup.py change needed.

Fixes #36831
