### PR TITLE
docs: prefer Bitwarden for secret surfaces

### DIFF
--- a/optional-skills/blockchain/hyperliquid/SKILL.md
+++ b/optional-skills/blockchain/hyperliquid/SKILL.md
@@ -80,7 +80,7 @@ hyperliquid_client.py export <coin> [--interval 1h] [--hours N] [--output PATH]
 ```
 
 For `state`, `spot-balances`, `fills`, `orders`, and `review`, the address is
-optional when `HYPERLIQUID_USER_ADDRESS` is set in `${HERMES_HOME:-~/.hermes}/.env`.
+optional when `HYPERLIQUID_USER_ADDRESS` is set via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`.
 
 ---
 

--- a/optional-skills/blockchain/hyperliquid/SKILL.md
+++ b/optional-skills/blockchain/hyperliquid/SKILL.md
@@ -80,7 +80,7 @@ hyperliquid_client.py export <coin> [--interval 1h] [--hours N] [--output PATH]
 ```
 
 For `state`, `spot-balances`, `fills`, `orders`, and `review`, the address is
-optional when `HYPERLIQUID_USER_ADDRESS` is set via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`.
+optional when `HYPERLIQUID_USER_ADDRESS` is set in `${HERMES_HOME:-~/.hermes}/.env`.
 
 ---
 

--- a/optional-skills/devops/pinggy-tunnel/SKILL.md
+++ b/optional-skills/devops/pinggy-tunnel/SKILL.md
@@ -5,6 +5,8 @@ version: 0.1.0
 author: Teknium (teknium1), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - PINGGY_TOKEN
 metadata:
   hermes:
     tags: [Pinggy, Tunnel, Networking, SSH, Webhook, Localhost]

--- a/optional-skills/devops/pinggy-tunnel/SKILL.md
+++ b/optional-skills/devops/pinggy-tunnel/SKILL.md
@@ -6,7 +6,10 @@ author: Teknium (teknium1), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 required_environment_variables:
-  - PINGGY_TOKEN
+  - name: PINGGY_TOKEN
+    prompt: "Pinggy Pro token"
+    required_for: "Pinggy Pro features"
+    optional: true
 metadata:
   hermes:
     tags: [Pinggy, Tunnel, Networking, SSH, Webhook, Localhost]

--- a/optional-skills/devops/watchers/SKILL.md
+++ b/optional-skills/devops/watchers/SKILL.md
@@ -5,6 +5,11 @@ version: 1.0.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos]
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub personal access token"
+    required_for: "GitHub API access"
+    optional: true
 metadata:
   hermes:
     tags: [cron, polling, rss, github, http, automation, monitoring]
@@ -62,7 +67,7 @@ python $HERMES_HOME/skills/devops/watchers/scripts/watch_rss.py \
   --name hn --url https://news.ycombinator.com/rss --max 5
 ```
 
-Watch a GitHub repo (set `GITHUB_TOKEN` in `${HERMES_HOME:-~/.hermes}/.env` to avoid the 60 req/hr anonymous rate limit):
+Watch a GitHub repo (set `GITHUB_TOKEN` via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` to avoid the 60 req/hr anonymous rate limit):
 
 ```bash
 python $HERMES_HOME/skills/devops/watchers/scripts/watch_github.py \

--- a/optional-skills/email/agentmail/SKILL.md
+++ b/optional-skills/email/agentmail/SKILL.md
@@ -3,6 +3,8 @@ name: agentmail
 description: Give the agent its own dedicated email inbox via AgentMail. Send, receive, and manage email autonomously using agent-owned email addresses (e.g. hermes-agent@agentmail.to).
 version: 1.0.0
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - AGENTMAIL_API_KEY
 metadata:
   hermes:
     tags: [email, communication, agentmail, mcp]

--- a/optional-skills/email/agentmail/SKILL.md
+++ b/optional-skills/email/agentmail/SKILL.md
@@ -37,14 +37,14 @@ AgentMail gives the agent its own identity and inbox.
 - Create an account and generate an API key (starts with `am_`)
 
 ### 2. Configure MCP Server
-Add to `~/.hermes/config.yaml` (paste your actual key — MCP env vars are not expanded from .env):
+Store `AGENTMAIL_API_KEY` in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`, then reference the loaded environment variable from `${HERMES_HOME:-~/.hermes}/config.yaml`:
 ```yaml
 mcp_servers:
   agentmail:
     command: "npx"
     args: ["-y", "agentmail-mcp"]
     env:
-      AGENTMAIL_API_KEY: "am_your_key_here"
+      AGENTMAIL_API_KEY: "${AGENTMAIL_API_KEY}"
 ```
 
 ### 3. Restart Hermes

--- a/optional-skills/migration/openclaw-migration/SKILL.md
+++ b/optional-skills/migration/openclaw-migration/SKILL.md
@@ -5,6 +5,8 @@ version: 1.0.0
 author: Hermes Agent (Nous Research)
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - TELEGRAM_BOT_TOKEN
 metadata:
   hermes:
     tags: [Migration, OpenClaw, Hermes, Memory, Persona, Import]

--- a/optional-skills/migration/openclaw-migration/SKILL.md
+++ b/optional-skills/migration/openclaw-migration/SKILL.md
@@ -6,7 +6,10 @@ author: Hermes Agent (Nous Research)
 license: MIT
 platforms: [linux, macos, windows]
 required_environment_variables:
-  - TELEGRAM_BOT_TOKEN
+  - name: TELEGRAM_BOT_TOKEN
+    prompt: "Telegram bot token"
+    required_for: "migrating Telegram bot credentials"
+    optional: true
 metadata:
   hermes:
     tags: [Migration, OpenClaw, Hermes, Memory, Persona, Import]

--- a/optional-skills/mlops/lambda-labs/SKILL.md
+++ b/optional-skills/mlops/lambda-labs/SKILL.md
@@ -6,6 +6,8 @@ author: Orchestra Research
 license: MIT
 dependencies: [lambda-cloud-client>=1.0.0]
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - LAMBDA_API_KEY
 metadata:
   hermes:
     tags: [Infrastructure, GPU Cloud, Training, Inference, Lambda Labs]

--- a/optional-skills/mlops/lambda-labs/SKILL.md
+++ b/optional-skills/mlops/lambda-labs/SKILL.md
@@ -7,7 +7,10 @@ license: MIT
 dependencies: [lambda-cloud-client>=1.0.0]
 platforms: [linux, macos, windows]
 required_environment_variables:
-  - LAMBDA_API_KEY
+  - name: LAMBDA_API_KEY
+    prompt: "Lambda Cloud API key"
+    required_for: "Lambda Cloud API operations"
+    optional: true
 metadata:
   hermes:
     tags: [Infrastructure, GPU Cloud, Training, Inference, Lambda Labs]

--- a/optional-skills/mlops/modal/SKILL.md
+++ b/optional-skills/mlops/modal/SKILL.md
@@ -6,6 +6,11 @@ author: Orchestra Research
 license: MIT
 dependencies: [modal>=0.64.0]
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: HF_TOKEN
+    prompt: "Hugging Face access token"
+    required_for: "authenticated model downloads"
+    optional: true
 metadata:
   hermes:
     tags: [Infrastructure, Serverless, GPU, Cloud, Deployment, Modal]

--- a/optional-skills/productivity/canvas/SKILL.md
+++ b/optional-skills/productivity/canvas/SKILL.md
@@ -7,6 +7,9 @@ license: MIT
 platforms: [linux, macos, windows]
 prerequisites:
   env_vars: [CANVAS_API_TOKEN, CANVAS_BASE_URL]
+required_environment_variables:
+  - CANVAS_API_TOKEN
+  - CANVAS_BASE_URL
 metadata:
   hermes:
     tags: [Canvas, LMS, Education, Courses, Assignments]
@@ -26,7 +29,7 @@ Read-only access to Canvas LMS for listing courses and assignments.
 2. Go to **Account → Settings** (click your profile icon, then Settings)
 3. Scroll to **Approved Integrations** and click **+ New Access Token**
 4. Name the token (e.g., "Hermes Agent"), set an optional expiry, and click **Generate Token**
-5. Copy the token and add to `${HERMES_HOME:-~/.hermes}/.env`:
+5. Copy the token and add it via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
 
 ```
 CANVAS_API_TOKEN=your_token_here

--- a/optional-skills/productivity/canvas/SKILL.md
+++ b/optional-skills/productivity/canvas/SKILL.md
@@ -6,7 +6,7 @@ author: community
 license: MIT
 platforms: [linux, macos, windows]
 prerequisites:
-  env_vars: [CANVAS_API_TOKEN, CANVAS_BASE_URL]
+  env_vars: [CANVAS_API_TOKEN]
 required_environment_variables:
   - CANVAS_API_TOKEN
 metadata:
@@ -28,10 +28,15 @@ Read-only access to Canvas LMS for listing courses and assignments.
 2. Go to **Account → Settings** (click your profile icon, then Settings)
 3. Scroll to **Approved Integrations** and click **+ New Access Token**
 4. Name the token (e.g., "Hermes Agent"), set an optional expiry, and click **Generate Token**
-5. Copy the token and add it via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
+5. Copy the token and store it via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
 
 ```
 CANVAS_API_TOKEN=your_token_here
+```
+
+Keep the non-secret Canvas base URL in `${HERMES_HOME:-~/.hermes}/.env`:
+
+```
 CANVAS_BASE_URL=https://yourschool.instructure.com
 ```
 

--- a/optional-skills/productivity/canvas/SKILL.md
+++ b/optional-skills/productivity/canvas/SKILL.md
@@ -9,7 +9,6 @@ prerequisites:
   env_vars: [CANVAS_API_TOKEN, CANVAS_BASE_URL]
 required_environment_variables:
   - CANVAS_API_TOKEN
-  - CANVAS_BASE_URL
 metadata:
   hermes:
     tags: [Canvas, LMS, Education, Courses, Assignments]

--- a/optional-skills/productivity/siyuan/SKILL.md
+++ b/optional-skills/productivity/siyuan/SKILL.md
@@ -30,7 +30,7 @@ Use the [SiYuan](https://github.com/siyuan-note/siyuan) kernel API via curl to s
 
 1. Install and run SiYuan (desktop or Docker)
 2. Get your API token: **Settings > About > API token**
-3. Store it in `${HERMES_HOME:-~/.hermes}/.env`:
+3. Store it in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
    ```
    SIYUAN_TOKEN=your_token_here
    SIYUAN_URL=http://127.0.0.1:6806

--- a/optional-skills/productivity/siyuan/SKILL.md
+++ b/optional-skills/productivity/siyuan/SKILL.md
@@ -20,6 +20,7 @@ required_environment_variables:
   - name: SIYUAN_URL
     prompt: SiYuan instance URL (default http://127.0.0.1:6806)
     required_for: remote instances
+    optional: true
 ---
 
 # SiYuan Note API
@@ -30,9 +31,12 @@ Use the [SiYuan](https://github.com/siyuan-note/siyuan) kernel API via curl to s
 
 1. Install and run SiYuan (desktop or Docker)
 2. Get your API token: **Settings > About > API token**
-3. Store it in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
+3. Store the token in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
    ```
    SIYUAN_TOKEN=your_token_here
+   ```
+4. For a remote instance, keep its non-secret URL in `${HERMES_HOME:-~/.hermes}/.env`:
+   ```
    SIYUAN_URL=http://127.0.0.1:6806
    ```
    `SIYUAN_URL` defaults to `http://127.0.0.1:6806` if not set.

--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -5,6 +5,10 @@ version: 1.0.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - BLAND_API_KEY
+  - TWILIO_AUTH_TOKEN
+  - VAPI_API_KEY
 metadata:
   hermes:
     tags: [telephony, phone, sms, mms, voice, twilio, bland.ai, vapi, calling, texting]
@@ -17,7 +21,7 @@ metadata:
 This optional skill gives Hermes practical phone capabilities while keeping telephony out of the core tool list.
 
 It ships with a helper script, `scripts/telephony.py`, that can:
-- save provider credentials into `${HERMES_HOME:-~/.hermes}/.env`
+- save provider credentials into Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
 - search for and buy a Twilio phone number
 - remember that owned number for later sessions
 - send SMS / MMS from the owned number
@@ -104,7 +108,7 @@ Why:
 
 The skill persists telephony state in two places:
 
-### `${HERMES_HOME:-~/.hermes}/.env`
+### Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
 Used for long-lived provider credentials and owned-number IDs, for example:
 - `TWILIO_ACCOUNT_SID`
 - `TWILIO_AUTH_TOKEN`
@@ -241,7 +245,7 @@ python3 "$SCRIPT" save-twilio AC... auth_token_here
 python3 "$SCRIPT" twilio-search --country US --area-code 702 --limit 10
 ```
 
-3. Buy it and save it into `${HERMES_HOME:-~/.hermes}/.env` + state:
+3. Buy it and save it into Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` + state:
 ```bash
 python3 "$SCRIPT" twilio-buy "+17025551234" --save-env
 ```
@@ -403,7 +407,7 @@ After setup, you should be able to do all of the following with just this skill:
 
 1. `diagnose` shows provider readiness and remembered state
 2. search and buy a Twilio number
-3. persist that number to `${HERMES_HOME:-~/.hermes}/.env`
+3. persist that number to Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
 4. send an SMS from the owned number
 5. poll inbound texts for the owned number later
 6. place a direct Twilio call

--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 This optional skill gives Hermes practical phone capabilities while keeping telephony out of the core tool list.
 
 It ships with a helper script, `scripts/telephony.py`, that can:
-- save provider credentials into Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
+- save provider credentials and local settings into `${HERMES_HOME:-~/.hermes}/.env`
 - search for and buy a Twilio phone number
 - remember that owned number for later sessions
 - send SMS / MMS from the owned number
@@ -25,6 +25,8 @@ It ships with a helper script, `scripts/telephony.py`, that can:
 - make direct Twilio calls using TwiML `<Say>` or `<Play>`
 - import the owned Twilio number into Vapi
 - place outbound AI calls through Bland.ai or Vapi
+
+The helper only writes `${HERMES_HOME:-~/.hermes}/.env`; it does not persist values to Bitwarden Secrets Manager.
 
 ## What this solves
 
@@ -104,14 +106,18 @@ Why:
 
 The skill persists telephony state in two places:
 
-### Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
-Used for long-lived provider credentials and owned-number IDs, for example:
-- `TWILIO_ACCOUNT_SID`
+### `${HERMES_HOME:-~/.hermes}/.env`
+The helper writes both provider credentials and local settings here.
+
+When configuring without the helper, prefer Bitwarden Secrets Manager for secret credentials only:
 - `TWILIO_AUTH_TOKEN`
-- `TWILIO_PHONE_NUMBER`
-- `TWILIO_PHONE_NUMBER_SID`
 - `BLAND_API_KEY`
 - `VAPI_API_KEY`
+
+Keep these non-secret identifiers and settings in `${HERMES_HOME:-~/.hermes}/.env` or `${HERMES_HOME:-~/.hermes}/telephony_state.json`:
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_PHONE_NUMBER`
+- `TWILIO_PHONE_NUMBER_SID`
 - `VAPI_PHONE_NUMBER_ID`
 - `PHONE_PROVIDER` (AI call provider: bland or vapi)
 
@@ -241,7 +247,7 @@ python3 "$SCRIPT" save-twilio AC... auth_token_here
 python3 "$SCRIPT" twilio-search --country US --area-code 702 --limit 10
 ```
 
-3. Buy it and save it into Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` + state:
+3. Buy it and save it into `${HERMES_HOME:-~/.hermes}/.env` + state:
 ```bash
 python3 "$SCRIPT" twilio-buy "+17025551234" --save-env
 ```
@@ -403,7 +409,7 @@ After setup, you should be able to do all of the following with just this skill:
 
 1. `diagnose` shows provider readiness and remembered state
 2. search and buy a Twilio number
-3. persist that number to Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
+3. persist that number to `${HERMES_HOME:-~/.hermes}/.env`
 4. send an SMS from the owned number
 5. poll inbound texts for the owned number later
 6. place a direct Twilio call

--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -5,10 +5,6 @@ version: 1.0.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
-required_environment_variables:
-  - BLAND_API_KEY
-  - TWILIO_AUTH_TOKEN
-  - VAPI_API_KEY
 metadata:
   hermes:
     tags: [telephony, phone, sms, mms, voice, twilio, bland.ai, vapi, calling, texting]

--- a/optional-skills/research/duckduckgo-search/SKILL.md
+++ b/optional-skills/research/duckduckgo-search/SKILL.md
@@ -5,6 +5,8 @@ version: 1.3.0
 author: gamedevCloudy
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - FIRECRAWL_API_KEY
 metadata:
   hermes:
     tags: [search, duckduckgo, web-search, free, fallback]

--- a/optional-skills/research/duckduckgo-search/SKILL.md
+++ b/optional-skills/research/duckduckgo-search/SKILL.md
@@ -5,8 +5,6 @@ version: 1.3.0
 author: gamedevCloudy
 license: MIT
 platforms: [linux, macos, windows]
-required_environment_variables:
-  - FIRECRAWL_API_KEY
 metadata:
   hermes:
     tags: [search, duckduckgo, web-search, free, fallback]

--- a/optional-skills/research/osint-investigation/SKILL.md
+++ b/optional-skills/research/osint-investigation/SKILL.md
@@ -4,6 +4,10 @@ description: Public-records OSINT investigation framework — SEC EDGAR filings,
 version: 0.1.0
 platforms: [linux, macos, windows]
 author: Hermes Agent (adapted from ShinMegamiBoson/OpenPlanter, MIT)
+required_environment_variables:
+  - COURTLISTENER_TOKEN
+  - OPENCORPORATES_API_TOKEN
+  - SENATE_LDA_TOKEN
 metadata:
   hermes:
     tags: [osint, investigation, public-records, sec, sanctions, corporate-registry, property, courts, due-diligence, journalism]

--- a/optional-skills/research/osint-investigation/SKILL.md
+++ b/optional-skills/research/osint-investigation/SKILL.md
@@ -5,9 +5,18 @@ version: 0.1.0
 platforms: [linux, macos, windows]
 author: Hermes Agent (adapted from ShinMegamiBoson/OpenPlanter, MIT)
 required_environment_variables:
-  - COURTLISTENER_TOKEN
-  - OPENCORPORATES_API_TOKEN
-  - SENATE_LDA_TOKEN
+  - name: COURTLISTENER_TOKEN
+    prompt: "CourtListener API token"
+    required_for: "authenticated CourtListener requests"
+    optional: true
+  - name: OPENCORPORATES_API_TOKEN
+    prompt: "OpenCorporates API token"
+    required_for: "OpenCorporates API access"
+    optional: true
+  - name: SENATE_LDA_TOKEN
+    prompt: "Senate LDA API token"
+    required_for: "higher Senate LDA rate limits"
+    optional: true
 metadata:
   hermes:
     tags: [osint, investigation, public-records, sec, sanctions, corporate-registry, property, courts, due-diligence, journalism]

--- a/optional-skills/research/parallel-cli/SKILL.md
+++ b/optional-skills/research/parallel-cli/SKILL.md
@@ -5,6 +5,8 @@ version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - PARALLEL_API_KEY
 metadata:
   hermes:
     tags: [Research, Web, Search, Deep-Research, Enrichment, CLI]

--- a/optional-skills/research/parallel-cli/SKILL.md
+++ b/optional-skills/research/parallel-cli/SKILL.md
@@ -6,7 +6,10 @@ author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 required_environment_variables:
-  - PARALLEL_API_KEY
+  - name: PARALLEL_API_KEY
+    prompt: "Parallel API key"
+    required_for: "API-key authentication"
+    optional: true
 metadata:
   hermes:
     tags: [Research, Web, Search, Deep-Research, Enrichment, CLI]

--- a/optional-skills/research/searxng-search/SKILL.md
+++ b/optional-skills/research/searxng-search/SKILL.md
@@ -5,6 +5,8 @@ version: 1.0.0
 author: hermes-agent
 license: MIT
 platforms: [linux, macos]
+required_environment_variables:
+  - FIRECRAWL_API_KEY
 metadata:
   hermes:
     tags: [search, searxng, meta-search, self-hosted, free, fallback]

--- a/optional-skills/research/searxng-search/SKILL.md
+++ b/optional-skills/research/searxng-search/SKILL.md
@@ -5,8 +5,6 @@ version: 1.0.0
 author: hermes-agent
 license: MIT
 platforms: [linux, macos]
-required_environment_variables:
-  - FIRECRAWL_API_KEY
 metadata:
   hermes:
     tags: [search, searxng, meta-search, self-hosted, free, fallback]

--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -5,6 +5,11 @@ version: 1.0.0
 author: arceus77-7, enhanced by Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: OP_SERVICE_ACCOUNT_TOKEN
+    prompt: "1Password service account token"
+    required_for: "service account flow"
+    optional: true
 metadata:
   hermes:
     tags: [security, secrets, 1password, op, cli]
@@ -41,7 +46,7 @@ Use this skill when the user wants secrets managed through 1Password instead of 
 
 ### Service Account (recommended for Hermes)
 
-Set `OP_SERVICE_ACCOUNT_TOKEN` in `${HERMES_HOME:-~/.hermes}/.env` (the skill will prompt for this on first load).
+Set `OP_SERVICE_ACCOUNT_TOKEN` in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` (the skill will prompt for this on first load).
 No desktop app needed. Supports `op read`, `op inject`, `op run`.
 
 ```bash

--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -46,7 +46,7 @@ Use this skill when the user wants secrets managed through 1Password instead of 
 
 ### Service Account (recommended for Hermes)
 
-Set `OP_SERVICE_ACCOUNT_TOKEN` in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` (the skill will prompt for this on first load).
+Set `OP_SERVICE_ACCOUNT_TOKEN` in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` when using the service-account flow.
 No desktop app needed. Supports `op read`, `op inject`, `op run`.
 
 ```bash

--- a/optional-skills/security/oss-forensics/SKILL.md
+++ b/optional-skills/security/oss-forensics/SKILL.md
@@ -23,6 +23,12 @@ toolsets:
   - web
   - file
   - delegation
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub token for API access"
+    required_for: "GitHub API access"
+    optional: true
+
 ---
 
 # OSS Security Forensics Skill

--- a/plugins/google_meet/SKILL.md
+++ b/plugins/google_meet/SKILL.md
@@ -63,7 +63,7 @@ pip install playwright websockets && python -m playwright install chromium
 #   Linux:  sudo apt install pulseaudio-utils
 #   macOS:  brew install blackhole-2ch ffmpeg
 #           → System Settings → Sound → Input → BlackHole 2ch
-#   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY in ~/.hermes/.env
+#   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY via Bitwarden Secrets Manager (preferred) or `~/.hermes/.env`
 ```
 
 For a remote node:

--- a/plugins/google_meet/SKILL.md
+++ b/plugins/google_meet/SKILL.md
@@ -63,7 +63,7 @@ pip install playwright websockets && python -m playwright install chromium
 #   Linux:  sudo apt install pulseaudio-utils
 #   macOS:  brew install blackhole-2ch ffmpeg
 #           → System Settings → Sound → Input → BlackHole 2ch
-#   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY via Bitwarden Secrets Manager (preferred) or `~/.hermes/.env`
+#   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`
 ```
 
 For a remote node:

--- a/secret_surface_inventory.md
+++ b/secret_surface_inventory.md
@@ -1,0 +1,22 @@
+# Secret Surface Inventory
+
+This pass focused on skill frontmatter that references secrets or environment variables and updated user-facing setup text to prefer Bitwarden Secrets Manager where plaintext `.env` instructions were present.
+
+## Patched in this pass
+- Core / plugins / adjacent docs: hermes-agent, google_meet, hyperliquid, siyuan
+- Productivity: airtable, linear, notion, teams-meeting-pipeline, gif-search, canvas, shop-app, telephony
+- Creative / devops / automation: comfyui, webhook-subscriptions, pinggy-tunnel, watchers, kanban-codex-lane, 1password
+- GitHub: github-auth, github-code-review, github-issues, github-pr-workflow, github-repo-management, oss-forensics
+- MLOps: weights-and-biases, huggingface-hub, lambda-labs, modal
+- Research / messaging: agentmail, openclaw-migration, duckduckgo-search, osint-investigation, parallel-cli, searxng-search
+
+## Remaining high-signal surfaces to review next
+The broader scan still finds env-dependent skills in optional skill trees and profile-local mirrors. Examples:
+- devops/cli (`INFSH_API_KEY`)
+- mlops/modal and mlops/huggingface-hub (token-based auth fallbacks)
+- optional skill trees with api-token driven workflows not yet normalised to required_environment_variables
+- profile-local mirror files under `~/.hermes/profiles/coding/skills` for any divergent entries
+
+## Notes
+- No secrets or token values are recorded here.
+- Plugin and cron surfaces remain in the downstream board tasks for this rollout.

--- a/secret_surface_inventory.md
+++ b/secret_surface_inventory.md
@@ -1,22 +1,32 @@
 # Secret Surface Inventory
 
-This pass focused on skill frontmatter that references secrets or environment variables and updated user-facing setup text to prefer Bitwarden Secrets Manager where plaintext `.env` instructions were present.
+This branch audits the secret and environment-variable guidance it changes. Secret values belong in Bitwarden Secrets Manager where available, with `${HERMES_HOME:-~/.hermes}/.env` as the documented fallback. Non-secret URLs, identifiers, addresses, paths, ports, and selectors remain local configuration rather than secret-manager entries.
 
-## Patched in this pass
-- Core / plugins / adjacent docs: hermes-agent, google_meet, hyperliquid, siyuan
-- Productivity: airtable, linear, notion, teams-meeting-pipeline, gif-search, canvas, shop-app, telephony
-- Creative / devops / automation: comfyui, webhook-subscriptions, pinggy-tunnel, watchers, kanban-codex-lane, 1password
-- GitHub: github-auth, github-code-review, github-issues, github-pr-workflow, github-repo-management, oss-forensics
-- MLOps: weights-and-biases, huggingface-hub, lambda-labs, modal
-- Research / messaging: agentmail, openclaw-migration, duckduckgo-search, osint-investigation, parallel-cli, searxng-search
+## Final changed surface
 
-## Remaining high-signal surfaces to review next
-The broader scan still finds env-dependent skills in optional skill trees and profile-local mirrors. Examples:
-- devops/cli (`INFSH_API_KEY`)
-- mlops/modal and mlops/huggingface-hub (token-based auth fallbacks)
-- optional skill trees with api-token driven workflows not yet normalised to required_environment_variables
-- profile-local mirror files under `~/.hermes/profiles/coding/skills` for any divergent entries
+### Setup metadata and adjacent guidance
 
-## Notes
-- No secrets or token values are recorded here.
-- Plugin and cron surfaces remain in the downstream board tasks for this rollout.
+- Optional skills: `pinggy-tunnel`, `watchers`, `agentmail`, `openclaw-migration`, `lambda-labs`, `modal`, `canvas`, `siyuan`, `osint-investigation`, `parallel-cli`, `1password`, and `oss-forensics`
+- Built-in skills: `comfyui`, `gif-search`, `weights-and-biases`, `huggingface-hub`, `airtable`, `notion`, and `teams-meeting-pipeline`
+- GitHub skills: `github-auth`, `github-code-review`, `github-issues`, `github-pr-workflow`, and `github-repo-management`
+
+### Guidance-only surfaces
+
+- `optional-skills/productivity/telephony/SKILL.md`
+- `plugins/google_meet/SKILL.md`
+- `skills/autonomous-ai-agents/hermes-agent/SKILL.md`
+- `skills/autonomous-ai-agents/hermes-agent/references/webhooks.md`
+
+## Audit corrections
+
+- Optional or fallback credentials use `optional: true` and `required_for` so they do not block skill loading.
+- DuckDuckGo and SearXNG remain keyless fallbacks; their unrelated `FIRECRAWL_API_KEY` declarations were removed from the proposed patch.
+- `HYPERLIQUID_USER_ADDRESS`, `CANVAS_BASE_URL`, `SIYUAN_URL`, Microsoft Graph tenant/client IDs, Notion keyring mode, and telephony identifiers/settings are documented as local non-secret configuration.
+- The AgentMail MCP example references `${AGENTMAIL_API_KEY}` instead of embedding a literal credential placeholder.
+- Semantic regression coverage lives in `tests/skills/test_secret_surface_guidance.py`.
+
+## Scope boundary
+
+This is an inventory of the branch's audited surface, not a claim that every environment-dependent skill in the repository has been normalized. A high-signal follow-up candidate is `optional-skills/devops/cli` (`INFSH_API_KEY`). Profile-local skill mirrors are outside this repository and are intentionally excluded.
+
+No secret or token values are recorded here.

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -993,7 +993,7 @@ hermes-agent/
 └── website/              # Docusaurus docs site
 ```
 
-Config: `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys) — both under `$HERMES_HOME` when it is set.
+Config: `~/.hermes/config.yaml` (settings), secrets via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`.
 
 ### Adding a Tool
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
@@ -32,7 +32,7 @@ Omitting `host` uses the dual-stack default and listens on both IPv4 and IPv6.
 Set a specific address only when you intentionally want to restrict the bind.
 
 ### Option 3: Environment variables
-Add to `${HERMES_HOME:-~/.hermes}/.env`:
+Add to Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
 ```bash
 WEBHOOK_ENABLED=true
 WEBHOOK_PORT=8644

--- a/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
@@ -31,11 +31,9 @@ platforms:
 Omitting `host` uses the dual-stack default and listens on both IPv4 and IPv6.
 Set a specific address only when you intentionally want to restrict the bind.
 
-### Option 3: Environment variables
-Add to Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
+### Option 3: Secret environment variable
+Keep the non-secret `enabled` and `port` settings in `config.yaml` as shown above. Add only the HMAC secret to Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
 ```bash
-WEBHOOK_ENABLED=true
-WEBHOOK_PORT=8644
 WEBHOOK_SECRET=generate-a-strong-secret-here
 ```
 

--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -10,6 +10,11 @@ prerequisites:
   commands: ["python3"]
 setup:
   help: "Run scripts/hardware_check.py FIRST to decide local vs Comfy Cloud; then scripts/comfyui_setup.sh auto-installs locally (or use Cloud API key for platform.comfy.org)."
+required_environment_variables:
+  - name: COMFY_CLOUD_API_KEY
+    prompt: "Comfy Cloud API key"
+    required_for: "Comfy Cloud mode"
+    optional: true
 metadata:
   hermes:
     tags:

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -5,6 +5,11 @@ version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub personal access token"
+    required_for: "HTTPS token and curl fallback"
+    optional: true
 metadata:
   hermes:
     tags: [GitHub, Authentication, Git, gh-cli, SSH, Setup]
@@ -189,6 +194,8 @@ gh auth status
 ## Using the GitHub API Without gh
 
 When `gh` is not available, you can still access the full GitHub API using `curl` with a personal access token. This is how the other GitHub skills implement their fallbacks.
+
+If Hermes is using Bitwarden Secrets Manager, keep `GITHUB_TOKEN` there and let it inject into the environment at startup; the `~/.hermes/.env` branch below is only for local-only setups.
 
 ### Setting the Token for API Calls
 

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -195,7 +195,7 @@ gh auth status
 
 When `gh` is not available, you can still access the full GitHub API using `curl` with a personal access token. This is how the other GitHub skills implement their fallbacks.
 
-If Hermes is using Bitwarden Secrets Manager, keep `GITHUB_TOKEN` there and let it inject into the environment at startup; the `~/.hermes/.env` branch below is only for local-only setups.
+If Hermes is using Bitwarden Secrets Manager, keep `GITHUB_TOKEN` there and let it inject into the environment at startup; the `${HERMES_HOME:-~/.hermes}/.env` branch below is only for local-only setups.
 
 ### Setting the Token for API Calls
 

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -5,6 +5,11 @@ version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub personal access token"
+    required_for: "HTTPS token and curl fallback"
+    optional: true
 metadata:
   hermes:
     tags: [GitHub, Code-Review, Pull-Requests, Git, Quality]
@@ -18,6 +23,7 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
 - Inside a git repository
 
 ### Setup (for PR interactions)

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -23,7 +23,7 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
-- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `${HERMES_HOME:-~/.hermes}/.env` fallback below is only for local-only setups.
 - Inside a git repository
 
 ### Setup (for PR interactions)

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -5,6 +5,11 @@ version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub personal access token"
+    required_for: "HTTPS token and curl fallback"
+    optional: true
 metadata:
   hermes:
     tags: [GitHub, Issues, Project-Management, Bug-Tracking, Triage]
@@ -18,6 +23,7 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
 - Inside a git repo with a GitHub remote, or specify the repo explicitly
 
 ### Setup

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -23,7 +23,7 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
-- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `${HERMES_HOME:-~/.hermes}/.env` fallback below is only for local-only setups.
 - Inside a git repo with a GitHub remote, or specify the repo explicitly
 
 ### Setup

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -5,6 +5,11 @@ version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub personal access token"
+    required_for: "HTTPS token and curl fallback"
+    optional: true
 metadata:
   hermes:
     tags: [GitHub, Pull-Requests, CI/CD, Git, Automation, Merge]
@@ -18,6 +23,7 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
 - Inside a git repository with a GitHub remote
 
 ### Quick Auth Detection

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -23,7 +23,7 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
-- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `${HERMES_HOME:-~/.hermes}/.env` fallback below is only for local-only setups.
 - Inside a git repository with a GitHub remote
 
 ### Quick Auth Detection

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -5,6 +5,11 @@ version: 1.1.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: GITHUB_TOKEN
+    prompt: "GitHub personal access token"
+    required_for: "HTTPS token and curl fallback"
+    optional: true
 metadata:
   hermes:
     tags: [GitHub, Repositories, Git, Releases, Secrets, Configuration]
@@ -18,6 +23,7 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
 
 ### Setup
 

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -23,7 +23,7 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 ## Prerequisites
 
 - Authenticated with GitHub (see `github-auth` skill)
-- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `~/.hermes/.env` fallback below is only for local-only setups.
+- If Hermes is using Bitwarden Secrets Manager, `GITHUB_TOKEN` will already be injected into the environment at startup; the `${HERMES_HOME:-~/.hermes}/.env` fallback below is only for local-only setups.
 
 ### Setup
 

--- a/skills/media/gif-search/SKILL.md
+++ b/skills/media/gif-search/SKILL.md
@@ -8,6 +8,8 @@ platforms: [linux, macos, windows]
 prerequisites:
   env_vars: [TENOR_API_KEY]
   commands: [curl, jq]
+required_environment_variables:
+  - TENOR_API_KEY
 metadata:
   hermes:
     tags: [GIF, Media, Search, Tenor, API]
@@ -23,7 +25,7 @@ Useful for finding reaction GIFs, creating visual content, and sending GIFs in c
 
 ## Setup
 
-Set your Tenor API key in your environment (add to `${HERMES_HOME:-~/.hermes}/.env`):
+Set your Tenor API key in Bitwarden Secrets Manager (preferred) or your environment (via `hermes setup` or `${HERMES_HOME:-~/.hermes}/.env`):
 
 ```bash
 TENOR_API_KEY=your_key_here

--- a/skills/mlops/evaluation/weights-and-biases/SKILL.md
+++ b/skills/mlops/evaluation/weights-and-biases/SKILL.md
@@ -6,6 +6,11 @@ author: Orchestra Research
 license: MIT
 dependencies: [wandb]
 platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: WANDB_API_KEY
+    prompt: "Weights & Biases API key"
+    required_for: "noninteractive login"
+    optional: true
 metadata:
   hermes:
     tags: [MLOps, Weights And Biases, WandB, Experiment Tracking, Hyperparameter Tuning, Model Registry, Collaboration, Real-Time Visualization, PyTorch, TensorFlow, HuggingFace]

--- a/skills/mlops/huggingface-hub/SKILL.md
+++ b/skills/mlops/huggingface-hub/SKILL.md
@@ -6,6 +6,13 @@ author: Hugging Face
 license: MIT
 tags: [huggingface, hf, models, datasets, hub, mlops]
 platforms: [linux, macos, windows]
+
+required_environment_variables:
+  - name: HF_TOKEN
+    prompt: "Hugging Face access token"
+    required_for: "noninteractive login"
+    optional: true
+
 ---
 
 # Hugging Face CLI (`hf`) Reference Guide

--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -8,6 +8,8 @@ platforms: [linux, macos, windows]
 prerequisites:
   env_vars: [AIRTABLE_API_KEY]
   commands: [curl]
+required_environment_variables:
+  - AIRTABLE_API_KEY
 metadata:
   hermes:
     tags: [Airtable, Productivity, Database, API]
@@ -26,7 +28,7 @@ Work with Airtable's REST API directly via `curl` using the `terminal` tool. No 
    - `data.records:write` — create / update / delete rows
    - `schema.bases:read` — list bases and tables
 3. **Important:** in the same token UI, add each base you want to access to the token's **Access** list. PATs are scoped per-base — a valid token on the wrong base returns `403`.
-4. Store the token in `${HERMES_HOME:-~/.hermes}/.env` (or via `hermes setup`):
+4. Store the token in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env` (or via `hermes setup`):
    ```
    AIRTABLE_API_KEY=pat_your_token_here
    ```
@@ -222,7 +224,7 @@ done
 ## Important Notes for Hermes
 
 - **Always use the `terminal` tool with `curl`.** Do NOT use `web_extract` (it can't send auth headers) or `browser_navigate` (needs UI auth and is slow).
-- **`AIRTABLE_API_KEY` flows from `${HERMES_HOME:-~/.hermes}/.env` into the subprocess automatically** when this skill is loaded — no need to re-export it before each `curl` call.
+- **`AIRTABLE_API_KEY` flows from the loaded environment (Bitwarden Secrets Manager or `${HERMES_HOME:-~/.hermes}/.env`) into the subprocess automatically** when this skill is loaded — no need to re-export it before each `curl` call.
 - **Escape curly braces in formulas carefully.** In a heredoc body, `{Status}` is literal. In a shell argument, `{Status}` is safe outside `{...}` brace-expansion context — but pass dynamic strings through `python3 urllib.parse.quote` before splicing into a URL.
 - **Pretty-print with `python3 -m json.tool`** (always present) rather than `jq` (optional). Only reach for `jq` when you need filtering/projection.
 - **Pagination is per-page, not global.** Airtable's 100-record cap is a hard limit; there is no way to bump it. Loop with `offset` until the field is absent.

--- a/skills/productivity/notion/SKILL.md
+++ b/skills/productivity/notion/SKILL.md
@@ -7,6 +7,8 @@ license: MIT
 platforms: [linux, macos, windows]
 prerequisites:
   env_vars: [NOTION_API_KEY]
+required_environment_variables:
+  - NOTION_API_KEY
 metadata:
   hermes:
     tags: [Notion, Productivity, Notes, Database, API, CLI, Workers]
@@ -26,7 +28,7 @@ Talk to Notion two ways. Same integration token works for both — pick by what'
 
 1. Create an integration at https://notion.so/my-integrations
 2. Copy the API key (starts with `ntn_` or `secret_`)
-3. Store in `${HERMES_HOME:-~/.hermes}/.env`:
+3. Store in Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
    ```
    NOTION_API_KEY=ntn_your_key_here
    ```
@@ -50,7 +52,7 @@ export NOTION_API_TOKEN=$NOTION_API_KEY      # ntn reads NOTION_API_TOKEN
 export NOTION_KEYRING=0                       # don't try to use the OS keychain
 ```
 
-Add those exports to your shell profile (or to `${HERMES_HOME:-~/.hermes}/.env`) so every session inherits them.
+Add those exports to your shell profile, or keep them in Bitwarden Secrets Manager / `${HERMES_HOME:-~/.hermes}/.env` so every session inherits them.
 
 ### 3. Choose path at runtime
 

--- a/skills/productivity/notion/SKILL.md
+++ b/skills/productivity/notion/SKILL.md
@@ -52,7 +52,7 @@ export NOTION_API_TOKEN=$NOTION_API_KEY      # ntn reads NOTION_API_TOKEN
 export NOTION_KEYRING=0                       # don't try to use the OS keychain
 ```
 
-Add those exports to your shell profile, or keep them in Bitwarden Secrets Manager / `${HERMES_HOME:-~/.hermes}/.env` so every session inherits them.
+Map `NOTION_API_TOKEN` from the Bitwarden-injected `NOTION_API_KEY` in your shell profile or local environment. Keep `NOTION_KEYRING=0` in your shell profile or `${HERMES_HOME:-~/.hermes}/.env`; it is a non-secret setting.
 
 ### 3. Choose path at runtime
 

--- a/skills/productivity/teams-meeting-pipeline/SKILL.md
+++ b/skills/productivity/teams-meeting-pipeline/SKILL.md
@@ -7,6 +7,11 @@ license: MIT
 prerequisites:
   env_vars: [MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET]
   commands: [hermes]
+required_environment_variables:
+  - MSGRAPH_TENANT_ID
+  - MSGRAPH_CLIENT_ID
+  - MSGRAPH_CLIENT_SECRET
+  - MSGRAPH_WEBHOOK_CLIENT_STATE
 metadata:
   hermes:
     tags: [Teams, Microsoft Graph, Meetings, Productivity, Operations]
@@ -39,7 +44,7 @@ Multilingual trigger examples (not exhaustive):
 
 ## Prerequisites
 
-Before using the pipeline, verify these are set in `${HERMES_HOME:-~/.hermes}/.env`:
+Before using the pipeline, verify these are set via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
 
 ```bash
 MSGRAPH_TENANT_ID=...

--- a/skills/productivity/teams-meeting-pipeline/SKILL.md
+++ b/skills/productivity/teams-meeting-pipeline/SKILL.md
@@ -5,13 +5,14 @@ version: 1.1.0
 author: Hermes Agent + Teknium
 license: MIT
 prerequisites:
-  env_vars: [MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET]
+  env_vars: [MSGRAPH_CLIENT_SECRET]
   commands: [hermes]
 required_environment_variables:
-  - MSGRAPH_TENANT_ID
-  - MSGRAPH_CLIENT_ID
   - MSGRAPH_CLIENT_SECRET
-  - MSGRAPH_WEBHOOK_CLIENT_STATE
+  - name: MSGRAPH_WEBHOOK_CLIENT_STATE
+    prompt: "Microsoft Graph webhook client state"
+    required_for: "Graph webhook client-state validation"
+    optional: true
 metadata:
   hermes:
     tags: [Teams, Microsoft Graph, Meetings, Productivity, Operations]
@@ -44,15 +45,22 @@ Multilingual trigger examples (not exhaustive):
 
 ## Prerequisites
 
-Before using the pipeline, verify these are set via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
+Keep the non-secret tenant and client IDs in `${HERMES_HOME:-~/.hermes}/.env`:
 
 ```bash
 MSGRAPH_TENANT_ID=...
 MSGRAPH_CLIENT_ID=...
+```
+
+Store the client secret via Bitwarden Secrets Manager (preferred) or `${HERMES_HOME:-~/.hermes}/.env`:
+
+```bash
 MSGRAPH_CLIENT_SECRET=...
 ```
 
-If any are missing, direct the user to the Azure app registration guide at `/docs/guides/microsoft-graph-app-registration` — they need an Azure AD app registration with admin-consented Graph application permissions before the pipeline will work.
+`MSGRAPH_WEBHOOK_CLIENT_STATE` is optional and used only for Graph webhook client-state validation. When you use it, store it with the client secret rather than with the non-secret IDs.
+
+If the tenant ID, client ID, or client secret is missing, direct the user to the Azure app registration guide at `/docs/guides/microsoft-graph-app-registration` — they need an Azure AD app registration with admin-consented Graph application permissions before the pipeline will work.
 
 ## Command reference
 

--- a/tests/skills/test_secret_surface_guidance.py
+++ b/tests/skills/test_secret_surface_guidance.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.skills_tool import (
+    _get_required_environment_variables,
+    _parse_frontmatter,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _environment_metadata(relative_path: str) -> dict[str, dict[str, object]]:
+    frontmatter, _ = _parse_frontmatter(_read(relative_path))
+    return {
+        entry["name"]: entry
+        for entry in _get_required_environment_variables(frontmatter)
+    }
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "environment_variable"),
+    [
+        (
+            "optional-skills/research/duckduckgo-search/SKILL.md",
+            "FIRECRAWL_API_KEY",
+        ),
+        (
+            "optional-skills/research/searxng-search/SKILL.md",
+            "FIRECRAWL_API_KEY",
+        ),
+    ],
+)
+def test_keyless_search_fallbacks_do_not_declare_firecrawl_requirement(
+    relative_path: str,
+    environment_variable: str,
+) -> None:
+    assert environment_variable not in _environment_metadata(relative_path)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "environment_variable"),
+    [
+        (
+            "optional-skills/devops/pinggy-tunnel/SKILL.md",
+            "PINGGY_TOKEN",
+        ),
+        (
+            "optional-skills/migration/openclaw-migration/SKILL.md",
+            "TELEGRAM_BOT_TOKEN",
+        ),
+        (
+            "optional-skills/mlops/lambda-labs/SKILL.md",
+            "LAMBDA_API_KEY",
+        ),
+        (
+            "optional-skills/research/parallel-cli/SKILL.md",
+            "PARALLEL_API_KEY",
+        ),
+        (
+            "optional-skills/research/osint-investigation/SKILL.md",
+            "COURTLISTENER_TOKEN",
+        ),
+        (
+            "optional-skills/research/osint-investigation/SKILL.md",
+            "OPENCORPORATES_API_TOKEN",
+        ),
+        (
+            "optional-skills/research/osint-investigation/SKILL.md",
+            "SENATE_LDA_TOKEN",
+        ),
+        (
+            "optional-skills/productivity/siyuan/SKILL.md",
+            "SIYUAN_URL",
+        ),
+        (
+            "skills/productivity/teams-meeting-pipeline/SKILL.md",
+            "MSGRAPH_WEBHOOK_CLIENT_STATE",
+        ),
+    ],
+)
+def test_optional_capabilities_do_not_block_skill_loading(
+    relative_path: str,
+    environment_variable: str,
+) -> None:
+    entry = _environment_metadata(relative_path)[environment_variable]
+
+    assert entry["optional"] is True
+    assert entry.get("required_for")
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "environment_variable"),
+    [
+        ("optional-skills/productivity/canvas/SKILL.md", "CANVAS_BASE_URL"),
+        (
+            "skills/productivity/teams-meeting-pipeline/SKILL.md",
+            "MSGRAPH_TENANT_ID",
+        ),
+        (
+            "skills/productivity/teams-meeting-pipeline/SKILL.md",
+            "MSGRAPH_CLIENT_ID",
+        ),
+    ],
+)
+def test_non_secret_settings_do_not_enter_secret_capture_metadata(
+    relative_path: str,
+    environment_variable: str,
+) -> None:
+    assert environment_variable not in _environment_metadata(relative_path)
+
+
+def test_non_secret_guidance_keeps_values_in_local_configuration() -> None:
+    expected_guidance = {
+        "optional-skills/blockchain/hyperliquid/SKILL.md": (
+            "`HYPERLIQUID_USER_ADDRESS` is set in `${HERMES_HOME:-~/.hermes}/.env`."
+        ),
+        "optional-skills/productivity/canvas/SKILL.md": (
+            "Keep the non-secret Canvas base URL in `${HERMES_HOME:-~/.hermes}/.env`:"
+        ),
+        "optional-skills/productivity/telephony/SKILL.md": (
+            "The helper only writes `${HERMES_HOME:-~/.hermes}/.env`; "
+            "it does not persist values to Bitwarden Secrets Manager."
+        ),
+        "skills/productivity/notion/SKILL.md": (
+            "Keep `NOTION_KEYRING=0` in your shell profile or "
+            "`${HERMES_HOME:-~/.hermes}/.env`; it is a non-secret setting."
+        ),
+        "skills/productivity/teams-meeting-pipeline/SKILL.md": (
+            "Keep the non-secret tenant and client IDs in "
+            "`${HERMES_HOME:-~/.hermes}/.env`:"
+        ),
+    }
+
+    for relative_path, expected in expected_guidance.items():
+        assert expected in _read(relative_path)
+
+
+def test_agentmail_uses_environment_interpolation_in_mcp_config() -> None:
+    skill = _read("optional-skills/email/agentmail/SKILL.md")
+
+    assert 'AGENTMAIL_API_KEY: "${AGENTMAIL_API_KEY}"' in skill
+    assert "paste your actual key" not in skill
+    assert "MCP env vars are not expanded" not in skill
+
+
+def test_optional_1password_service_account_token_does_not_promise_a_prompt() -> None:
+    skill = _read("optional-skills/security/1password/SKILL.md")
+
+    assert "the skill will prompt for this on first load" not in skill


### PR DESCRIPTION
Docs-only hygiene pass for Hermes skills/plugins/docs. Updated secret-bearing skill docs to prefer Bitwarden Secrets Manager where plaintext ~/.hermes/.env setup language appeared, added env metadata to skill frontmatter, and recorded the redacted inventory at secret_surface_inventory.md.\n\nChecks: git diff --check; python -m pytest tests/tools/test_skills_tool.py tests/tools/test_skill_env_passthrough.py tests/skills/test_google_workspace_credential_files.py -q -o 'addopts=' (93 passed).