### PR TITLE
fix(auxiliary): default to openrouter/free instead of paid Gemini Flash for auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -414,8 +414,8 @@ NOUS_EXTRA_BODY = _nous_extra_body()
 auxiliary_is_nous: bool = False
 
 # Default auxiliary models per provider
-_OPENROUTER_MODEL = "google/gemini-3-flash-preview"
-_NOUS_MODEL = "google/gemini-3-flash-preview"
+_OPENROUTER_MODEL = "openrouter/free"
+_NOUS_MODEL = "openrouter/free"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
@@ -1576,7 +1576,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     # The /api/nous/recommended-models endpoint is the authoritative source:
     # it distinguishes paid vs free tier recommendations, and get_nous_recommended_aux_model
     # auto-detects the caller's tier via check_nous_free_tier().  Fall back to
-    # _NOUS_MODEL (google/gemini-3-flash-preview) when the Portal is unreachable
+    # _NOUS_MODEL (openrouter/free) when the Portal is unreachable
     # or returns a null recommendation for this task type.
     model = _NOUS_MODEL
     try:


### PR DESCRIPTION
## Summary

Changes the default model for auxiliary tasks (compression, vision, web extraction) from `google/gemini-3-flash-preview` (paid, $0.50/M tokens) to `openrouter/free` (OpenRouter's free-tier routing endpoint).

## Problem

The auxiliary client hardcodes `_OPENROUTER_MODEL` and `_NOUS_MODEL` to `google/gemini-3-flash-preview` — a paid Vertex/Gemini model. When the main model fails or auxiliary tasks fire, the fallback chain silently routes through OpenRouter to this paid model. Users get surprise bills for models they never selected.

Reported as **P1 issue #36759**: a user was charged ~$1 AUD for a single unauthorized GPT-5.5 call through the auxiliary fallback chain when their selected free model (owl-alpha) had a transient issue.

## Fix

Both fallback defaults changed from `google/gemini-3-flash-preview` to `openrouter/free`.

`openrouter/free` is OpenRouter's own routing endpoint that:
- **Model-agnostic**: dynamically selects the best available free model
- **Cost-safe**: errors if no free models are available — never bills
- **Multimodal-capable**: OpenRouter's free tier includes vision models for auxiliary vision tasks
- **Self-updating**: as models join/leave the free tier, routing adapts — no hardcoded model name
- **200K context**: sufficient for auxiliary tasks

## Background

Ghost Stack runs 6 Hermes agents in production across 5 nodes and encountered this same pattern — auxiliary calls 401'd until we forced them to a free model. The `openrouter/free` endpoint is the correct upstream fix: endpoint-specific, model-agnostic, cost-safe by design.

## Related

- Issue #36759: Auxiliary fallback ignores session-level model switch and routes to paid model
- Issue #24029: Related discussion about free tier fallback