### PR TITLE
fix(doctor): skip npm audit and explain when no package-lock.json (#36893)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1461,6 +1461,21 @@ def run_doctor(args):
         for npm_dir, label in npm_dirs:
             if not (npm_dir / "node_modules").exists():
                 continue
+            # `npm audit` requires a `package-lock.json`. Some Hermes-managed
+            # installs (e.g. Windows native, where agent-browser is vendored
+            # into %LOCALAPPDATA%\hermes\hermes-agent\node_modules) ship the
+            # node_modules folder without a lockfile. Running `npm audit` in
+            # that case still produces a non-empty vulnerabilities dict
+            # (advisories are matched against installed package versions in
+            # node_modules), but the only safe remediation — `npm audit fix`
+            # — cannot run without a lockfile, and we do not want users
+            # hand-editing the Hermes-managed install. Skip the audit and
+            # explain the situation instead. Issue #36893.
+            if not (npm_dir / "package-lock.json").exists():
+                check_info(f"{label}: skipping npm audit (no package-lock.json in this Hermes-managed install)")
+                check_info("Vulnerabilities, if any, are managed by the Hermes release pipeline")
+                check_info(f"Do not run `npm audit fix` inside {npm_dir} — it is regenerated on upgrade")
+                continue
             try:
                 # Use resolved absolute path so Windows can execute
                 # npm.cmd (CreateProcessW can't run bare .cmd names).

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1358,3 +1358,140 @@ class TestDoctorStaleMaxIterationsDrift:
             monkeypatch, tmp_path, fix=False, ghost=None, cfg_turns=400,
         )
         assert "shadows" not in out
+
+
+# ---------------------------------------------------------------------------
+# Regression: hermes doctor must not flag npm vulnerabilities when the
+# Hermes-managed install has no package-lock.json (Windows native ships
+# `agent-browser` as a vendored node_modules folder without a lockfile).
+# The user's "fix path" must explain why, not just say "run npm audit fix".
+# Issue #36893.
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_npm_audit(npm_calls: list) -> object:
+    """Subprocess.run stub that records calls and returns a clean audit JSON."""
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0].endswith("npm") and cmd[1] == "audit":
+            npm_calls.append((cmd, kwargs.get("cwd")))
+            return SimpleNamespace(
+                returncode=0,
+                stdout='{"metadata":{"vulnerabilities":{"critical":2,"high":1,"moderate":3}}}',
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return fake_run
+
+
+def test_run_doctor_skips_npm_audit_when_no_lockfile(monkeypatch, tmp_path):
+    """When `node_modules/agent-browser` exists but `package-lock.json` does
+    not (Windows native install), doctor must NOT report vulnerabilities and
+    must NOT suggest `npm audit fix` — both are un-actionable for the user.
+    Regression for #36893."""
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    (project / "node_modules" / "agent-browser").mkdir(parents=True)
+    (project / "node_modules" / "agent-browser" / "package.json").write_text(
+        '{"name":"agent-browser","version":"0.26.0"}', encoding="utf-8"
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None)
+    monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None)
+
+    npm_calls: list = []
+    monkeypatch.setattr(doctor_mod.subprocess, "run", _make_fake_npm_audit(npm_calls))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert npm_calls == [], f"npm audit was called despite missing lockfile: {npm_calls}"
+    assert "npm vulnerabilities" not in out, (
+        f"Doctor reported npm vulnerabilities without a lockfile:\n{out}"
+    )
+    assert "has 6 npm vulnerabilities" not in out, (
+        f"Doctor still reports 'has 6 npm vulnerabilities' on the issues list:\n{out}"
+    )
+    assert "skipping npm audit" in out, (
+        f"Doctor did not explain the lockfile requirement:\n{out}"
+    )
+    assert "package-lock" in out or "lockfile" in out, (
+        f"Doctor did not mention package-lock/lockfile:\n{out}"
+    )
+    assert "Do not run" in out and "Hermes-managed install" in out, (
+        f"Doctor did not warn against modifying the Hermes-managed install:\n{out}"
+    )
+
+
+def test_run_doctor_runs_npm_audit_when_lockfile_present(monkeypatch, tmp_path):
+    """When `package-lock.json` IS present, the audit must run normally —
+    the new no-lockfile path must not regress the normal case."""
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    (project / "node_modules" / "agent-browser").mkdir(parents=True)
+    (project / "node_modules" / "agent-browser" / "package.json").write_text(
+        '{"name":"agent-browser","version":"0.26.0"}', encoding="utf-8"
+    )
+    (project / "package-lock.json").write_text('{"lockfileVersion":3}', encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None)
+    monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None)
+
+    npm_calls: list = []
+    monkeypatch.setattr(doctor_mod.subprocess, "run", _make_fake_npm_audit(npm_calls))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert len(npm_calls) >= 1, f"npm audit was NOT called despite a lockfile being present"
+    assert "Browser tools" in out
+    assert "critical" in out


### PR DESCRIPTION
## Summary
Fixes `hermes doctor` reporting un-actionable npm-vulnerability warnings on Windows native (and any Hermes-managed) installs that ship `agent-browser` vendored under `node_modules/` without a `package-lock.json`.

When the lockfile is missing the doctor now:
1. Skips the `npm audit` call (it cannot be safely remediated anyway)
2. Prints an info line explaining the audit was skipped
3. Tells the user that vulnerabilities are managed by the Hermes release pipeline
4. Tells the user **not** to run `npm audit fix` inside the Hermes-managed path

When the lockfile IS present the existing audit logic is unchanged.

## Issue
Fixes #36893

## Test plan
- [x] `tests/hermes_cli/test_doctor.py::test_run_doctor_skips_npm_audit_when_no_lockfile` — new regression test: no lockfile → audit not called, clear info messages emitted
- [x] `tests/hermes_cli/test_doctor.py::test_run_doctor_runs_npm_audit_when_lockfile_present` — new regression test: lockfile present → audit runs and surfaces vulnerabilities as before
- [x] All 61 existing `test_doctor.py` tests still pass
- [x] All 70 `test_windows_native_support.py` + `test_windows_compat.py` tests still pass
- [x] All 20 `test_security_advisories.py` tests still pass

## How it was implemented
Followed TDD:
1. RED — wrote the failing regression test, ran it, saw the audit was being called and the "X npm vulnerabilities" string was being emitted
2. GREEN — added a 3-line guard in `hermes_cli/doctor.py` that checks for `package-lock.json` before invoking `npm audit`; both new tests pass
3. REFACTOR — kept the change minimal (one `if not ... : ... continue` block) and added a comment explaining the Windows-native motivation; no other refactoring needed

## Caveats
- I cannot run a Windows native Hermes install from this Termux/Android environment, so the exact phrasing of the info messages was chosen to match the issue's request ("a doctor remediation message specific to the managed Windows native install") but the underlying logic is platform-agnostic.
- The fix does not change behavior for installs that DO have a `package-lock.json` (the common case for development checkouts).