### PR TITLE
chore: add benfrank241 to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "ben.bartholomew@vectorize.io": "benfrank241",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",
     "subw3@mail2.sysu.edu.cn": "Subway2023",
     "zhipengli@thebrainly.ai": "a1245582339",


### PR DESCRIPTION
Maps `ben.bartholomew@vectorize.io` -> `benfrank241` so the contributor attribution audit (`contributor_audit.py` strict mode) passes when their commit lands via #36824.

Prerequisite for merging #36824 (fix: guard os.fchmod for Windows in atomic_json_write).