### PR TITLE
fix(gateway): bound adapter network awaits on the shutdown path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2295,6 +2295,24 @@ class GatewayRunner:
                 platform.value, time.monotonic() - started_at, e,
             )
 
+    async def _teardown_adapters(self) -> None:
+        """Tear every adapter down concurrently during clean shutdown.
+
+        Each teardown is individually bounded (see _safe_adapter_teardown),
+        so running them under one gather makes the phase ~max(timeout)
+        instead of N×timeout — a wedged adapter no longer extends the window
+        launchd/systemd allow before SIGKILL. Adapters touch only their own
+        state; shared cleanup runs after this returns. return_exceptions is
+        belt-and-suspenders: the helper never raises.
+        """
+        await asyncio.gather(
+            *(
+                self._safe_adapter_teardown(adapter, platform)
+                for platform, adapter in list(self.adapters.items())
+            ),
+            return_exceptions=True,
+        )
+
     async def _bounded_shutdown_send(self, adapter, *args, **kwargs):
         """Send a shutdown notification under the shared per-adapter timeout.
 
@@ -6520,8 +6538,7 @@ class GatewayRunner:
                     )
                     self._cleanup_agent_resources(_agent)
 
-            for platform, adapter in list(self.adapters.items()):
-                await self._safe_adapter_teardown(adapter, platform)
+            await self._teardown_adapters()
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2294,6 +2294,28 @@ class GatewayRunner:
                 platform.value, time.monotonic() - started_at, e,
             )
 
+    async def _bounded_shutdown_send(self, adapter, *args, **kwargs):
+        """Send a shutdown notification under the shared per-adapter timeout.
+
+        Returns the adapter's result, or None on timeout. A wedged send
+        (half-dead platform, TCP black-hole) must not hang _stop_impl before
+        adapter teardown runs. None matches the adapter contract for a send
+        with no structured result, so callers fall through their existing
+        ``result is not None`` failure check and stop re-targeting the same
+        wedged chat.
+        """
+        timeout = self._adapter_disconnect_timeout_secs()
+        try:
+            if timeout <= 0:
+                return await adapter.send(*args, **kwargs)
+            return await asyncio.wait_for(adapter.send(*args, **kwargs), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out after %.1fs sending shutdown notification to %s; continuing",
+                timeout, getattr(getattr(adapter, "platform", None), "value", None),
+            )
+            return None
+
     def _adapter_disconnect_timeout_secs(self) -> float:
         """Return the per-adapter disconnect timeout used during shutdown."""
         raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
@@ -3706,7 +3728,7 @@ class GatewayRunner:
                     adapter=adapter,
                 )
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                result = await self._bounded_shutdown_send(adapter, chat_id, msg, metadata=metadata)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -3761,9 +3783,9 @@ class GatewayRunner:
                     adapter=adapter,
                 )
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await self._bounded_shutdown_send(adapter, str(home.chat_id), msg, metadata=metadata)
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await self._bounded_shutdown_send(adapter, str(home.chat_id), msg)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2220,15 +2220,16 @@ class GatewayRunner:
             )
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
-        """Call adapter.disconnect() defensively, swallowing any error.
+        """Bounded, never-raising adapter.disconnect() — the shared resolver.
 
-        Used when adapter.connect() failed or raised — the adapter may
-        have allocated partial resources (aiohttp.ClientSession, poll
-        tasks, child subprocesses) that would otherwise leak and surface
-        as "Unclosed client session" warnings at process exit.
+        Used after a failed connect (partial resources — aiohttp sessions,
+        poll tasks, subprocesses — would otherwise leak as "Unclosed client
+        session" warnings) and on the fatal-error path, where the same
+        network failure that killed the adapter can wedge its disconnect.
 
-        Must tolerate partial-init state and never raise, since callers
-        use it inside error-handling blocks.
+        Must tolerate partial-init state and never raise, since callers use
+        it inside error-handling blocks and rely on reaching the cleanup
+        that follows.
         """
         timeout = self._adapter_disconnect_timeout_secs()
         try:
@@ -2244,7 +2245,7 @@ class GatewayRunner:
             )
         except Exception as e:
             logger.debug(
-                "Defensive %s disconnect after failed connect raised: %s",
+                "Defensive %s disconnect raised: %s",
                 platform.value if platform is not None else "adapter",
                 e,
             )
@@ -2753,8 +2754,10 @@ class GatewayRunner:
 
         existing = self.adapters.get(adapter.platform)
         if existing is adapter:
+            # finally so a teardown-time cancellation still drops the dead
+            # adapter; _safe_adapter_disconnect itself never raises.
             try:
-                await adapter.disconnect()
+                await self._safe_adapter_disconnect(adapter, adapter.platform)
             finally:
                 self.adapters.pop(adapter.platform, None)
                 self.delivery_router.adapters = self.adapters

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2249,6 +2249,51 @@ class GatewayRunner:
                 e,
             )
 
+    async def _safe_adapter_teardown(self, adapter, platform) -> None:
+        """Bounded, never-raising per-adapter teardown for clean shutdown.
+
+        Each op runs under the shared per-adapter timeout
+        (HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT, default 5s) so a single
+        wedged adapter cannot stall shutdown before it reaches the
+        runtime-lock / PID-file cleanup that follows.
+
+        NOTE: for thread-backed adapters (e.g. Feishu's run_in_executor WS
+        client) the timeout abandons the worker thread rather than closing
+        the socket gracefully; the daemon thread is reclaimed at process
+        exit. This is bounded teardown, not graceful disconnect.
+        """
+        timeout = self._adapter_disconnect_timeout_secs()
+        started_at = time.monotonic()
+
+        async def _bounded(coro):
+            if timeout <= 0:
+                return await coro
+            return await asyncio.wait_for(coro, timeout=timeout)
+
+        try:
+            await _bounded(adapter.cancel_background_tasks())
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out after %.1fs cancelling %s background tasks; continuing shutdown",
+                timeout, platform.value,
+            )
+        except Exception as e:
+            logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
+
+        try:
+            await _bounded(adapter.disconnect())
+            logger.info("✓ %s disconnected (%.2fs)", platform.value, time.monotonic() - started_at)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out after %.1fs disconnecting %s adapter (%.2fs total); continuing shutdown",
+                timeout, platform.value, time.monotonic() - started_at,
+            )
+        except Exception as e:
+            logger.error(
+                "✗ %s disconnect error after %.2fs: %s",
+                platform.value, time.monotonic() - started_at, e,
+            )
+
     def _adapter_disconnect_timeout_secs(self) -> float:
         """Return the per-adapter disconnect timeout used during shutdown."""
         raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
@@ -6451,25 +6496,7 @@ class GatewayRunner:
                     self._cleanup_agent_resources(_agent)
 
             for platform, adapter in list(self.adapters.items()):
-                _adapter_started_at = time.monotonic()
-                try:
-                    await adapter.cancel_background_tasks()
-                except Exception as e:
-                    logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
-                try:
-                    await adapter.disconnect()
-                    logger.info(
-                        "✓ %s disconnected (%.2fs)",
-                        platform.value,
-                        time.monotonic() - _adapter_started_at,
-                    )
-                except Exception as e:
-                    logger.error(
-                        "✗ %s disconnect error after %.2fs: %s",
-                        platform.value,
-                        time.monotonic() - _adapter_started_at,
-                        e,
-                    )
+                await self._safe_adapter_teardown(adapter, platform)
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -60,6 +60,12 @@ class _FakeGateway:
     async def _notify_active_sessions_of_shutdown(self):
         pass
 
+    async def _teardown_adapters(self):
+        # Real GatewayRunner extracts the per-adapter shutdown loop into this
+        # method; the fake has no live adapters, so a no-op mirrors the empty
+        # ``self.adapters`` iteration the inline loop used to perform.
+        pass
+
     async def _drain_active_agents(self, timeout):
         return {}, False
 

--- a/tests/gateway/test_shutdown_disconnect_timeout.py
+++ b/tests/gateway/test_shutdown_disconnect_timeout.py
@@ -39,3 +39,23 @@ async def test_hung_disconnect_does_not_stall_teardown(monkeypatch):
         _runner()._safe_adapter_teardown(_HangingDisconnect(), _platform()),
         timeout=2.0,
     )
+
+
+class _HangingSend:
+    """send() never completes — models a TCP black-hole platform."""
+
+    platform = _platform()
+
+    async def send(self, *args, **kwargs):
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_hung_notify_send_is_bounded(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.1")
+    result = await asyncio.wait_for(
+        _runner()._bounded_shutdown_send(_HangingSend(), "chat-id", "bye"),
+        timeout=2.0,
+    )
+    # A timed-out send yields None (no structured result); shutdown continues.
+    assert result is None

--- a/tests/gateway/test_shutdown_disconnect_timeout.py
+++ b/tests/gateway/test_shutdown_disconnect_timeout.py
@@ -105,5 +105,65 @@ async def test_teardown_runs_adapters_concurrently(monkeypatch):
     await asyncio.wait_for(runner._teardown_adapters(), timeout=2.0)
     elapsed = loop.time() - start
 
-    # Concurrent: ~one timeout (0.2s), not the 0.4s a sequential loop would take.
-    assert elapsed < 0.35
+    # Both adapters hang, so each is cut at the 0.2s bound. Run concurrently
+    # the phase is ~one timeout; a sequential loop would take ~0.4s. The lower
+    # bound proves the bound actually fired (not a short-circuit); the upper
+    # bound proves concurrency, with slack for loaded CI.
+    assert 0.18 < elapsed < 0.38
+
+
+class _SlowSend:
+    """send() takes longer than an insta-timeout would allow, then succeeds."""
+
+    platform = _platform()
+
+    async def send(self, *args, **kwargs):
+        await asyncio.sleep(0.05)
+        return "ok"
+
+
+class _SlowTeardown:
+    """disconnect() takes real time; records whether it ran to completion."""
+
+    def __init__(self):
+        self.disconnected = False
+
+    async def cancel_background_tasks(self):
+        return None
+
+    async def disconnect(self):
+        await asyncio.sleep(0.05)
+        self.disconnected = True
+
+
+# A timeout of 0 is the operator opt-out: every bounded site must take a bare
+# ``await`` (truly unbounded), NOT ``wait_for(coro, timeout=0)`` — which would
+# insta-timeout and either return None or abandon a mid-flight op. These three
+# behavioral tests pin that contract for each helper: a 0.05s op set against a
+# "0" timeout must run to completion / return its real result.
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_opts_out_bounded_send(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0")
+    result = await _runner()._bounded_shutdown_send(_SlowSend(), "chat-id", "bye")
+    # Real result passes through — proves no wait_for(..., timeout=0) → None.
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_opts_out_teardown(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0")
+    adapter = _SlowTeardown()
+    await _runner()._safe_adapter_teardown(adapter, _platform())
+    # disconnect() ran to completion — a wait_for(timeout=0) would have
+    # cancelled it mid-sleep, leaving this False.
+    assert adapter.disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_opts_out_safe_disconnect(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0")
+    adapter = _SlowTeardown()
+    await _runner()._safe_adapter_disconnect(adapter, _platform())
+    assert adapter.disconnected is True

--- a/tests/gateway/test_shutdown_disconnect_timeout.py
+++ b/tests/gateway/test_shutdown_disconnect_timeout.py
@@ -92,3 +92,18 @@ async def test_fatal_error_disconnect_is_bounded(monkeypatch):
     # reconnection bookkeeping that follows still runs.
     await asyncio.wait_for(runner._handle_adapter_fatal_error(adapter), timeout=2.0)
     assert pf not in runner.adapters
+
+
+@pytest.mark.asyncio
+async def test_teardown_runs_adapters_concurrently(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.2")
+    runner = _runner()
+    runner.adapters = {Platform.TELEGRAM: _HangingDisconnect(), Platform.DISCORD: _HangingDisconnect()}
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    await asyncio.wait_for(runner._teardown_adapters(), timeout=2.0)
+    elapsed = loop.time() - start
+
+    # Concurrent: ~one timeout (0.2s), not the 0.4s a sequential loop would take.
+    assert elapsed < 0.35

--- a/tests/gateway/test_shutdown_disconnect_timeout.py
+++ b/tests/gateway/test_shutdown_disconnect_timeout.py
@@ -11,6 +11,7 @@ import types
 
 import pytest
 
+from gateway.config import Platform
 from gateway.run import GatewayRunner
 
 
@@ -59,3 +60,35 @@ async def test_hung_notify_send_is_bounded(monkeypatch):
     )
     # A timed-out send yields None (no structured result); shutdown continues.
     assert result is None
+
+
+class _FatalHangingAdapter:
+    """disconnect() hangs; the adapter reports a non-retryable fatal error."""
+
+    fatal_error_code = "boom"
+    fatal_error_message = "unrecoverable"
+    fatal_error_retryable = False
+
+    def __init__(self, platform):
+        self.platform = platform
+
+    async def disconnect(self):
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_fatal_error_disconnect_is_bounded(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.1")
+    runner = _runner()
+    pf = Platform.TELEGRAM
+    other = Platform.DISCORD  # second adapter keeps shutdown off the all-gone path
+    adapter = _FatalHangingAdapter(pf)
+    runner.adapters = {pf: adapter, other: object()}
+    runner.delivery_router = types.SimpleNamespace(adapters=runner.adapters)
+    runner._failed_platforms = {}
+    monkeypatch.setattr(runner, "_update_platform_runtime_status", lambda *a, **k: None)
+
+    # A hung disconnect must not block popping the dead adapter so the
+    # reconnection bookkeeping that follows still runs.
+    await asyncio.wait_for(runner._handle_adapter_fatal_error(adapter), timeout=2.0)
+    assert pf not in runner.adapters

--- a/tests/gateway/test_shutdown_disconnect_timeout.py
+++ b/tests/gateway/test_shutdown_disconnect_timeout.py
@@ -1,0 +1,41 @@
+"""A wedged adapter must never stall the gateway's shutdown path.
+
+Adapter network ops reachable from ``_stop_impl`` are bounded at the call
+site so one stuck socket can't hang shutdown into a SIGKILL that leaves
+stale gateway.pid / gateway.lock. This suite covers each bounded op as
+its commit lands (teardown, notify-sends, fatal-error disconnect).
+"""
+
+import asyncio
+import types
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+def _runner():
+    return object.__new__(GatewayRunner)
+
+
+def _platform(name="telegram"):
+    return types.SimpleNamespace(value=name, platform=name)
+
+
+class _HangingDisconnect:
+    """cancel_background_tasks() returns; disconnect() never completes."""
+
+    async def cancel_background_tasks(self):
+        return None
+
+    async def disconnect(self):
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_hung_disconnect_does_not_stall_teardown(monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.1")
+    await asyncio.wait_for(
+        _runner()._safe_adapter_teardown(_HangingDisconnect(), _platform()),
+        timeout=2.0,
+    )


### PR DESCRIPTION
## Summary

On the gateway shutdown path (`GatewayRunner._stop_impl`), adapter network calls — `disconnect()`, `cancel_background_tasks()`, and the shutdown-notification `send()`s — were awaited with no timeout while the runtime lock was held. A half-dead platform (TCP black-hole, wedged WebSocket) makes one of these awaits block indefinitely, so the process never exits; launchd/systemd then SIGKILLs it mid-shutdown, leaving a stale `gateway.pid` / `gateway.lock` that the next start treats as a live instance.

This change wraps each of those awaits in `asyncio.wait_for` at the call site, using the existing `HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT` knob (`_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0`, `gateway/run.py:67`). No new env var or constant.

## Change

`gateway/run.py` only (helpers + call sites):

- `_safe_adapter_teardown` (`gateway/run.py:2253`) bounds `disconnect()` + `cancel_background_tasks()` per adapter. Called from `_teardown_adapters` (`gateway/run.py:2298`), which replaces the former sequential per-adapter loop and runs the teardowns under one `asyncio.gather(return_exceptions=True)` — call site `gateway/run.py:6541`.
- `_bounded_shutdown_send` (`gateway/run.py:2316`) bounds the three shutdown-notification sends (`gateway/run.py:3752`, `:3807`, `:3809`). On timeout it logs a `WARNING` and returns `None`; `None` is the existing adapter contract for a send with no structured result, so the callers' `result is not None` check is unchanged and the target is added to the `notified` dedup set.
- `_safe_adapter_disconnect` (`gateway/run.py:2222`, pre-existing) now bounds its `disconnect()` and is used on the fatal-error path inside the existing `try/finally` at `gateway/run.py:2778`.

Each helper takes a bare `await` (no `wait_for`) when the resolved timeout is `<= 0`, preserving an opt-out. The helpers catch `Exception` and `asyncio.TimeoutError`, not `CancelledError` (a `BaseException` on Python ≥3.11), so cancellation still propagates; the `try/finally` and `gather(return_exceptions=True)` perform cleanup in that case.

Unchanged: `gateway/status.py` (PID/lock machinery); `_db.close()` (`gateway/run.py:6598`) and `shutdown_cached_clients()` (`gateway/run.py:6584`), which are synchronous (see Note); `_launch_detached_restart_command()` (fire-and-forget `subprocess.Popen`); the agent drain, which is bounded by its own deadline argument.

## Behavior

| Call site | Before | After |
|---|---|---|
| teardown loop (`run.py:6541`) | sequential per-adapter `disconnect()` + `cancel_background_tasks()`, each unbounded | concurrent `gather`; each op bounded by the timeout; phase ≈ `max(timeout)` rather than the per-adapter sum |
| notify sends (`run.py:3752/:3807/:3809`) | unbounded `send()`; a wedged socket blocks `_stop_impl` | bounded `send()`; on timeout returns `None`, caller logs and continues to the next target |
| fatal-error disconnect (`run.py:2778`) | unbounded `disconnect()`; if it raised, the exception left the fire-and-forget task before the `if adapter.fatal_error_retryable:` block below the `try/finally`, so a retryable platform was not queued for reconnect | bounded `disconnect()`, error swallowed; the reconnection-queueing block is always reached |
| any bounded op, `timeout <= 0` | n/a | bare `await`, unbounded (opt-out) |

## Testing

`uv run --extra dev pytest <the 13 tests/gateway files exercising the changed methods> -p no:xdist` → 227 passed. The 228th, `test_gateway_shutdown.py::test_gateway_stop_systemd_service_restart_exits_cleanly`, asserts the Linux systemd exit code (`0`) but does not patch `sys.platform`, so it only passes on a Linux host (forcing `sys.platform="linux"` makes it pass; the macOS branch — exit `75` — is covered by its sibling `test_gateway_stop_launchd_service_restart_keeps_nonzero_exit`). It reproduces on unmodified `main` and is in the service-restart exit-code path, which this change does not touch. Run xdist-isolated because two further unrelated areas pollute across workers in the full `tests/gateway/` run (telegram model-picker/slash-confirm; wecom-callback, which also needs the optional `defusedxml` dep) — those pass when each file runs alone.

New `tests/gateway/test_shutdown_disconnect_timeout.py` (7 tests):
- `test_hung_disconnect_does_not_stall_teardown` — `_safe_adapter_teardown` returns within 2s when `disconnect()` never completes.
- `test_hung_notify_send_is_bounded` — `_bounded_shutdown_send` returns `None` on a never-completing `send()`.
- `test_fatal_error_disconnect_is_bounded` — `_handle_adapter_fatal_error` still pops the dead adapter from `self.adapters` when `disconnect()` hangs.
- `test_teardown_runs_adapters_concurrently` — two hanging adapters at a 0.2s timeout finish in `0.18 < elapsed < 0.38` (lower bound: the timeout fired; upper bound: `gather` ran them concurrently, not the ~0.4s of a sequential loop).
- `test_zero_timeout_opts_out_bounded_send` / `_teardown` / `_safe_disconnect` — with the env set to `"0"`, a 0.05s op runs to completion / returns its real value, confirming the `<= 0` branch takes a bare `await` rather than `wait_for(..., timeout=0)`.

Modified `tests/gateway/test_shutdown_cache_cleanup.py` — its `_FakeGateway` drives the real `_stop_impl`, so it gains a one-line `_teardown_adapters` no-op to match the extracted method.

Verification is unit-level: the timeout bounding is exercised directly; the end-to-end sequence (wedged socket → SIGKILL → stale file) is not reproduced in CI.

## Note

`_db.close()` (`gateway/run.py:6598`) and `shutdown_cached_clients()` (`gateway/run.py:6584`) remain on the shutdown path as synchronous, unbounded calls; `asyncio.wait_for` cannot interrupt a synchronous call, and running `_db.close()` in a thread and abandoning it on timeout would leave the SQLite WAL lock held — the lock that the close exists to release. These are local, process-owned operations. A future change could quiesce writers / checkpoint the WAL before close if a stall is ever observed there.

## Related

- #14130 — earlier approach: a timeout around `adapter.disconnect()` in the shutdown loop, with a hardcoded interval. This change covers that call plus `cancel_background_tasks()`, the notify sends, and the fatal-error disconnect, and reads the interval from the existing env knob.
- #25569 — addresses the same symptom at the PID layer (`gateway/status.py`). `main` already performs a stale-PID pre-clean before the `O_EXCL` write (`gateway/status.py:286` `_cleanup_invalid_pid_path`, `:999` `get_running_pid`) and replaced `os.kill(pid, 0)` with `_pid_exists` for Windows correctness in `324567c93`.
- #28603 — a diagnostic-message change for stale-lock startup failures, in a region this change does not touch.
- #13511, #13655, #28561 — the stale-file reclaim these describe is handled on `main`: the advisory lock auto-releases on holder death (`fcntl.flock` / `msvcrt.locking`, `gateway/status.py:327-329`), and `get_running_pid()` unlinks the stale `gateway.pid` and `gateway.lock` before the next start acquires the lock.

Fixes #14128
Addresses #14176
Refs #13511, #13655, #14130, #25569, #28561, #28603
