### PR TITLE
fix(auxiliary): improve "no auxiliary LLM provider" warning messages (#10149)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1410,9 +1410,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # No provider configured — long cooldown, unlikely to self-resolve
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
             self._last_summary_error = "no auxiliary LLM provider configured"
-            logger.warning("Context compression: no provider available for "
-                            "summary. Middle turns will be dropped without summary "
-                            "for %d seconds.",
+            logger.warning("Context compression: no auxiliary LLM provider configured — "
+                            "summary unavailable. Middle turns will be dropped without "
+                            "summary for %d seconds. Set OPENROUTER_API_KEY or run "
+                            "`hermes setup` to configure one.",
                             _SUMMARY_FAILURE_COOLDOWN_SECONDS)
             return None
         except Exception as e:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -112,13 +112,17 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 msg = (
                     "⚠ No auxiliary LLM provider configured — context "
                     "compression will drop middle turns without a summary. "
-                    "Run `hermes setup` or set OPENROUTER_API_KEY."
+                    "Auxiliary models handle vision, extraction, and "
+                    "compression. Set OPENROUTER_API_KEY in your .env or "
+                    "run `hermes setup` to configure one."
                 )
             agent._compression_warning = msg
             agent._emit_status(msg)
             logger.warning(
-                "No auxiliary LLM provider for compression — "
-                "summaries will be unavailable."
+                "No auxiliary LLM provider configured — "
+                "context compression and vision tasks are "
+                "unavailable. Set OPENROUTER_API_KEY or run "
+                "`hermes setup` to enable these features."
             )
             return
 

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -105,6 +105,7 @@ TIPS = [
     "hermes models routes vision, compression, and aux tasks to cheaper models — cuts background token cost 85%+ without downgrading your main chat model.",
 
     # --- Configuration ---
+    "Auxiliary LLM providers handle vision, compression, and web extraction — set OPENROUTER_API_KEY in your .env or run `hermes setup` to enable these features.",
     "Set display.bell_on_complete: true in config.yaml to hear a bell when long tasks finish.",
     "Set display.streaming: true to see tokens appear in real time as the model generates.",
     "Set display.show_reasoning: true to watch the model's chain-of-thought reasoning.",


### PR DESCRIPTION
## Summary
- Rewords the "No auxiliary LLM provider configured" warning to explain *what* auxiliary models do (vision, extraction, compression) and *how* to fix it (set `OPENROUTER_API_KEY` or run `hermes setup`)
- Updates the log message in `context_compressor.py` to match
- Adds a CLI startup tip about auxiliary providers in `tips.py`

## Related
Closes #10149

## Test plan
- [x] `test_compression_feasibility.py` — 16 passed (assertion `"No auxiliary LLM provider" in messages[0]` still holds)
- [x] `test_context_compressor.py` — 91 passed
- [x] Syntax-validated all 3 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Mike (Claude Code/Banana) <noreply@anthropic.com>