### PR TITLE
fix(stepfun): add reasoning_effort support for step-3.7-flash

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1832,6 +1832,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
         summary_extra_body = {}
+        # Top-level api_kwargs the provider profile wants on native (non-transport)
+        # summary calls — e.g. StepFun/Kimi reasoning_effort. Computed once in the
+        # first summary branch and reused by the retry branch below (#36942).
+        _profile_top_level: dict[str, Any] = {}
         try:
             from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP
         except Exception:
@@ -1904,6 +1908,21 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                         base_url=agent.base_url,
                         reasoning_config=agent.reasoning_config,
                     )
+                    # The transport applies build_api_kwargs_extras() — top-level
+                    # kwargs (e.g. StepFun/Kimi reasoning_effort) plus extra_body
+                    # additions. This hand-built summary path bypasses the
+                    # transport, so mirror it here or native StepFun summaries
+                    # drop the top-level field (#36942).
+                    _pe_extra, _pe_top = provider_profile.build_api_kwargs_extras(
+                        reasoning_config=agent.reasoning_config,
+                        supports_reasoning=agent._supports_reasoning_extra_body(),
+                        model=agent.model,
+                        base_url=agent.base_url,
+                        session_id=getattr(agent, "session_id", None),
+                    )
+                    if _pe_extra:
+                        profile_extra_body = {**profile_extra_body, **_pe_extra}
+                    _profile_top_level.update(_pe_top)
             except Exception:
                 pass
 
@@ -1938,6 +1957,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
             if summary_extra_body:
                 summary_kwargs["extra_body"] = summary_extra_body
+            for _pk, _pv in _profile_top_level.items():
+                summary_kwargs.setdefault(_pk, _pv)
 
             if agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
@@ -1991,6 +2012,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
+                for _pk, _pv in _profile_top_level.items():
+                    summary_kwargs.setdefault(_pk, _pv)
 
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
                 _retry_result = agent._get_transport().normalize_response(summary_response)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -336,8 +336,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "stepfun": [
-        "step-3.5-flash",
+        "step-3.7-flash",
         "step-3.5-flash-2603",
+        "step-3.5-flash",
     ],
     "moonshot": [
         "kimi-k2.6",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -101,7 +101,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "zai": ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
-    "stepfun": ["step-3.5-flash", "step-3.5-flash-2603"],
+    "stepfun": ["step-3.7-flash", "step-3.5-flash-2603", "step-3.5-flash"],
     "arcee": ["trinity-large-thinking", "trinity-large-preview", "trinity-mini"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],

--- a/optional-skills/security/godmode/scripts/godmode_race.py
+++ b/optional-skills/security/godmode/scripts/godmode_race.py
@@ -42,7 +42,7 @@ ULTRAPLINIAN_MODELS = [
     'x-ai/grok-code-fast-1',
     'xiaomi/mimo-v2-flash',
     'openai/gpt-oss-20b',
-    'stepfun/step-3.7-flash',  # updated for reasoning_effort support
+    'stepfun/step-3.5-flash',
     'nvidia/nemotron-3-nano-30b-a3b',
     # STANDARD TIER (11-24)
     'anthropic/claude-3.5-sonnet',

--- a/optional-skills/security/godmode/scripts/godmode_race.py
+++ b/optional-skills/security/godmode/scripts/godmode_race.py
@@ -42,7 +42,7 @@ ULTRAPLINIAN_MODELS = [
     'x-ai/grok-code-fast-1',
     'xiaomi/mimo-v2-flash',
     'openai/gpt-oss-20b',
-    'stepfun/step-3.5-flash',
+    'stepfun/step-3.7-flash',  # updated for reasoning_effort support
     'nvidia/nemotron-3-nano-30b-a3b',
     # STANDARD TIER (11-24)
     'anthropic/claude-3.5-sonnet',

--- a/plugins/model-providers/stepfun/__init__.py
+++ b/plugins/model-providers/stepfun/__init__.py
@@ -31,8 +31,10 @@ def _model_supports_reasoning_effort(model: str | None) -> bool:
     m = (model or "").strip().lower()
     if not m:
         return False
-    # step-3.7-flash and any obvious future reasoning siblings
-    if "3.7" in m or "reasoning" in m:
+    # Anchor on the ``step-3.7`` token (not a bare ``3.7`` substring) so we
+    # don't accidentally match unrelated version strings like ``step-13.7``.
+    # ``stepfun/step-3.7-flash`` still matches since the token is a substring.
+    if "step-3.7" in m or "reasoning" in m:
         return True
     return False
 

--- a/plugins/model-providers/stepfun/__init__.py
+++ b/plugins/model-providers/stepfun/__init__.py
@@ -1,12 +1,85 @@
-"""StepFun provider profile."""
+"""StepFun provider profile.
+
+Step-3.7-flash (and future reasoning-capable StepFun models) require
+top-level ``reasoning_effort`` (low/medium/high) on the Chat Completions
+path. See StepFun docs: "The Chat Completions API uses ``reasoning_effort``
+to control the effort level".
+
+This profile implements the minimal hook so the native ``stepfun`` provider
+actually uses the model's agentic strengths instead of defaulting to the
+cheap "low" tier.
+
+Pattern copied from DeepSeekProfile (which does the same top-level
+reasoning_effort emission).
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-stepfun = ProviderProfile(
+
+def _model_supports_reasoning_effort(model: str | None) -> bool:
+    """Return True for StepFun models that accept reasoning_effort.
+
+    Currently only step-3.7-flash (and any future *-reasoning or 3.7+ variants).
+    We keep it explicit so non-reasoning StepFun models (if they ever appear)
+    stay untouched.
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    # step-3.7-flash and any obvious future reasoning siblings
+    if "3.7" in m or "reasoning" in m:
+        return True
+    return False
+
+
+class StepFunProfile(ProviderProfile):
+    """StepFun Step Plan — emit top-level reasoning_effort for capable models."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not _model_supports_reasoning_effort(model):
+            # Older 3.5-flash etc. — leave the wire format exactly as before.
+            return extra_body, top_level
+
+        # User explicitly turned reasoning off for this turn.
+        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
+            # StepFun does not require a special "disabled" marker the way
+            # DeepSeek does, so we simply omit reasoning_effort and let the
+            # server use its (low) default. This keeps the request minimal.
+            return extra_body, top_level
+
+        # Map Hermes reasoning_config.effort to StepFun values.
+        # Hermes uses: low, medium, high, (sometimes xhigh).
+        # StepFun accepts exactly: low, medium, high.
+        effort = "medium"  # safe default for agent workloads
+        if isinstance(reasoning_config, dict):
+            raw = (reasoning_config.get("effort") or "").strip().lower()
+            if raw in {"low", "medium", "high"}:
+                effort = raw
+            elif raw in {"xhigh", "max"}:
+                effort = "high"
+
+        top_level["reasoning_effort"] = effort
+        return extra_body, top_level
+
+
+stepfun = StepFunProfile(
     name="stepfun",
     aliases=("step", "stepfun-coding-plan"),
-    default_aux_model="step-3.5-flash",
+    default_aux_model="step-3.7-flash",
     env_vars=("STEPFUN_API_KEY",),
     base_url="https://api.stepfun.ai/step_plan/v1",
 )

--- a/tests/plugins/model_providers/test_stepfun_profile.py
+++ b/tests/plugins/model_providers/test_stepfun_profile.py
@@ -134,6 +134,7 @@ class TestStepFunModelGating:
             None,                     # missing
             "step-3-unknown",         # unrecognized
             "some-other-model",
+            "step-13.7-flash",        # bare-substring over-match guard
         ],
     )
     def test_non_reasoning_models_emit_nothing(self, stepfun_profile, model):

--- a/tests/plugins/model_providers/test_stepfun_profile.py
+++ b/tests/plugins/model_providers/test_stepfun_profile.py
@@ -1,0 +1,165 @@
+"""Unit tests for the StepFun provider profile's reasoning_effort wiring.
+
+Step-3.7-flash (and future reasoning-capable StepFun models) use top-level
+``reasoning_effort`` (low/medium/high) on the Chat Completions path.
+The profile must emit this correctly and leave legacy 3.5-flash models
+completely untouched.
+
+These tests pin the profile's wire-shape contract so StepFun requests stay
+correctly shaped without going live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def stepfun_profile():
+    """Resolve the registered StepFun profile.
+
+    Going through ``providers.get_provider_profile`` keeps the test honest —
+    if someone later replaces the registered class with a plain
+    ``ProviderProfile``, every assertion below collapses.
+    """
+    # ``model_tools`` triggers plugin discovery on import, which is what
+    # registers the StepFun profile in the global provider registry.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("stepfun")
+    assert profile is not None, "stepfun provider profile must be registered"
+    return profile
+
+
+class TestStepFunReasoningWireShape:
+    """``build_api_kwargs_extras`` produces StepFun's exact wire format."""
+
+    def test_37_flash_default_effort_is_medium(self, stepfun_profile):
+        """No reasoning_config or no effort → medium (good agent default)."""
+        extra_body, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="step-3.7-flash"
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "medium"}
+
+    def test_37_flash_explicit_high_effort(self, stepfun_profile):
+        extra_body, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="step-3.7-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    def test_standard_efforts_pass_through(self, stepfun_profile, effort):
+        _, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="step-3.7-flash",
+        )
+        assert top_level == {"reasoning_effort": effort}
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
+    def test_xhigh_and_max_normalize_to_high(self, stepfun_profile, effort):
+        _, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="step-3.7-flash",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_explicitly_disabled_omits_effort(self, stepfun_profile):
+        """``reasoning_config.enabled=False`` → omit reasoning_effort entirely.
+
+        StepFun will then use its server default (low for flash-tier models).
+        We deliberately do not send a "disabled" marker.
+        """
+        extra_body, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="step-3.7-flash"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_disabled_ignores_effort_field(self, stepfun_profile):
+        """Effort silently dropped when reasoning is turned off."""
+        _, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+            model="step-3.7-flash",
+        )
+        assert top_level == {}
+
+    def test_unknown_effort_falls_back_to_medium(self, stepfun_profile):
+        """Garbage effort → still emit medium (safe default)."""
+        _, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "garbage"},
+            model="step-3.7-flash",
+        )
+        assert top_level == {"reasoning_effort": "medium"}
+
+    def test_empty_effort_falls_back_to_medium(self, stepfun_profile):
+        _, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": ""},
+            model="step-3.7-flash",
+        )
+        assert top_level == {"reasoning_effort": "medium"}
+
+
+class TestStepFunModelGating:
+    """Only 3.7+ / reasoning models get the parameter; legacy models stay clean."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "step-3.7-flash",
+            "step-3.7-flash-something",
+            "stepfun/step-3.7-flash",
+            "STEP-3.7-FLASH",  # case-insensitive
+            "some-reasoning-model",
+            "step-3.7-reasoning",
+        ],
+    )
+    def test_reasoning_capable_models_emit_effort(self, stepfun_profile, model):
+        extra_body, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}, model=model
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "step-3.5-flash",
+            "step-3.5-flash-2603",
+            "step-3.5-flash-something",
+            "",                       # bare/unknown
+            None,                     # missing
+            "step-3-unknown",         # unrecognized
+            "some-other-model",
+        ],
+    )
+    def test_non_reasoning_models_emit_nothing(self, stepfun_profile, model):
+        extra_body, top_level = stepfun_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}, model=model
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+
+class TestStepFunFullKwargsIntegration:
+    """End-to-end: the transport produces correct top-level reasoning_effort."""
+
+    def test_full_kwargs_include_reasoning_effort(self, stepfun_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="step-3.7-flash",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=stepfun_profile,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://api.stepfun.ai/step_plan/v1",
+            provider_name="stepfun",
+        )
+        assert kwargs["model"] == "step-3.7-flash"
+        assert kwargs["reasoning_effort"] == "high"
+        # No extra_body.reasoning pollution for StepFun
+        assert "reasoning" not in kwargs.get("extra_body", {})

--- a/tests/providers/test_e2e_wiring.py
+++ b/tests/providers/test_e2e_wiring.py
@@ -116,3 +116,31 @@ class TestDeepSeekProfileWiring:
             ollama_num_ctx=None,
         )
         assert kwargs["messages"] == msgs
+
+
+class TestStepFunProfileWiring:
+    """Minimal e2e wiring check for the new StepFunProfile (reasoning_effort path)."""
+
+    def test_stepfun_profile_is_used(self, transport):
+        profile = get_provider_profile("stepfun")
+        # Just confirm we get a proper subclass, not the bare base
+        from plugins.model_providers.stepfun import StepFunProfile
+        assert isinstance(profile, StepFunProfile)
+
+    def test_stepfun_no_forced_max_tokens(self, transport):
+        profile = get_provider_profile("stepfun")
+        kwargs = transport.build_kwargs(
+            model="step-3.7-flash",
+            messages=_msgs(),
+            tools=None,
+            provider_profile=profile,
+            max_tokens=None,
+            max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+            timeout=300,
+            reasoning_config=None,
+            request_overrides=None,
+            session_id="test",
+            ollama_num_ctx=None,
+        )
+        # StepFun profile does not force max_tokens
+        assert kwargs.get("max_tokens") is None or "max_tokens" not in kwargs

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3893,6 +3893,29 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_applies_stepfun_top_level_reasoning_effort(self, agent):
+        """Regression (#36942): the iteration-limit summary path hand-builds
+        kwargs and calls chat.completions.create() directly, bypassing
+        ChatCompletionsTransport. It must still apply the provider profile's
+        build_api_kwargs_extras() so native StepFun summaries carry top-level
+        reasoning_effort, matching the transport path.
+        """
+        import model_tools  # noqa: F401 — triggers provider-profile discovery
+        agent.provider = "stepfun"
+        agent.base_url = "https://api.stepfun.ai/step_plan/v1"
+        agent.model = "step-3.7-flash"
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs.get("reasoning_effort") == "high"
+
     def test_summary_request_removes_orphan_tool_result(self, agent):
         """Regression: max-iterations summary request must NOT contain
         orphan tool results (tool_call_id with no matching assistant tool_call)."""


### PR DESCRIPTION
## What does this PR do?

Adds first-class support for StepFun's `reasoning_effort` parameter (low/medium/high) when using `step-3.7-flash` (and future reasoning-capable models) through the native `stepfun` provider.

Previously, `step-3.7-flash` was being surfaced as a recommended/default model (via Nous Portal curated lists and live API discovery), but Hermes never sent the required top-level `reasoning_effort` parameter. This caused the model to run at its low-effort default, resulting in poor performance for agentic/tool-calling workloads despite strong published benchmarks.

## Related Issue

No pre-existing issue. Discovered during evaluation of newly-released models as defaults.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/model-providers/stepfun/__init__.py`: Converted bare `ProviderProfile` to `StepFunProfile` subclass implementing `build_api_kwargs_extras` to emit top-level `reasoning_effort`. The model gate anchors on the `step-3.7` token (not a bare `3.7` substring) so unrelated version strings like `step-13.7-*` are not matched.
- `hermes_cli/models.py`: Updated `_PROVIDER_MODELS["stepfun"]` so `step-3.7-flash` is the first/default entry.
- `hermes_cli/setup.py`: Updated interactive setup wizard model list for stepfun.
- `tests/plugins/model_providers/test_stepfun_profile.py`: New dedicated test file (modeled on existing DeepSeek profile tests) — **28 tests, all passing** under the official hermetic runner.
- `tests/providers/test_e2e_wiring.py`: Added `TestStepFunProfileWiring` class (2 tests).

## How to Test

1. Add a valid `STEPFUN_API_KEY` and select the `stepfun` provider.
2. Choose (or default to) `step-3.7-flash`.
3. Start an agent session and perform tool-calling work. Verify `reasoning_effort` appears in outgoing Chat Completions requests.
4. Confirm legacy `step-3.5-flash` / `step-3.5-flash-2603` continue to work without any `reasoning_effort` parameter.
5. Run the new tests (they pass cleanly):
   ```
   ./scripts/run_tests.sh tests/plugins/model_providers/test_stepfun_profile.py -q
   ```

All 28 tests in the new profile test file pass under the exact CI conditions (`scripts/run_tests.sh` with hermetic isolation, clean env, `PYTHONHASHSEED=0`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (equivalent to `pytest tests/ -q` under CI conditions) and the relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
