### PR TITLE
fix(agent): route compression count warning through _emit_status for TUI delivery

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -569,11 +569,12 @@ def compress_context(
     # Warn on repeated compressions (quality degrades with each pass)
     _cc = agent.context_compressor.compression_count
     if _cc >= 2:
-        agent._vprint(
+        msg = (
             f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-            f"accuracy may degrade. Consider /new to start fresh.",
-            force=True,
+            f"accuracy may degrade. Consider /new to start fresh."
         )
+        agent._compression_warning = msg
+        agent._emit_status(msg)
 
     # Keep the post-compression rough estimate for diagnostics, but do not
     # treat it as provider-reported prompt usage. Schema-heavy rough estimates

--- a/tests/agent/test_compression_count_warning.py
+++ b/tests/agent/test_compression_count_warning.py
@@ -1,0 +1,81 @@
+"""Regression: compression count warning must use _emit_status, not _vprint.
+
+Issue #36908: In TUI mode, ``_vprint`` writes to stdout which the Ink UI
+does not consume — the warning is silently swallowed.  The fix routes the
+warning through ``agent._compression_warning`` + ``agent._emit_status()``
+so it reaches all platforms (CLI, TUI, Telegram, Discord, etc.).
+
+This test verifies the invariant at the code level: the warning path in
+``compress_context`` must call ``_emit_status`` (not ``_vprint``).
+"""
+
+import ast
+import textwrap
+from pathlib import Path
+
+
+def test_warning_uses_emit_status_not_vprint():
+    """The compression-count warning block must use _emit_status, not _vprint.
+
+    This is a source-level invariant check: parse the function and verify
+    that the ``if _cc >= 2:`` block calls ``_emit_status`` and does NOT
+    call ``_vprint``.
+    """
+    source = Path(__file__).resolve().parents[2] / "agent" / "conversation_compression.py"
+    tree = ast.parse(source.read_text())
+
+    # Find the compress_context function
+    compress_fn = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "compress_context":
+            compress_fn = node
+            break
+    assert compress_fn is not None, "compress_context function not found"
+
+    # Find the ``if _cc >= 2:`` block
+    warning_block = None
+    for node in ast.walk(compress_fn):
+        if isinstance(node, ast.If):
+            # Check for ``_cc >= 2``
+            test = node.test
+            if (isinstance(test, ast.Compare)
+                    and isinstance(test.left, ast.Name)
+                    and test.left.id == "_cc"
+                    and len(test.ops) == 1
+                    and isinstance(test.ops[0], ast.GtE)
+                    and len(test.comparators) == 1
+                    and isinstance(test.comparators[0], ast.Constant)
+                    and test.comparators[0].value == 2):
+                warning_block = node
+                break
+    assert warning_block is not None, "if _cc >= 2 block not found"
+
+    # Collect all attribute calls in the warning block
+    calls = []
+    for node in ast.walk(warning_block):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                calls.append(node.func.attr)
+            elif isinstance(node.func, ast.Name):
+                calls.append(node.func.id)
+
+    # Must call _emit_status
+    assert "_emit_status" in calls, (
+        f"_emit_status not called in warning block. Found: {calls}"
+    )
+
+    # Must NOT call _vprint
+    assert "_vprint" not in calls, (
+        f"_vprint still called in warning block (should use _emit_status). Found: {calls}"
+    )
+
+
+def test_warning_stored_for_gateway_replay():
+    """The warning must be stored in agent._compression_warning for gateway replay."""
+    source = Path(__file__).resolve().parents[2] / "agent" / "conversation_compression.py"
+    content = source.read_text()
+
+    # The warning block must assign to _compression_warning
+    assert "agent._compression_warning = msg" in content or \
+           "agent._compression_warning=" in content, \
+        "_compression_warning assignment not found in conversation_compression.py"


### PR DESCRIPTION
## What does this PR do?

Routes the compression count warning (shown when a session is compressed 2+ times) through `agent._emit_status()` instead of `agent._vprint()`, fixing silent swallowing in TUI mode. Also stores the warning in `agent._compression_warning` for gateway replay.

## Related Issue

Fixes #36908

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: Replace `agent._vprint(force=True)` with `agent._compression_warning = msg` + `agent._emit_status(msg)` in the `if _cc >= 2` block, matching the pattern already used by the compression feasibility warning (lines 117-118, 231-232).
- `tests/agent/test_compression_count_warning.py`: Add regression tests verifying (1) the warning block uses `_emit_status` and not `_vprint`, and (2) the warning is stored in `_compression_warning` for gateway replay.

## How to Test

1. Run `pytest tests/agent/test_compression_count_warning.py -xvs` — both tests should pass
2. Run `pytest tests/agent/test_context_compressor.py -xvs` — all 91 existing tests should still pass
3. Run `pytest tests/run_agent/test_compression_feasibility.py -xvs` — all 16 feasibility tests should still pass
4. Verify the fix in TUI mode: `hermes --tui`, compress a session twice, confirm the "accuracy may degrade" warning appears in the TUI interface

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/conversation_compression.py:compress_context` — the `_cc >= 2` warning block
- Blast radius: LOW — single function, isolated warning path
- Related patterns: Same `_compression_warning + _emit_status` pattern used at lines 117-118 and 231-232 in the same file for compression feasibility warnings
