### PR TITLE
fix(agent): tolerate legacy tool dispatcher kwargs

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -23,6 +23,7 @@ Methods covered:
 from __future__ import annotations
 
 import copy
+import inspect
 import json
 import logging
 import re
@@ -71,6 +72,22 @@ def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
         return True
     memory_manager = getattr(agent, "_memory_manager", None)
     return bool(memory_manager and memory_manager.has_tool(function_name))
+
+
+def _handle_function_call_accepts_kwarg(handle_function_call, name: str) -> bool:
+    """Return whether a loaded handle_function_call accepts ``name``.
+
+    Live installs can temporarily contain a newer runtime helper with an older
+    model_tools dispatcher during source sync. In that state blindly passing
+    newly-added keyword arguments breaks every registry tool call.
+    """
+    try:
+        params = inspect.signature(handle_function_call).parameters
+    except (TypeError, ValueError):
+        return True
+    if name in params:
+        return True
+    return any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
 
 
 def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
@@ -2684,26 +2701,49 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
     else:
         def _execute(next_args: dict) -> Any:
+            handle_function_call = _ra().handle_function_call
             dispatch_kwargs = dict(
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
-                turn_id=getattr(agent, "_current_turn_id", "") or "",
-                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
                 skip_pre_tool_call_hook=True,
-                skip_tool_request_middleware=True,
-                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                tool_request_middleware_trace=list(_tool_middleware_trace),
             )
+            optional_kwargs = {
+                "turn_id": getattr(agent, "_current_turn_id", "") or "",
+                "api_request_id": getattr(agent, "_current_api_request_id", "") or "",
+                "skip_tool_request_middleware": True,
+                "tool_request_middleware_trace": list(_tool_middleware_trace),
+                "enabled_toolsets": getattr(agent, "enabled_toolsets", None),
+                "disabled_toolsets": getattr(agent, "disabled_toolsets", None),
+            }
             if skip_tool_execution_middleware:
-                dispatch_kwargs["skip_tool_execution_middleware"] = True
-            return _ra().handle_function_call(
-                function_name,
-                next_args,
-                effective_task_id,
-                **dispatch_kwargs,
-            )
+                optional_kwargs["skip_tool_execution_middleware"] = True
+            for key, value in optional_kwargs.items():
+                if _handle_function_call_accepts_kwarg(handle_function_call, key):
+                    dispatch_kwargs[key] = value
+            try:
+                return handle_function_call(
+                    function_name,
+                    next_args,
+                    effective_task_id,
+                    **dispatch_kwargs,
+                )
+            except TypeError as exc:
+                message = str(exc)
+                unsupported = [
+                    key for key in ("enabled_toolsets", "disabled_toolsets")
+                    if key in dispatch_kwargs and f"unexpected keyword argument '{key}'" in message
+                ]
+                if not unsupported:
+                    raise
+                for key in ("enabled_toolsets", "disabled_toolsets"):
+                    dispatch_kwargs.pop(key, None)
+                return handle_function_call(
+                    function_name,
+                    next_args,
+                    effective_task_id,
+                    **dispatch_kwargs,
+                )
 
     if skip_tool_execution_middleware:
         return _execute(function_args)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3155,6 +3155,67 @@ class TestConcurrentToolExecution:
             )
             assert result == "result"
 
+    def test_invoke_tool_supports_legacy_handle_function_call(self, agent, monkeypatch):
+        """Mixed live installs can have old handle_function_call signatures."""
+        calls = []
+
+        def legacy_handle_function_call(
+            function_name,
+            function_args,
+            task_id=None,
+            *,
+            tool_call_id=None,
+            session_id=None,
+            enabled_tools=None,
+            skip_pre_tool_call_hook=False,
+        ):
+            calls.append({
+                "function_name": function_name,
+                "function_args": function_args,
+                "task_id": task_id,
+                "tool_call_id": tool_call_id,
+                "session_id": session_id,
+                "enabled_tools": enabled_tools,
+                "skip_pre_tool_call_hook": skip_pre_tool_call_hook,
+            })
+            return "legacy-result"
+
+        monkeypatch.setattr(run_agent, "handle_function_call", legacy_handle_function_call)
+
+        result = agent._invoke_tool("web_search", {"q": "test"}, "task-1")
+
+        assert result == "legacy-result"
+        assert calls == [{
+            "function_name": "web_search",
+            "function_args": {"q": "test"},
+            "task_id": "task-1",
+            "tool_call_id": None,
+            "session_id": agent.session_id,
+            "enabled_tools": list(agent.valid_tool_names),
+            "skip_pre_tool_call_hook": True,
+        }]
+
+    def test_invoke_tool_retries_when_toolset_kwargs_rejected(self, agent, monkeypatch):
+        """Retry without toolset kwargs if a dynamic dispatcher rejects them."""
+        calls = []
+
+        def rejecting_handle_function_call(function_name, function_args, task_id=None, **kwargs):
+            calls.append(dict(kwargs))
+            if "enabled_toolsets" in kwargs:
+                raise TypeError("handle_function_call() got an unexpected keyword argument 'enabled_toolsets'")
+            return "retry-result"
+
+        monkeypatch.setattr(run_agent, "handle_function_call", rejecting_handle_function_call)
+
+        result = agent._invoke_tool("web_search", {"q": "test"}, "task-1")
+
+        assert result == "retry-result"
+        assert len(calls) == 2
+        assert "enabled_toolsets" in calls[0]
+        assert "disabled_toolsets" in calls[0]
+        assert "enabled_toolsets" not in calls[1]
+        assert "disabled_toolsets" not in calls[1]
+
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])


### PR DESCRIPTION
## What

Make agent_runtime_helpers.invoke_tool compatible with mixed live installs where the loaded model_tools.handle_function_call is older than the helper. The helper now checks whether the dispatcher accepts enabled_toolsets and disabled_toolsets before passing them, and retries once without those new kwargs if a dynamic dispatcher rejects them.

## Why

A live dflash worker on taro hit this traceback:

TypeError: handle_function_call() got an unexpected keyword argument enabled_toolsets

That happened after a partial install/sync left agent_runtime_helpers.py newer than model_tools.py. The result is severe: ordinary registry tools can fail before the agent can make progress.

## Verification

- python3 -m pytest tests/run_agent/test_run_agent.py -k invoke_tool passed: 6 passed.
- python3 -m py_compile agent/agent_runtime_helpers.py run_agent.py tests/run_agent/test_run_agent.py completed with rc=0.
- git diff --check upstream/main...HEAD completed with rc=0.

## Notes

This PR is based directly on upstream/main and contains one commit touching only agent/agent_runtime_helpers.py and tests/run_agent/test_run_agent.py. It preserves toolset scoping for fully updated installs.