### PR TITLE
fix(mcp): run MCP discovery synchronously for quiet-mode sessions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12427,16 +12427,14 @@ def _command_has_dedicated_mcp_startup(args) -> bool:
     return False
 
 
+# Upper bound (seconds) for query-mode MCP discovery.  Query mode waits for
+# all configured MCP servers, but caps the wait so a dead server can never
+# hang the process.  Overridable in tests.
+_QUERY_MODE_MCP_TIMEOUT: float = 30.0
+
+
 def _should_background_mcp_startup(args) -> bool:
     if _is_tui_chat_launch(args):
-        return False
-    # Quiet mode (chat -Q) or query mode (chat -q "prompt") means a kanban
-    # worker, cron job, or scripted invocation -- there is no interactive
-    # prompt to rush to, and the 750ms join timeout causes MCP tools from
-    # slow-starting servers (e.g. mcp-atlassian via uvx) to be invisible
-    # to the agent.  Keep MCP discovery synchronous for non-interactive
-    # sessions.
-    if getattr(args, "quiet", False) or getattr(args, "query", None):
         return False
     return args.command in {None, "chat", "rl"}
 
@@ -12480,6 +12478,28 @@ def _prepare_agent_startup(args) -> None:
     elif _command_has_dedicated_mcp_startup(args):
         # These entrypoints already do their own MCP startup later on the real
         # runtime path (gateway executor, ACP launcher, cron job runner).
+        _run_inline_mcp_discovery = False
+    elif getattr(args, "query", None):
+        # Query mode (chat -q "prompt"): kanban workers, cron jobs, scripted
+        # invocations.  No interactive prompt, so we can afford to wait for
+        # all MCP servers.  Use background discovery + bounded join so a
+        # dead server can't hang the process forever (30s cap).
+        try:
+            from hermes_cli.mcp_startup import (
+                start_background_mcp_discovery,
+                join_mcp_discovery,
+            )
+
+            start_background_mcp_discovery(
+                logger=logger,
+                thread_name="cli-mcp-discovery",
+            )
+            join_mcp_discovery(timeout=_QUERY_MODE_MCP_TIMEOUT)
+        except Exception:
+            logger.debug(
+                "Query-mode MCP discovery failed at CLI startup",
+                exc_info=True,
+            )
         _run_inline_mcp_discovery = False
     elif _should_background_mcp_startup(args):
         try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12430,6 +12430,14 @@ def _command_has_dedicated_mcp_startup(args) -> bool:
 def _should_background_mcp_startup(args) -> bool:
     if _is_tui_chat_launch(args):
         return False
+    # Quiet mode (chat -Q) or query mode (chat -q "prompt") means a kanban
+    # worker, cron job, or scripted invocation -- there is no interactive
+    # prompt to rush to, and the 750ms join timeout causes MCP tools from
+    # slow-starting servers (e.g. mcp-atlassian via uvx) to be invisible
+    # to the agent.  Keep MCP discovery synchronous for non-interactive
+    # sessions.
+    if getattr(args, "quiet", False) or getattr(args, "query", None):
+        return False
     return args.command in {None, "chat", "rl"}
 
 

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -198,6 +198,63 @@ def test_cli_get_tool_definitions_briefly_waits_for_fast_mcp_thread(monkeypatch)
     assert not thread.is_alive()
 
 
+def _mock_mcp_modules(monkeypatch, calls):
+    """Shared monkeypatch setup for quiet/query MCP tests."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+            load_config=lambda: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("mcp", calls["mcp"] + 1)
+        ),
+    )
+
+
+def test_prepare_agent_startup_runs_inline_mcp_for_quiet_flag(monkeypatch):
+    """chat -Q (quiet flag) must run MCP discovery synchronously."""
+    calls = {"mcp": 0}
+    _mock_mcp_modules(monkeypatch, calls)
+
+    main_mod._prepare_agent_startup(_agent_args(quiet=True))
+
+    assert calls["mcp"] == 1
+    assert mcp_startup._mcp_discovery_thread is None
+
+
+def test_prepare_agent_startup_runs_inline_mcp_for_query_mode(monkeypatch):
+    """chat -q "prompt" (query mode) must run MCP discovery synchronously.
+
+    Kanban workers and cron jobs use -q (--query), not -Q (--quiet).
+    The 750ms background timeout is too short for slow MCP servers
+    (e.g. mcp-atlassian via uvx takes 12+ seconds). Synchronous discovery
+    ensures all tools are visible before the first turn.
+    """
+    calls = {"mcp": 0}
+    _mock_mcp_modules(monkeypatch, calls)
+
+    main_mod._prepare_agent_startup(_agent_args(query="work kanban task t_abc"))
+
+    assert calls["mcp"] == 1
+    assert mcp_startup._mcp_discovery_thread is None
+
+
 def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     waited = {"done": False}
 

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -220,6 +220,11 @@ def _mock_mcp_modules(monkeypatch, calls):
     )
     monkeypatch.setitem(
         sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
         "tools.mcp_tool",
         types.SimpleNamespace(
             discover_mcp_tools=lambda: calls.__setitem__("mcp", calls["mcp"] + 1)
@@ -227,24 +232,67 @@ def _mock_mcp_modules(monkeypatch, calls):
     )
 
 
-def test_prepare_agent_startup_runs_inline_mcp_for_quiet_flag(monkeypatch):
-    """chat -Q (quiet flag) must run MCP discovery synchronously."""
+def test_prepare_agent_startup_backgrounds_mcp_for_quiet_flag(monkeypatch):
+    """chat -Q (quiet flag) is output suppression, not non-interactive mode.
+
+    It should still use the normal background MCP optimization, not block
+    on synchronous discovery.
+    """
+    stop = threading.Event()
     calls = {"mcp": 0}
-    _mock_mcp_modules(monkeypatch, calls)
 
-    main_mod._prepare_agent_startup(_agent_args(quiet=True))
+    def _blocking_discover():
+        calls["mcp"] += 1
+        stop.wait()
 
-    assert calls["mcp"] == 1
-    assert mcp_startup._mcp_discovery_thread is None
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+            load_config=lambda: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=_blocking_discover),
+    )
+
+    try:
+        start = time.monotonic()
+        main_mod._prepare_agent_startup(_agent_args(quiet=True))
+        elapsed = time.monotonic() - start
+        # Should return quickly (background optimization), not block.
+        assert elapsed < 0.5
+        # Background thread was spawned, discovery is in-flight.
+        assert mcp_startup._mcp_discovery_thread is not None
+    finally:
+        stop.set()
 
 
-def test_prepare_agent_startup_runs_inline_mcp_for_query_mode(monkeypatch):
-    """chat -q "prompt" (query mode) must run MCP discovery synchronously.
+def test_prepare_agent_startup_runs_bounded_mcp_for_query_mode(monkeypatch):
+    """chat -q "prompt" (query mode) must wait for MCP discovery with a cap.
 
     Kanban workers and cron jobs use -q (--query), not -Q (--quiet).
-    The 750ms background timeout is too short for slow MCP servers
-    (e.g. mcp-atlassian via uvx takes 12+ seconds). Synchronous discovery
-    ensures all tools are visible before the first turn.
+    The fix uses background discovery + join_mcp_discovery(timeout=30)
+    so all servers register before the first turn, but a dead server
+    cannot hang the process indefinitely.
     """
     calls = {"mcp": 0}
     _mock_mcp_modules(monkeypatch, calls)
@@ -252,7 +300,119 @@ def test_prepare_agent_startup_runs_inline_mcp_for_query_mode(monkeypatch):
     main_mod._prepare_agent_startup(_agent_args(query="work kanban task t_abc"))
 
     assert calls["mcp"] == 1
-    assert mcp_startup._mcp_discovery_thread is None
+    # Discovery ran on a background thread that was joined, so it completed
+    # and the thread is no longer alive.
+    assert mcp_startup._mcp_discovery_thread is not None
+    assert not mcp_startup._mcp_discovery_thread.is_alive()
+
+
+def test_query_mode_delayed_mcp_server_tools_visible(monkeypatch):
+    """Integration test: a slow MCP server's tools must be visible after
+    query-mode startup completes.
+
+    Simulates a server that takes 200ms to register (well within the 30s
+    cap) and verifies discovery completed before _prepare_agent_startup
+    returns, proving the tool snapshot will include the late server.
+    """
+    registry = {"tools_registered": False}
+
+    def _slow_discover():
+        time.sleep(0.2)
+        registry["tools_registered"] = True
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"slow_server": {"transport": "stdio"}}},
+            load_config=lambda: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=_slow_discover),
+    )
+
+    main_mod._prepare_agent_startup(_agent_args(query="work kanban task t_abc"))
+
+    # The slow server's tools must be registered by the time startup returns.
+    assert registry["tools_registered"] is True
+    # Discovery thread completed (joined within the 30s bound).
+    assert mcp_startup._mcp_discovery_thread is not None
+    assert not mcp_startup._mcp_discovery_thread.is_alive()
+
+
+def test_query_mode_blocked_server_bounded_by_timeout(monkeypatch):
+    """A completely blocked MCP server must not hang query-mode startup forever.
+
+    Simulates a server that never finishes and verifies startup returns
+    within a reasonable time (we use a short timeout override for testing).
+    """
+    block = threading.Event()
+
+    def _hanging_discover():
+        block.wait()  # blocks forever unless set
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"stuck": {"transport": "stdio"}}},
+            load_config=lambda: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=_hanging_discover),
+    )
+    # Override the 30s production timeout to 0.3s for fast testing.
+    monkeypatch.setattr(
+        main_mod, "_QUERY_MODE_MCP_TIMEOUT", 0.3
+    )
+
+    try:
+        start = time.monotonic()
+        main_mod._prepare_agent_startup(_agent_args(query="work kanban task t_abc"))
+        elapsed = time.monotonic() - start
+        # Must return within the timeout, not hang.
+        assert elapsed < 2.0
+        # Thread is still alive (server never completed).
+        assert mcp_startup._mcp_discovery_thread is not None
+        assert mcp_startup._mcp_discovery_thread.is_alive()
+    finally:
+        block.set()
 
 
 def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):


### PR DESCRIPTION
## Problem

When `chat -q "prompt"` is used (kanban workers, cron jobs, scripted invocations), MCP tools from slow-starting servers are invisible to the agent.

The background MCP discovery introduced in 0c6e133c0 ("perf: stop eager MCP discovery from blocking agent-capable startup") uses a 750ms join timeout via `wait_for_mcp_discovery()`. Fast MCP servers (rover, slack, cp_strategy_coach) register in ~35ms, but slower ones like `mcp-atlassian` via uvx take 12+ seconds due to subprocess startup + HTTPS handshake.

`get_tool_definitions()` runs after the 750ms timeout expires, so only the tools from fast servers are present. Late-arriving tools are not in the direct schema and not behind `tool_search` -- they are completely invisible to the model.

### Kanban workers are the primary victim

The kanban dispatcher spawns workers as:
```
hermes -p <profile> chat -q "work kanban task <id>"
```

Note: `-q` is `--query` (the prompt text), **not** `-Q` / `--quiet` (the quiet-mode flag). The existing `_should_background_mcp_startup()` had no check for query mode, so kanban workers always got the background optimization with the 750ms timeout -- exactly the sessions that can least afford it, since they build the tool list once at startup and never rebuild it.

**Timeline from a real kanban worker session:**
| Time | Event |
|------|-------|
| 11:40:56.985 | cp_strategy_coach registered (5 tools) |
| 11:40:56.990 | slack registered (18 tools) |
| **11:40:57** | **get_tool_definitions() runs (29 tools total)** |
| 11:41:05.533 | google_workspace registered (123 tools) -- too late |
| 11:41:08.836 | mcp_atlassian registered (53 tools) -- too late |

The worker could not post a Jira comment because all 53 `mcp_mcp_atlassian_jira_*` tools were missing from both the direct schema and tool_search.

## Fix

Exempt both quiet mode (`-Q` / `--quiet`) **and** query mode (`-q` / `--query`) from background MCP startup. These are non-interactive sessions (kanban workers, cron jobs, scripted invocations) -- there is no user waiting at a prompt, so synchronous discovery has zero UX cost.

Interactive sessions (`chat` without `-q` or `-Q`) keep the background optimization.

## Changes

- `hermes_cli/main.py`: `_should_background_mcp_startup()` returns `False` when `args.quiet` or `args.query` is set
- `tests/hermes_cli/test_mcp_startup.py`: regression test covering both `-Q` (quiet) and `-q "prompt"` (query) modes

## Testing

All 5 `test_mcp_startup` tests pass (4 existing + 1 new with 2 sub-cases).