### PR TITLE
fix(kanban): per-board diagnosis for stuck dispatcher warnings

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6085,12 +6085,21 @@ class GatewayRunner:
                 if bad_ticks >= HEALTH_WINDOW:
                     now = int(time.time())
                     if now - last_warn_at >= 300:
+                        # Per-board diagnosis: identify which boards have
+                        # spawnable work stuck behind 0 spawns.  Runs once
+                        # per warning (every 5+ min), not every tick.
+                        try:
+                            diag = await asyncio.to_thread(_kb.board_dispatch_health)
+                        except Exception:
+                            diag = []
+                        board_detail = _kb.BoardDispatchHealth.format_stuck(diag)
                         logger.warning(
                             "kanban dispatcher stuck: ready queue non-empty for "
-                            "%d consecutive ticks but 0 workers spawned. Check "
-                            "profile health (venv, PATH, credentials) and "
-                            "`hermes kanban list --status ready`.",
+                            "%d consecutive ticks but 0 workers spawned "
+                            "[boards: %s]. Check profile health (venv, PATH, "
+                            "credentials) and `hermes kanban list --status ready`.",
                             bad_ticks,
+                            board_detail,
                         )
                         last_warn_at = now
             except asyncio.CancelledError:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2300,10 +2300,17 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             now = int(time.time())
             # Rate-limit repeats: at most one warning per 5 minutes.
             if now - health_state["last_warn_at"] >= 300:
+                # Per-board diagnosis so the operator knows WHICH board.
+                try:
+                    diag = kb.board_dispatch_health()
+                except Exception:
+                    diag = []
+                board_detail = kb.BoardDispatchHealth.format_stuck(diag)
                 print(
                     f"[{_fmt_ts(now)}] WARN dispatcher stuck: "
                     f"ready queue non-empty for {health_state['bad_ticks']} "
-                    f"consecutive ticks but 0 workers spawned successfully. "
+                    f"consecutive ticks but 0 workers spawned "
+                    f"[boards: {board_detail}]. "
                     f"Check profile health (venv, PATH, credentials) and "
                     f"`hermes kanban list --status ready` / "
                     f"`hermes kanban list --status blocked` for recent "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5718,7 +5718,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL"
+        "    AND assignee != '' AND claim_lock IS NULL"
     ).fetchall()
     if not rows:
         return False
@@ -5756,6 +5756,130 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
         if profile_exists(row["assignee"]):
             return True
     return False
+
+
+@dataclass
+class BoardDispatchHealth:
+    """Per-board dispatch health summary.
+
+    Returned by :func:`board_dispatch_health` and consumed by the
+    gateway and CLI daemon stuck-detectors to identify WHICH boards
+    have spawnable work backing up behind zero spawns.
+    """
+
+    slug: str
+    ready: int = 0
+    """Count of ready tasks with a non-empty assignee and no active claim lock."""
+    ready_nonspawnable: int = 0
+    """Ready tasks assigned to control-plane lanes (e.g. ``orion-cc``)
+    rather than real Hermes profiles.  These are *not* operator-actionable —
+    they will be claimed by external terminals via ``claim_task``."""
+    running: int = 0
+    """Count of running tasks."""
+    spawnable: bool = False
+    """True if at least one ready task is assigned to a real Hermes profile."""
+
+    def __str__(self) -> str:
+        parts = [f"{self.slug} ({self.ready} ready, {self.running} running)"]
+        if self.ready_nonspawnable:
+            parts.append(f"({self.ready_nonspawnable} terminal lanes)")
+        return " ".join(parts)
+
+    @staticmethod
+    def format_stuck(boards: list[BoardDispatchHealth]) -> str:
+        """Format a human-readable summary of boards with spawnable work.
+
+        Returns a comma-separated string like
+        ``"ss-remediation-v2 (3 ready, 0 running), terax-remote (1 ready, 1 running)"``
+        or ``"unknown"`` if the list is empty.
+        """
+        stuck = [b for b in boards if b.spawnable]
+        return ", ".join(str(b) for b in stuck) if stuck else "unknown"
+
+
+def board_dispatch_health() -> list[BoardDispatchHealth]:
+    """Return per-board dispatch health summaries for all active boards.
+
+    Opens and closes per-board connections internally so the caller
+    does not need to manage connection lifecycles or bounce between
+    threads per board.  Safe to call from ``asyncio.to_thread()``.
+
+    .. note:: Performance
+       Each active board incurs one ``connect()`` + two COUNT queries +
+       one ``has_spawnable_ready`` probe + one optional GROUP BY for
+       terminal-lane partitioning.  For setups with many boards this is
+       O(boards × DB-ops); the diagnostic is rate-limited to once per
+       5 minutes by the callers, so the overhead is acceptable at typical
+       board counts (< 50).
+    """
+    try:
+        boards = list_boards(include_archived=False)
+    except Exception:
+        boards = [read_board_metadata(DEFAULT_BOARD)]
+
+    # Attempt to import profile_exists once for all boards rather than
+    # per-board (has_spawnable_ready does a local import internally).
+    _profile_exists = None
+    try:
+        from hermes_cli.profiles import profile_exists as _profile_exists  # noqa: N813
+    except Exception:
+        pass
+
+    results: list[BoardDispatchHealth] = []
+    for b in boards:
+        slug = b.get("slug") or DEFAULT_BOARD
+        conn = None
+        try:
+            conn = connect(board=slug)
+            ready = int(conn.execute(
+                "SELECT COUNT(*) FROM tasks "
+                "WHERE status = 'ready' AND assignee IS NOT NULL "
+                "AND assignee != '' AND claim_lock IS NULL"
+            ).fetchone()[0])
+            running = int(conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+            ).fetchone()[0])
+            try:
+                spawnable = has_spawnable_ready(conn)
+            except Exception:
+                # has_spawnable_ready can raise on pathological assignees
+                # (e.g. profile_exists('') ValueError).  In that case the
+                # ready count is authoritative — if there are ready tasks
+                # with non-empty assignees, conservatively assume spawnable.
+                spawnable = ready > 0
+            # Count how many ready tasks belong to non-profile (terminal)
+            # assignees so the operator can distinguish "real stuck" from
+            # "correctly idle".  Uses a per-task COUNT, not per-assignee.
+            # Excludes empty-string assignees to avoid ValueError in
+            # profile_exists('') (see has_spawnable_ready guard).
+            ready_nonspawnable = 0
+            if ready > 0 and _profile_exists is not None:
+                assignee_counts = conn.execute(
+                    "SELECT assignee, COUNT(*) AS cnt FROM tasks "
+                    "WHERE status = 'ready' AND assignee IS NOT NULL "
+                    "AND assignee != '' AND claim_lock IS NULL "
+                    "GROUP BY assignee"
+                ).fetchall()
+                ready_nonspawnable = sum(
+                    r["cnt"] for r in assignee_counts
+                    if not _profile_exists(r["assignee"])
+                )
+            results.append(BoardDispatchHealth(
+                slug=slug,
+                ready=ready,
+                ready_nonspawnable=ready_nonspawnable,
+                running=running,
+                spawnable=spawnable,
+            ))
+        except Exception:
+            results.append(BoardDispatchHealth(slug=slug))
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+    return results
 
 
 def dispatch_once(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",
+    "bradhallett@users.noreply.github.com": "bradhallett",
     "subw3@mail2.sysu.edu.cn": "Subway2023",
     "zhipengli@thebrainly.ai": "a1245582339",
     "mathijs.vd.hurk@gmail.com": "mathijsvandenhurk",

--- a/tests/hermes_cli/test_kanban_dispatch_health.py
+++ b/tests/hermes_cli/test_kanban_dispatch_health.py
@@ -1,0 +1,356 @@
+"""Tests for BoardDispatchHealth, board_dispatch_health(), and format_stuck().
+
+These cover the per-board dispatch health probe used by the gateway and
+CLI daemon stuck-detectors to identify WHICH boards have spawnable work
+backing up behind zero spawns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def fake_profile(monkeypatch):
+    """Make profile_exists return True for any name."""
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.profile_exists",
+        lambda name: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_exists",
+        lambda name: True,
+        raising=False,
+    )
+
+
+def _set_running(conn, task_id: str) -> None:
+    """Directly flip a task into running status for test purposes."""
+    conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (task_id,))
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# BoardDispatchHealth dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestBoardDispatchHealthDataclass:
+    def test_str_format(self):
+        h = kb.BoardDispatchHealth(slug="my-board", ready=3, running=1, spawnable=True)
+        assert str(h) == "my-board (3 ready, 1 running)"
+
+    def test_str_format_with_terminal_lanes(self):
+        h = kb.BoardDispatchHealth(
+            slug="mixed", ready=5, ready_nonspawnable=2, running=1, spawnable=True,
+        )
+        assert str(h) == "mixed (5 ready, 1 running) (2 terminal lanes)"
+
+    def test_str_format_zero_counts(self):
+        h = kb.BoardDispatchHealth(slug="empty-board")
+        assert str(h) == "empty-board (0 ready, 0 running)"
+
+    def test_defaults(self):
+        h = kb.BoardDispatchHealth(slug="test")
+        assert h.ready == 0
+        assert h.ready_nonspawnable == 0
+        assert h.running == 0
+        assert h.spawnable is False
+
+
+# ---------------------------------------------------------------------------
+# format_stuck (staticmethod)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatStuck:
+    def test_empty_list(self):
+        assert kb.BoardDispatchHealth.format_stuck([]) == "unknown"
+
+    def test_all_spawnable(self):
+        boards = [
+            kb.BoardDispatchHealth(slug="board-a", ready=3, running=1, spawnable=True),
+            kb.BoardDispatchHealth(slug="board-b", ready=1, running=0, spawnable=True),
+        ]
+        result = kb.BoardDispatchHealth.format_stuck(boards)
+        assert result == "board-a (3 ready, 1 running), board-b (1 ready, 0 running)"
+
+    def test_mixed_spawnable(self):
+        """Only spawnable boards appear in output."""
+        boards = [
+            kb.BoardDispatchHealth(slug="idle-board", spawnable=False),
+            kb.BoardDispatchHealth(slug="stuck-board", ready=5, running=0, spawnable=True),
+        ]
+        result = kb.BoardDispatchHealth.format_stuck(boards)
+        assert result == "stuck-board (5 ready, 0 running)"
+        assert "idle-board" not in result
+
+    def test_none_spawnable(self):
+        boards = [
+            kb.BoardDispatchHealth(slug="a", spawnable=False),
+            kb.BoardDispatchHealth(slug="b", spawnable=False),
+        ]
+        assert kb.BoardDispatchHealth.format_stuck(boards) == "unknown"
+
+    def test_spawnable_with_terminal_lanes_annotation(self):
+        """Terminal lane count is surfaced in the stuck summary."""
+        boards = [
+            kb.BoardDispatchHealth(
+                slug="mixed", ready=5, ready_nonspawnable=2,
+                running=1, spawnable=True,
+            ),
+        ]
+        result = kb.BoardDispatchHealth.format_stuck(boards)
+        assert "2 terminal lanes" in result
+
+
+# ---------------------------------------------------------------------------
+# board_dispatch_health (integration with DB)
+# ---------------------------------------------------------------------------
+
+
+class TestBoardDispatchHealthProbe:
+    def test_empty_board(self, kanban_home, fake_profile):
+        """Default board with no tasks returns ready=0, running=0, spawnable=False."""
+        results = kb.board_dispatch_health()
+        assert len(results) >= 1
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 0
+        assert default.ready_nonspawnable == 0
+        assert default.running == 0
+        assert default.spawnable is False
+
+    def test_counts_ready_tasks(self, kanban_home, fake_profile):
+        """Ready + assigned + unclaimed tasks are counted."""
+        with kb.connect() as conn:
+            # No parents → status defaults to 'ready'
+            kb.create_task(conn, title="t1", assignee="worker")
+            kb.create_task(conn, title="t2", assignee="worker")
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 2
+
+    def test_counts_running_tasks(self, kanban_home, fake_profile):
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="t1", assignee="worker")
+            _set_running(conn, tid)
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.running == 1
+
+    def test_spawnable_true_for_real_profile(self, kanban_home, fake_profile):
+        with kb.connect() as conn:
+            kb.create_task(conn, title="t1", assignee="worker")
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.spawnable is True
+
+    def test_spawnable_false_for_unassigned(self, kanban_home, fake_profile):
+        """Unassigned tasks don't count as spawnable."""
+        with kb.connect() as conn:
+            kb.create_task(conn, title="t1")
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.spawnable is False
+
+    def test_nonspawnable_counted_for_terminal_lanes(self, kanban_home, monkeypatch):
+        """Tasks assigned to non-existent profiles (terminal lanes) are
+        counted in ready_nonspawnable but don't make spawnable=True."""
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.profile_exists",
+            lambda name: False,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_exists",
+            lambda name: False,
+            raising=False,
+        )
+        with kb.connect() as conn:
+            kb.create_task(conn, title="t1", assignee="orion-cc")
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 1
+        assert default.ready_nonspawnable == 1
+        assert default.spawnable is False
+
+    def test_nonspawnable_counts_tasks_not_assignees(self, kanban_home, monkeypatch):
+        """Multiple tasks to the same terminal-lane assignee count all tasks,
+        not just distinct assignees."""
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.profile_exists",
+            lambda name: False,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_exists",
+            lambda name: False,
+            raising=False,
+        )
+        with kb.connect() as conn:
+            kb.create_task(conn, title="t1", assignee="orion-cc")
+            kb.create_task(conn, title="t2", assignee="orion-cc")
+            kb.create_task(conn, title="t3", assignee="orion-cc")
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 3
+        assert default.ready_nonspawnable == 3  # 3 tasks, not 1 assignee
+        assert default.spawnable is False
+
+    def test_mixed_spawnable_and_nonspawnable(self, kanban_home, monkeypatch):
+        """Both spawnable and non-spawnable tasks on the same board."""
+        call_count = {"n": 0}
+        def _exists(name):
+            call_count["n"] += 1
+            return name == "worker"
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.profile_exists",
+            _exists,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_exists",
+            _exists,
+            raising=False,
+        )
+        with kb.connect() as conn:
+            kb.create_task(conn, title="t1", assignee="worker")
+            kb.create_task(conn, title="t2", assignee="orion-cc")
+            kb.create_task(conn, title="t3", assignee="orion-research")
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 3
+        assert default.ready_nonspawnable == 2
+        assert default.spawnable is True
+
+    def test_multiple_boards(self, kanban_home, fake_profile):
+        """Health is reported per-board across all active boards."""
+        kb.create_board("project-x")
+        # Add a task to the default board
+        with kb.connect() as conn:
+            kb.create_task(conn, title="default-task", assignee="worker")
+        # Add a running task to project-x
+        with kb.connect(board="project-x") as conn:
+            tid = kb.create_task(conn, title="x-task", assignee="worker")
+            _set_running(conn, tid)
+        results = kb.board_dispatch_health()
+        slugs = {r.slug for r in results}
+        assert "default" in slugs
+        assert "project-x" in slugs
+        # Verify per-board counts
+        default = [r for r in results if r.slug == "default"][0]
+        project_x = [r for r in results if r.slug == "project-x"][0]
+        assert default.ready == 1
+        assert project_x.running == 1
+
+    def test_graceful_on_corrupt_board(self, kanban_home, fake_profile):
+        """A board with a corrupt/missing DB should not crash the probe."""
+        kb.create_board("broken")
+        # Delete the DB to simulate corruption
+        db_path = kb.kanban_db_path("broken")
+        if db_path.exists():
+            db_path.unlink()
+        # Should still return an entry for the broken board (with defaults)
+        results = kb.board_dispatch_health()
+        broken = [r for r in results if r.slug == "broken"]
+        assert len(broken) == 1
+        assert broken[0].ready == 0
+        assert broken[0].ready_nonspawnable == 0
+        assert broken[0].running == 0
+        assert broken[0].spawnable is False
+
+    def test_list_boards_failure_falls_back_to_default(self, kanban_home, fake_profile):
+        """If list_boards raises, falls back to default board only."""
+        with patch.object(kb, "list_boards", side_effect=RuntimeError("boom")):
+            results = kb.board_dispatch_health()
+        assert len(results) == 1
+        assert results[0].slug == "default"
+
+    def test_empty_string_assignee_does_not_crash(self, kanban_home, fake_profile):
+        """Tasks with assignee='' should not crash the probe via
+        profile_exists('') ValueError."""
+        with kb.connect() as conn:
+            # Create a task, then manually set assignee to empty string
+            tid = kb.create_task(conn, title="t1", assignee="worker")
+            conn.execute("UPDATE tasks SET assignee = '' WHERE id = ?", (tid,))
+            conn.commit()
+        # Should not raise — empty-string assignees are excluded from counts
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 0  # excluded by assignee != ''
+        assert default.ready_nonspawnable == 0
+
+    def test_empty_assignee_does_not_silence_real_spawnable(self, kanban_home, fake_profile):
+        """A board with one real task AND one empty-assignee task should
+        still report the real task's health — not silently drop everything
+        because has_spawnable_ready crashes on profile_exists('')."""
+        with kb.connect() as conn:
+            kb.create_task(conn, title="good", assignee="worker")
+            tid2 = kb.create_task(conn, title="bad", assignee="worker")
+            conn.execute("UPDATE tasks SET assignee = '' WHERE id = ?", (tid2,))
+            conn.commit()
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 1  # the good task counted
+        assert default.spawnable is True
+
+    def test_claim_locked_tasks_excluded_from_ready(self, kanban_home, fake_profile):
+        """Tasks with a claim_lock set should not be counted as ready."""
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="locked", assignee="worker")
+            conn.execute(
+                "UPDATE tasks SET claim_lock = ? WHERE id = ?",
+                ("session-abc", tid),
+            )
+            conn.commit()
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 0
+        assert default.running == 0
+
+    def test_profile_import_failure_skips_nonspawnable(self, kanban_home, monkeypatch):
+        """When hermes_cli.profiles can't be imported, ready_nonspawnable
+        stays 0 — the probe can't distinguish real profiles from terminal
+        lanes, so it reports conservatively."""
+        # Seed a task assigned to a non-profile lane.
+        with kb.connect() as conn:
+            kb.create_task(conn, title="t1", assignee="orion-cc")
+        # Make importing hermes_cli.profiles.profile_exists raise ImportError
+        # so board_dispatch_health's `from ... import` fails and
+        # _profile_exists stays None.
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_exists",
+            None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.profile_exists",
+            None,
+            raising=False,
+        )
+        results = kb.board_dispatch_health()
+        default = [r for r in results if r.slug == "default"][0]
+        assert default.ready == 1
+        assert default.ready_nonspawnable == 0  # can't introspect → 0


### PR DESCRIPTION
## Summary

When the kanban dispatcher fires the "stuck" warning (ready queue non-empty but 0 workers spawned for N consecutive ticks), operators see no indication of **which board** has spawnable work backing up. This PR adds per-board diagnosis to make the warning actionable.

**Before:**
```
WARN kanban dispatcher stuck: ready queue non-empty for 15 consecutive ticks but 0 workers spawned
```

**After:**
```
WARN kanban dispatcher stuck: ready queue non-empty for 15 consecutive ticks but 0 workers spawned [boards: ss-remediation (3 ready, 0 running), terax-remote (1 ready, 1 running)].
```

## Changes

- **`BoardDispatchHealth` dataclass** (`kanban_db.py`): per-board summary with `ready`, `running`, `spawnable`, and `ready_nonspawnable` (terminal-lane tasks like `orion-cc` that are claimed externally, not spawned). Includes `__str__` and `format_stuck()` static method.

- **`board_dispatch_health()` probe** (`kanban_db.py`): iterates all active boards with per-board connection lifecycle. Three layers of error handling: caller catches diagnostic failure, probe catches per-board failure, inner `has_spawnable_ready` crash caught with conservative fallback.

- **Gateway integration** (`gateway/run.py`): calls probe via `asyncio.to_thread()` in the stuck-detector, rate-limited to once per 5 minutes.

- **CLI daemon integration** (`hermes_cli/kanban.py`): calls probe directly (synchronous context), same rate limit.

- **Bug fix**: `has_spawnable_ready()` SQL now filters `assignee != ''` to prevent `profile_exists('')` ValueError on pathological task data.

- **24 new tests** covering dataclass formatting, `format_stuck` filtering, DB integration, multi-board, corrupt DB, empty-string assignees, claim-locked tasks, import failure fallback, and terminal-lane partitioning.

## Bug Fixed: `has_spawnable_ready` Empty-String Crash

The existing `has_spawnable_ready()` queries `WHERE assignee IS NOT NULL` but does not filter out empty strings. When a task has `assignee=""`, the function passes that empty string to `profile_exists("")`, which raises `ValueError`. This PR adds the filter at source and adds a fallback handler in the probe.

## Validation

```
$ pytest tests/hermes_cli/test_kanban_dispatch_health.py -v
24 passed in 0.41s

$ pytest tests/hermes_cli/test_kanban_dispatch_health.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_cli.py -q
493 passed, 1 skipped in 11.36s
```

Zero regressions across 493 kanban tests.
