### PR TITLE
feat(models): order OpenRouter picker by live usage rankings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1098,10 +1098,19 @@ DEFAULT_CONFIG = {
     #   pick the strongest available coder (router's documented default
     #   when the plugins block is omitted).
     #   See: https://openrouter.ai/docs/guides/routing/routers/pareto-router
+    # sort_by_usage: order the OpenRouter model picker by real-world usage.
+    #   When true (default), the picker reorders the curated list by OpenRouter's
+    #   public daily-usage rankings (openrouter.ai/rankings, via the
+    #   /datasets/rankings-daily dataset). Models flagged "pinned" in the model
+    #   catalog stay at the top regardless; everything else is sorted most-used
+    #   first, with curated order as the tiebreaker for models with no usage data.
+    #   Falls back to curated order when no OpenRouter key / network is available.
+    #   Set false to keep the hand-curated catalog order.
     "openrouter": {
         "response_cache": True,
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
+        "sort_by_usage": True,
     },
 
     # AWS Bedrock provider configuration.

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -340,6 +340,27 @@ def get_curated_openrouter_models() -> list[tuple[str, str]] | None:
     return out or None
 
 
+def get_pinned_openrouter_model_ids() -> list[str]:
+    """Return OpenRouter model ids flagged ``"pinned": true`` in the manifest.
+
+    Pinned models are the editorial headline picks that should stay at the top
+    of the picker regardless of usage-based reordering. Order follows the
+    manifest's ``models`` array order. Returns ``[]`` when the manifest is
+    unavailable or nothing is pinned (so usage ranking drives the whole list).
+    """
+    block = _get_provider_block("openrouter")
+    if not block:
+        return []
+    out: list[str] = []
+    for m in block.get("models", []):
+        if not isinstance(m, dict) or not m.get("pinned"):
+            continue
+        mid = str(m.get("id") or "").strip()
+        if mid:
+            out.append(mid)
+    return out
+
+
 def get_curated_nous_models() -> list[str] | None:
     """Return Nous Portal's curated list of model ids from the manifest.
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -77,6 +77,18 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("inclusionai/ring-2.6-1t:free",           "free"),
 ]
 
+# Headline models pinned to the top of the OpenRouter picker, in this order,
+# regardless of usage-based reordering (openrouter.sort_by_usage). Kept as a
+# separate tuple rather than widening OPENROUTER_MODELS entries so the many
+# ``for mid, _ in OPENROUTER_MODELS`` callers stay intact. build_model_catalog
+# emits ``"pinned": true`` for these ids; the runtime reads pins back from the
+# manifest via get_pinned_openrouter_model_ids(). Every id here MUST also appear
+# in OPENROUTER_MODELS (enforced by the catalog sync test).
+_OPENROUTER_PINNED_IDS: tuple[str, ...] = (
+    "anthropic/claude-opus-4.8",
+    "openai/gpt-5.5",
+)
+
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 
 
@@ -1189,6 +1201,26 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     return "tools" in params
 
 
+def _openrouter_sort_by_usage_enabled() -> bool:
+    """Return True when the picker should reorder OpenRouter by usage rankings.
+
+    Controlled by ``openrouter.sort_by_usage`` in config (default True).
+    Failure to load config defaults to enabled — the reorder itself degrades
+    gracefully to manifest order when ranking data is unavailable, so the
+    safe default is to attempt it.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        block = cfg.get("openrouter")
+        if isinstance(block, dict) and "sort_by_usage" in block:
+            return bool(block.get("sort_by_usage"))
+    except Exception:
+        pass
+    return True
+
+
 def fetch_openrouter_models(
     timeout: float = 8.0,
     *,
@@ -1251,6 +1283,30 @@ def fetch_openrouter_models(
     if not curated:
         return list(_openrouter_catalog_cache or fallback)
 
+    # Reorder by real-world OpenRouter usage when enabled (default on).
+    # Pinned headline models (manifest ``"pinned": true``) stay first; the
+    # rest are sorted by the public daily-usage rankings, with manifest order
+    # as the tiebreaker for models OpenRouter has no usage data for. Any
+    # failure (no key, network, rate limit) degrades silently to manifest
+    # order via an empty ranking map.
+    if _openrouter_sort_by_usage_enabled():
+        try:
+            from hermes_cli.model_catalog import get_pinned_openrouter_model_ids
+            from hermes_cli.openrouter_rankings import (
+                fetch_openrouter_rankings,
+                reorder_by_usage,
+            )
+
+            pinned_ids = get_pinned_openrouter_model_ids()
+            ranks = fetch_openrouter_rankings(force_refresh=force_refresh)
+            if ranks or pinned_ids:
+                curated = reorder_by_usage(curated, ranks, pinned_ids)
+        except Exception:
+            pass  # keep manifest order
+
+    # The top entry (after any reorder) is the headline recommendation. Strip
+    # a stale "free" badge there only if it was purely pricing-derived; keep
+    # any explicit manifest description otherwise by relabeling to recommended.
     first_id, _ = curated[0]
     curated[0] = (first_id, "recommended")
     _openrouter_catalog_cache = curated

--- a/hermes_cli/openrouter_rankings.py
+++ b/hermes_cli/openrouter_rankings.py
@@ -1,0 +1,345 @@
+"""OpenRouter daily usage rankings — drives picker ordering.
+
+OpenRouter publishes a documented dataset endpoint,
+``GET /api/v1/datasets/rankings-daily``, returning the top-50 public models
+per day by total token usage (``prompt_tokens + completion_tokens``) — the
+same data behind the public chart at https://openrouter.ai/rankings.
+
+We use it to **order** the curated OpenRouter picker list by real-world demand
+instead of a hand-maintained sequence, while keeping the manifest's curation
+(which models *appear*, tool/free filtering, and any pinned headline models)
+untouched.
+
+Design
+------
+* ``fetch_openrouter_rankings()`` returns ``{canonical_model_id: rank_int}``
+  for the most recent day, where rank 0 is the most-used model. The endpoint
+  IDs are *dated permaslugs* (e.g. ``anthropic/claude-4.7-opus-20260416``);
+  we normalize them to OpenRouter routing IDs (``anthropic/claude-opus-4.7``)
+  so they line up with the picker's model IDs.
+* Authentication: any valid OpenRouter API key (the same key used for
+  inference). When no key is available the fetch is skipped and callers fall
+  back to manifest order.
+* Cached on disk for ``_RANKINGS_TTL_HOURS`` so the picker never blocks on the
+  network more than once a day. The dataset itself only updates ~daily.
+* Every failure path is silent and degrades to "no ranking data" so the picker
+  keeps working offline / without a key / on a rate-limit.
+
+The reorder itself (pinned-first, ranked tail, manifest tiebreak) lives in
+``reorder_by_usage()`` and is pure/testable — it takes the ranking map as an
+argument and never touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from hermes_cli import __version__ as _HERMES_VERSION
+
+logger = logging.getLogger(__name__)
+
+RANKINGS_URL = "https://openrouter.ai/api/v1/datasets/rankings-daily"
+_RANKINGS_TTL_HOURS = 24.0
+_FETCH_TIMEOUT = 8.0
+_HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
+
+# In-process cache: {canonical_id: rank}. None = not yet loaded this session.
+_rankings_cache: dict[str, int] | None = None
+_rankings_cache_at: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Permaslug → canonical routing ID normalization
+# ---------------------------------------------------------------------------
+
+# The rankings dataset uses dated permaslugs that don't always map to the
+# routing ID by a simple date-suffix strip. Most differ only by a trailing
+# ``-YYYYMMDD`` date; a few reorder name components (OpenRouter lists Anthropic
+# as ``claude-<gen>-opus`` in rankings but routes it as ``claude-opus-<gen>``).
+#
+# ``normalize_permaslug`` handles the mechanical cases (date suffix, ``:free``
+# variant tag). ``_PERMASLUG_ALIASES`` covers the handful of family reorderings
+# that can't be derived mechanically. Keep this table tiny — it only needs
+# entries for *curated* models whose permaslug shape differs structurally from
+# their routing ID.
+_DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
+
+# Maps a *normalized-but-still-wrong* permaslug stem to the routing ID.
+# Built for the Anthropic opus/sonnet component reorder seen in the live data
+# (e.g. "claude-4.7-opus" → "claude-opus-4.7"). Generated lazily/structurally
+# below rather than enumerated per-version so new Claude releases self-map.
+_ANTHROPIC_REORDER_RE = re.compile(
+    r"^anthropic/claude-(?P<gen>\d+(?:\.\d+)?)-(?P<tier>opus|sonnet|haiku)$"
+)
+
+
+def _strip_date_and_tags(permaslug: str) -> tuple[str, bool]:
+    """Return ``(stem, is_free)`` with the date suffix and ``:free`` tag removed."""
+    is_free = permaslug.endswith(":free")
+    stem = permaslug[: -len(":free")] if is_free else permaslug
+    stem = _DATE_SUFFIX_RE.sub("", stem)
+    return stem, is_free
+
+
+def normalize_permaslug(permaslug: str) -> str | None:
+    """Map a rankings ``model_permaslug`` to an OpenRouter routing ID.
+
+    Returns ``None`` for the reserved ``other`` aggregate row or anything that
+    doesn't look like a ``vendor/model`` slug.
+
+    Mechanical transforms:
+      * drop trailing ``-YYYYMMDD`` date
+      * preserve a ``:free`` variant tag
+      * reorder Anthropic ``claude-<gen>-<tier>`` → ``claude-<tier>-<gen>``
+    """
+    if not isinstance(permaslug, str):
+        return None
+    permaslug = permaslug.strip()
+    if not permaslug or permaslug == "other" or "/" not in permaslug:
+        return None
+
+    stem, is_free = _strip_date_and_tags(permaslug)
+
+    m = _ANTHROPIC_REORDER_RE.match(stem)
+    if m:
+        stem = f"anthropic/claude-{m.group('tier')}-{m.group('gen')}"
+
+    return f"{stem}:free" if is_free else stem
+
+
+# ---------------------------------------------------------------------------
+# Disk cache
+# ---------------------------------------------------------------------------
+
+
+def _cache_path() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "cache" / "openrouter_rankings.json"
+
+
+def _read_disk_cache() -> tuple[dict[str, int] | None, float]:
+    path = _cache_path()
+    try:
+        mtime = path.stat().st_mtime
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, FileNotFoundError, json.JSONDecodeError):
+        return (None, 0.0)
+    if not isinstance(data, dict):
+        return (None, 0.0)
+    ranks = data.get("ranks")
+    if not isinstance(ranks, dict):
+        return (None, 0.0)
+    out: dict[str, int] = {}
+    for k, v in ranks.items():
+        if isinstance(k, str) and isinstance(v, int):
+            out[k] = v
+    return (out, mtime)
+
+
+def _write_disk_cache(ranks: dict[str, int]) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"ranks": ranks, "saved_at": time.time()}, fh, indent=2)
+        from utils import atomic_replace
+
+        atomic_replace(tmp, path)
+    except OSError as exc:
+        logger.info("openrouter rankings cache write failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+def _resolve_openrouter_api_key() -> str:
+    """Best-effort OpenRouter API key for the rankings call (auth required)."""
+    key = os.getenv("OPENROUTER_API_KEY", "").strip()
+    if key:
+        return key
+    try:
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("openrouter")
+        return str(creds.get("api_key") or "").strip()
+    except Exception:
+        return ""
+
+
+def _parse_latest_day_ranks(payload: Any) -> dict[str, int]:
+    """Build ``{canonical_id: rank}`` from the rankings payload's latest day.
+
+    Rank 0 = most-used. The ``other`` aggregate row is dropped. When two
+    permaslugs normalize to the same routing ID (a dated + ``:free`` variant of
+    the same model), the higher-usage (lower-rank) one wins.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    rows = payload.get("data")
+    if not isinstance(rows, list) or not rows:
+        return {}
+
+    latest = ""
+    for r in rows:
+        if isinstance(r, dict):
+            d = str(r.get("date") or "")
+            if d > latest:
+                latest = d
+    if not latest:
+        return {}
+
+    day: list[tuple[str, int]] = []
+    for r in rows:
+        if not isinstance(r, dict) or str(r.get("date") or "") != latest:
+            continue
+        slug = r.get("model_permaslug")
+        try:
+            tokens = int(str(r.get("total_tokens") or "0"))
+        except (TypeError, ValueError):
+            tokens = 0
+        canonical = normalize_permaslug(slug) if slug is not None else None
+        if canonical is None:
+            continue
+        day.append((canonical, tokens))
+
+    day.sort(key=lambda t: t[1], reverse=True)
+    ranks: dict[str, int] = {}
+    for idx, (canonical, _tokens) in enumerate(day):
+        ranks.setdefault(canonical, idx)  # first (highest usage) wins
+    return ranks
+
+
+def fetch_openrouter_rankings(
+    *,
+    force_refresh: bool = False,
+    timeout: float = _FETCH_TIMEOUT,
+) -> dict[str, int]:
+    """Return ``{canonical_model_id: rank}`` for the latest day, or ``{}``.
+
+    Rank 0 is the most-used model. Cached in-process and on disk for
+    ``_RANKINGS_TTL_HOURS``. Returns ``{}`` on any failure (no key, network,
+    rate limit, parse) so callers fall back to manifest order.
+    """
+    global _rankings_cache, _rankings_cache_at
+
+    now = time.time()
+    ttl = _RANKINGS_TTL_HOURS * 3600.0
+
+    if not force_refresh and _rankings_cache is not None and (now - _rankings_cache_at) < ttl:
+        return dict(_rankings_cache)
+
+    disk, disk_mtime = _read_disk_cache()
+    if not force_refresh and disk is not None and (now - disk_mtime) < ttl:
+        _rankings_cache = disk
+        _rankings_cache_at = disk_mtime
+        return dict(disk)
+
+    api_key = _resolve_openrouter_api_key()
+    if not api_key:
+        # No key — can't call the authed endpoint. Use stale disk if present.
+        if disk is not None:
+            _rankings_cache = disk
+            _rankings_cache_at = disk_mtime
+            return dict(disk)
+        return {}
+
+    try:
+        req = urllib.request.Request(
+            RANKINGS_URL,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+                "User-Agent": _HERMES_USER_AGENT,
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        logger.info("openrouter rankings fetch failed: %s", exc)
+        if disk is not None:
+            _rankings_cache = disk
+            _rankings_cache_at = disk_mtime
+            return dict(disk)
+        return {}
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.info("openrouter rankings fetch errored: %s", exc)
+        return dict(disk) if disk is not None else {}
+
+    ranks = _parse_latest_day_ranks(payload)
+    if not ranks:
+        if disk is not None:
+            _rankings_cache = disk
+            _rankings_cache_at = disk_mtime
+            return dict(disk)
+        return {}
+
+    _write_disk_cache(ranks)
+    _rankings_cache = ranks
+    _rankings_cache_at = now
+    return dict(ranks)
+
+
+# ---------------------------------------------------------------------------
+# Reorder (pure — no network)
+# ---------------------------------------------------------------------------
+
+
+def reorder_by_usage(
+    curated: list[tuple[str, str]],
+    ranks: dict[str, int],
+    pinned_ids: list[str],
+) -> list[tuple[str, str]]:
+    """Reorder ``curated`` ``[(id, desc), ...]`` by OpenRouter usage rank.
+
+    Ordering rules:
+      1. **Pinned** models (in ``pinned_ids`` order) come first, always,
+         regardless of usage — these are the editorial headline picks.
+      2. The remaining models are sorted by ``ranks[id]`` ascending (rank 0 =
+         most used first).
+      3. Models with no ranking data keep their original manifest order and
+         are appended after all ranked models (stable: a model OpenRouter has
+         never seen shouldn't leapfrog one with real usage).
+
+    The function is stable and never drops or adds entries — it only permutes
+    ``curated``. Descriptions/badges are preserved verbatim.
+    """
+    if not curated:
+        return []
+
+    by_id = {mid: (mid, desc) for mid, desc in curated}
+    original_index = {mid: i for i, (mid, _desc) in enumerate(curated)}
+    consumed: set[str] = set()
+
+    result: list[tuple[str, str]] = []
+
+    # 1. Pinned first, in the given order, skipping any not present in curated.
+    for pid in pinned_ids:
+        if pid in by_id and pid not in consumed:
+            result.append(by_id[pid])
+            consumed.add(pid)
+
+    remaining = [mid for mid, _ in curated if mid not in consumed]
+
+    # 2 + 3. Ranked models by usage, then unranked in manifest order.
+    def sort_key(mid: str) -> tuple[int, int, int]:
+        if mid in ranks:
+            return (0, ranks[mid], original_index[mid])
+        return (1, 0, original_index[mid])
+
+    for mid in sorted(remaining, key=sort_key):
+        result.append(by_id[mid])
+
+    return result

--- a/scripts/build_model_catalog.py
+++ b/scripts/build_model_catalog.py
@@ -33,7 +33,11 @@ sys.path.insert(0, REPO_ROOT)
 # Ensure HERMES_HOME is set for imports that touch it at module level.
 os.environ.setdefault("HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes"))
 
-from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS  # noqa: E402
+from hermes_cli.models import (  # noqa: E402
+    OPENROUTER_MODELS,
+    _OPENROUTER_PINNED_IDS,
+    _PROVIDER_MODELS,
+)
 
 OUTPUT_PATH = os.path.join(REPO_ROOT, "website", "static", "api", "model-catalog.json")
 CATALOG_VERSION = 1
@@ -53,11 +57,18 @@ def build_catalog() -> dict:
                     "display_name": "OpenRouter",
                     "note": (
                         "Descriptions drive picker badges. Live /api/v1/models "
-                        "filters curated ids by tool-calling support and free pricing."
+                        "filters curated ids by tool-calling support and free pricing. "
+                        'Models flagged "pinned" stay at the top of the picker '
+                        "regardless of usage-based reordering (openrouter.sort_by_usage); "
+                        "everything else is ordered by openrouter.ai/rankings daily usage."
                     ),
                 },
                 "models": [
-                    {"id": mid, "description": desc}
+                    (
+                        {"id": mid, "description": desc, "pinned": True}
+                        if mid in _OPENROUTER_PINNED_IDS
+                        else {"id": mid, "description": desc}
+                    )
                     for mid, desc in OPENROUTER_MODELS
                 ],
             },

--- a/tests/hermes_cli/test_openrouter_rankings.py
+++ b/tests/hermes_cli/test_openrouter_rankings.py
@@ -1,0 +1,190 @@
+"""Tests for OpenRouter usage-rankings picker ordering.
+
+Covers:
+  * permaslug → canonical routing-id normalization
+  * latest-day rank extraction from the dataset payload
+  * the pure reorder (pinned-first, usage-ranked, manifest tiebreak)
+  * graceful fallback when ranking data is empty
+"""
+
+from __future__ import annotations
+
+import hermes_cli.openrouter_rankings as orr
+from hermes_cli.openrouter_rankings import (
+    _parse_latest_day_ranks,
+    normalize_permaslug,
+    reorder_by_usage,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_permaslug
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePermaslug:
+    def test_strips_date_suffix(self):
+        assert normalize_permaslug("xiaomi/mimo-v2.5-20260422") == "xiaomi/mimo-v2.5"
+        assert (
+            normalize_permaslug("deepseek/deepseek-v4-flash-20260423")
+            == "deepseek/deepseek-v4-flash"
+        )
+
+    def test_preserves_free_tag(self):
+        assert (
+            normalize_permaslug("nvidia/nemotron-3-super-120b-a12b-20230311:free")
+            == "nvidia/nemotron-3-super-120b-a12b:free"
+        )
+
+    def test_anthropic_component_reorder(self):
+        # rankings list claude-<gen>-<tier>; routing id is claude-<tier>-<gen>
+        assert (
+            normalize_permaslug("anthropic/claude-4.7-opus-20260416")
+            == "anthropic/claude-opus-4.7"
+        )
+        assert (
+            normalize_permaslug("anthropic/claude-4.6-sonnet-20260217")
+            == "anthropic/claude-sonnet-4.6"
+        )
+        assert (
+            normalize_permaslug("anthropic/claude-4.8-opus-20260528")
+            == "anthropic/claude-opus-4.8"
+        )
+
+    def test_no_date_passes_through(self):
+        assert normalize_permaslug("openrouter/owl-alpha") == "openrouter/owl-alpha"
+
+    def test_other_and_garbage_return_none(self):
+        assert normalize_permaslug("other") is None
+        assert normalize_permaslug("") is None
+        assert normalize_permaslug("no-slug-here") is None
+        assert normalize_permaslug(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _parse_latest_day_ranks
+# ---------------------------------------------------------------------------
+
+
+class TestParseLatestDayRanks:
+    def _payload(self):
+        return {
+            "data": [
+                # older day — must be ignored
+                {"date": "2026-05-30", "model_permaslug": "x/old", "total_tokens": "999"},
+                # latest day
+                {"date": "2026-05-31", "model_permaslug": "deepseek/deepseek-v4-flash-20260423", "total_tokens": "389441645148"},
+                {"date": "2026-05-31", "model_permaslug": "tencent/hy3-preview-20260421", "total_tokens": "362650457872"},
+                {"date": "2026-05-31", "model_permaslug": "anthropic/claude-4.7-opus-20260416", "total_tokens": "217765264111"},
+                {"date": "2026-05-31", "model_permaslug": "other", "total_tokens": "100"},
+            ],
+            "meta": {"end_date": "2026-05-31"},
+        }
+
+    def test_uses_latest_day_only_and_ranks_by_tokens(self):
+        ranks = _parse_latest_day_ranks(self._payload())
+        assert ranks["deepseek/deepseek-v4-flash"] == 0
+        assert ranks["tencent/hy3-preview"] == 1
+        assert ranks["anthropic/claude-opus-4.7"] == 2
+        # older-day model and `other` excluded
+        assert "x/old" not in ranks
+        assert "other" not in ranks
+
+    def test_empty_payload(self):
+        assert _parse_latest_day_ranks({}) == {}
+        assert _parse_latest_day_ranks({"data": []}) == {}
+        assert _parse_latest_day_ranks(None) == {}
+
+    def test_dedup_keeps_higher_usage(self):
+        payload = {
+            "data": [
+                {"date": "2026-05-31", "model_permaslug": "z/m-20260101", "total_tokens": "50"},
+                {"date": "2026-05-31", "model_permaslug": "z/m-20260202", "total_tokens": "500"},
+            ]
+        }
+        ranks = _parse_latest_day_ranks(payload)
+        # both normalize to z/m; the 500-token one (rank 0) wins
+        assert ranks == {"z/m": 0}
+
+
+# ---------------------------------------------------------------------------
+# reorder_by_usage
+# ---------------------------------------------------------------------------
+
+
+class TestReorderByUsage:
+    CURATED = [
+        ("anthropic/claude-opus-4.8", ""),
+        ("openai/gpt-5.5", ""),
+        ("moonshotai/kimi-k2.6", "recommended"),
+        ("deepseek/deepseek-v4-flash", ""),
+        ("tencent/hy3-preview", "free"),
+        ("some/unranked-model", ""),
+    ]
+
+    def test_pinned_first_then_usage_then_tiebreak(self):
+        ranks = {
+            "tencent/hy3-preview": 0,       # most used
+            "deepseek/deepseek-v4-flash": 1,
+            "moonshotai/kimi-k2.6": 5,
+            # opus-4.8 / gpt-5.5 also ranked high but are PINNED so order is forced
+            "anthropic/claude-opus-4.8": 0,
+            "openai/gpt-5.5": 0,
+            # some/unranked-model intentionally absent
+        }
+        pinned = ["anthropic/claude-opus-4.8", "openai/gpt-5.5"]
+        out = [mid for mid, _ in reorder_by_usage(self.CURATED, ranks, pinned)]
+        assert out[0] == "anthropic/claude-opus-4.8"
+        assert out[1] == "openai/gpt-5.5"
+        # then ranked tail by usage
+        assert out[2] == "tencent/hy3-preview"
+        assert out[3] == "deepseek/deepseek-v4-flash"
+        assert out[4] == "moonshotai/kimi-k2.6"
+        # unranked model last, preserving manifest order
+        assert out[5] == "some/unranked-model"
+
+    def test_descriptions_preserved(self):
+        ranks = {"tencent/hy3-preview": 0}
+        out = dict(reorder_by_usage(self.CURATED, ranks, []))
+        assert out["tencent/hy3-preview"] == "free"
+        assert out["moonshotai/kimi-k2.6"] == "recommended"
+
+    def test_no_ranks_keeps_manifest_order_with_pins(self):
+        # empty ranking map (fallback path) — only pins move, rest unchanged
+        out = [mid for mid, _ in reorder_by_usage(self.CURATED, {}, ["openai/gpt-5.5"])]
+        assert out[0] == "openai/gpt-5.5"
+        # remaining keep original relative order
+        assert out[1:] == [
+            "anthropic/claude-opus-4.8",
+            "moonshotai/kimi-k2.6",
+            "deepseek/deepseek-v4-flash",
+            "tencent/hy3-preview",
+            "some/unranked-model",
+        ]
+
+    def test_empty_curated(self):
+        assert reorder_by_usage([], {"x/y": 0}, ["a/b"]) == []
+
+    def test_pin_not_in_curated_is_skipped(self):
+        out = [mid for mid, _ in reorder_by_usage(self.CURATED, {}, ["not/present"])]
+        assert out == [mid for mid, _ in self.CURATED]
+
+    def test_no_entries_dropped_or_added(self):
+        ranks = {"tencent/hy3-preview": 0, "moonshotai/kimi-k2.6": 1}
+        out = reorder_by_usage(self.CURATED, ranks, ["openai/gpt-5.5"])
+        assert sorted(m for m, _ in out) == sorted(m for m, _ in self.CURATED)
+        assert len(out) == len(self.CURATED)
+
+
+# ---------------------------------------------------------------------------
+# fetch_openrouter_rankings — fallback behavior (no network)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFallback:
+    def test_no_key_no_disk_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(orr, "_rankings_cache", None)
+        monkeypatch.setattr(orr, "_rankings_cache_at", 0.0)
+        monkeypatch.setattr(orr, "_cache_path", lambda: tmp_path / "nope.json")
+        monkeypatch.setattr(orr, "_resolve_openrouter_api_key", lambda: "")
+        assert orr.fetch_openrouter_rankings(force_refresh=True) == {}

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-01T08:20:18Z",
+  "updated_at": "2026-06-01T17:12:02Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -9,12 +9,13 @@
     "openrouter": {
       "metadata": {
         "display_name": "OpenRouter",
-        "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing."
+        "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing. Models flagged \"pinned\" stay at the top of the picker regardless of usage-based reordering (openrouter.sort_by_usage); everything else is ordered by openrouter.ai/rankings daily usage."
       },
       "models": [
         {
           "id": "anthropic/claude-opus-4.8",
-          "description": ""
+          "description": "",
+          "pinned": true
         },
         {
           "id": "anthropic/claude-opus-4.8-fast",
@@ -30,7 +31,8 @@
         },
         {
           "id": "openai/gpt-5.5",
-          "description": ""
+          "description": "",
+          "pinned": true
         },
         {
           "id": "openai/gpt-5.5-pro",


### PR DESCRIPTION
## Summary

Orders the OpenRouter model picker by **real-world usage** instead of a hand-maintained sequence, using OpenRouter's public daily-usage dataset (`GET /api/v1/datasets/rankings-daily` — the data behind [openrouter.ai/rankings](https://openrouter.ai/rankings)). Headline models stay pinned at the top; everything else is ordered most-used-first.

Motivation: with the picker list growing, the hand-curated order in the catalog drifts and doesn't reflect what people actually run. The TUI picker in particular has no text filter (see #30849), so list order is the primary way users find a model there — making the order accurate matters.

## What it does

- **Pinned headlines first.** Models flagged `"pinned": true` in the model catalog (`anthropic/claude-opus-4.8`, `openai/gpt-5.5`) stay at the top, in declared order, regardless of usage.
- **The rest sorted by usage.** Remaining curated models are ordered by the latest day's `total_tokens` from the rankings dataset (most-used first). Models with no usage data keep curated order and sort after ranked ones.
- **Curation unchanged.** Which models *appear*, the tool-calling filter, and free-pricing badges all behave exactly as before — this only permutes order.
- **Gated by `openrouter.sort_by_usage`** (default `true`). Degrades silently to curated order when there's no OpenRouter key, no network, or a rate-limit. 24h disk+memory cache so the picker never blocks on the network more than once a day.

## Implementation

- `hermes_cli/openrouter_rankings.py` (new): authed fetch + cache, permaslug→routing-id normalization (date-suffix strip, `:free` tag, Anthropic `claude-<gen>-<tier>` → `claude-<tier>-<gen>` reorder), and a pure `reorder_by_usage()` (pinned → usage-ranked → curated tiebreak).
- `hermes_cli/models.py`: `_OPENROUTER_PINNED_IDS` source constant + `_openrouter_sort_by_usage_enabled()`; reorder wired into `fetch_openrouter_models()` after the existing tool/free filtering.
- `hermes_cli/model_catalog.py`: `get_pinned_openrouter_model_ids()` reads the `"pinned"` flag from the manifest. The existing `(id, description)` 2-tuple contract is unchanged — pins are a separate accessor, not a widened tuple.
- `scripts/build_model_catalog.py`: emits `"pinned": true` for `_OPENROUTER_PINNED_IDS` so the generated manifest stays the single source of truth (the in-repo sync test still passes).
- `hermes_cli/config.py`: `openrouter.sort_by_usage: True` with docs.

## Notes / scope

- This is **OpenRouter-global usage**, not Hermes-specific — OpenRouter doesn't expose per-app rankings publicly. It's a better signal than a static list, but it reflects all OpenRouter traffic, not just Hermes users. Called out so reviewers can weigh whether that's the right signal.
- Cross-provider token counts aren't directly comparable (each provider's own tokenizer), but for coarse ordering that's fine.
- The pin flags only take effect once the regenerated manifest is published/merged; older installs reading the previously-published manifest simply see no `pinned` key (ranking still reorders everything).

## Test plan

- New `tests/hermes_cli/test_openrouter_rankings.py` — normalization, latest-day rank extraction, pin precedence, usage ordering, curated tiebreak, no-drop/no-add invariant, and no-key/no-network fallback.
- Verified end-to-end against the live endpoint: opus-4.8 pins #1 (with `recommended` badge), gpt-5.5 #2, remaining models ordered by live daily usage.
- `tests/hermes_cli/test_model_catalog.py` (manifest sync) + `test_models.py` green.
