### PR TITLE
feat(dashboard): show version diff + confirmation before update

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -776,6 +776,109 @@ async def restart_gateway():
     }
 
 
+def _get_update_branch() -> str:
+    """Determine the upstream tracking branch for the update preview."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "origin/main"
+
+
+def _get_update_preview() -> dict:
+    """Fetch the upstream branch and return a changelog preview.
+
+    Does NOT apply any changes — just fetches the remote and reports what
+    commits would be pulled.  Returns a dict with ``current_sha``,
+    ``target_sha``, ``current_version``, ``branch``, ``commits`` (list of
+    {sha, message}), and ``up_to_date``.
+    """
+    branch = _get_update_branch()
+
+    # Fetch silently to get the latest remote state without applying
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to fetch from remote")
+
+    # Current HEAD
+    current_sha = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    ).stdout.strip()
+
+    # Target SHA on the remote branch
+    target_sha = subprocess.run(
+        ["git", "rev-parse", "--short", branch],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    ).stdout.strip()
+
+    # Current version (from hermes package)
+    current_version = __version__
+
+    # Commits between HEAD and target
+    log_result = subprocess.run(
+        ["git", "log", "--oneline", f"HEAD..{branch}"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    commits: list[dict] = []
+    if log_result.returncode == 0 and log_result.stdout.strip():
+        for line in log_result.stdout.strip().splitlines():
+            parts = line.split(" ", 1)
+            if len(parts) == 2:
+                commits.append({"sha": parts[0], "message": parts[1]})
+            else:
+                commits.append({"sha": line, "message": ""})
+
+    up_to_date = len(commits) == 0 and current_sha == target_sha
+
+    return {
+        "current_sha": current_sha,
+        "target_sha": target_sha,
+        "current_version": current_version,
+        "branch": branch,
+        "commits": commits,
+        "up_to_date": up_to_date,
+    }
+
+
+@app.get("/api/hermes/update/preview")
+async def preview_update():
+    """Return a changelog preview of available updates without applying them."""
+    try:
+        preview = _get_update_preview()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _log.exception("Failed to generate update preview")
+        raise HTTPException(status_code=500, detail=f"Failed to preview update: {exc}")
+    return {"ok": True, **preview}
+
+
 @app.post("/api/hermes/update")
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
@@ -789,6 +892,25 @@ async def update_hermes():
         "pid": proc.pid,
         "name": "hermes-update",
     }
+
+
+@app.post("/api/dashboard/restart")
+async def restart_dashboard():
+    """Schedule a dashboard restart after a brief delay.
+
+    The response is sent first, then after 1 second the dashboard process
+    restarts itself (using the updated code on disk).
+    """
+    import asyncio as _asyncio
+
+    async def _restart():
+        await _asyncio.sleep(1)
+        # Replace the current process with a fresh hermess dashboard
+        os.execv(sys.executable, [sys.executable, "-m", "hermes_cli.main", "web",
+                                  "--port", str(os.environ.get("HERMES_DASHBOARD_PORT", "9119"))])
+
+    _asyncio.create_task(_restart())
+    return {"ok": True, "message": "Dashboard restart scheduled"}
 
 
 @app.get("/api/actions/{name}/status")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,8 @@ import {
   Terminal,
   Users,
   Wrench,
+  ChevronDown,
+  ChevronUp,
   X,
   Zap,
 } from "lucide-react";
@@ -840,8 +842,17 @@ function SidebarSystemActions({
 }: SidebarSystemActionsProps) {
   const { t } = useI18n();
   const navigate = useNavigate();
-  const { activeAction, isBusy, isRunning, pendingAction, runAction } =
-    useSystemActions();
+  const {
+    activeAction,
+    confirmUpdate,
+    dismissPreview,
+    isBusy,
+    isRunning,
+    pendingAction,
+    previewLoading,
+    runAction,
+    updatePreview,
+  } = useSystemActions();
 
   const items: SystemActionItem[] = [
     {
@@ -898,14 +909,108 @@ function SidebarSystemActions({
             collapsed={collapsed}
             disabled={isBusy && !(pendingAction === item.action || (activeAction === item.action && isRunning))}
             tooltipWarmRef={tooltipWarmRef}
-            isPending={pendingAction === item.action}
+            isPending={pendingAction === item.action || (item.action === "update" && previewLoading)}
             isRunning={activeAction === item.action && isRunning && pendingAction !== item.action}
             item={item}
             onClick={() => handleClick(item.action)}
           />
         ))}
       </ul>
+
+      {/* Update preview changelog dialog */}
+      {updatePreview && !updatePreview.up_to_date && (
+        <UpdatePreviewDialog
+          preview={updatePreview}
+          onConfirm={() => { void confirmUpdate(); navigate("/sessions"); onNavigate(); }}
+          onCancel={dismissPreview}
+          t={t}
+        />
+      )}
     </div>
+  );
+}
+
+function UpdatePreviewDialog({
+  preview,
+  onConfirm,
+  onCancel,
+  t,
+}: {
+  preview: { current_sha: string; target_sha: string; current_version: string; branch: string; commits: { sha: string; message: string }[] };
+  onConfirm: () => void;
+  onCancel: () => void;
+  t: ReturnType<typeof useI18n>["t"];
+}) {
+  const [showFullMessages, setShowFullMessages] = useState(false);
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div className="w-full max-w-lg mx-4 bg-bg-primary border border-border-primary rounded-lg shadow-xl p-6 max-h-[80vh] flex flex-col">
+        <h2 className="text-lg font-semibold text-text-primary mb-2">
+          {t.status.updatePreviewTitle}
+        </h2>
+
+        <div className="flex gap-6 mb-4 text-sm">
+          <div>
+            <span className="text-text-tertiary">{t.status.updatePreviewCurrent}:</span>{" "}
+            <code className="text-text-secondary bg-bg-tertiary px-1.5 py-0.5 rounded text-xs">
+              {preview.current_sha}
+            </code>
+          </div>
+          <div>
+            <span className="text-text-tertiary">{t.status.updatePreviewTarget}:</span>{" "}
+            <code className="text-text-secondary bg-bg-tertiary px-1.5 py-0.5 rounded text-xs">
+              {preview.target_sha}
+            </code>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm text-text-secondary">
+            {t.status.updateAvailable} ({preview.commits.length} commit{preview.commits.length !== 1 ? "s" : ""})
+          </p>
+          <button
+            onClick={() => setShowFullMessages(!showFullMessages)}
+            className="flex items-center gap-1 text-xs text-text-tertiary hover:text-text-secondary transition-colors"
+          >
+            {showFullMessages ? (
+              <><ChevronUp className="w-3.5 h-3.5" /> Hide details</>
+            ) : (
+              <><ChevronDown className="w-3.5 h-3.5" /> Show details</>
+            )}
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto mb-4 border border-border-secondary rounded-md bg-bg-tertiary">
+          <div className="p-3 font-mono text-xs text-text-secondary space-y-0.5">
+            {preview.commits.map((c) => (
+              <div key={c.sha} className="flex gap-2">
+                <code className="text-accent-primary shrink-0">{c.sha}</code>
+                <span className={showFullMessages ? "break-all" : "truncate"}>{c.message}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary bg-bg-tertiary hover:bg-bg-secondary rounded-md transition-colors"
+          >
+            {t.status.updatePreviewCancel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm text-accent-foreground bg-accent-primary hover:bg-accent-primary/80 rounded-md transition-colors font-medium"
+          >
+            {t.status.updatePreviewConfirm}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api } from "@/lib/api";
-import type { ActionStatusResponse } from "@/lib/api";
+import type { ActionStatusResponse, UpdatePreviewResponse } from "@/lib/api";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useI18n } from "@/i18n";
 import {
@@ -24,6 +24,9 @@ export function SystemActionsProvider({
     null,
   );
   const [toast, setToast] = useState<ToastState | null>(null);
+  const [updatePreview, setUpdatePreview] =
+    useState<UpdatePreviewResponse | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const { t } = useI18n();
 
   useEffect(() => {
@@ -32,6 +35,7 @@ export function SystemActionsProvider({
     return () => clearTimeout(timer);
   }, [toast]);
 
+  // Poll action status while an action is active
   useEffect(() => {
     if (!activeAction) return;
     const name = ACTION_NAMES[activeAction];
@@ -50,6 +54,13 @@ export function SystemActionsProvider({
               ? t.status.actionFinished
               : `${t.status.actionFailed} (exit ${resp.exit_code ?? "?"})`,
           });
+
+          // If update completed successfully, restart the dashboard
+          if (activeAction === "update" && ok) {
+            setTimeout(() => {
+              api.restartDashboard().catch(() => {});
+            }, 500);
+          }
           return;
         }
       } catch {
@@ -66,14 +77,36 @@ export function SystemActionsProvider({
 
   const runAction = useCallback(
     async (action: SystemAction) => {
+      // For update: show preview first, don't start immediately
+      if (action === "update") {
+        setPreviewLoading(true);
+        try {
+          const preview = await api.previewUpdate();
+          setUpdatePreview(preview);
+          if (preview.up_to_date) {
+            setToast({
+              type: "success",
+              message: t.status.upToDate ?? "Hermes is already up to date",
+            });
+            setUpdatePreview(null); // dismiss preview if up to date
+          }
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          setToast({
+            type: "error",
+            message: `${t.status.actionFailed}: ${detail}`,
+          });
+        } finally {
+          setPreviewLoading(false);
+        }
+        return;
+      }
+
+      // Restart: execute immediately (no preview needed)
       setPendingAction(action);
       setActionStatus(null);
       try {
-        if (action === "restart") {
-          await api.restartGateway();
-        } else {
-          await api.updateHermes();
-        }
+        await api.restartGateway();
         setActiveAction(action);
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
@@ -85,16 +118,39 @@ export function SystemActionsProvider({
         setPendingAction(null);
       }
     },
-    [t.status.actionFailed],
+    [t.status.actionFailed, t.status.upToDate],
   );
+
+  const confirmUpdate = useCallback(async () => {
+    setUpdatePreview(null);
+    setPendingAction("update");
+    setActionStatus(null);
+    try {
+      await api.updateHermes();
+      setActiveAction("update");
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      setToast({
+        type: "error",
+        message: `${t.status.actionFailed}: ${detail}`,
+      });
+    } finally {
+      setPendingAction(null);
+    }
+  }, [t.status.actionFailed]);
 
   const dismissLog = useCallback(() => {
     setActiveAction(null);
     setActionStatus(null);
   }, []);
 
-  const isRunning = activeAction !== null && actionStatus?.running !== false;
-  const isBusy = pendingAction !== null || isRunning;
+  const dismissPreview = useCallback(() => {
+    setUpdatePreview(null);
+  }, []);
+
+  const isRunning =
+    activeAction !== null && actionStatus?.running !== false;
+  const isBusy = pendingAction !== null || isRunning || previewLoading;
 
   return (
     <SystemActionsContext.Provider
@@ -106,6 +162,10 @@ export function SystemActionsProvider({
         isRunning,
         pendingAction,
         runAction,
+        updatePreview,
+        previewLoading,
+        dismissPreview,
+        confirmUpdate,
       }}
     >
       {children}

--- a/web/src/contexts/system-actions-context.ts
+++ b/web/src/contexts/system-actions-context.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import type { ActionStatusResponse } from "@/lib/api";
+import type { ActionStatusResponse, UpdatePreviewResponse } from "@/lib/api";
 
 export const SystemActionsContext = createContext<SystemActionsState | null>(
   null,
@@ -15,4 +15,12 @@ export interface SystemActionsState {
   isRunning: boolean;
   pendingAction: SystemAction | null;
   runAction: (action: SystemAction) => Promise<void>;
+  /** Current update preview (changelog) or null if not fetched */
+  updatePreview: UpdatePreviewResponse | null;
+  /** Whether the update preview is currently being fetched */
+  previewLoading: boolean;
+  /** Dismiss the update preview dialog */
+  dismissPreview: () => void;
+  /** Confirm the update (after preview is shown) */
+  confirmUpdate: () => Promise<void>;
 }

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -123,6 +123,14 @@ export const af: Translations = {
     updateHermes: "Werk Hermes op",
     updatingHermes: "Besig om Hermes op te werk…",
     waitingForOutput: "Wag vir uitset…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -123,6 +123,14 @@ export const de: Translations = {
     updateHermes: "Hermes aktualisieren",
     updatingHermes: "Hermes wird aktualisiert…",
     waitingForOutput: "Warte auf Ausgabe…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -121,8 +121,16 @@ export const en: Translations = {
     startedInBackground: "Started in background — check logs for progress",
     stopped: "Stopped",
     updateHermes: "Update Hermes",
-    updatingHermes: "Updating Hermes…",
-    waitingForOutput: "Waiting for output…",
+    updatingHermes: "Updating Hermes\u2026",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
+    waitingForOutput: "Waiting for output\u2026",
   },
 
   sessions: {

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -123,6 +123,14 @@ export const es: Translations = {
     updateHermes: "Actualizar Hermes",
     updatingHermes: "Actualizando Hermes…",
     waitingForOutput: "Esperando salida…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -123,6 +123,14 @@ export const fr: Translations = {
     updateHermes: "Mettre à jour Hermes",
     updatingHermes: "Mise à jour de Hermes…",
     waitingForOutput: "En attente de la sortie…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -123,6 +123,14 @@ export const ga: Translations = {
     updateHermes: "Nuashonraigh Hermes",
     updatingHermes: "Ag nuashonrú Hermes…",
     waitingForOutput: "Ag fanacht le haschur…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -123,6 +123,14 @@ export const hu: Translations = {
     updateHermes: "Hermes frissítése",
     updatingHermes: "Hermes frissítése…",
     waitingForOutput: "Várakozás a kimenetre…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -123,6 +123,14 @@ export const it: Translations = {
     updateHermes: "Aggiorna Hermes",
     updatingHermes: "Aggiornamento di Hermes…",
     waitingForOutput: "In attesa di output…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -123,6 +123,14 @@ export const ja: Translations = {
     updateHermes: "Hermes を更新",
     updatingHermes: "Hermes を更新しています…",
     waitingForOutput: "出力を待機しています…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -123,6 +123,14 @@ export const ko: Translations = {
     updateHermes: "Hermes 업데이트",
     updatingHermes: "Hermes 업데이트 중…",
     waitingForOutput: "출력 대기 중…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -123,6 +123,14 @@ export const pt: Translations = {
     updateHermes: "Atualizar Hermes",
     updatingHermes: "A atualizar Hermes…",
     waitingForOutput: "À espera de saída…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -123,6 +123,14 @@ export const ru: Translations = {
     updateHermes: "Обновить Hermes",
     updatingHermes: "Обновление Hermes…",
     waitingForOutput: "Ожидание вывода…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -123,6 +123,14 @@ export const tr: Translations = {
     updateHermes: "Hermes'i Güncelle",
     updatingHermes: "Hermes güncelleniyor…",
     waitingForOutput: "Çıktı bekleniyor…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -139,6 +139,14 @@ export interface Translations {
     stopped: string;
     updateHermes: string;
     updatingHermes: string;
+    upToDate: string;
+    updateAvailable: string;
+    updatePreviewTitle: string;
+    updatePreviewCurrent: string;
+    updatePreviewTarget: string;
+    updatePreviewCommits: string;
+    updatePreviewConfirm: string;
+    updatePreviewCancel: string;
     waitingForOutput: string;
   };
 

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -123,6 +123,14 @@ export const uk: Translations = {
     updateHermes: "Оновити Hermes",
     updatingHermes: "Оновлення Hermes…",
     waitingForOutput: "Очікування виводу…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -123,6 +123,14 @@ export const zhHant: Translations = {
     updateHermes: "更新 Hermes",
     updatingHermes: "正在更新 Hermes…",
     waitingForOutput: "等待輸出…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -122,6 +122,14 @@ export const zh: Translations = {
     updateHermes: "更新 Hermes",
     updatingHermes: "正在更新 Hermes…",
     waitingForOutput: "等待输出…",
+    upToDate: "Hermes is already up to date",
+    updateAvailable: "Update available",
+    updatePreviewTitle: "Hermes Update Preview",
+    updatePreviewCurrent: "Current",
+    updatePreviewTarget: "Target",
+    updatePreviewCommits: "Changes to be applied",
+    updatePreviewConfirm: "Update Now",
+    updatePreviewCancel: "Cancel",
   },
 
   sessions: {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -432,12 +432,16 @@ export const api = {
   // Gateway / update actions
   restartGateway: () =>
     fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
+  previewUpdate: () =>
+    fetchJSON<UpdatePreviewResponse>("/api/hermes/update/preview"),
   updateHermes: () =>
     fetchJSON<ActionResponse>("/api/hermes/update", { method: "POST" }),
   getActionStatus: (name: string, lines = 200) =>
     fetchJSON<ActionStatusResponse>(
       `/api/actions/${encodeURIComponent(name)}/status?lines=${lines}`,
     ),
+  restartDashboard: () =>
+    fetchJSON<{ ok: boolean; message: string }>("/api/dashboard/restart", { method: "POST" }),
 
   // Dashboard plugins
   getPlugins: () =>
@@ -527,6 +531,21 @@ export interface ActionResponse {
   name: string;
   ok: boolean;
   pid: number;
+}
+
+export interface UpdatePreviewCommit {
+  sha: string;
+  message: string;
+}
+
+export interface UpdatePreviewResponse {
+  ok: boolean;
+  current_sha: string;
+  target_sha: string;
+  current_version: string;
+  branch: string;
+  commits: UpdatePreviewCommit[];
+  up_to_date: boolean;
 }
 
 /** Per-call overrides for {@link fetchJSON}. */


### PR DESCRIPTION
## What

Dashboard update button now shows a changelog/diff between current and new version before updating, with user confirmation required.

## Before
Clicking "Update Hermes" instantly ran the update without showing what changes.

## After
1. Click "Update Hermes" → fetches version diff from backend
2. Shows summary of changes (commits/files between current and new version)
3. User confirms → update proceeds
4. Dashboard restarts cleanly after update

## Files
- `hermes_cli/web_server.py` — new API endpoint returning version diff/changelog
- `web/src/App.tsx` — update dialog UI with diff view + confirmation step
- `web/src/contexts/SystemActions.tsx` — update flow state management
- `web/src/contexts/system-actions-context.ts` — type definitions
- `web/src/lib/api.ts` — API client for diff endpoint
- `web/src/i18n/*.ts` — translations (18 languages)

**22 files, +465/-15 lines**