### PR TITLE
fix(skills): ignore asset markdown in skill_view collision scan

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -85,6 +85,7 @@ AUTHOR_MAP = {
     "yichengqiao21@gmail.com": "YarrowQiao",
     "erhanyasarx@gmail.com": "erhnysr",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
+    "cryptoworlldz@gmail.com": "worlldz",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "schepers.zander1@gmail.com": "Strontvod",
     "ed@bebop.crew": "someaka",

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1223,6 +1223,25 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is True
         assert "EXTERNAL BODY" in result["content"]
 
+    def test_asset_markdown_name_does_not_trigger_false_collision(self, tmp_path):
+        """A markdown asset in another skill should not be treated as a
+        legacy flat skill candidate."""
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+
+        _make_skill(local_dir, "shared-name", body="TARGET BODY")
+        other_skill = _make_skill(local_dir, "other-skill", body="OTHER BODY")
+        assets_dir = other_skill / "assets"
+        assets_dir.mkdir()
+        (assets_dir / "shared-name.md").write_text("asset payload", encoding="utf-8")
+
+        with patch("tools.skills_tool.SKILLS_DIR", local_dir):
+            raw = skill_view("shared-name")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "TARGET BODY" in result["content"]
+
     def test_two_externals_same_name_also_refuse(self, tmp_path):
         """Collision detection is symmetric — two external dirs with
         same-name skills also trigger the refusal."""

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -935,6 +935,19 @@ def skill_view(
             seen_md.add(key)
             candidates.append((sd, smd))
 
+        def _is_nested_under_directory_skill(search_root: Path, found_md: Path) -> bool:
+            try:
+                rel_parts = found_md.relative_to(search_root).parts[:-1]
+            except Exception:
+                return False
+
+            current = search_root
+            for part in rel_parts:
+                current = current / part
+                if (current / "SKILL.md").exists():
+                    return True
+            return False
+
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
@@ -963,6 +976,11 @@ def skill_view(
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
                 if found_md.name != "SKILL.md":
+                    # Ignore linked/reference files nested under a directory
+                    # skill. Only standalone legacy flat skills should
+                    # participate in bare-name resolution.
+                    if _is_nested_under_directory_skill(search_dir, found_md):
+                        continue
                     _record(None, found_md)
 
         if len(candidates) > 1:


### PR DESCRIPTION
Fixes #35745

`skill_view` was treating nested legacy `*.md` files under another directory skill (for example `assets/shared-name.md`) as bare-name skill candidates.

That caused false collision reports even when there was only one real skill with the requested name.

This patch keeps the existing collision protection for actual same-name skills, but ignores linked markdown files nested under directory skills when scanning legacy flat skill files.

Validation:
`uv run --extra dev pytest tests/tools/test_skills_tool.py -q -k 'asset_markdown_name_does_not_trigger_false_collision or TestSkillViewCollisionDetection'`

Result:
`7 passed, 80 deselected`