### PR TITLE
feat: add safe Bitwarden inventory and prune flow

### DIFF
--- a/hermes_cli/bitwarden_migration.py
+++ b/hermes_cli/bitwarden_migration.py
@@ -1,0 +1,524 @@
+"""Safe Bitwarden migration helpers for profile-local ``.env`` files.
+
+These helpers are deliberately read-only until ``apply_prune_plan`` runs.
+They never touch ``config.yaml`` beyond reading the Bitwarden settings that
+control verification.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+import yaml
+
+from agent.secret_sources.bitwarden import fetch_bitwarden_secrets
+from hermes_cli.profiles import get_active_profile_name, list_profiles, resolve_profile_env
+from hermes_constants import get_hermes_home
+from utils import atomic_replace, is_truthy_value
+
+ENV_ASSIGNMENT_RE = re.compile(
+    r"^\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*="
+)
+ENV_SURFACE = ".env"
+
+BOOTSTRAP_CLASS = "bootstrap-secret"
+SECRET_CLASS = "secret"
+NON_SECRET_CLASS = "non-secret"
+
+_SECRET_MARKERS = (
+    "API_KEY",
+    "ACCESS_TOKEN",
+    "REFRESH_TOKEN",
+    "PRIVATE_KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "_KEY",
+)
+
+
+@dataclass(frozen=True)
+class BitwardenSettings:
+    enabled: bool
+    access_token_env: str
+    project_id: str
+    server_url: str
+
+
+@dataclass(frozen=True)
+class InventoryRow:
+    profile: str
+    surface: str
+    env_path: Path
+    key: str
+    classification: str
+    state: str
+
+
+@dataclass(frozen=True)
+class PruneRow:
+    profile: str
+    surface: str
+    env_path: Path
+    key: str
+    classification: str
+    state: str
+    action: str
+    reason: str
+    bws_resolved: bool | None = None
+
+
+@dataclass(frozen=True)
+class PrunePlan:
+    profile: str
+    profile_home: Path
+    env_path: Path
+    config_path: Path
+    settings: BitwardenSettings
+    rows: list[PruneRow]
+    warnings: list[str]
+    verification_error: str | None = None
+
+    def removable_keys(self) -> list[str]:
+        return [row.key for row in self.rows if row.action == "remove"]
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    profile: str
+    env_path: Path
+    backup_path: Path | None
+    removed_keys: list[str]
+    changed: bool
+
+
+def classify_env_key(key: str, *, bootstrap_key: str = "BWS_ACCESS_TOKEN") -> str:
+    """Return a conservative secret classification for a single env var name."""
+    if key == bootstrap_key:
+        return BOOTSTRAP_CLASS
+
+    upper = key.upper()
+    if any(marker in upper for marker in _SECRET_MARKERS):
+        return SECRET_CLASS
+    return NON_SECRET_CLASS
+
+
+def _read_yaml_mapping(config_path: Path) -> tuple[dict[str, object], list[str]]:
+    warnings: list[str] = []
+    if not config_path.exists():
+        return {}, warnings
+
+    try:
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - surfaced as a warning for the CLI
+        return {}, [f"could not read {config_path.name}: {exc}"]
+
+    if loaded is None:
+        return {}, warnings
+    if not isinstance(loaded, dict):
+        return {}, [f"{config_path.name} did not contain a mapping"]
+    return loaded, warnings
+
+
+def load_bitwarden_settings(profile_home: Path) -> tuple[BitwardenSettings, list[str]]:
+    """Read the Bitwarden config for one profile without mutating anything."""
+    config_path = profile_home / "config.yaml"
+    config, warnings = _read_yaml_mapping(config_path)
+    secrets = config.get("secrets")
+    bws = secrets.get("bitwarden") if isinstance(secrets, dict) else None
+    if not isinstance(bws, dict):
+        return (
+            BitwardenSettings(
+                enabled=False,
+                access_token_env="BWS_ACCESS_TOKEN",
+                project_id="",
+                server_url="",
+            ),
+            warnings,
+        )
+
+    access_token_env = str(bws.get("access_token_env") or "BWS_ACCESS_TOKEN").strip()
+    if not access_token_env:
+        access_token_env = "BWS_ACCESS_TOKEN"
+
+    return (
+        BitwardenSettings(
+            enabled=is_truthy_value(bws.get("enabled"), default=False),
+            access_token_env=access_token_env,
+            project_id=str(bws.get("project_id") or "").strip(),
+            server_url=str(bws.get("server_url") or "").strip(),
+        ),
+        warnings,
+    )
+
+
+def _read_env_assignments(env_path: Path) -> list[tuple[str, str]]:
+    """Parse a .env file into ordered ``(key, value)`` assignments.
+
+    The parser is intentionally conservative: it only recognizes top-level
+    assignments (with optional ``export``) and treats everything after the first
+    ``=`` as value text.  That is enough for inventory and pruning without
+    needing to load the file into ``os.environ``.
+    """
+    if not env_path.exists():
+        return []
+
+    assignments: list[tuple[str, str]] = []
+    for line in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = ENV_ASSIGNMENT_RE.match(line)
+        if not match:
+            continue
+        key = match.group("key")
+        raw_value = line[match.end() :]
+        assignments.append((key, _normalize_env_value(raw_value)))
+    return assignments
+
+
+def _normalize_env_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if not value:
+        return ""
+
+    # Strip one layer of matching quotes if present.
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+
+    # Drop a simple inline comment for unquoted values.
+    if " #" in value:
+        value = value.split(" #", 1)[0].rstrip()
+    return value
+
+
+def _assignment_map(assignments: Iterable[tuple[str, str]]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for key, value in assignments:
+        values[key] = value
+    return values
+
+
+def _profile_targets(
+    profile_name: str | None = None,
+    *,
+    all_profiles: bool = False,
+) -> list[tuple[str, Path]]:
+    if all_profiles:
+        targets: list[tuple[str, Path]] = []
+        for profile in list_profiles():
+            targets.append((profile.name, profile.path))
+        return targets
+
+    if profile_name:
+        return [(profile_name, Path(resolve_profile_env(profile_name)))]
+
+    return [(get_active_profile_name() or "default", get_hermes_home())]
+
+
+def inventory_rows_for_profile(profile_name: str, profile_home: Path) -> list[InventoryRow]:
+    env_path = profile_home / ".env"
+    if not env_path.exists():
+        return []
+
+    settings, _warnings = load_bitwarden_settings(profile_home)
+    assignments = _read_env_assignments(env_path)
+    values = _assignment_map(assignments)
+    rows: list[InventoryRow] = []
+    seen: set[str] = set()
+    for key, _value in assignments:
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(
+            InventoryRow(
+                profile=profile_name,
+                surface=ENV_SURFACE,
+                env_path=env_path,
+                key=key,
+                classification=classify_env_key(
+                    key,
+                    bootstrap_key=settings.access_token_env,
+                ),
+                state="set" if values.get(key, "").strip() else "blank",
+            )
+        )
+    return rows
+
+
+def collect_inventory_rows(
+    profile_name: str | None = None,
+    *,
+    all_profiles: bool = False,
+) -> list[InventoryRow]:
+    rows: list[InventoryRow] = []
+    for name, home in _profile_targets(profile_name, all_profiles=all_profiles):
+        rows.extend(inventory_rows_for_profile(name, home))
+    return rows
+
+
+def prune_plan_for_profile(
+    profile_name: str,
+    profile_home: Path,
+    *,
+    fetcher: Callable[..., tuple[dict[str, str], list[str]]] | None = None,
+) -> PrunePlan:
+    """Build a safe, read-only plan for pruning plaintext secrets."""
+    env_path = profile_home / ".env"
+    config_path = profile_home / "config.yaml"
+    settings, warnings = load_bitwarden_settings(profile_home)
+    assignments = _read_env_assignments(env_path)
+    values = _assignment_map(assignments)
+    fetcher = fetcher or fetch_bitwarden_secrets
+
+    rows: list[PruneRow] = []
+    verification_error: str | None = None
+    secret_names: set[str] = set()
+
+    if not env_path.exists():
+        return PrunePlan(
+            profile=profile_name,
+            profile_home=profile_home,
+            env_path=env_path,
+            config_path=config_path,
+            settings=settings,
+            rows=[],
+            warnings=warnings,
+            verification_error=None,
+        )
+
+    if not settings.enabled:
+        verification_error = "Bitwarden is disabled in config.yaml"
+    else:
+        token = values.get(settings.access_token_env, "").strip()
+        if not token:
+            verification_error = (
+                f"{settings.access_token_env} is not set in {env_path.name}"
+            )
+        elif not settings.project_id:
+            verification_error = "Bitwarden project_id is not configured"
+        else:
+            try:
+                fetched, fetch_warnings = fetcher(
+                    access_token=token,
+                    project_id=settings.project_id,
+                    server_url=settings.server_url,
+                    use_cache=False,
+                    home_path=profile_home,
+                )
+                warnings.extend(fetch_warnings)
+                secret_names = set(fetched)
+            except Exception as exc:  # noqa: BLE001 - surfaced to the CLI
+                verification_error = f"Bitwarden verification failed: {exc}"
+
+    seen: set[str] = set()
+    for key, value in assignments:
+        if key in seen:
+            continue
+        seen.add(key)
+        classification = classify_env_key(
+            key,
+            bootstrap_key=settings.access_token_env,
+        )
+        state = "set" if value.strip() else "blank"
+        if classification == BOOTSTRAP_CLASS:
+            rows.append(
+                PruneRow(
+                    profile=profile_name,
+                    surface=ENV_SURFACE,
+                    env_path=env_path,
+                    key=key,
+                    classification=classification,
+                    state=state,
+                    action="keep",
+                    reason="bootstrap token is kept locally",
+                    bws_resolved=None,
+                )
+            )
+            continue
+
+        if classification == NON_SECRET_CLASS:
+            rows.append(
+                PruneRow(
+                    profile=profile_name,
+                    surface=ENV_SURFACE,
+                    env_path=env_path,
+                    key=key,
+                    classification=classification,
+                    state=state,
+                    action="keep",
+                    reason="non-secret config stays in .env",
+                    bws_resolved=None,
+                )
+            )
+            continue
+
+        if verification_error is not None:
+            rows.append(
+                PruneRow(
+                    profile=profile_name,
+                    surface=ENV_SURFACE,
+                    env_path=env_path,
+                    key=key,
+                    classification=classification,
+                    state=state,
+                    action="keep",
+                    reason=verification_error,
+                    bws_resolved=None,
+                )
+            )
+            continue
+
+        if not state == "set":
+            rows.append(
+                PruneRow(
+                    profile=profile_name,
+                    surface=ENV_SURFACE,
+                    env_path=env_path,
+                    key=key,
+                    classification=classification,
+                    state=state,
+                    action="keep",
+                    reason="blank secret entry is left untouched",
+                    bws_resolved=key in secret_names,
+                )
+            )
+            continue
+
+        if key in secret_names:
+            rows.append(
+                PruneRow(
+                    profile=profile_name,
+                    surface=ENV_SURFACE,
+                    env_path=env_path,
+                    key=key,
+                    classification=classification,
+                    state=state,
+                    action="remove",
+                    reason="verified in Bitwarden project",
+                    bws_resolved=True,
+                )
+            )
+        else:
+            rows.append(
+                PruneRow(
+                    profile=profile_name,
+                    surface=ENV_SURFACE,
+                    env_path=env_path,
+                    key=key,
+                    classification=classification,
+                    state=state,
+                    action="keep",
+                    reason="not found in Bitwarden project",
+                    bws_resolved=False,
+                )
+            )
+
+    return PrunePlan(
+        profile=profile_name,
+        profile_home=profile_home,
+        env_path=env_path,
+        config_path=config_path,
+        settings=settings,
+        rows=rows,
+        warnings=warnings,
+        verification_error=verification_error,
+    )
+
+
+def prune_plan_for_current_profile(
+    *,
+    fetcher: Callable[..., tuple[dict[str, str], list[str]]] | None = None,
+) -> PrunePlan:
+    profile_name = get_active_profile_name() or "default"
+    return prune_plan_for_profile(
+        profile_name,
+        get_hermes_home(),
+        fetcher=fetcher,
+    )
+
+
+def apply_prune_plan(plan: PrunePlan) -> PruneResult:
+    """Apply a prune plan to ``plan.env_path`` and create a local backup."""
+    remove_keys = {row.key for row in plan.rows if row.action == "remove"}
+    if not remove_keys:
+        return PruneResult(
+            profile=plan.profile,
+            env_path=plan.env_path,
+            backup_path=None,
+            removed_keys=[],
+            changed=False,
+        )
+
+    original_lines = plan.env_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    kept_lines: list[str] = []
+    removed_keys: list[str] = []
+    for line in original_lines:
+        match = ENV_ASSIGNMENT_RE.match(line)
+        if match and match.group("key") in remove_keys:
+            removed_keys.append(match.group("key"))
+            continue
+        kept_lines.append(line)
+
+    if not removed_keys:
+        return PruneResult(
+            profile=plan.profile,
+            env_path=plan.env_path,
+            backup_path=None,
+            removed_keys=[],
+            changed=False,
+        )
+
+    backup_path = _make_backup_path(plan.env_path)
+    shutil.copy2(plan.env_path, backup_path)
+    _tighten_mode(backup_path)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(plan.env_path.parent),
+        prefix=f".{plan.env_path.name}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write("".join(kept_lines))
+            fh.flush()
+            os.fsync(fh.fileno())
+        atomic_replace(tmp_path, plan.env_path)
+        _tighten_mode(plan.env_path)
+    except Exception:
+        raise
+
+    return PruneResult(
+        profile=plan.profile,
+        env_path=plan.env_path,
+        backup_path=backup_path,
+        removed_keys=removed_keys,
+        changed=True,
+    )
+
+
+def _make_backup_path(env_path: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    candidate = env_path.with_name(
+        f"{env_path.name}.bak-pre-bitwarden-prune-{stamp}"
+    )
+    suffix = 0
+    while candidate.exists():
+        suffix += 1
+        candidate = env_path.with_name(
+            f"{env_path.name}.bak-pre-bitwarden-prune-{stamp}-{suffix}"
+        )
+    return candidate
+
+
+def _tighten_mode(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass

--- a/hermes_cli/bitwarden_migration.py
+++ b/hermes_cli/bitwarden_migration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import stat
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -537,6 +538,7 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
             changed=False,
         )
 
+    original_mode = stat.S_IMODE(plan.env_path.stat().st_mode)
     original_lines, assignments = _read_env_assignment_spans(plan.env_path)
     if any(not assignment.complete for assignment in assignments):
         return PruneResult(
@@ -582,8 +584,8 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
             fh.write("".join(kept_lines))
             fh.flush()
             os.fsync(fh.fileno())
+        os.chmod(tmp_path, original_mode)
         atomic_replace(tmp_path, plan.env_path)
-        _tighten_mode(plan.env_path)
     except Exception:
         raise
 

--- a/hermes_cli/bitwarden_migration.py
+++ b/hermes_cli/bitwarden_migration.py
@@ -294,10 +294,14 @@ def prune_plan_for_profile(
     if not settings.enabled:
         verification_error = "Bitwarden is disabled in config.yaml"
     else:
-        token = values.get(settings.access_token_env, "").strip()
+        token = (
+            values.get(settings.access_token_env, "").strip()
+            or os.environ.get(settings.access_token_env, "").strip()
+        )
         if not token:
             verification_error = (
-                f"{settings.access_token_env} is not set in {env_path.name}"
+                f"{settings.access_token_env} is not set in {env_path.name} "
+                "or the process environment"
             )
         elif not settings.project_id:
             verification_error = "Bitwarden project_id is not configured"

--- a/hermes_cli/bitwarden_migration.py
+++ b/hermes_cli/bitwarden_migration.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import re
-import shutil
 import stat
 import tempfile
 from dataclasses import dataclass
@@ -40,6 +39,14 @@ _VERIFICATION_FAILURE = (
 _ENV_PARSE_FAILURE = (
     "Could not safely parse .env; no plaintext secrets were removed. "
     "Fix unterminated quoted values, then retry."
+)
+_ENV_ENCODING_FAILURE = (
+    "Could not safely decode .env as UTF-8; no plaintext secrets were removed. "
+    "Convert the file to UTF-8 without data loss, then retry."
+)
+_ENV_READ_FAILURE = (
+    "Could not safely read .env; no plaintext secrets were removed. "
+    "Check the file permissions, then retry."
 )
 
 _SECRET_MARKERS = (
@@ -118,6 +125,10 @@ class PruneResult:
     changed: bool
 
 
+class PruneRollbackError(RuntimeError):
+    """Raised when pruning fails and the original file cannot be fully restored."""
+
+
 def classify_env_key(key: str, *, bootstrap_key: str = "BWS_ACCESS_TOKEN") -> str:
     """Return a conservative secret classification for a single env var name."""
     if key == bootstrap_key:
@@ -178,14 +189,10 @@ def load_bitwarden_settings(profile_home: Path) -> tuple[BitwardenSettings, list
     )
 
 
-def _read_env_assignment_spans(env_path: Path) -> tuple[list[str], list[_EnvAssignment]]:
-    if not env_path.exists():
-        return [], []
-
-    lines = env_path.read_text(
-        encoding="utf-8",
-        errors="replace",
-    ).splitlines(keepends=True)
+def _parse_env_assignment_spans(
+    contents: bytes,
+) -> tuple[list[str], list[_EnvAssignment]]:
+    lines = contents.decode("utf-8").splitlines(keepends=True)
     assignments: list[_EnvAssignment] = []
     line_index = 0
     while line_index < len(lines):
@@ -219,6 +226,12 @@ def _read_env_assignment_spans(env_path: Path) -> tuple[list[str], list[_EnvAssi
         line_index = end_line
 
     return lines, assignments
+
+
+def _read_env_assignment_spans(env_path: Path) -> tuple[list[str], list[_EnvAssignment]]:
+    if not env_path.exists():
+        return [], []
+    return _parse_env_assignment_spans(env_path.read_bytes())
 
 
 def _read_env_assignments(env_path: Path) -> list[tuple[str, str]]:
@@ -342,17 +355,6 @@ def prune_plan_for_profile(
     env_path = profile_home / ".env"
     config_path = profile_home / "config.yaml"
     settings, warnings = load_bitwarden_settings(profile_home)
-    _lines, assignment_spans = _read_env_assignment_spans(env_path)
-    assignments = [
-        (assignment.key, assignment.value) for assignment in assignment_spans
-    ]
-    values = _assignment_map(assignments)
-    fetcher = fetcher or fetch_bitwarden_secrets
-
-    rows: list[PruneRow] = []
-    verification_error: str | None = None
-    secret_names: set[str] = set()
-
     if not env_path.exists():
         return PrunePlan(
             profile=profile_name,
@@ -365,39 +367,63 @@ def prune_plan_for_profile(
             verification_error=None,
         )
 
-    if any(not assignment.complete for assignment in assignment_spans):
-        verification_error = _ENV_PARSE_FAILURE
-    elif not settings.enabled:
-        verification_error = "Bitwarden is disabled in config.yaml"
-    else:
-        token = (
-            values.get(settings.access_token_env, "").strip()
-            or os.environ.get(settings.access_token_env, "").strip()
-        )
-        if not token:
-            verification_error = (
-                f"{settings.access_token_env} is not set in {env_path.name} "
-                "or the process environment"
-            )
-        elif not settings.project_id:
-            verification_error = "Bitwarden project_id is not configured"
+    verification_error: str | None = None
+    try:
+        _lines, assignment_spans = _read_env_assignment_spans(env_path)
+    except UnicodeDecodeError:
+        assignment_spans = []
+        verification_error = _ENV_ENCODING_FAILURE
+    except OSError:
+        assignment_spans = []
+        verification_error = _ENV_READ_FAILURE
+
+    assignments = [
+        (assignment.key, assignment.value) for assignment in assignment_spans
+    ]
+    values = _assignment_map(assignments)
+    fetcher = fetcher or fetch_bitwarden_secrets
+
+    rows: list[PruneRow] = []
+    secret_names: set[str] = set()
+
+    if verification_error is None:
+        if any(not assignment.complete for assignment in assignment_spans):
+            verification_error = _ENV_PARSE_FAILURE
+        elif not settings.enabled:
+            verification_error = "Bitwarden is disabled in config.yaml"
         else:
-            try:
-                fetched, fetch_warnings = fetcher(
-                    access_token=token,
-                    project_id=settings.project_id,
-                    server_url=settings.server_url,
-                    use_cache=False,
-                    home_path=profile_home,
+            token = (
+                values.get(settings.access_token_env, "").strip()
+                or os.environ.get(settings.access_token_env, "").strip()
+            )
+            if not token:
+                verification_error = (
+                    f"{settings.access_token_env} is not set in {env_path.name} "
+                    "or the process environment"
                 )
-                if fetch_warnings:
-                    warnings.append(
-                        "Bitwarden verification returned "
-                        f"{len(fetch_warnings)} warning(s); backend details were redacted."
+            elif not settings.project_id:
+                verification_error = "Bitwarden project_id is not configured"
+            else:
+                try:
+                    fetched, fetch_warnings = fetcher(
+                        access_token=token,
+                        project_id=settings.project_id,
+                        server_url=settings.server_url,
+                        use_cache=False,
+                        home_path=profile_home,
                     )
-                secret_names = set(fetched)
-            except Exception:  # noqa: BLE001 - backend details may contain secrets
-                verification_error = _VERIFICATION_FAILURE
+                    if fetch_warnings:
+                        warnings.append(
+                            "Bitwarden verification returned "
+                            f"{len(fetch_warnings)} warning(s); backend details were redacted."
+                        )
+                    secret_names = {
+                        key
+                        for key, value in fetched.items()
+                        if isinstance(value, str) and bool(value.strip())
+                    }
+                except Exception:  # noqa: BLE001 - backend details may contain secrets
+                    verification_error = _VERIFICATION_FAILURE
 
     seen: set[str] = set()
     for key, value in assignments:
@@ -527,7 +553,7 @@ def prune_plan_for_current_profile(
 
 
 def apply_prune_plan(plan: PrunePlan) -> PruneResult:
-    """Apply a prune plan to ``plan.env_path`` and create a local backup."""
+    """Apply a prune plan to ``plan.env_path`` and create a private backup."""
     remove_keys = {row.key for row in plan.rows if row.action == "remove"}
     if not remove_keys:
         return PruneResult(
@@ -538,8 +564,10 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
             changed=False,
         )
 
-    original_mode = stat.S_IMODE(plan.env_path.stat().st_mode)
-    original_lines, assignments = _read_env_assignment_spans(plan.env_path)
+    with plan.env_path.open("rb") as source:
+        original_mode = stat.S_IMODE(os.fstat(source.fileno()).st_mode)
+        original_bytes = source.read()
+    original_lines, assignments = _parse_env_assignment_spans(original_bytes)
     if any(not assignment.complete for assignment in assignments):
         return PruneResult(
             profile=plan.profile,
@@ -557,10 +585,6 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
         removed_keys.append(assignment.key)
         removed_line_indexes.update(range(assignment.start_line, assignment.end_line))
 
-    kept_lines = [
-        line for index, line in enumerate(original_lines) if index not in removed_line_indexes
-    ]
-
     if not removed_keys:
         return PruneResult(
             profile=plan.profile,
@@ -570,24 +594,38 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
             changed=False,
         )
 
+    kept_bytes = "".join(
+        line
+        for index, line in enumerate(original_lines)
+        if index not in removed_line_indexes
+    ).encode("utf-8")
     backup_path = _make_backup_path(plan.env_path)
-    shutil.copy2(plan.env_path, backup_path)
-    _tighten_mode(backup_path)
+    tmp_path: Path | None = None
 
-    fd, tmp_path = tempfile.mkstemp(
-        dir=str(plan.env_path.parent),
-        prefix=f".{plan.env_path.name}_",
-        suffix=".tmp",
-    )
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write("".join(kept_lines))
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.chmod(tmp_path, original_mode)
-        atomic_replace(tmp_path, plan.env_path)
-    except Exception:
+        _create_private_backup(backup_path, original_bytes)
+        _verify_private_path(backup_path)
+        tmp_path = _create_private_temp(plan.env_path, kept_bytes)
+        replace_result = atomic_replace(tmp_path, plan.env_path)
+        replaced_path = Path(replace_result or plan.env_path)
+        tmp_path = None
+        os.chmod(replaced_path, original_mode)
+    except BaseException:
+        restored = _restore_original_if_needed(
+            plan.env_path,
+            original_bytes,
+            original_mode,
+        )
+        if restored:
+            _remove_artifact(backup_path)
+        else:
+            raise PruneRollbackError(
+                "Secret pruning failed and automatic rollback did not complete. "
+                "Inspect the private .env backup and active .env before retrying."
+            ) from None
         raise
+    finally:
+        _remove_artifact(tmp_path)
 
     return PruneResult(
         profile=plan.profile,
@@ -596,6 +634,131 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
         removed_keys=removed_keys,
         changed=True,
     )
+
+
+def _write_all(fd: int, contents: bytes) -> None:
+    remaining = memoryview(contents)
+    while remaining:
+        try:
+            written = os.write(fd, remaining)
+        except InterruptedError:
+            continue
+        if written <= 0:
+            raise OSError("could not complete private file write")
+        remaining = remaining[written:]
+
+
+def _prepare_private_fd(fd: int) -> None:
+    if hasattr(os, "fchmod"):
+        os.fchmod(fd, 0o600)
+    if os.name != "nt" and stat.S_IMODE(os.fstat(fd).st_mode) != 0o600:
+        raise PermissionError("private file mode verification failed")
+
+
+def _write_private_fd(fd: int, contents: bytes) -> None:
+    _prepare_private_fd(fd)
+    _write_all(fd, contents)
+    os.fsync(fd)
+    if os.name != "nt" and stat.S_IMODE(os.fstat(fd).st_mode) != 0o600:
+        raise PermissionError("private file mode changed during write")
+
+
+def _create_private_backup(path: Path, contents: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd = os.open(path, flags, 0o600)
+    try:
+        _write_private_fd(fd, contents)
+        os.close(fd)
+        fd = -1
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        _remove_artifact(path)
+        raise
+
+
+def _create_private_temp(env_path: Path, contents: bytes) -> Path:
+    fd, raw_path = tempfile.mkstemp(
+        dir=str(env_path.parent),
+        prefix=f".{env_path.name}_",
+        suffix=".tmp",
+    )
+    path = Path(raw_path)
+    try:
+        _write_private_fd(fd, contents)
+        os.close(fd)
+        fd = -1
+        _verify_private_path(path)
+        return path
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        _remove_artifact(path)
+        raise
+
+
+def _verify_private_path(path: Path) -> None:
+    if os.name != "nt" and stat.S_IMODE(path.stat().st_mode) != 0o600:
+        raise PermissionError("private file mode verification failed")
+
+
+def _restore_original_if_needed(
+    env_path: Path,
+    original_bytes: bytes,
+    original_mode: int,
+) -> bool:
+    try:
+        current_bytes = env_path.read_bytes()
+    except OSError:
+        return False
+
+    if current_bytes != original_bytes:
+        rollback_path: Path | None = None
+        try:
+            rollback_path = _create_private_temp(env_path, original_bytes)
+            replace_result = atomic_replace(rollback_path, env_path)
+            restored_path = Path(replace_result or env_path)
+            rollback_path = None
+            try:
+                os.chmod(restored_path, original_mode)
+            except OSError:
+                pass
+        except BaseException:
+            pass
+        finally:
+            _remove_artifact(rollback_path)
+    else:
+        try:
+            os.chmod(env_path, original_mode)
+        except OSError:
+            pass
+
+    try:
+        if env_path.read_bytes() != original_bytes:
+            return False
+        return os.name == "nt" or stat.S_IMODE(env_path.stat().st_mode) == original_mode
+    except OSError:
+        return False
+
+
+def _remove_artifact(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def _make_backup_path(env_path: Path) -> Path:
@@ -610,10 +773,3 @@ def _make_backup_path(env_path: Path) -> Path:
             f"{env_path.name}.bak-pre-bitwarden-prune-{stamp}-{suffix}"
         )
     return candidate
-
-
-def _tighten_mode(path: Path) -> None:
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass

--- a/hermes_cli/bitwarden_migration.py
+++ b/hermes_cli/bitwarden_migration.py
@@ -32,6 +32,15 @@ BOOTSTRAP_CLASS = "bootstrap-secret"
 SECRET_CLASS = "secret"
 NON_SECRET_CLASS = "non-secret"
 
+_VERIFICATION_FAILURE = (
+    "Bitwarden verification failed; no plaintext secrets were removed. "
+    "Check Bitwarden configuration and credentials, then retry."
+)
+_ENV_PARSE_FAILURE = (
+    "Could not safely parse .env; no plaintext secrets were removed. "
+    "Fix unterminated quoted values, then retry."
+)
+
 _SECRET_MARKERS = (
     "API_KEY",
     "ACCESS_TOKEN",
@@ -50,6 +59,15 @@ class BitwardenSettings:
     access_token_env: str
     project_id: str
     server_url: str
+
+
+@dataclass(frozen=True)
+class _EnvAssignment:
+    key: str
+    value: str
+    start_line: int
+    end_line: int
+    complete: bool
 
 
 @dataclass(frozen=True)
@@ -117,8 +135,8 @@ def _read_yaml_mapping(config_path: Path) -> tuple[dict[str, object], list[str]]
 
     try:
         loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001 - surfaced as a warning for the CLI
-        return {}, [f"could not read {config_path.name}: {exc}"]
+    except Exception:  # noqa: BLE001 - config errors must not expose file contents
+        return {}, [f"could not read {config_path.name}; fix its YAML syntax and retry"]
 
     if loaded is None:
         return {}, warnings
@@ -159,26 +177,75 @@ def load_bitwarden_settings(profile_home: Path) -> tuple[BitwardenSettings, list
     )
 
 
-def _read_env_assignments(env_path: Path) -> list[tuple[str, str]]:
-    """Parse a .env file into ordered ``(key, value)`` assignments.
-
-    The parser is intentionally conservative: it only recognizes top-level
-    assignments (with optional ``export``) and treats everything after the first
-    ``=`` as value text.  That is enough for inventory and pruning without
-    needing to load the file into ``os.environ``.
-    """
+def _read_env_assignment_spans(env_path: Path) -> tuple[list[str], list[_EnvAssignment]]:
     if not env_path.exists():
-        return []
+        return [], []
 
-    assignments: list[tuple[str, str]] = []
-    for line in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
-        match = ENV_ASSIGNMENT_RE.match(line)
+    lines = env_path.read_text(
+        encoding="utf-8",
+        errors="replace",
+    ).splitlines(keepends=True)
+    assignments: list[_EnvAssignment] = []
+    line_index = 0
+    while line_index < len(lines):
+        match = ENV_ASSIGNMENT_RE.match(lines[line_index])
         if not match:
+            line_index += 1
             continue
-        key = match.group("key")
-        raw_value = line[match.end() :]
-        assignments.append((key, _normalize_env_value(raw_value)))
-    return assignments
+
+        raw_parts = [lines[line_index][match.end() :]]
+        end_line = line_index + 1
+        complete = True
+        quote_info = _opening_quote(raw_parts[0])
+        if quote_info is not None:
+            quote, content_start = quote_info
+            complete = _find_closing_quote(raw_parts[0][content_start:], quote) is not None
+            while not complete and end_line < len(lines):
+                continuation = lines[end_line]
+                raw_parts.append(continuation)
+                end_line += 1
+                complete = _find_closing_quote(continuation, quote) is not None
+
+        assignments.append(
+            _EnvAssignment(
+                key=match.group("key"),
+                value=_normalize_env_value("".join(raw_parts)),
+                start_line=line_index,
+                end_line=end_line,
+                complete=complete,
+            )
+        )
+        line_index = end_line
+
+    return lines, assignments
+
+
+def _read_env_assignments(env_path: Path) -> list[tuple[str, str]]:
+    """Parse ordered assignments without loading values into ``os.environ``."""
+    _lines, assignments = _read_env_assignment_spans(env_path)
+    return [(assignment.key, assignment.value) for assignment in assignments]
+
+
+def _opening_quote(raw_value: str) -> tuple[str, int] | None:
+    leading_space = len(raw_value) - len(raw_value.lstrip())
+    if leading_space >= len(raw_value):
+        return None
+    quote = raw_value[leading_space]
+    if quote not in {'"', "'"}:
+        return None
+    return quote, leading_space + 1
+
+
+def _find_closing_quote(text: str, quote: str) -> int | None:
+    escaped = False
+    for index, character in enumerate(text):
+        if character == quote and not escaped:
+            return index
+        if character == "\\":
+            escaped = not escaped
+        else:
+            escaped = False
+    return None
 
 
 def _normalize_env_value(raw_value: str) -> str:
@@ -186,9 +253,12 @@ def _normalize_env_value(raw_value: str) -> str:
     if not value:
         return ""
 
-    # Strip one layer of matching quotes if present.
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
-        return value[1:-1]
+    quote_info = _opening_quote(value)
+    if quote_info is not None:
+        quote, content_start = quote_info
+        content = value[content_start:]
+        closing_quote = _find_closing_quote(content, quote)
+        return content if closing_quote is None else content[:closing_quote]
 
     # Drop a simple inline comment for unquoted values.
     if " #" in value:
@@ -271,7 +341,10 @@ def prune_plan_for_profile(
     env_path = profile_home / ".env"
     config_path = profile_home / "config.yaml"
     settings, warnings = load_bitwarden_settings(profile_home)
-    assignments = _read_env_assignments(env_path)
+    _lines, assignment_spans = _read_env_assignment_spans(env_path)
+    assignments = [
+        (assignment.key, assignment.value) for assignment in assignment_spans
+    ]
     values = _assignment_map(assignments)
     fetcher = fetcher or fetch_bitwarden_secrets
 
@@ -291,7 +364,9 @@ def prune_plan_for_profile(
             verification_error=None,
         )
 
-    if not settings.enabled:
+    if any(not assignment.complete for assignment in assignment_spans):
+        verification_error = _ENV_PARSE_FAILURE
+    elif not settings.enabled:
         verification_error = "Bitwarden is disabled in config.yaml"
     else:
         token = (
@@ -314,10 +389,14 @@ def prune_plan_for_profile(
                     use_cache=False,
                     home_path=profile_home,
                 )
-                warnings.extend(fetch_warnings)
+                if fetch_warnings:
+                    warnings.append(
+                        "Bitwarden verification returned "
+                        f"{len(fetch_warnings)} warning(s); backend details were redacted."
+                    )
                 secret_names = set(fetched)
-            except Exception as exc:  # noqa: BLE001 - surfaced to the CLI
-                verification_error = f"Bitwarden verification failed: {exc}"
+            except Exception:  # noqa: BLE001 - backend details may contain secrets
+                verification_error = _VERIFICATION_FAILURE
 
     seen: set[str] = set()
     for key, value in assignments:
@@ -458,17 +537,27 @@ def apply_prune_plan(plan: PrunePlan) -> PruneResult:
             changed=False,
         )
 
-    original_lines = plan.env_path.read_text(encoding="utf-8", errors="replace").splitlines(
-        keepends=True
-    )
-    kept_lines: list[str] = []
+    original_lines, assignments = _read_env_assignment_spans(plan.env_path)
+    if any(not assignment.complete for assignment in assignments):
+        return PruneResult(
+            profile=plan.profile,
+            env_path=plan.env_path,
+            backup_path=None,
+            removed_keys=[],
+            changed=False,
+        )
+
+    removed_line_indexes: set[int] = set()
     removed_keys: list[str] = []
-    for line in original_lines:
-        match = ENV_ASSIGNMENT_RE.match(line)
-        if match and match.group("key") in remove_keys:
-            removed_keys.append(match.group("key"))
+    for assignment in assignments:
+        if assignment.key not in remove_keys:
             continue
-        kept_lines.append(line)
+        removed_keys.append(assignment.key)
+        removed_line_indexes.update(range(assignment.start_line, assignment.end_line))
+
+    kept_lines = [
+        line for index, line in enumerate(original_lines) if index not in removed_line_indexes
+    ]
 
     if not removed_keys:
         return PruneResult(

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -1,11 +1,13 @@
 """CLI handlers for ``hermes secrets bitwarden ...``.
 
 Subcommands:
-    setup    — interactive wizard: install bws, prompt for token + project, test fetch
-    status   — show current config + binary version + last fetch outcome
-    sync     — run a fetch right now and show what would be applied (dry-run friendly)
-    disable  — flip ``secrets.bitwarden.enabled`` to False
-    install  — just download the bws binary (no token / project required)
+    setup      — interactive wizard: install bws, prompt for token + project, test fetch
+    status     — show current config + binary version + last fetch outcome
+    sync       — run a fetch right now and show what would be applied (dry-run friendly)
+    inventory  — list candidate env var names by profile without printing values
+    prune      — verify Bitwarden secrets, then dry-run/apply removal of plaintext .env secrets
+    disable    — flip ``secrets.bitwarden.enabled`` to False
+    install    — just download the bws binary (no token / project required)
 """
 
 from __future__ import annotations
@@ -23,6 +25,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from agent.secret_sources import bitwarden as bw
+from hermes_cli import bitwarden_migration as bwm
 from hermes_cli.config import (
     get_env_path,
     load_config,
@@ -78,6 +81,37 @@ def register_cli(parent_parser: argparse.ArgumentParser) -> None:
         help="Actually export the secrets into the current shell's env (default: dry-run)",
     )
     sync.set_defaults(func=cmd_sync)
+
+    inventory = sub.add_parser(
+        "inventory",
+        help="List candidate env var names by profile without printing values",
+    )
+    inventory_group = inventory.add_mutually_exclusive_group()
+    inventory_group.add_argument(
+        "--profile",
+        help="Inventory one named profile (default: the active profile)",
+    )
+    inventory_group.add_argument(
+        "--all-profiles",
+        action="store_true",
+        help="Inventory every profile under ~/.hermes/profiles",
+    )
+    inventory.set_defaults(func=cmd_inventory)
+
+    prune = sub.add_parser(
+        "prune",
+        help="Dry-run/apply removal of plaintext .env secrets after Bitwarden verification",
+    )
+    prune.add_argument(
+        "--profile",
+        help="Prune one named profile (default: the active profile)",
+    )
+    prune.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually rewrite the profile-local .env and make a timestamped backup",
+    )
+    prune.set_defaults(func=cmd_prune)
 
     disable = sub.add_parser("disable", help="Turn off the Bitwarden integration")
     disable.set_defaults(func=cmd_disable)
@@ -285,6 +319,76 @@ def cmd_setup(args: argparse.Namespace) -> int:
         "  Refresh: [cyan]hermes secrets bitwarden sync[/cyan]\n"
         "  Disable: [cyan]hermes secrets bitwarden disable[/cyan]"
     )
+    return 0
+
+
+def cmd_inventory(args: argparse.Namespace) -> int:
+    profile_name = getattr(args, "profile", None)
+    all_profiles = bool(getattr(args, "all_profiles", False))
+    rows = bwm.collect_inventory_rows(profile_name, all_profiles=all_profiles)
+
+    if not rows:
+        if all_profiles:
+            print("No .env entries were found in any profile.")
+        else:
+            print("No .env entries were found for the selected profile.")
+        return 0
+
+    print("PROFILE | SURFACE | CLASS | STATE | KEY")
+    for row in rows:
+        print(
+            f"{row.profile} | {row.surface} | {row.classification} | {row.state} | {row.key}"
+        )
+    return 0
+
+
+def cmd_prune(args: argparse.Namespace) -> int:
+    profile_name = getattr(args, "profile", None)
+    if profile_name:
+        from hermes_cli.profiles import resolve_profile_env
+
+        profile_home = Path(resolve_profile_env(profile_name))
+        profile_label = profile_name
+    else:
+        from hermes_constants import get_hermes_home
+
+        profile_home = get_hermes_home()
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile_label = get_active_profile_name() or "default"
+
+    plan = bwm.prune_plan_for_profile(profile_label, profile_home)
+
+    print(f"Profile: {plan.profile}")
+    print(f"Surface: {plan.env_path}")
+    print(f"Config:  {plan.config_path} (read-only)")
+    print("PROFILE | ACTION | CLASS | STATE | KEY | REASON")
+    for row in plan.rows:
+        print(
+            f"{row.profile} | {row.action} | {row.classification} | {row.state} | {row.key} | {row.reason}"
+        )
+
+    for warning in plan.warnings:
+        print(f"warning: {warning}")
+
+    if not getattr(args, "apply", False):
+        print("Dry-run only: add --apply to rewrite the .env file after Bitwarden verification.")
+        return 0
+
+    if plan.verification_error:
+        print(f"error: {plan.verification_error}")
+        return 1
+
+    result = bwm.apply_prune_plan(plan)
+    if not result.changed:
+        print("No plaintext secret entries were eligible for removal.")
+        return 0
+
+    print(f"Applied {len(result.removed_keys)} removal(s) to {result.env_path}")
+    if result.backup_path is not None:
+        print(f"Backup: {result.backup_path} (0600)")
+    print("config.yaml was not modified.")
+    print(f"Removed: {', '.join(result.removed_keys)}")
     return 0
 
 

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -379,7 +379,14 @@ def cmd_prune(args: argparse.Namespace) -> int:
         print(f"error: {plan.verification_error}")
         return 1
 
-    result = bwm.apply_prune_plan(plan)
+    try:
+        result = bwm.apply_prune_plan(plan)
+    except Exception:  # noqa: BLE001 - filesystem errors may contain secret values
+        print(
+            "error: Secret pruning could not complete safely. "
+            "Check .env and parent-directory permissions, then retry."
+        )
+        return 1
     if not result.changed:
         print("No plaintext secret entries were eligible for removal.")
         return 0

--- a/tests/hermes_cli/test_bitwarden_migration.py
+++ b/tests/hermes_cli/test_bitwarden_migration.py
@@ -1,0 +1,293 @@
+"""Tests for the safe Bitwarden migration helpers and CLI wrappers."""
+
+from __future__ import annotations
+
+import stat
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_cli import bitwarden_migration as bwm  # noqa: E402
+from hermes_cli import secrets_cli  # noqa: E402
+
+
+@pytest.fixture
+def make_profile(tmp_path: Path):
+    def _make_profile(name: str, env_text: str, config_text: str) -> Path:
+        profile_home = tmp_path / name
+        profile_home.mkdir(parents=True, exist_ok=True)
+        (profile_home / ".env").write_text(env_text, encoding="utf-8")
+        (profile_home / "config.yaml").write_text(config_text, encoding="utf-8")
+        return profile_home
+
+    return _make_profile
+
+
+class TestInventory:
+    def test_all_profiles_redacts_values_and_marks_bootstrap_secret(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        coding_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=sk-coding-secret
+PATH=/usr/local/bin
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        ops_home = make_profile(
+            "ops",
+            """BWS_ACCESS_TOKEN=0.ops-token
+DISCORD_CHANNEL_ID=1234567890
+GITHUB_TOKEN=ghp_ops_secret
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: ops-project
+""",
+        )
+
+        monkeypatch.setattr(
+            bwm,
+            "list_profiles",
+            lambda: [
+                SimpleNamespace(name="coding", path=coding_home),
+                SimpleNamespace(name="ops", path=ops_home),
+            ],
+        )
+
+        rc = secrets_cli.cmd_inventory(Namespace(profile=None, all_profiles=True))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "PROFILE | SURFACE | CLASS | STATE | KEY" in out
+        assert "coding | .env | bootstrap-secret | set | BWS_ACCESS_TOKEN" in out
+        assert "ops | .env | bootstrap-secret | set | BWS_ACCESS_TOKEN" in out
+        assert "coding | .env | secret | set | OPENAI_API_KEY" in out
+        assert "coding | .env | non-secret | set | PATH" in out
+        assert "ops | .env | non-secret | set | DISCORD_CHANNEL_ID" in out
+        assert "sk-coding-secret" not in out
+        assert "0.coding-token" not in out
+        assert "ghp_ops_secret" not in out
+        assert "0.ops-token" not in out
+
+
+class TestPrunePlanning:
+    def test_disabled_bitwarden_config_stays_read_only(
+        self,
+        make_profile,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=sk-coding-secret
+PATH=/usr/local/bin
+""",
+            """secrets:
+  bitwarden:
+    enabled: false
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+
+        called = {"count": 0}
+
+        def fake_fetch(**_kwargs):
+            called["count"] += 1
+            return ({"OPENAI_API_KEY": "sk-coding-secret"}, [])
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=fake_fetch,
+        )
+
+        assert called["count"] == 0
+        assert plan.verification_error == "Bitwarden is disabled in config.yaml"
+        assert plan.removable_keys() == []
+        actions = {row.key: row.action for row in plan.rows}
+        assert actions["BWS_ACCESS_TOKEN"] == "keep"
+        assert actions["OPENAI_API_KEY"] == "keep"
+        assert actions["PATH"] == "keep"
+
+
+class TestPruneApply:
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_apply_prune_plan_creates_0600_backup_and_leaves_config_untouched(
+        self,
+        make_profile,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=sk-coding-secret
+PATH=/usr/local/bin
+DISCORD_CHANNEL_ID=1234567890
+GITHUB_TOKEN=ghp_ops_secret
+UNVERIFIED_SECRET=keep-me
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+    server_url: https://vault.bitwarden.eu
+""",
+        )
+        env_path = profile_home / ".env"
+        config_path = profile_home / "config.yaml"
+        original_config = config_path.read_text(encoding="utf-8")
+
+        def fake_fetch(**kwargs):
+            assert kwargs["access_token"] == "0.coding-token"
+            assert kwargs["project_id"] == "coding-project"
+            assert kwargs["server_url"] == "https://vault.bitwarden.eu"
+            assert kwargs["use_cache"] is False
+            assert kwargs["home_path"] == profile_home
+            return (
+                {
+                    "OPENAI_API_KEY": "sk-coding-secret",
+                    "GITHUB_TOKEN": "ghp_ops_secret",
+                },
+                ["verified project"],
+            )
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=fake_fetch,
+        )
+        assert plan.verification_error is None
+        assert plan.warnings == ["verified project"]
+        assert [row.action for row in plan.rows if row.key == "OPENAI_API_KEY"] == ["remove"]
+        assert [row.action for row in plan.rows if row.key == "GITHUB_TOKEN"] == ["remove"]
+        assert [row.action for row in plan.rows if row.key == "UNVERIFIED_SECRET"] == ["keep"]
+
+        result = bwm.apply_prune_plan(plan)
+
+        assert result.changed is True
+        assert result.removed_keys == ["OPENAI_API_KEY", "GITHUB_TOKEN"]
+        assert result.backup_path is not None
+        assert result.backup_path.exists()
+        assert result.backup_path.name.startswith(".env.bak-pre-bitwarden-prune-")
+        assert stat.S_IMODE(result.backup_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+        assert result.backup_path.read_text(encoding="utf-8") == (
+            "BWS_ACCESS_TOKEN=0.coding-token\n"
+            "OPENAI_API_KEY=sk-coding-secret\n"
+            "PATH=/usr/local/bin\n"
+            "DISCORD_CHANNEL_ID=1234567890\n"
+            "GITHUB_TOKEN=ghp_ops_secret\n"
+            "UNVERIFIED_SECRET=keep-me\n"
+        )
+        rewritten = env_path.read_text(encoding="utf-8")
+        assert "OPENAI_API_KEY=" not in rewritten
+        assert "GITHUB_TOKEN=" not in rewritten
+        assert "BWS_ACCESS_TOKEN=0.coding-token" in rewritten
+        assert "PATH=/usr/local/bin" in rewritten
+        assert "DISCORD_CHANNEL_ID=1234567890" in rewritten
+        assert "UNVERIFIED_SECRET=keep-me" in rewritten
+        assert config_path.read_text(encoding="utf-8") == original_config
+
+
+class TestCliWrappers:
+    def test_cmd_prune_defaults_to_dry_run_without_applying(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=sk-coding-secret
+PATH=/usr/local/bin
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        original_env = env_path.read_text(encoding="utf-8")
+        config_path = profile_home / "config.yaml"
+
+        plan = bwm.PrunePlan(
+            profile="coding",
+            profile_home=profile_home,
+            env_path=env_path,
+            config_path=config_path,
+            settings=bwm.BitwardenSettings(
+                enabled=True,
+                access_token_env="BWS_ACCESS_TOKEN",
+                project_id="coding-project",
+                server_url="",
+            ),
+            rows=[
+                bwm.PruneRow(
+                    profile="coding",
+                    surface=".env",
+                    env_path=env_path,
+                    key="OPENAI_API_KEY",
+                    classification="secret",
+                    state="set",
+                    action="remove",
+                    reason="verified in Bitwarden project",
+                    bws_resolved=True,
+                ),
+                bwm.PruneRow(
+                    profile="coding",
+                    surface=".env",
+                    env_path=env_path,
+                    key="PATH",
+                    classification="non-secret",
+                    state="set",
+                    action="keep",
+                    reason="non-secret config stays in .env",
+                    bws_resolved=None,
+                ),
+            ],
+            warnings=[],
+            verification_error=None,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile_name: str(profile_home),
+        )
+        monkeypatch.setattr(bwm, "prune_plan_for_profile", lambda *_args, **_kwargs: plan)
+
+        def _should_not_apply(_plan):
+            raise AssertionError("cmd_prune applied changes in dry-run mode")
+
+        monkeypatch.setattr(bwm, "apply_prune_plan", _should_not_apply)
+
+        rc = secrets_cli.cmd_prune(Namespace(profile="coding", apply=False))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Dry-run only: add --apply to rewrite the .env file after Bitwarden verification." in out
+        assert "OPENAI_API_KEY" in out
+        assert "PATH" in out
+        assert env_path.read_text(encoding="utf-8") == original_env
+        assert not list(profile_home.glob("*.bak-pre-bitwarden-prune-*"))

--- a/tests/hermes_cli/test_bitwarden_migration.py
+++ b/tests/hermes_cli/test_bitwarden_migration.py
@@ -311,6 +311,93 @@ PATH=/usr/local/bin
         assert plan.verification_error is None
         assert plan.removable_keys() == ["OPENAI_API_KEY"]
 
+    def test_empty_bitwarden_values_do_not_authorize_plaintext_removal(
+        self,
+        make_profile,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=working-local-value
+GITHUB_TOKEN=working-local-value
+PRIVATE_KEY=working-local-value
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=lambda **_kwargs: (
+                {
+                    "OPENAI_API_KEY": "",
+                    "GITHUB_TOKEN": " \t\r\n",
+                    "PRIVATE_KEY": "resolved-value",
+                },
+                [],
+            ),
+        )
+
+        rows = {row.key: row for row in plan.rows}
+        assert rows["OPENAI_API_KEY"].action == "keep"
+        assert rows["OPENAI_API_KEY"].bws_resolved is False
+        assert rows["GITHUB_TOKEN"].action == "keep"
+        assert rows["GITHUB_TOKEN"].bws_resolved is False
+        assert rows["PRIVATE_KEY"].action == "remove"
+        assert rows["PRIVATE_KEY"].bws_resolved is True
+        assert plan.removable_keys() == ["PRIVATE_KEY"]
+
+    def test_non_utf8_env_fails_closed_before_verification_or_artifact_creation(
+        self,
+        make_profile,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            "placeholder\n",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        original_bytes = (
+            b"BWS_ACCESS_TOKEN=0.coding-token\n"
+            b"OPENAI_API_KEY=working-local-value\n"
+            b"RETAINED_LABEL=latin-1-\xff\n"
+        )
+        env_path.write_bytes(original_bytes)
+        fetch_calls = 0
+
+        def should_not_fetch(**_kwargs):
+            nonlocal fetch_calls
+            fetch_calls += 1
+            return ({"OPENAI_API_KEY": "resolved-value"}, [])
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=should_not_fetch,
+        )
+        result = bwm.apply_prune_plan(plan)
+
+        assert fetch_calls == 0
+        assert plan.verification_error == (
+            "Could not safely decode .env as UTF-8; no plaintext secrets were removed. "
+            "Convert the file to UTF-8 without data loss, then retry."
+        )
+        assert plan.removable_keys() == []
+        assert result.changed is False
+        assert env_path.read_bytes() == original_bytes
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+        assert not list(profile_home.glob("..env_*.tmp"))
+
 
 class TestPruneApply:
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
@@ -394,6 +481,222 @@ UNVERIFIED_SECRET=keep-me
         assert config_path.read_text(encoding="utf-8") == original_config
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_backup_permission_failure_is_redacted_and_leaves_no_plaintext_artifact(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            f"""BWS_ACCESS_TOKEN={ACCESS_TOKEN_SENTINEL}
+OPENAI_API_KEY={SECRET_VALUE_SENTINEL}
+RETAINED_SECRET=keep-me
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        env_path.chmod(0o644)
+        original_bytes = env_path.read_bytes()
+
+        monkeypatch.setattr(
+            bwm,
+            "fetch_bitwarden_secrets",
+            lambda **_kwargs: ({"OPENAI_API_KEY": "resolved-value"}, []),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile_name: str(profile_home),
+        )
+
+        def fail_backup_fchmod(_fd, _mode):
+            raise OSError(
+                f"{EXCEPTION_SENTINEL}: token={ACCESS_TOKEN_SENTINEL}; "
+                f"value={SECRET_VALUE_SENTINEL}"
+            )
+
+        monkeypatch.setattr(bwm.os, "fchmod", fail_backup_fchmod)
+
+        rc = secrets_cli.cmd_prune(Namespace(profile="coding", apply=True))
+        out = capsys.readouterr().out
+
+        assert rc == 1
+        assert "Secret pruning could not complete safely" in out
+        assert EXCEPTION_SENTINEL not in out
+        assert ACCESS_TOKEN_SENTINEL not in out
+        assert SECRET_VALUE_SENTINEL not in out
+        assert env_path.read_bytes() == original_bytes
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o644
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+        assert not list(profile_home.glob("..env_*.tmp"))
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_atomic_replace_failure_cleans_private_temp_and_redacts_output(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            f"""BWS_ACCESS_TOKEN={ACCESS_TOKEN_SENTINEL}
+OPENAI_API_KEY={SECRET_VALUE_SENTINEL}
+UNVERIFIED_SECRET=keep-me
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        env_path.chmod(0o644)
+        original_bytes = env_path.read_bytes()
+
+        monkeypatch.setattr(
+            bwm,
+            "fetch_bitwarden_secrets",
+            lambda **_kwargs: ({"OPENAI_API_KEY": "resolved-value"}, []),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile_name: str(profile_home),
+        )
+
+        def fail_atomic_replace(source, destination):
+            source_path = Path(source)
+            assert Path(destination) == env_path
+            assert stat.S_IMODE(source_path.stat().st_mode) == 0o600
+            temp_bytes = source_path.read_bytes()
+            assert ACCESS_TOKEN_SENTINEL.encode() in temp_bytes
+            assert b"UNVERIFIED_SECRET=keep-me" in temp_bytes
+            raise OSError(
+                f"{EXCEPTION_SENTINEL}: token={ACCESS_TOKEN_SENTINEL}; "
+                f"value={SECRET_VALUE_SENTINEL}"
+            )
+
+        monkeypatch.setattr(bwm, "atomic_replace", fail_atomic_replace)
+
+        rc = secrets_cli.cmd_prune(Namespace(profile="coding", apply=True))
+        out = capsys.readouterr().out
+
+        assert rc == 1
+        assert "Secret pruning could not complete safely" in out
+        assert EXCEPTION_SENTINEL not in out
+        assert ACCESS_TOKEN_SENTINEL not in out
+        assert SECRET_VALUE_SENTINEL not in out
+        assert env_path.read_bytes() == original_bytes
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o644
+        assert not list(profile_home.glob("..env_*.tmp"))
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_destination_chmod_failure_restores_original_bytes_and_mode(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=working-local-value
+UNVERIFIED_SECRET=keep-me
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        env_path.chmod(0o644)
+        original_bytes = env_path.read_bytes()
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=lambda **_kwargs: ({"OPENAI_API_KEY": "resolved-value"}, []),
+        )
+        real_chmod = bwm.os.chmod
+        chmod_calls = 0
+
+        def fail_first_chmod(path, mode):
+            nonlocal chmod_calls
+            chmod_calls += 1
+            if chmod_calls == 1:
+                raise OSError("destination chmod failed")
+            return real_chmod(path, mode)
+
+        monkeypatch.setattr(bwm.os, "chmod", fail_first_chmod)
+
+        with pytest.raises(OSError, match="destination chmod failed"):
+            bwm.apply_prune_plan(plan)
+
+        assert chmod_calls == 2
+        assert env_path.read_bytes() == original_bytes
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o644
+        assert not list(profile_home.glob("..env_*.tmp"))
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_failed_rollback_keeps_only_private_recovery_artifacts(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=working-local-value
+UNVERIFIED_SECRET=keep-me
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        env_path.chmod(0o644)
+        original_bytes = env_path.read_bytes()
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=lambda **_kwargs: ({"OPENAI_API_KEY": "resolved-value"}, []),
+        )
+        replace_calls = 0
+
+        def replace_then_block_rollback(source, destination):
+            nonlocal replace_calls
+            replace_calls += 1
+            if replace_calls == 1:
+                bwm.os.replace(source, destination)
+                raise OSError("replacement failed after destination mutation")
+            raise OSError("rollback replacement failed")
+
+        monkeypatch.setattr(bwm, "atomic_replace", replace_then_block_rollback)
+
+        with pytest.raises(bwm.PruneRollbackError, match="rollback did not complete"):
+            bwm.apply_prune_plan(plan)
+
+        assert replace_calls == 2
+        assert env_path.read_bytes() != original_bytes
+        assert b"OPENAI_API_KEY" not in env_path.read_bytes()
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+        backups = list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == original_bytes
+        assert stat.S_IMODE(backups[0].stat().st_mode) == 0o600
+        assert not list(profile_home.glob("..env_*.tmp"))
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
     def test_apply_prunes_complete_multiline_assignment_atomically(
         self,
         make_profile,
@@ -464,6 +767,108 @@ UNVERIFIED_SECRET=keep-me
             "CHANNEL_ID=1234567890\n"
             "UNVERIFIED_SECRET=keep-me\n"
         )
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    @pytest.mark.parametrize("failure", ["write", "fsync"])
+    def test_temp_write_failures_leave_original_and_clean_artifacts(
+        self,
+        failure: str,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            """BWS_ACCESS_TOKEN=0.coding-token
+OPENAI_API_KEY=working-local-value
+UNVERIFIED_SECRET=keep-me
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        env_path.chmod(0o644)
+        original_bytes = env_path.read_bytes()
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=lambda **_kwargs: ({"OPENAI_API_KEY": "resolved-value"}, []),
+        )
+
+        if failure == "write":
+            def fail_write(_fd, _data):
+                raise OSError("write failed")
+
+            monkeypatch.setattr(bwm.os, "write", fail_write)
+        else:
+            real_fsync = bwm.os.fsync
+            fsync_calls = 0
+
+            def fail_second_fsync(fd):
+                nonlocal fsync_calls
+                fsync_calls += 1
+                if fsync_calls == 2:
+                    raise OSError("fsync failed")
+                return real_fsync(fd)
+
+            monkeypatch.setattr(bwm.os, "fsync", fail_second_fsync)
+
+        with pytest.raises(OSError):
+            bwm.apply_prune_plan(plan)
+
+        assert env_path.read_bytes() == original_bytes
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o644
+        assert not list(profile_home.glob("..env_*.tmp"))
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_apply_preserves_exact_retained_utf8_bytes_and_line_endings(
+        self,
+        make_profile,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            "placeholder\n",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        original_bytes = (
+            b"# retained comment\r\n"
+            b"BWS_ACCESS_TOKEN=0.coding-token\r\n"
+            b"RETAINED_LABEL=caf\xc3\xa9\r\n"
+            b"OPENAI_API_KEY=remove-me\r\n"
+            b"UNVERIFIED_SECRET=keep-me\r\n"
+        )
+        expected_bytes = (
+            b"# retained comment\r\n"
+            b"BWS_ACCESS_TOKEN=0.coding-token\r\n"
+            b"RETAINED_LABEL=caf\xc3\xa9\r\n"
+            b"UNVERIFIED_SECRET=keep-me\r\n"
+        )
+        env_path.write_bytes(original_bytes)
+        env_path.chmod(0o640)
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=lambda **_kwargs: ({"OPENAI_API_KEY": "resolved-value"}, []),
+        )
+
+        result = bwm.apply_prune_plan(plan)
+
+        assert result.changed is True
+        assert env_path.read_bytes() == expected_bytes
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o640
+        assert result.backup_path is not None
+        assert result.backup_path.read_bytes() == original_bytes
+        assert stat.S_IMODE(result.backup_path.stat().st_mode) == 0o600
 
     def test_unterminated_multiline_assignment_fails_closed(
         self,

--- a/tests/hermes_cli/test_bitwarden_migration.py
+++ b/tests/hermes_cli/test_bitwarden_migration.py
@@ -314,7 +314,7 @@ PATH=/usr/local/bin
 
 class TestPruneApply:
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
-    def test_apply_prune_plan_creates_0600_backup_and_leaves_config_untouched(
+    def test_apply_prune_plan_preserves_env_mode_and_creates_0600_backup(
         self,
         make_profile,
     ) -> None:
@@ -336,6 +336,7 @@ UNVERIFIED_SECRET=keep-me
 """,
         )
         env_path = profile_home / ".env"
+        env_path.chmod(0o640)
         config_path = profile_home / "config.yaml"
         original_config = config_path.read_text(encoding="utf-8")
 
@@ -374,7 +375,7 @@ UNVERIFIED_SECRET=keep-me
         assert result.backup_path.exists()
         assert result.backup_path.name.startswith(".env.bak-pre-bitwarden-prune-")
         assert stat.S_IMODE(result.backup_path.stat().st_mode) == 0o600
-        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o640
         assert result.backup_path.read_text(encoding="utf-8") == (
             "BWS_ACCESS_TOKEN=0.coding-token\n"
             "OPENAI_API_KEY=sk-coding-secret\n"
@@ -419,6 +420,7 @@ UNVERIFIED_SECRET=keep-me
 """,
         )
         env_path = profile_home / ".env"
+        original_mode = stat.S_IMODE(env_path.stat().st_mode)
 
         def fake_fetch(**_kwargs):
             return ({"PRIVATE_KEY": "line-one\nline-two"}, [])
@@ -452,7 +454,7 @@ UNVERIFIED_SECRET=keep-me
         assert result.backup_path is not None
         assert result.backup_path.read_text(encoding="utf-8") == original_env
         assert stat.S_IMODE(result.backup_path.stat().st_mode) == 0o600
-        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(env_path.stat().st_mode) == original_mode
         assert env_path.read_text(encoding="utf-8") == (
             "# keep leading comment\n"
             "BWS_ACCESS_TOKEN=0.coding-token\n"

--- a/tests/hermes_cli/test_bitwarden_migration.py
+++ b/tests/hermes_cli/test_bitwarden_migration.py
@@ -128,6 +128,38 @@ PATH=/usr/local/bin
         assert actions["OPENAI_API_KEY"] == "keep"
         assert actions["PATH"] == "keep"
 
+    def test_shell_only_bootstrap_token_verifies_target_profile(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            "OPENAI_API_KEY=plaintext-placeholder\n",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.shell-token")
+
+        def fake_fetch(**kwargs):
+            assert kwargs["access_token"] == "0.shell-token"
+            assert kwargs["project_id"] == "coding-project"
+            assert kwargs["home_path"] == profile_home
+            return ({"OPENAI_API_KEY": "resolved-value"}, [])
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=fake_fetch,
+        )
+
+        assert plan.verification_error is None
+        assert plan.removable_keys() == ["OPENAI_API_KEY"]
+
 
 class TestPruneApply:
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")

--- a/tests/hermes_cli/test_bitwarden_migration.py
+++ b/tests/hermes_cli/test_bitwarden_migration.py
@@ -18,6 +18,12 @@ from hermes_cli import bitwarden_migration as bwm  # noqa: E402
 from hermes_cli import secrets_cli  # noqa: E402
 
 
+ACCESS_TOKEN_SENTINEL = "ACCESS_TOKEN_SENTINEL_12345"
+SECRET_VALUE_SENTINEL = "SECRET_VALUE_SENTINEL_12345"
+STDERR_SENTINEL = "STDERR_SENTINEL_12345"
+EXCEPTION_SENTINEL = "EXCEPTION_SENTINEL_12345"
+
+
 @pytest.fixture
 def make_profile(tmp_path: Path):
     def _make_profile(name: str, env_text: str, config_text: str) -> Path:
@@ -39,8 +45,8 @@ class TestInventory:
     ) -> None:
         coding_home = make_profile(
             "coding",
-            """BWS_ACCESS_TOKEN=0.coding-token
-OPENAI_API_KEY=sk-coding-secret
+            f"""BWS_ACCESS_TOKEN={ACCESS_TOKEN_SENTINEL}
+OPENAI_API_KEY={SECRET_VALUE_SENTINEL}
 PATH=/usr/local/bin
 """,
             """secrets:
@@ -83,13 +89,158 @@ GITHUB_TOKEN=ghp_ops_secret
         assert "coding | .env | secret | set | OPENAI_API_KEY" in out
         assert "coding | .env | non-secret | set | PATH" in out
         assert "ops | .env | non-secret | set | DISCORD_CHANNEL_ID" in out
-        assert "sk-coding-secret" not in out
-        assert "0.coding-token" not in out
+        assert SECRET_VALUE_SENTINEL not in out
+        assert ACCESS_TOKEN_SENTINEL not in out
         assert "ghp_ops_secret" not in out
         assert "0.ops-token" not in out
 
 
 class TestPrunePlanning:
+    @pytest.mark.parametrize(("apply", "expected_rc"), [(False, 0), (True, 1)])
+    def test_verification_exception_is_redacted_and_never_mutates_env(
+        self,
+        apply: bool,
+        expected_rc: int,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            f"""BWS_ACCESS_TOKEN={ACCESS_TOKEN_SENTINEL}
+OPENAI_API_KEY={SECRET_VALUE_SENTINEL}
+PATH=/usr/local/bin
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+        original_env = env_path.read_text(encoding="utf-8")
+
+        def failing_fetch(**kwargs):
+            assert kwargs["access_token"] == ACCESS_TOKEN_SENTINEL
+            raise RuntimeError(
+                f"{EXCEPTION_SENTINEL}: backend stderr {STDERR_SENTINEL}; "
+                f"token={ACCESS_TOKEN_SENTINEL}; value={SECRET_VALUE_SENTINEL}"
+            )
+
+        monkeypatch.setattr(bwm, "fetch_bitwarden_secrets", failing_fetch)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile_name: str(profile_home),
+        )
+
+        rc = secrets_cli.cmd_prune(Namespace(profile="coding", apply=apply))
+        out = capsys.readouterr().out
+
+        assert rc == expected_rc
+        assert (
+            "Bitwarden verification failed; no plaintext secrets were removed. "
+            "Check Bitwarden configuration and credentials, then retry."
+        ) in out
+        assert EXCEPTION_SENTINEL not in out
+        assert STDERR_SENTINEL not in out
+        assert ACCESS_TOKEN_SENTINEL not in out
+        assert SECRET_VALUE_SENTINEL not in out
+        assert env_path.read_text(encoding="utf-8") == original_env
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+
+    def test_config_parse_exception_is_redacted_and_never_mutates_env(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            f"""BWS_ACCESS_TOKEN={ACCESS_TOKEN_SENTINEL}
+OPENAI_API_KEY={SECRET_VALUE_SENTINEL}
+""",
+            "secrets: ignored-by-failing-parser\n",
+        )
+        env_path = profile_home / ".env"
+        original_env = env_path.read_text(encoding="utf-8")
+
+        def failing_yaml_load(_contents):
+            raise RuntimeError(
+                f"{EXCEPTION_SENTINEL}: {STDERR_SENTINEL}; "
+                f"token={ACCESS_TOKEN_SENTINEL}; value={SECRET_VALUE_SENTINEL}"
+            )
+
+        monkeypatch.setattr(bwm.yaml, "safe_load", failing_yaml_load)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile_name: str(profile_home),
+        )
+
+        rc = secrets_cli.cmd_prune(Namespace(profile="coding", apply=True))
+        out = capsys.readouterr().out
+
+        assert rc == 1
+        assert "could not read config.yaml; fix its YAML syntax and retry" in out
+        assert EXCEPTION_SENTINEL not in out
+        assert STDERR_SENTINEL not in out
+        assert ACCESS_TOKEN_SENTINEL not in out
+        assert SECRET_VALUE_SENTINEL not in out
+        assert env_path.read_text(encoding="utf-8") == original_env
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
+
+    @pytest.mark.parametrize("apply", [False, True])
+    def test_fetch_warnings_are_redacted_from_prune_output(
+        self,
+        apply: bool,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ) -> None:
+        profile_home = make_profile(
+            "coding",
+            f"""BWS_ACCESS_TOKEN={ACCESS_TOKEN_SENTINEL}
+OPENAI_API_KEY={SECRET_VALUE_SENTINEL}
+PATH=/usr/local/bin
+""",
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+
+        def warning_fetch(**kwargs):
+            assert kwargs["access_token"] == ACCESS_TOKEN_SENTINEL
+            return (
+                {"OPENAI_API_KEY": SECRET_VALUE_SENTINEL},
+                [f"backend stderr {STDERR_SENTINEL}: {SECRET_VALUE_SENTINEL}"],
+            )
+
+        monkeypatch.setattr(bwm, "fetch_bitwarden_secrets", warning_fetch)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile_name: str(profile_home),
+        )
+
+        rc = secrets_cli.cmd_prune(Namespace(profile="coding", apply=apply))
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert (
+            "warning: Bitwarden verification returned 1 warning(s); "
+            "backend details were redacted."
+        ) in out
+        assert STDERR_SENTINEL not in out
+        assert ACCESS_TOKEN_SENTINEL not in out
+        assert SECRET_VALUE_SENTINEL not in out
+        rewritten = (profile_home / ".env").read_text(encoding="utf-8")
+        if apply:
+            assert "OPENAI_API_KEY=" not in rewritten
+        else:
+            assert f"OPENAI_API_KEY={SECRET_VALUE_SENTINEL}" in rewritten
+
     def test_disabled_bitwarden_config_stays_read_only(
         self,
         make_profile,
@@ -208,7 +359,9 @@ UNVERIFIED_SECRET=keep-me
             fetcher=fake_fetch,
         )
         assert plan.verification_error is None
-        assert plan.warnings == ["verified project"]
+        assert plan.warnings == [
+            "Bitwarden verification returned 1 warning(s); backend details were redacted."
+        ]
         assert [row.action for row in plan.rows if row.key == "OPENAI_API_KEY"] == ["remove"]
         assert [row.action for row in plan.rows if row.key == "GITHUB_TOKEN"] == ["remove"]
         assert [row.action for row in plan.rows if row.key == "UNVERIFIED_SECRET"] == ["keep"]
@@ -238,6 +391,116 @@ UNVERIFIED_SECRET=keep-me
         assert "DISCORD_CHANNEL_ID=1234567890" in rewritten
         assert "UNVERIFIED_SECRET=keep-me" in rewritten
         assert config_path.read_text(encoding="utf-8") == original_config
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_apply_prunes_complete_multiline_assignment_atomically(
+        self,
+        make_profile,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        original_env = """# keep leading comment
+BWS_ACCESS_TOKEN=0.coding-token
+API_URL=https://api.example.test/v1
+PRIVATE_KEY="line-one
+line-two"
+# keep middle comment
+PORT=8443
+CHANNEL_ID=1234567890
+UNVERIFIED_SECRET=keep-me
+"""
+        profile_home = make_profile(
+            "coding",
+            original_env,
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+        env_path = profile_home / ".env"
+
+        def fake_fetch(**_kwargs):
+            return ({"PRIVATE_KEY": "line-one\nline-two"}, [])
+
+        atomic_calls: list[tuple[Path, Path]] = []
+        real_atomic_replace = bwm.atomic_replace
+
+        def tracking_atomic_replace(source, destination):
+            source_path = Path(source)
+            destination_path = Path(destination)
+            assert source_path.exists()
+            assert source_path.parent == env_path.parent
+            atomic_calls.append((source_path, destination_path))
+            real_atomic_replace(source, destination)
+
+        monkeypatch.setattr(bwm, "atomic_replace", tracking_atomic_replace)
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=fake_fetch,
+        )
+        result = bwm.apply_prune_plan(plan)
+
+        assert plan.verification_error is None
+        assert plan.removable_keys() == ["PRIVATE_KEY"]
+        assert result.changed is True
+        assert result.removed_keys == ["PRIVATE_KEY"]
+        assert len(atomic_calls) == 1
+        assert atomic_calls[0][1] == env_path
+        assert result.backup_path is not None
+        assert result.backup_path.read_text(encoding="utf-8") == original_env
+        assert stat.S_IMODE(result.backup_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+        assert env_path.read_text(encoding="utf-8") == (
+            "# keep leading comment\n"
+            "BWS_ACCESS_TOKEN=0.coding-token\n"
+            "API_URL=https://api.example.test/v1\n"
+            "# keep middle comment\n"
+            "PORT=8443\n"
+            "CHANNEL_ID=1234567890\n"
+            "UNVERIFIED_SECRET=keep-me\n"
+        )
+
+    def test_unterminated_multiline_assignment_fails_closed(
+        self,
+        make_profile,
+    ) -> None:
+        original_env = """BWS_ACCESS_TOKEN=0.coding-token
+PRIVATE_KEY="line-one
+line-two
+OPENAI_API_KEY=must-not-be-removed
+"""
+        profile_home = make_profile(
+            "coding",
+            original_env,
+            """secrets:
+  bitwarden:
+    enabled: true
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: coding-project
+""",
+        )
+
+        plan = bwm.prune_plan_for_profile(
+            "coding",
+            profile_home,
+            fetcher=lambda **_kwargs: (
+                {"PRIVATE_KEY": "resolved", "OPENAI_API_KEY": "resolved"},
+                [],
+            ),
+        )
+        result = bwm.apply_prune_plan(plan)
+
+        assert plan.verification_error == (
+            "Could not safely parse .env; no plaintext secrets were removed. "
+            "Fix unterminated quoted values, then retry."
+        )
+        assert plan.removable_keys() == []
+        assert result.changed is False
+        assert (profile_home / ".env").read_text(encoding="utf-8") == original_env
+        assert not list(profile_home.glob(".env.bak-pre-bitwarden-prune-*"))
 
 
 class TestCliWrappers:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -433,6 +433,8 @@ Pull API keys from an external secret manager at process startup instead of stor
 | `setup` | Interactive wizard: install the pinned `bws` binary, store an access token, and pick a project. Accepts `--project-id`, `--access-token`, and `--server-url` for non-interactive use. |
 | `status` | Show current config, binary path/version, and last fetch info. |
 | `sync` | Fetch secrets now and report what changed. Add `--apply` to actually export the secrets into the current shell's environment (default is dry-run). |
+| `inventory` | List candidate environment-variable names without printing values. Use `--profile NAME` for one profile or `--all-profiles` for every profile. |
+| `prune` | Verify plaintext `.env` secret names against Bitwarden, then show a safe removal plan. Defaults to dry-run; add `--profile NAME` and `--apply` to rewrite that profile's `.env` with a timestamped backup. |
 | `install` | Download and verify the pinned `bws` binary. `--force` re-downloads even if a managed copy already exists. |
 | `disable` | Turn off the Bitwarden integration. |
 

--- a/website/docs/user-guide/secrets/bitwarden.md
+++ b/website/docs/user-guide/secrets/bitwarden.md
@@ -100,6 +100,32 @@ secrets:
 | `override_existing` | `true` | When true, Bitwarden values overwrite anything already in env (so rotation in the web app actually takes effect). Flip to `false` if you want `.env` / shell exports to win locally. |
 | `auto_install` | `true` | When true, `bws` is auto-downloaded into `~/.hermes/bin/` on first use. |
 
+## Inventory and prune a profile-local .env
+
+When you want to move plaintext secrets out of a profile-local `.env` and into Bitwarden, use the dedicated inventory/prune flow:
+
+```bash
+# List candidate env var names without printing values
+hermes secrets bitwarden inventory --profile coding
+
+# Scan every Hermes profile's .env file
+hermes secrets bitwarden inventory --all-profiles
+
+# Dry-run: verify Bitwarden has the secret before removing it from .env
+hermes secrets bitwarden prune --profile coding
+
+# Apply: create a timestamped 0600 backup, then remove only verified secret entries
+hermes secrets bitwarden prune --profile coding --apply
+```
+
+Notes:
+
+- The inventory command only prints env var names, profiles, and classification (`secret`, `non-secret`, or `bootstrap-secret`). It never prints values.
+- `prune` is dry-run by default.
+- The bootstrap token (`access_token_env`, usually `BWS_ACCESS_TOKEN`) is intentionally kept in the profile-local `.env` so Hermes can keep talking to Bitwarden.
+- `prune --apply` only rewrites the selected profile's `.env`; it does not touch `config.yaml`, and it leaves non-secret config like paths, CPU/memory, and channel IDs alone.
+- Before rewriting, Hermes creates a local backup named like `.env.bak-pre-bitwarden-prune-<timestamp>` and tightens it to mode `0600`.
+
 ## Failure modes
 
 Bitwarden never blocks Hermes startup. If anything goes wrong, you'll see a one-line warning in stderr and Hermes continues with whatever credentials `.env` already had:

--- a/website/docs/user-guide/secrets/bitwarden.md
+++ b/website/docs/user-guide/secrets/bitwarden.md
@@ -124,18 +124,20 @@ Notes:
 - `prune` is dry-run by default.
 - The bootstrap token (`access_token_env`, usually `BWS_ACCESS_TOKEN`) is intentionally kept in the profile-local `.env` so Hermes can keep talking to Bitwarden.
 - `prune --apply` only rewrites the selected profile's `.env`; it does not touch `config.yaml`, and it leaves non-secret config like paths, CPU/memory, and channel IDs alone.
+- Backend exception and warning details are redacted from prune output because they may contain credentials. If verification fails, `--apply` exits nonzero without changing `.env`.
+- Quoted multiline values are treated as one logical assignment. Hermes removes every line of a verified assignment, and an unterminated quoted value makes the whole prune fail closed.
 - Before rewriting, Hermes creates a local backup named like `.env.bak-pre-bitwarden-prune-<timestamp>` and tightens it to mode `0600`.
 
 ## Failure modes
 
-Bitwarden never blocks Hermes startup. If anything goes wrong, you'll see a one-line warning in stderr and Hermes continues with whatever credentials `.env` already had:
+Bitwarden never blocks Hermes startup. If anything goes wrong, you'll see a one-line warning in stderr and Hermes continues with whatever credentials `.env` already had. Raw backend responses are not printed because they can include access tokens or secret values:
 
 | Symptom | Cause | Fix |
 |---|---|---|
 | `BWS_ACCESS_TOKEN is not set` | Enabled in config but token cleared from `.env` | Re-run `hermes secrets bitwarden setup` |
-| `bws exited 1: invalid access token` | Token revoked or wrong | Generate a new token, re-run setup |
-| `[400 Bad Request] {"error":"invalid_client"}` | Token is for a Bitwarden region other than the one `bws` is calling (e.g. EU token hitting the US identity endpoint) | Re-run setup and pick the right region, or set `secrets.bitwarden.server_url` to `https://vault.bitwarden.eu` (or your self-hosted URL) |
-| `bws timed out` | Network blocked or Bitwarden API slow | Check connectivity to `api.bitwarden.com` (or your `server_url`) |
+| Bitwarden authentication failed (backend details redacted) | Token revoked or wrong | Generate a new token, then re-run setup |
+| Bitwarden verification failed after a region or endpoint change | Token is for a Bitwarden region other than the one `bws` is calling (e.g. EU token hitting the US identity endpoint) | Re-run setup and pick the right region, or set `secrets.bitwarden.server_url` to `https://vault.bitwarden.eu` (or your self-hosted URL) |
+| Bitwarden request timed out | Network blocked or Bitwarden API slow | Check connectivity to `api.bitwarden.com` (or your `server_url`) |
 | `bws binary not available` | `auto_install: false` and `bws` not on PATH | Install manually from [github.com/bitwarden/sdk-sm/releases](https://github.com/bitwarden/sdk-sm/releases) or flip `auto_install` back on |
 | `Checksum mismatch` | Download corrupted or tampered | Re-run, will retry; if it persists, file an issue |
 


### PR DESCRIPTION
## Summary
- Adds a redacted `hermes secrets bitwarden inventory` flow that lists candidate env var names by profile and never prints values.
- Adds a dry-run-by-default `prune` flow that verifies Bitwarden first, preserves non-secret config, and makes 0600 backups before any rewrite.
- Covers redaction, backup permissions, and dry-run safety with targeted tests.

## Validation
- `python -m pytest tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py tests/hermes_cli/test_bitwarden_migration.py -q`

## Notes
- The change is committed locally and pushed to the fork branch `bee-san:t_8b5f23e2`.
