### PR TITLE
fix: inject api_key when rebuilding OpenAI client during stream retry

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3013,7 +3013,12 @@ class AIAgent:
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:
-                new_client = self._create_openai_client(self._client_kwargs, reason=reason, shared=True)
+                kwargs = dict(self._client_kwargs)
+                if not kwargs.get("api_key"):
+                    key = getattr(self, "api_key", "") or getattr(self, "_anthropic_api_key", "")
+                    if key:
+                        kwargs["api_key"] = key
+                new_client = self._create_openai_client(kwargs, reason=reason, shared=True)
             except Exception as exc:
                 logger.warning(
                     "Failed to rebuild shared OpenAI client (%s) %s error=%s",


### PR DESCRIPTION
## Summary

When a provider uses `anthropic_messages` transport (e.g. `minimax-cn`, `minimax`), 
`agent._client_kwargs` is initialized as `{}` (agent_init.py:649) because no OpenAI 
client is needed for normal operation. However, when a streaming error triggers a retry, 
`chat_completion_helpers.py:2224` calls `_replace_primary_openai_client()` which 
creates an OpenAI client with the empty kwargs dict. Without `api_key`, 
`openai.OpenAI()` falls back to `OPENAI_API_KEY` env var, which is typically unset 
for non-OpenAI providers, causing the retry to fail silently and the message to be lost.

## Root Cause

`run_agent.py:3016`: `self._create_openai_client(self._client_kwargs, ...)` 
receives `{}` — no `api_key`. Meanwhile `agent.api_key` is correctly set 
at agent_init.py:634 for the anthropic path, and tracked separately in 
`agent._anthropic_api_key`.

## Fix

Before creating the OpenAI client, copy `agent.api_key` (or `_anthropic_api_key`) 
into the kwargs dict if `api_key` is missing. This mirrors the pattern already 
used at agent_init.py:691-712 where the OpenAI path explicitly passes api_key 
+ base_url.

## Reproduction

1. Configure `minimax_cn` provider with MiniMax API key
2. Start gateway with WeChat platform
3. MiniMax's `/anthropic` endpoint drops stream after ~90s → triggers retry
4. Stream retry path calls `_replace_primary_openai_client()`
5. Fails with: `The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable`
6. Agent message silently lost, gateway process may terminate

## Test Plan

- [x] Existing anthropic_messages flow unchanged (kwargs copy, not mutation)
- [ ] `_replace_primary_openai_client` succeeds when agent has api_key but empty `_client_kwargs`
