### PR TITLE
fix: use time.monotonic() for elapsed-time deadlines (gateway_windows, comfyui)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -820,8 +820,8 @@ def _wait_for_gateway_ready(timeout_s: float = 6.0, interval_s: float = 0.4) -> 
     """
     from hermes_cli.gateway import find_gateway_pids
 
-    deadline = time.time() + timeout_s
-    while time.time() < deadline:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
         pids = list(find_gateway_pids())
         if pids:
             return pids

--- a/skills/creative/comfyui/scripts/run_workflow.py
+++ b/skills/creative/comfyui/scripts/run_workflow.py
@@ -274,8 +274,8 @@ class ComfyRunner:
         ws = websocket.create_connection(ws_url, timeout=timeout)
         try:
             ws.settimeout(timeout)
-            deadline = time.time() + timeout
-            while time.time() < deadline:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
                 msg = ws.recv()
                 if isinstance(msg, bytes):
                     # Binary preview frame — ignore for now; ws_monitor.py prints them


### PR DESCRIPTION
## What

Replace `time.time()` with `time.monotonic()` at two interval-measurement deadline + poll-loop sites:

- `hermes_cli/gateway_windows.py:823` — gateway PID discovery poll
- `skills/creative/comfyui/scripts/run_workflow.py:277` — WebSocket recv loop

## Why

`time.time()` is wall-clock and subject to NTP corrections, manual time changes, and container clock skew. A backward jump leaves the loop running past its intended timeout; a forward jump kills it early.

`time.monotonic()` is the documented stdlib choice for measuring an interval (PEP 418): it is guaranteed not to go backwards and is unaffected by adjustments to the system clock.

## Test plan

- [x] `python -c \"import ast; ast.parse(open(...).read())\"` on both files
- [x] No behaviour change in normal operation — loops still wait the same elapsed time.

## Platform

CLI (gateway PID discovery, ComfyUI skill).

## Issue

Forward-lint cleanup spotted by static audit.