### PR TITLE
feat: add advisor kanban swarm tool

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -50,6 +50,68 @@ ONESHOT_GRACE_SECONDS = 120
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
 _IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_KANBAN_TASK_ID_RE = re.compile(r"\bt_[0-9a-f]{6,}\b", re.IGNORECASE)
+_KANBAN_MONITOR_NAME_RE = re.compile(
+    r"\bkanban-t_[0-9a-f]{6,}-(?:monitor|watch(?:er)?|poll(?:er)?|notifier|status)\b",
+    re.IGNORECASE,
+)
+_KANBAN_MONITOR_ACTION_RE = re.compile(
+    r"\b(?:monitor|watch(?:er|ing)?|poll(?:er|ing)?|check(?:ing)?|notify|notification|wait(?:ing)?)\b",
+    re.IGNORECASE,
+)
+_KANBAN_MONITOR_STATE_RE = re.compile(
+    r"\b(?:status|done|complete|completed|completion|blocked|finished|terminal|closed|resolved|outcome)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_temporary_kanban_monitor_job(name: Optional[str], prompt: Optional[str]) -> bool:
+    """Return True for one-card Kanban completion/status monitor jobs.
+
+    These jobs are used as short-lived gateway feedback helpers. They should
+    never be open-ended recurring cron jobs: once the watched card completes or
+    blocks, a forever monitor keeps re-notifying the chat. Match the canonical
+    ``kanban-t_<id>-monitor`` shape and close common disguised forms like
+    "check task t_<id> until done" without blocking unrelated recurring jobs
+    that merely mention a task id as historical context.
+    """
+    text = f"{name or ''}\n{prompt or ''}".lower()
+    if _KANBAN_MONITOR_NAME_RE.search(text):
+        return True
+    if "monitoring a hermes kanban task" in text:
+        return True
+    if _KANBAN_TASK_ID_RE.search(text) is None:
+        return False
+    if "task id:" in text and ("kanban" in text or _KANBAN_MONITOR_ACTION_RE.search(text)):
+        return True
+    return bool(_KANBAN_MONITOR_ACTION_RE.search(text) and _KANBAN_MONITOR_STATE_RE.search(text))
+
+
+def _repeat_times(repeat: Optional[Any]) -> Optional[int]:
+    if isinstance(repeat, dict):
+        return repeat.get("times")
+    return repeat
+
+
+def _validate_temporary_kanban_monitor_repeat(
+    *,
+    name: Optional[str],
+    prompt: Optional[str],
+    schedule: Dict[str, Any],
+    repeat: Optional[Any],
+) -> None:
+    """Reject open-ended recurring temporary Kanban monitor jobs."""
+    if not _is_temporary_kanban_monitor_job(name, prompt):
+        return
+    if (schedule or {}).get("kind") == "once":
+        return
+    times = _repeat_times(repeat)
+    if times is None or not isinstance(times, int) or isinstance(times, bool) or times <= 0:
+        raise ValueError(
+            "Temporary Kanban monitor cron jobs must be finite or self-cleaning: "
+            "set a positive repeat count, use a one-shot schedule, or remove/pause "
+            "the monitor after the first completed/blocked delivery."
+        )
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -601,6 +663,16 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
+    # Validate short-lived Kanban monitors before the legacy repeat coercion
+    # below so non-int values (for example "3") are rejected with the monitor
+    # guard instead of leaking out as a generic TypeError from repeat <= 0.
+    _validate_temporary_kanban_monitor_repeat(
+        name=name,
+        prompt=prompt,
+        schedule=parsed_schedule,
+        repeat=repeat,
+    )
+
     # Normalize repeat: treat 0 or negative values as None (infinite)
     if repeat is not None and repeat <= 0:
         repeat = None
@@ -608,6 +680,13 @@ def create_job(
     # Auto-set repeat=1 for one-shot schedules if not specified
     if parsed_schedule["kind"] == "once" and repeat is None:
         repeat = 1
+
+    _validate_temporary_kanban_monitor_repeat(
+        name=name,
+        prompt=prompt,
+        schedule=parsed_schedule,
+        repeat=repeat,
+    )
 
     # Default delivery to origin if available, otherwise local
     if deliver is None:
@@ -804,6 +883,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             )
             if updated.get("state") != "paused":
                 updated["next_run_at"] = compute_next_run(updated_schedule)
+
+        _validate_temporary_kanban_monitor_repeat(
+            name=updated.get("name"),
+            prompt=updated.get("prompt"),
+            schedule=updated.get("schedule") or {},
+            repeat=updated.get("repeat"),
+        )
 
         if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
             updated["next_run_at"] = compute_next_run(updated["schedule"])

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10116,8 +10116,8 @@ class GatewayRunner:
         handler: the model calls `kanban_create`, the worker eventually
         completes, but `kanban_notify_subs` has no row, so the user never hears
         back. This helper scans the completed agent turn for successful
-        `kanban_create` tool calls and adds the same notification subscription
-        using the original gateway source.
+        `kanban_create` / `kanban_create_swarm` tool calls and adds the same
+        notification subscription using the original gateway source.
         """
         platform = getattr(source, "platform", None)
         platform_value = getattr(platform, "value", None)
@@ -10142,7 +10142,7 @@ class GatewayRunner:
                 continue
             for call in msg.get("tool_calls") or []:
                 fn = call.get("function") or {}
-                if fn.get("name") != "kanban_create":
+                if fn.get("name") not in {"kanban_create", "kanban_create_swarm"}:
                     continue
                 call_id = call.get("id")
                 if not call_id:
@@ -10179,20 +10179,29 @@ class GatewayRunner:
                 continue
             if not isinstance(payload, dict):
                 continue
-            # `kanban_create` returns {"ok": true, "task_id": ...}; some
-            # older tool helpers use {"success": true}. Require an explicit
-            # success marker and ignore structured tool errors even if they
-            # happen to contain a task_id-like string.
+            # `kanban_create` returns {"ok": true, "task_id": ...};
+            # `kanban_create_swarm` returns {"ok": true, "task_ids": [...]}
+            # plus root/worker/verifier/synthesizer ids. Some older tool helpers
+            # use {"success": true}. Require an explicit success marker and
+            # ignore structured tool errors even if they contain task-id-like text.
             if payload.get("error") or not (
                 payload.get("ok") is True or payload.get("success") is True
             ):
                 continue
-            task_id = payload.get("task_id") or payload.get("id")
-            if not isinstance(task_id, str) or not task_id.startswith("t_"):
+            raw_task_ids = payload.get("task_ids")
+            task_ids: list[str]
+            if isinstance(raw_task_ids, list):
+                task_ids = [tid for tid in raw_task_ids if isinstance(tid, str)]
+            else:
+                task_id = payload.get("task_id") or payload.get("id")
+                task_ids = [task_id] if isinstance(task_id, str) else []
+            task_ids = [tid for tid in task_ids if tid.startswith("t_")]
+            if not task_ids:
                 continue
             result_board = payload.get("board")
             board = str(result_board) if result_board else kanban_calls[call_id]
-            subscriptions.append((task_id, board))
+            for task_id in task_ids:
+                subscriptions.append((task_id, board))
 
         if not subscriptions:
             return []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9311,6 +9311,10 @@ class GatewayRunner:
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
+            try:
+                await self._auto_subscribe_kanban_create_tool_results(source, agent_messages)
+            except Exception as _kanban_sub_exc:
+                logger.debug("kanban_create tool auto-subscribe failed: %s", _kanban_sub_exc)
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
@@ -10091,6 +10095,126 @@ class GatewayRunner:
             f"Slash commands you can run: {runnable_str}"
         )
 
+
+    async def _auto_subscribe_kanban_create_tool_results(
+        self,
+        source: Any,
+        messages: list[dict],
+    ) -> list[str]:
+        """Subscribe the current gateway chat to cards created by the tool path.
+
+        The `/kanban create` slash command already auto-subscribes the
+        originating chat/thread. Normal assistant tool use bypasses that slash
+        handler: the model calls `kanban_create`, the worker eventually
+        completes, but `kanban_notify_subs` has no row, so the user never hears
+        back. This helper scans the completed agent turn for successful
+        `kanban_create` tool calls and adds the same notification subscription
+        using the original gateway source.
+        """
+        platform = getattr(source, "platform", None)
+        platform_value = getattr(platform, "value", None)
+        platform_str = (platform_value if platform_value is not None else str(platform or "")).lower()
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        if not platform_str or not chat_id:
+            return []
+        thread_id = str(getattr(source, "thread_id", "") or "")
+        user_id = str(getattr(source, "user_id", "") or "") or None
+        notifier_profile = (
+            getattr(self, "_kanban_notifier_profile", None)
+            or self._active_profile_name()
+        )
+
+        kanban_calls: dict[str, Optional[str]] = {}
+        for msg in messages or []:
+            if msg.get("role") != "assistant":
+                continue
+            for call in msg.get("tool_calls") or []:
+                fn = call.get("function") or {}
+                if fn.get("name") != "kanban_create":
+                    continue
+                call_id = call.get("id")
+                if not call_id:
+                    continue
+                board = None
+                raw_args = fn.get("arguments") or "{}"
+                if isinstance(raw_args, str):
+                    try:
+                        args = json.loads(raw_args)
+                    except Exception:
+                        args = {}
+                elif isinstance(raw_args, dict):
+                    args = raw_args
+                else:
+                    args = {}
+                if isinstance(args, dict) and args.get("board"):
+                    board = str(args.get("board"))
+                kanban_calls[call_id] = board
+
+        if not kanban_calls:
+            return []
+
+        subscriptions: list[tuple[str, Optional[str]]] = []
+        for msg in messages or []:
+            if msg.get("role") != "tool":
+                continue
+            call_id = msg.get("tool_call_id")
+            if call_id not in kanban_calls:
+                continue
+            content = msg.get("content")
+            try:
+                payload = json.loads(content) if isinstance(content, str) else (content or {})
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            # `kanban_create` returns {"ok": true, "task_id": ...}; some
+            # older tool helpers use {"success": true}. Require an explicit
+            # success marker and ignore structured tool errors even if they
+            # happen to contain a task_id-like string.
+            if payload.get("error") or not (
+                payload.get("ok") is True or payload.get("success") is True
+            ):
+                continue
+            task_id = payload.get("task_id") or payload.get("id")
+            if not isinstance(task_id, str) or not task_id.startswith("t_"):
+                continue
+            result_board = payload.get("board")
+            board = str(result_board) if result_board else kanban_calls[call_id]
+            subscriptions.append((task_id, board))
+
+        if not subscriptions:
+            return []
+
+        deduped_subscriptions = list(dict.fromkeys(subscriptions))
+
+        def _subscribe_all() -> list[str]:
+            from hermes_cli import kanban_db as _kb
+
+            subscribed: list[str] = []
+            for task_id, board in deduped_subscriptions:
+                conn = _kb.connect(board=board)
+                try:
+                    _kb.add_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=platform_str,
+                        chat_id=chat_id,
+                        thread_id=thread_id or None,
+                        user_id=user_id,
+                        notifier_profile=notifier_profile,
+                    )
+                    subscribed.append(task_id)
+                finally:
+                    conn.close()
+            return subscribed
+
+        subscribed = await asyncio.to_thread(_subscribe_all)
+        if subscribed:
+            logger.info(
+                "kanban_create tool auto-subscribed %d task(s) for %s gateway chat",
+                len(subscribed), platform_str,
+            )
+        return subscribed
 
     async def _handle_kanban_command(self, event: MessageEvent) -> str:
         """Handle /kanban — delegate to the shared kanban CLI.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9311,8 +9311,15 @@ class GatewayRunner:
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
+            history_len = agent_result.get("history_offset", len(history))
+            if not isinstance(history_len, int) or history_len < 0:
+                history_len = len(history)
             try:
-                await self._auto_subscribe_kanban_create_tool_results(source, agent_messages)
+                await self._auto_subscribe_kanban_create_tool_results(
+                    source,
+                    agent_messages,
+                    history_offset=history_len,
+                )
             except Exception as _kanban_sub_exc:
                 logger.debug("kanban_create tool auto-subscribe failed: %s", _kanban_sub_exc)
             _response_time = time.time() - _msg_start_time
@@ -10100,6 +10107,7 @@ class GatewayRunner:
         self,
         source: Any,
         messages: list[dict],
+        history_offset: Optional[int] = None,
     ) -> list[str]:
         """Subscribe the current gateway chat to cards created by the tool path.
 
@@ -10124,8 +10132,12 @@ class GatewayRunner:
             or self._active_profile_name()
         )
 
+        iter_messages: list[dict] = messages or []
+        if history_offset is not None and isinstance(history_offset, int):
+            iter_messages = iter_messages[max(history_offset, 0):]
+
         kanban_calls: dict[str, Optional[str]] = {}
-        for msg in messages or []:
+        for msg in iter_messages:
             if msg.get("role") != "assistant":
                 continue
             for call in msg.get("tool_calls") or []:
@@ -10154,7 +10166,7 @@ class GatewayRunner:
             return []
 
         subscriptions: list[tuple[str, Optional[str]]] = []
-        for msg in messages or []:
+        for msg in iter_messages:
             if msg.get("role") != "tool":
                 continue
             call_id = msg.get("tool_call_id")

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -24,6 +24,7 @@ from typing import Any, Iterable, Optional
 from hermes_cli import kanban_db as kb
 
 BLACKBOARD_PREFIX = "[swarm:blackboard] "
+ROOT_BODY_PREFIX = "Kanban Swarm v1 planning/root card."
 
 
 @dataclass(frozen=True)
@@ -47,12 +48,22 @@ class SwarmCreated:
     verifier_id: str
     synthesizer_id: str
 
+    @property
+    def task_ids(self) -> list[str]:
+        return [
+            self.root_id,
+            *list(self.worker_ids),
+            self.verifier_id,
+            self.synthesizer_id,
+        ]
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "root_id": self.root_id,
             "worker_ids": list(self.worker_ids),
             "verifier_id": self.verifier_id,
             "synthesizer_id": self.synthesizer_id,
+            "task_ids": self.task_ids,
         }
 
 
@@ -61,6 +72,55 @@ def _require_text(value: str, field_name: str) -> str:
     if not text:
         raise ValueError(f"{field_name} is required")
     return text
+
+
+def _created_from_topology(root_id: str, topology: Any) -> SwarmCreated | None:
+    """Recover a SwarmCreated handle from root blackboard topology."""
+
+    if not isinstance(topology, dict):
+        return None
+    worker_ids = [str(x) for x in topology.get("worker_ids", []) if x]
+    verifier_id = topology.get("verifier_id")
+    synthesizer_id = topology.get("synthesizer_id")
+    if not (worker_ids and verifier_id and synthesizer_id):
+        return None
+    return SwarmCreated(
+        root_id=root_id,
+        worker_ids=worker_ids,
+        verifier_id=str(verifier_id),
+        synthesizer_id=str(synthesizer_id),
+    )
+
+
+def _idempotency_hit(conn: sqlite3.Connection, idempotency_key: str) -> str | None:
+    row = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ? "
+        "AND status != 'archived' "
+        "ORDER BY created_at DESC LIMIT 1",
+        (idempotency_key,),
+    ).fetchone()
+    return str(row["id"]) if row else None
+
+
+def _recover_or_reject_idempotency_hit(
+    conn: sqlite3.Connection,
+    idempotency_key: Optional[str],
+) -> SwarmCreated | None:
+    if not idempotency_key:
+        return None
+    existing_root = _idempotency_hit(conn, idempotency_key)
+    if not existing_root:
+        return None
+    existing = _created_from_topology(
+        existing_root,
+        latest_blackboard(conn, existing_root).get("topology"),
+    )
+    if existing is not None:
+        return existing
+    raise ValueError(
+        "idempotency_key already belongs to non-swarm task "
+        f"{existing_root}; refusing to mutate it into a swarm root"
+    )
 
 
 def _swarm_context(root_id: str, goal: str) -> str:
@@ -90,6 +150,7 @@ def create_swarm(
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> SwarmCreated:
     """Create a durable Kanban swarm graph.
 
@@ -108,15 +169,21 @@ def create_swarm(
         _require_text(spec.profile, f"workers[{i}].profile")
         _require_text(spec.title, f"workers[{i}].title")
 
+    existing = _recover_or_reject_idempotency_hit(conn, idempotency_key)
+    if existing is not None:
+        return existing
+
+    root_body = (
+        f"{ROOT_BODY_PREFIX} This card is completed "
+        "immediately so parallel workers can start while it remains the "
+        "shared blackboard and audit anchor.\n\n"
+        f"Goal:\n{goal}"
+    )
+
     root = kb.create_task(
         conn,
         title=root_title or f"Swarm: {goal.splitlines()[0][:80]}",
-        body=(
-            "Kanban Swarm v1 planning/root card. This card is completed "
-            "immediately so parallel workers can start while it remains the "
-            "shared blackboard and audit anchor.\n\n"
-            f"Goal:\n{goal}"
-        ),
+        body=root_body,
         assignee=created_by,
         created_by=created_by,
         tenant=tenant,
@@ -125,23 +192,21 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["kanban-orchestrator"],
+        session_id=session_id,
     )
 
-    # If idempotency returned an existing non-archived root, do not duplicate the
-    # swarm graph. Recover the topology from the root's latest blackboard, if it
-    # was created by this helper previously.
-    existing = latest_blackboard(conn, root).get("topology")
-    if isinstance(existing, dict):
-        worker_ids = [str(x) for x in existing.get("worker_ids", []) if x]
-        verifier_id = existing.get("verifier_id")
-        synthesizer_id = existing.get("synthesizer_id")
-        if worker_ids and verifier_id and synthesizer_id:
-            return SwarmCreated(
-                root_id=root,
-                worker_ids=worker_ids,
-                verifier_id=str(verifier_id),
-                synthesizer_id=str(synthesizer_id),
-            )
+    # If an idempotency race happened between the preflight lookup and
+    # create_task(), it may have returned an existing non-swarm task. Do not
+    # complete/link under that task. A genuine prior swarm returns from topology.
+    existing = _created_from_topology(root, latest_blackboard(conn, root).get("topology"))
+    if existing is not None:
+        return existing
+    root_task = kb.get_task(conn, root)
+    if idempotency_key and root_task and not (root_task.body or "").startswith(ROOT_BODY_PREFIX):
+        raise ValueError(
+            "idempotency_key already belongs to non-swarm task "
+            f"{root}; refusing to mutate it into a swarm root"
+        )
 
     kb.complete_task(
         conn,
@@ -170,6 +235,7 @@ def create_swarm(
             workspace_path=workspace_path,
             skills=spec.skills or None,
             max_runtime_seconds=spec.max_runtime_seconds,
+            session_id=session_id,
         )
         worker_ids.append(worker_id)
 
@@ -191,6 +257,7 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["requesting-code-review"],
+        session_id=session_id,
     )
 
     synthesizer_body = (
@@ -210,6 +277,7 @@ def create_swarm(
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
         skills=["humanizer"],
+        session_id=session_id,
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -257,6 +257,95 @@ class TestJobCRUD:
         job = create_job(prompt="Recurring", schedule="every 1h")
         assert job["repeat"]["times"] is None
 
+    def test_temporary_kanban_monitor_rejects_infinite_recurring_repeat(self, tmp_cron_dir):
+        prompt = "You are monitoring a Hermes Kanban task for the user. Task ID: t_3af28728."
+
+        with pytest.raises(ValueError, match="Temporary Kanban monitor"):
+            create_job(
+                prompt=prompt,
+                schedule="every 3m",
+                name="kanban-t_3af28728-monitor",
+            )
+
+    def test_temporary_kanban_monitor_allows_finite_repeat(self, tmp_cron_dir):
+        prompt = "You are monitoring a Hermes Kanban task for the user. Task ID: t_3af28728."
+
+        job = create_job(
+            prompt=prompt,
+            schedule="every 3m",
+            name="kanban-t_3af28728-monitor",
+            repeat=3,
+        )
+
+        assert job["repeat"]["times"] == 3
+
+    def test_temporary_kanban_monitor_rejects_disguised_single_card_watch(self, tmp_cron_dir):
+        prompt = "Check whether task t_3af28728 is done or blocked and notify the chat."
+
+        with pytest.raises(ValueError, match="Temporary Kanban monitor"):
+            create_job(
+                prompt=prompt,
+                schedule="every 3m",
+                name="task-status-watcher",
+            )
+
+    def test_temporary_kanban_monitor_allows_benign_task_id_reference(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Generate a weekly audit summary mentioning task t_3af28728 as historical context.",
+            schedule="every 1h",
+            name="weekly-summary",
+        )
+
+        assert job["repeat"]["times"] is None
+
+    def test_temporary_kanban_monitor_rejects_non_int_repeat(self, tmp_cron_dir):
+        prompt = "You are monitoring a Hermes Kanban task for the user. Task ID: t_3af28728."
+
+        with pytest.raises(ValueError, match="positive repeat count"):
+            create_job(
+                prompt=prompt,
+                schedule="every 3m",
+                name="kanban-t_3af28728-monitor",
+                repeat="3",  # type: ignore[arg-type] - regression for bad API input
+            )
+
+    def test_update_rejects_temporary_kanban_monitor_infinite_repeat(self, tmp_cron_dir):
+        prompt = "You are monitoring a Hermes Kanban task for the user. Task ID: t_3af28728."
+        job = create_job(
+            prompt=prompt,
+            schedule="every 3m",
+            name="kanban-t_3af28728-monitor",
+            repeat=3,
+        )
+
+        with pytest.raises(ValueError, match="Temporary Kanban monitor"):
+            update_job(job["id"], {"repeat": {"times": None, "completed": 0}})
+
+    @pytest.mark.parametrize("bad_repeat", [0, -1])
+    def test_update_rejects_temporary_kanban_monitor_non_positive_repeat(self, tmp_cron_dir, bad_repeat):
+        prompt = "You are monitoring a Hermes Kanban task for the user. Task ID: t_3af28728."
+        job = create_job(
+            prompt=prompt,
+            schedule="every 3m",
+            name="kanban-t_3af28728-monitor",
+            repeat=3,
+        )
+
+        with pytest.raises(ValueError, match="positive repeat count"):
+            update_job(job["id"], {"repeat": {"times": bad_repeat, "completed": 0}})
+
+    def test_temporary_kanban_monitor_allows_one_shot_without_explicit_repeat(self, tmp_cron_dir):
+        prompt = "You are monitoring a Hermes Kanban task for the user. Task ID: t_3af28728."
+
+        job = create_job(
+            prompt=prompt,
+            schedule="3m",
+            name="kanban-t_3af28728-monitor",
+        )
+
+        assert job["schedule"]["kind"] == "once"
+        assert job["repeat"]["times"] == 1
+
     def test_default_delivery_origin(self, tmp_cron_dir):
         job = create_job(
             prompt="Test", schedule="30m",

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,5 +1,7 @@
 import asyncio
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 
 from gateway.config import Platform
@@ -233,3 +235,221 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_gateway_auto_subscribes_chat_for_kanban_create_tool_result(tmp_path, monkeypatch):
+    """Agent-created Kanban cards should notify the originating gateway chat.
+
+    `/kanban create` already auto-subscribes in the slash-command path. This
+    pins the normal agent-tool path: when the model calls `kanban_create` during
+    a Discord/Telegram turn, the gateway should subscribe the current source so
+    the user hears terminal events without manually polling the board.
+    """
+    db_path = tmp_path / "tool-create-autosub.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="tool-created", assignee="worker")
+    finally:
+        conn.close()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "tool-created", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"ok": True, "task_id": tid}),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == [tid]
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "discord-chat"
+    assert subs[0]["thread_id"] == "discord-thread"
+    assert subs[0]["user_id"] == "user-1"
+    assert subs[0]["notifier_profile"] == "main"
+
+
+def test_gateway_does_not_subscribe_failed_kanban_create_tool_result(tmp_path, monkeypatch):
+    db_path = tmp_path / "tool-create-failed.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "bad", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"error": "kanban_create: bad board", "task_id": "t_deadbeef"}),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()
+
+
+def test_gateway_auto_subscribes_tool_result_board_field(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+
+    conn = kb.connect(board="custom-board")
+    try:
+        tid = kb.create_task(conn, title="tool-created", assignee="worker")
+    finally:
+        conn.close()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="telegram-chat",
+        thread_id="",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "tool-created", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"ok": True, "task_id": tid, "board": "custom-board"}),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == [tid]
+    default_conn = kb.connect()
+    custom_conn = kb.connect(board="custom-board")
+    try:
+        assert kb.list_notify_subs(default_conn) == []
+        subs = kb.list_notify_subs(custom_conn, tid)
+    finally:
+        default_conn.close()
+        custom_conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "telegram-chat"
+    assert subs[0]["thread_id"] == ""
+
+
+def test_gateway_ignores_malformed_kanban_create_tool_content(tmp_path, monkeypatch):
+    db_path = tmp_path / "tool-create-malformed.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": "{not-json",
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "{not-json",
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -478,6 +478,73 @@ def test_gateway_auto_subscribes_tool_result_board_field(tmp_path, monkeypatch):
     assert subs[0]["thread_id"] == ""
 
 
+def test_gateway_auto_subscribes_all_kanban_create_swarm_task_ids(tmp_path, monkeypatch):
+    """A swarm tool result returns many card ids; the gateway must subscribe
+    the originating chat to all of them so completion/block events close the
+    loop for every worker/verifier/synthesizer lane.
+    """
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+
+    task_ids = []
+    with kb.connect(board="swarm-board") as conn:
+        for title in ["root", "worker-a", "verifier", "synthesizer"]:
+            task_ids.append(kb.create_task(conn, title=title, assignee="worker"))
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_swarm",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create_swarm",
+                        "arguments": json.dumps({"board": "swarm-board"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_swarm",
+            "content": json.dumps({
+                "ok": True,
+                "root_id": task_ids[0],
+                "worker_ids": [task_ids[1]],
+                "verifier_id": task_ids[2],
+                "synthesizer_id": task_ids[3],
+                "task_ids": task_ids,
+                "board": "swarm-board",
+            }),
+        },
+    ]
+
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(source, messages)
+    )
+
+    assert subscribed == task_ids
+    with kb.connect(board="swarm-board") as conn:
+        for task_id in task_ids:
+            subs = kb.list_notify_subs(conn, task_id)
+            assert len(subs) == 1
+            assert subs[0]["platform"] == "discord"
+            assert subs[0]["chat_id"] == "discord-chat"
+            assert subs[0]["thread_id"] == "discord-thread"
+
+
 def test_gateway_ignores_malformed_kanban_create_tool_content(tmp_path, monkeypatch):
     db_path = tmp_path / "tool-create-malformed.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -302,6 +302,75 @@ def test_gateway_auto_subscribes_chat_for_kanban_create_tool_result(tmp_path, mo
     assert subs[0]["notifier_profile"] == "main"
 
 
+def test_gateway_auto_subscribe_ignores_historical_kanban_create_before_history_offset(
+    tmp_path,
+    monkeypatch,
+):
+    """Do not auto-subscribe historical successful tool calls outside current turn."""
+    db_path = tmp_path / "tool-create-history-offset.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        old_tid = kb.create_task(conn, title="historical", assignee="worker")
+    finally:
+        conn.close()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="discord-chat",
+        thread_id="discord-thread",
+        user_id="user-1",
+    )
+    historical_messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_create",
+                        "arguments": json.dumps({"title": "historical", "assignee": "worker"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": json.dumps({"ok": True, "task_id": old_tid}),
+        },
+    ]
+    current_turn_messages = [
+        {
+            "role": "assistant",
+            "content": "I can help with your current request. No Kanban call was made.",
+        }
+    ]
+
+    # The helper should only inspect current-turn messages, so the historical
+    # successful kanban_create must not create a subscription when offset points
+    # to the start of the current turn.
+    subscribed = asyncio.run(
+        runner._auto_subscribe_kanban_create_tool_results(
+            source,
+            historical_messages + current_turn_messages,
+            history_offset=len(historical_messages),
+        )
+    )
+
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, old_tid) == []
+    finally:
+        conn.close()
+
+
 def test_gateway_does_not_subscribe_failed_kanban_create_tool_result(tmp_path, monkeypatch):
     db_path = tmp_path / "tool-create-failed.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -115,3 +115,56 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
     finally:
         conn.close()
+
+
+def test_create_swarm_propagates_session_id_to_every_card(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Run a session-scoped swarm.",
+            workers=[SwarmWorkerSpec(profile="researcher", title="Evidence", body="Find proof")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+            session_id="gateway-session-123",
+        )
+
+        for task_id in [
+            created.root_id,
+            *created.worker_ids,
+            created.verifier_id,
+            created.synthesizer_id,
+        ]:
+            assert kb.get_task(conn, task_id).session_id == "gateway-session-123"
+    finally:
+        conn.close()
+
+
+def test_create_swarm_refuses_idempotency_key_owned_by_non_swarm_task(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        existing = kb.create_task(
+            conn,
+            title="ordinary idempotent task",
+            assignee="worker",
+            idempotency_key="shared-key",
+        )
+
+        try:
+            create_swarm(
+                conn,
+                goal="Should not mutate the ordinary task.",
+                workers=[SwarmWorkerSpec(profile="researcher", title="Evidence", body="Find proof")],
+                verifier_assignee="reviewer",
+                synthesizer_assignee="writer",
+                idempotency_key="shared-key",
+            )
+        except ValueError as exc:
+            assert "idempotency_key already belongs to non-swarm task" in str(exc)
+        else:  # pragma: no cover - test should fail before this branch
+            raise AssertionError("expected non-swarm idempotency collision to fail")
+
+        assert kb.get_task(conn, existing).status == "ready"
+        assert kb.child_ids(conn, existing) == []
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -117,6 +117,57 @@ def test_worker_with_kanban_toolset_still_hides_board_routing(monkeypatch, tmp_p
     )
 
 
+def test_kanban_create_swarm_visible_only_for_advisor_orchestrators(monkeypatch, tmp_path):
+    """The swarm creator is a narrow advisor/runtime tool, not a generic
+    worker lifecycle surface.
+
+    A profile with `toolsets: [kanban]` can route normal cards, but only the
+    configured mission-owner advisor lanes should see the higher-level swarm
+    graph helper in their model schema.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.kanban_tools  # ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    def kanban_names_for(profile: str) -> set[str]:
+        monkeypatch.setenv("HERMES_PROFILE", profile)
+        invalidate_check_fn_cache()
+        schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+        names = {s["function"].get("name") for s in schema if "function" in s}
+        return {n for n in names if n and n.startswith("kanban_")}
+
+    assert "kanban_create_swarm" in kanban_names_for("tech-advisor")
+    assert "kanban_create_swarm" in kanban_names_for("social-advisor")
+    assert "kanban_create_swarm" not in kanban_names_for("test-orchestrator")
+
+
+def test_kanban_create_swarm_hidden_from_dispatcher_workers(monkeypatch, tmp_path):
+    """Focused Kanban workers must not see the advisor-level swarm helper,
+    even if their profile name is an advisor and their config contains kanban.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    monkeypatch.setenv("HERMES_PROFILE", "tech-advisor")
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.kanban_tools  # ensure registered
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    assert "kanban_create_swarm" not in names
+
+
 def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
     """Orchestrator profiles with toolsets: [kanban] see all kanban tools."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
@@ -836,6 +887,131 @@ def test_create_session_id_absent_when_env_unset(monkeypatch, worker_env):
         assert new_task.session_id is None
     finally:
         conn.close()
+
+
+def test_create_swarm_happy_path_stamps_session_id(monkeypatch, worker_env):
+    """Advisor-level swarm tool creates a full graph and stamps the
+    originating gateway/ACP session id on every card for runtime correlation.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "tech-advisor")
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-swarm-tool")
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.kanban_swarm import latest_blackboard
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create_swarm({
+        "goal": "Parallel implementation with verifier gate.",
+        "workers": [
+            {
+                "profile": "backend-engineer",
+                "title": "Implement backend slice",
+                "body": "Do backend work",
+                "skills": ["test-driven-development"],
+                "priority": 4,
+                "max_runtime_seconds": 1800,
+            },
+            {
+                "profile": "frontend-engineer",
+                "title": "Implement frontend slice",
+                "body": "Do frontend work",
+            },
+        ],
+        "verifier_assignee": "independent-reviewer",
+        "synthesizer_assignee": "script-producer",
+        "idempotency_key": "swarm-tool-main",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, d
+    assert d["task_ids"] == [
+        d["root_id"],
+        *d["worker_ids"],
+        d["verifier_id"],
+        d["synthesizer_id"],
+    ]
+
+    with kb.connect() as conn:
+        root = kb.get_task(conn, d["root_id"])
+        workers = [kb.get_task(conn, tid) for tid in d["worker_ids"]]
+        verifier = kb.get_task(conn, d["verifier_id"])
+        synthesizer = kb.get_task(conn, d["synthesizer_id"])
+        assert root.status == "done"
+        assert [w.status for w in workers] == ["ready", "ready"]
+        assert verifier.status == "todo"
+        assert synthesizer.status == "todo"
+        assert all(
+            kb.get_task(conn, tid).session_id == "sess-swarm-tool"
+            for tid in d["task_ids"]
+        )
+        assert set(kb.parent_ids(conn, d["verifier_id"])) == set(d["worker_ids"])
+        assert kb.parent_ids(conn, d["synthesizer_id"]) == [d["verifier_id"]]
+        board = latest_blackboard(conn, d["root_id"])
+        assert board["topology"]["worker_ids"] == d["worker_ids"]
+
+
+def test_create_swarm_idempotency_reuses_existing_swarm(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "social-advisor")
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    args = {
+        "goal": "Research then synthesize.",
+        "workers": [
+            {"profile": "independent-researcher", "title": "Evidence", "body": "Find sources"},
+        ],
+        "verifier_assignee": "independent-reviewer",
+        "synthesizer_assignee": "script-producer",
+        "idempotency_key": "stable-swarm-key",
+    }
+    first = json.loads(kt._handle_create_swarm(args))
+    assert first["ok"] is True, first
+    with kb.connect() as conn:
+        count_after_first = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    second = json.loads(kt._handle_create_swarm(args))
+    assert second["ok"] is True, second
+    assert second["task_ids"] == first["task_ids"]
+    with kb.connect() as conn:
+        count_after_second = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    assert count_after_second == count_after_first
+
+
+def test_create_swarm_idempotency_refuses_non_swarm_collision(monkeypatch, worker_env):
+    """An idempotency hit on a non-swarm card must not be mutated into a
+    swarm root or have children linked under it.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "tech-advisor")
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        existing = kb.create_task(
+            conn,
+            title="ordinary task",
+            assignee="backend-engineer",
+            idempotency_key="collision-key",
+        )
+
+    out = kt._handle_create_swarm({
+        "goal": "Should not hijack the ordinary task.",
+        "workers": [
+            {"profile": "backend-engineer", "title": "Worker", "body": "Work"},
+        ],
+        "verifier_assignee": "independent-reviewer",
+        "synthesizer_assignee": "script-producer",
+        "idempotency_key": "collision-key",
+    })
+    d = json.loads(out)
+    assert "idempotency_key already belongs to non-swarm task" in d.get("error", "")
+    with kb.connect() as conn:
+        task = kb.get_task(conn, existing)
+        assert task.title == "ordinary task"
+        assert task.status == "ready"
+        assert kb.child_ids(conn, existing) == []
 
 
 def test_create_rejects_no_title(worker_env):
@@ -1710,7 +1886,7 @@ def test_board_param_rejects_invalid_slug(multi_board_env):
 
 
 def test_board_param_in_all_schemas():
-    """All nine kanban_* tool schemas must expose an optional ``board``
+    """All ten kanban_* tool schemas must expose an optional ``board``
     parameter. This pins the contract surfaced to the LLM — adding a
     new kanban tool without ``board`` will fail CI immediately."""
     from tools import kanban_tools as kt
@@ -1723,6 +1899,7 @@ def test_board_param_in_all_schemas():
         kt.KANBAN_HEARTBEAT_SCHEMA,
         kt.KANBAN_COMMENT_SCHEMA,
         kt.KANBAN_CREATE_SCHEMA,
+        kt.KANBAN_CREATE_SWARM_SCHEMA,
         kt.KANBAN_UNBLOCK_SCHEMA,
         kt.KANBAN_LINK_SCHEMA,
     ]

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -758,6 +758,7 @@ def test_create_happy_path(worker_env):
     assert d["ok"] is True
     assert d["task_id"]
     assert d["status"] == "todo"  # parent isn't done yet
+    assert "board" in d
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 KANBAN_LIST_DEFAULT_LIMIT = 50
 KANBAN_LIST_MAX_LIMIT = 200
+KANBAN_SWARM_ADVISOR_PROFILES = {"tech-advisor", "social-advisor"}
 
 
 def _profile_has_kanban_toolset() -> bool:
@@ -90,9 +91,23 @@ def _check_kanban_orchestrator_mode() -> bool:
     return _profile_has_kanban_toolset()
 
 
+def _check_kanban_swarm_advisor_mode() -> bool:
+    """Expose the high-level swarm graph helper only to mission-owner advisors.
+
+    Normal kanban orchestrators can still compose graphs with kanban_create and
+    kanban_link. ``kanban_create_swarm`` is intentionally narrower because it
+    can fan out multiple durable cards in one tool call and should only appear
+    for the advisor lanes that own complex-task dispatch decisions.
+    """
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return False
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    return profile in KANBAN_SWARM_ADVISOR_PROFILES and _profile_has_kanban_toolset()
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
 
 def _default_task_id(arg: Optional[str]) -> Optional[str]:
     """Resolve ``task_id`` arg or fall back to the env var the dispatcher set."""
@@ -302,6 +317,21 @@ def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers "
             "must use kanban_complete, kanban_block, kanban_heartbeat, or "
             "kanban_comment for their assigned task."
+        )
+    return None
+
+
+def _require_swarm_advisor_tool(tool_name: str) -> Optional[str]:
+    guard = _require_orchestrator_tool(tool_name)
+    if guard:
+        return guard
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if profile not in KANBAN_SWARM_ADVISOR_PROFILES:
+        allowed = ", ".join(sorted(KANBAN_SWARM_ADVISOR_PROFILES))
+        return tool_error(
+            f"{tool_name} is only available to mission-owner advisor profiles "
+            f"({allowed}). Use kanban_create and kanban_link for generic "
+            "orchestrator routing."
         )
     return None
 
@@ -813,6 +843,90 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(f"kanban_create: {e}")
 
 
+def _parse_swarm_workers(raw_workers: Any):
+    if not isinstance(raw_workers, (list, tuple)) or not raw_workers:
+        raise ValueError("workers must be a non-empty list")
+    from hermes_cli.kanban_swarm import SwarmWorkerSpec
+
+    workers = []
+    for idx, raw in enumerate(raw_workers, start=1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"workers[{idx}] must be an object")
+        profile = str(raw.get("profile") or "").strip()
+        title = str(raw.get("title") or "").strip()
+        if not profile:
+            raise ValueError(f"workers[{idx}].profile is required")
+        if not title:
+            raise ValueError(f"workers[{idx}].title is required")
+        skills = raw.get("skills") or []
+        if isinstance(skills, str):
+            skills = [skills]
+        if not isinstance(skills, (list, tuple)):
+            raise ValueError(f"workers[{idx}].skills must be a list of strings")
+        priority = raw.get("priority")
+        max_runtime_seconds = raw.get("max_runtime_seconds")
+        workers.append(SwarmWorkerSpec(
+            profile=profile,
+            title=title,
+            body=str(raw.get("body") or title),
+            skills=[str(s).strip() for s in skills if str(s).strip()],
+            priority=int(priority) if priority is not None else 0,
+            max_runtime_seconds=(
+                int(max_runtime_seconds) if max_runtime_seconds is not None else None
+            ),
+        ))
+    return workers
+
+
+def _handle_create_swarm(args: dict, **kw) -> str:
+    """Create a complete Kanban Swarm v1 graph in one advisor tool call."""
+    guard = _require_swarm_advisor_tool("kanban_create_swarm")
+    if guard:
+        return guard
+    goal = args.get("goal")
+    if not goal or not str(goal).strip():
+        return tool_error("goal is required")
+    verifier_assignee = args.get("verifier_assignee")
+    if not verifier_assignee or not str(verifier_assignee).strip():
+        return tool_error("verifier_assignee is required")
+    synthesizer_assignee = args.get("synthesizer_assignee")
+    if not synthesizer_assignee or not str(synthesizer_assignee).strip():
+        return tool_error("synthesizer_assignee is required")
+    priority = args.get("priority")
+    board = args.get("board")
+    try:
+        workers = _parse_swarm_workers(args.get("workers"))
+        kb, conn = _connect(board=board)
+        try:
+            from hermes_cli.kanban_swarm import create_swarm
+
+            created = create_swarm(
+                conn,
+                goal=str(goal).strip(),
+                workers=workers,
+                verifier_assignee=str(verifier_assignee).strip(),
+                synthesizer_assignee=str(synthesizer_assignee).strip(),
+                root_title=args.get("root_title"),
+                verifier_title=str(args.get("verifier_title") or "Verify swarm outputs"),
+                synthesizer_title=str(args.get("synthesizer_title") or "Synthesize swarm outputs"),
+                tenant=args.get("tenant") or os.environ.get("HERMES_TENANT"),
+                created_by=os.environ.get("HERMES_PROFILE") or "swarm-orchestrator",
+                workspace_kind=str(args.get("workspace_kind") or "scratch"),
+                workspace_path=args.get("workspace_path"),
+                priority=int(priority) if priority is not None else 0,
+                idempotency_key=args.get("idempotency_key"),
+                session_id=args.get("session_id") or os.environ.get("HERMES_SESSION_ID"),
+            )
+            return _ok(**created.as_dict(), board=board)
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_create_swarm: {e}")
+    except Exception as e:
+        logger.exception("kanban_create_swarm failed")
+        return tool_error(f"kanban_create_swarm: {e}")
+
+
 def _handle_unblock(args: dict, **kw) -> str:
     """Transition a blocked task back to ready."""
     guard = _require_orchestrator_tool("kanban_unblock")
@@ -1288,6 +1402,112 @@ KANBAN_CREATE_SCHEMA = {
     },
 }
 
+KANBAN_CREATE_SWARM_SCHEMA = {
+    "name": "kanban_create_swarm",
+    "description": (
+        "Advisor-only narrow tool: create a Kanban Swarm v1 graph for a "
+        "complex task in one call. It writes a completed root/blackboard card, "
+        "parallel worker cards, a verifier gate, and a synthesizer card. Only "
+        "mission-owner advisor profiles (tech-advisor or social-advisor) should "
+        "use this; generic orchestrators should compose with kanban_create and "
+        "kanban_link."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {
+                "type": "string",
+                "description": "Overall mission goal for the swarm.",
+            },
+            "workers": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "profile": {
+                            "type": "string",
+                            "description": "Assignee profile for this parallel worker card.",
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Worker card title.",
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Worker spec / acceptance criteria.",
+                        },
+                        "skills": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional skills to force-load for this worker.",
+                        },
+                        "priority": {
+                            "type": "integer",
+                            "description": "Optional per-worker dispatcher priority.",
+                        },
+                        "max_runtime_seconds": {
+                            "type": "integer",
+                            "description": "Optional per-worker runtime cap.",
+                        },
+                    },
+                    "required": ["profile", "title"],
+                },
+                "description": "One or more parallel worker card specs.",
+            },
+            "verifier_assignee": {
+                "type": "string",
+                "description": "Profile that gates worker outputs before synthesis.",
+            },
+            "synthesizer_assignee": {
+                "type": "string",
+                "description": "Profile that produces the final deliverable after verification.",
+            },
+            "root_title": {
+                "type": "string",
+                "description": "Optional root/blackboard card title.",
+            },
+            "verifier_title": {
+                "type": "string",
+                "description": "Optional verifier card title.",
+            },
+            "synthesizer_title": {
+                "type": "string",
+                "description": "Optional synthesizer card title.",
+            },
+            "tenant": {
+                "type": "string",
+                "description": "Optional tenant/project namespace.",
+            },
+            "priority": {
+                "type": "integer",
+                "description": "Default dispatcher priority for root/verifier/synthesizer cards.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": (
+                    "Retry-safety key. Reusing a prior swarm key returns the "
+                    "existing graph; a collision with a non-swarm task is refused."
+                ),
+            },
+            "workspace_kind": {
+                "type": "string",
+                "enum": ["scratch", "dir", "worktree"],
+                "description": "Workspace flavor for created cards.",
+            },
+            "workspace_path": {
+                "type": "string",
+                "description": "Absolute shared/worktree path when workspace_kind requires it.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Optional explicit session id; defaults to HERMES_SESSION_ID.",
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["goal", "workers", "verifier_assignee", "synthesizer_assignee"],
+    },
+}
+
 KANBAN_UNBLOCK_SCHEMA = {
     "name": "kanban_unblock",
     "description": (
@@ -1392,6 +1612,15 @@ registry.register(
     handler=_handle_create,
     check_fn=_check_kanban_mode,
     emoji="➕",
+)
+
+registry.register(
+    name="kanban_create_swarm",
+    toolset="kanban",
+    schema=KANBAN_CREATE_SWARM_SCHEMA,
+    handler=_handle_create_swarm,
+    check_fn=_check_kanban_swarm_advisor_mode,
+    emoji="🐝",
 )
 
 registry.register(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -802,6 +802,7 @@ def _handle_create(args: dict, **kw) -> str:
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                board=board,
             )
         finally:
             conn.close()

--- a/toolsets.py
+++ b/toolsets.py
@@ -66,7 +66,7 @@ _HERMES_CORE_TOOLS = [
     # tools/kanban_tools.py.
     "kanban_show", "kanban_list",
     "kanban_complete", "kanban_block", "kanban_heartbeat",
-    "kanban_comment", "kanban_create", "kanban_link",
+    "kanban_comment", "kanban_create", "kanban_create_swarm", "kanban_link",
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
@@ -268,7 +268,7 @@ TOOLSETS = {
         "tools": [
             "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
             "kanban_heartbeat", "kanban_comment",
-            "kanban_create", "kanban_link",
+            "kanban_create", "kanban_create_swarm", "kanban_link",
             "kanban_unblock",
         ],
         "includes": [],


### PR DESCRIPTION
## Summary
- add advisor-only `kanban_create_swarm` tool for `tech-advisor` / `social-advisor`
- wire swarm task id expansion into gateway auto-subscribe handling
- propagate `session_id` and expose `task_ids` from kanban swarm creation
- include existing kanban auto-subscribe hardening commits on this branch

## Test Plan
- `.venv/bin/python -m pytest tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_swarm.py tests/gateway/test_kanban_notifier.py tests/test_toolsets.py -q -o 'addopts='`
- Result: 130 passed

## Notes
- Draft PR because full suite was not run in this step.
- Local working tree still has unrelated pre-existing dirty files outside this PR scope; they were not staged or committed.
