### PR TITLE
fix(kanban): re-check all parents in link_tasks, not just the one being added

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2353,9 +2353,20 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    signal_fn=None,
+) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
+    # Captured inside the write txn so we can terminate the orphaned
+    # worker process *after* the txn commits — avoids holding the DB
+    # write lock during the SIGTERM/SIGKILL wait loop (up to ~5 s).
+    _reclaim_pid: Optional[int] = None
+    _reclaim_lock: Optional[str] = None
     with write_txn(conn):
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
@@ -2391,6 +2402,11 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             # Demote running → todo + release claim (race case:
             # dispatcher claimed the child after a done parent was
             # linked but before this undone parent was linked).
+            run_row = conn.execute(
+                "SELECT worker_pid, claim_lock FROM tasks "
+                "WHERE id = ? AND status = 'running'",
+                (child_id,),
+            ).fetchone()
             cur = conn.execute(
                 "UPDATE tasks SET status = 'todo', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
@@ -2398,6 +2414,8 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
                 (child_id,),
             )
             if cur.rowcount == 1:
+                _reclaim_pid = run_row["worker_pid"] if run_row else None
+                _reclaim_lock = run_row["claim_lock"] if run_row else None
                 _end_run(
                     conn, child_id,
                     outcome="reclaimed", status="reclaimed",
@@ -2406,6 +2424,10 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
+        )
+    if _reclaim_pid:
+        _terminate_reclaimed_worker(
+            _reclaim_pid, _reclaim_lock, signal_fn=signal_fn,
         )
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2383,10 +2383,26 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         ).fetchall()
         all_parents_done = all(p["status"] in ("done", "archived") for p in parents)
         if not all_parents_done:
+            # Demote ready → todo (common case: linked before dispatch).
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
+            # Demote running → todo + release claim (race case:
+            # dispatcher claimed the child after a done parent was
+            # linked but before this undone parent was linked).
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'todo', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status = 'running'",
+                (child_id,),
+            )
+            if cur.rowcount == 1:
+                _end_run(
+                    conn, child_id,
+                    outcome="reclaimed", status="reclaimed",
+                    error=f"parent_not_done_on_link parent={parent_id}",
+                )
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2368,11 +2368,21 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        # Re-check ALL parents after linking — not just the one being added.
+        # If a child was created "ready" (no parents), then multiple parents
+        # are linked one-by-one, the child must stay blocked until *every*
+        # parent is done.  Without the all-parents re-check, a done parent
+        # linked first keeps the child "ready", and a dispatcher tick
+        # between links (race window) can spawn the worker before the
+        # remaining parents are even wired.
+        parents = conn.execute(
+            "SELECT t.status FROM tasks t "
+            "JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ?",
+            (child_id,),
+        ).fetchall()
+        all_parents_done = all(p["status"] in ("done", "archived") for p in parents)
+        if not all_parents_done:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -293,6 +293,49 @@ def test_link_detects_cycle(kanban_home):
             kb.link_tasks(conn, b, a)
 
 
+def test_link_demotes_running_child_to_todo_when_parent_not_done(kanban_home):
+    """Regression test for race: A (done) linked → child claimed → B (undone) linked.
+
+    When a child is created ``ready`` and parents are linked one-by-one,
+    a dispatcher tick between links can claim the child after a done
+    parent is linked but before an undone parent is linked.  The undone
+    parent's ``link_tasks`` must demote the already-running child back
+    to ``todo`` and release the claim so ``recompute_ready`` can
+    re-promote it once all parents are truly done.
+    """
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a", assignee="alice")
+        b = kb.create_task(conn, title="b", assignee="alice")
+        c = kb.create_task(conn, title="c", assignee="alice")
+        assert kb.get_task(conn, c).status == "ready"
+
+        # Complete A so it's done.
+        kb.complete_task(conn, a, result="ok")
+        assert kb.get_task(conn, a).status == "done"
+
+        # Link A → C: all linked parents (just A) are done → C stays ready.
+        kb.link_tasks(conn, a, c)
+        assert kb.get_task(conn, c).status == "ready"
+
+        # Simulate dispatcher race: claim C before B is linked.
+        claimed = kb.claim_task(conn, c)
+        assert claimed is not None
+        assert claimed.status == "running"
+
+        # Link B → C: B is not done → must demote C from running → todo
+        # and release the claim.
+        kb.link_tasks(conn, b, c)
+        task = kb.get_task(conn, c)
+        assert task.status == "todo"
+        assert task.claim_lock is None
+
+        # Verify C's run was ended.
+        run = kb.latest_run(conn, c)
+        assert run is not None
+        assert run.outcome == "reclaimed"
+        assert "parent_not_done_on_link" in (run.error or "")
+
+
 def test_recompute_ready_cascades_through_chain(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -336,6 +336,99 @@ def test_link_demotes_running_child_to_todo_when_parent_not_done(kanban_home):
         assert "parent_not_done_on_link" in (run.error or "")
 
 
+def test_link_demoted_child_rejects_stale_completion(kanban_home):
+    """A zombie worker holding the pre-demotion run_id cannot complete.
+
+    After ``link_tasks`` demotes a running child back to ``todo`` and
+    calls ``_end_run`` (which NULLs ``current_run_id``), the orphaned
+    worker's subsequent ``complete_task(expected_run_id=<stale>)`` must
+    be rejected by the CAS guard — both because ``status`` is no longer
+    in ``('running', 'ready', 'blocked')`` and because
+    ``current_run_id`` no longer matches.
+    """
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a", assignee="alice")
+        b = kb.create_task(conn, title="b", assignee="alice")
+        c = kb.create_task(conn, title="c", assignee="alice")
+
+        kb.complete_task(conn, a, result="ok")
+        kb.link_tasks(conn, a, c)
+        assert kb.get_task(conn, c).status == "ready"
+
+        claimed = kb.claim_task(conn, c)
+        assert claimed is not None
+        stale_run_id = claimed.current_run_id
+
+        kb.link_tasks(conn, b, c)
+        assert kb.get_task(conn, c).status == "todo"
+
+        ok = kb.complete_task(
+            conn, c, result="zombie", expected_run_id=stale_run_id,
+        )
+        assert ok is False
+        task = kb.get_task(conn, c)
+        assert task.status == "todo"
+        assert task.result is None
+
+
+def test_link_terminates_orphaned_worker_on_demote(
+    kanban_home, monkeypatch,
+):
+    """When a running child is demoted during ``link_tasks``, the
+    orphaned worker process is terminated via ``signal_fn``.
+
+    Mirrors the ``reclaim_task`` / ``release_stale_claims`` pattern:
+    the claim metadata (pid + lock) is captured inside the write txn,
+    and ``_terminate_reclaimed_worker`` runs *after* commit so the
+    SIGTERM wait loop doesn't hold the DB write lock.
+    """
+    import signal as _signal
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a", assignee="alice")
+        b = kb.create_task(conn, title="b", assignee="alice")
+        c = kb.create_task(conn, title="c", assignee="alice")
+
+        kb.complete_task(conn, a, result="ok")
+        kb.link_tasks(conn, a, c)
+
+        # Simulate a host-local dispatcher claim with a live worker_pid.
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:{'ab' * 8}"
+        future = int(time.time()) + 3600
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=?, "
+            "claim_expires=?, worker_pid=? WHERE id=?",
+            (lock, future, 99999, c),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, claim_lock, "
+            "claim_expires, worker_pid, started_at) "
+            "VALUES (?, 'running', ?, ?, ?, ?)",
+            (c, lock, future, 99999, int(time.time())),
+        )
+        run_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "UPDATE tasks SET current_run_id=? WHERE id=?", (run_id, c),
+        )
+        conn.commit()
+
+        signals_sent: list[int] = []
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+        kb.link_tasks(
+            conn, b, c,
+            signal_fn=lambda pid, sig: signals_sent.append(sig),
+        )
+
+        assert signals_sent == [_signal.SIGTERM]
+        task = kb.get_task(conn, c)
+        assert task.status == "todo"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+
+
 def test_recompute_ready_cascades_through_chain(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")


### PR DESCRIPTION
## Problem

`link_tasks()` only demoted a child back to `todo` when the **parent being linked right now** was not done. It did not check other parents that had already been linked.

### Race condition

When a child task is created `ready` (no parents), then multiple parents are linked one-by-one:

1. Parent A is done → linked to child → child stays `ready`
2. **Race window**: dispatcher tick picks up child before remaining parents are wired
3. Parent B is linked → but child already dispatched, executing without all parent context

### Impact

Kanban workers spawned with incomplete parent results, causing incorrect output and wasted runs.

## Fix

After inserting the link, re-check **all** parents of the child:

```python
parents = conn.execute(
    "SELECT t.status FROM tasks t "
    "JOIN task_links l ON l.parent_id = t.id "
    "WHERE l.child_id = ?",
    (child_id,),
).fetchall()
all_parents_done = all(p["status"] in ("done", "archived") for p in parents)
if not all_parents_done:
    conn.execute(
        "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
        (child_id,),
    )
```

When the last parent completes, `complete_task` → `recompute_ready` will correctly promote the child.