### PR TITLE
fix(docker): install python3-venv so ensurepip fallback works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc python3-dev python3-venv libffi-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------


### PR DESCRIPTION
Closes #36813

## Summary

The Hermes Agent Docker image (Debian 13 trixie) was missing the `python3-venv` apt package, which is what ships the `ensurepip` stdlib module. Hermes' lazy-deps installer uses a uv → pip → ensurepip install ladder, and the Tier-2 fallback path calls `python3 -m ensurepip --upgrade --default-pip` to bootstrap pip into the user venv when uv is unavailable. Without `python3-venv` installed at build time, that command returns exit status 1 and the user gets the confusing error quoted in #36813 (`pip not available and ensurepip failed: Command '...python3 -m ensurepip --upgrade --default-pip' returned non-zero exit status 1.`) the first time any tool needs a lazily-installed Python dep.

This PR adds `python3-venv` to the single `apt-get install` line in the runtime stage, right after `python3-dev`, so the existing layer still installs everything in one shot. No new RUN layer, no new package manager call, no source code changes.

## Diffstat

```
Dockerfile | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

## Repro / Verification

Issue #36813 (manual repro from the bug report):

1. Pull the published image: `docker pull nousresearch/hermes-agent:latest`
2. Start a chat session that triggers a tool needing a lazy Python dep (e.g. `web_search()` or `web_extract()` — firecrawl). Tier-1 uv path can be forced to fail by stripping it from PATH or by setting the env var the lazy-deps installer honors to disable uv.
3. Observe the Tier-2 fallback blow up with the `ensurepip failed` error.

After this fix:

1. Rebuild the image from this branch: `docker build -t hermes-agent:test -f Dockerfile .`
2. Run a shell against it: `docker run --rm -it hermes-agent:test bash`
3. Sanity-check that ensurepip is now wired in: `python3 -m ensurepip --version` → should print a pip version (e.g. `ensurepip (Python 3.13.5)`).
4. Run `python3 -c "import venv; venv.ensurepip"` to confirm the venv module's bundled pip-bootstrap helper resolves. Both should succeed where the unpatched image fails with `No module named 'ensurepip'`.
5. Trigger the original repro (lazy firecrawl install) and confirm the Tier-2 fallback now returns a working pip instead of the prior hard failure.

This PR was authored from an environment without a Docker daemon (Termux on Android 16), so the build itself was not run locally; verification is the manual steps above. The CI `docker-lint` (hadolint) and `docker-publish` (build + smoke test) workflows exercise the patched Dockerfile on the PR branch.

## Checklist

- [x] Targets the active Dockerfile (`./Dockerfile`, the only Dockerfile referenced by `docker-publish.yml`, `docker-compose.yml`, and `docker-compose.windows.yml`).
- [x] No other files modified — only `Dockerfile`.
- [x] Single `apt-get install` line in the runtime stage; no new RUN, no new layer.
- [x] Package added in the same RUN as the rest of the Python apt packages, grouped with `python3-dev`.
- [x] No source code, tests, host-side install script (`scripts/install.sh`), or unrelated docs touched.
- [x] One fix per PR — only the `python3-venv` addition.
- [x] DRAFT — not marked ready for review.