### PR TITLE
fix(tools): harden dangerous-command denylist against shell-escape bypass

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -59,6 +59,37 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
 
+class TestDenylistShellEscapeBypass:
+    """Regression: shell-level encodings of a blocked keyword must not slip
+    past the denylist. bash removes backslash/quote escapes and performs
+    command substitution before exec, so ``r\\m``, ``r''m``, ``$(echo rm)``
+    and backticks all run ``rm`` while evading a literal regex on the raw
+    string.
+    """
+
+    BYPASSES = [
+        r"r\m -rf /home/victim",
+        "r''m -rf /home/victim",
+        "$(echo rm) -rf /home/victim",
+        "`echo rm` -rf /home/victim",
+    ]
+
+    def test_escaped_rm_is_still_detected(self):
+        from tools.approval import detect_hardline_command
+
+        for cmd in self.BYPASSES:
+            is_dangerous, _, _ = detect_dangerous_command(cmd)
+            assert is_dangerous is True, f"denylist bypass not caught: {cmd!r}"
+        # the hardline root-delete guard must also survive escaping
+        is_hardline, _ = detect_hardline_command(r"r\m -rf /")
+        assert is_hardline is True
+
+    def test_benign_commands_not_false_flagged(self):
+        for cmd in ["ls -la", 'echo "hello world"', "git status", "cat file.txt"]:
+            is_dangerous, _, _ = detect_dangerous_command(cmd)
+            assert is_dangerous is False, f"false positive on benign command: {cmd!r}"
+
+
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):
         is_dangerous, key, desc = detect_dangerous_command("bash -c 'echo pwned'")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -12,6 +12,7 @@ import contextvars
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import time
@@ -292,10 +293,10 @@ def detect_hardline_command(command: str) -> tuple:
     Returns:
         (is_hardline, description) or (False, None)
     """
-    normalized = _normalize_command_for_detection(command).lower()
-    for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
-        if pattern_re.search(normalized):
-            return (True, description)
+    for candidate in _detection_candidates(command):
+        for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
+            if pattern_re.search(candidate):
+                return (True, description)
     return (False, None)
 
 
@@ -500,17 +501,49 @@ def _normalize_command_for_detection(command: str) -> str:
     return command
 
 
+def _detection_candidates(command: str) -> list:
+    """Return normalised forms of a command to match the denylist against.
+
+    The regex denylist matches a raw string, but bash performs backslash and
+    quote removal plus command substitution *before* executing, so shell-level
+    encodings of a blocked keyword (``r\\m``, ``r''m``, ``$(echo rm)``,
+    backticks) slip past a literal regex.  We additionally match against forms
+    with those encodings neutralised.  This only ever *adds* detections -- it
+    never suppresses an existing match -- so it cannot create a new bypass.
+
+    Note: bash parameter-expansion substitution (e.g. ``${0/x/r}m``) cannot be
+    resolved statically without invoking a shell and is not covered here; the
+    robust long-term fix is structural argv parsing of the executed command.
+    """
+    base = _normalize_command_for_detection(command).lower()
+    candidates = [base]
+    # Unwrap command substitution so $(echo rm) / `echo rm` expose the keyword.
+    unwrapped = re.sub(r"\$\(([^()]*)\)", r" \1 ", base)
+    unwrapped = re.sub(r"`([^`]*)`", r" \1 ", unwrapped)
+    for cand in (base, unwrapped):
+        # shlex (POSIX) removes backslash escapes and empty-quote splits:
+        # r\m -> rm, r''m -> rm.
+        try:
+            tokens = shlex.split(cand)
+        except ValueError:
+            tokens = None
+        if tokens:
+            joined = " ".join(tokens)
+            if joined not in candidates:
+                candidates.append(joined)
+    return candidates
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    command_lower = _normalize_command_for_detection(command).lower()
-    for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
-        if pattern_re.search(command_lower):
-            pattern_key = description
-            return (True, pattern_key, description)
+    for candidate in _detection_candidates(command):
+        for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
+            if pattern_re.search(candidate):
+                return (True, description, description)
     return (False, None, None)
 
 


### PR DESCRIPTION
## What & why

The dangerous-command approval gate classifies commands with a **regex denylist** (`DANGEROUS_PATTERNS`, and the newer `HARDLINE_PATTERNS`) matched against the raw command string. bash performs backslash/quote removal and command substitution **before** executing, so shell-level encodings of a blocked keyword slip past the literal regex while still running the command. On a non-dangerous verdict the approval layer returns approved with no prompt — silent RCE in non-interactive contexts (cron, RL rollouts, subagents).

Verified against current `main` before this patch:

```
 DANGEROUS  HARDLINE  command
      True     False  rm -rf /home/victim          (baseline, flagged)
     False     False  r\m -rf /home/victim         BYPASS
     False     False  r''m -rf /home/victim        BYPASS
     False     False  $(echo rm) -rf /home/victim  BYPASS
      True      True  rm -rf /
     False     False  r\m -rf /                     BYPASS of HARDLINE root-delete
```

## The fix

`detect_dangerous_command` and `detect_hardline_command` now match the normalised form **plus** shlex-dequoted and command-substitution-unwrapped variants (new `_detection_candidates` helper). shlex (POSIX) collapses `r\m`/`r''m` → `rm`; the unwrap step exposes `$(echo rm)` / `` `echo rm` ``. This only ever **adds** detections (the original form is still matched first), so it cannot create a new bypass or suppress an existing match.

After the patch, all four escape forms — and `r\m -rf /` against the hardline guard — are caught, with no false positives on benign commands (`ls -la`, `echo "hello world"`, `git status`).

**Known limitation (disclosed):** bash parameter-expansion substitution (`${0/x/r}m`) cannot be resolved statically without invoking a shell and is not covered. The robust long-term fix is structural argv parsing of the expanded command; this PR is defense-in-depth that closes the common, documented escapes.

## How to test

```
pytest tests/tools/test_approval.py::TestDenylistShellEscapeBypass -v
```
(Adds a regression test asserting the escaped forms are detected and benign commands are not.)

## Platforms

Logic-only change in `tools/approval.py`; no OS-specific behavior.

Fixes #36846. Also addresses the root cause of #36847 (the `tui_gateway` path that reuses this classifier).

Reported privately first as `GHSA-gmqw-rqrf-c48w` (closed 2026-05-14 without a fix); still reproducible on `main`, hence this patch.
