### PR TITLE
fix(desktop): import WSL Hermes state on Windows

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -43,6 +43,7 @@ const {
   resolveTestWsUrl,
   tokenPreview
 } = require('./connection-config.cjs')
+const { importWslHermesHomeIfNeeded } = require('./wsl-hermes-home.cjs')
 const {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
@@ -182,10 +183,16 @@ if (INSTALL_STAMP) {
 //   Windows: %LOCALAPPDATA%\hermes (matches install.ps1)
 //   macOS / Linux: ~/.hermes (matches install.sh)
 //
-// Special case for Windows: if the user has a legacy ~/.hermes directory
-// (e.g., from a prior pip install or a manual setup) AND no
-// %LOCALAPPDATA%\hermes yet, prefer the legacy path so we don't orphan their
-// existing config / sessions / .env. New installs go to %LOCALAPPDATA%.
+// Special cases for Windows:
+//   1. If the user has a legacy native ~/.hermes directory (e.g., from a prior
+//      pip install or a manual setup) AND no %LOCALAPPDATA%\hermes yet, prefer
+//      the legacy path so we don't orphan their existing config / sessions /
+//      .env.
+//   2. If there is no native Hermes home at all, try a one-time import from a
+//      WSL Hermes home before first bootstrap. The import copies user state
+//      only, not OS-specific runtime directories like hermes-agent/, venv/,
+//      node/, git/, logs/, or bootstrap caches.
+// New native installs still run from %LOCALAPPDATA%.
 //
 // HERMES_DESKTOP_USER_DATA_DIR (used by test:desktop:fresh) puts the sandbox
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
@@ -199,6 +206,14 @@ function resolveHermesHome() {
     // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
     // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
     if (!directoryExists(localappdata) && directoryExists(legacy)) return legacy
+    if (!directoryExists(localappdata)) {
+      importWslHermesHomeIfNeeded({
+        destination: localappdata,
+        env: process.env,
+        logger: message => console.log(`[hermes] ${message}`),
+        windowsHome: app.getPath('home')
+      })
+    }
     return localappdata
   }
   return path.join(app.getPath('home'), '.hermes')

--- a/apps/desktop/electron/wsl-hermes-home.cjs
+++ b/apps/desktop/electron/wsl-hermes-home.cjs
@@ -1,0 +1,186 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const DEFAULT_WSL_ROOTS = ['\\\\wsl.localhost', '\\\\wsl$']
+const COMMON_WSL_DISTROS = ['Ubuntu', 'Ubuntu-24.04', 'Ubuntu-22.04', 'Debian']
+const HERMES_HOME_MARKERS = [
+  '.env',
+  'auth.json',
+  'config.yaml',
+  'config.yml',
+  'cron',
+  'memories',
+  'plugins',
+  'profiles',
+  'sessions',
+  'skills'
+]
+const MIGRATION_EXCLUDE_NAMES = new Set([
+  '.venv',
+  '__pycache__',
+  'bootstrap-cache',
+  'git',
+  'hermes-agent',
+  'logs',
+  'node',
+  'tmp',
+  'venv'
+])
+
+function directoryExists(dirPath, fsImpl = fs) {
+  try {
+    return fsImpl.statSync(dirPath).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function readDirectoryNames(dirPath, fsImpl = fs) {
+  try {
+    return fsImpl
+      .readdirSync(dirPath, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name)
+  } catch {
+    return []
+  }
+}
+
+function unique(items) {
+  return Array.from(new Set(items.filter(Boolean)))
+}
+
+function windowsUsernameFromHome(windowsHome, pathImpl = path) {
+  return pathImpl.basename(String(windowsHome || '').replace(/[\\/]+$/, ''))
+}
+
+function candidateWslHermesHomes(options = {}) {
+  const {
+    env = process.env,
+    fsImpl = fs,
+    pathImpl = path,
+    windowsHome = '',
+    wslRoots = DEFAULT_WSL_ROOTS
+  } = options
+  const username = String(env.USERNAME || env.USER || windowsUsernameFromHome(windowsHome, pathImpl) || '').trim()
+  const candidates = []
+
+  for (const root of wslRoots) {
+    const distros = unique([...COMMON_WSL_DISTROS, ...readDirectoryNames(root, fsImpl)])
+
+    for (const distro of distros) {
+      const homeRoot = pathImpl.join(root, distro, 'home')
+      const users = username ? unique([username, ...readDirectoryNames(homeRoot, fsImpl)]) : readDirectoryNames(homeRoot, fsImpl)
+
+      for (const user of users) {
+        candidates.push(pathImpl.join(homeRoot, user, '.hermes'))
+      }
+    }
+  }
+
+  return unique(candidates)
+}
+
+function isHermesHomeCandidate(candidate, fsImpl = fs, pathImpl = path) {
+  if (!directoryExists(candidate, fsImpl)) return false
+  return HERMES_HOME_MARKERS.some(marker => {
+    try {
+      fsImpl.statSync(pathImpl.join(candidate, marker))
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
+function shouldCopyHermesHomeEntry(entryName) {
+  return !MIGRATION_EXCLUDE_NAMES.has(String(entryName || '').toLowerCase())
+}
+
+function copyHermesHomeState(source, destination, options = {}) {
+  const { fsImpl = fs, pathImpl = path } = options
+
+  if (!isHermesHomeCandidate(source, fsImpl, pathImpl)) {
+    return { copied: false, reason: 'source-not-hermes-home', source, destination }
+  }
+  if (directoryExists(destination, fsImpl)) {
+    return { copied: false, reason: 'destination-exists', source, destination }
+  }
+
+  const entries = fsImpl.readdirSync(source, { withFileTypes: true }).filter(entry => shouldCopyHermesHomeEntry(entry.name))
+
+  if (entries.length === 0) {
+    return { copied: false, reason: 'no-migratable-entries', source, destination }
+  }
+
+  fsImpl.mkdirSync(destination, { recursive: true })
+  try {
+    for (const entry of entries) {
+      fsImpl.cpSync(pathImpl.join(source, entry.name), pathImpl.join(destination, entry.name), {
+        errorOnExist: false,
+        force: false,
+        recursive: true
+      })
+    }
+  } catch (error) {
+    try {
+      fsImpl.rmSync(destination, { force: true, recursive: true })
+    } catch {
+      // Best effort: leave the original copy error as the actionable failure.
+    }
+    throw error
+  }
+
+  return {
+    copied: true,
+    copiedEntries: entries.map(entry => entry.name),
+    destination,
+    source
+  }
+}
+
+function importWslHermesHomeIfNeeded(options = {}) {
+  const { destination, fsImpl = fs, logger = null, pathImpl = path } = options
+
+  if (!destination) {
+    return { imported: false, reason: 'missing-destination' }
+  }
+  if (directoryExists(destination, fsImpl)) {
+    return { imported: false, reason: 'destination-exists', destination }
+  }
+
+  let lastError = null
+  for (const source of candidateWslHermesHomes(options)) {
+    if (!isHermesHomeCandidate(source, fsImpl, pathImpl)) continue
+
+    try {
+      const result = copyHermesHomeState(source, destination, options)
+      if (result.copied) {
+        logger?.(`Imported WSL Hermes state from ${source} into ${destination}`)
+        return { ...result, imported: true }
+      }
+    } catch (error) {
+      lastError = error
+      logger?.(`Failed to import WSL Hermes state from ${source}: ${error.message}`)
+    }
+  }
+
+  return {
+    destination,
+    error: lastError ? String(lastError.message || lastError) : null,
+    imported: false,
+    reason: lastError ? 'copy-failed' : 'no-source'
+  }
+}
+
+module.exports = {
+  COMMON_WSL_DISTROS,
+  DEFAULT_WSL_ROOTS,
+  MIGRATION_EXCLUDE_NAMES,
+  candidateWslHermesHomes,
+  copyHermesHomeState,
+  importWslHermesHomeIfNeeded,
+  isHermesHomeCandidate,
+  shouldCopyHermesHomeEntry,
+  windowsUsernameFromHome
+}

--- a/apps/desktop/electron/wsl-hermes-home.test.cjs
+++ b/apps/desktop/electron/wsl-hermes-home.test.cjs
@@ -1,0 +1,132 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  candidateWslHermesHomes,
+  copyHermesHomeState,
+  importWslHermesHomeIfNeeded,
+  isHermesHomeCandidate,
+  shouldCopyHermesHomeEntry,
+  windowsUsernameFromHome
+} = require('./wsl-hermes-home.cjs')
+
+function makeTempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-wsl-home-'))
+}
+
+function writeFile(filePath, content = '') {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content, 'utf8')
+}
+
+test('windowsUsernameFromHome falls back to basename of Windows home', () => {
+  assert.equal(windowsUsernameFromHome(path.join('C:', 'Users', 'Ada')), 'Ada')
+  assert.equal(windowsUsernameFromHome(''), '')
+})
+
+test('candidateWslHermesHomes checks common and discovered WSL distros', () => {
+  const root = makeTempRoot()
+  try {
+    fs.mkdirSync(path.join(root, 'Fedora', 'home', 'ada'), { recursive: true })
+
+    const candidates = candidateWslHermesHomes({
+      env: { USERNAME: 'ada' },
+      wslRoots: [root]
+    })
+
+    assert.ok(candidates.includes(path.join(root, 'Ubuntu', 'home', 'ada', '.hermes')))
+    assert.ok(candidates.includes(path.join(root, 'Fedora', 'home', 'ada', '.hermes')))
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('isHermesHomeCandidate requires a real Hermes marker', () => {
+  const root = makeTempRoot()
+  try {
+    const empty = path.join(root, 'empty')
+    const hermes = path.join(root, 'hermes')
+    fs.mkdirSync(empty)
+    fs.mkdirSync(hermes)
+    writeFile(path.join(hermes, 'config.yaml'), 'model: test\n')
+
+    assert.equal(isHermesHomeCandidate(empty), false)
+    assert.equal(isHermesHomeCandidate(hermes), true)
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('copyHermesHomeState copies user state but skips runtime directories', () => {
+  const root = makeTempRoot()
+  try {
+    const source = path.join(root, 'wsl', 'Ubuntu', 'home', 'ada', '.hermes')
+    const destination = path.join(root, 'LocalAppData', 'hermes')
+    writeFile(path.join(source, 'config.yaml'), 'model: test\n')
+    writeFile(path.join(source, '.env'), 'HERMES_API_KEY=test\n')
+    writeFile(path.join(source, 'skills', 'demo', 'SKILL.md'), '# demo\n')
+    writeFile(path.join(source, 'hermes-agent', 'venv', 'pyvenv.cfg'), 'runtime\n')
+    writeFile(path.join(source, 'logs', 'desktop.log'), 'noise\n')
+
+    const result = copyHermesHomeState(source, destination)
+
+    assert.equal(result.copied, true)
+    assert.deepEqual(new Set(result.copiedEntries), new Set(['.env', 'config.yaml', 'skills']))
+    assert.equal(fs.existsSync(path.join(destination, 'config.yaml')), true)
+    assert.equal(fs.existsSync(path.join(destination, 'skills', 'demo', 'SKILL.md')), true)
+    assert.equal(fs.existsSync(path.join(destination, 'hermes-agent')), false)
+    assert.equal(fs.existsSync(path.join(destination, 'logs')), false)
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('importWslHermesHomeIfNeeded does not overwrite an existing native Hermes home', () => {
+  const root = makeTempRoot()
+  try {
+    const destination = path.join(root, 'LocalAppData', 'hermes')
+    fs.mkdirSync(destination, { recursive: true })
+
+    const result = importWslHermesHomeIfNeeded({
+      destination,
+      env: { USERNAME: 'ada' },
+      wslRoots: [root]
+    })
+
+    assert.equal(result.imported, false)
+    assert.equal(result.reason, 'destination-exists')
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('importWslHermesHomeIfNeeded imports first valid WSL Hermes home', () => {
+  const root = makeTempRoot()
+  try {
+    const source = path.join(root, 'Ubuntu', 'home', 'ada', '.hermes')
+    const destination = path.join(root, 'LocalAppData', 'hermes')
+    writeFile(path.join(source, 'auth.json'), '{"ok": true}\n')
+
+    const result = importWslHermesHomeIfNeeded({
+      destination,
+      env: { USERNAME: 'ada' },
+      wslRoots: [root]
+    })
+
+    assert.equal(result.imported, true)
+    assert.equal(result.source, source)
+    assert.equal(fs.existsSync(path.join(destination, 'auth.json')), true)
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('shouldCopyHermesHomeEntry excludes OS-specific runtime state', () => {
+  assert.equal(shouldCopyHermesHomeEntry('hermes-agent'), false)
+  assert.equal(shouldCopyHermesHomeEntry('venv'), false)
+  assert.equal(shouldCopyHermesHomeEntry('logs'), false)
+  assert.equal(shouldCopyHermesHomeEntry('config.yaml'), true)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/wsl-hermes-home.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

- add a desktop helper that discovers WSL Hermes homes under the standard WSL UNC roots
- import user state into %LOCALAPPDATA%\hermes on first native Windows launch only when no native Hermes home exists
- skip runtime-specific directories such as hermes-agent, venv, node, git, logs, and bootstrap caches, with focused Node tests

Fixes #36546

## Verification

- npm run test:desktop:platforms
- node --check electron/main.cjs && node --check electron/wsl-hermes-home.cjs && node --check electron/wsl-hermes-home.test.cjs
- npx eslint electron/wsl-hermes-home.cjs electron/wsl-hermes-home.test.cjs
- git diff --check

## Notes

- npm run lint currently fails on existing unrelated desktop lint debt across electron/backend-probes.test.cjs, electron/bootstrap-runner.cjs, electron/main.cjs, and multiple src files; this PR keeps that cleanup out of scope.