### PR TITLE
Fix cron, CLI, doctor, and Termux regressions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2116,6 +2116,20 @@ def _cprint(text: str):
             pass
 
 
+def _cli_visible_print(text: str = "") -> None:
+    """Print normally unless prompt_toolkit owns the live terminal."""
+    try:
+        from prompt_toolkit.application import get_app_or_none
+        app = get_app_or_none()
+    except Exception:
+        app = None
+
+    if app is not None and getattr(app, "_is_running", False):
+        _cprint(text)
+    else:
+        print(text)
+
+
 # ---------------------------------------------------------------------------
 # File-drop / local attachment detection — extracted as pure helpers for tests.
 # ---------------------------------------------------------------------------
@@ -6336,30 +6350,30 @@ class HermesCLI:
 
         from hermes_cli.main import _relative_time
 
-        print()
+        _cli_visible_print()
         if reason == "history":
-            print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
+            _cli_visible_print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
         else:
-            print("  Recent sessions:")
-        print()
-        print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+            _cli_visible_print("  Recent sessions:")
+        _cli_visible_print()
+        _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
-        print()
-        print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
-        print("  Example: /resume 2")
-        print()
+            _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+        _cli_visible_print()
+        _cli_visible_print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
+        _cli_visible_print("  Example: /resume 2")
+        _cli_visible_print()
         return True
 
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
             if not self._show_recent_sessions(reason="history"):
-                print("(._.) No conversation history yet.")
+                _cli_visible_print("(._.) No conversation history yet.")
             return
 
         preview_limit = 400
@@ -6372,14 +6386,14 @@ class HermesCLI:
                 return
 
             noun = "message" if hidden_tool_messages == 1 else "messages"
-            print("\n  [Tools]")
-            print(f"    ({hidden_tool_messages} tool {noun} hidden)")
+            _cli_visible_print("\n  [Tools]")
+            _cli_visible_print(f"    ({hidden_tool_messages} tool {noun} hidden)")
             hidden_tool_messages = 0
 
-        print()
-        print("+" + "-" * 50 + "+")
-        print("|" + " " * 12 + "(^_^) Conversation History" + " " * 11 + "|")
-        print("+" + "-" * 50 + "+")
+        _cli_visible_print()
+        _cli_visible_print("+" + "-" * 50 + "+")
+        _cli_visible_print("|" + " " * 12 + "(^_^) Conversation History" + " " * 11 + "|")
+        _cli_visible_print("+" + "-" * 50 + "+")
 
         for msg in self.conversation_history:
             role = msg.get("role", "unknown")
@@ -6398,13 +6412,13 @@ class HermesCLI:
             content_text = "" if content is None else str(content)
 
             if role == "user":
-                print(f"\n  [You #{visible_index}]")
-                print(
+                _cli_visible_print(f"\n  [You #{visible_index}]")
+                _cli_visible_print(
                     f"    {content_text[:preview_limit]}{'...' if len(content_text) > preview_limit else ''}"
                 )
                 continue
 
-            print(f"\n  [Hermes #{visible_index}]")
+            _cli_visible_print(f"\n  [Hermes #{visible_index}]")
             tool_calls = msg.get("tool_calls") or []
             if content_text:
                 preview = content_text[:preview_limit]
@@ -6417,10 +6431,10 @@ class HermesCLI:
             else:
                 preview = "(no text response)"
                 suffix = ""
-            print(f"    {preview}{suffix}")
+            _cli_visible_print(f"    {preview}{suffix}")
 
         flush_tool_summary()
-        print()
+        _cli_visible_print()
     
     def _notify_session_boundary(self, event_type: str) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -428,17 +428,33 @@ def load_jobs() -> List[Dict[str, Any]]:
     ensure_dirs()
     if not JOBS_FILE.exists():
         return []
-    
+
+    def _extract_jobs(data: Any, *, repair_reason: str | None = None) -> List[Dict[str, Any]]:
+        if isinstance(data, list):
+            save_jobs(data)
+            logger.warning("Auto-repaired jobs.json (%s)", repair_reason or "top-level was a list")
+            return data
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"Cron database corrupted: top-level is {type(data).__name__}, expected object"
+            )
+        jobs = data.get("jobs", [])
+        if not isinstance(jobs, list):
+            raise RuntimeError(
+                f"Cron database corrupted: jobs field is {type(jobs).__name__}, expected list"
+            )
+        return jobs
+
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            return data.get("jobs", [])
+            return _extract_jobs(data, repair_reason="top-level was a list, expected object")
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
-                jobs = data.get("jobs", [])
+                jobs = _extract_jobs(data, repair_reason="top-level was a list, expected object")
                 if jobs:
                     # Auto-repair: rewrite with proper escaping
                     save_jobs(jobs)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3974,22 +3974,47 @@ class GatewayRunner:
             )
             return
 
-        cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
-        shell_cmd = (
-            f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-            f"{cmd} gateway restart"
-        )
+        import textwrap
+
+        cmd_argv = [*hermes_cmd, "gateway", "restart"]
+        watcher = textwrap.dedent(
+            """
+            import os, subprocess, sys, time
+            pid = int(sys.argv[1])
+            cmd = sys.argv[2:]
+            deadline = time.monotonic() + 120
+
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    break
+                except PermissionError:
+                    pass
+                except OSError:
+                    break
+                time.sleep(0.2)
+
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            """
+        ).strip()
+        watcher_argv = [sys.executable, "-c", watcher, str(current_pid), *cmd_argv]
         setsid_bin = shutil.which("setsid")
         if setsid_bin:
             subprocess.Popen(
-                [setsid_bin, "bash", "-lc", shell_cmd],
+                [setsid_bin, "--", *watcher_argv],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
         else:
             subprocess.Popen(
-                ["bash", "-lc", shell_cmd],
+                watcher_argv,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -683,7 +683,9 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
 
     # Update check — use prefetched result if available
     try:
-        behind = get_update_result(timeout=0.5)
+        from hermes_cli.config import cfg_get, load_config
+        show_update_banner = cfg_get(load_config(), "display", "show_update_banner", default=True)
+        behind = get_update_result(timeout=0.5) if show_update_banner is not False else None
         if behind is not None and behind != 0:
             from hermes_cli.config import get_managed_update_command, recommended_update_command
             if behind > 0:

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -177,7 +177,7 @@ def _warn_if_gateway_running(auto_yes: bool) -> None:
         "conflicts (Telegram, Discord, and Slack only allow one active "
         "session per token)."
     )
-    print_info("Recommendation: stop the gateway first with 'hermes stop'.")
+    print_info("Recommendation: stop the gateway first with 'hermes gateway stop'.")
     print()
     if not auto_yes and not prompt_yes_no("Continue anyway?", default=False):
         print_info("Migration cancelled. Stop the gateway and try again.")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1293,6 +1293,7 @@ DEFAULT_CONFIG = {
         # starts delegating, nudging the user toward the live spawn-tree
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
+        "show_update_banner": True,
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -204,6 +204,32 @@ def _fail_and_issue(text: str, detail: str, fix: str, issues: list[str]) -> None
     issues.append(fix)
 
 
+def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
+    """Return toolsets enabled for the CLI, or None if config resolution fails."""
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+
+        return {str(toolset) for toolset in _get_platform_tools(load_config() or {}, "cli")}
+    except Exception:
+        return None
+
+
+def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
+    """Filter unavailable API-key toolsets to those enabled for the CLI."""
+    api_key_unavailable = [
+        item for item in unavailable
+        if item.get("missing_vars") or item.get("env_vars")
+    ]
+    enabled_toolsets = _enabled_cli_toolsets_for_doctor()
+    if enabled_toolsets is None:
+        return api_key_unavailable
+    return [
+        item for item in api_key_unavailable
+        if str(item.get("name") or "") in enabled_toolsets
+    ]
+
+
 def _read_pyproject_version() -> str | None:
     """Read the ``version = "..."`` from ``pyproject.toml`` at the project root.
 
@@ -1895,8 +1921,10 @@ def run_doctor(args):
             else:
                 check_warn(item["name"], "(system dependency not met)")
 
-        # Count disabled tools with API key requirements
-        api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
+        # Count missing API-key requirements only for toolsets enabled in the
+        # current CLI platform. Default-off or explicitly disabled toolsets may
+        # still show warnings above, but should not pollute the final summary.
+        api_disabled = _missing_api_key_toolsets_for_summary(unavailable)
         if api_disabled:
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
@@ -37,6 +38,39 @@ class TestCliResumeCommand:
         assert "Research" in output
         assert "/resume 2" in output
         assert "/resume <session title>" in output
+
+    def test_show_recent_sessions_uses_prompt_toolkit_safe_print(self):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_002", "title": "Coding", "preview": "build feature", "last_active": None},
+        ])
+
+        running_app = SimpleNamespace(_is_running=True)
+        with (
+            patch("prompt_toolkit.application.get_app_or_none", return_value=running_app),
+            patch("cli._cprint") as mock_cprint,
+        ):
+            shown = cli_obj._show_recent_sessions(reason="sessions")
+
+        assert shown is True
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "Recent sessions" in printed
+        assert "Coding" in printed
+
+    def test_show_history_uses_prompt_toolkit_safe_print(self):
+        cli_obj = _make_cli()
+        cli_obj.conversation_history = [{"role": "user", "content": "Hello"}]
+
+        running_app = SimpleNamespace(_is_running=True)
+        with (
+            patch("prompt_toolkit.application.get_app_or_none", return_value=running_app),
+            patch("cli._cprint") as mock_cprint,
+        ):
+            cli_obj.show_history()
+
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "Conversation History" in printed
+        assert "Hello" in printed
 
     def test_handle_resume_by_index_switches_to_numbered_session(self):
         cli_obj = _make_cli()

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -187,6 +187,24 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 class TestJobCRUD:
+    def test_load_jobs_repairs_top_level_list(self, tmp_cron_dir):
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        jobs_file.parent.mkdir(parents=True)
+        jobs_file.write_text('[{"id": "legacy", "prompt": "hi"}]', encoding="utf-8")
+
+        jobs = load_jobs()
+
+        assert jobs == [{"id": "legacy", "prompt": "hi"}]
+        assert jobs_file.read_text(encoding="utf-8").lstrip().startswith("{")
+
+    def test_load_jobs_rejects_non_object_top_level(self, tmp_cron_dir):
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        jobs_file.parent.mkdir(parents=True)
+        jobs_file.write_text('"not a job store"', encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="top-level is str"):
+            load_jobs()
+
     def test_create_and_get(self, tmp_cron_dir):
         job = create_job(prompt="Check server status", schedule="30m")
         assert job["id"]

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,6 +1,7 @@
 import asyncio
 import shutil
 import subprocess
+import sys
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -196,9 +197,38 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
 
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
-    assert cmd[:2] == ["/usr/bin/setsid", "bash"]
-    assert "gateway restart" in cmd[-1]
-    assert "kill -0 321" in cmd[-1]
+    assert cmd[:3] == ["/usr/bin/setsid", "--", sys.executable]
+    assert "os.kill(pid, 0)" in cmd[4]
+    assert "subprocess.Popen" in cmd[4]
+    assert cmd[-3:] == ["/usr/bin/hermes", "gateway", "restart"]
+    assert kwargs["start_new_session"] is True
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_command_without_setsid_avoids_shell(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["/usr/bin/hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[:3] == [sys.executable, "-c", cmd[2]]
+    assert "bash" not in cmd
+    assert "os.kill(pid, 0)" in cmd[2]
+    assert cmd[-3:] == ["/usr/bin/hermes", "gateway", "restart"]
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -70,6 +70,31 @@ def test_build_welcome_banner_uses_normalized_toolset_names():
     assert "web_tools:" not in output
 
 
+def test_build_welcome_banner_can_suppress_update_warning():
+    """display.show_update_banner=false suppresses the update block."""
+    with (
+        patch.object(model_tools, "check_tool_availability", return_value=(["web"], [])),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=3) as mock_update,
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+        patch("hermes_cli.banner.get_latest_release_tag", return_value=None),
+        patch("hermes_cli.config.load_config", return_value={"display": {"show_update_banner": False}}),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="anthropic/test-model",
+            cwd="/tmp/project",
+            tools=[{"function": {"name": "web_search"}}],
+            get_toolset_for_tool=lambda name: "web",
+        )
+
+    output = console.export_text()
+    assert "commit behind" not in output
+    assert "commits behind" not in output
+    mock_update.assert_not_called()
+
+
 def test_build_welcome_banner_title_is_hyperlinked_to_release():
     """Panel title (version label) is wrapped in an OSC-8 hyperlink to the GitHub release."""
     import io

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -73,6 +73,22 @@ class TestFindOpenclawDirs:
         assert found == []
 
 
+class TestGatewayWarning:
+    def test_warn_if_gateway_running_suggests_gateway_stop(self, capsys):
+        with (
+            patch("gateway.status.get_running_pid", return_value=123),
+            patch(
+                "gateway.status.read_runtime_status",
+                return_value={"platforms": {"telegram": {"state": "connected"}}},
+            ),
+        ):
+            claw_mod._warn_if_gateway_running(auto_yes=True)
+
+        output = capsys.readouterr().out
+        assert "hermes gateway stop" in output
+        assert "'hermes stop'" not in output
+
+
 # ---------------------------------------------------------------------------
 # _scan_workspace_state
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -38,6 +38,30 @@ class TestProviderEnvDetection:
         content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***"
         assert _has_provider_env_config(content)
 
+
+class TestDoctorToolAvailabilitySummary:
+    def test_missing_api_key_summary_ignores_disabled_toolsets(self, monkeypatch):
+        unavailable = [
+            {"name": "rl", "missing_vars": ["TINKER_API_KEY"]},
+            {"name": "web", "missing_vars": ["EXA_API_KEY"]},
+        ]
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"web"})
+
+        filtered = doctor._missing_api_key_toolsets_for_summary(unavailable)
+
+        assert [item["name"] for item in filtered] == ["web"]
+
+    def test_missing_api_key_summary_falls_back_when_config_unavailable(self, monkeypatch):
+        unavailable = [
+            {"name": "rl", "missing_vars": ["TINKER_API_KEY"]},
+            {"name": "web", "missing_vars": ["EXA_API_KEY"]},
+        ]
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: None)
+
+        filtered = doctor._missing_api_key_toolsets_for_summary(unavailable)
+
+        assert [item["name"] for item in filtered] == ["rl", "web"]
+
     def test_detects_custom_endpoint_without_openrouter_key(self):
         content = "OPENAI_BASE_URL=http://localhost:8080/v1\n"
         assert _has_provider_env_config(content)


### PR DESCRIPTION
## Summary
- repair bare-list cron jobs.json files and reject invalid top-level / jobs field shapes with RuntimeError instead of AttributeError
- correct the OpenClaw migration gateway-stop recommendation
- route /sessions and /history output through prompt_toolkit-safe printing when the interactive app owns the terminal
- replace the POSIX detached gateway restart shell chain with a detached Python watcher so Termux/Android restarts do not kill the new gateway
- honor display.show_update_banner=false and avoid running the update check when the banner is disabled
- keep disabled/default-off toolsets out of doctor's final missing-API-key summary

Fixes #36867
Fixes #36771
Fixes #36815
Fixes #29603
Fixes #36287
Fixes #11336

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_banner.py tests/hermes_cli/test_doctor.py -- -k 'show_update_banner or ToolAvailabilitySummary'\n- scripts/run_tests.sh tests/hermes_cli/test_banner.py tests/gateway/test_restart_drain.py tests/cron/test_jobs.py tests/hermes_cli/test_claw.py tests/cli/test_cli_resume_command.py tests/cli/test_cli_init.py\n- python -m py_compile hermes_cli/banner.py hermes_cli/config.py hermes_cli/doctor.py gateway/run.py cron/jobs.py cli.py\n\nNote: a full run of tests/hermes_cli/test_doctor.py was stopped after it hung in environment-heavy checks unrelated to these helper tests.