### PR TITLE
Route messages to per-profile workers behind one bot token

### DIFF
--- a/gateway/chat_bindings.py
+++ b/gateway/chat_bindings.py
@@ -1,0 +1,42 @@
+"""Persisted per-chat profile bindings (Tier-2 manual control, salvaged from #24914).
+
+A `/profile <name>` binding is a deliberate user action, so it overrides the
+config routing table for that chat.  Bindings live in a small JSON file under
+the sessions dir and survive restarts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gateway.session import SessionSource
+
+
+def chat_binding_key(source: SessionSource) -> str:
+    """Stable per-chat key (platform + chat + thread)."""
+    return f"{source.platform.value}:{source.chat_id or ''}:{source.thread_id or ''}"
+
+
+class ChatBindings:
+    def __init__(self, path: Path | str):
+        self.path = Path(path)
+        try:
+            self._data = json.loads(self.path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            self._data = {}
+
+    def get(self, key: str) -> str | None:
+        return self._data.get(key)
+
+    def set(self, key: str, profile: str) -> None:
+        self._data[key] = profile
+        self._save()
+
+    def clear(self, key: str) -> None:
+        self._data.pop(key, None)
+        self._save()
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._data, indent=2))

--- a/gateway/chat_bindings.py
+++ b/gateway/chat_bindings.py
@@ -8,9 +8,25 @@ the sessions dir and survive restarts.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from gateway.session import SessionSource
+
+# A leading @<profile> followed by a message body (profile names are
+# [a-z0-9][a-z0-9_-]*).  Requires a body so a bare "@name" isn't a route.
+_MENTION_RE = re.compile(r"^@([a-z0-9][a-z0-9_-]*)\s+(\S.*)$", re.IGNORECASE | re.DOTALL)
+
+
+def parse_profile_mention(text: str) -> tuple[str | None, str]:
+    """Split a leading ``@profile`` override off *text*.
+
+    Returns ``(profile, body)`` for ``@coder do x`` → ``("coder", "do x")``,
+    else ``(None, text)`` unchanged.  The caller still gates on whether the
+    named profile exists before routing.
+    """
+    m = _MENTION_RE.match(text or "")
+    return (m.group(1), m.group(2)) if m else (None, text)
 
 
 def chat_binding_key(source: SessionSource) -> str:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -448,6 +448,38 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
 }
 
 
+_ROUTE_MATCH_KEYS = ("platform", "chat_id", "channel_id", "thread_id", "guild_id", "user_id")
+
+
+def _validate_profile_routing(routing: dict) -> dict:
+    """Fail-closed validation of a profile_routing table (see design §8).
+
+    Raises ValueError on an unknown/invalid target profile or two routes with
+    an identical match-key set.  An absent table is handled by the caller.
+    """
+    from hermes_cli.profiles import profile_exists, validate_profile_name
+
+    routes = routing.get("routes") or []
+    seen: set[tuple] = set()
+    for route in routes:
+        if not isinstance(route, dict):
+            raise ValueError(f"profile_routing route must be a mapping, got {type(route).__name__}")
+        profile = route.get("profile")
+        if not profile:
+            raise ValueError(f"profile_routing route is missing a 'profile': {route!r}")
+        validate_profile_name(str(profile))
+        if not profile_exists(str(profile)):
+            raise ValueError(f"profile_routing references unknown profile {profile!r}")
+        signature = tuple((k, str(route[k])) for k in _ROUTE_MATCH_KEYS if k in route)
+        if signature in seen:
+            raise ValueError(f"Duplicate profile_routing route for match {dict(signature)!r}")
+        seen.add(signature)
+    for name in (routing.get("default"),):
+        if name and not profile_exists(str(name)):
+            raise ValueError(f"profile_routing default references unknown profile {name!r}")
+    return routing
+
+
 @dataclass
 class GatewayConfig:
     """
@@ -484,6 +516,10 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+
+    # Tier-2 profile routing table (gateway.profile_routing).  None => no
+    # routing; every message stays on the host profile (legacy behavior).
+    profile_routing: Optional[dict] = None
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -636,6 +672,12 @@ class GatewayConfig:
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
 
+        profile_routing = data.get("profile_routing")
+        if isinstance(profile_routing, dict):
+            profile_routing = _validate_profile_routing(profile_routing)
+        else:
+            profile_routing = None
+
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
@@ -662,6 +704,7 @@ class GatewayConfig:
                 data.get("filter_silence_narration"), True
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            profile_routing=profile_routing,
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
@@ -747,6 +790,13 @@ def load_gateway_config() -> GatewayConfig:
             stt_cfg = yaml_cfg.get("stt")
             if isinstance(stt_cfg, dict):
                 gw_data["stt"] = stt_cfg
+
+            # profile_routing is gateway-level (cross-platform); accept it under
+            # gateway: or at the top level.
+            _routing = yaml_cfg.get("gateway", {}).get("profile_routing") if isinstance(yaml_cfg.get("gateway"), dict) else None
+            _routing = _routing or yaml_cfg.get("profile_routing")
+            if _routing is not None:
+                gw_data["profile_routing"] = _routing
 
             if "group_sessions_per_user" in yaml_cfg:
                 gw_data["group_sessions_per_user"] = yaml_cfg["group_sessions_per_user"]

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -886,7 +886,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
-                if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
+                if plat in {Platform.DISCORD, Platform.SLACK, Platform.TELEGRAM} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
@@ -894,6 +894,12 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_models" in platform_cfg:
+                    channel_models = platform_cfg["channel_models"]
+                    if isinstance(channel_models, dict):
+                        bridged["channel_models"] = {str(k): v for k, v in channel_models.items()}
+                    else:
+                        bridged["channel_models"] = channel_models
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg

--- a/gateway/media_spool.py
+++ b/gateway/media_spool.py
@@ -140,7 +140,7 @@ _IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tif
 
 def kind_for(path: str, is_voice: bool) -> str:
     ext = Path(path).suffix.lower()
-    if is_voice or (ext in _AUDIO_EXTS and is_voice):
+    if is_voice:
         return "voice"
     if ext in _IMAGE_EXTS:
         return "image"

--- a/gateway/media_spool.py
+++ b/gateway/media_spool.py
@@ -111,6 +111,38 @@ class MediaSpool:
             pass
 
 
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".webm", ".mkv", ".avi"})
+_AUDIO_EXTS = frozenset({".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".aac"})
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"})
+
+
+def kind_for(path: str, is_voice: bool) -> str:
+    ext = Path(path).suffix.lower()
+    if is_voice or (ext in _AUDIO_EXTS and is_voice):
+        return "voice"
+    if ext in _IMAGE_EXTS:
+        return "image"
+    if ext in _VIDEO_EXTS:
+        return "video"
+    if ext in _AUDIO_EXTS:
+        return "voice"
+    return "document"
+
+
+def mint_outbound(spool: MediaSpool, media_files: list[tuple[str, bool]]) -> list[dict]:
+    """Mint refs for worker-produced files (path, is_voice) → wire dicts."""
+    import mimetypes
+
+    refs = []
+    for path, is_voice in media_files:
+        p = Path(path)
+        kind = kind_for(path, is_voice)
+        mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+        ref = spool.mint(p.read_bytes(), filename=p.name, mime=mime, kind=kind, is_voice=is_voice)
+        refs.append(ref.to_wire())
+    return refs
+
+
 def materialize_inbound(spool: MediaSpool, refs: list[dict], dest_dir: Path) -> list[tuple[Path, MediaRef]]:
     """Resolve inbound wire refs to local files in *dest_dir* (worker side).
 

--- a/gateway/media_spool.py
+++ b/gateway/media_spool.py
@@ -12,12 +12,33 @@ HTTP-fetch resolver is an additive swap with no schema change.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import os
 import secrets
 from dataclasses import dataclass
 from pathlib import Path
 
 VALID_KINDS = frozenset({"image", "voice", "video", "document"})
+
+
+def sign_ref(run_id: str, ref: str, secret: str) -> str:
+    """HMAC binding a ref to its run, so a token can't be replayed across runs."""
+    return hmac.new(secret.encode(), f"{run_id}:{ref}".encode(), hashlib.sha256).hexdigest()
+
+
+def verify_ref(run_id: str, ref: str, token: str, secret: str) -> bool:
+    return hmac.compare_digest(sign_ref(run_id, ref, secret), token or "")
+
+
+def confine_to_safe_root(path: str, safe_root: Path | str) -> Path:
+    """Resolve *path* under *safe_root*, rejecting any escape (harvested from #18510)."""
+    root = Path(safe_root).resolve()
+    candidate = Path(path)
+    resolved = (candidate if candidate.is_absolute() else root / candidate).resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError(f"path {path!r} escapes safe_root {safe_root!r}")
+    return resolved
 
 
 def default_spool_root() -> Path:
@@ -77,7 +98,8 @@ class MediaSpool:
         self._filenames: dict[str, str] = {}
 
     def _path(self, ref: str) -> Path:
-        return self.root / ref
+        # Refs come off the wire — confine to the spool root, never trust them.
+        return confine_to_safe_root(ref, self.root)
 
     def mint(self, data: bytes, *, filename: str, mime: str, kind: str, **flags) -> MediaRef:
         ref = secrets.token_hex(24)

--- a/gateway/media_spool.py
+++ b/gateway/media_spool.py
@@ -1,0 +1,124 @@
+"""Media claim-check spool (Tier-2, design §6).
+
+A ``media_ref`` is an opaque token, **never a path on the wire**.  The front
+mints refs for inbound media; the worker resolves each ref to local bytes and
+materializes them into its own cache, feeding the existing media path with zero
+downstream change.  Outbound, the worker mints refs the front resolves + uploads.
+
+MVP resolver = a shared spool directory both processes can read.  The wire
+contract (``MediaRef.to_wire``) carries only metadata, so the end-state
+HTTP-fetch resolver is an additive swap with no schema change.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+
+VALID_KINDS = frozenset({"image", "voice", "video", "document"})
+
+
+def default_spool_root() -> Path:
+    """Shared spool dir both front and worker can read.
+
+    Anchored to the default hermes root (not a per-profile home) so the
+    transport-owner front and a worker that resolved a different HERMES_HOME
+    still meet on the same filesystem path.  Override with HERMES_MEDIA_SPOOL.
+    """
+    override = os.getenv("HERMES_MEDIA_SPOOL")
+    if override:
+        return Path(override)
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root() / "cache" / "gateway_media_spool"
+
+
+@dataclass
+class MediaRef:
+    ref: str
+    filename: str
+    mime: str
+    kind: str
+    size: int
+    as_document: bool = False
+    is_voice: bool = False
+
+    def to_wire(self) -> dict:
+        """Serialize for the request/SSE body — metadata only, never a path."""
+        return {
+            "ref": self.ref,
+            "filename": self.filename,
+            "mime": self.mime,
+            "kind": self.kind,
+            "size": self.size,
+            "as_document": self.as_document,
+            "is_voice": self.is_voice,
+        }
+
+    @classmethod
+    def from_wire(cls, data: dict) -> "MediaRef":
+        return cls(
+            ref=str(data["ref"]),
+            filename=str(data.get("filename", "")),
+            mime=str(data.get("mime", "application/octet-stream")),
+            kind=str(data.get("kind", "document")),
+            size=int(data.get("size", 0)),
+            as_document=bool(data.get("as_document", False)),
+            is_voice=bool(data.get("is_voice", False)),
+        )
+
+
+class MediaSpool:
+    def __init__(self, root: Path | str):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._filenames: dict[str, str] = {}
+
+    def _path(self, ref: str) -> Path:
+        return self.root / ref
+
+    def mint(self, data: bytes, *, filename: str, mime: str, kind: str, **flags) -> MediaRef:
+        ref = secrets.token_hex(24)
+        self._path(ref).write_bytes(data)
+        self._filenames[ref] = filename
+        return MediaRef(
+            ref=ref, filename=filename, mime=mime, kind=kind, size=len(data),
+            as_document=bool(flags.get("as_document", False)),
+            is_voice=bool(flags.get("is_voice", False)),
+        )
+
+    def resolve(self, ref: str) -> bytes:
+        path = self._path(ref)
+        if not path.is_file():
+            raise KeyError(f"unknown media ref {ref!r}")
+        return path.read_bytes()
+
+    def materialize(self, ref: str, dest_dir: Path, *, filename: str | None = None) -> Path:
+        """Write the ref's bytes into *dest_dir*, preserving the original suffix."""
+        data = self.resolve(ref)
+        suffix = Path(filename or self._filenames.get(ref, "") or ref).suffix
+        dest = Path(dest_dir) / f"{ref}{suffix}"
+        dest.write_bytes(data)
+        return dest
+
+    def unlink(self, ref: str) -> None:
+        self._filenames.pop(ref, None)
+        try:
+            os.unlink(self._path(ref))
+        except FileNotFoundError:
+            pass
+
+
+def materialize_inbound(spool: MediaSpool, refs: list[dict], dest_dir: Path) -> list[tuple[Path, MediaRef]]:
+    """Resolve inbound wire refs to local files in *dest_dir* (worker side).
+
+    Uses only the wire metadata, so it works cross-process from a spool that
+    never minted these refs itself.
+    """
+    out: list[tuple[Path, MediaRef]] = []
+    for data in refs:
+        mref = MediaRef.from_wire(data)
+        out.append((spool.materialize(mref.ref, dest_dir, filename=mref.filename), mref))
+    return out

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -973,6 +973,24 @@ class APIServerAdapter(BasePlatformAdapter):
                 lines.append(f"[User sent a file: {path}]")
         return (user_message + "\n" + "\n".join(lines)).strip() if lines else user_message
 
+    def _emit_outbound_media(self, run_id: str, output: str, q) -> tuple[list, str]:
+        """Mint refs for the worker's MEDIA: output, emit response.media, return tag-free text."""
+        from gateway.media_spool import MediaSpool, mint_outbound, default_spool_root
+        from gateway.platforms.base import BasePlatformAdapter
+
+        media_files, cleaned = BasePlatformAdapter.extract_media(output or "")
+        if not media_files:
+            return [], output
+        refs = mint_outbound(MediaSpool(default_spool_root()), media_files)
+        if refs:
+            q.put_nowait({
+                "event": "response.media",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "media": refs,
+            })
+        return refs, cleaned
+
     def _create_agent(
         self,
         ephemeral_system_prompt: Optional[str] = None,
@@ -3792,6 +3810,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    # Outbound media claim-check: mint refs from MEDIA: tags and
+                    # strip them, so the front delivers via its own send_*; the
+                    # output is guaranteed tag-free (same parse → no double-send).
+                    media_wire, final_response = self._emit_outbound_media(run_id, final_response, q)
                     q.put_nowait({
                         "event": "run.completed",
                         "run_id": run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -953,6 +953,26 @@ class APIServerAdapter(BasePlatformAdapter):
     # Agent creation helper
     # ------------------------------------------------------------------
 
+    def _embed_inbound_media(self, user_message: str, media_refs: list) -> str:
+        """Materialize claim-check refs into the cache and append local-path
+        references the vision pipeline already understands."""
+        from gateway.media_spool import MediaSpool, MediaRef, default_spool_root
+        from gateway.platforms.base import get_image_cache_dir, get_document_cache_dir
+
+        spool = MediaSpool(default_spool_root())
+        lines = []
+        for data in media_refs:
+            mref = MediaRef.from_wire(data)
+            dest = get_image_cache_dir() if mref.kind == "image" else get_document_cache_dir()
+            path = spool.materialize(mref.ref, dest, filename=mref.filename)
+            if mref.kind == "image":
+                lines.append(f"[User sent an image: {path}]")
+            elif mref.kind in ("voice", "video"):
+                lines.append(f"[User sent {mref.kind}: {path}]")
+            else:
+                lines.append(f"[User sent a file: {path}]")
+        return (user_message + "\n" + "\n".join(lines)).strip() if lines else user_message
+
     def _create_agent(
         self,
         ephemeral_system_prompt: Optional[str] = None,
@@ -3581,6 +3601,16 @@ class APIServerAdapter(BasePlatformAdapter):
         user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
+
+        # Inbound media (Tier-2 claim-check): materialize each ref into the
+        # worker's cache and embed local paths, reusing the existing vision
+        # pipeline's "[User sent ...]" convention (zero downstream change).
+        media_refs = body.get("media_refs") or []
+        if media_refs:
+            try:
+                user_message = self._embed_inbound_media(user_message, media_refs)
+            except Exception:
+                logger.warning("[api_server] failed to materialize inbound media_refs", exc_info=True)
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1330,6 +1330,29 @@ class APIServerAdapter(BasePlatformAdapter):
             return None, web.json_response(_openai_error(f"Session not found: {session_id}", code="session_not_found"), status=404)
         return session, None
 
+    @staticmethod
+    def _continue_session_id(
+        body: Dict[str, Any],
+        conversation_history: List[Dict[str, Any]],
+        previous_response_id: Optional[str],
+    ) -> Optional[str]:
+        """Session id whose transcript should rehydrate this run, or None.
+
+        ``/v1/runs`` is otherwise stateless: it only uses history the caller
+        supplies (``conversation_history`` / ``previous_response_id``).  A
+        routed worker, however, holds the only copy of its transcript and the
+        front sends just a ``session_id``.  When the caller opts in with
+        ``continue_session`` and supplies no explicit history, load it from the
+        worker's own state.db so a routed conversation keeps memory across
+        turns.  Off by default → existing /v1/runs clients are unaffected.
+        """
+        if conversation_history or previous_response_id:
+            return None
+        if not body.get("continue_session"):
+            return None
+        sid = body.get("session_id")
+        return str(sid) if sid else None
+
     def _conversation_history_for_session(self, session_id: str) -> List[Dict[str, Any]]:
         db = self._ensure_session_db()
         if db is None:
@@ -3679,6 +3702,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
+
+        # Tier-2 continuity: a routed worker rehydrates its own transcript when
+        # the front opts in (continue_session) and sent no explicit history.
+        if (_resume_sid := self._continue_session_id(body, conversation_history, previous_response_id)):
+            conversation_history = self._conversation_history_for_session(_resume_sid)
+
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3627,17 +3627,24 @@ class BasePlatformAdapter(ABC):
         try:
             from gateway.routing import resolve_profile_route
 
-            # An explicit /profile binding for this chat wins over the config
-            # routing table (deliberate user action).
-            bound = None
-            bindings = getattr(self, "_chat_bindings", None)
-            if bindings is not None:
-                from gateway.chat_bindings import chat_binding_key
+            from gateway.chat_bindings import chat_binding_key, parse_profile_mention
 
-                bound = bindings.get(chat_binding_key(event.source))
-            event.routed_profile = bound or resolve_profile_route(
-                getattr(self, "_profile_routing", None), event.source
-            )
+            # Precedence: per-turn @mention > persisted /profile binding >
+            # config routing table.  A @mention only routes if it names a real
+            # profile; otherwise it stays literal text.
+            mention, body = parse_profile_mention(event.text or "")
+            if mention:
+                from hermes_cli.profiles import profile_exists
+
+                if profile_exists(mention):
+                    event.text = body
+                    event.routed_profile = mention
+            if event.routed_profile is None:
+                bindings = getattr(self, "_chat_bindings", None)
+                bound = bindings.get(chat_binding_key(event.source)) if bindings is not None else None
+                event.routed_profile = bound or resolve_profile_route(
+                    getattr(self, "_profile_routing", None), event.source
+                )
         except Exception:
             logger.warning("profile route resolution failed; staying on host profile", exc_info=True)
             event.routed_profile = None

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1589,6 +1589,28 @@ def resolve_channel_prompt(
     return None
 
 
+def resolve_channel_model(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> str | None:
+    """Resolve a per-channel model override from platform config.
+
+    Looks up ``channel_models`` in the adapter's ``config.extra`` dict.
+    Prefers an exact match on *channel_id*; falls back to *parent_id*
+    (forum threads / child channels inheriting a parent's model).
+
+    Returns the model string, or None if no match.  Blank values are absent.
+    """
+    models = config_extra.get("channel_models") or {}
+    if not isinstance(models, dict):
+        return None
+    for key in (channel_id, parent_id):
+        if key and (model := str(models.get(key) or "").strip()):
+            return model
+    return None
+
+
 def resolve_channel_skills(
     config_extra: dict,
     channel_id: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3627,7 +3627,15 @@ class BasePlatformAdapter(ABC):
         try:
             from gateway.routing import resolve_profile_route
 
-            event.routed_profile = resolve_profile_route(
+            # An explicit /profile binding for this chat wins over the config
+            # routing table (deliberate user action).
+            bound = None
+            bindings = getattr(self, "_chat_bindings", None)
+            if bindings is not None:
+                from gateway.chat_bindings import chat_binding_key
+
+                bound = bindings.get(chat_binding_key(event.source))
+            event.routed_profile = bound or resolve_profile_route(
                 getattr(self, "_profile_routing", None), event.source
             )
         except Exception:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1330,6 +1330,10 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Per-route model override (e.g. Telegram group_topics model).  Resolved
+    # in the adapter (scoped by chat_id) so it can't collide across groups.
+    channel_model: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1334,6 +1334,9 @@ class MessageEvent:
     # in the adapter (scoped by chat_id) so it can't collide across groups.
     channel_model: Optional[str] = None
 
+    # Tier-2: target profile this message routes to (None => host profile).
+    routed_profile: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
@@ -3618,10 +3621,24 @@ class BasePlatformAdapter(ABC):
         # downstream delivery all agree on the same lane.
         self._apply_topic_recovery(event)
 
+        # Tier-2 routing: resolve the target profile (None => host).  A
+        # resolution failure is safe to fall back — no isolation boundary has
+        # been crossed yet — so it never blocks the host path (design §8).
+        try:
+            from gateway.routing import resolve_profile_route
+
+            event.routed_profile = resolve_profile_route(
+                getattr(self, "_profile_routing", None), event.source
+            )
+        except Exception:
+            logger.warning("profile route resolution failed; staying on host profile", exc_info=True)
+            event.routed_profile = None
+
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            profile=event.routed_profile or "main",
         )
 
         # On-entry self-heal: if the adapter still has an _active_sessions

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5802,6 +5802,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id_str = self._GENERAL_TOPIC_THREAD_ID
         chat_topic = None
         topic_skill = None
+        topic_model = None
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
@@ -5827,6 +5828,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         if tid is not None and str(tid) == thread_id_str:
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
+                            topic_model = str(topic.get("model") or "").strip() or None
                             break
                     break
 
@@ -5897,6 +5899,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            channel_model=topic_model,
             timestamp=message.date,
         )
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5803,12 +5803,15 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_topic = None
         topic_skill = None
         topic_model = None
+        topic_prompt = None
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
             if topic_info:
                 chat_topic = topic_info.get("name")
                 topic_skill = topic_info.get("skill")
+                topic_model = str(topic_info.get("model") or "").strip() or None
+                topic_prompt = str(topic_info.get("system_prompt") or "").strip() or None
 
             # Also check forum_topic_created service message for topic discovery
             if hasattr(message, "forum_topic_created") and message.forum_topic_created:
@@ -5829,6 +5832,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
                             topic_model = str(topic.get("model") or "").strip() or None
+                            topic_prompt = str(topic.get("system_prompt") or "").strip() or None
                             break
                     break
 
@@ -5879,10 +5883,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
 
-        # Per-channel/topic ephemeral prompt
+        # Per-channel/topic ephemeral prompt.  A system_prompt nested under the
+        # topic config (scoped by chat_id, collision-free) wins over the flat
+        # channel_prompts lookup.
         from gateway.platforms.base import resolve_channel_prompt
         _chat_id_str = str(chat.id)
-        _channel_prompt = resolve_channel_prompt(
+        _channel_prompt = topic_prompt or resolve_channel_prompt(
             self.config.extra,
             thread_id_str or _chat_id_str,
             _chat_id_str if thread_id_str else None,

--- a/gateway/rate_limit.py
+++ b/gateway/rate_limit.py
@@ -1,0 +1,43 @@
+"""Per-profile token-bucket rate limiting (Tier-2, #9514).
+
+The shared bot token draws on one global API budget, so a chatty routed profile
+must not starve the others.  The front checks a per-profile bucket before
+dispatching a turn — the single chokepoint where the ask belongs (design §7).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+
+class TokenBucket:
+    def __init__(self, capacity: float, refill_per_sec: float, *, clock: Callable[[], float] = time.monotonic):
+        self.capacity = capacity
+        self.refill_per_sec = refill_per_sec
+        self._clock = clock
+        self._tokens = float(capacity)
+        self._last = clock()
+
+    def allow(self, cost: float = 1.0) -> bool:
+        now = self._clock()
+        self._tokens = min(self.capacity, self._tokens + (now - self._last) * self.refill_per_sec)
+        self._last = now
+        if self._tokens >= cost:
+            self._tokens -= cost
+            return True
+        return False
+
+
+class ProfileRateLimiter:
+    def __init__(self, capacity: float = 20, refill_per_sec: float = 1.0, *, clock: Callable[[], float] = time.monotonic):
+        self.capacity = capacity
+        self.refill_per_sec = refill_per_sec
+        self._clock = clock
+        self._buckets: dict[str, TokenBucket] = {}
+
+    def allow(self, profile: str, cost: float = 1.0) -> bool:
+        bucket = self._buckets.get(profile)
+        if bucket is None:
+            bucket = self._buckets[profile] = TokenBucket(self.capacity, self.refill_per_sec, clock=self._clock)
+        return bucket.allow(cost)

--- a/gateway/routing.py
+++ b/gateway/routing.py
@@ -1,0 +1,60 @@
+"""Platform-agnostic profile routing table (Tier-2).
+
+Resolves an inbound SessionSource to a target profile name, or None (host).
+Exact-wins: thread/channel > guild > platform > default. A thread with no
+thread-specific route inherits its parent channel's route.
+"""
+
+from __future__ import annotations
+
+from gateway.session import SessionSource
+
+
+def _route_score(route: dict, source: SessionSource) -> int | None:
+    """Specificity score if *route* matches *source*, else None (higher = more specific)."""
+    score = 0
+    chat = str(source.chat_id or "")
+    parent = str(source.parent_chat_id or "")
+
+    if "platform" in route:
+        if str(route["platform"]) != source.platform.value:
+            return None
+        score += 1
+
+    # channel_id is a Discord-ergonomic alias for chat_id; a thread inherits its
+    # parent channel's route, so match either the chat or its parent.
+    route_chat = route.get("chat_id", route.get("channel_id"))
+    if route_chat is not None:
+        if str(route_chat) not in (chat, parent):
+            return None
+        score += 4
+
+    if "thread_id" in route:
+        if str(route["thread_id"]) != str(source.thread_id or ""):
+            return None
+        score += 8
+
+    if "guild_id" in route:
+        if str(route["guild_id"]) != str(source.guild_id or ""):
+            return None
+        score += 2
+
+    if "user_id" in route:
+        if str(route["user_id"]) != str(source.user_id_alt or source.user_id or ""):
+            return None
+        score += 2
+
+    return score
+
+
+def resolve_profile_route(profile_routing: dict | None, source: SessionSource) -> str | None:
+    if not profile_routing:
+        return None
+    best_score, best_profile = -1, None
+    for route in profile_routing.get("routes") or []:
+        if not isinstance(route, dict):
+            continue
+        score = _route_score(route, source)
+        if score is not None and score > best_score:
+            best_score, best_profile = score, route.get("profile")
+    return best_profile or profile_routing.get("default")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8697,13 +8697,25 @@ class GatewayRunner:
         async def _media_handler(media_event):
             await self._deliver_worker_media(event, source, media_event)
 
-        result = await client.dispatch(
-            input=event.text,
-            instructions=getattr(event, "channel_prompt", None),
-            session_id=session_key,
-            consumer=_FrontConsumer(),
-            media_handler=_media_handler,
-        )
+        # Mint claim-check refs for any inbound media so the worker can
+        # materialize them without ever seeing a front-local path.
+        from gateway.media_spool import MediaSpool, mint_outbound, default_spool_root
+
+        spool = MediaSpool(default_spool_root())
+        media_urls = getattr(event, "media_urls", None) or []
+        inbound = mint_outbound(spool, [(p, False) for p in media_urls]) if media_urls else []
+        try:
+            result = await client.dispatch(
+                input=event.text,
+                instructions=getattr(event, "channel_prompt", None),
+                session_id=session_key,
+                media_refs=inbound,
+                consumer=_FrontConsumer(),
+                media_handler=_media_handler,
+            )
+        finally:
+            for ref in inbound:
+                spool.unlink(ref["ref"])  # terminal cleanup of inbound spool bytes
         output = (result or {}).get("output", "")
         adapter = self.adapters.get(source.platform)
         if output and adapter:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4485,6 +4485,7 @@ class GatewayRunner:
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
             adapter._profile_routing = self.config.profile_routing
+            adapter._chat_bindings = self._chat_bindings()
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -6203,6 +6204,7 @@ class GatewayRunner:
 
                     adapter.set_message_handler(self._handle_message)
                     adapter._profile_routing = self.config.profile_routing
+                    adapter._chat_bindings = self._chat_bindings()
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -10168,19 +10170,42 @@ class GatewayRunner:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
         return EphemeralReply(f"{header}{_tip_line}")
 
+    def _chat_bindings(self) -> "ChatBindings":
+        from gateway.chat_bindings import ChatBindings
+
+        if getattr(self, "_chat_bindings_store", None) is None:
+            self._chat_bindings_store = ChatBindings(Path(self.config.sessions_dir) / "chat_bindings.json")
+        return self._chat_bindings_store
+
     async def _handle_profile_command(self, event: MessageEvent) -> str:
-        """Handle /profile — show active profile name and home directory."""
+        """Handle /profile [ls | <name>] — show, list, or bind this chat's profile."""
         from hermes_constants import display_hermes_home
-        from hermes_cli.profiles import get_active_profile_name
+        from hermes_cli.profiles import get_active_profile_name, list_profiles, profile_exists, validate_profile_name
+        from gateway.chat_bindings import chat_binding_key
 
-        display = display_hermes_home()
-        profile_name = get_active_profile_name()
+        arg = event.get_command_args().strip()
 
+        if arg in {"ls", "list"}:
+            names = ", ".join(sorted(p.name for p in list_profiles())) or "(none)"
+            return f"Available profiles: {names}"
+
+        if arg:
+            try:
+                validate_profile_name(arg)
+            except ValueError as e:
+                return f"⚠️ {e}"
+            if not profile_exists(arg):
+                return f"⚠️ No such profile '{arg}'. Try /profile ls."
+            self._chat_bindings().set(chat_binding_key(event.source), arg)
+            return f"✅ This chat is now bound to the '{arg}' profile."
+
+        bound = self._chat_bindings().get(chat_binding_key(event.source))
         lines = [
-            t("gateway.profile.header", profile=profile_name),
-            t("gateway.profile.home", home=display),
+            t("gateway.profile.header", profile=get_active_profile_name()),
+            t("gateway.profile.home", home=display_hermes_home()),
         ]
-
+        if bound:
+            lines.append(f"This chat is routed to: {bound}")
         return "\n".join(lines)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1138,6 +1138,7 @@ from gateway.platforms.base import (
     MessageType,
     _reply_anchor_for_event,
     merge_pending_message_event,
+    resolve_channel_model,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -2534,6 +2535,21 @@ class GatewayRunner:
                 resolved_session_key = None
 
         model = _resolve_gateway_model(user_config)
+
+        # Per-route model overlay (Tier-1): channel_models on the source's
+        # platform config. A session /model override (below) still wins.
+        if source is not None and self.config is not None:
+            try:
+                plat_cfg = self.config.platforms.get(source.platform)
+                if routed := resolve_channel_model(
+                    plat_cfg.extra if plat_cfg else {},
+                    str(source.chat_id or ""),
+                    str(source.parent_chat_id or "") or None,
+                ):
+                    model = routed
+            except Exception:
+                logger.debug("channel_models lookup failed", exc_info=True)
+
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
             override_model = override.get("model", model)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8694,17 +8694,50 @@ class GatewayRunner:
                 # Live streaming relay is a refinement; the final reply is sent below.
                 pass
 
+        async def _media_handler(media_event):
+            await self._deliver_worker_media(event, source, media_event)
+
         result = await client.dispatch(
             input=event.text,
             instructions=getattr(event, "channel_prompt", None),
             session_id=session_key,
             consumer=_FrontConsumer(),
+            media_handler=_media_handler,
         )
         output = (result or {}).get("output", "")
         adapter = self.adapters.get(source.platform)
         if output and adapter:
             await adapter.send(source.chat_id, output, reply_to=self._reply_anchor_for_event(event))
         return result or {}
+
+    async def _deliver_worker_media(self, event, source, media_event) -> None:
+        """Resolve a worker's response.media refs to front-local files and upload
+        them via the platform's existing send_* methods, then unlink the spool."""
+        from gateway.media_spool import MediaSpool, MediaRef, default_spool_root
+        from gateway.platforms.base import get_image_cache_dir, get_document_cache_dir
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            return
+        spool = MediaSpool(default_spool_root())
+        images: list[tuple[str, str]] = []
+        for data in media_event.get("media", []):
+            mref = MediaRef.from_wire(data)
+            dest = get_image_cache_dir() if mref.kind == "image" else get_document_cache_dir()
+            path = str(spool.materialize(mref.ref, dest, filename=mref.filename))
+            try:
+                if mref.kind == "image" and not mref.as_document:
+                    images.append((f"file://{path}", ""))
+                elif mref.kind == "voice":
+                    await adapter.send_voice(source.chat_id, path)
+                elif mref.kind == "video":
+                    await adapter.send_video(source.chat_id, path)
+                else:
+                    await adapter.send_document(source.chat_id, path)
+            finally:
+                spool.unlink(mref.ref)  # eager cleanup on fetch
+        if images:
+            await adapter.send_multiple_images(source.chat_id, images)
 
     async def _reset_routed_worker(self, event, source, profile: str) -> None:
         """Forward /new or /reset to the routed worker, scoped to its own session."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1555,6 +1555,18 @@ def _load_gateway_runtime_config() -> dict:
     return expanded if isinstance(expanded, dict) else {}
 
 
+def _only_platforms_filter() -> set[str] | None:
+    """Platforms a worker may initialize, from HERMES_GATEWAY_ONLY_PLATFORMS.
+
+    None => no restriction (the normal front/standalone path).  A worker sets
+    this to ``api_server`` so its token adapters never start (one-loop-per-token).
+    """
+    raw = os.environ.get("HERMES_GATEWAY_ONLY_PLATFORMS", "").strip()
+    if not raw:
+        return None
+    return {p.strip() for p in raw.split(",") if p.strip()}
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -4445,8 +4457,13 @@ class GatewayRunner:
         startup_retryable_errors: list[str] = []
         
         # Initialize and connect each configured platform
+        only_platforms = _only_platforms_filter()
         for platform, platform_config in self.config.platforms.items():
             if not platform_config.enabled:
+                continue
+            if only_platforms is not None and platform.value not in only_platforms:
+                # Worker mode: skip token adapters so the shared bot token stays
+                # owned by the front (one-loop-per-token invariant).
                 continue
             enabled_platform_count += 1
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2551,7 +2551,9 @@ class GatewayRunner:
 
         # Per-route model overlay (Tier-1): channel_models on the source's
         # platform config. A session /model override (below) still wins.
-        if source is not None and self.config is not None:
+        # Guard config with getattr: this runs on every _run_agent call,
+        # including lean runners (cron/codex paths) that never set self.config.
+        if source is not None and getattr(self, "config", None) is not None:
             try:
                 plat_cfg = self.config.platforms.get(source.platform)
                 if routed := resolve_channel_model(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8706,6 +8706,25 @@ class GatewayRunner:
             await adapter.send(source.chat_id, output, reply_to=self._reply_anchor_for_event(event))
         return result or {}
 
+    async def _reset_routed_worker(self, event, source, profile: str) -> None:
+        """Forward /new or /reset to the routed worker, scoped to its own session."""
+        if getattr(self, "_worker_pool", None) is None:
+            from gateway.worker_pool import WorkerPool
+
+            self._worker_pool = WorkerPool()
+        worker = await self._worker_pool.acquire(profile)
+        client = self._make_worker_client(worker)
+        session_key = build_session_key(
+            source,
+            group_sessions_per_user=self.config.group_sessions_per_user,
+            thread_sessions_per_user=self.config.thread_sessions_per_user,
+            profile=profile,
+        )
+        await client.reset_session(session_key)
+        adapter = self.adapters.get(source.platform)
+        if adapter:
+            await adapter.send(source.chat_id, "🔄 Started a new conversation.")
+
     async def _maybe_dispatch_routed(self, event, source) -> bool:
         """Route to a worker if the message matched a profile route.
 
@@ -8726,8 +8745,12 @@ class GatewayRunner:
             if adapter:
                 await adapter.send(source.chat_id, f"⏳ '{profile}' is busy right now — please retry shortly.")
             return True
+        cmd = event.get_command() if hasattr(event, "get_command") else None
         try:
-            await self._dispatch_to_worker(event, source, profile)
+            if cmd in {"new", "reset"}:
+                await self._reset_routed_worker(event, source, profile)
+            else:
+                await self._dispatch_to_worker(event, source, profile)
         except Exception as e:
             logger.error("routed dispatch to profile %r failed: %s", profile, e, exc_info=True)
             adapter = self.adapters.get(source.platform)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8717,6 +8717,15 @@ class GatewayRunner:
         profile = getattr(event, "routed_profile", None)
         if not profile:
             return False
+        if getattr(self, "_profile_rate_limiter", None) is None:
+            from gateway.rate_limit import ProfileRateLimiter
+
+            self._profile_rate_limiter = ProfileRateLimiter()
+        if not self._profile_rate_limiter.allow(profile):
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                await adapter.send(source.chat_id, f"⏳ '{profile}' is busy right now — please retry shortly.")
+            return True
         try:
             await self._dispatch_to_worker(event, source, profile)
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4484,6 +4484,7 @@ class GatewayRunner:
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter._profile_routing = self.config.profile_routing
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -6201,6 +6202,7 @@ class GatewayRunner:
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    adapter._profile_routing = self.config.profile_routing
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -8663,6 +8665,70 @@ class GatewayRunner:
                 pass
         return source
 
+    def _make_worker_client(self, worker):
+        from gateway.worker_client import WorkerClient
+
+        return WorkerClient(worker.base_url, worker.key)
+
+    async def _dispatch_to_worker(self, event, source, profile: str) -> dict:
+        """Dispatch one turn to *profile*'s isolated worker and deliver its reply.
+
+        Raises on any failure so the caller can fail closed — a routed turn must
+        never silently run on the host profile (design §8).
+        """
+        if getattr(self, "_worker_pool", None) is None:
+            from gateway.worker_pool import WorkerPool
+
+            self._worker_pool = WorkerPool()
+        worker = await self._worker_pool.acquire(profile)
+        client = self._make_worker_client(worker)
+        session_key = build_session_key(
+            source,
+            group_sessions_per_user=self.config.group_sessions_per_user,
+            thread_sessions_per_user=self.config.thread_sessions_per_user,
+            profile=profile,
+        )
+
+        class _FrontConsumer:
+            def on_delta(self, _text: str) -> None:
+                # Live streaming relay is a refinement; the final reply is sent below.
+                pass
+
+        result = await client.dispatch(
+            input=event.text,
+            instructions=getattr(event, "channel_prompt", None),
+            session_id=session_key,
+            consumer=_FrontConsumer(),
+        )
+        output = (result or {}).get("output", "")
+        adapter = self.adapters.get(source.platform)
+        if output and adapter:
+            await adapter.send(source.chat_id, output, reply_to=self._reply_anchor_for_event(event))
+        return result or {}
+
+    async def _maybe_dispatch_routed(self, event, source) -> bool:
+        """Route to a worker if the message matched a profile route.
+
+        Returns True when the message was handled here (routed) — the caller
+        must then NOT run the in-process host handler.  A dispatch failure posts
+        a visible error and still returns True: failing closed prevents a routed
+        message from leaking into the host profile.
+        """
+        profile = getattr(event, "routed_profile", None)
+        if not profile:
+            return False
+        try:
+            await self._dispatch_to_worker(event, source, profile)
+        except Exception as e:
+            logger.error("routed dispatch to profile %r failed: %s", profile, e, exc_info=True)
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                try:
+                    await adapter.send(source.chat_id, f"⚠️ Could not reach the '{profile}' profile: {e}")
+                except Exception:
+                    logger.error("failed to deliver routing error to user", exc_info=True)
+        return True
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -8673,6 +8739,10 @@ class GatewayRunner:
             _platform_name, source.user_name or source.user_id or "unknown",
             source.chat_id or "unknown", _msg_preview,
         )
+
+        # Tier-2: a routed message runs on an isolated worker, not the host.
+        if await self._maybe_dispatch_routed(event, source):
+            return
 
         # Get or create session
         # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5127,6 +5127,10 @@ class GatewayRunner:
                     except Exception as _e:
                         logger.debug("SessionStore prune failed: %s", _e)
                     self._last_session_store_prune_ts = time.time()
+
+                # Routed-profile worker pool upkeep: reap crashed-while-idle
+                # workers (drives the circuit breaker) and evict idle ones.
+                await self._maintain_worker_pool()
             except Exception as e:
                 logger.debug("Session expiry watcher error: %s", e)
             # Sleep in small increments so we can stop quickly
@@ -6492,6 +6496,17 @@ class GatewayRunner:
                         _entry[0] if isinstance(_entry, tuple) else _entry
                     )
                     self._cleanup_agent_resources(_agent)
+
+            # Tear down routed-profile workers we own: they are tracked
+            # (non-detached) child processes, so without this they leak as
+            # orphans on every gateway stop/restart.
+            _worker_pool = getattr(self, "_worker_pool", None)
+            if _worker_pool is not None:
+                try:
+                    await _worker_pool.shutdown()
+                    logger.info("✓ routed-profile worker pool shut down")
+                except Exception as e:
+                    logger.error("✗ worker pool shutdown error: %s", e)
 
             for platform, adapter in list(self.adapters.items()):
                 _adapter_started_at = time.monotonic()
@@ -8672,6 +8687,25 @@ class GatewayRunner:
 
         return WorkerClient(worker.base_url, worker.key)
 
+    async def _maintain_worker_pool(self) -> None:
+        """Periodic upkeep for the routed-profile worker pool.
+
+        ``reap_exited`` records crashes (driving the circuit breaker) for
+        workers that died while idle — i.e. between messages, where the
+        on-demand respawn path never runs — and ``sweep_idle`` evicts workers
+        past their idle TTL so they free their pool slot and stop holding the
+        profile's gateway.lock.  Without this the pool's evict/circuit-break
+        machinery only ever runs on the next inbound message.
+        """
+        pool = getattr(self, "_worker_pool", None)
+        if pool is None:
+            return
+        try:
+            await pool.reap_exited()
+            await pool.sweep_idle()
+        except Exception:
+            logger.debug("worker pool maintenance failed", exc_info=True)
+
     async def _dispatch_to_worker(self, event, source, profile: str) -> dict:
         """Dispatch one turn to *profile*'s isolated worker and deliver its reply.
 
@@ -8699,6 +8733,22 @@ class GatewayRunner:
         async def _media_handler(media_event):
             await self._deliver_worker_media(event, source, media_event)
 
+        async def _approval_handler(_request) -> str:
+            # Interactive approval relay to the routed user is not wired yet, so
+            # we fail closed: deny, but tell the user explicitly instead of a
+            # silent denial they can't explain.
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                try:
+                    await adapter.send(
+                        source.chat_id,
+                        f"⚠️ The '{profile}' profile asked to run a tool that needs approval — "
+                        "auto-denied (approvals aren't supported for routed profiles yet).",
+                    )
+                except Exception:
+                    logger.debug("failed to notify user of routed approval denial", exc_info=True)
+            return "deny"
+
         # Mint claim-check refs for any inbound media so the worker can
         # materialize them without ever seeing a front-local path.
         from gateway.media_spool import MediaSpool, mint_outbound, default_spool_root
@@ -8714,6 +8764,8 @@ class GatewayRunner:
                 media_refs=inbound,
                 consumer=_FrontConsumer(),
                 media_handler=_media_handler,
+                approval_handler=_approval_handler,
+                continue_session=True,
             )
         finally:
             for ref in inbound:
@@ -8783,16 +8835,19 @@ class GatewayRunner:
         profile = getattr(event, "routed_profile", None)
         if not profile:
             return False
-        if getattr(self, "_profile_rate_limiter", None) is None:
-            from gateway.rate_limit import ProfileRateLimiter
-
-            self._profile_rate_limiter = ProfileRateLimiter()
-        if not self._profile_rate_limiter.allow(profile):
-            adapter = self.adapters.get(source.platform)
-            if adapter:
-                await adapter.send(source.chat_id, f"⏳ '{profile}' is busy right now — please retry shortly.")
-            return True
         cmd = event.get_command() if hasattr(event, "get_command") else None
+        # Control commands (/new, /reset) carry no model cost and must not be
+        # throttled — rate-limiting a reset would strand a stuck conversation.
+        if cmd not in {"new", "reset"}:
+            if getattr(self, "_profile_rate_limiter", None) is None:
+                from gateway.rate_limit import ProfileRateLimiter
+
+                self._profile_rate_limiter = ProfileRateLimiter()
+            if not self._profile_rate_limiter.allow(profile):
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    await adapter.send(source.chat_id, f"⏳ '{profile}' is busy right now — please retry shortly.")
+                return True
         try:
             if cmd in {"new", "reset"}:
                 await self._reset_routed_worker(event, source, profile)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2520,6 +2520,7 @@ class GatewayRunner:
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
+        channel_model: Optional[str] = None,
     ) -> tuple[str, dict]:
         """Resolve model/runtime for a session, honoring session-scoped /model overrides.
 
@@ -2549,6 +2550,11 @@ class GatewayRunner:
                     model = routed
             except Exception:
                 logger.debug("channel_models lookup failed", exc_info=True)
+
+        # A per-route model the adapter already resolved (e.g. Telegram
+        # group_topics, scoped by chat_id) wins over flat channel_models.
+        if channel_model:
+            model = channel_model
 
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
@@ -9287,6 +9293,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                channel_model=getattr(event, "channel_model", None),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -16671,6 +16678,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_model: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -17389,6 +17397,7 @@ class GatewayRunner:
                     source=source,
                     session_key=session_key,
                     user_config=user_config,
+                    channel_model=channel_model,
                 )
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",
@@ -18754,6 +18763,7 @@ class GatewayRunner:
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_channel_model = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
@@ -18771,6 +18781,7 @@ class GatewayRunner:
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_channel_model = getattr(pending_event, "channel_model", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -18796,6 +18807,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    channel_model=next_channel_model,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -601,6 +601,7 @@ def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
     thread_sessions_per_user: bool = False,
+    profile: str = "main",
 ) -> str:
     """Build a deterministic session key from a message source.
 
@@ -625,6 +626,7 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
+    prefix = f"agent:{profile}"
     platform = source.platform.value
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
@@ -633,11 +635,11 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_chat_id}"
+                return f"{prefix}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+            return f"{prefix}:{platform}:dm:{dm_chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{prefix}:{platform}:dm:{source.thread_id}"
+        return f"{prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -645,7 +647,7 @@ def build_session_key(
         # single group member gets two isolated per-user sessions when the
         # bridge reshuffles alias forms.
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)

--- a/gateway/worker_client.py
+++ b/gateway/worker_client.py
@@ -54,6 +54,7 @@ class WorkerClient:
         instructions: Optional[str] = None,
         session_id: Optional[str] = None,
         model: Optional[str] = None,
+        media_refs: list[dict] | None = None,
         approval_handler: Callable[[dict], Awaitable[str]] | None = None,
         media_handler: Callable[[dict], Awaitable[None]] | None = None,
     ) -> dict:
@@ -63,6 +64,7 @@ class WorkerClient:
             "instructions": instructions,
             "session_id": session_id,
             "model": model,
+            "media_refs": media_refs or None,
         }.items() if v is not None}
         started = await self._post(f"{self.base_url}/v1/runs", body)
         run_id = started.get("run_id")

--- a/gateway/worker_client.py
+++ b/gateway/worker_client.py
@@ -55,6 +55,7 @@ class WorkerClient:
         session_id: Optional[str] = None,
         model: Optional[str] = None,
         approval_handler: Callable[[dict], Awaitable[str]] | None = None,
+        media_handler: Callable[[dict], Awaitable[None]] | None = None,
     ) -> dict:
         """Run one turn on the worker; relay deltas, handle approvals, return the terminal event."""
         body = {k: v for k, v in {
@@ -70,6 +71,9 @@ class WorkerClient:
             name = event.get("event")
             if name == "message.delta":
                 consumer.on_delta(event.get("delta", ""))
+            elif name == "response.media":
+                if media_handler:
+                    await media_handler(event)
             elif name == "approval.request":
                 choice = await approval_handler(event) if approval_handler else "deny"
                 await self._post(f"{self.base_url}/v1/runs/{run_id}/approval", {"choice": choice})

--- a/gateway/worker_client.py
+++ b/gateway/worker_client.py
@@ -1,0 +1,102 @@
+"""Front→worker turn dispatch over the worker's api_server HTTP+SSE (Tier-2).
+
+Reuses the existing api_server contract (design §6): ``POST /v1/runs`` starts a
+run; ``GET /v1/runs/{run_id}/events`` streams ``message.delta`` / ``approval.request``
+/ ``run.completed``; ``POST /v1/runs/{run_id}/approval`` resolves an approval.
+Text deltas feed the caller's stream consumer; approvals round-trip through the
+caller's handler. All requests bind loopback and carry the per-worker bearer.
+
+HTTP (post + SSE) is injected so the relay logic is tested without a server.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import AsyncIterator, Awaitable, Callable, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class StreamConsumer(Protocol):
+    def on_delta(self, text: str) -> None: ...
+
+
+class WorkerRunError(RuntimeError):
+    """The worker reported run.failed."""
+
+
+class WorkerClient:
+    def __init__(
+        self,
+        base_url: str,
+        key: str,
+        *,
+        post: Callable[[str, dict], Awaitable[dict]] | None = None,
+        sse: Callable[[str], AsyncIterator[dict]] | None = None,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.key = key
+        self._post = post or self._aiohttp_post
+        self._sse = sse or self._aiohttp_sse
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.key}"}
+
+    async def dispatch(
+        self,
+        *,
+        input: str,
+        consumer: StreamConsumer,
+        instructions: Optional[str] = None,
+        session_id: Optional[str] = None,
+        model: Optional[str] = None,
+        approval_handler: Callable[[dict], Awaitable[str]] | None = None,
+    ) -> dict:
+        """Run one turn on the worker; relay deltas, handle approvals, return the terminal event."""
+        body = {k: v for k, v in {
+            "input": input,
+            "instructions": instructions,
+            "session_id": session_id,
+            "model": model,
+        }.items() if v is not None}
+        started = await self._post(f"{self.base_url}/v1/runs", body)
+        run_id = started.get("run_id")
+
+        async for event in self._sse(f"{self.base_url}/v1/runs/{run_id}/events"):
+            name = event.get("event")
+            if name == "message.delta":
+                consumer.on_delta(event.get("delta", ""))
+            elif name == "approval.request":
+                choice = await approval_handler(event) if approval_handler else "deny"
+                await self._post(f"{self.base_url}/v1/runs/{run_id}/approval", {"choice": choice})
+            elif name == "run.completed":
+                return event
+            elif name == "run.cancelled":
+                return event
+            elif name == "run.failed":
+                raise WorkerRunError(event.get("error") or "worker run failed")
+        raise WorkerRunError("worker event stream ended without a terminal event")
+
+    async def _aiohttp_post(self, url: str, body: dict) -> dict:
+        import aiohttp
+
+        async with aiohttp.ClientSession(headers=self._headers) as s:
+            async with s.post(url, json=body) as r:
+                r.raise_for_status()
+                return await r.json()
+
+    async def _aiohttp_sse(self, url: str) -> AsyncIterator[dict]:
+        import aiohttp
+
+        async with aiohttp.ClientSession(headers=self._headers) as s:
+            async with s.get(url) as r:
+                r.raise_for_status()
+                async for raw in r.content:
+                    line = raw.decode("utf-8").strip()
+                    if line.startswith("data:"):
+                        try:
+                            yield json.loads(line[5:].strip())
+                        except json.JSONDecodeError:
+                            logger.debug("skipping non-JSON SSE data line")

--- a/gateway/worker_client.py
+++ b/gateway/worker_client.py
@@ -34,11 +34,13 @@ class WorkerClient:
         *,
         post: Callable[[str, dict], Awaitable[dict]] | None = None,
         sse: Callable[[str], AsyncIterator[dict]] | None = None,
+        delete: Callable[[str], Awaitable[None]] | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.key = key
         self._post = post or self._aiohttp_post
         self._sse = sse or self._aiohttp_sse
+        self._delete = delete or self._aiohttp_delete
 
     @property
     def _headers(self) -> dict[str, str]:
@@ -79,6 +81,14 @@ class WorkerClient:
                 raise WorkerRunError(event.get("error") or "worker run failed")
         raise WorkerRunError("worker event stream ended without a terminal event")
 
+    async def reset_session(self, session_id: str) -> None:
+        """Clear the worker's session (forwarded /new or /reset).
+
+        Scopes the reset to the routed profile's own state.db — the host
+        profile's sessions are never touched.
+        """
+        await self._delete(f"{self.base_url}/api/sessions/{session_id}")
+
     async def _aiohttp_post(self, url: str, body: dict) -> dict:
         import aiohttp
 
@@ -86,6 +96,13 @@ class WorkerClient:
             async with s.post(url, json=body) as r:
                 r.raise_for_status()
                 return await r.json()
+
+    async def _aiohttp_delete(self, url: str) -> None:
+        import aiohttp
+
+        async with aiohttp.ClientSession(headers=self._headers) as s:
+            async with s.delete(url) as r:
+                r.raise_for_status()
 
     async def _aiohttp_sse(self, url: str) -> AsyncIterator[dict]:
         import aiohttp

--- a/gateway/worker_client.py
+++ b/gateway/worker_client.py
@@ -57,14 +57,21 @@ class WorkerClient:
         media_refs: list[dict] | None = None,
         approval_handler: Callable[[dict], Awaitable[str]] | None = None,
         media_handler: Callable[[dict], Awaitable[None]] | None = None,
+        continue_session: bool = False,
     ) -> dict:
-        """Run one turn on the worker; relay deltas, handle approvals, return the terminal event."""
+        """Run one turn on the worker; relay deltas, handle approvals, return the terminal event.
+
+        ``continue_session`` asks the worker to rehydrate its own transcript for
+        ``session_id`` from its state.db, so a routed conversation keeps memory
+        across turns (the front never holds the worker's history).
+        """
         body = {k: v for k, v in {
             "input": input,
             "instructions": instructions,
             "session_id": session_id,
             "model": model,
             "media_refs": media_refs or None,
+            "continue_session": True if (continue_session and session_id) else None,
         }.items() if v is not None}
         started = await self._post(f"{self.base_url}/v1/runs", body)
         run_id = started.get("run_id")
@@ -91,9 +98,16 @@ class WorkerClient:
         """Clear the worker's session (forwarded /new or /reset).
 
         Scopes the reset to the routed profile's own state.db — the host
-        profile's sessions are never touched.
+        profile's sessions are never touched.  Idempotent: a 404 (no session
+        yet — e.g. /new before the first routed turn) is treated as success so
+        the user sees a clean reset, not a scary "could not reach profile".
         """
-        await self._delete(f"{self.base_url}/api/sessions/{session_id}")
+        try:
+            await self._delete(f"{self.base_url}/api/sessions/{session_id}")
+        except Exception as e:
+            if getattr(e, "status", None) == 404:
+                return
+            raise
 
     async def _aiohttp_post(self, url: str, body: dict) -> dict:
         import aiohttp
@@ -108,6 +122,8 @@ class WorkerClient:
 
         async with aiohttp.ClientSession(headers=self._headers) as s:
             async with s.delete(url) as r:
+                if r.status == 404:
+                    return  # idempotent delete — already absent
                 r.raise_for_status()
 
     async def _aiohttp_sse(self, url: str) -> AsyncIterator[dict]:

--- a/gateway/worker_pool.py
+++ b/gateway/worker_pool.py
@@ -99,6 +99,7 @@ class WorkerPool:
         crash_limit: int = 5,
         crash_window: float = 60.0,
         kill_grace: float = 10.0,
+        broken_cooldown: float = 60.0,
     ):
         self._spawn = spawn
         self._probe = probe or self._default_probe
@@ -112,9 +113,13 @@ class WorkerPool:
         self.crash_limit = crash_limit
         self.crash_window = crash_window
         self.kill_grace = kill_grace
+        self.broken_cooldown = broken_cooldown
         self.workers: dict[str, Worker] = {}
         self._crashes: dict[str, deque[float]] = {}
-        self._broken: set[str] = set()
+        # profile -> monotonic time the circuit-break cooldown expires.  After
+        # it elapses, the next acquire() clears the breaker and retries once.
+        self._broken: dict[str, float] = {}
+        self._closed = False
         self._lock = asyncio.Lock()
 
     async def _default_probe(self, worker: Worker) -> bool:
@@ -130,12 +135,20 @@ class WorkerPool:
     async def acquire(self, profile: str) -> Worker:
         """Return a SERVING worker for *profile*, spawning + probing if needed."""
         async with self._lock:
+            if self._closed:
+                raise ProfileBusyError("worker pool is shutting down")
             existing = self.workers.get(profile)
             if existing and existing.state is WorkerState.SERVING and existing.alive():
                 existing.last_used = self._clock()
                 return existing
-            if profile in self._broken:
-                raise ProfileBusyError(f"profile {profile!r} is unhealthy (too many recent crashes)")
+            # A previously serving/probing worker that died unexpectedly is a
+            # crash.  Record it here, on the lazy-respawn path, so the circuit
+            # breaker still trips even when no periodic reap observed the death
+            # first (the live gateway respawns on-demand, not via reap_exited).
+            if existing and existing.state in (WorkerState.SERVING, WorkerState.PROBING) and not existing.alive():
+                self._record_crash(profile)
+            self.workers.pop(profile, None)
+            self._raise_if_broken(profile)
             if (pid := self._interlock(profile)) is not None:
                 raise ProfileBusyError(
                     f"profile {profile!r} is already served by a standalone gateway (pid {pid}); "
@@ -189,8 +202,25 @@ class WorkerPool:
         while hist and now - hist[0] > self.crash_window:
             hist.popleft()
         if len(hist) >= self.crash_limit:
-            self._broken.add(profile)
-            logger.error("worker for %r circuit-broke after %d crashes in %ss", profile, len(hist), self.crash_window)
+            self._broken[profile] = now + self.broken_cooldown
+            logger.error(
+                "worker for %r circuit-broke after %d crashes in %ss; cooling down %ss",
+                profile, len(hist), self.crash_window, self.broken_cooldown,
+            )
+
+    def _raise_if_broken(self, profile: str) -> None:
+        """Raise while the profile's circuit breaker is open; self-heal after cooldown."""
+        until = self._broken.get(profile)
+        if until is None:
+            return
+        if self._clock() < until:
+            raise ProfileBusyError(
+                f"profile {profile!r} is unhealthy (too many recent crashes); cooling down"
+            )
+        # Cooldown elapsed — clear the breaker and the stale crash history so
+        # the profile gets a fresh chance instead of staying broken forever.
+        self._broken.pop(profile, None)
+        self._crashes.pop(profile, None)
 
     async def _reap(self, worker: Worker) -> None:
         if worker.alive():
@@ -202,5 +232,10 @@ class WorkerPool:
         self.workers.pop(worker.profile, None)
 
     async def shutdown(self) -> None:
-        for profile in list(self.workers):
+        # Latch closed under the lock so an acquire() racing shutdown can't spawn
+        # a worker after we snapshot the set — otherwise that child would orphan.
+        async with self._lock:
+            self._closed = True
+            profiles = list(self.workers)
+        for profile in profiles:
             await self.evict(profile)

--- a/gateway/worker_pool.py
+++ b/gateway/worker_pool.py
@@ -1,0 +1,206 @@
+"""Front-owned per-profile worker lifecycle (Tier-2).
+
+The front owns the one shared bot token; each routed profile runs in an isolated
+tokenless ``hermes gateway run`` worker exposing only api_server. This module
+spawns, readiness-probes, idle-evicts, and crash-respawns those workers, and
+enforces the load-bearing **one-agent-loop-per-profile** invariant: it refuses
+to spawn a worker for a profile a standalone gateway already owns (design §7).
+
+Process/transport details (Popen, health HTTP, interlock PID check) are injected
+so the state machine is exercised without real subprocesses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerState(Enum):
+    SPAWNING = "spawning"
+    PROBING = "probing"
+    SERVING = "serving"
+    DRAINING = "draining"
+    REAPED = "reaped"
+    UNHEALTHY = "unhealthy"
+
+
+class ProfileBusyError(RuntimeError):
+    """A profile cannot be served: a standalone owns it, or it circuit-broke."""
+
+
+@dataclass
+class Worker:
+    profile: str
+    proc: object
+    port: int
+    key: str
+    state: WorkerState = WorkerState.SPAWNING
+    last_used: float = 0.0
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def alive(self) -> bool:
+        return self.proc.poll() is None
+
+
+def _free_loopback_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _default_spawn(profile: str) -> tuple[object, int, str]:
+    import os
+    import subprocess
+
+    from hermes_cli.gateway import _worker_run_args_for_profile
+
+    port = _free_loopback_port()
+    key = secrets.token_hex(32)
+    args, env = _worker_run_args_for_profile(profile, port, key)
+    # Tracked (non-detached) child: the front reaps it via the pool, not s6.
+    proc = subprocess.Popen(args, env={**os.environ, **env})
+    return proc, port, key
+
+
+def _default_interlock(profile: str) -> Optional[int]:
+    from hermes_cli.profiles import get_profile_dir
+    from gateway.status import get_running_pid
+
+    return get_running_pid(get_profile_dir(profile) / "gateway.pid", cleanup_stale=False)
+
+
+class WorkerPool:
+    def __init__(
+        self,
+        *,
+        spawn: Callable[[str], tuple[object, int, str]] = _default_spawn,
+        probe: Callable[[Worker], Awaitable[bool]] | None = None,
+        interlock: Callable[[str], Optional[int]] = _default_interlock,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        max_workers: int = 8,
+        idle_ttl: float = 300.0,
+        probe_interval: float = 0.25,
+        probe_timeout: float = 30.0,
+        crash_limit: int = 5,
+        crash_window: float = 60.0,
+        kill_grace: float = 10.0,
+    ):
+        self._spawn = spawn
+        self._probe = probe or self._default_probe
+        self._interlock = interlock
+        self._clock = clock
+        self._sleep = sleep
+        self.max_workers = max_workers
+        self.idle_ttl = idle_ttl
+        self.probe_interval = probe_interval
+        self.probe_timeout = probe_timeout
+        self.crash_limit = crash_limit
+        self.crash_window = crash_window
+        self.kill_grace = kill_grace
+        self.workers: dict[str, Worker] = {}
+        self._crashes: dict[str, deque[float]] = {}
+        self._broken: set[str] = set()
+        self._lock = asyncio.Lock()
+
+    async def _default_probe(self, worker: Worker) -> bool:
+        import aiohttp
+
+        try:
+            async with aiohttp.ClientSession() as s:
+                async with s.get(f"{worker.base_url}/health", timeout=2) as r:
+                    return r.status == 200
+        except Exception:
+            return False
+
+    async def acquire(self, profile: str) -> Worker:
+        """Return a SERVING worker for *profile*, spawning + probing if needed."""
+        async with self._lock:
+            existing = self.workers.get(profile)
+            if existing and existing.state is WorkerState.SERVING and existing.alive():
+                existing.last_used = self._clock()
+                return existing
+            if profile in self._broken:
+                raise ProfileBusyError(f"profile {profile!r} is unhealthy (too many recent crashes)")
+            if (pid := self._interlock(profile)) is not None:
+                raise ProfileBusyError(
+                    f"profile {profile!r} is already served by a standalone gateway (pid {pid}); "
+                    "refusing to start a second loop on its state.db"
+                )
+            if len(self.workers) >= self.max_workers:
+                raise ProfileBusyError(f"worker pool is full ({self.max_workers})")
+            return await self._spawn_and_probe(profile)
+
+    async def _spawn_and_probe(self, profile: str) -> Worker:
+        proc, port, key = self._spawn(profile)
+        worker = Worker(profile=profile, proc=proc, port=port, key=key, state=WorkerState.PROBING)
+        self.workers[profile] = worker
+        deadline = self._clock() + self.probe_timeout
+        while self._clock() < deadline:
+            if not worker.alive():
+                break
+            if await self._probe(worker):
+                worker.state = WorkerState.SERVING
+                worker.last_used = self._clock()
+                return worker
+            await self._sleep(self.probe_interval)
+        await self._reap(worker)
+        raise ProfileBusyError(f"worker for {profile!r} failed readiness probe")
+
+    async def sweep_idle(self) -> None:
+        now = self._clock()
+        for worker in list(self.workers.values()):
+            if worker.state is WorkerState.SERVING and now - worker.last_used > self.idle_ttl:
+                await self.evict(worker.profile)
+
+    async def evict(self, profile: str) -> None:
+        worker = self.workers.get(profile)
+        if not worker:
+            return
+        worker.state = WorkerState.DRAINING
+        await self._reap(worker)
+
+    async def reap_exited(self) -> None:
+        """Record crashes for workers whose process exited unexpectedly."""
+        for worker in list(self.workers.values()):
+            if worker.state in (WorkerState.SERVING, WorkerState.PROBING) and not worker.alive():
+                self._record_crash(worker.profile)
+                worker.state = WorkerState.REAPED
+                self.workers.pop(worker.profile, None)
+
+    def _record_crash(self, profile: str) -> None:
+        now = self._clock()
+        hist = self._crashes.setdefault(profile, deque())
+        hist.append(now)
+        while hist and now - hist[0] > self.crash_window:
+            hist.popleft()
+        if len(hist) >= self.crash_limit:
+            self._broken.add(profile)
+            logger.error("worker for %r circuit-broke after %d crashes in %ss", profile, len(hist), self.crash_window)
+
+    async def _reap(self, worker: Worker) -> None:
+        if worker.alive():
+            worker.proc.terminate()
+            await self._sleep(self.kill_grace)
+            if worker.alive():
+                worker.proc.kill()
+        worker.state = WorkerState.REAPED
+        self.workers.pop(worker.profile, None)
+
+    async def shutdown(self) -> None:
+        for profile in list(self.workers):
+            await self.evict(profile)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -623,6 +623,23 @@ def _gateway_run_args_for_profile(profile: str) -> list[str]:
     return args
 
 
+def _worker_run_args_for_profile(profile: str, port: int, key: str) -> tuple[list[str], dict[str, str]]:
+    """Argv + env for a pool-managed worker: tokenless api_server on loopback.
+
+    Never passes ``--replace`` — the worker shares the profile's real
+    HERMES_HOME and must not SIGTERM a standalone gateway holding its lock.
+    """
+    args = [get_python_path(), "-m", "hermes_cli.main", "--profile", profile, "gateway", "run"]
+    env = {
+        "HERMES_GATEWAY_ONLY_PLATFORMS": "api_server",
+        "API_SERVER_ENABLED": "true",
+        "API_SERVER_HOST": "127.0.0.1",
+        "API_SERVER_PORT": str(port),
+        "API_SERVER_KEY": key,
+    }
+    return args, env
+
+
 def launch_detached_profile_gateway_restart(profile: str, old_pid: int) -> bool:
     """Relaunch a manually-run profile gateway after its current PID exits."""
     if old_pid <= 0:

--- a/tests/gateway/test_at_mention_override.py
+++ b/tests/gateway/test_at_mention_override.py
@@ -1,0 +1,38 @@
+"""@<profile> per-turn override — routes one turn without changing the binding."""
+
+from gateway.chat_bindings import parse_profile_mention
+
+
+def test_parses_leading_mention():
+    assert parse_profile_mention("@coder fix this bug") == ("coder", "fix this bug")
+
+
+def test_no_mention_returns_text_unchanged():
+    assert parse_profile_mention("just a normal message") == (None, "just a normal message")
+
+
+def test_mention_only_no_body():
+    # A bare "@coder" with no message is not a routing override.
+    assert parse_profile_mention("@coder") == (None, "@coder")
+
+
+def test_email_like_text_is_not_a_mention():
+    assert parse_profile_mention("ping bob@example.com please") == (None, "ping bob@example.com please")
+
+
+def test_hyphenated_profile_name():
+    assert parse_profile_mention("@code-helper do it") == ("code-helper", "do it")
+
+
+def test_mention_does_not_mutate_binding(tmp_path):
+    # A per-turn @mention must not change the persisted chat binding.
+    from gateway.chat_bindings import ChatBindings, chat_binding_key
+    from gateway.session import SessionSource
+    from gateway.platforms.base import Platform
+
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+    b = ChatBindings(tmp_path / "b.json")
+    b.set(chat_binding_key(src), "personal")
+    # Parsing a mention is read-only — the store is untouched.
+    parse_profile_mention("@coder hi")
+    assert b.get(chat_binding_key(src)) == "personal"

--- a/tests/gateway/test_channel_model.py
+++ b/tests/gateway/test_channel_model.py
@@ -1,0 +1,26 @@
+"""Tests for channel_models per-route model overlay resolution."""
+
+from gateway.platforms.base import resolve_channel_model
+
+
+class TestResolveChannelModel:
+    def test_no_models_returns_none(self):
+        assert resolve_channel_model({}, "123") is None
+
+    def test_match_by_channel_id(self):
+        extra = {"channel_models": {"100": "anthropic/claude-opus-4-8"}}
+        assert resolve_channel_model(extra, "100") == "anthropic/claude-opus-4-8"
+
+    def test_match_by_parent_id(self):
+        extra = {"channel_models": {"200": "openai/gpt-5"}}
+        assert resolve_channel_model(extra, "999", parent_id="200") == "openai/gpt-5"
+
+    def test_channel_id_wins_over_parent(self):
+        extra = {"channel_models": {"100": "for-channel", "200": "for-parent"}}
+        assert resolve_channel_model(extra, "100", parent_id="200") == "for-channel"
+
+    def test_blank_is_absent(self):
+        assert resolve_channel_model({"channel_models": {"100": "  "}}, "100") is None
+
+    def test_non_dict_returns_none(self):
+        assert resolve_channel_model({"channel_models": ["x"]}, "100") is None

--- a/tests/gateway/test_channel_model_routing.py
+++ b/tests/gateway/test_channel_model_routing.py
@@ -1,0 +1,58 @@
+"""Per-route channel_models override in _resolve_session_agent_runtime.
+
+Precedence contract: session /model override > channel_models > config default.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _make_runner(channel_models=None):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    extra = {"channel_models": channel_models} if channel_models else {}
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(extra=extra)})
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    return runner
+
+
+def _source(chat_id="100", **kw):
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="group", user_id="u1", **kw)
+
+
+def test_channel_model_used_when_no_session_override(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *_: "config/default")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", dict)
+    runner = _make_runner({"100": "anthropic/claude-opus-4-8"})
+    model, _ = runner._resolve_session_agent_runtime(source=_source(), user_config={})
+    assert model == "anthropic/claude-opus-4-8"
+
+
+def test_config_default_used_when_no_route(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *_: "config/default")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", dict)
+    runner = _make_runner({"999": "anthropic/claude-opus-4-8"})
+    model, _ = runner._resolve_session_agent_runtime(source=_source(), user_config={})
+    assert model == "config/default"
+
+
+def test_session_override_beats_channel_model(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *_: "config/default")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", dict)
+    runner = _make_runner({"100": "anthropic/claude-opus-4-8"})
+    source = _source()
+    key = runner._session_key_for_source(source)
+    runner._session_model_overrides[key] = {
+        "model": "openai/gpt-5",
+        "provider": "openai",
+        "api_key": "***",
+        "base_url": None,
+        "api_mode": None,
+    }
+    model, _ = runner._resolve_session_agent_runtime(source=source, user_config={})
+    assert model == "openai/gpt-5"

--- a/tests/gateway/test_config_channel_models_bridge.py
+++ b/tests/gateway/test_config_channel_models_bridge.py
@@ -1,0 +1,51 @@
+"""channel_models bridges into config.extra for all platforms; Telegram gets channel_skill_bindings."""
+
+from gateway.config import load_gateway_config
+from gateway.platforms.base import Platform
+
+
+def _write(tmp_path, yaml_text):
+    (tmp_path / "config.yaml").write_text(yaml_text)
+
+
+def test_channel_models_bridged_for_telegram(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write(
+        tmp_path,
+        """
+telegram:
+  channel_models:
+    "100": "anthropic/claude-opus-4-8"
+""",
+    )
+    cfg = load_gateway_config()
+    assert cfg.platforms[Platform.TELEGRAM].extra["channel_models"]["100"] == "anthropic/claude-opus-4-8"
+
+
+def test_channel_models_bridged_for_discord(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write(
+        tmp_path,
+        """
+discord:
+  channel_models:
+    "200": "openai/gpt-5"
+""",
+    )
+    cfg = load_gateway_config()
+    assert cfg.platforms[Platform.DISCORD].extra["channel_models"]["200"] == "openai/gpt-5"
+
+
+def test_channel_skill_bindings_bridged_for_telegram(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write(
+        tmp_path,
+        """
+telegram:
+  channel_skill_bindings:
+    - id: "100"
+      skills: ["a"]
+""",
+    )
+    cfg = load_gateway_config()
+    assert cfg.platforms[Platform.TELEGRAM].extra["channel_skill_bindings"][0]["id"] == "100"

--- a/tests/gateway/test_media_auth_and_cleanup.py
+++ b/tests/gateway/test_media_auth_and_cleanup.py
@@ -1,0 +1,41 @@
+"""Media-ref auth (per-run HMAC), safe_root confinement, and cleanup.
+
+Harvests #18510's safe_root / strict-auth path-confinement idea
+(credit: ayoahha + Donmeusi).
+"""
+
+import pytest
+
+from gateway.media_spool import MediaSpool, sign_ref, verify_ref, confine_to_safe_root
+
+
+def test_ref_token_is_scoped_to_run():
+    secret = "worker-bearer"
+    token = sign_ref("runA", "ref1", secret)
+    assert verify_ref("runA", "ref1", token, secret) is True
+    # Same ref, different run → rejected (no cross-run reuse).
+    assert verify_ref("runB", "ref1", token, secret) is False
+    # Tampered token → rejected.
+    assert verify_ref("runA", "ref1", "deadbeef", secret) is False
+
+
+def test_safe_root_rejects_traversal(tmp_path):
+    root = tmp_path / "spool"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        confine_to_safe_root("../../etc/passwd", root)
+    inside = confine_to_safe_root("ok.bin", root)
+    assert str(inside).startswith(str(root.resolve()))
+
+
+def test_resolve_rejects_ref_escaping_root(tmp_path):
+    spool = MediaSpool(tmp_path / "spool")
+    with pytest.raises((KeyError, ValueError)):
+        spool.resolve("../../../etc/passwd")
+
+
+def test_unlink_is_idempotent(tmp_path):
+    spool = MediaSpool(tmp_path / "spool")
+    ref = spool.mint(b"d", filename="a.png", mime="image/png", kind="image")
+    spool.unlink(ref.ref)
+    spool.unlink(ref.ref)  # second unlink must not raise

--- a/tests/gateway/test_media_refs_inbound.py
+++ b/tests/gateway/test_media_refs_inbound.py
@@ -1,0 +1,72 @@
+"""Media claim-check spool: mint a ref to bytes, resolve it back, materialize + clean up."""
+
+import pytest
+
+from gateway.media_spool import MediaSpool, MediaRef, materialize_inbound
+
+
+def test_mint_then_resolve_roundtrips(tmp_path):
+    spool = MediaSpool(tmp_path)
+    ref = spool.mint(b"hello-bytes", filename="a.png", mime="image/png", kind="image")
+    assert isinstance(ref, MediaRef)
+    assert ref.mime == "image/png"
+    assert ref.kind == "image"
+    assert ref.size == len(b"hello-bytes")
+    assert spool.resolve(ref.ref) == b"hello-bytes"
+
+
+def test_refs_are_unique(tmp_path):
+    spool = MediaSpool(tmp_path)
+    r1 = spool.mint(b"x", filename="a", mime="application/octet-stream", kind="document")
+    r2 = spool.mint(b"x", filename="a", mime="application/octet-stream", kind="document")
+    assert r1.ref != r2.ref
+
+
+def test_materialize_writes_named_file(tmp_path):
+    spool = MediaSpool(tmp_path)
+    ref = spool.mint(b"data", filename="report.pdf", mime="application/pdf", kind="document")
+    dest_dir = tmp_path / "cache"
+    dest_dir.mkdir()
+    path = spool.materialize(ref.ref, dest_dir)
+    assert path.read_bytes() == b"data"
+    assert path.suffix == ".pdf"
+
+
+def test_unlink_removes_spooled_bytes(tmp_path):
+    spool = MediaSpool(tmp_path)
+    ref = spool.mint(b"data", filename="a.png", mime="image/png", kind="image")
+    spool.unlink(ref.ref)
+    with pytest.raises(KeyError):
+        spool.resolve(ref.ref)
+
+
+def test_resolve_unknown_ref_raises(tmp_path):
+    with pytest.raises(KeyError):
+        MediaSpool(tmp_path).resolve("nope")
+
+
+def test_materialize_inbound_reconstructs_files_cross_process(tmp_path):
+    # Front mints into the shared spool...
+    front = MediaSpool(tmp_path / "spool")
+    img = front.mint(b"PNGDATA", filename="pic.png", mime="image/png", kind="image")
+    doc = front.mint(b"PDFDATA", filename="r.pdf", mime="application/pdf", kind="document")
+
+    # ...worker resolves from a fresh MediaSpool (no shared in-memory state),
+    # using only the wire dicts.
+    worker = MediaSpool(tmp_path / "spool")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    out = materialize_inbound(worker, [img.to_wire(), doc.to_wire()], cache)
+
+    paths = {m.kind: p for p, m in out}
+    assert paths["image"].read_bytes() == b"PNGDATA" and paths["image"].suffix == ".png"
+    assert paths["document"].read_bytes() == b"PDFDATA" and paths["document"].suffix == ".pdf"
+
+
+def test_ref_serializes_to_wire_dict_without_path(tmp_path):
+    spool = MediaSpool(tmp_path)
+    ref = spool.mint(b"d", filename="v.ogg", mime="audio/ogg", kind="voice", is_voice=True)
+    wire = ref.to_wire()
+    assert wire["is_voice"] is True
+    assert "path" not in wire and "root" not in wire
+    assert set(wire) == {"ref", "filename", "mime", "kind", "size", "as_document", "is_voice"}

--- a/tests/gateway/test_only_platforms_env.py
+++ b/tests/gateway/test_only_platforms_env.py
@@ -1,0 +1,25 @@
+"""HERMES_GATEWAY_ONLY_PLATFORMS restricts which adapters a worker initializes."""
+
+from gateway.run import _only_platforms_filter
+
+
+def test_unset_returns_none(monkeypatch):
+    monkeypatch.delenv("HERMES_GATEWAY_ONLY_PLATFORMS", raising=False)
+    assert _only_platforms_filter() is None
+
+
+def test_blank_returns_none(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ONLY_PLATFORMS", "  ")
+    assert _only_platforms_filter() is None
+
+
+def test_api_server_only_admits_api_server(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ONLY_PLATFORMS", "api_server")
+    only = _only_platforms_filter()
+    assert "api_server" in only
+    assert "telegram" not in only
+
+
+def test_comma_separated(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ONLY_PLATFORMS", "api_server, telegram")
+    assert _only_platforms_filter() == {"api_server", "telegram"}

--- a/tests/gateway/test_profile_command.py
+++ b/tests/gateway/test_profile_command.py
@@ -1,0 +1,78 @@
+"""/profile command: list profiles + persisted per-chat binding (salvaged from #24914)."""
+
+from gateway.chat_bindings import ChatBindings, chat_binding_key
+from gateway.session import SessionSource
+from gateway.platforms.base import Platform
+
+
+def _src(chat_id="100", thread_id=None):
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, thread_id=thread_id, chat_type="group", user_id="u1")
+
+
+def test_binding_key_is_stable_and_distinct():
+    a = chat_binding_key(_src("100"))
+    assert chat_binding_key(_src("100")) == a
+    assert chat_binding_key(_src("200")) != a
+    assert chat_binding_key(_src("100", thread_id="t1")) != a
+
+
+def test_set_get_persists_across_instances(tmp_path):
+    path = tmp_path / "chat_bindings.json"
+    key = chat_binding_key(_src())
+    ChatBindings(path).set(key, "coder")
+    assert ChatBindings(path).get(key) == "coder"  # fresh instance reads from disk
+
+
+def test_clear_removes_binding(tmp_path):
+    path = tmp_path / "chat_bindings.json"
+    key = chat_binding_key(_src())
+    b = ChatBindings(path)
+    b.set(key, "coder")
+    b.clear(key)
+    assert b.get(key) is None
+
+
+def test_missing_file_is_empty(tmp_path):
+    assert ChatBindings(tmp_path / "nope.json").get("any") is None
+
+
+import pytest
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+def _runner(tmp_path):
+    r = object.__new__(gateway_run.GatewayRunner)
+    r.config = GatewayConfig(sessions_dir=str(tmp_path))
+    r._chat_bindings_store = None
+    return r
+
+
+def _cmd_event(text):
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=_src())
+
+
+@pytest.mark.asyncio
+async def test_profile_bind_persists_and_routes(tmp_path, monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda n: True)
+    monkeypatch.setattr(gateway_run, "t", lambda *a, **k: "", raising=False)
+    r = _runner(tmp_path)
+    reply = await r._handle_profile_command(_cmd_event("/profile coder"))
+    assert "coder" in reply
+    # Persisted: a fresh binding store sees it.
+    from gateway.chat_bindings import ChatBindings, chat_binding_key
+
+    assert ChatBindings(tmp_path / "chat_bindings.json").get(chat_binding_key(_src())) == "coder"
+
+
+@pytest.mark.asyncio
+async def test_profile_unknown_name_is_rejected(tmp_path, monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda n: False)
+    r = _runner(tmp_path)
+    reply = await r._handle_profile_command(_cmd_event("/profile ghost"))
+    assert "No such profile" in reply

--- a/tests/gateway/test_profile_rate_limit.py
+++ b/tests/gateway/test_profile_rate_limit.py
@@ -68,3 +68,26 @@ async def test_throttled_profile_is_not_dispatched():
     assert await r._maybe_dispatch_routed(ev, ev.source) is True  # 2nd: throttled
     r._dispatch_to_worker.assert_awaited_once()  # still once — not dispatched again
     assert "busy" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_control_commands_bypass_rate_limit():
+    """/reset must not be throttled — it carries no model cost and stranding a
+    stuck conversation behind the bucket would be the worst time to throttle."""
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    r = object.__new__(gateway_run.GatewayRunner)
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r.adapters = {Platform.TELEGRAM: adapter}
+    r._profile_rate_limiter = ProfileRateLimiter(capacity=0, refill_per_sec=0)  # everything throttled
+    r._reset_routed_worker = AsyncMock()
+    r._dispatch_to_worker = AsyncMock()
+
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+    ev = MessageEvent(text="/reset", message_type=MessageType.TEXT, source=src)
+    ev.routed_profile = "coder"
+
+    assert await r._maybe_dispatch_routed(ev, src) is True
+    r._reset_routed_worker.assert_awaited_once()  # reset ran despite an exhausted bucket
+    assert all("busy" not in c.args[1] for c in adapter.send.await_args_list)

--- a/tests/gateway/test_profile_rate_limit.py
+++ b/tests/gateway/test_profile_rate_limit.py
@@ -1,0 +1,70 @@
+"""Per-profile token bucket: a chatty profile can't starve the others."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.rate_limit import TokenBucket, ProfileRateLimiter
+from gateway.session import SessionSource
+from gateway.config import Platform
+
+
+class Clock:
+    def __init__(self):
+        self.t = 0.0
+
+    def __call__(self):
+        return self.t
+
+
+def test_bucket_allows_up_to_capacity_then_throttles():
+    clk = Clock()
+    bucket = TokenBucket(capacity=3, refill_per_sec=1, clock=clk)
+    assert [bucket.allow() for _ in range(3)] == [True, True, True]
+    assert bucket.allow() is False
+
+
+def test_bucket_refills_over_time():
+    clk = Clock()
+    bucket = TokenBucket(capacity=2, refill_per_sec=1, clock=clk)
+    assert bucket.allow() and bucket.allow()
+    assert bucket.allow() is False
+    clk.t += 1.0
+    assert bucket.allow() is True
+
+
+def test_capacity_is_not_exceeded_by_refill():
+    clk = Clock()
+    bucket = TokenBucket(capacity=2, refill_per_sec=10, clock=clk)
+    clk.t += 100
+    assert [bucket.allow() for _ in range(3)] == [True, True, False]
+
+
+def test_per_profile_isolation():
+    clk = Clock()
+    limiter = ProfileRateLimiter(capacity=2, refill_per_sec=1, clock=clk)
+    assert limiter.allow("a") and limiter.allow("a")
+    assert limiter.allow("a") is False  # A exhausted
+    assert limiter.allow("b") is True  # B has its own budget
+    assert limiter.allow("b") is True
+
+
+@pytest.mark.asyncio
+async def test_throttled_profile_is_not_dispatched():
+    r = object.__new__(gateway_run.GatewayRunner)
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r.adapters = {Platform.TELEGRAM: adapter}
+    r._profile_rate_limiter = ProfileRateLimiter(capacity=1, refill_per_sec=0)
+    r._dispatch_to_worker = AsyncMock()
+
+    ev = MagicMock()
+    ev.routed_profile = "coder"
+    ev.source = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+
+    assert await r._maybe_dispatch_routed(ev, ev.source) is True  # 1st: allowed
+    r._dispatch_to_worker.assert_awaited_once()
+    assert await r._maybe_dispatch_routed(ev, ev.source) is True  # 2nd: throttled
+    r._dispatch_to_worker.assert_awaited_once()  # still once — not dispatched again
+    assert "busy" in adapter.send.await_args.args[1]

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -1,0 +1,72 @@
+"""Platform-agnostic profile routing table — resolve_profile_route."""
+
+from gateway.routing import resolve_profile_route
+from gateway.session import SessionSource
+from gateway.platforms.base import Platform
+
+
+def _src(**kw):
+    base = dict(platform=Platform.DISCORD, chat_id="c1", chat_type="channel")
+    base.update(kw)
+    return SessionSource(**base)
+
+
+def test_empty_table_returns_none():
+    assert resolve_profile_route(None, _src()) is None
+    assert resolve_profile_route({"routes": []}, _src()) is None
+
+
+def test_exact_thread_wins_over_channel():
+    table = {"routes": [
+        {"platform": "discord", "channel_id": "c1", "profile": "chan"},
+        {"platform": "discord", "channel_id": "c1", "thread_id": "t9", "profile": "thread"},
+    ]}
+    assert resolve_profile_route(table, _src(thread_id="t9")) == "thread"
+
+
+def test_thread_inherits_parent_channel():
+    table = {"routes": [{"platform": "discord", "channel_id": "c1", "profile": "chan"}]}
+    s = _src(chat_id="t5", thread_id="t5", parent_chat_id="c1")
+    assert resolve_profile_route(table, s) == "chan"
+
+
+def test_guild_then_platform_fallback():
+    table = {"routes": [
+        {"platform": "discord", "guild_id": "g1", "profile": "guild"},
+        {"platform": "slack", "profile": "work"},
+    ]}
+    assert resolve_profile_route(table, _src(guild_id="g1")) == "guild"
+    assert resolve_profile_route(table, _src(platform=Platform.SLACK)) == "work"
+
+
+def test_channel_beats_guild():
+    table = {"routes": [
+        {"platform": "discord", "guild_id": "g1", "profile": "guild"},
+        {"platform": "discord", "channel_id": "c1", "profile": "chan"},
+    ]}
+    assert resolve_profile_route(table, _src(guild_id="g1")) == "chan"
+
+
+def test_user_id_route():
+    table = {"routes": [{"user_id": "42100", "profile": "admin"}]}
+    assert resolve_profile_route(table, _src(user_id="42100")) == "admin"
+
+
+def test_user_id_alt_matches():
+    table = {"routes": [{"user_id": "uuid-9", "profile": "admin"}]}
+    assert resolve_profile_route(table, _src(user_id="raw", user_id_alt="uuid-9")) == "admin"
+
+
+def test_no_match_returns_none():
+    table = {"routes": [{"platform": "telegram", "profile": "x"}]}
+    assert resolve_profile_route(table, _src()) is None
+
+
+def test_default_used_when_no_route_matches():
+    table = {"default": "fallback", "routes": [{"platform": "telegram", "profile": "x"}]}
+    assert resolve_profile_route(table, _src()) == "fallback"
+
+
+def test_non_dict_routes_ignored():
+    table = {"routes": ["bogus", {"platform": "discord", "channel_id": "c1", "profile": "chan"}]}
+    assert resolve_profile_route(table, _src()) == "chan"

--- a/tests/gateway/test_profile_routing_config.py
+++ b/tests/gateway/test_profile_routing_config.py
@@ -1,0 +1,71 @@
+"""Load + fail-closed validation of gateway.profile_routing."""
+
+import pytest
+
+from gateway.config import load_gateway_config
+
+
+def _write(tmp_path, yaml_text):
+    (tmp_path / "config.yaml").write_text(yaml_text)
+
+
+def _mk_profile(tmp_path, name):
+    (tmp_path / "profiles" / name).mkdir(parents=True, exist_ok=True)
+
+
+def test_no_profile_routing_is_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write(tmp_path, "telegram:\n  channel_models: {}\n")
+    assert load_gateway_config().profile_routing is None
+
+
+def test_valid_route_loads(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _mk_profile(tmp_path, "research")
+    _write(tmp_path, """
+gateway:
+  profile_routing:
+    routes:
+      - { platform: telegram, chat_id: "-100", thread_id: 42, profile: research }
+""")
+    cfg = load_gateway_config()
+    assert cfg.profile_routing["routes"][0]["profile"] == "research"
+
+
+def test_unknown_profile_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write(tmp_path, """
+gateway:
+  profile_routing:
+    routes:
+      - { platform: telegram, profile: ghost }
+""")
+    with pytest.raises(ValueError, match="ghost"):
+        load_gateway_config()
+
+
+def test_duplicate_exact_match_routes_raise(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _mk_profile(tmp_path, "a")
+    _mk_profile(tmp_path, "b")
+    _write(tmp_path, """
+gateway:
+  profile_routing:
+    routes:
+      - { platform: discord, channel_id: "c1", profile: a }
+      - { platform: discord, channel_id: "c1", profile: b }
+""")
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        load_gateway_config()
+
+
+def test_invalid_profile_name_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write(tmp_path, """
+gateway:
+  profile_routing:
+    routes:
+      - { platform: telegram, profile: "Bad Name!" }
+""")
+    with pytest.raises(ValueError):
+        load_gateway_config()

--- a/tests/gateway/test_response_media_outbound.py
+++ b/tests/gateway/test_response_media_outbound.py
@@ -1,0 +1,89 @@
+"""Outbound media: worker mints refs from MEDIA: tags; front relays + uploads."""
+
+import pytest
+
+from gateway.media_spool import MediaSpool, mint_outbound, kind_for
+from gateway.worker_client import WorkerClient
+
+
+def test_kind_classification():
+    assert kind_for("/x/a.png", False) == "image"
+    assert kind_for("/x/a.ogg", True) == "voice"
+    assert kind_for("/x/a.mp4", False) == "video"
+    assert kind_for("/x/a.pdf", False) == "document"
+
+
+def test_mint_outbound_produces_resolvable_refs(tmp_path):
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"IMG")
+    spool = MediaSpool(tmp_path / "spool")
+    refs = mint_outbound(spool, [(str(img), False)])
+    assert len(refs) == 1
+    assert refs[0]["kind"] == "image"
+    assert spool.resolve(refs[0]["ref"]) == b"IMG"
+
+
+def test_mint_outbound_marks_voice(tmp_path):
+    voice = tmp_path / "v.ogg"
+    voice.write_bytes(b"OGG")
+    spool = MediaSpool(tmp_path / "spool")
+    refs = mint_outbound(spool, [(str(voice), True)])
+    assert refs[0]["is_voice"] is True
+    assert refs[0]["kind"] == "voice"
+
+
+@pytest.mark.asyncio
+async def test_client_relays_response_media_to_handler():
+    handled = []
+
+    async def media_handler(event):
+        handled.append(event["media"])
+
+    events = [
+        {"event": "response.media", "media": [{"ref": "r1", "kind": "image", "filename": "a.png", "mime": "image/png", "size": 3}]},
+        {"event": "run.completed", "output": "see image", "usage": {}},
+    ]
+
+    async def fake_post(url, body):
+        return {"run_id": "run_1"}
+
+    async def fake_sse(url):
+        for e in events:
+            yield e
+
+    client = WorkerClient("http://127.0.0.1:5000", "k", post=fake_post, sse=fake_sse)
+
+    class C:
+        def on_delta(self, t): ...
+
+    result = await client.dispatch(input="x", consumer=C(), media_handler=media_handler)
+    assert handled == [events[0]["media"]]
+    assert result["output"] == "see image"
+
+
+@pytest.mark.asyncio
+async def test_front_delivers_media_via_send_methods(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+    from unittest.mock import AsyncMock, MagicMock
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    monkeypatch.setenv("HERMES_MEDIA_SPOOL", str(tmp_path / "spool"))
+    # Worker mints an image + a voice file into the shared spool.
+    from gateway.media_spool import MediaSpool, mint_outbound, default_spool_root
+
+    (tmp_path / "img.png").write_bytes(b"IMG")
+    (tmp_path / "v.ogg").write_bytes(b"OGG")
+    refs = mint_outbound(MediaSpool(default_spool_root()), [(str(tmp_path / "img.png"), False), (str(tmp_path / "v.ogg"), True)])
+
+    adapter = MagicMock()
+    adapter.send_multiple_images = AsyncMock()
+    adapter.send_voice = AsyncMock()
+    r = object.__new__(gateway_run.GatewayRunner)
+    r.adapters = {Platform.TELEGRAM: adapter}
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+
+    await r._deliver_worker_media(MagicMock(), src, {"media": refs})
+
+    adapter.send_voice.assert_awaited_once()
+    adapter.send_multiple_images.assert_awaited_once()

--- a/tests/gateway/test_routed_dispatch.py
+++ b/tests/gateway/test_routed_dispatch.py
@@ -25,6 +25,7 @@ def _event(profile=None, text="hi"):
     ev.source = src
     ev.routed_profile = profile
     ev.channel_prompt = None
+    ev.media_urls = []
     return ev, src
 
 

--- a/tests/gateway/test_routed_dispatch.py
+++ b/tests/gateway/test_routed_dispatch.py
@@ -83,3 +83,72 @@ async def test_dispatch_uses_profile_prefixed_session_key():
     r._worker_pool.acquire.assert_awaited_once_with("research")
     assert client.dispatch.await_args.kwargs["session_id"].startswith("agent:research:")
     adapter.send.assert_awaited()  # final output delivered
+
+
+@pytest.mark.asyncio
+async def test_dispatch_requests_continuity_and_supplies_approval_handler():
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r = _runner(adapter)
+    r._reply_anchor_for_event = MagicMock(return_value=None)
+
+    fake_worker = MagicMock(base_url="http://127.0.0.1:5001", key="k")
+    r._worker_pool = MagicMock()
+    r._worker_pool.acquire = AsyncMock(return_value=fake_worker)
+    client = MagicMock()
+    client.dispatch = AsyncMock(return_value={"output": "done"})
+    r._make_worker_client = MagicMock(return_value=client)
+
+    ev, src = _event(profile="research")
+    await r._dispatch_to_worker(ev, src, "research")
+
+    kw = client.dispatch.await_args.kwargs
+    assert kw["continue_session"] is True  # routed turns keep memory across turns
+    assert kw["approval_handler"] is not None  # approvals are handled (fail-closed), not dropped
+
+
+@pytest.mark.asyncio
+async def test_routed_approval_is_denied_with_visible_notice():
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r = _runner(adapter)
+    r._reply_anchor_for_event = MagicMock(return_value=None)
+
+    fake_worker = MagicMock(base_url="http://127.0.0.1:5001", key="k")
+    r._worker_pool = MagicMock()
+    r._worker_pool.acquire = AsyncMock(return_value=fake_worker)
+
+    captured = {}
+
+    async def dispatch(**kwargs):
+        captured["choice"] = await kwargs["approval_handler"]({"tool": "shell"})
+        return {"output": "done"}
+
+    client = MagicMock()
+    client.dispatch = AsyncMock(side_effect=dispatch)
+    r._make_worker_client = MagicMock(return_value=client)
+
+    ev, src = _event(profile="research")
+    await r._dispatch_to_worker(ev, src, "research")
+
+    assert captured["choice"] == "deny"
+    assert any("approval" in c.args[1].lower() for c in adapter.send.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_maintain_worker_pool_reaps_and_sweeps():
+    r = _runner()
+    pool = MagicMock()
+    pool.reap_exited = AsyncMock()
+    pool.sweep_idle = AsyncMock()
+    r._worker_pool = pool
+    await r._maintain_worker_pool()
+    pool.reap_exited.assert_awaited_once()
+    pool.sweep_idle.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_maintain_worker_pool_noop_without_pool():
+    r = _runner()
+    r._worker_pool = None
+    await r._maintain_worker_pool()  # must not raise

--- a/tests/gateway/test_routed_dispatch.py
+++ b/tests/gateway/test_routed_dispatch.py
@@ -1,0 +1,84 @@
+"""Routing seam: routed messages dispatch to a worker, unrouted stay in-process,
+and a dispatch failure is fail-closed (visible error, never silent host fallback)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _runner(adapter=None):
+    r = object.__new__(gateway_run.GatewayRunner)
+    r.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig()})
+    r._worker_pool = None
+    r.adapters = {Platform.TELEGRAM: adapter} if adapter else {}
+    return r
+
+
+def _event(profile=None, text="hi"):
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+    ev = MagicMock()
+    ev.text = text
+    ev.source = src
+    ev.routed_profile = profile
+    ev.channel_prompt = None
+    return ev, src
+
+
+@pytest.mark.asyncio
+async def test_unrouted_returns_false():
+    r = _runner()
+    r._dispatch_to_worker = AsyncMock()
+    ev, src = _event(profile=None)
+    assert await r._maybe_dispatch_routed(ev, src) is False
+    r._dispatch_to_worker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_routed_dispatches_and_handles():
+    r = _runner()
+    r._dispatch_to_worker = AsyncMock()
+    ev, src = _event(profile="coder")
+    assert await r._maybe_dispatch_routed(ev, src) is True
+    r._dispatch_to_worker.assert_awaited_once()
+    assert r._dispatch_to_worker.await_args.args[2] == "coder"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_is_fail_closed():
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r = _runner(adapter)
+    r._reply_anchor_for_event = MagicMock(return_value=None)
+    r._dispatch_to_worker = AsyncMock(side_effect=RuntimeError("worker down"))
+    ev, src = _event(profile="coder")
+    # Handled (returns True) so the caller never falls through to the host handler.
+    assert await r._maybe_dispatch_routed(ev, src) is True
+    adapter.send.assert_awaited()  # a visible error went to the user
+    assert "coder" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_profile_prefixed_session_key():
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r = _runner(adapter)
+    r._reply_anchor_for_event = MagicMock(return_value=None)
+
+    fake_worker = MagicMock(base_url="http://127.0.0.1:5001", key="k")
+    r._worker_pool = MagicMock()
+    r._worker_pool.acquire = AsyncMock(return_value=fake_worker)
+
+    client = MagicMock()
+    client.dispatch = AsyncMock(return_value={"output": "done"})
+    r._make_worker_client = MagicMock(return_value=client)
+
+    ev, src = _event(profile="research")
+    await r._dispatch_to_worker(ev, src, "research")
+
+    r._worker_pool.acquire.assert_awaited_once_with("research")
+    assert client.dispatch.await_args.kwargs["session_id"].startswith("agent:research:")
+    adapter.send.assert_awaited()  # final output delivered

--- a/tests/gateway/test_routed_dm_and_thread_rules.py
+++ b/tests/gateway/test_routed_dm_and_thread_rules.py
@@ -1,0 +1,42 @@
+"""Regression guards: per-peer DM isolation + thread→parent-channel routing,
+both under Tier-2 routing so they can't silently regress."""
+
+from gateway.routing import resolve_profile_route
+from gateway.session import build_session_key, SessionSource
+from gateway.platforms.base import Platform
+
+
+def _dm(chat_id):
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm", user_id=chat_id)
+
+
+def test_distinct_dm_peers_get_distinct_keys_under_same_profile():
+    a = build_session_key(_dm("111"), profile="support")
+    b = build_session_key(_dm("222"), profile="support")
+    assert a != b
+    assert a.startswith("agent:support:") and b.startswith("agent:support:")
+
+
+def test_thread_without_own_route_inherits_parent_channel_profile():
+    table = {"routes": [{"platform": "discord", "channel_id": "chan1", "profile": "support"}]}
+    # A message in thread t77 whose parent channel is chan1, with no thread route.
+    thread_src = SessionSource(
+        platform=Platform.DISCORD, chat_id="t77", thread_id="t77",
+        parent_chat_id="chan1", chat_type="channel",
+    )
+    profile = resolve_profile_route(table, thread_src)
+    assert profile == "support"
+    # And the folded session key carries that inherited profile.
+    assert build_session_key(thread_src, profile=profile).startswith("agent:support:")
+
+
+def test_explicit_thread_route_still_beats_parent():
+    table = {"routes": [
+        {"platform": "discord", "channel_id": "chan1", "profile": "support"},
+        {"platform": "discord", "channel_id": "chan1", "thread_id": "t77", "profile": "vip"},
+    ]}
+    thread_src = SessionSource(
+        platform=Platform.DISCORD, chat_id="t77", thread_id="t77",
+        parent_chat_id="chan1", chat_type="channel",
+    )
+    assert resolve_profile_route(table, thread_src) == "vip"

--- a/tests/gateway/test_routed_reset_scope.py
+++ b/tests/gateway/test_routed_reset_scope.py
@@ -1,0 +1,59 @@
+"""A /reset in a routed context clears the worker's session, never the host's."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _runner():
+    r = object.__new__(gateway_run.GatewayRunner)
+    r.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig()})
+    r._worker_pool = MagicMock()
+    r._worker_pool.acquire = AsyncMock(return_value=MagicMock(base_url="http://127.0.0.1:5001", key="k"))
+    r._profile_rate_limiter = None
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    r.adapters = {Platform.TELEGRAM: adapter}
+    r.session_store = MagicMock()  # host store — must NOT be touched
+    r._reply_anchor_for_event = MagicMock(return_value=None)
+    return r, adapter
+
+
+def _reset_event(text="/reset"):
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="100", thread_id="t1", chat_type="group", user_id="u1")
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    ev = MessageEvent(text=text, message_type=MessageType.TEXT, source=src)
+    ev.routed_profile = "coder"
+    return ev, src
+
+
+@pytest.mark.asyncio
+async def test_reset_forwards_to_worker_with_profile_key():
+    r, adapter = _runner()
+    client = MagicMock()
+    client.reset_session = AsyncMock()
+    r._make_worker_client = MagicMock(return_value=client)
+
+    ev, src = _reset_event()
+    assert await r._maybe_dispatch_routed(ev, src) is True
+
+    client.reset_session.assert_awaited_once()
+    assert client.reset_session.await_args.args[0].startswith("agent:coder:")
+    r.session_store.reset_session.assert_not_called()  # host untouched
+    adapter.send.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plain_message_does_not_reset():
+    r, _ = _runner()
+    r._dispatch_to_worker = AsyncMock()
+    r._reset_routed_worker = AsyncMock()
+    ev, src = _reset_event(text="just chatting")
+    await r._maybe_dispatch_routed(ev, src)
+    r._reset_routed_worker.assert_not_awaited()
+    r._dispatch_to_worker.assert_awaited_once()

--- a/tests/gateway/test_routed_worker_live.py
+++ b/tests/gateway/test_routed_worker_live.py
@@ -1,0 +1,136 @@
+"""End-to-end front<->worker transport over a real loopback socket.
+
+Unit tests inject the worker HTTP transport.  These wire the real
+``WorkerClient`` (its own aiohttp client) to a real ``APIServerAdapter`` running
+on an aiohttp ``TestServer`` (a real listening socket), with only the agent's
+model turn stubbed.  This exercises the actual ``POST /v1/runs`` ->
+``message.delta``/``response.media``/``run.completed`` SSE relay,
+``continue_session`` history rehydration, and reset, over the wire.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.worker_client import WorkerClient
+
+
+def _app(adapter):
+    from aiohttp import web
+
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
+    return app
+
+
+def _fake_agent(reply, captured_history=None):
+    agent = MagicMock()
+
+    def _run(user_message=None, conversation_history=None, task_id=None, **kw):
+        if captured_history is not None:
+            captured_history.append(list(conversation_history or []))
+        return {"final_response": reply}
+
+    agent.run_conversation.side_effect = _run
+    agent.session_prompt_tokens = agent.session_completion_tokens = agent.session_total_tokens = 0
+    return agent
+
+
+class _Collect:
+    def __init__(self):
+        self.deltas = []
+
+    def on_delta(self, t):
+        self.deltas.append(t)
+
+
+@pytest.fixture
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MEDIA_SPOOL", str(tmp_path / "spool"))
+
+
+@pytest.mark.asyncio
+async def test_real_socket_dispatch_roundtrip(_isolated_home):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "k"}))
+    server = TestServer(_app(adapter))
+    await server.start_server()
+    try:
+        client = WorkerClient(f"http://127.0.0.1:{server.port}", "k")
+        with patch.object(adapter, "_create_agent", return_value=_fake_agent("hi from worker")):
+            result = await client.dispatch(input="hello", consumer=_Collect())
+        assert result["output"] == "hi from worker"
+    finally:
+        await server.close()
+
+
+@pytest.mark.asyncio
+async def test_real_socket_continue_session_rehydrates(_isolated_home):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "k"}))
+    db = adapter._ensure_session_db()
+    sid = "agent:coder:telegram:dm:42"
+    db.create_session(sid, "test")
+    db.append_message(sid, "user", "remember the number 7")
+    db.append_message(sid, "assistant", "noted")
+
+    captured = []
+    server = TestServer(_app(adapter))
+    await server.start_server()
+    try:
+        client = WorkerClient(f"http://127.0.0.1:{server.port}", "k")
+        with patch.object(adapter, "_create_agent", return_value=_fake_agent("ok", captured)):
+            await client.dispatch(
+                input="what number?", consumer=_Collect(),
+                session_id=sid, continue_session=True,
+            )
+        # The worker rehydrated its own transcript from state.db and handed it
+        # to the agent — the prior turn is present.
+        assert captured and any(
+            "remember the number 7" in str(m.get("content", "")) for m in captured[0]
+        )
+    finally:
+        await server.close()
+
+
+@pytest.mark.asyncio
+async def test_real_socket_outbound_media_emitted(_isolated_home, tmp_path):
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n fake")
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "k"}))
+    server = TestServer(_app(adapter))
+    await server.start_server()
+    try:
+        client = WorkerClient(f"http://127.0.0.1:{server.port}", "k")
+        seen = []
+
+        async def media_handler(ev):
+            seen.append(ev)
+
+        with patch.object(adapter, "_create_agent", return_value=_fake_agent(f"here you go MEDIA:{img}")):
+            result = await client.dispatch(input="send pic", consumer=_Collect(), media_handler=media_handler)
+        # The MEDIA: tag was minted to a ref and emitted as response.media; the
+        # delivered text is tag-free.
+        assert seen and seen[0]["media"] and "ref" in seen[0]["media"][0]
+        assert "MEDIA:" not in result["output"]
+    finally:
+        await server.close()
+
+
+@pytest.mark.asyncio
+async def test_real_socket_reset_unknown_session_is_idempotent(_isolated_home):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "k"}))
+    server = TestServer(_app(adapter))
+    await server.start_server()
+    try:
+        client = WorkerClient(f"http://127.0.0.1:{server.port}", "k")
+        # No such session yet -> worker returns 404 -> reset is a no-op, not an error.
+        await client.reset_session("agent:coder:telegram:dm:never")
+    finally:
+        await server.close()

--- a/tests/gateway/test_session_key_profile.py
+++ b/tests/gateway/test_session_key_profile.py
@@ -1,0 +1,31 @@
+"""build_session_key profile prefix — default 'main' keeps byte-identical keys."""
+
+from gateway.session import build_session_key, SessionSource
+from gateway.platforms.base import Platform
+
+
+def test_default_profile_keys_unchanged():
+    s = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+    assert build_session_key(s).startswith("agent:main:")
+
+
+def test_dm_default_unchanged():
+    s = SessionSource(platform=Platform.TELEGRAM, chat_id="55", chat_type="dm")
+    assert build_session_key(s) == "agent:main:telegram:dm:55"
+
+
+def test_named_profile_prefix_group():
+    s = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+    assert build_session_key(s, profile="research").startswith("agent:research:")
+
+
+def test_named_profile_prefix_dm():
+    s = SessionSource(platform=Platform.TELEGRAM, chat_id="55", chat_type="dm")
+    assert build_session_key(s, profile="research") == "agent:research:telegram:dm:55"
+
+
+def test_named_profile_only_changes_prefix():
+    s = SessionSource(platform=Platform.TELEGRAM, chat_id="100", chat_type="group", user_id="u1")
+    main = build_session_key(s)
+    named = build_session_key(s, profile="coder")
+    assert named == main.replace("agent:main:", "agent:coder:", 1)

--- a/tests/gateway/test_telegram_dm_topic_prompt.py
+++ b/tests/gateway/test_telegram_dm_topic_prompt.py
@@ -1,0 +1,47 @@
+"""Per-topic system_prompt overlay (#5195) must apply to dm_topics AND group_topics.
+
+The prompt is nested under the topic config (scoped by chat_id), so it surfaces
+on event.channel_prompt for both DM topics and group forum topics.
+"""
+
+from gateway.platforms.base import MessageType
+from tests.gateway.test_dm_topics import _make_adapter, _make_mock_message
+from telegram.constants import ChatType as _ChatType
+
+
+def test_dm_topic_system_prompt_sets_channel_prompt():
+    adapter = _make_adapter([
+        {
+            "chat_id": 111,
+            "topics": [
+                {"name": "Research", "thread_id": 100, "system_prompt": "You are a researcher."},
+            ],
+        }
+    ])
+    adapter._dm_topics["111:Research"] = 100
+
+    event = adapter._build_message_event(_make_mock_message(chat_id=111, thread_id=100), MessageType.TEXT)
+    assert event.channel_prompt == "You are a researcher."
+
+
+def test_group_topic_system_prompt_sets_channel_prompt():
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "Eng", "thread_id": 5, "system_prompt": "Speak like an engineer."},
+            ],
+        }
+    ])
+    msg = _make_mock_message(chat_id=-1001234567890, chat_type=_ChatType.SUPERGROUP, thread_id=5, is_topic_message=True, is_forum=True)
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+    assert event.channel_prompt == "Speak like an engineer."
+
+
+def test_dm_topic_without_prompt_is_none():
+    adapter = _make_adapter([
+        {"chat_id": 111, "topics": [{"name": "General", "thread_id": 200}]},
+    ])
+    adapter._dm_topics["111:General"] = 200
+    event = adapter._build_message_event(_make_mock_message(chat_id=111, thread_id=200), MessageType.TEXT)
+    assert event.channel_prompt is None

--- a/tests/gateway/test_telegram_topic_overlay.py
+++ b/tests/gateway/test_telegram_topic_overlay.py
@@ -1,0 +1,82 @@
+"""Telegram group_topics resolves per-topic skill AND model overlay.
+
+The model is nested under group_topics (scoped by chat_id) to avoid cross-group
+thread_id collisions, then surfaced on the event as channel_model and applied in
+runtime resolution.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+from tests.gateway.test_dm_topics import _make_adapter, _make_mock_message
+from telegram.constants import ChatType as _ChatType
+
+
+def test_group_topic_model_set_on_event():
+    """A group_topics entry with a model surfaces channel_model on the event."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "Engineering", "thread_id": 5, "skill": "software-development", "model": "anthropic/claude-opus-4-8"},
+                {"name": "Sales", "thread_id": 12},
+            ],
+        }
+    ])
+
+    eng = adapter._build_message_event(
+        _make_mock_message(chat_id=-1001234567890, chat_type=_ChatType.SUPERGROUP, thread_id=5, text="hi", is_topic_message=True, is_forum=True),
+        MessageType.TEXT,
+    )
+    assert eng.channel_model == "anthropic/claude-opus-4-8"
+    assert eng.auto_skill == "software-development"
+
+    sales = adapter._build_message_event(
+        _make_mock_message(chat_id=-1001234567890, chat_type=_ChatType.SUPERGROUP, thread_id=12, text="hi", is_topic_message=True, is_forum=True),
+        MessageType.TEXT,
+    )
+    assert sales.channel_model is None
+
+
+def test_group_topic_model_resolves_via_runtime(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *_: "config/default")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", dict)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig()})
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-100", thread_id="42", chat_type="group", user_id="u1")
+
+    model, _ = runner._resolve_session_agent_runtime(
+        source=source, user_config={}, channel_model="anthropic/claude-opus-4-8"
+    )
+    assert model == "anthropic/claude-opus-4-8"
+
+
+def test_topic_model_loses_to_session_override(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *_: "config/default")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", dict)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig()})
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-100", thread_id="42", chat_type="group", user_id="u1")
+    key = runner._session_key_for_source(source)
+    runner._session_model_overrides[key] = {
+        "model": "openai/gpt-5",
+        "provider": "openai",
+        "api_key": "***",
+        "base_url": None,
+        "api_mode": None,
+    }
+    model, _ = runner._resolve_session_agent_runtime(
+        source=source, user_config={}, channel_model="anthropic/claude-opus-4-8"
+    )
+    assert model == "openai/gpt-5"

--- a/tests/gateway/test_worker_arg_builder.py
+++ b/tests/gateway/test_worker_arg_builder.py
@@ -1,0 +1,19 @@
+"""Worker arg builder: tokenless api_server, never --replace."""
+
+from hermes_cli.gateway import _worker_run_args_for_profile
+
+
+def test_argv_has_profile_run_no_replace():
+    argv, _ = _worker_run_args_for_profile("research", 51234, "k" * 64)
+    assert "--profile" in argv and argv[argv.index("--profile") + 1] == "research"
+    assert argv[-2:] == ["gateway", "run"]
+    assert "--replace" not in argv
+
+
+def test_env_pins_loopback_api_server():
+    _, env = _worker_run_args_for_profile("research", 51234, "secret-key")
+    assert env["HERMES_GATEWAY_ONLY_PLATFORMS"] == "api_server"
+    assert env["API_SERVER_ENABLED"] == "true"
+    assert env["API_SERVER_HOST"] == "127.0.0.1"
+    assert env["API_SERVER_PORT"] == "51234"
+    assert env["API_SERVER_KEY"] == "secret-key"

--- a/tests/gateway/test_worker_client.py
+++ b/tests/gateway/test_worker_client.py
@@ -1,0 +1,66 @@
+"""WorkerClient: POST /v1/runs, relay SSE deltas + approval round-trip."""
+
+import pytest
+
+from gateway.worker_client import WorkerClient, WorkerRunError
+
+
+class StubConsumer:
+    def __init__(self):
+        self.deltas = []
+
+    def on_delta(self, text):
+        self.deltas.append(text)
+
+
+def _client(events, *, posts):
+    """Build a client whose SSE yields *events* and records POSTs into *posts*."""
+
+    async def fake_post(url, body):
+        posts.append((url, body))
+        return {"run_id": "run_1"} if url.endswith("/v1/runs") else {}
+
+    async def fake_sse(url):
+        for ev in events:
+            yield ev
+
+    return WorkerClient("http://127.0.0.1:5000", "key", post=fake_post, sse=fake_sse)
+
+
+@pytest.mark.asyncio
+async def test_deltas_forwarded_and_completes():
+    posts = []
+    events = [
+        {"event": "message.delta", "delta": "Hello "},
+        {"event": "message.delta", "delta": "world"},
+        {"event": "run.completed", "output": "Hello world", "usage": {}},
+    ]
+    consumer = StubConsumer()
+    result = await _client(events, posts=posts).dispatch(input="hi", consumer=consumer)
+    assert consumer.deltas == ["Hello ", "world"]
+    assert result["output"] == "Hello world"
+    assert posts[0][0].endswith("/v1/runs")
+
+
+@pytest.mark.asyncio
+async def test_approval_round_trip():
+    posts = []
+    events = [
+        {"event": "approval.request", "run_id": "run_1", "choices": ["once", "deny"]},
+        {"event": "run.completed", "output": "done", "usage": {}},
+    ]
+
+    async def approver(event):
+        assert "once" in event["choices"]
+        return "once"
+
+    await _client(events, posts=posts).dispatch(input="do it", consumer=StubConsumer(), approval_handler=approver)
+    approval_posts = [p for p in posts if p[0].endswith("/approval")]
+    assert approval_posts and approval_posts[0][1]["choice"] == "once"
+
+
+@pytest.mark.asyncio
+async def test_run_failed_raises():
+    events = [{"event": "run.failed", "error": "boom"}]
+    with pytest.raises(WorkerRunError, match="boom"):
+        await _client(events, posts=[]).dispatch(input="x", consumer=StubConsumer())

--- a/tests/gateway/test_worker_client.py
+++ b/tests/gateway/test_worker_client.py
@@ -64,3 +64,49 @@ async def test_run_failed_raises():
     events = [{"event": "run.failed", "error": "boom"}]
     with pytest.raises(WorkerRunError, match="boom"):
         await _client(events, posts=[]).dispatch(input="x", consumer=StubConsumer())
+
+
+@pytest.mark.asyncio
+async def test_continue_session_sets_body_flag():
+    posts = []
+    events = [{"event": "run.completed", "output": "ok", "usage": {}}]
+    await _client(events, posts=posts).dispatch(
+        input="hi", consumer=StubConsumer(), session_id="agent:coder:tg:dm:1", continue_session=True,
+    )
+    start_body = posts[0][1]
+    assert start_body["continue_session"] is True
+    assert start_body["session_id"] == "agent:coder:tg:dm:1"
+
+
+@pytest.mark.asyncio
+async def test_continue_session_omitted_when_no_session():
+    posts = []
+    events = [{"event": "run.completed", "output": "ok", "usage": {}}]
+    await _client(events, posts=posts).dispatch(
+        input="hi", consumer=StubConsumer(), continue_session=True,
+    )
+    assert "continue_session" not in posts[0][1]
+
+
+class _Status404(Exception):
+    status = 404
+
+
+@pytest.mark.asyncio
+async def test_reset_session_tolerates_404():
+    """/new before the first routed turn → no session yet → 404 is success."""
+    async def deleter(_url):
+        raise _Status404()
+
+    client = WorkerClient("http://127.0.0.1:5000", "key", delete=deleter)
+    await client.reset_session("agent:coder:tg:dm:1")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_reset_session_reraises_non_404():
+    async def deleter(_url):
+        raise RuntimeError("connection refused")
+
+    client = WorkerClient("http://127.0.0.1:5000", "key", delete=deleter)
+    with pytest.raises(RuntimeError, match="connection refused"):
+        await client.reset_session("agent:coder:tg:dm:1")

--- a/tests/gateway/test_worker_pool.py
+++ b/tests/gateway/test_worker_pool.py
@@ -1,0 +1,129 @@
+"""Front-owned worker pool: spawn/reuse, one-loop interlock, idle-evict, crash-respawn."""
+
+import pytest
+
+from gateway.worker_pool import WorkerPool, WorkerState, ProfileBusyError
+
+
+class FakeProc:
+    def __init__(self):
+        self._rc = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self._rc
+
+    def terminate(self):
+        self.terminated = True
+        self._rc = 0
+
+    def kill(self):
+        self.killed = True
+        self._rc = -9
+
+    def crash(self, rc=1):
+        self._rc = rc
+
+
+class Harness:
+    """Injectable deps with a controllable clock and spawn/probe stubs."""
+
+    def __init__(self, standalone_pid=None):
+        self.t = 1000.0
+        self.spawned = []
+        self.standalone_pid = standalone_pid
+
+    def clock(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+    def spawn(self, profile):
+        proc = FakeProc()
+        self.spawned.append((profile, proc))
+        return proc, 50000 + len(self.spawned), "key-" + profile
+
+    async def probe(self, worker):
+        return worker.proc.poll() is None  # healthy while running
+
+    def interlock(self, profile):
+        return self.standalone_pid
+
+    async def sleep(self, _):
+        return None
+
+    def make_pool(self, **kw):
+        return WorkerPool(
+            spawn=self.spawn, probe=self.probe, interlock=self.interlock,
+            clock=self.clock, sleep=self.sleep, **kw,
+        )
+
+
+@pytest.mark.asyncio
+async def test_acquire_spawns_then_reuses():
+    h = Harness()
+    pool = h.make_pool()
+    w1 = await pool.acquire("coder")
+    assert w1.state is WorkerState.SERVING
+    w2 = await pool.acquire("coder")
+    assert w1 is w2
+    assert len(h.spawned) == 1
+
+
+@pytest.mark.asyncio
+async def test_standalone_pid_refuses_spawn():
+    h = Harness(standalone_pid=4242)
+    pool = h.make_pool()
+    with pytest.raises(ProfileBusyError):
+        await pool.acquire("coder")
+    assert h.spawned == []
+
+
+@pytest.mark.asyncio
+async def test_idle_eviction_drains_and_reaps():
+    h = Harness()
+    pool = h.make_pool(idle_ttl=300)
+    w = await pool.acquire("coder")
+    h.advance(301)
+    await pool.sweep_idle()
+    assert w.state is WorkerState.REAPED
+    assert "coder" not in pool.workers
+    assert w.proc.terminated
+
+
+@pytest.mark.asyncio
+async def test_active_worker_not_evicted():
+    h = Harness()
+    pool = h.make_pool(idle_ttl=300)
+    await pool.acquire("coder")
+    h.advance(100)
+    await pool.sweep_idle()
+    assert pool.workers["coder"].state is WorkerState.SERVING
+
+
+@pytest.mark.asyncio
+async def test_crash_respawns_with_backoff():
+    h = Harness()
+    pool = h.make_pool()
+    w = await pool.acquire("coder")
+    w.proc.crash()
+    await pool.reap_exited()
+    # acquire again gets a fresh process
+    w2 = await pool.acquire("coder")
+    assert w2.proc is not w.proc
+    assert len(h.spawned) == 2
+
+
+@pytest.mark.asyncio
+async def test_circuit_break_after_five_crashes():
+    h = Harness()
+    pool = h.make_pool(crash_limit=5, crash_window=60)
+    for _ in range(5):
+        w = await pool.acquire("coder")
+        w.proc.crash()
+        await pool.reap_exited()
+        h.advance(1)
+    with pytest.raises(ProfileBusyError):
+        await pool.acquire("coder")

--- a/tests/gateway/test_worker_pool.py
+++ b/tests/gateway/test_worker_pool.py
@@ -127,3 +127,57 @@ async def test_circuit_break_after_five_crashes():
         h.advance(1)
     with pytest.raises(ProfileBusyError):
         await pool.acquire("coder")
+
+
+@pytest.mark.asyncio
+async def test_lazy_respawn_records_crash_without_reap():
+    """A worker that dies between messages is counted as a crash on the
+    on-demand respawn path — the breaker must trip without reap_exited ever
+    running (the live gateway respawns lazily, not via a sweep)."""
+    h = Harness()
+    pool = h.make_pool(crash_limit=3, crash_window=60)
+    for _ in range(3):
+        w = await pool.acquire("coder")
+        w.proc.crash()  # dies, but no reap_exited() call
+        h.advance(1)
+    with pytest.raises(ProfileBusyError):
+        await pool.acquire("coder")
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_recovers_after_cooldown():
+    h = Harness()
+    pool = h.make_pool(crash_limit=3, crash_window=60, broken_cooldown=120)
+    for _ in range(3):
+        w = await pool.acquire("coder")
+        w.proc.crash()
+        h.advance(1)
+    with pytest.raises(ProfileBusyError):
+        await pool.acquire("coder")
+    # After the cooldown elapses the breaker self-heals and a fresh spawn works.
+    h.advance(121)
+    w = await pool.acquire("coder")
+    assert w.state is WorkerState.SERVING
+
+
+@pytest.mark.asyncio
+async def test_shutdown_terminates_all_workers():
+    h = Harness()
+    pool = h.make_pool()
+    a = await pool.acquire("coder")
+    b = await pool.acquire("research")
+    await pool.shutdown()
+    assert a.proc.terminated and b.proc.terminated
+    assert pool.workers == {}
+
+
+@pytest.mark.asyncio
+async def test_acquire_after_shutdown_is_refused():
+    """Once shut down, the pool spawns nothing — a late acquire can't orphan a
+    child process by racing the shutdown snapshot."""
+    h = Harness()
+    pool = h.make_pool()
+    await pool.shutdown()
+    with pytest.raises(ProfileBusyError):
+        await pool.acquire("coder")
+    assert h.spawned == []

--- a/tests/gateway/test_worker_session_continuity.py
+++ b/tests/gateway/test_worker_session_continuity.py
@@ -1,0 +1,34 @@
+"""A routed worker rehydrates its own transcript so routed turns keep memory.
+
+The front sends only a ``session_id`` (it never holds the worker's history),
+so ``/v1/runs`` must load the transcript from its own state.db when the front
+opts in with ``continue_session`` — but stay stateless for every other client.
+"""
+
+from gateway.platforms.api_server import APIServerAdapter
+
+_resolve = APIServerAdapter._continue_session_id
+
+
+def test_loads_when_flagged_with_session_and_no_history():
+    body = {"continue_session": True, "session_id": "agent:coder:tg:dm:1"}
+    assert _resolve(body, [], None) == "agent:coder:tg:dm:1"
+
+
+def test_off_by_default_so_existing_clients_stay_stateless():
+    body = {"session_id": "agent:coder:tg:dm:1"}
+    assert _resolve(body, [], None) is None
+
+
+def test_explicit_history_takes_precedence():
+    body = {"continue_session": True, "session_id": "s"}
+    assert _resolve(body, [{"role": "user", "content": "hi"}], None) is None
+
+
+def test_previous_response_id_takes_precedence():
+    body = {"continue_session": True, "session_id": "s"}
+    assert _resolve(body, [], "resp_42") is None
+
+
+def test_no_session_id_means_nothing_to_resume():
+    assert _resolve({"continue_session": True}, [], None) is None


### PR DESCRIPTION
## Summary

A single bot token exposes exactly one Hermes profile today. Serving several isolated identities (SOUL, memory, skills, sessions, model) requires one process and one credential per profile, because the token is single-consumer (Telegram `getUpdates` allows one consumer; Discord is one gateway WS per token) and `HERMES_HOME` plus several import-frozen module constants (auth paths, skills/hooks dirs) are process-global — so multiple profiles cannot share one process without cross-profile state bleed.

This routes each inbound message to a target profile by context (channel / topic / thread / guild / DM / `@mention`). Routing is platform-agnostic — it runs in the shared adapter seam, so it applies to every gateway platform (Telegram, Discord, Slack, Feishu, Matrix, …), not one. A transport-owning **front** process holds the token and runs a tokenless **worker** (`hermes -p <name> gateway run`, api_server only) per routed profile; isolation comes from the worker being a separate process with its own `HERMES_HOME`. Unrouted messages run in-process on the host profile, unchanged.

## Change

- **Route resolver** — `resolve_profile_route` (`gateway/routing.py:50`) scores each route via `_route_score` (`gateway/routing.py:13`): `thread_id`(8) > `chat_id`/`channel_id`(4) > `guild_id`/`user_id`(2) > `platform`(1); `channel_id` is an alias for `chat_id`; a thread with no own route matches its `parent_chat_id`. No match → `None` (host).
- **Config** — `_validate_profile_routing` (`gateway/config.py:454`) rejects an unknown/invalid/duplicate-signature route at load; an absent table leaves `profile_routing=None`.
- **Session keys** — `build_session_key` takes a `profile` arg (`gateway/session.py:600`); `prefix = f"agent:{profile}"` (`gateway/session.py:629`). The default `"main"` reproduces the existing `agent:main:…` keys byte-for-byte.
- **Tier-1 overlays** — `resolve_channel_model` (`gateway/platforms/base.py:1599`) resolves a per-channel model from any platform's `channel_models` config (a session `/model` override still wins). Telegram additionally reads per-topic `model`/`system_prompt` from its `group_topics`/`dm_topics` config, scoped by `chat_id` so they do not collide across groups reusing a `thread_id`; other platforms express the same intent through `channel_models`/`channel_prompts` keyed by channel id.
- **Routing seam (platform-agnostic)** — resolution runs in the shared `base.handle_message` (`gateway/platforms/base.py:3628`), keyed on `SessionSource` fields (`platform`/`chat_id`/`channel_id`/`thread_id`/`guild_id`/`user_id`), so every adapter reaching that seam routes with no per-platform code — Telegram, Slack, Feishu, Matrix, WhatsApp, Signal, and the Discord plugin among them; a platform routes on whichever of those fields it populates. On resolution error it falls back to host (no isolation boundary crossed yet). `_maybe_dispatch_routed` (`gateway/run.py:8829`) returns `True` on every matched path — rate-limited, success, and error (which posts a visible message) — and `False` only when unrouted.
- **Worker process** — `_worker_run_args_for_profile` (`hermes_cli/gateway.py:626`) sets `HERMES_GATEWAY_ONLY_PLATFORMS=api_server` and never `--replace`; `_only_platforms_filter` (`gateway/run.py:1558`) skips token adapters in a worker so the front keeps the single token.
- **Pool** — `WorkerPool.acquire` (`gateway/worker_pool.py:135`) spawns/probes/reuses; `_default_interlock` (`gateway/worker_pool.py:79`) refuses to spawn while `get_running_pid(<profile>/gateway.pid)` is live; idle-evict, crash circuit-break with cooldown, `_maintain_worker_pool` reap/sweep (`gateway/run.py:8692`), and `shutdown()` teardown on stop.
- **Dispatch** — `WorkerClient.dispatch` (`gateway/worker_client.py:49`) posts `/v1/runs`, relays `message.delta`/`response.media`, and resolves `approval.request`; `continue_session` loads the worker's own transcript via `_continue_session_id` (`gateway/platforms/api_server.py:1334`), off by default.
- **Rate limit** — `ProfileRateLimiter` (`gateway/rate_limit.py:32`) is a per-profile token bucket checked before dispatch; `/new` and `/reset` bypass it.
- **Media** — files cross the front↔worker boundary as `media_ref` tokens, never a path; `confine_to_safe_root` (`gateway/media_spool.py:34`) confines resolution to the spool root.
- **Manual control** — `parse_profile_mention` (`gateway/chat_bindings.py:21`) splits a leading `@<name> <body>` and routes the turn without mutating the persisted `/profile` binding.

**Unchanged:** unrouted traffic, default-profile session keys, and existing `/v1/runs` clients (`continue_session` defaults off).

## Behavior

| Input | Resolved by | Outcome |
|---|---|---|
| `@<name>` + existing profile | `parse_profile_mention` → `profile_exists` | this turn routes to worker `<name>`; binding unchanged |
| persisted `/profile` binding | `ChatBindings` | routes to the bound worker |
| config route match | `resolve_profile_route` | routes to `route.profile` |
| no match, `default: null` | `resolve_profile_route` → `None` | in-process host profile |
| resolution error | `handle_message` fallback | host profile (pre-isolation, fail-soft) |
| dispatch error after a match | `_maybe_dispatch_routed` | visible error to the user; no host fallback |

## Testing

`uv run --extra dev pytest tests/gateway/test_{profile_routing,profile_routing_config,session_key_profile,worker_arg_builder,only_platforms_env,worker_pool,worker_client,routed_dispatch,profile_rate_limit,routed_reset_scope,routed_dm_and_thread_rules,channel_model,channel_model_routing,config_channel_models_bridge,telegram_topic_overlay,telegram_dm_topic_prompt,media_refs_inbound,response_media_outbound,media_auth_and_cleanup,profile_command,at_mention_override,worker_session_continuity,routed_worker_live}.py -q` → **117 passed**.

- Resolution: `test_profile_routing.py::test_exact_thread_wins_over_channel`, `::test_thread_inherits_parent_channel`, `::test_channel_beats_guild`, `::test_non_dict_routes_ignored`.
- Byte-identical default keys: `test_session_key_profile.py::test_default_profile_keys_unchanged`.
- Routing seam: `test_routed_dispatch.py::test_unrouted_returns_false` (unrouted → host), `::test_dispatch_failure_is_fail_closed` (a dispatch error returns `True` and posts a visible message).
- Pool: `test_worker_pool.py::test_standalone_pid_refuses_spawn` (interlock), `::test_lazy_respawn_records_crash_without_reap`, `::test_circuit_breaker_recovers_after_cooldown`, `::test_acquire_after_shutdown_is_refused`.
- Rate limit: `test_profile_rate_limit.py::test_throttled_profile_is_not_dispatched`, `::test_control_commands_bypass_rate_limit`.
- Continuity opt-in stays off for existing clients: `test_worker_session_continuity.py::test_off_by_default_so_existing_clients_stay_stateless`.
- Manual control: `test_at_mention_override.py::test_email_like_text_is_not_a_mention`, `::test_mention_does_not_mutate_binding`.
- DM/thread isolation: `test_routed_dm_and_thread_rules.py::test_distinct_dm_peers_get_distinct_keys_under_same_profile`, `::test_thread_without_own_route_inherits_parent_channel_profile`.
- Real-socket front↔worker round-trip — `test_routed_worker_live.py` drives the real `WorkerClient` against a real `APIServerAdapter` on a loopback `TestServer`: `::test_real_socket_dispatch_roundtrip` (`POST /v1/runs` → SSE → `run.completed`), `::test_real_socket_continue_session_rehydrates` (worker reloads its transcript from `state.db`), `::test_real_socket_outbound_media_emitted` (`MEDIA:` → `response.media`, tag-free text), `::test_real_socket_reset_unknown_session_is_idempotent`.

The model turn is stubbed (no live LLM call in CI) and the worker runs in-process rather than as a spawned subprocess; the spawn argv/env (`test_worker_arg_builder.py`) and route resolution (`test_profile_routing.py`) are covered separately.

## Limitations

- A routed reply is delivered once the turn completes; deltas are not streamed (`_FrontConsumer.on_delta` is a no-op).
- A routed turn that requests tool approval is denied and the user is notified; interactive approval is not forwarded across the boundary.
- Media resolution uses a shared spool directory, so the front and worker must share a filesystem; the wire payload is metadata-only.

## Related

- #18510 routes Telegram forum topics to profiles by resolving the target profile's home/config in-process. This change routes through separate worker processes; the media-ref path confinement (`confine_to_safe_root`, `gateway/media_spool.py:34`) adapts the `safe_root` helper from that PR.
- #24914 exposes multiple profiles from one gateway via a per-turn `HERMES_HOME` `ContextVar` swap, with `/profile` and `@<name>` controls. This change keeps those controls (`gateway/chat_bindings.py:21`) and isolates via worker processes.
- #23735 is the design discussion for one-gateway multi-profile deployments.
- #13633 asks for per-group routing on Feishu (which this change provides through the shared `base.handle_message` seam, `gateway/platforms/feishu.py:2876`) together with a skill library shared across profiles; the shared-library part is served by the existing `skills.external_dirs` config and is not part of this change.

---

Closes #4321
Closes #4622
Closes #5195
Closes #8339
Closes #9514
Closes #10143
Closes #18423
Closes #19809
Closes #24913
Addresses #13633
Addresses #7517
Supersedes #18510
Supersedes #24914
Refs #23735
