### PR TITLE
fix(mattermost): thread progress and status side-channel sends

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -319,7 +319,14 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     return text
 
 
-async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
+async def _send_or_update_status_coro(
+    adapter,
+    chat_id,
+    status_key,
+    content,
+    metadata,
+    reply_to=None,
+):
     """Route a status message through adapter.send_or_update_status when supported.
 
     Issue #30045: adapters that implement send_or_update_status (currently
@@ -329,7 +336,7 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
         return await sender(chat_id, status_key, content, metadata=metadata)
-    return await adapter.send(chat_id, content, metadata=metadata)
+    return await adapter.send(chat_id, content, reply_to=reply_to, metadata=metadata)
 
 
 def _telegramize_command_mentions(text: str, platform: Any) -> str:
@@ -1494,6 +1501,23 @@ def _check_unavailable_skill(command_name: str) -> str | None:
 def _platform_config_key(platform: "Platform") -> str:
     """Map a Platform enum to its config.yaml key (LOCAL→"cli", rest→enum value)."""
     return "cli" if platform == Platform.LOCAL else platform.value
+
+
+def _progress_thread_id_for_source(
+    source: SessionSource,
+    event_message_id: Optional[str],
+) -> Optional[str]:
+    """Return the thread target for gateway progress/status side-channel sends.
+
+    Some platforms need the triggering top-level message id as a synthetic
+    thread target for progress bubbles, even though the inbound event itself is
+    not already inside a thread.  Final responses already pass that id via
+    ``reply_to``; progress/status paths need the same anchor explicitly.
+    """
+    thread_id = getattr(source, "thread_id", None)
+    if source.platform in {Platform.SLACK, Platform.MATTERMOST}:
+        return thread_id or event_message_id
+    return thread_id
 
 
 def _teams_pipeline_plugin_enabled() -> bool:
@@ -16899,15 +16923,18 @@ class GatewayRunner:
         #
         # Threading metadata is platform-specific:
         # - Slack DM threading needs event_message_id fallback (reply thread)
+        # - Mattermost thread mode also needs the triggering top-level post id:
+        #   final replies pass it as reply_to, but progress/status sends run on
+        #   a separate side-channel and otherwise land as top-level posts.
         # - Telegram forum topics use message_thread_id; Hermes-created private
         #   DM topic lanes require both thread metadata and a reply anchor
         # - Feishu only honors reply_in_thread when sending a reply, so topic
         #   progress uses the triggering event message as the reply target
         # - Other platforms should use explicit source.thread_id only
-        if source.platform == Platform.SLACK:
-            _progress_thread_id = source.thread_id or event_message_id
-        else:
-            _progress_thread_id = source.thread_id
+        _progress_thread_id = _progress_thread_id_for_source(
+            source,
+            event_message_id,
+        )
         _progress_metadata = (
             self._thread_metadata_for_source(source, event_message_id)
             if _progress_thread_id == source.thread_id
@@ -16915,7 +16942,7 @@ class GatewayRunner:
         ) if _progress_thread_id else None
         _progress_reply_to = (
             event_message_id
-            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
+            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and event_message_id
             else None
         )
 
@@ -17297,7 +17324,8 @@ class GatewayRunner:
                 "reply_to_message_id": event_message_id,
             }
         else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+            _status_thread_metadata = _progress_metadata
+        _status_reply_to = _progress_reply_to
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -17316,7 +17344,14 @@ class GatewayRunner:
                 )
                 return
             _fut = safe_schedule_threadsafe(
-                _send_or_update_status_coro(_status_adapter, _status_chat_id, event_type, prepared_message, _status_thread_metadata),
+                _send_or_update_status_coro(
+                    _status_adapter,
+                    _status_chat_id,
+                    event_type,
+                    prepared_message,
+                    _status_thread_metadata,
+                    reply_to=_status_reply_to,
+                ),
                 _loop_for_step,
                 logger=logger,
                 log_message=f"status_callback ({event_type}) scheduling error",
@@ -17490,6 +17525,7 @@ class GatewayRunner:
                     _status_adapter.send(
                         _status_chat_id,
                         text,
+                        reply_to=_status_reply_to,
                         metadata=_status_thread_metadata,
                     ),
                     _loop_for_step,
@@ -17591,6 +17627,7 @@ class GatewayRunner:
                     _status_adapter.send(
                         _status_chat_id,
                         message,
+                        reply_to=_status_reply_to,
                         metadata=_status_thread_metadata,
                     ),
                     _loop_for_step,
@@ -17827,6 +17864,7 @@ class GatewayRunner:
                         _status_adapter.send(
                             _status_chat_id,
                             msg,
+                            reply_to=_status_reply_to,
                             metadata=_status_thread_metadata,
                         ),
                         _loop_for_step,
@@ -18360,6 +18398,7 @@ class GatewayRunner:
                         _notify_res = await _notify_adapter.send(
                             source.chat_id,
                             _heartbeat_text,
+                            reply_to=_status_reply_to,
                             metadata=_status_thread_metadata,
                         )
                         if getattr(_notify_res, "success", False) and getattr(
@@ -18460,6 +18499,7 @@ class GatewayRunner:
                                     f"If the agent does not respond soon, it will "
                                     f"be timed out in {_remaining_mins} min. "
                                     f"You can continue waiting or use /reset.",
+                                    reply_to=_status_reply_to,
                                     metadata=_status_thread_metadata,
                                 )
                             except Exception as _warn_err:
@@ -18695,6 +18735,7 @@ class GatewayRunner:
                             await adapter.send(
                                 source.chat_id,
                                 first_response,
+                                reply_to=_status_reply_to,
                                 metadata=_status_thread_metadata,
                             )
                         except Exception as e:

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -286,11 +286,17 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
+            # Thread support: reply_to is the root post ID.  Gateway
+            # side-channel sends (tool progress, status, heartbeats) often
+            # carry only generic metadata, so accept metadata.thread_id as the
+            # same thread target when no explicit reply anchor was supplied.
+            thread_target = reply_to
+            if not thread_target and metadata:
+                thread_target = metadata.get("thread_id")
+            if thread_target and self._reply_mode == "thread":
                 # Ensure root_id points to the thread root, not a reply.
                 # Mattermost rejects non-root post IDs as root_id.
-                resolved_root = await self._resolve_root_id(reply_to)
+                resolved_root = await self._resolve_root_id(str(thread_target))
                 payload["root_id"] = resolved_root
 
             data = await self._api_post("posts", payload)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -66,6 +66,68 @@ class TestMattermostConfigLoading:
 
 
 # ---------------------------------------------------------------------------
+# Gateway progress routing
+# ---------------------------------------------------------------------------
+
+class TestMattermostProgressRouting:
+    def test_top_level_message_anchors_progress_to_triggering_post(self):
+        """Progress/status bubbles should use the same root as the final reply."""
+        from gateway.run import _progress_thread_id_for_source
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="channel_1",
+            chat_type="channel",
+        )
+
+        assert _progress_thread_id_for_source(source, "trigger_post") == "trigger_post"
+
+    def test_thread_reply_keeps_existing_thread_root(self):
+        from gateway.run import _progress_thread_id_for_source
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="channel_1",
+            chat_type="channel",
+            thread_id="root_post",
+        )
+
+        assert _progress_thread_id_for_source(source, "reply_post") == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_status_fallback_forwards_reply_anchor(self):
+        """Status side-channels pass reply_to when the adapter has no updater."""
+        from types import SimpleNamespace
+
+        from gateway.platforms.base import SendResult
+        from gateway.run import _send_or_update_status_coro
+
+        adapter = SimpleNamespace(
+            send=AsyncMock(return_value=SendResult(success=True, message_id="status_post"))
+        )
+        metadata = {"thread_id": "root_post"}
+
+        result = await _send_or_update_status_coro(
+            adapter,
+            "channel_1",
+            "lifecycle",
+            "Working...",
+            metadata,
+            reply_to="trigger_post",
+        )
+
+        assert result.success is True
+        adapter.send.assert_awaited_once_with(
+            "channel_1",
+            "Working...",
+            reply_to="trigger_post",
+            metadata=metadata,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Adapter format / truncate
 # ---------------------------------------------------------------------------
 
@@ -212,6 +274,38 @@ class TestMattermostSend:
         self.adapter._session.get = MagicMock(return_value=mock_get_resp)
 
         result = await self.adapter.send("channel_1", "Reply!", reply_to="root_post")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_send_uses_metadata_thread_id_for_status_side_channels(self):
+        """Progress/status sends can thread via metadata when reply_to is absent."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "progress_post"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_get_resp = AsyncMock()
+        mock_get_resp.status = 200
+        mock_get_resp.json = AsyncMock(return_value={"id": "root_post", "root_id": ""})
+        mock_get_resp.text = AsyncMock(return_value="")
+        mock_get_resp.__aenter__ = AsyncMock(return_value=mock_get_resp)
+        mock_get_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        self.adapter._session.get = MagicMock(return_value=mock_get_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "🔧 terminal...",
+            metadata={"thread_id": "root_post"},
+        )
 
         assert result.success is True
         payload = self.adapter._session.post.call_args[1]["json"]


### PR DESCRIPTION
## Summary

Mattermost `MATTERMOST_REPLY_MODE=thread` now keeps gateway side-channel messages in the same thread as the final answer. Before this change, a top-level channel post could get a correctly-threaded final response while tool-progress, status, heartbeat, timeout-warning, and queued-follow-up bubbles still landed in the parent channel.

## Root cause

Final replies and progress/status messages use different gateway paths:

- final replies pass the triggering Mattermost post id as `reply_to`, so `MattermostAdapter.send()` converts it to `root_id` when thread mode is enabled
- progress/status side-channels derive their routing from `source.thread_id`; for a top-level channel post that starts a new thread, `source.thread_id` is still empty, so those sends had neither `reply_to` nor usable metadata
- `MattermostAdapter.send()` also ignored generic `metadata["thread_id"]`, so metadata-routed side-channel sends could not recover the thread target even when the runner had one

## Changes

- Add `_progress_thread_id_for_source()` so Mattermost, like Slack, can use the triggering post id as the synthetic progress/status thread target when the inbound message is top-level.
- Reuse the computed progress metadata for status/interim/heartbeat/timeout/queued-first-response paths instead of recomputing from `source.thread_id` only.
- Forward the same reply anchor through fallback status sends and other status-like side-channel sends.
- Teach `MattermostAdapter.send()` to honor `metadata["thread_id"]` as a thread target when `reply_to` is absent, while preserving explicit `reply_to` precedence and `reply_mode == "thread"` gating.
- Add regression coverage for top-level Mattermost progress anchoring, existing-thread preservation, status fallback `reply_to` forwarding, and adapter metadata-thread routing.

Related: #31805, #30385, #20874, #29993 cover overlapping Mattermost thread leaks. This PR is the current-main focused version that fixes both the runner-side top-level progress target and the adapter metadata fallback.

## Test plan

- [x] `./scripts/run_tests.sh tests/gateway/test_mattermost.py tests/gateway/test_telegram_status_update.py tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py tests/gateway/test_run_cleanup_progress.py tests/gateway/test_gateway_inactivity_timeout.py`
- [x] `python3 -m py_compile gateway/run.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `/home/adityargadgil/.hermes/hermes-agent/venv/bin/ruff check gateway/run.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`

I also attempted the broader `./scripts/run_tests.sh tests/gateway`; it reached 59% before the local 600s command cap with unrelated existing failures/timeouts in `test_agent_cache.py`, `test_feishu_bot_admission.py`, and `test_feishu_comment.py`. The Mattermost and progress-topic files passed in that broader run.

## Risk

Low-to-medium. The behavior change is scoped to gateway side-channel routing and Mattermost send payload construction. `reply_to` still wins over metadata, Mattermost `root_id` is still set only in `reply_mode == "thread"`, and adapters with `send_or_update_status()` keep their existing status-updater path.