### PR TITLE
fix(gateway): reject empty BlueBubbles webhook token + refuse unauthenticated non-loopback bind

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -9,6 +9,7 @@ downloading from PR #4588 (YuhangLin).
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -197,6 +198,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # aiohttp access logs write that request target to agent.log.
         self._runner = web.AppRunner(app, access_log=None)
         await self._runner.setup()
+        # Refuse to expose an unauthenticated webhook on a non-loopback bind.
+        # Without a password the auth check accepts any request, so binding to
+        # a reachable interface (e.g. 0.0.0.0) would be an open inbound funnel.
+        if self.webhook_host not in {"127.0.0.1", "localhost", "::1"} and not self.password:
+            raise RuntimeError(
+                "Refusing to start the BlueBubbles webhook on non-loopback host "
+                f"{self.webhook_host!r} without BLUEBUBBLES_PASSWORD set — this "
+                "would expose an unauthenticated webhook. Set a password or bind "
+                "to 127.0.0.1."
+            )
         site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
         await site.start()
         self._mark_connected()
@@ -796,7 +807,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             or request.headers.get("x-guid")
             or request.headers.get("x-bluebubbles-guid")
         )
-        if token != self.password:
+        # Reject empty tokens explicitly: the `or`-chain above returns "" when
+        # any auth source is supplied with an empty value, and self.password
+        # defaults to "" when BLUEBUBBLES_PASSWORD is unset, so a bare
+        # `token != self.password` would let "" == "" authenticate. Use a
+        # constant-time comparison and require both sides to be non-empty.
+        if (
+            not token
+            or not self.password
+            or not hmac.compare_digest(str(token), str(self.password))
+        ):
             return web.json_response({"error": "unauthorized"}, status=401)
         try:
             raw = await request.read()


### PR DESCRIPTION
## What & why

The BlueBubbles webhook builds its auth token from an `or`-chain over five request-supplied sources and compares it with `token != self.password`. `self.password` defaults to `""` when `BLUEBUBBLES_PASSWORD` is unset, and supplying **any** source as an empty value makes the chain return `""`, so `"" != ""` is `False` → the request authenticates. When the adapter is network-exposed without a password, an attacker can forge inbound iMessage webhook events.

Reproduction (empty-valued header bypasses auth when no password is set):
```http
POST /bluebubbles-webhook HTTP/1.1
Host: target:8645
x-bluebubbles-guid:

{}
```

## The fix

- Reject empty tokens and use `hmac.compare_digest` for constant-time comparison: require both `token` and `self.password` to be non-empty.
- Refuse to start when bound to a non-loopback host (e.g. `0.0.0.0`) without a password set — mirroring the existing guard in `gateway/platforms/api_server.py`.

## How to test

```python
# empty token / empty password -> 401 (was: authenticated)
# missing token                -> 401 (unchanged)
# correct token                -> 200 (unchanged)
```
Default `127.0.0.1` bind without a password still starts (loopback only); a `0.0.0.0` bind without a password now raises at startup instead of exposing an open webhook.

## Platforms

Logic-only change in `gateway/platforms/bluebubbles.py`.

Fixes #36849. Reported privately as part of `GHSA-gmqw-rqrf-c48w` (closed 2026-05-14 without a fix); still reproducible on `main`.
