### PR TITLE
Refresh Hermes env before cron and MCP loads

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -74,6 +74,23 @@ _BWS_CHECKSUM_NAME = f"bws-sha256-checksums-{_BWS_VERSION}.txt"
 _BWS_DOWNLOAD_TIMEOUT = 60
 _BWS_RUN_TIMEOUT = 30
 
+
+def _safe_fetch_error(detail: str = "") -> str:
+    """Return an actionable error that never includes backend output."""
+    suffix = f" ({detail})" if detail else ""
+    return (
+        f"Bitwarden secret fetch failed{suffix}. Check the access token, "
+        "project, and network, or run `hermes secrets bitwarden setup`."
+    )
+
+
+class _BwsFetchFailure(RuntimeError):
+    """Sanitized BWS failure carrying non-secret classification metadata."""
+
+    def __init__(self, detail: str, error_kind: ErrorKind) -> None:
+        super().__init__(_safe_fetch_error(detail))
+        self.error_kind = error_kind
+
 # In-process cache so repeated load_hermes_dotenv() calls (CLI startup,
 # gateway hot-reload, test suites) don't re-fetch from BSM.
 _CacheKey = Tuple[str, str, str]  # (access_token_fingerprint, project_id, server_url)
@@ -146,8 +163,10 @@ def find_bws(*, install_if_missing: bool = False) -> Optional[Path]:
     if install_if_missing:
         try:
             return install_bws()
-        except Exception as exc:  # noqa: BLE001 — never block startup
-            logger.warning("bws auto-install failed: %s", exc)
+        except Exception:  # noqa: BLE001 — never block startup
+            logger.warning(
+                "bws auto-install failed; run `hermes secrets bitwarden setup`"
+            )
             return None
     return None
 
@@ -441,18 +460,22 @@ def _run_bws_list(
             stdin=subprocess.DEVNULL,
         )
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"bws timed out after {_BWS_RUN_TIMEOUT}s fetching secrets"
+        raise _BwsFetchFailure(
+            f"timed out after {_BWS_RUN_TIMEOUT}s", ErrorKind.TIMEOUT
         ) from exc
     except OSError as exc:
-        raise RuntimeError(f"failed to invoke bws: {exc}") from exc
+        raise _BwsFetchFailure(
+            "failed to invoke bws", ErrorKind.BINARY_MISSING
+        ) from exc
 
     if proc.returncode != 0:
-        # bws writes auth/network errors to stderr in plain English.
-        # Strip ANSI just in case and surface the first 200 chars.
-        err = (proc.stderr or proc.stdout or "").strip().replace("\x1b", "")
-        raise RuntimeError(
-            f"bws exited {proc.returncode}: {err[:200]}"
+        # Treat both streams as secret-bearing.  Some CLI failures include
+        # request material or returned values, so never copy either stream
+        # into exceptions, logs, or user-facing output.
+        backend_output = f"{proc.stderr or ''}\n{proc.stdout or ''}"
+        raise _BwsFetchFailure(
+            f"bws exited {proc.returncode}",
+            _classify_bws_error(backend_output),
         )
 
     raw = proc.stdout.strip()
@@ -461,8 +484,12 @@ def _run_bws_list(
 
     try:
         payload = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"bws returned non-JSON output: {exc}") from exc
+    except json.JSONDecodeError:
+        # Suppress the decoder exception as well as its message: the
+        # exception retains the entire secret-bearing stdout in ``doc``.
+        raise _BwsFetchFailure(
+            "bws returned non-JSON output", ErrorKind.INTERNAL
+        ) from None
 
     if not isinstance(payload, list):
         raise RuntimeError(
@@ -536,7 +563,11 @@ def apply_bitwarden_secrets(
         )
         return result
 
-    binary = find_bws(install_if_missing=auto_install)
+    try:
+        binary = find_bws(install_if_missing=auto_install)
+    except Exception:  # noqa: BLE001 — startup path must not raise or leak
+        result.error = _safe_fetch_error("bws binary unavailable")
+        return result
     result.binary_path = binary
     if binary is None:
         result.error = (
@@ -554,8 +585,8 @@ def apply_bitwarden_secrets(
             server_url=server_url,
             home_path=home_path,
         )
-    except RuntimeError as exc:
-        result.error = str(exc)
+    except Exception:  # noqa: BLE001 — source failures must not block startup
+        result.error = _safe_fetch_error()
         return result
 
     result.secrets = secrets
@@ -663,7 +694,12 @@ class BitwardenSource(SecretSource):
             return result
 
         auto_install = bool(cfg.get("auto_install", True))
-        binary = find_bws(install_if_missing=auto_install)
+        try:
+            binary = find_bws(install_if_missing=auto_install)
+        except Exception:  # noqa: BLE001 — startup path must not raise or leak
+            result.error = _safe_fetch_error("bws binary unavailable")
+            result.error_kind = ErrorKind.BINARY_MISSING
+            return result
         result.binary_path = binary
         if binary is None:
             result.error = (
@@ -687,9 +723,13 @@ class BitwardenSource(SecretSource):
                 server_url=str(cfg.get("server_url", "") or "").strip(),
                 home_path=home_path,
             )
-        except RuntimeError as exc:
-            result.error = str(exc)
-            result.error_kind = _classify_bws_error(str(exc))
+        except Exception as exc:  # noqa: BLE001 — never leak backend exception text
+            result.error = _safe_fetch_error()
+            result.error_kind = (
+                exc.error_kind
+                if isinstance(exc, _BwsFetchFailure)
+                else _classify_bws_error(str(exc))
+            )
             return result
 
         result.secrets = secrets

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -28,10 +28,12 @@ third-party backends ship as standalone plugin repos implementing
 from __future__ import annotations
 
 import concurrent.futures
+import hashlib
+import hmac
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Mapping, Optional, Tuple
 
 from agent.secret_sources.base import (
     SECRET_SOURCE_API_VERSION,
@@ -57,6 +59,7 @@ class AppliedVar:
     source: str          # SecretSource.name
     shape: str           # "mapped" | "bulk"
     overrode_env: bool   # replaced a pre-existing .env/shell value
+    value_fingerprint: str = ""
 
 
 @dataclass
@@ -84,6 +87,11 @@ class ApplyReport:
     @property
     def applied_any(self) -> bool:
         return bool(self.provenance)
+
+
+def _fingerprint_secret_value(value: str) -> str:
+    """Fingerprint a secret without retaining another plaintext copy."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -275,8 +283,12 @@ def _ordered_enabled_sources(secrets_cfg: dict) -> List[SecretSource]:
     return enabled
 
 
-def apply_all(secrets_cfg: dict, home_path: Path,
-              environ: Optional[Dict[str, str]] = None) -> ApplyReport:
+def apply_all(
+    secrets_cfg: dict,
+    home_path: Path,
+    environ: Optional[Dict[str, str]] = None,
+    previous_ownership: Optional[Mapping[str, AppliedVar]] = None,
+) -> ApplyReport:
     """Fetch from every enabled source and apply the merged result to env.
 
     ``environ`` defaults to ``os.environ``; injectable for tests.
@@ -299,8 +311,6 @@ def apply_all(secrets_cfg: dict, home_path: Path,
 
     secrets_cfg = secrets_cfg if isinstance(secrets_cfg, dict) else {}
     enabled = _ordered_enabled_sources(secrets_cfg)
-    if not enabled:
-        return report
 
     # Mapped sources outrank bulk sources regardless of list order:
     # an explicit VAR→ref binding is stronger intent than a project dump.
@@ -321,6 +331,20 @@ def apply_all(secrets_cfg: dict, home_path: Path,
         except Exception:  # noqa: BLE001
             pass
 
+    # Values still matching a prior source fingerprint are not shell/.env
+    # inputs. Remove them temporarily so a successful refresh can rotate or
+    # delete them under the normal precedence rules. Raw values live only in
+    # this local scope and are restored when their owning source fails.
+    refresh_candidates: Dict[str, Tuple[str, AppliedVar]] = {}
+    for var, prior in (previous_ownership or {}).items():
+        current = env.get(var)
+        if current is None or not prior.value_fingerprint:
+            continue
+        current_fingerprint = _fingerprint_secret_value(current)
+        if hmac.compare_digest(current_fingerprint, prior.value_fingerprint):
+            refresh_candidates[var] = (current, prior)
+            env.pop(var, None)
+
     # Apply phase — sequential, first-wins, fully attributed.
     claimed: Dict[str, str] = {}  # var → source name that won it
     for source, cfg, result in fetches:
@@ -329,6 +353,16 @@ def apply_all(secrets_cfg: dict, home_path: Path,
                           result=result)
         report.sources.append(sr)
         if not result.ok:
+            # A failed source retains its previous known-good values at its
+            # normal precedence position. Earlier successful sources still
+            # win; later sources see these names as claimed and cannot replace
+            # the fallback merely because its owner was temporarily offline.
+            for var, (value, prior) in refresh_candidates.items():
+                if prior.source != source.name or var in claimed or var in env:
+                    continue
+                env[var] = value
+                claimed[var] = source.name
+                report.provenance[var] = prior
             continue
 
         try:
@@ -365,6 +399,7 @@ def apply_all(secrets_cfg: dict, home_path: Path,
                 source=source.name,
                 shape=source.shape,
                 overrode_env=existed,
+                value_fingerprint=_fingerprint_secret_value(value),
             )
 
     return report

--- a/cli.py
+++ b/cli.py
@@ -10257,7 +10257,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             shutdown_mcp_servers()
 
             # Reconnect (reads config.yaml fresh)
-            new_tools = discover_mcp_tools()
+            new_tools = discover_mcp_tools(refresh_env=True)
 
             # Compute what changed
             with _lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15376,7 +15376,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await loop.run_in_executor(None, shutdown_mcp_servers)
 
             # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+            new_tools = await loop.run_in_executor(
+                None, lambda: discover_mcp_tools(refresh_env=True)
+            )
 
             # Compute what changed
             with _lock:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -37,6 +37,11 @@ _WARNED_UTF32_PATHS: set[str] = set()
 # the .env case and they don't know Bitwarden is wired up).
 _SECRET_SOURCES: dict[str, str] = {}
 
+# Full source-ownership metadata for refreshes. Only cryptographic value
+# fingerprints are retained globally; raw secret values remain in os.environ.
+_SECRET_OWNERSHIP: dict[str, object] = {}
+_PENDING_SECRET_OWNERSHIP: dict[str, object] = {}
+
 # HERMES_HOME paths we've already pulled external secrets for during this
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
 # several hot modules (cli.py, hermes_cli/main.py, run_agent.py,
@@ -71,6 +76,8 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    _PENDING_SECRET_OWNERSHIP.update(_SECRET_OWNERSHIP)
+    _SECRET_OWNERSHIP.clear()
     _SECRET_SOURCES.clear()
 
 
@@ -403,30 +410,42 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         cfg = _load_secrets_config(home_path)
     except Exception:  # noqa: BLE001 — config errors must not block startup
         return
-    if not cfg:
+    if not cfg and not _PENDING_SECRET_OWNERSHIP:
         return
 
     try:
-        from agent.secret_sources.registry import apply_all
+        from agent.secret_sources.registry import (
+            _fingerprint_secret_value,
+            apply_all,
+        )
     except ImportError:
         return
 
     try:
-        report = apply_all(cfg, home_path)
+        report = apply_all(
+            cfg,
+            home_path,
+            previous_ownership=_PENDING_SECRET_OWNERSHIP,
+        )
     except Exception:  # noqa: BLE001 — belt-and-braces; apply_all shouldn't raise
         return
 
-    if report.applied_any:
+    if any(src.applied for src in report.sources):
         # Re-run the ASCII sanitization pass: vault values are
         # user-supplied and might have the same copy-paste corruption as
         # a manually edited .env (see #6843).
         _sanitize_loaded_credentials()
-        # Remember where each var came from so setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" /
-        # "(from 1Password)" — otherwise users see "credentials ✓" with
-        # no hint the value came from a vault rather than .env.
-        for name, applied in report.provenance.items():
-            _SECRET_SOURCES[name] = applied.source
+
+    _SECRET_SOURCES.clear()
+    _SECRET_OWNERSHIP.clear()
+    for name, applied in report.provenance.items():
+        current = os.environ.get(name)
+        if current is None:
+            continue
+        applied.value_fingerprint = _fingerprint_secret_value(current)
+        _SECRET_SOURCES[name] = applied.source
+        _SECRET_OWNERSHIP[name] = applied
+    _PENDING_SECRET_OWNERSHIP.clear()
 
     for src in report.sources:
         if src.applied:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -81,6 +81,29 @@ def reset_secret_source_cache() -> None:
     _SECRET_SOURCES.clear()
 
 
+def _restore_pending_secret_source_labels() -> None:
+    """Surface still-current pending provenance after a config-load failure."""
+    _SECRET_SOURCES.clear()
+    if not _PENDING_SECRET_OWNERSHIP:
+        return
+    try:
+        from agent.secret_sources.registry import _fingerprint_secret_value
+    except Exception:  # noqa: BLE001 — provenance recovery must not block startup
+        return
+
+    for name, applied in _PENDING_SECRET_OWNERSHIP.items():
+        current = os.environ.get(name)
+        fingerprint = getattr(applied, "value_fingerprint", "")
+        source = getattr(applied, "source", "")
+        if (
+            current is not None
+            and fingerprint
+            and source
+            and _fingerprint_secret_value(current) == fingerprint
+        ):
+            _SECRET_SOURCES[name] = source
+
+
 def format_secret_source_suffix(env_var: str) -> str:
     """Return a human-readable suffix like ``" (from Bitwarden)"`` or ``""``.
 
@@ -404,12 +427,17 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     home_key = str(Path(home_path).resolve())
     if home_key in _APPLIED_HOMES:
         return
-    _APPLIED_HOMES.add(home_key)
 
     try:
         cfg = _load_secrets_config(home_path)
     except Exception:  # noqa: BLE001 — config errors must not block startup
+        _restore_pending_secret_source_labels()
         return
+    if cfg is None:
+        _restore_pending_secret_source_labels()
+        return
+
+    _APPLIED_HOMES.add(home_key)
     if not cfg and not _PENDING_SECRET_OWNERSHIP:
         return
 
@@ -463,11 +491,13 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         print(f"  Secret sources: {conflict}", file=sys.stderr)
 
 
-def _load_secrets_config(home_path: Path) -> dict:
+def _load_secrets_config(home_path: Path) -> dict | None:
     """Read just the ``secrets:`` section out of config.yaml.
 
     Imported lazily and isolated from the main config loader so a
-    malformed config can't take down dotenv loading entirely.
+    malformed config can't take down dotenv loading entirely. ``None``
+    distinguishes an unreadable/unparseable file from a valid config with
+    no enabled secret sources.
     """
     config_path = home_path / "config.yaml"
     if not config_path.exists():
@@ -475,10 +505,17 @@ def _load_secrets_config(home_path: Path) -> dict:
     try:
         import yaml  # type: ignore
     except ImportError:
-        return {}
+        return None
     try:
         with open(config_path, "r", encoding="utf-8") as f:
-            data = fast_safe_load(f) or {}
+            data = fast_safe_load(f)
     except Exception:  # noqa: BLE001
+        return None
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return None
+    secrets = data.get("secrets")
+    if secrets is None:
         return {}
-    return data.get("secrets") or {}
+    return secrets if isinstance(secrets, dict) else None

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -61,7 +61,7 @@ def get_secret_source(env_var: str) -> str | None:
 
 
 def reset_secret_source_cache() -> None:
-    """Forget which HERMES_HOME paths have already had external secrets applied.
+    """Forget previously applied secret-source labels and home-path caches.
 
     The first call to ``_apply_external_secret_sources(home_path)`` in a
     process pulls from Bitwarden (or other configured backend), records the
@@ -71,6 +71,7 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    _SECRET_SOURCES.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2144,9 +2144,9 @@ class TestRunJobConfigEnvVarExpansion:
         assert error is None
         mock_reset.assert_called_once_with()
         assert load_calls
-        # Cron must refresh Hermes env before expanding config.yaml.
-        # MCP discovery may refresh env again later in the job, which is fine.
-        assert load_calls[0] == (str(tmp_path), None)
+        # Cron performs a profile-home refresh (no project_env). Other startup
+        # paths may load the repository .env earlier in the same job.
+        assert any(project_env is None for _home, project_env in load_calls)
         assert mock_agent_cls.call_args.kwargs["model"] == "gpt-4o-mini-cron-test"
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2113,6 +2113,39 @@ class TestRunJobConfigEnvVarExpansion:
         # Unresolved refs are kept verbatim — _expand_env_vars contract
         assert kwargs["model"] == "${_HERMES_TEST_CRON_UNSET_VAR}"
 
+    def test_load_hermes_dotenv_refreshes_before_config_expansion(self, tmp_path, monkeypatch):
+        """Cron reloads Hermes env sources before expanding config.yaml references."""
+        (tmp_path / "config.yaml").write_text("model: ${_HERMES_TEST_CRON_MODEL}\n")
+        monkeypatch.delenv("_HERMES_TEST_CRON_MODEL", raising=False)
+
+        job = {"id": "refresh-job", "name": "refresh test", "prompt": "hi"}
+        fake_db = MagicMock()
+        load_calls = []
+
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            load_calls.append((str(hermes_home), None if project_env is None else str(project_env)))
+            os.environ["_HERMES_TEST_CRON_MODEL"] = "gpt-4o-mini-cron-test"
+            return [tmp_path / ".env"]
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache") as mock_reset, \
+             patch("hermes_cli.env_loader.load_hermes_dotenv", side_effect=fake_load_hermes_dotenv), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        mock_reset.assert_called_once_with()
+        assert load_calls == [(str(tmp_path), None)]
+        assert mock_agent_cls.call_args.kwargs["model"] == "gpt-4o-mini-cron-test"
+
 
 class TestRunJobModelResolution:
     """Verify defensive model resolution for jobs stored with ``model: null``.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1745,7 +1745,78 @@ class TestRunJobSessionPersistence:
         assert success is True
         assert error is None
         # reset MUST precede the reload, else _APPLIED_HOMES no-ops the re-pull.
-        assert call_order[:2] == ["reset", "load"], call_order
+        reset_index = call_order.index("reset")
+        assert call_order[reset_index : reset_index + 2] == ["reset", "load"], call_order
+
+    def test_run_job_drops_removed_source_secret_between_runs(
+        self, tmp_path, monkeypatch
+    ):
+        """A long-lived scheduler must not retain a remotely deleted key."""
+        key = "HERMES_TEST_CRON_REMOTE_SECRET"
+        job = {"id": "bsm-refresh-job", "name": "bsm-refresh", "prompt": "hello"}
+        fake_db = MagicMock()
+        seen = []
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+        monkeypatch.delenv(key, raising=False)
+        (tmp_path / "config.yaml").write_text(
+            "secrets:\n"
+            "  bitwarden:\n"
+            "    enabled: true\n"
+            "    project_id: cron-project\n"
+            "    cache_ttl_seconds: 0\n"
+            "    override_existing: false\n"
+            "    auto_install: false\n",
+            encoding="utf-8",
+        )
+
+        import agent.secret_sources.bitwarden as bw_module
+        from agent.secret_sources.base import FetchResult
+        from agent.secret_sources import registry as reg_module
+        from hermes_cli import env_loader
+
+        results = iter(({key: "first-remote-value"}, {}))
+        monkeypatch.setattr(
+            bw_module.BitwardenSource,
+            "fetch",
+            lambda _self, _config, _hermes_home: FetchResult(
+                secrets=dict(next(results))
+            ),
+        )
+        reg_module._reset_registry_for_tests()
+        env_loader._SECRET_SOURCES.clear()
+        env_loader._SECRET_OWNERSHIP.clear()
+        env_loader._PENDING_SECRET_OWNERSHIP.clear()
+        env_loader._APPLIED_HOMES.clear()
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                seen.append(os.environ.get(key))
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent", FakeAgent):
+            first = run_job(job)
+            second = run_job(job)
+
+        assert first[0] is True
+        assert second[0] is True
+        assert seen == ["first-remote-value", None]
 
     def test_run_job_clears_stale_auto_delivery_thread_id_between_jobs(self, tmp_path, monkeypatch):
         jobs = [

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2143,7 +2143,10 @@ class TestRunJobConfigEnvVarExpansion:
         assert success is True
         assert error is None
         mock_reset.assert_called_once_with()
-        assert load_calls == [(str(tmp_path), None)]
+        assert load_calls
+        # Cron must refresh Hermes env before expanding config.yaml.
+        # MCP discovery may refresh env again later in the job, which is fine.
+        assert load_calls[0] == (str(tmp_path), None)
         assert mock_agent_cls.call_args.kwargs["model"] == "gpt-4o-mini-cron-test"
 
 

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -51,6 +51,24 @@ def hermes_home(tmp_path, monkeypatch):
     return home
 
 
+def test_find_bws_auto_install_failure_redacts_exception(
+    tmp_path, monkeypatch, caplog
+):
+    leaked = "installer-exception-secret-sentinel"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("BWS_BINARY", raising=False)
+    monkeypatch.setattr(bw.shutil, "which", lambda _name: None)
+
+    def _fail_install():
+        raise RuntimeError(leaked)
+
+    monkeypatch.setattr(bw, "install_bws", _fail_install)
+
+    assert bw.find_bws(install_if_missing=True) is None
+    assert "bws auto-install failed" in caplog.text
+    assert leaked not in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # _platform_asset_name
 # ---------------------------------------------------------------------------
@@ -309,25 +327,71 @@ def test_fetch_skips_invalid_env_names(monkeypatch, tmp_path):
     assert len(warnings) == 3
 
 
-def test_fetch_auth_failure(monkeypatch, tmp_path):
+def test_fetch_failure_redacts_backend_output_and_access_token(monkeypatch, tmp_path):
     fake_binary = tmp_path / "bws"
     fake_binary.write_text("")
+
+    access_token = "BWS-ACCESS-TOKEN-SENTINEL"
+    stdout_sentinel = "BWS-STDOUT-SENTINEL"
+    stderr_sentinel = "BWS-STDERR-SENTINEL"
+    fetched_value = "BWS-FETCHED-VALUE-SENTINEL"
 
     monkeypatch.setattr(
         bw.subprocess,
         "run",
         lambda *a, **kw: mock.Mock(
-            returncode=1, stdout="", stderr="Error: invalid access token"
+            returncode=1,
+            stdout=f"{stdout_sentinel} {fetched_value}",
+            stderr=f"{stderr_sentinel} {access_token}",
         ),
     )
 
-    with pytest.raises(RuntimeError, match="invalid access token"):
+    with pytest.raises(RuntimeError) as exc_info:
         bw.fetch_bitwarden_secrets(
-            access_token="0.bad",
+            access_token=access_token,
             project_id="p",
             binary=fake_binary,
             use_cache=False,
         )
+
+    message = str(exc_info.value)
+    assert "Bitwarden secret fetch failed" in message
+    assert "hermes secrets bitwarden setup" in message
+    for sentinel in (access_token, stdout_sentinel, stderr_sentinel, fetched_value):
+        assert sentinel not in message
+
+
+def test_source_classifies_auth_failure_without_surfacing_backend_output(
+    tmp_path, monkeypatch
+):
+    leaked = "remote-secret-that-must-not-leak"
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "super-secret-token")
+    monkeypatch.setattr(bw, "find_bws", lambda **_kw: Path("/fake/bws"))
+    monkeypatch.setattr(
+        bw.subprocess,
+        "run",
+        lambda *_a, **_kw: subprocess.CompletedProcess(
+            args=["bws"],
+            returncode=1,
+            stdout=leaked,
+            stderr=f"401 Unauthorized: {leaked}",
+        ),
+    )
+
+    result = bw.BitwardenSource().fetch(
+        {
+            "enabled": True,
+            "project_id": "project-id",
+            "cache_ttl_seconds": 0,
+            "auto_install": False,
+        },
+        tmp_path,
+    )
+
+    assert result.error_kind == bw.ErrorKind.AUTH_FAILED
+    assert result.error is not None
+    assert leaked not in result.error
+    assert "super-secret-token" not in result.error
 
 
 def test_fetch_timeout(monkeypatch, tmp_path):
@@ -351,22 +415,26 @@ def test_fetch_timeout(monkeypatch, tmp_path):
 def test_fetch_non_json(monkeypatch, tmp_path):
     fake_binary = tmp_path / "bws"
     fake_binary.write_text("")
+    leaked = "non-json-secret-output-sentinel"
 
     monkeypatch.setattr(
         bw.subprocess,
         "run",
         lambda *a, **kw: mock.Mock(
-            returncode=0, stdout="not json at all", stderr=""
+            returncode=0, stdout=leaked, stderr=""
         ),
     )
 
-    with pytest.raises(RuntimeError, match="non-JSON"):
+    with pytest.raises(RuntimeError, match="non-JSON") as exc_info:
         bw.fetch_bitwarden_secrets(
             access_token="0.t",
             project_id="p",
             binary=fake_binary,
             use_cache=False,
         )
+
+    assert exc_info.value.__cause__ is None
+    assert leaked not in str(exc_info.value)
 
 
 def test_fetch_cache_hits(monkeypatch, tmp_path):
@@ -587,13 +655,21 @@ def test_apply_never_overrides_bootstrap_token(monkeypatch, tmp_path):
 
 
 def test_apply_swallows_fetch_errors(monkeypatch, tmp_path):
-    """A fetch failure produces an error, NOT an exception."""
-    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.t")
+    """A fetch failure produces a safe error, NOT an exception."""
+    access_token = "BWS-APPLY-TOKEN-SENTINEL"
+    fetched_value = "BWS-APPLY-VALUE-SENTINEL"
+    exception_sentinel = "BWS-APPLY-EXCEPTION-SENTINEL"
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", access_token)
     fake_binary = tmp_path / "bws"
     fake_binary.write_text("")
     monkeypatch.setattr(
-        bw.subprocess, "run",
-        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="bad token"),
+        bw,
+        "fetch_bitwarden_secrets",
+        mock.Mock(
+            side_effect=RuntimeError(
+                f"{exception_sentinel}: {access_token} {fetched_value}"
+            )
+        ),
     )
     monkeypatch.setattr(bw, "find_bws", lambda **kw: fake_binary)
 
@@ -601,7 +677,10 @@ def test_apply_swallows_fetch_errors(monkeypatch, tmp_path):
         enabled=True, project_id="p", auto_install=False,
     )
     assert not result.ok
-    assert "bad token" in result.error
+    assert "Bitwarden secret fetch failed" in result.error
+    assert "hermes secrets bitwarden setup" in result.error
+    for sentinel in (access_token, fetched_value, exception_sentinel):
+        assert sentinel not in result.error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -7,6 +7,7 @@ don't see an unexplained "credentials ✓" line when their .env is empty.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -24,10 +25,14 @@ from hermes_cli import env_loader  # noqa: E402
 def _reset_sources():
     """Each test starts with a clean source map and applied-home guard."""
     env_loader._SECRET_SOURCES.clear()
-    env_loader.reset_secret_source_cache()
+    env_loader._SECRET_OWNERSHIP.clear()
+    env_loader._PENDING_SECRET_OWNERSHIP.clear()
+    env_loader._APPLIED_HOMES.clear()
     yield
     env_loader._SECRET_SOURCES.clear()
-    env_loader.reset_secret_source_cache()
+    env_loader._SECRET_OWNERSHIP.clear()
+    env_loader._PENDING_SECRET_OWNERSHIP.clear()
+    env_loader._APPLIED_HOMES.clear()
 
 
 def test_get_secret_source_returns_none_for_untracked_var():
@@ -126,6 +131,95 @@ def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch)
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None
+
+
+def test_bitwarden_backend_failure_output_is_safe_and_startup_continues(
+    tmp_path, monkeypatch, capsys, caplog
+):
+    access_token = "BWS-ENV-TOKEN-SENTINEL"
+    stdout_sentinel = "BWS-ENV-STDOUT-SENTINEL"
+    stderr_sentinel = "BWS-ENV-STDERR-SENTINEL"
+    fetched_value = "BWS-ENV-VALUE-SENTINEL"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", access_token)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n"
+        "    cache_ttl_seconds: 0\n"
+        "    auto_install: false\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+    monkeypatch.setattr(
+        bw_module.subprocess,
+        "run",
+        lambda *a, **kw: bw_module.subprocess.CompletedProcess(
+            args=a[0],
+            returncode=1,
+            stdout=f"{stdout_sentinel} {fetched_value}",
+            stderr=f"{stderr_sentinel} {access_token}",
+        ),
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    user_and_log_output = captured.out + captured.err + caplog.text
+    assert "Bitwarden secret fetch failed" in user_and_log_output
+    assert "hermes secrets bitwarden setup" in user_and_log_output
+    for sentinel in (access_token, stdout_sentinel, stderr_sentinel, fetched_value):
+        assert sentinel not in user_and_log_output
+
+
+def test_bitwarden_fetch_exception_is_safe_and_startup_continues(
+    tmp_path, monkeypatch, capsys, caplog
+):
+    access_token = "BWS-EXC-TOKEN-SENTINEL"
+    fetched_value = "BWS-EXC-VALUE-SENTINEL"
+    exception_sentinel = "BWS-EXCEPTION-SENTINEL"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", access_token)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n"
+        "    auto_install: false\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+
+    def _raise_fetch_error(**_kwargs):
+        raise RuntimeError(
+            f"{exception_sentinel}: {access_token} {fetched_value}"
+        )
+
+    monkeypatch.setattr(bw_module, "fetch_bitwarden_secrets", _raise_fetch_error)
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    user_and_log_output = captured.out + captured.err + caplog.text
+    assert "Bitwarden secret fetch failed" in user_and_log_output
+    assert "hermes secrets bitwarden setup" in user_and_log_output
+    for sentinel in (access_token, fetched_value, exception_sentinel):
+        assert sentinel not in user_and_log_output
 
 
 def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypatch):
@@ -275,3 +369,250 @@ def test_apply_external_secret_sources_bad_ttl_does_not_crash(tmp_path, monkeypa
 
     # Coerced to the 300s default rather than raising ValueError.
     assert captured["cache_ttl_seconds"] == 300
+
+
+def _configure_bitwarden_refresh(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: refresh-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n"
+        "    cache_ttl_seconds: 0\n"
+        "    override_existing: false\n"
+        "    auto_install: false\n",
+        encoding="utf-8",
+    )
+
+
+def _install_bitwarden_fetch_sequence(monkeypatch, outcomes):
+    import agent.secret_sources.bitwarden as bw_module
+
+    remaining = iter(outcomes)
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+
+    def _fetch(**_kwargs):
+        outcome = next(remaining)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return dict(outcome), []
+
+    monkeypatch.setattr(bw_module, "fetch_bitwarden_secrets", _fetch)
+
+
+def test_refresh_rotates_source_owned_value(tmp_path, monkeypatch):
+    key = "HERMES_TEST_ROTATING_SECRET"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [{key: "first-vault-value"}, {key: "second-vault-value"}],
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+    assert os.environ[key] == "first-vault-value"
+
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == "second-vault-value"
+    assert env_loader.get_secret_source(key) == "bitwarden"
+
+
+def test_refresh_removes_source_owned_value_missing_from_successful_fetch(
+    tmp_path, monkeypatch
+):
+    key = "HERMES_TEST_REMOVED_SECRET"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [{key: "removed-vault-value"}, {}],
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+    assert os.environ[key] == "removed-vault-value"
+
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert key not in os.environ
+    assert env_loader.get_secret_source(key) is None
+
+
+def test_refresh_tracks_sanitized_source_value_for_later_removal(
+    tmp_path, monkeypatch
+):
+    key = "HERMES_TEST_REMOVED_API_KEY"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [{key: "source—value"}, {}],
+    )
+
+    env_loader.load_hermes_dotenv(hermes_home=tmp_path)
+    assert os.environ[key] == "sourcevalue"
+
+    env_loader.reset_secret_source_cache()
+    env_loader.load_hermes_dotenv(hermes_home=tmp_path)
+
+    assert key not in os.environ
+    assert env_loader.get_secret_source(key) is None
+
+
+def test_refresh_failure_retains_previous_known_good_source_value(
+    tmp_path, monkeypatch
+):
+    key = "HERMES_TEST_RETAINED_SECRET"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [{key: "known-good-vault-value"}, RuntimeError("backend unavailable")],
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == "known-good-vault-value"
+    assert env_loader.get_secret_source(key) == "bitwarden"
+
+
+def test_refresh_does_not_delete_later_shell_replacement(tmp_path, monkeypatch):
+    key = "HERMES_TEST_SHELL_REPLACEMENT"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [{key: "vault-value"}, {key: "rotated-vault-value"}],
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+    os.environ[key] = "later-shell-value"
+
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == "later-shell-value"
+    assert env_loader.get_secret_source(key) is None
+
+
+def test_refresh_does_not_delete_later_dotenv_replacement(tmp_path, monkeypatch):
+    key = "HERMES_TEST_DOTENV_REPLACEMENT"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [{key: "vault-value"}, {}],
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+    (tmp_path / ".env").write_text(f"{key}=later-dotenv-value\n", encoding="utf-8")
+
+    env_loader.reset_secret_source_cache()
+    env_loader.load_hermes_dotenv(hermes_home=tmp_path)
+
+    assert os.environ[key] == "later-dotenv-value"
+    assert env_loader.get_secret_source(key) is None
+
+
+def test_refresh_source_collision_still_uses_first_winner(tmp_path, monkeypatch):
+    key = "HERMES_TEST_COLLIDING_SECRET"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "test-op-token")
+    monkeypatch.delenv(key, raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  sources: [bitwarden, onepassword]\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: refresh-project\n"
+        "    override_existing: false\n"
+        "    auto_install: false\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    override_existing: false\n"
+        "    env:\n"
+        f"      {key}: op://Private/Test/credential\n",
+        encoding="utf-8",
+    )
+    _install_bitwarden_fetch_sequence(
+        monkeypatch,
+        [
+            {key: "first-bitwarden-value"},
+            {key: "second-bitwarden-value"},
+            {key: "third-bitwarden-value"},
+        ],
+    )
+
+    import agent.secret_sources.onepassword as op_module
+
+    op_values = iter(
+        (
+            "first-onepassword-value",
+            "second-onepassword-value",
+            RuntimeError("onepassword unavailable"),
+        )
+    )
+    monkeypatch.setattr(op_module, "find_op", lambda *_a, **_kw: Path("/fake/op"))
+
+    def _fetch_onepassword(**_kw):
+        value = next(op_values)
+        if isinstance(value, Exception):
+            raise value
+        return {key: value}, []
+
+    monkeypatch.setattr(
+        op_module,
+        "fetch_onepassword_secrets",
+        _fetch_onepassword,
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+    assert os.environ[key] == "first-onepassword-value"
+    assert env_loader.get_secret_source(key) == "onepassword"
+
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == "second-onepassword-value"
+    assert env_loader.get_secret_source(key) == "onepassword"
+
+    env_loader.reset_secret_source_cache()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == "second-onepassword-value"
+    assert env_loader.get_secret_source(key) == "onepassword"

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -400,6 +400,161 @@ def _install_bitwarden_fetch_sequence(monkeypatch, outcomes):
     monkeypatch.setattr(bw_module, "fetch_bitwarden_secrets", _fetch)
 
 
+def _prime_bitwarden_refresh(tmp_path, monkeypatch, key, outcomes):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-bootstrap-token")
+    monkeypatch.delenv(key, raising=False)
+    _configure_bitwarden_refresh(tmp_path)
+    _install_bitwarden_fetch_sequence(monkeypatch, outcomes)
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+    env_loader._apply_external_secret_sources(tmp_path)
+
+
+def test_refresh_malformed_config_retains_known_good_value_and_provenance(
+    tmp_path, monkeypatch, capsys, caplog
+):
+    key = "HERMES_TEST_MALFORMED_CONFIG_SECRET"
+    known_good = "known-good-malformed-config-value"
+    config_sentinel = "MALFORMED-CONFIG-SENTINEL"
+    _prime_bitwarden_refresh(tmp_path, monkeypatch, key, [{key: known_good}])
+
+    env_loader.reset_secret_source_cache()
+    (tmp_path / "config.yaml").write_text(
+        f"secrets:\n  bitwarden: [{config_sentinel}\n",
+        encoding="utf-8",
+    )
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == known_good
+    assert env_loader.get_secret_source(key) == "bitwarden"
+    assert key in env_loader._PENDING_SECRET_OWNERSHIP
+    assert str(tmp_path.resolve()) not in env_loader._APPLIED_HOMES
+    captured = capsys.readouterr()
+    output = captured.out + captured.err + caplog.text
+    assert config_sentinel not in output
+    assert known_good not in output
+
+
+def test_refresh_unreadable_config_retains_known_good_value_and_provenance(
+    tmp_path, monkeypatch, capsys, caplog
+):
+    key = "HERMES_TEST_UNREADABLE_CONFIG_SECRET"
+    known_good = "known-good-unreadable-config-value"
+    error_sentinel = "UNREADABLE-CONFIG-SENTINEL"
+    config_path = tmp_path / "config.yaml"
+    _prime_bitwarden_refresh(tmp_path, monkeypatch, key, [{key: known_good}])
+
+    env_loader.reset_secret_source_cache()
+    real_open = open
+
+    def _deny_config_read(path, *args, **kwargs):
+        if path == config_path:
+            raise PermissionError(error_sentinel)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _deny_config_read)
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == known_good
+    assert env_loader.get_secret_source(key) == "bitwarden"
+    assert key in env_loader._PENDING_SECRET_OWNERSHIP
+    assert str(tmp_path.resolve()) not in env_loader._APPLIED_HOMES
+    captured = capsys.readouterr()
+    output = captured.out + captured.err + caplog.text
+    assert error_sentinel not in output
+    assert known_good not in output
+
+
+def test_refresh_non_mapping_secrets_retains_known_good_value_and_provenance(
+    tmp_path, monkeypatch
+):
+    key = "HERMES_TEST_NON_MAPPING_CONFIG_SECRET"
+    known_good = "known-good-non-mapping-config-value"
+    _prime_bitwarden_refresh(tmp_path, monkeypatch, key, [{key: known_good}])
+
+    env_loader.reset_secret_source_cache()
+    (tmp_path / "config.yaml").write_text(
+        "secrets: [not, a, mapping]\n",
+        encoding="utf-8",
+    )
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == known_good
+    assert env_loader.get_secret_source(key) == "bitwarden"
+    assert key in env_loader._PENDING_SECRET_OWNERSHIP
+    assert str(tmp_path.resolve()) not in env_loader._APPLIED_HOMES
+
+
+@pytest.mark.parametrize("config_text", ["false\n", "0\n", "[]\n", '""\n'])
+def test_refresh_falsy_non_mapping_config_retains_known_good_value(
+    tmp_path, monkeypatch, config_text
+):
+    key = "HERMES_TEST_FALSY_NON_MAPPING_CONFIG_SECRET"
+    known_good = "known-good-falsy-non-mapping-config-value"
+    _prime_bitwarden_refresh(tmp_path, monkeypatch, key, [{key: known_good}])
+
+    env_loader.reset_secret_source_cache()
+    (tmp_path / "config.yaml").write_text(config_text, encoding="utf-8")
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == known_good
+    assert env_loader.get_secret_source(key) == "bitwarden"
+    assert key in env_loader._PENDING_SECRET_OWNERSHIP
+    assert str(tmp_path.resolve()) not in env_loader._APPLIED_HOMES
+
+
+def test_refresh_recovers_after_malformed_config_becomes_valid(tmp_path, monkeypatch):
+    key = "HERMES_TEST_CONFIG_RECOVERY_SECRET"
+    _prime_bitwarden_refresh(
+        tmp_path,
+        monkeypatch,
+        key,
+        [{key: "known-good-value"}, {key: "recovered-value"}],
+    )
+
+    env_loader.reset_secret_source_cache()
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  bitwarden: [unterminated\n",
+        encoding="utf-8",
+    )
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    _configure_bitwarden_refresh(tmp_path)
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert os.environ[key] == "recovered-value"
+    assert env_loader.get_secret_source(key) == "bitwarden"
+    assert key in env_loader._SECRET_OWNERSHIP
+    assert key not in env_loader._PENDING_SECRET_OWNERSHIP
+
+
+def test_refresh_intentional_disable_removes_source_owned_value(
+    tmp_path, monkeypatch
+):
+    key = "HERMES_TEST_DISABLED_SOURCE_SECRET"
+    _prime_bitwarden_refresh(
+        tmp_path,
+        monkeypatch,
+        key,
+        [{key: "value-to-remove"}],
+    )
+
+    env_loader.reset_secret_source_cache()
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  bitwarden:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert key not in os.environ
+    assert env_loader.get_secret_source(key) is None
+    assert key not in env_loader._SECRET_OWNERSHIP
+    assert key not in env_loader._PENDING_SECRET_OWNERSHIP
+
+
 def test_refresh_rotates_source_owned_value(tmp_path, monkeypatch):
     key = "HERMES_TEST_ROTATING_SECRET"
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -180,6 +180,7 @@ def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypa
 
     # reset_secret_source_cache() forces a fresh pull on the next call.
     env_loader.reset_secret_source_cache()
+    assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None
     env_loader._apply_external_secret_sources(tmp_path)
     assert call_count["n"] == 2
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -147,6 +147,48 @@ class TestLoadMCPConfig:
         assert call_order == ["dotenv", "config"]
         assert result["remote"]["headers"]["Authorization"] == "Bearer bws-secret"
 
+    def test_explicit_refresh_reloads_rotated_secret_before_expansion(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("TEST_MCP_ROTATING_TOKEN", raising=False)
+        values = iter(("first-secret", "second-secret"))
+        call_order = []
+
+        def fake_reset():
+            call_order.append("reset")
+
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            call_order.append("dotenv")
+            monkeypatch.setenv("TEST_MCP_ROTATING_TOKEN", next(values))
+            return []
+
+        config = {
+            "mcp_servers": {
+                "remote": {
+                    "url": "https://example.invalid/mcp",
+                    "headers": {
+                        "Authorization": "Bearer ${TEST_MCP_ROTATING_TOKEN}",
+                    },
+                }
+            }
+        }
+
+        with patch(
+            "hermes_cli.env_loader.reset_secret_source_cache",
+            side_effect=fake_reset,
+        ), patch(
+            "hermes_cli.env_loader.load_hermes_dotenv",
+            side_effect=fake_load_hermes_dotenv,
+        ), patch("hermes_cli.config.load_config", return_value=config):
+            from tools.mcp_tool import _load_mcp_config
+
+            first = _load_mcp_config(refresh_env=True)
+            second = _load_mcp_config(refresh_env=True)
+
+        assert call_order == ["reset", "dotenv", "reset", "dotenv"]
+        assert first["remote"]["headers"]["Authorization"] == "Bearer first-secret"
+        assert second["remote"]["headers"]["Authorization"] == "Bearer second-secret"
+
     def test_mcp_servers_not_dict_returns_empty(self):
         """mcp_servers set to non-dict value -> empty dict."""
         with patch("hermes_cli.config.load_config", return_value={"mcp_servers": "invalid"}):

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -6,6 +6,7 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 import asyncio
 import concurrent.futures
 import json
+import os
 import threading
 import time
 from types import SimpleNamespace
@@ -114,6 +115,37 @@ class TestLoadMCPConfig:
             result = _load_mcp_config()
             assert "filesystem" in result
             assert result["filesystem"]["command"] == "npx"
+
+    def test_load_hermes_dotenv_runs_before_config_expansion(self, monkeypatch):
+        """MCP config expansion should see env values loaded from Hermes first."""
+        monkeypatch.delenv("TEST_MCP_TOKEN", raising=False)
+        call_order = []
+
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            call_order.append("dotenv")
+            monkeypatch.setenv("TEST_MCP_TOKEN", "bws-secret")
+            return []
+
+        def fake_load_config():
+            call_order.append("config")
+            assert os.environ.get("TEST_MCP_TOKEN") == "bws-secret"
+            return {
+                "mcp_servers": {
+                    "remote": {
+                        "headers": {
+                            "Authorization": "Bearer ${TEST_MCP_TOKEN}",
+                        },
+                    }
+                }
+            }
+
+        with patch("hermes_cli.env_loader.load_hermes_dotenv", side_effect=fake_load_hermes_dotenv), \
+             patch("hermes_cli.config.load_config", side_effect=fake_load_config):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config()
+
+        assert call_order == ["dotenv", "config"]
+        assert result["remote"]["headers"]["Authorization"] == "Bearer bws-secret"
 
     def test_mcp_servers_not_dict_returns_empty(self):
         """mcp_servers set to non-dict value -> empty dict."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3999,16 +3999,17 @@ def _load_mcp_config() -> Dict[str, dict]:
 
         if _env_enabled("HERMES_SAFE_MODE"):
             return {}
-        config = load_config()
-        servers = config.get("mcp_servers")
-        if not servers or not isinstance(servers, dict):
-            return {}
-        # Ensure .env vars are available for interpolation
+        # Load Hermes env first so any ${VAR} placeholders in config.yaml
+        # expand against BSM/.env values rather than stale shell state.
         try:
             from hermes_cli.env_loader import load_hermes_dotenv
             load_hermes_dotenv()
         except Exception:
             pass
+        config = load_config()
+        servers = config.get("mcp_servers")
+        if not servers or not isinstance(servers, dict):
+            return {}
         safe_servers: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
             interpolated = _interpolate_env_vars(cfg)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3982,7 +3982,7 @@ def _filter_suspicious_mcp_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
     return safe_servers
 
 
-def _load_mcp_config() -> Dict[str, dict]:
+def _load_mcp_config(*, refresh_env: bool = False) -> Dict[str, dict]:
     """Read ``mcp_servers`` from the Hermes config file.
 
     Returns a dict of ``{server_name: server_config}`` or empty dict.
@@ -4002,7 +4002,12 @@ def _load_mcp_config() -> Dict[str, dict]:
         # Load Hermes env first so any ${VAR} placeholders in config.yaml
         # expand against BSM/.env values rather than stale shell state.
         try:
-            from hermes_cli.env_loader import load_hermes_dotenv
+            from hermes_cli.env_loader import (
+                load_hermes_dotenv,
+                reset_secret_source_cache,
+            )
+            if refresh_env:
+                reset_secret_source_cache()
             load_hermes_dotenv()
         except Exception:
             pass
@@ -5280,11 +5285,14 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     return _existing_tool_names()
 
 
-def discover_mcp_tools() -> List[str]:
+def discover_mcp_tools(*, refresh_env: bool = False) -> List[str]:
     """Entry point: load config, connect to MCP servers, register tools.
 
     Called from ``model_tools`` after ``discover_builtin_tools()``. Safe to call even when
     the ``mcp`` package is not installed (returns empty list).
+
+    ``refresh_env`` is for explicit reload commands; startup and cron paths
+    already load the environment before discovery.
 
     Idempotent for already-connected servers. If some servers failed on a
     previous call, only the missing ones are retried.
@@ -5296,7 +5304,11 @@ def discover_mcp_tools() -> List[str]:
         logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []
 
-    servers = _load_mcp_config()
+    servers = (
+        _load_mcp_config(refresh_env=True)
+        if refresh_env
+        else _load_mcp_config()
+    )
     if not servers:
         logger.debug("No MCP servers configured")
         return []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12624,7 +12624,7 @@ def _(rid, params: dict) -> dict:
         from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools
 
         shutdown_mcp_servers()
-        discover_mcp_tools()
+        discover_mcp_tools(refresh_env=True)
         if session:
             agent = session["agent"]
             # Rebuild the cached agent's tool snapshot so the current session


### PR DESCRIPTION
## Summary
- Re-read Hermes .env/BSM secrets before cron jobs and MCP config expansion so rotated values are visible during per-run reloads.
- Added regression coverage for cron reload, env-source cache reset, and MCP config interpolation order.

## Tests
- python -m pytest tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py -q -o 'addopts='
- python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='
- python -m pytest tests/cron/test_cron_profile.py -q -o 'addopts='
- python -m pytest tests/cron/test_cron_workdir.py -q -o 'addopts='
- python -m pytest tests/hermes_cli/test_config_env_expansion.py -q -o 'addopts='
- python -m pytest tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_tools_config.py tests/hermes_cli/test_custom_provider_model_switch.py -q -o 'addopts='
- python -m pytest tests/tools/test_mcp_tool.py -q -o 'addopts='