### PR TITLE
fix(feishu): render markdown tables via post instead of force-text downgrade

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -154,8 +154,8 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# A header row (line starting with |) followed by a separator line: routes table
+# content into the post 'md' pipeline, which Feishu renders natively.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -4308,16 +4308,16 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # _MARKDOWN_TABLE_RE and the post row-splitter match on literal "\n", so a
+        # CRLF table would slip through detection and leak raw pipes as plain text.
+        content = content.replace("\r\n", "\n").replace("\r", "\n")
+        # Route markdown-rich content (GFM tables included) through post so Feishu
+        # renders it natively. Feishu added server-side table support to post 'md'
+        # elements, so the old force-text table downgrade is obsolete (verified on
+        # feishu.cn; see docs/plans/2026-05-30-feishu-markdown-table-rendering.md).
+        if _MARKDOWN_TABLE_RE.search(content) or _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        return "text", json.dumps({"text": content}, ensure_ascii=False)
 
     async def _send_uploaded_file_message(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -21,6 +21,32 @@ except ImportError:
     _HAS_LARK_OAPI = False
 
 
+async def _direct(func, *args, **kwargs):
+    """Stand-in for asyncio.to_thread that runs the SDK call inline."""
+    return func(*args, **kwargs)
+
+
+def _capturing_adapter():
+    """A FeishuAdapter whose message API records the last create/update request."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    captured = {}
+
+    class _MessageAPI:
+        def __getattr__(self, _name):  # create and update both record then succeed
+            def call(request):
+                captured["request"] = request
+                captured["method"] = _name
+                return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_1"))
+
+            return call
+
+    adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+    return adapter, captured
+
+
 def _mock_event_dispatcher_builder(mock_handler_class):
     mock_builder = Mock()
     mock_builder.register_p2_im_message_message_read_v1 = Mock(return_value=mock_builder)
@@ -2577,6 +2603,65 @@ class TestAdapterBehavior(unittest.TestCase):
         payload = json.loads(captured["request"].request_body.content)
         elements = payload["zh_cn"]["content"][0]
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_routes_markdown_table_to_post(self):
+        """A GFM table renders as post; the raw pipes are passed through, not downgraded to text."""
+        adapter, captured = _capturing_adapter()
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content="| A | B |\n|---|---|\n| 1 | 2 |"))
+        self.assertTrue(result.success)
+        body = captured["request"].request_body
+        self.assertEqual(body.msg_type, "post")
+        self.assertIn("| A | B |", body.content)
+        self.assertEqual(captured["method"], "create")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_routes_markdown_table_to_post(self):
+        """The shared payload seam carries the fix to the streaming/edit (update) path."""
+        adapter, captured = _capturing_adapter()
+        table = "| A | B |\n|---|---|\n| 1 | 2 |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            asyncio.run(adapter.edit_message(chat_id="oc_chat", message_id="om_1", content=table))
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["method"], "update")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_keeps_post_for_prose_surrounding_a_table(self):
+        """Mixed prose + table stays post, so the rest of the markdown is no longer stripped (#23938)."""
+        adapter, _ = _capturing_adapter()
+        msg_type, _payload = adapter._build_outbound_payload("## H\n\n**bold** intro\n\n| A | B |\n|---|---|\n| 1 | 2 |")
+        self.assertEqual(msg_type, "post")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_normalizes_crlf_table_to_post(self):
+        """A CRLF table is normalized before detection instead of leaking as raw text."""
+        adapter, _ = _capturing_adapter()
+        msg_type, _payload = adapter._build_outbound_payload("| A | B |\r\n|---|---|\r\n| 1 | 2 |")
+        self.assertEqual(msg_type, "post")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_outbound_single_pipe_line_stays_plain_text(self):
+        """A lone pipe (e.g. a type union) is not a table and must not route to post."""
+        adapter, _ = _capturing_adapter()
+        msg_type, _payload = adapter._build_outbound_payload("def f(x: int | str) -> bool: ...")
+        self.assertEqual(msg_type, "text")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_table_detection_ignores_horizontal_rule(self):
+        from gateway.platforms.feishu import _MARKDOWN_TABLE_RE
+
+        self.assertIsNone(_MARKDOWN_TABLE_RE.search("above\n\n---\n\nbelow"))
+        self.assertIsNotNone(_MARKDOWN_TABLE_RE.search("| A | B |\n|---|---|"))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_table_inside_code_fence_stays_a_single_post_row(self):
+        """Now that fenced content reaches post, a fenced table must stay one verbatim code row."""
+        from gateway.platforms.feishu import _build_markdown_post_rows
+
+        rows = _build_markdown_post_rows("```\n| A | B |\n|---|---|\n| 1 | 2 |\n```")
+        self.assertEqual(len(rows), 1)
+        self.assertIn("```", rows[0][0]["text"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):


### PR DESCRIPTION
## Summary
Markdown tables sent through the Feishu adapter arrived as raw `|---|` text, and any message that contained a table had its other markdown stripped as well. `_build_outbound_payload` (`gateway/platforms/feishu.py:4310`) routed any table-matching content straight to plain text — a workaround from before Feishu's post `md` elements rendered tables server-side. This removes the downgrade so table content goes through the existing `post`/`tag:md` pipeline, and normalizes CRLF before detection so `\r\n` tables are matched.

## Change
- `_build_outbound_payload` (`feishu.py:4310`): route content matching `_MARKDOWN_TABLE_RE` (`:159`) **or** `_MARKDOWN_HINT_RE` (`:153`) to `post` via `_build_markdown_post_payload`; everything else to `text`. Previously the table-matching branch returned `text` directly.
- `_build_outbound_payload` (`feishu.py:4310`): `content = content.replace("\r\n", "\n").replace("\r", "\n")` before detection — `_MARKDOWN_TABLE_RE` and the post row-splitter match a literal `\n`, so a CRLF table was missed.
- Unchanged: `_MARKDOWN_HINT_RE` (`:153`); the post→text fallback that triggers on a `content format of the post type is incorrect` rejection (`_POST_CONTENT_INVALID_RE`, `:165`); the shared payload call in `send` (`:1785`) and `edit_message` (`:1839`).

## Behavior
| Content | Before | After |
|---|---|---|
| GFM table, no other markdown | `text` (raw `\|---\|`) | `post` (`tag:md`) |
| Table + surrounding markdown | `text`, surrounding markdown stripped | `post` (`tag:md`) |
| Table with CRLF line endings | `text` (detection missed `\r\n`) | `post` (normalized, then `tag:md`) |
| Non-table markdown (headings, bold, lists) | `post` | `post` (unchanged) |
| Plain text; lone `\|` (e.g. `int \| str`) | `text` | `text` (unchanged) |

## Testing
`uv run --extra dev --extra feishu python -m pytest tests/gateway/test_feishu.py` — 206 passed. 6 failures in `TestWebhookSecurity` / url-verification predate this change and reproduce on `origin/main`. New tests:
- `test_send_routes_markdown_table_to_post` — a bare table sends as `post`; pins the SDK call to `create`.
- `test_edit_message_routes_markdown_table_to_post` — the same seam routes `edit_message` as `post`; pins the call to `update`.
- `test_outbound_keeps_post_for_prose_surrounding_a_table` — mixed prose+table stays `post`.
- `test_outbound_normalizes_crlf_table_to_post` — a `\r\n` table routes to `post`.
- `test_outbound_single_pipe_line_stays_plain_text` — a lone pipe stays `text`.
- `test_table_detection_ignores_horizontal_rule` — `_MARKDOWN_TABLE_RE` does not match a `---` rule.
- `test_table_inside_code_fence_stays_a_single_post_row` — a fenced table stays one verbatim row.

The tests assert routing to `post`; the server-side render is not exercised by CI and was checked manually on feishu.cn.

## Note
The post→text fallback triggers on a `content format of the post type is incorrect` rejection; it does not cover a payload the API accepts but renders empty. Table rendering is confirmed on feishu.cn and unconfirmed on larksuite.com — there, a non-rendering table would display as an empty message rather than raw text. A `_domain_name == "lark"` guard can route the international domain to `text` if a check shows that case.

## Related
Other PRs targeting this area, by approach:
- post + `tag:md`: #22047, #26108, #29552
- card / CardKit 2.0 component: #12114, #23861, #25453, #28837, #31038, #32488, #33310
- pipe table wrapped in a code fence: #19015, #32648
- table converted to a bullet list: #29510

---
Fixes: #7310 #9549 #18704 #18756 #23938 #25452 #26658 #27529 #29245 #32607
Addresses: #21866
Refs: #6003 #6363 #16084 #19226 #21326 #26236 #27695 #7022 #21778
