### PR TITLE
fix(cron): mark job failed when script fails, not masked by LLM fallback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1343,11 +1343,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # the whole agent run. We pass the result into _build_job_prompt so
     # the script is only executed once.
     prerun_script = None
+    _script_failed = False
     script_path = job.get("script")
     if script_path:
         prerun_script = _run_job_script(script_path)
         _ran_ok, _script_output = prerun_script
-        if _ran_ok and not _parse_wake_gate(_script_output):
+        if not _ran_ok:
+            _script_failed = True
+        elif not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
                 job_name, job_id,
@@ -1786,6 +1789,19 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 {logged_response}
 """
+        
+        # If the pre-run script failed (non-zero exit / timeout), the agent
+        # ran successfully against an error-report prompt — but the *job*
+        # itself must still be marked failed so the operator sees the script
+        # failure in cron metadata (last_status != ok).  Without this guard
+        # the LLM fallback masks the script failure as a successful run.
+        # (issue #36845)
+        if _script_failed:
+            logger.warning(
+                "Job '%s': pre-run script failed — marking run as failed "
+                "despite successful agent fallback", job_name,
+            )
+            return False, output, final_response, "Script failed/timed out"
         
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None

--- a/tests/cron/test_script_failure_not_masked.py
+++ b/tests/cron/test_script_failure_not_masked.py
@@ -1,0 +1,141 @@
+"""Regression test: script failure must not be masked as last_status=ok by LLM fallback.
+
+Issue #36845: When a script-backed cron job's pre-run script fails (non-zero exit
+or timeout), the LLM fallback path still runs and produces an error report.
+Previously the agent's successful run was treated as overall job success,
+masking the underlying script failure in cron metadata (last_status=ok).
+
+The fix ensures _run_job_impl returns success=False when _script_failed=True,
+even though the agent completed without error.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestScriptFailureNotMasked:
+    """Script failure should propagate through LLM fallback as job failure."""
+
+    def test_script_failure_propagates_through_agent_fallback(self, tmp_path):
+        """When script fails but agent runs, job should be marked failed."""
+        from cron.scheduler import run_job
+
+        script = tmp_path / "scripts" / "fail.py"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("import sys; sys.exit(1)")
+
+        job = {
+            "id": "script-fail-test",
+            "name": "backup",
+            "prompt": "Summarize the script error",
+            "script": str(script),
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "The backup script failed with exit code 1."
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        # The job should be marked as FAILED even though the agent ran fine
+        assert success is False, \
+            "Job should be marked failed when script fails, even if agent succeeds"
+        assert error is not None, "Error message should be present"
+        assert "script" in error.lower() or "failed" in error.lower(), \
+            f"Error should mention script failure, got: {error}"
+        # The agent response should still be available for delivery
+        assert final_response == "The backup script failed with exit code 1."
+
+    def test_script_success_still_returns_true(self, tmp_path):
+        """When script succeeds and agent runs, job should succeed normally."""
+        from cron.scheduler import run_job
+
+        script = tmp_path / "scripts" / "ok.py"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("print('data collected')")
+
+        job = {
+            "id": "script-ok-test",
+            "name": "collect",
+            "prompt": "Analyze the data",
+            "script": str(script),
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "Analysis complete."
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True, "Job should succeed when script and agent both succeed"
+        assert error is None
+        assert final_response == "Analysis complete."
+
+    def test_no_script_job_succeeds_normally(self, tmp_path):
+        """Jobs without scripts should not be affected by the fix."""
+        from cron.scheduler import run_job
+
+        job = {
+            "id": "no-script-test",
+            "name": "daily",
+            "prompt": "Generate a summary",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "Summary done."
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a script-backed cron job's script failure (non-zero exit or timeout) is masked as `last_status=ok` by the LLM fallback path. When the pre-run script fails, the agent runs against an error-report prompt and succeeds — but the overall job should still be marked as failed so the operator sees the script failure in cron metadata.

## Related Issue

Fixes #36845

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Track script failure via `_script_failed` flag in `_run_job_impl`. When the pre-run script fails (`_run_job_script` returns `ok=False`), set the flag. At the final return, if `_script_failed` is `True`, return `success=False` with error `"Script failed/timed out"` instead of `True`.
- `tests/cron/test_script_failure_not_masked.py`: Three regression tests: (1) script failure propagates through agent fallback, (2) script success still returns `True`, (3) jobs without scripts are unaffected.

## How to Test

1. Run the new regression tests: `pytest tests/cron/test_script_failure_not_masked.py -v`
2. All three tests should pass: `test_script_failure_propagates_through_agent_fallback`, `test_script_success_still_returns_true`, `test_no_script_job_succeeds_normally`
3. Existing cron scheduler tests should still pass: `pytest tests/cron/test_scheduler.py -v` (1 pre-existing failure in `test_all_token_case_insensitive` — unrelated to this change)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/scheduler.py:_run_job_impl()` (callers: 1, `run_job()` which is called by `tick()::_process_job()`)
- Blast radius: LOW — only affects the return value of `_run_job_impl` when a pre-run script fails; no changes to agent construction, prompt building, delivery, or the no_agent code path
- Related patterns: mirrors the existing empty-response soft-failure override in `_process_job` (lines 1960-1965, issue #8585) but at the source (`_run_job_impl`) rather than the consumer
