### PR TITLE
fix(web_server): use get_running_loop() for run_in_executor in MiniMax OAuth flow

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3162,7 +3162,7 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
                     code_challenge=challenge,
                     state=state,
                 )
-        device_data = await asyncio.get_event_loop().run_in_executor(
+        device_data = await asyncio.get_running_loop().run_in_executor(
             None, _do_minimax_request
         )
         sid, sess = _new_oauth_session("minimax-oauth", "device_code")


### PR DESCRIPTION
## What

Replace `asyncio.get_event_loop().run_in_executor(...)` with `asyncio.get_running_loop().run_in_executor(...)` in the MiniMax OAuth device-code handler.

## Why

`asyncio.get_event_loop()` is deprecated in 3.10+ when no running loop is set and is slated for removal in 3.14. Inside an `async def` handler we already have a running loop, so `asyncio.get_running_loop()` is the documented stdlib replacement.

## Test plan

- [x] `python -c \"import ast; ast.parse(open('hermes_cli/web_server.py').read())\"`
- [x] No behaviour change — `run_in_executor` still dispatches to the same loop's default executor.

## Platform

CLI web server (OAuth).

## Issue

Forward-lint cleanup spotted by static audit.