### PR TITLE
fix(model_tools): warn when enabled toolset names resolve to zero tools

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -357,6 +357,22 @@ def _compute_tool_definitions(
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
                 tools_to_include.update(resolved)
+                if not resolved:
+                    # Warn regardless of quiet_mode — an empty resolution for
+                    # an explicitly-listed toolset is always a misconfiguration
+                    # or a registry-timing miss (e.g. MCP server name listed in
+                    # platform_toolsets before the server's tools are registered).
+                    # Without this warning the failure is completely silent in
+                    # gateway quiet_mode and causes the agent to receive no tools
+                    # AND lose tool-use enforcement guidance. (#35703)
+                    logger.warning(
+                        "Toolset '%s' is configured but resolved to zero tools. "
+                        "If this is an MCP server name, ensure the server is "
+                        "connected and its tools are registered before building "
+                        "the agent (check gateway startup logs for "
+                        "'MCP: registered N tool(s)').",
+                        toolset_name,
+                    )
                 if not quiet_mode:
                     print(f"✅ Enabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
             elif toolset_name in _LEGACY_TOOLSET_MAP:
@@ -364,8 +380,12 @@ def _compute_tool_definitions(
                 tools_to_include.update(legacy_tools)
                 if not quiet_mode:
                     print(f"✅ Enabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+            else:
+                # Unknown toolset — warn regardless of quiet_mode so the
+                # misconfiguration is visible in logs even in production.
+                logger.warning("Unknown toolset '%s' in enabled_toolsets — skipping.", toolset_name)
+                if not quiet_mode:
+                    print(f"⚠️  Unknown toolset: {toolset_name}")
     else:
         # Default: start with everything
         from toolsets import get_all_toolsets

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -357,3 +357,108 @@ class TestCoerceNumberInfNan:
         assert _coerce_number("42") == 42
         assert _coerce_number("3.14") == 3.14
         assert _coerce_number("1e3") == 1000
+
+
+# =========================================================================
+# get_tool_definitions — empty-toolset warnings (#35703)
+# =========================================================================
+
+class TestEmptyToolsetWarnings:
+    """Verify that logger.warning fires regardless of quiet_mode when an
+    explicitly-listed toolset resolves to zero tools or is unknown.
+
+    Regression guard for issue #35703: with platform_toolsets.api_server set
+    to MCP server names (e.g. [matzip, vault]), the failure was completely
+    silent in gateway quiet_mode=True — the agent received no tools AND lost
+    tool-use enforcement guidance with no visible log entry.
+    """
+
+    def test_unknown_toolset_warns_in_quiet_mode(self, caplog):
+        """Unknown toolset name emits logger.warning even with quiet_mode=True."""
+        import logging
+        from model_tools import _compute_tool_definitions
+        from unittest.mock import patch
+
+        with (
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+            patch("model_tools.validate_toolset", return_value=False),
+            patch("model_tools._LEGACY_TOOLSET_MAP", {}),
+        ):
+            _compute_tool_definitions(
+                enabled_toolsets=["totally_nonexistent_mcp_srv"],
+                quiet_mode=True,
+            )
+
+        assert any(
+            "totally_nonexistent_mcp_srv" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        ), f"Expected a WARNING mentioning the unknown toolset. Records: {caplog.records}"
+
+    def test_valid_toolset_resolving_to_empty_warns_in_quiet_mode(self, caplog):
+        """A toolset that validates but resolves to zero tools emits logger.warning
+        even with quiet_mode=True.  This is the api_server MCP timing scenario:
+        validate_toolset('matzip') returns True (alias registered) but
+        resolve_toolset('matzip') returns [] because the MCP server's tools
+        haven't been registered yet.
+        """
+        import logging
+        from model_tools import _compute_tool_definitions
+        from unittest.mock import patch
+
+        with (
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+            patch("model_tools.validate_toolset", return_value=True),
+            patch("model_tools.resolve_toolset", return_value=[]),
+        ):
+            _compute_tool_definitions(
+                enabled_toolsets=["matzip"],
+                quiet_mode=True,
+            )
+
+        assert any(
+            "matzip" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        ), f"Expected a WARNING mentioning 'matzip'. Records: {caplog.records}"
+
+    def test_unknown_toolset_warns_in_verbose_mode(self, caplog):
+        """Unknown toolset warning fires in verbose mode too (not only quiet)."""
+        import logging
+        from model_tools import _compute_tool_definitions
+        from unittest.mock import patch
+
+        with (
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+            patch("model_tools.validate_toolset", return_value=False),
+            patch("model_tools._LEGACY_TOOLSET_MAP", {}),
+        ):
+            _compute_tool_definitions(
+                enabled_toolsets=["another_unknown_srv"],
+                quiet_mode=False,
+            )
+
+        assert any(
+            "another_unknown_srv" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_valid_populated_toolset_does_not_warn(self, caplog):
+        """No spurious warning when a valid toolset resolves to actual tools."""
+        import logging
+        from model_tools import _compute_tool_definitions
+        from unittest.mock import patch
+
+        with (
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+            patch("model_tools.validate_toolset", return_value=True),
+            patch("model_tools.resolve_toolset", return_value=["mcp_srv_tool_a"]),
+            patch("model_tools.registry.get_definitions", return_value=[]),
+        ):
+            _compute_tool_definitions(
+                enabled_toolsets=["my_mcp_srv"],
+                quiet_mode=True,
+            )
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("my_mcp_srv" in m for m in warning_msgs), (
+            f"Unexpected warning for a populated toolset. Warnings: {warning_msgs}"
+        )


### PR DESCRIPTION
## What changed and why

When `platform_toolsets.api_server` (or any platform) is explicitly set to MCP server names like `[matzip, vault]`, and those names haven't been registered in the tool registry yet — due to an MCP timing issue or an out-of-process build — the failure was completely silent in `quiet_mode=True` (the gateway default).

The agent received no tools AND silently lost `TOOL_USE_ENFORCEMENT_GUIDANCE` (which is gated on `valid_tool_names`), leaving weak models like gpt-4o-mini to narrate instead of calling tools. Per the reporter's controlled A/B repro: `[matzip, vault]` → ~1130 tokens (no tools), 0 `tool_turns`; *(unset)* → 15143 tokens, 2 `tool_turns`, correct answer.

The fix adds `logger.warning` calls in `_compute_tool_definitions` that fire **regardless of `quiet_mode`** when:
- A toolset name passes `validate_toolset()` but `resolve_toolset()` returns `[]` (MCP server name listed before server tools are registered)
- A toolset name is entirely unknown (not in `TOOLSETS`, registry, or legacy map)

Both warnings include the toolset name so operators can identify the culprit entry in `platform_toolsets` and know to check the MCP startup log (`MCP: registered N tool(s) from M server(s)`).

Addresses the reporter's explicit request:
> A one-line warning when an explicit toolset entry resolves an MCP server name to zero tools would have surfaced this immediately.

## How to test

1. Configure `platform_toolsets.api_server: [matzip, vault]` in `config.yaml` with `mcp_servers` defined.
2. Start the gateway (MCP servers running) and send a query that should use an MCP tool via `POST /v1/chat/completions`.
3. Check gateway logs — if MCP registration hasn't completed, a WARNING line like `Toolset 'matzip' is configured but resolved to zero tools ...` should appear.
4. Run the new tests: `pytest tests/test_model_tools.py::TestEmptyToolsetWarnings -v`

## What platforms tested on

- macOS (Darwin 24.6.0, Python 3.11) — full test suite passes

Fixes #35703

<!-- autocontrib:worker-id=issue-followup-a40d4ab9 kind=pr-open -->