### PR TITLE
fix(tui): fail closed when approval module is unavailable in shell.exec

### DIFF
--- a/tests/tui_gateway/test_shell_exec_fail_closed.py
+++ b/tests/tui_gateway/test_shell_exec_fail_closed.py
@@ -1,0 +1,67 @@
+"""Tests for shell.exec fail-closed behaviour in the TUI gateway.
+
+shell.exec gates dangerous commands via tools.approval.detect_dangerous_command.
+If that module cannot be imported the gate must fail CLOSED (refuse to run)
+rather than swallowing the ImportError and executing the command unchecked.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from tui_gateway import server
+
+
+def _shell_exec(params):
+    """Dispatch shell.exec through the method registry, as the server does."""
+    return server._methods["shell.exec"](1, params)
+
+
+def test_fail_closed_when_approval_module_unavailable():
+    """ImportError on tools.approval must block, not execute."""
+    run_mock = MagicMock()
+    # sys.modules[name] = None makes `from name import ...` raise ImportError.
+    with patch.dict(sys.modules, {"tools.approval": None}), \
+            patch.object(server.subprocess, "run", run_mock):
+        resp = _shell_exec({"command": "echo hi"})
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4005
+    assert "approval module unavailable" in resp["error"]["message"]
+    run_mock.assert_not_called()  # command must not run when the gate is down
+
+
+def test_dangerous_command_blocked_without_executing():
+    """A dangerous verdict blocks and never reaches subprocess.run."""
+    fake = types.ModuleType("tools.approval")
+    fake.detect_dangerous_command = lambda cmd: (True, "recursive-delete", "recursive delete")
+    run_mock = MagicMock()
+    with patch.dict(sys.modules, {"tools.approval": fake}), \
+            patch.object(server.subprocess, "run", run_mock):
+        resp = _shell_exec({"command": "rm -rf /tmp/x"})
+
+    assert resp["error"]["code"] == 4005
+    assert "recursive delete" in resp["error"]["message"]
+    run_mock.assert_not_called()
+
+
+def test_safe_command_executes_when_approval_available():
+    """A non-dangerous verdict proceeds to execution (gate open)."""
+    fake = types.ModuleType("tools.approval")
+    fake.detect_dangerous_command = lambda cmd: (False, None, None)
+    run_mock = MagicMock(
+        return_value=types.SimpleNamespace(stdout="hi\n", stderr="", returncode=0)
+    )
+    with patch.dict(sys.modules, {"tools.approval": fake}), \
+            patch.object(server.subprocess, "run", run_mock):
+        resp = _shell_exec({"command": "echo hi"})
+
+    assert "result" in resp
+    assert resp["result"]["code"] == 0
+    assert resp["result"]["stdout"] == "hi\n"
+    run_mock.assert_called_once()
+
+
+def test_empty_command_rejected():
+    resp = _shell_exec({"command": ""})
+    assert resp["error"]["code"] == 4004

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7826,7 +7826,11 @@ def _(rid, params: dict) -> dict:
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        pass
+        # Fail closed: if the approval module can't be imported we cannot
+        # classify the command, so refuse rather than running it unchecked.
+        return _err(
+            rid, 4005, "blocked: approval module unavailable; refusing shell.exec"
+        )
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## What & why

`tui_gateway`'s `shell.exec` gates dangerous commands via `tools.approval.detect_dangerous_command`, but wraps the import/check in `except ImportError: pass`. If the approval module fails to import, the only safety check on this path is silently skipped and the command runs unchecked via `subprocess.run(..., shell=True)`.

## The fix

Fail closed: on `ImportError`, return a `4005 blocked` error instead of falling through to execution.

```python
except ImportError:
    return _err(rid, 4005, "blocked: approval module unavailable; refusing shell.exec")
```

## How to test

Send a `shell.exec` request in an environment where `tools.approval` is importable (normal case — unchanged behavior), and confirm that a forced import failure now yields `4005` rather than executing.

## Platforms

Logic-only change in `tui_gateway/server.py`.

Addresses the secondary fail-open path in #36847. (The primary bypass — the shared regex classifier — is fixed in the `tools/approval.py` PR.) Reported privately as `GHSA-2jg5-795w-3rv5` (closed 2026-05-14 without a fix).
