### PR TITLE
fix(kanban): update HERMES_KANBAN_BOARD env on boards switch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1137,6 +1137,10 @@ def _cmd_boards_switch(args: argparse.Namespace) -> int:
         )
         return 1
     kb.set_current_board(normed)
+    # Mirror the switch in the process environment so that downstream
+    # subprocesses spawned by THIS process see the new board immediately,
+    # even when the caller has a pre-existing HERMES_KANBAN_BOARD env pin.
+    os.environ["HERMES_KANBAN_BOARD"] = normed
     print(f"Active board is now {normed!r}.")
     return 0
 


### PR DESCRIPTION
## Summary

`hermes kanban boards switch <slug>` writes the new board to `~/.hermes/kanban/current` but does **not** update `os.environ['HERMES_KANBAN_BOARD']`. When the env var is already pinned (e.g. by `_pin_kanban_board_env` at chat startup), subsequent `hermes kanban` CLI commands in the same process tree ignore the disk file because `get_current_board()` checks the env var first (highest precedence).

Resolution order:
1. `HERMES_KANBAN_BOARD` env var
2. `kanban/current` file
3. `default`

## Fix

Mirror the switch into the process environment after writing the file, using the same pattern already established for `--board` overrides (line 902 in the same file).

## Reproduction

```bash
hermes kanban boards switch daybook-v2
hermes kanban boards current
# Expected: daybook-v2
# Actual:   main  (when HERMES_KANBAN_BOARD=main is inherited from parent)
```

## Notes

This fix handles the in-process case. The parent->child propagation issue (agent pins env at chat startup, subprocesses inherit it) is a separate architectural concern.