### PR TITLE
fix(approval): gate perl/ruby -i in-place edits of Hermes config/env

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -428,6 +428,27 @@ class TestHermesConfigWriteProtection:
         dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/config.yaml")
         assert dangerous is True
 
+    def test_perl_in_place_config(self):
+        # perl -i performs the same in-place mutation as sed -i but was not
+        # caught by the -e/-c pattern (which targets code evaluation).
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/approvals.mode: on/approvals.mode: off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+        assert "in-place" in desc.lower() or "perl" in desc.lower()
+
+    def test_ruby_in_place_config(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "ruby -i -pe 'gsub(/manual/, \"off\")' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_perl_in_place_env(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/SECRET=old/SECRET=new/' ~/.hermes/.env"
+        )
+        assert dangerous is True
+
     def test_read_is_safe(self):
         # Reading config is not a write — must not trip.
         dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/config.yaml")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -412,6 +412,10 @@ DANGEROUS_PATTERNS = [
     # the terminal side is not an open door. See #14639.
     (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
     (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
+    # perl -i and ruby -i perform the same in-place mutation as sed -i but are
+    # not caught by the -e/-c script-execution pattern above (which targets code
+    # evaluation, not file mutation). Pairs the sed -i coverage from #14639.
+    (rf'\b(?:perl|ruby)\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),


### PR DESCRIPTION
## Summary

`sed -i` coverage for `~/.hermes/config.yaml` and `.env` was added in #14639, but `perl -i` and `ruby -i` — which perform the same direct file mutation — were not covered. The existing `perl`/`ruby` pattern only catches `-e`/`-c` (code evaluation), not `-i` (file mutation), leaving this bypass open:

```bash
perl -i -pe 's/approvals.mode: on/approvals.mode: off/' ~/.hermes/config.yaml
```

`config.yaml` is the security policy (`approvals.mode`, `yolo`, and the permanent-approval allowlist live there). The mtime-keyed config cache reloads it mid-session, so a successful write immediately disables the gate — identical threat model to the `sed -i` gap that #14639 closed.

## Changes

- `tools/approval.py`: adds one pattern — `\b(?:perl|ruby)\s+-[^\s]*i` against both `_HERMES_CONFIG_PATH` and `_HERMES_ENV_PATH`, directly mirroring the `sed -i` lines
- `tests/tools/test_approval.py`: three new tests in `TestHermesConfigWriteProtection` — `perl -i` on config.yaml, `ruby -i` on config.yaml, `perl -i` on `.env`

## Test plan

- [ ] `uv run --frozen python -m pytest tests/tools/test_approval.py -x -q` — 200 passed (197 existing + 3 new)
- [ ] `perl -i` and `ruby -i` against `~/.hermes/config.yaml` are now flagged as dangerous
- [ ] `perl -e` / `perl -c` (code execution) and `cat ~/.hermes/config.yaml` (read) still behave correctly — no false positives introduced