### PR TITLE
feat(model): Copilot auto-picker MVP for /model

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -46,6 +46,64 @@ from agent.models_dev import (
 logger = logging.getLogger(__name__)
 
 
+# Copilot auto-picker (MVP): deterministic preference order used when the
+# user requests `/model auto --provider copilot` (or shorthand `copilot:auto`).
+# Keep this list conservative and provider-local for the first iteration.
+_COPILOT_AUTO_MODEL_PREFERENCES: tuple[str, ...] = (
+    "gpt-5.4",
+    "claude-sonnet-4.6",
+    "gpt-5.4-mini",
+    "gpt-4.1",
+    "gpt-4o",
+)
+
+
+def _is_copilot_provider(provider_id: str) -> bool:
+    return (provider_id or "").strip().lower() in {"copilot", "github-copilot"}
+
+
+def _select_copilot_auto_model(
+    *,
+    provider_id: str,
+    current_model: str,
+) -> tuple[str, str]:
+    """Return (model_id, warning_text) for Copilot auto-picker mode.
+
+    The MVP uses a deterministic preference list and the provider's live catalog
+    (when available). If no catalog is available, we fall back to the first
+    preference to keep `/model` responsive in degraded network conditions.
+    """
+    available = list_provider_models(provider_id) or []
+    available_lc = {m.lower(): m for m in available if isinstance(m, str) and m.strip()}
+
+    for preferred in _COPILOT_AUTO_MODEL_PREFERENCES:
+        picked = available_lc.get(preferred.lower())
+        if picked:
+            return picked, f"Auto picker selected `{picked}` for Copilot."
+
+    # If none of the preferred models are visible but the current model is still
+    # available on Copilot, keep the user on their current model.
+    current = (current_model or "").strip()
+    if current and current.lower() in available_lc:
+        picked = available_lc[current.lower()]
+        return picked, (
+            f"Auto picker kept current model `{picked}` on Copilot "
+            f"(preferred candidates unavailable)."
+        )
+
+    if available:
+        picked = available[0]
+        return picked, (
+            f"Auto picker selected `{picked}` from Copilot catalog "
+            f"(preferred candidates unavailable)."
+        )
+
+    picked = _COPILOT_AUTO_MODEL_PREFERENCES[0]
+    return picked, (
+        f"Auto picker selected fallback `{picked}` (Copilot catalog unavailable)."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Non-agentic model warning
 # ---------------------------------------------------------------------------
@@ -665,6 +723,14 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+    auto_warning = ""
+
+    # Shorthand: /model copilot:auto (or github-copilot:auto) implies an
+    # explicit provider switch to Copilot plus auto model selection.
+    lowered = new_model.lower()
+    if not explicit_provider and lowered in {"copilot:auto", "github-copilot:auto"}:
+        explicit_provider = "copilot"
+        new_model = "auto"
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -734,6 +800,21 @@ def switch_model(
         alias_result = resolve_alias(new_model, target_provider)
         if alias_result is not None:
             _, new_model, resolved_alias = alias_result
+
+        # Copilot auto-picker: /model auto --provider copilot
+        if _is_copilot_provider(target_provider) and new_model.strip().lower() == "auto":
+            try:
+                new_model, auto_warning = _select_copilot_auto_model(
+                    provider_id=target_provider,
+                    current_model=current_model,
+                )
+            except Exception:
+                # Keep behavior robust; if auto-pick fails unexpectedly,
+                # fall back to deterministic default.
+                new_model = _COPILOT_AUTO_MODEL_PREFERENCES[0]
+                auto_warning = (
+                    f"Auto picker selected fallback `{new_model}` after internal error."
+                )
 
     # =================================================================
     # PATH B: No explicit provider — resolve from model input
@@ -1012,6 +1093,8 @@ def switch_model(
     warnings: list[str] = []
     if validation.get("message"):
         warnings.append(validation["message"])
+    if auto_warning:
+        warnings.append(auto_warning)
     hermes_warn = _check_hermes_model_warning(new_model)
     if hermes_warn:
         warnings.append(hermes_warn)

--- a/tests/hermes_cli/test_model_switch_copilot_auto_picker.py
+++ b/tests/hermes_cli/test_model_switch_copilot_auto_picker.py
@@ -1,0 +1,81 @@
+"""Regression tests for Copilot auto model picker in /model switch flow.
+
+MVP behavior:
+- ``/model auto --provider copilot`` should resolve to a concrete Copilot model.
+- ``/model copilot:auto`` should imply provider switch to Copilot.
+- Selection should use fallback order when top preference is unavailable.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _switch_auto(*, raw_input: str, current_provider: str = "openrouter", explicit_provider: str = ""):
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "ghu_test_token",
+                "base_url": "https://api.githubcopilot.com",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model="gpt-4o",
+            current_base_url="",
+            current_api_key="",
+            explicit_provider=explicit_provider,
+        )
+
+
+def test_copilot_auto_with_explicit_provider_selects_concrete_model():
+    with patch(
+        "hermes_cli.model_switch.list_provider_models",
+        return_value=["gpt-5.4", "gpt-5.4-mini", "claude-sonnet-4.6"],
+    ):
+        result = _switch_auto(raw_input="auto", explicit_provider="copilot")
+
+    assert result.success, f"switch_model failed: {result.error_message}"
+    assert result.target_provider == "github-copilot"
+    assert result.new_model == "gpt-5.4"
+    assert "Auto picker selected" in (result.warning_message or "")
+
+
+def test_copilot_auto_uses_fallback_when_top_model_missing():
+    with patch(
+        "hermes_cli.model_switch.list_provider_models",
+        return_value=["gpt-5.4-mini", "claude-sonnet-4.6"],
+    ):
+        result = _switch_auto(raw_input="auto", explicit_provider="copilot")
+
+    assert result.success, f"switch_model failed: {result.error_message}"
+    assert result.new_model == "claude-sonnet-4.6"
+
+
+def test_copilot_auto_short_syntax_implies_provider_switch():
+    with patch(
+        "hermes_cli.model_switch.list_provider_models",
+        return_value=["gpt-5.4", "claude-sonnet-4.6"],
+    ):
+        result = _switch_auto(raw_input="copilot:auto", current_provider="openrouter")
+
+    assert result.success, f"switch_model failed: {result.error_message}"
+    assert result.target_provider == "github-copilot"
+    assert result.new_model == "gpt-5.4"


### PR DESCRIPTION
## Summary
This PR adds an MVP auto model picker for GitHub Copilot in Hermes model switching.

### What is included
- Support `/model auto --provider copilot`
- Support shorthand `/model copilot:auto` (and `github-copilot:auto`)
- Deterministic preference order for Copilot model selection:
  - `gpt-5.4`
  - `claude-sonnet-4.6`
  - `gpt-5.4-mini`
  - `gpt-4.1`
  - `gpt-4o`
- Catalog-aware fallback behavior when preferred models are unavailable
- User-facing warning message indicating which model auto-picker selected

### Why
Users coming from VS Code Copilot expect an "Auto"-like option that reduces manual model switching friction.

This MVP keeps behavior explicit and provider-local (Copilot only), without introducing global routing heuristics yet.

## Tests
Added:
- `tests/hermes_cli/test_model_switch_copilot_auto_picker.py`
  - resolves concrete model for explicit auto + Copilot provider
  - falls back when top preference is unavailable
  - supports shorthand `copilot:auto` provider switch

Executed locally on Windows:
- `python -m pytest tests/hermes_cli/test_model_switch_copilot_auto_picker.py -q -o addopts=''` → **3 passed**
- `python -m pytest tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/hermes_cli/test_model_switch_context_display.py -q -o addopts=''` → **10 passed**

Note: `-o addopts=''` is needed in this Windows environment to bypass default addopts incompatibilities.

## Scope / Non-goals (MVP)
- No multi-provider auto-routing
- No adaptive policy (speed/quality/cost) yet
- No task-type heuristics yet

## Follow-ups
- Optional user-selectable auto policies (balanced/speed/quality)
- Telemetry/trace for resolved model decisions
- Extend auto-picker pattern to other providers (if desired)
