### PR TITLE
feat: add Telegram raw update plugin hook

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -31,9 +31,15 @@ try:
         CommandHandler,
         CallbackQueryHandler,
         MessageHandler as TelegramMessageHandler,
+        TypeHandler,
         ContextTypes,
         filters,
     )
+    try:
+        from telegram.ext import ApplicationHandlerStop as _ApplicationHandlerStop
+    except ImportError:  # pragma: no cover - old/fake PTB in tests
+        _ApplicationHandlerStop = Exception
+    ApplicationHandlerStop = _ApplicationHandlerStop
     from telegram.constants import ParseMode, ChatType
     from telegram.request import HTTPXRequest
     TELEGRAM_AVAILABLE = True
@@ -46,9 +52,11 @@ except ImportError:
     InlineKeyboardMarkup = Any
     LinkPreviewOptions = None
     Application = Any
+    ApplicationHandlerStop = Exception
     CommandHandler = Any
     CallbackQueryHandler = Any
     TelegramMessageHandler = Any
+    TypeHandler = Any
     HTTPXRequest = Any
     filters = None
     ParseMode = None
@@ -87,6 +95,7 @@ from gateway.platforms.telegram_network import (
     parse_fallback_ip_env,
 )
 from utils import atomic_replace
+from hermes_cli.plugins import invoke_hook_async
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
@@ -118,7 +127,8 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global ApplicationHandlerStop, CommandHandler, CallbackQueryHandler
+    global TelegramMessageHandler, TypeHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -137,9 +147,13 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
-            MessageHandler as _MH,
+            MessageHandler as _MH, TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
+        try:
+            from telegram.ext import ApplicationHandlerStop as _AHS
+        except ImportError:  # pragma: no cover - old/fake PTB in tests
+            _AHS = Exception
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
         from telegram.request import HTTPXRequest as _HR
     except ImportError:
@@ -151,9 +165,11 @@ def check_telegram_requirements() -> bool:
     InlineKeyboardMarkup = _IKM
     LinkPreviewOptions = _LPO
     Application = _App
+    ApplicationHandlerStop = _AHS
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM
@@ -491,6 +507,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Raw Telegram hook de-duplication. Do not store markers on PTB Update
+        # instances: real Update objects may be slotted/immutable.
+        self._raw_update_hook_seen: Dict[tuple, None] = {}
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -1602,6 +1621,7 @@ class TelegramAdapter(BasePlatformAdapter):
             self._bot = self._app.bot
             
             # Register handlers
+            self._app.add_handler(TypeHandler(Update, self._handle_raw_update_hook), group=-100)
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 self._handle_text_message
@@ -3209,6 +3229,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
         """Handle inline keyboard button clicks."""
+        if await self._invoke_raw_update_hooks(update, context, handler="callback_query"):
+            return
         query = update.callback_query
         if not query or not query.data:
             return
@@ -5050,6 +5072,65 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, e)
 
+    async def _handle_raw_update_hook(
+        self, update, context
+    ) -> None:
+        """Run plugin raw-update hooks before Telegram's normal handlers.
+
+        ``TypeHandler(Update, ...)`` catches every PTB update shape, including
+        update types that do not pass the message/callback filters below. If a
+        plugin consumes the update, stop PTB from running subsequent handlers.
+        """
+        handled = await self._invoke_raw_update_hooks(update, context, handler="raw")
+        if handled:
+            raise ApplicationHandlerStop
+
+    def _raw_update_hook_cache_key(self, update) -> tuple:
+        update_id = getattr(update, "update_id", None)
+        if update_id is not None:
+            return ("update_id", update_id)
+        return ("object", id(update))
+
+    def _raw_update_hook_seen_cache(self) -> Dict[tuple, None]:
+        cache = getattr(self, "_raw_update_hook_seen", None)
+        if cache is None:
+            cache = {}
+            self._raw_update_hook_seen = cache
+        return cache
+
+    async def _invoke_raw_update_hooks(
+        self,
+        update,
+        context,
+        *,
+        handler: str,
+    ) -> bool:
+        """Return True when a plugin raw-update hook consumes an update."""
+        cache = self._raw_update_hook_seen_cache()
+        cache_key = self._raw_update_hook_cache_key(update)
+        if cache_key in cache:
+            return False
+
+        cache[cache_key] = None
+        while len(cache) > 2048:
+            cache.pop(next(iter(cache)), None)
+        results = await invoke_hook_async(
+            "telegram_raw_update",
+            update=update,
+            context=context,
+            adapter=self,
+            handler=handler,
+        )
+        for result in results:
+            if result is True:
+                return True
+            if not isinstance(result, dict):
+                continue
+            action = str(result.get("action", "")).strip().lower()
+            if action in {"handled", "skip", "stop", "consume", "consumed"}:
+                return True
+        return False
+
     def _effective_update_message(self, update: Update) -> Optional[Message]:
         """Return the message-like payload for normal messages and channel posts.
 
@@ -5067,6 +5148,8 @@ class TelegramAdapter(BasePlatformAdapter):
         rapid successive text messages from the same user/chat and aggregate
         them into a single MessageEvent before dispatching.
         """
+        if await self._invoke_raw_update_hooks(update, context, handler="text"):
+            return
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
@@ -5083,6 +5166,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
+        if await self._invoke_raw_update_hooks(update, context, handler="command"):
+            return
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
@@ -5097,6 +5182,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
+        if await self._invoke_raw_update_hooks(update, context, handler="location"):
+            return
         msg = self._effective_update_message(update)
         if not msg:
             return
@@ -5280,6 +5367,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
+        if await self._invoke_raw_update_hooks(update, context, handler="media"):
+            return
         if not update.message:
             return
         if not self._should_process_message(update.message):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -150,6 +150,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Telegram raw-update hook. Fired by the Telegram adapter before normal
+    # message/callback dispatch. Plugins may return True or a dict such as
+    # {"action": "handled"} / {"action": "skip"} to consume the update.
+    # Kwargs: update, context, adapter, handler.
+    "telegram_raw_update",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).
@@ -1567,6 +1572,32 @@ class PluginManager:
                 )
         return results
 
+    async def invoke_hook_async(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Async variant of :meth:`invoke_hook`.
+
+        Gateway/platform hooks run inside an event loop and may need to call
+        async platform APIs before deciding whether to consume an update. This
+        preserves the fail-soft behavior of ``invoke_hook`` while awaiting
+        callbacks that return awaitables.
+        """
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if inspect.isawaitable(ret):
+                    ret = await ret
+                if ret is not None:
+                    results.append(ret)
+            except Exception as exc:
+                logger.warning(
+                    "Async hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+        return results
+
     # -----------------------------------------------------------------------
     # Introspection
     # -----------------------------------------------------------------------
@@ -1645,6 +1676,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+async def invoke_hook_async(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a lifecycle hook and await async callbacks when needed."""
+    return await get_plugin_manager().invoke_hook_async(hook_name, **kwargs)
 
 
 

--- a/tests/gateway/test_telegram_raw_update_hook.py
+++ b/tests/gateway/test_telegram_raw_update_hook.py
@@ -1,0 +1,149 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class SlottedUpdate:
+    """Fake PTB-like update that rejects arbitrary marker attributes."""
+
+    __slots__ = ("update_id", "message", "effective_message", "callback_query")
+
+    def __init__(self, *, update_id, message=None, effective_message=None, callback_query=None):
+        self.update_id = update_id
+        self.message = message
+        self.effective_message = effective_message
+        self.callback_query = callback_query
+
+
+@pytest.mark.asyncio
+async def test_text_handler_raw_update_hook_can_handle_before_auth_and_dispatch(monkeypatch):
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = object.__new__(telegram_mod.TelegramAdapter)
+    adapter._should_process_message = MagicMock(return_value=True)
+    adapter._should_observe_unmentioned_group_message = MagicMock(return_value=False)
+    adapter._observe_unmentioned_group_message = MagicMock()
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._build_message_event = MagicMock()
+    adapter._clean_bot_trigger_text = MagicMock()
+    adapter._apply_telegram_group_observe_attribution = MagicMock()
+    adapter._enqueue_text_event = MagicMock()
+
+    msg = SimpleNamespace(text="hello", chat_id=123)
+    update = SimpleNamespace(update_id=42, message=msg, effective_message=msg)
+    context = object()
+    seen = {}
+
+    async def fake_invoke_hook_async(hook_name, **kwargs):
+        seen["hook_name"] = hook_name
+        seen["kwargs"] = kwargs
+        return [{"action": "handled", "reason": "business-inbox"}]
+
+    monkeypatch.setattr(telegram_mod, "invoke_hook_async", fake_invoke_hook_async, raising=False)
+
+    await adapter._handle_text_message(update, context)
+
+    assert seen["hook_name"] == "telegram_raw_update"
+    assert seen["kwargs"]["update"] is update
+    assert seen["kwargs"]["context"] is context
+    assert seen["kwargs"]["adapter"] is adapter
+    assert seen["kwargs"]["handler"] == "text"
+    adapter._should_process_message.assert_not_called()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter._ensure_forum_commands.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_text_handler_continues_normally_when_raw_update_hook_allows(monkeypatch):
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = object.__new__(telegram_mod.TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra={})
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.1
+    adapter._text_batch_split_delay_seconds = 0.1
+    adapter._should_process_message = MagicMock(return_value=True)
+    adapter._should_observe_unmentioned_group_message = MagicMock(return_value=False)
+    adapter._observe_unmentioned_group_message = MagicMock()
+    adapter._ensure_forum_commands = AsyncMock()
+    adapter._build_message_event = MagicMock(return_value=SimpleNamespace(text="hello", media_urls=[], media_types=[]))
+    adapter._clean_bot_trigger_text = MagicMock(return_value="hello")
+    adapter._apply_telegram_group_observe_attribution = MagicMock(side_effect=lambda event: event)
+    adapter._enqueue_text_event = MagicMock()
+
+    msg = SimpleNamespace(text="hello", chat_id=123)
+    update = SimpleNamespace(update_id=42, message=msg, effective_message=msg)
+
+    async def fake_invoke_hook_async(hook_name, **kwargs):
+        return [{"action": "allow"}]
+
+    monkeypatch.setattr(telegram_mod, "invoke_hook_async", fake_invoke_hook_async, raising=False)
+
+    await adapter._handle_text_message(update, object())
+
+    adapter._should_process_message.assert_called_once_with(msg)
+    adapter._ensure_forum_commands.assert_awaited_once_with(msg)
+    adapter._enqueue_text_event.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_raw_update_hook_does_not_mutate_slotted_update(monkeypatch):
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = object.__new__(telegram_mod.TelegramAdapter)
+    calls = []
+    msg = SimpleNamespace(text="hello", chat_id=123)
+    update = SlottedUpdate(update_id=4242, message=msg, effective_message=msg)
+
+    async def fake_invoke_hook_async(hook_name, **kwargs):
+        calls.append((hook_name, kwargs["handler"]))
+        return [{"action": "allow"}]
+
+    monkeypatch.setattr(telegram_mod, "invoke_hook_async", fake_invoke_hook_async, raising=False)
+
+    handled = await adapter._invoke_raw_update_hooks(update, object(), handler="raw")
+    handled_again = await adapter._invoke_raw_update_hooks(update, object(), handler="text")
+
+    assert handled is False
+    assert handled_again is False
+    assert calls == [("telegram_raw_update", "raw")]
+
+
+@pytest.mark.asyncio
+async def test_callback_query_raw_update_hook_can_handle_before_builtin_prefixes(monkeypatch):
+    from gateway.platforms import telegram as telegram_mod
+
+    adapter = object.__new__(telegram_mod.TelegramAdapter)
+    adapter._handle_model_picker_callback = AsyncMock()
+    adapter._handle_gmail_triage_callback = AsyncMock()
+    adapter._approval_state = {}
+    adapter._slash_confirm_state = {}
+    adapter._clarify_state = {}
+
+    query = SimpleNamespace(
+        data="mp:gpt-5",
+        message=SimpleNamespace(chat_id=123, chat=SimpleNamespace(type="private"), message_thread_id=None),
+        from_user=SimpleNamespace(id=602562, first_name="Alen"),
+        answer=AsyncMock(),
+    )
+    update = SimpleNamespace(update_id=99, callback_query=query)
+    context = object()
+
+    async def fake_invoke_hook_async(hook_name, **kwargs):
+        assert hook_name == "telegram_raw_update"
+        assert kwargs["handler"] == "callback_query"
+        assert kwargs["update"] is update
+        assert kwargs["context"] is context
+        assert kwargs["adapter"] is adapter
+        return [{"action": "skip", "reason": "plugin-callback"}]
+
+    monkeypatch.setattr(telegram_mod, "invoke_hook_async", fake_invoke_hook_async, raising=False)
+
+    await adapter._handle_callback_query(update, context)
+
+    adapter._handle_model_picker_callback.assert_not_awaited()
+    adapter._handle_gmail_triage_callback.assert_not_awaited()

--- a/tests/test_plugin_async_hooks.py
+++ b/tests/test_plugin_async_hooks.py
@@ -1,0 +1,37 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_invoke_hook_async_awaits_sync_and_async_callbacks():
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest, VALID_HOOKS
+
+    assert "telegram_raw_update" in VALID_HOOKS
+
+    manager = PluginManager()
+    ctx = PluginContext(PluginManifest(name="raw-hook-test", source="test"), manager)
+    calls = []
+
+    def sync_callback(**kwargs):
+        calls.append(("sync", kwargs["update"], kwargs["context"]))
+        return None
+
+    async def async_callback(**kwargs):
+        calls.append(("async", kwargs["update"], kwargs["context"]))
+        return {"action": "handled", "reason": "captured"}
+
+    ctx.register_hook("telegram_raw_update", sync_callback)
+    ctx.register_hook("telegram_raw_update", async_callback)
+
+    results = await manager.invoke_hook_async(
+        "telegram_raw_update",
+        update="update-object",
+        context="context-object",
+        adapter="telegram-adapter",
+        handler="text",
+    )
+
+    assert results == [{"action": "handled", "reason": "captured"}]
+    assert calls == [
+        ("sync", "update-object", "context-object"),
+        ("async", "update-object", "context-object"),
+    ]


### PR DESCRIPTION
## Summary
- Add `telegram_raw_update` plugin hook for Telegram updates before built-in dispatch.
- Add async plugin hook invocation support.
- Let plugins consume raw Telegram updates with `True` or handled/skip/stop/consume actions.
- Avoid mutating PTB `Update` objects; de-duplicate through an adapter-owned bounded cache.

## Test Plan
- [x] `/home/alen/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_plugin_async_hooks.py tests/gateway/test_telegram_raw_update_hook.py -q -o 'addopts='` → `5 passed`
- [x] `/home/alen/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_thread_fallback.py -q -o 'addopts='` → `46 passed`
- [x] `/home/alen/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/plugins.py gateway/platforms/telegram.py tests/test_plugin_async_hooks.py tests/gateway/test_telegram_raw_update_hook.py`
- [x] `git diff --check`

## Notes
- A broader mixed Telegram test run still shows the existing order-dependent `test_telegram_thread_fallback.py` chat_type failures when run with other Telegram tests. That same failure pattern was reproduced on clean main, while the fallback suite passes in isolation.
