### PR TITLE
fix(feishu): gather with return_exceptions in comment-context fetch

### DIFF
--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -1202,7 +1202,19 @@ async def handle_drive_comment_event(
     comment_task = asyncio.ensure_future(
         batch_query_comment(client, file_token, file_type, comment_id)
     )
-    doc_meta, comment_detail = await asyncio.gather(meta_task, comment_task)
+    doc_meta_result, comment_detail_result = await asyncio.gather(
+        meta_task, comment_task, return_exceptions=True,
+    )
+    if isinstance(doc_meta_result, BaseException):
+        logger.warning("[Feishu-Comment] query_document_meta failed: %s", doc_meta_result)
+        doc_meta = {}
+    else:
+        doc_meta = doc_meta_result
+    if isinstance(comment_detail_result, BaseException):
+        logger.warning("[Feishu-Comment] batch_query_comment failed: %s", comment_detail_result)
+        comment_detail = {}
+    else:
+        comment_detail = comment_detail_result
 
     doc_title = doc_meta.get("title", "Untitled")
     doc_url = doc_meta.get("url", "")


### PR DESCRIPTION
## What
Wrap the meta+comment parallel fetch in feishu_comment.py with return_exceptions=True so one failure doesn't kill the whole comment-context handler.

## Why
Without return_exceptions, one transient HTTP failure crashes the handler instead of letting it degrade to a partial render. Both downstream consumers already use .get() with defaults, so {} fallback is safe.

## Test plan
- [x] AST parse OK
- [x] Happy path unchanged
- [x] Surviving result is logged with WARNING and rendered as best-effort