### PR TITLE
fix(telegram): use asyncio.create_task in polling-conflict handler

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1142,8 +1142,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # gateway process is alive and reports "connected" but
                 # no messages are received or sent.
                 if self._polling_conflict_count < MAX_CONFLICT_RETRIES:
-                    loop = asyncio.get_event_loop()
-                    self._polling_error_task = loop.create_task(
+                    self._polling_error_task = asyncio.create_task(
                         self._handle_polling_conflict(retry_err)
                     )
                     return


### PR DESCRIPTION
## What

Drop the `loop = asyncio.get_event_loop(); loop.create_task(...)` two-step in `TelegramAdapter`'s polling-conflict recovery branch and call `asyncio.create_task(...)` directly.

## Why

`asyncio.get_event_loop()` is deprecated in Python 3.10+ when there is no running loop set and is slated for removal in 3.14. Inside this coroutine the loop is already running, so `asyncio.create_task()` binds to it implicitly — same behaviour, one fewer deprecation hazard, two fewer lines.

This was the last `get_event_loop()` call in `gateway/platforms/telegram.py`.

## Test plan

- [x] `python -c \"import ast; ast.parse(open('gateway/platforms/telegram.py').read())\"`
- [x] No behaviour change — `_polling_error_task` is still scheduled on the running loop awaiting `_polling_loop`.

## Platform

Telegram gateway adapter.

## Issue

No tracking issue — forward-lint cleanup spotted by static audit.