### PR TITLE
fix(gateway/signal): surface per-recipient send rejections

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -987,6 +987,23 @@ class SignalAdapter(BasePlatformAdapter):
         result = await self._rpc("send", params)
 
         if result is not None:
+            # Inspect the per-recipient delivery status. signal-cli returns
+            # `result = {"results": [{"recipientAddress": {...}, "type": "SUCCESS"}], ...}`
+            # on a successful transport send, but Signal itself can still reject
+            # the recipient (UNREGISTERED_FAILURE, RATE_LIMITED, etc.) — those
+            # only surface inside `results[*].type`, not as an RPC-level error.
+            # Without this check, a UNREGISTERED_FAILURE returns a non-None
+            # `result` and the live-adapter path silently reports success.
+            per_recipient = result.get("results") if isinstance(result, dict) else None
+            if isinstance(per_recipient, list) and per_recipient:
+                non_success = [
+                    r.get("type") for r in per_recipient
+                    if isinstance(r, dict) and r.get("type") and r.get("type") != "SUCCESS"
+                ]
+                if non_success:
+                    err = f"Signal rejected send: {','.join(non_success)}"
+                    logger.warning("Signal send to %s failed: %s", chat_id, err)
+                    return SendResult(success=False, error=err)
             self._track_sent_timestamp(result)
             # Signal has no editable message identifier. Returning None keeps the
             # stream consumer on the non-edit fallback path instead of pretending

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -568,6 +568,153 @@ class TestSignalRecipientResolution:
         assert captured[0]["params"]["recipient"] == ["68680952-6d86-45bc-85e0-1a4d186d53ee"]
 
 
+
+
+# ---------------------------------------------------------------------------
+# send() per-recipient type inspection
+#
+# Regression: signal-cli's `send` RPC returns a non-None envelope on a
+# successful transport send even when Signal itself rejects the recipient
+# (UNREGISTERED_FAILURE, RATE_LIMITED, etc.). Those errors only surface
+# inside `result["results"][*].type`, not at the RPC envelope level. The
+# adapter previously only checked `if result is not None` and silently
+# reported success in that case, so the cron scheduler's live-adapter
+# path logged "delivered" for messages that were never sent.
+# ---------------------------------------------------------------------------
+
+class TestSignalSendPerRecipientType:
+    """send() must inspect result.results[].type and surface rejections."""
+
+    @pytest.mark.asyncio
+    async def test_send_returns_success_when_all_recipients_success(self, monkeypatch):
+        """The happy path: signal-cli returns SUCCESS for the recipient."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+        adapter._remember_recipient_identifiers("+155****0000", "68680952-6d86-45bc-85e0-1a4d186d53ee")
+
+        success_envelope = {
+            "results": [
+                {
+                    "recipientAddress": {
+                        "uuid": "68680952-6d86-45bc-85e0-1a4d186d53ee",
+                        "number": "+155****0000",
+                        "username": None,
+                    },
+                    "type": "SUCCESS",
+                }
+            ],
+            "timestamp": 1780328867122,
+        }
+
+        async def mock_rpc(method, params, rpc_id=None, **kwargs):
+            return success_envelope
+
+        adapter._rpc = mock_rpc
+
+        result = await adapter.send(chat_id="+155****0000", content="hello")
+
+        assert result.success is True
+        assert result.message_id is None
+
+    @pytest.mark.asyncio
+    async def test_send_returns_failure_on_unregistered_failure(self, monkeypatch):
+        """UNREGISTERED_FAILURE inside results[].type must be surfaced as failure.
+
+        The RPC transport itself succeeds (non-None envelope returned), but
+        Signal rejected the recipient. The adapter must NOT report success in
+        that case — doing so caused the cron scheduler to silently drop
+        quit-smoking check-ins for both Samuel and Tyler.
+        """
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+        adapter._remember_recipient_identifiers("+155****0000", "68680952-6d86-45bc-85e0-1a4d186d53ee")
+
+        unregistered_envelope = {
+            "results": [
+                {
+                    "recipientAddress": {
+                        "uuid": None,
+                        "number": "+155****0000",
+                        "username": None,
+                    },
+                    "type": "UNREGISTERED_FAILURE",
+                }
+            ],
+            "timestamp": 1780146077705,
+        }
+
+        async def mock_rpc(method, params, rpc_id=None, **kwargs):
+            return unregistered_envelope
+
+        adapter._rpc = mock_rpc
+
+        result = await adapter.send(chat_id="+155****0000", content="hello")
+
+        assert result.success is False
+        assert "UNREGISTERED_FAILURE" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_send_returns_failure_when_any_recipient_rejected(self, monkeypatch):
+        """Multi-recipient sends: one rejection among many must fail the whole send."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+        adapter._remember_recipient_identifiers("+155****0000", "68680952-6d86-45bc-85e0-1a4d186d53ee")
+
+        mixed_envelope = {
+            "results": [
+                {
+                    "recipientAddress": {
+                        "uuid": "68680952-6d86-45bc-85e0-1a4d186d53ee",
+                        "number": "+155****0000",
+                        "username": None,
+                    },
+                    "type": "SUCCESS",
+                },
+                {
+                    "recipientAddress": {
+                        "uuid": None,
+                        "number": "+155****9999",
+                        "username": None,
+                    },
+                    "type": "RATE_LIMITED",
+                },
+            ],
+            "timestamp": 1780329000000,
+        }
+
+        async def mock_rpc(method, params, rpc_id=None, **kwargs):
+            return mixed_envelope
+
+        adapter._rpc = mock_rpc
+
+        result = await adapter.send(chat_id="+155****0000", content="hello")
+
+        assert result.success is False
+        assert "RATE_LIMITED" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_send_tolerates_legacy_envelope_without_results_key(self, monkeypatch):
+        """Old signal-cli versions and some test mocks return only a timestamp.
+
+        The adapter should still report success in that case so existing
+        tests and older daemons don't regress. The new type inspection
+        kicks in only when `results` is a non-empty list.
+        """
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+        adapter._remember_recipient_identifiers("+155****0000", "68680952-6d86-45bc-85e0-1a4d186d53ee")
+
+        legacy_envelope = {"timestamp": 1234567890}
+
+        async def mock_rpc(method, params, rpc_id=None, **kwargs):
+            return legacy_envelope
+
+        adapter._rpc = mock_rpc
+
+        result = await adapter.send(chat_id="+155****0000", content="hello")
+
+        assert result.success is True
+
 # ---------------------------------------------------------------------------
 # send_voice method (#5105)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`SignalAdapter.send()` previously only checked `if result is not None` to decide whether a send succeeded. signal-cli returns a non-None response envelope even when Signal itself rejects the recipient (`UNREGISTERED_FAILURE`, `RATE_LIMITED`, etc.) — those errors only surface inside `result["results"][*].type`, not at the RPC envelope level.

The cron scheduler's live-adapter path therefore reported `SUCCESS` for messages that were never actually sent, silently dropping quit-smoking check-ins (and anything else routed through the live-adapter path) for both recipients.

## Fix

After a non-None RPC response, inspect each entry in `result["results"]` and return `SendResult(success=False, error="Signal rejected send: <type>")` if any per-recipient type is not `"SUCCESS"`. The scheduler then falls back to the standalone delivery path, which already checks the same field and logs correctly.

Tolerates legacy envelopes (no `results` key) for backward compatibility with older signal-cli versions.

## Tests

Added `TestSignalSendPerRecipientType` covering:
- happy path (`SUCCESS` → success)
- `UNREGISTERED_FAILURE` → failure
- any recipient rejected → failure
- legacy envelope (no `results` key) → tolerated

## Reproduction

Before this patch, with two Signal recipients configured via the cron `deliver` field, the log shows:

```
INFO cron.scheduler: Job '372cfed88d78': delivered to signal:<UUID> via live adapter
INFO cron.scheduler: Job '372cfed88d78': delivered to signal:<UUID> via live adapter
```

but `errors.log` (when the live-adapter path is bypassed) shows:

```
WARNING gateway.platforms.signal: Signal RPC error (send): ... UNREGISTERED_FAILURE
ERROR cron.scheduler: delivery error: Signal RPC error on batch 1/1
```

After this patch, the second pattern is the canonical output and the cron scheduler's reported status matches reality.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)