### PR TITLE
feat(agent): add skills.index_mode for category-only skills index

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1070,6 +1070,21 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+
+    # Index mode is read up-front so it participates in the cache key — otherwise
+    # flipping `skills.index_mode` in config would be masked by a cached prompt
+    # built under the previous mode. "full" (default) = every skill listed;
+    # "categories" = category headers only (agent drills in via skills_list).
+    index_mode = "full"
+    try:
+        from hermes_cli.config import load_config
+
+        index_mode = str(
+            (load_config().get("skills", {}) or {}).get("index_mode", "full")
+        ).strip().lower() or "full"
+    except Exception as e:
+        logger.debug("Could not read skills.index_mode from config: %s", e)
+
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1077,6 +1092,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        index_mode,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1213,23 +1229,49 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
+        # index_mode was resolved up-front (see cache_key) so it participates in
+        # caching. "full" lists every skill; "categories" lists headers only and
+        # the agent drills in via skills_list(category=...). Category mode cuts
+        # the always-on skills prompt by ~70% (17.5K → ~5K with 158 skills).
         index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
+        if index_mode == "categories":
+            for category in sorted(skills_by_category.keys()):
+                # Deduplicate skills within the category for an accurate count
+                names = {n for n, _ in skills_by_category[category]}
+                count = len(names)
+                cat_desc = category_descriptions.get(category, "")
+                label = f"{count} skill{'s' if count != 1 else ''}"
+                if cat_desc:
+                    index_lines.append(f"  {category} ({label}): {cat_desc}")
                 else:
-                    index_lines.append(f"    - {name}")
+                    index_lines.append(f"  {category} ({label})")
+        else:
+            for category in sorted(skills_by_category.keys()):
+                cat_desc = category_descriptions.get(category, "")
+                if cat_desc:
+                    index_lines.append(f"  {category}: {cat_desc}")
+                else:
+                    index_lines.append(f"  {category}:")
+                # Deduplicate and sort skills within each category
+                seen = set()
+                for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    if desc:
+                        index_lines.append(f"    - {name}: {desc}")
+                    else:
+                        index_lines.append(f"    - {name}")
+
+        # In category mode, tell the agent how to drill into a category.
+        drilldown = (
+            "This is a CATEGORY index — individual skills are not listed here to "
+            "save context. When a category looks relevant to your task, call "
+            "skills_list(category='<name>') to see its skills, then skill_view(name) "
+            "to load one.\n"
+            if index_mode == "categories"
+            else ""
+        )
 
         result = (
             "## Skills (mandatory)\n"
@@ -1252,7 +1294,8 @@ def build_skills_system_prompt(
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
             "pitfalls you discovered, update it before finishing.\n"
-            "\n"
+            + drilldown
+            + "\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -546,6 +546,14 @@ skills:
   # Set to 0 to disable.
   creation_nudge_interval: 15
 
+  # How the always-on skills index is rendered in the system prompt.
+  #   full       (default) — list every skill under its category. Best
+  #              discoverability; costs the most context (grows with skill count).
+  #   categories — list only category headers with skill counts. The agent
+  #              drills into a category on demand via skills_list(category=...).
+  #              Cuts the skills prompt by ~70% when many skills are installed.
+  # index_mode: full
+
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
   # and resolved to an absolute path.  External dirs are read-only: skill

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -265,6 +265,59 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_default_index_mode_lists_individual_skills(self, monkeypatch, tmp_path):
+        """Default (full) mode lists each skill under its category."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        result = build_skills_system_prompt()
+        assert "- python-debug" in result
+        assert "CATEGORY index" not in result
+
+    def test_categories_index_mode_lists_only_headers(self, monkeypatch, tmp_path):
+        """categories mode lists category headers + counts, not individual skills."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"skills": {"index_mode": "categories"}},
+        )
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        result = build_skills_system_prompt()
+        # Category header with count is present...
+        assert "coding (1 skill)" in result
+        # ...but the individual skill is NOT listed inline.
+        assert "- python-debug" not in result
+        # Drilldown guidance tells the agent how to expand a category.
+        assert "CATEGORY index" in result
+        assert "skills_list(category=" in result
+
+    def test_index_mode_change_invalidates_cache(self, monkeypatch, tmp_path):
+        """Flipping index_mode in config must produce a different prompt (cache key)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        full = build_skills_system_prompt()
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"skills": {"index_mode": "categories"}},
+        )
+        categories = build_skills_system_prompt()
+        assert "- python-debug" in full
+        assert "- python-debug" not in categories
+        assert full != categories
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"


### PR DESCRIPTION
## What & Why

The skills index is injected into the system prompt on **every turn** and grows with the number of installed skills. On an install with ~158 skills it reaches **~17.5K chars**, almost all of it the per-skill listing. That's fixed context overhead paid on every message.

This adds a `skills.index_mode` config option to optionally collapse the index to category headers only:

- **`full`** (default) — current behavior, lists every skill under its category. **Unchanged.**
- **`categories`** — lists category headers + skill counts only; the agent drills into a category on demand via `skills_list(category=...)`.

Category mode cuts the always-on skills prompt by **~70% (17.5K → ~5K with 158 skills)** while preserving discoverability through the existing `skills_list` tool.

The change is **opt-in and fully backwards-compatible** — the default (`full`) produces byte-identical output to before.

## Implementation

- `agent/prompt_builder.py` — read `skills.index_mode` up-front so it participates in the prompt **cache key** (otherwise flipping the mode would be masked by a stale cached prompt), add the `categories` emit branch, and add drilldown guidance telling the agent to use `skills_list(category='<name>')`.
- `tests/agent/test_prompt_builder.py` — 3 new tests: full mode lists individual skills, categories mode lists headers only + drilldown guidance, and changing the mode invalidates the cache.
- `cli-config.yaml.example` — document the new option under the existing `skills:` block.

## How to test

```bash
hermes config set skills.index_mode categories
# start a session — the <available_skills> block now lists category headers + counts
hermes config set skills.index_mode full   # revert to per-skill listing
```

Automated:

```bash
scripts/run_tests.sh tests/agent/test_prompt_builder.py
# => 131 passed (128 existing + 3 new)
```

## Platforms tested

- Linux (Ubuntu, Python 3.11). No OS-specific code paths touched — pure prompt assembly + config read.