### PR TITLE
fix: clear stale "not found" warning when user_providers override rescues a model switch

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -958,7 +958,14 @@ def switch_model(
                         override = True
                         break
         if override:
-            validation = {"accepted": True, "persist": True, "recognized": False, "message": validation.get("message", "")}
+            # Model is explicitly listed in the user's provider config (e.g. an
+            # ollama cloud model that /v1/models doesn't advertise). The
+            # ``recognized=False`` flag is preserved so callers can still tell
+            # the model isn't in the live API listing, but the stale
+            # "not found in this provider's model listing" warning is cleared
+            # — the user has already declared the model is valid by listing
+            # it, and surfacing the rejection message here is misleading.
+            validation = {"accepted": True, "persist": True, "recognized": False, "message": None}
         else:
             msg = validation.get("message", "Invalid model")
             return ModelSwitchResult(

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -946,6 +946,38 @@ def test_user_provider_override_accepts_listed_private_models(
     assert result.error_message == ""
 
 
+def test_user_provider_override_clears_stale_warning_message():
+    """Regression: the user_providers override must not surface the validator's
+    stale ``not found in this provider's model listing`` message.
+
+    The validator returns ``accepted=False`` when the live ``/v1/models``
+    endpoint doesn't list the model — which is normal for ollama cloud
+    models, proxied endpoints, and any provider that hides aliased/private
+    models from its public listing. The override path rescues the switch by
+    checking the user's ``providers:`` config; the warning that prompted the
+    rejection must NOT propagate into the success result, because surfacing
+    a `⚠ not found` after a successful switch is contradictory and noisy.
+
+    The fix at ``model_switch.py`` line ~960 sets ``message=None`` on the
+    override branch so the CLI's ``⚠`` printer sees an empty warning list.
+    """
+    result = _run_user_provider_override_case(
+        slug="ollama-launch",
+        name="Ollama",
+        base_url="http://127.0.0.1:11434/v1",
+        models=["minimax-m3:cloud", "deepseek-v4-flash:cloud"],
+        raw_input="minimax-m3:cloud",
+    )
+
+    assert result.success is True
+    assert result.new_model == "minimax-m3:cloud"
+    assert result.error_message == ""
+    # The override cleared the stale warning — no "not found" message should
+    # leak through to the user.
+    assert result.warning_message == ""
+    assert "not found" not in result.warning_message.lower()
+
+
 @pytest.mark.parametrize(
     ("slug", "name", "base_url", "models", "raw_input"),
     [


### PR DESCRIPTION
When /v1/models doesn't list a model (e.g. ollama cloud models, proxied
endpoints, private aliases), `validate_requested_model` returns `accepted=False`
with a "not found in this provider's model listing" warning. The
`user_providers` override in `switch_model()` rescues the switch by checking
the user's `providers:` config, but the original rejection message was
preserved and surfaced via `result.warning_message` — producing a
contradictory "✓ switched" + "⚠ not found" output.

Clear `validation["message"]` on the override branch; `recognized=False` is
preserved so callers can still detect non-live-listed models. Adds a
regression test.

## Repro
```
/model minimax-m3:cloud
```
on an ollama setup where the model isn't yet materialized in `/v1/models`
(cloud models, freshly-pulled aliases, etc.). The switch succeeds but a
`⚠ Model `minimax-m3:cloud` was not found in this provider's model listing.`
warning is still shown, with misleading "Similar models" suggestions.

## Test
```
scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py
```
30/30 pass, including the new `test_user_provider_override_clears_stale_warning_message`
regression test.