### PR TITLE
fix(lsp): reap idle language-server clients

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -204,6 +204,7 @@ class LSPService:
         enabled = bool(lsp_cfg.get("enabled", True))
         wait_mode = lsp_cfg.get("wait_mode", "document")
         wait_timeout = float(lsp_cfg.get("wait_timeout", DIAGNOSTICS_DOCUMENT_WAIT))
+        idle_timeout = float(lsp_cfg.get("idle_timeout", DEFAULT_IDLE_TIMEOUT))
         install_strategy = lsp_cfg.get("install_strategy", "auto")
         servers_cfg = lsp_cfg.get("servers") or {}
         disabled = []
@@ -235,6 +236,7 @@ class LSPService:
             env_overrides=env_overrides,
             init_overrides=init_overrides,
             disabled_servers=disabled,
+            idle_timeout=idle_timeout,
         )
 
     # ------------------------------------------------------------------
@@ -442,6 +444,46 @@ class LSPService:
         self._loop.stop()
         clear_cache()
 
+    def _idle_clients_to_reap(self) -> List[Tuple[Tuple[str, str], LSPClient]]:
+        """Remove stale clients from service state and return them for shutdown."""
+        if not self._enabled or self._idle_timeout <= 0:
+            return []
+        now = time.time()
+        with self._state_lock:
+            stale = [
+                key
+                for key, last_used in list(self._last_used.items())
+                if now - last_used > self._idle_timeout
+            ]
+            clients = []
+            for key in stale:
+                client = self._clients.pop(key, None)
+                self._last_used.pop(key, None)
+                if client is not None:
+                    clients.append((key, client))
+            return clients
+
+    def _reap_idle_clients(self) -> None:
+        """Best-effort shutdown of clients idle past the configured timeout."""
+        for key, client in self._idle_clients_to_reap():
+            try:
+                self._loop.run(client.shutdown(), timeout=2.0)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("LSP idle reap shutdown failed for %s: %s", key, exc)
+
+    async def _reap_idle_clients_async(self) -> None:
+        """Async variant for use from the LSP background loop."""
+        clients = self._idle_clients_to_reap()
+        if not clients:
+            return
+        results = await asyncio.gather(
+            *(client.shutdown() for _, client in clients),
+            return_exceptions=True,
+        )
+        for (key, _client), result in zip(clients, results):
+            if isinstance(result, Exception):
+                logger.debug("LSP idle reap shutdown failed for %s: %s", key, result)
+
     # ------------------------------------------------------------------
     # async internals
     # ------------------------------------------------------------------
@@ -485,6 +527,7 @@ class LSPService:
         return list(client.diagnostics_for(file_path))
 
     async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
+        await self._reap_idle_clients_async()
         srv = find_server_for_file(file_path)
         if srv is None:
             return None

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from agent.lsp.manager import LSPService
+from agent.lsp.manager import DEFAULT_IDLE_TIMEOUT, LSPService
 from agent.lsp.servers import (
     SERVERS,
     ServerContext,
@@ -22,6 +22,28 @@ from agent.lsp.servers import (
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
+
+
+def _service(**kwargs):
+    defaults = {
+        "enabled": True,
+        "wait_mode": "document",
+        "wait_timeout": 2.0,
+        "install_strategy": "manual",
+    }
+    defaults.update(kwargs)
+    return LSPService(**defaults)
+
+
+class FakeClient:
+    def __init__(self, server_id: str = "pyright", workspace_root: str = "/tmp/workspace"):
+        self.shutdown_called = False
+        self.server_id = server_id
+        self.workspace_root = workspace_root
+        self.is_running = True
+
+    async def shutdown(self):
+        self.shutdown_called = True
 
 
 def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "pyright"):
@@ -174,3 +196,89 @@ def test_service_status_includes_clients(mock_pyright):
         assert any(c["server_id"] == "pyright" for c in info["clients"])
     finally:
         svc.shutdown()
+
+
+def test_reap_idle_clients_shuts_down_stale_client(monkeypatch):
+    svc = _service(idle_timeout=10)
+    client = FakeClient()
+    key = (client.server_id, client.workspace_root)
+    svc._clients[key] = client
+    svc._last_used[key] = 100.0
+    monkeypatch.setattr("agent.lsp.manager.time.time", lambda: 111.0)
+
+    try:
+        svc._reap_idle_clients()
+
+        assert client.shutdown_called is True
+        assert key not in svc._clients
+        assert key not in svc._last_used
+    finally:
+        svc.shutdown()
+
+
+def test_reap_idle_clients_keeps_recent_client(monkeypatch):
+    svc = _service(idle_timeout=10)
+    client = FakeClient()
+    key = (client.server_id, client.workspace_root)
+    svc._clients[key] = client
+    svc._last_used[key] = 105.0
+    monkeypatch.setattr("agent.lsp.manager.time.time", lambda: 111.0)
+
+    try:
+        svc._reap_idle_clients()
+
+        assert client.shutdown_called is False
+        assert svc._clients[key] is client
+        assert svc._last_used[key] == 105.0
+    finally:
+        svc.shutdown()
+
+
+def test_reap_idle_clients_disabled_when_timeout_nonpositive(monkeypatch):
+    svc = _service(idle_timeout=0)
+    client = FakeClient()
+    key = (client.server_id, client.workspace_root)
+    svc._clients[key] = client
+    svc._last_used[key] = 1.0
+    monkeypatch.setattr("agent.lsp.manager.time.time", lambda: 999.0)
+
+    try:
+        svc._reap_idle_clients()
+
+        assert client.shutdown_called is False
+        assert svc._clients[key] is client
+    finally:
+        svc.shutdown()
+
+
+def test_get_or_spawn_sweeps_before_reuse(monkeypatch, mock_pyright):
+    repo = mock_pyright
+    f = repo / "x.py"
+    f.write_text("")
+    svc = _service()
+    called = False
+
+    async def fake_reap():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(svc, "_reap_idle_clients_async", fake_reap)
+
+    try:
+        svc.get_diagnostics_sync(str(f))
+        assert called is True
+    finally:
+        svc.shutdown()
+
+
+def test_create_from_config_reads_idle_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"lsp": {"enabled": False, "idle_timeout": 42}},
+    )
+
+    svc = LSPService.create_from_config()
+
+    assert svc is not None
+    assert svc._idle_timeout == 42.0
+    assert svc._idle_timeout != DEFAULT_IDLE_TIMEOUT

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -135,6 +135,10 @@ lsp:
   #   manual  — only use binaries already on PATH
   install_strategy: auto
 
+  # How long an unused language-server client stays alive. Set to 0
+  # to disable idle reaping.
+  idle_timeout: 600
+
   # Per-server overrides (all optional).
   servers:
     pyright:
@@ -186,9 +190,10 @@ budget is `wait_timeout` seconds — typically the server responds in
 tens of milliseconds for pyright/tsserver and a few seconds for
 rust-analyzer mid-indexing.
 
-Servers are kept alive for the life of the Hermes process. There's
-no idle-timeout reaper — the cost of restarting the server's index
-on every write would be far higher than holding the daemon.
+Long-running Hermes processes keep one language server per workspace while it is active.
+Idle language servers are shut down after `lsp.idle_timeout` seconds, defaulting
+to 600 seconds, and are respawned automatically on the next relevant file
+operation. Set the timeout to `0` to disable idle reaping.
 
 ## Disabling
 


### PR DESCRIPTION
## What does this PR do?

Reaps idle LSP clients after the configured `lsp.idle_timeout` so language-server processes do not stay alive indefinitely after use.

The sweep is intentionally minimal: it runs before client reuse/spawn, removes stale clients from the service maps first, then performs best-effort async shutdown. Clients respawn normally on the next relevant file operation.

`idle_timeout <= 0` disables idle reaping.

Note: I found existing related PRs #36684 and #25109 after preparing this branch. This PR is an alternative, smaller implementation that avoids a background reaper task and instead sweeps idle clients before LSP client reuse/spawn.

## Related Issue

No linked issue.

Related PRs: #36684, #25109

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/lsp/manager.py`
  - Parse `lsp.idle_timeout` from config.
  - Reap stale LSP clients before client reuse/spawn.
  - Remove stale clients from `_clients` / `_last_used` before best-effort shutdown.
  - Await async `client.shutdown()` directly inside the async sweep path.
  - Treat `idle_timeout <= 0` as disabled.

- `tests/agent/lsp/test_service.py`
  - Add coverage for stale client shutdown/removal.
  - Add coverage for recent client retention.
  - Add coverage for disabled reaping with `idle_timeout <= 0`.
  - Add coverage that sweeping happens before reuse/spawn.
  - Add coverage for config parsing.

- `website/docs/user-guide/features/lsp.md`
  - Document `lsp.idle_timeout`.
  - Document the default idle timeout.
  - Document `0` as the opt-out behavior.

## How to Test

1. Run targeted LSP tests:

   
bash
   python -m pytest tests/agent/lsp -q -o 'addopts='
   

   Result: `150 passed`

2. Run compile checks:

   
bash
   python -m py_compile agent/lsp/manager.py agent/lsp/__init__.py tests/agent/lsp/test_service.py
   

3. Run diff whitespace check:

   
bash
   git diff --check upstream/main..HEAD
   

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted verification:

text
python -m pytest tests/agent/lsp -q -o 'addopts='
150 passed

python -m py_compile agent/lsp/manager.py agent/lsp/__init__.py tests/agent/lsp/test_service.py
passed

git diff --check upstream/main..HEAD
passed