### PR TITLE
fix(gateway): keep cron ticker alive after tick failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19068,7 +19068,13 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop)
         except Exception as e:
-            logger.debug("Cron tick error: %s", e)
+            logger.warning("Cron tick error: %s", e, exc_info=True)
+        except BaseException as e:
+            # Keep the gateway's background cron thread alive even if a
+            # non-Exception escapes one tick (for example from lower-level
+            # worker/runtime primitives). One bad tick must not permanently
+            # stop all cron scheduling.
+            logger.error("Cron tick fatal error: %s", e, exc_info=True)
 
         tick_count += 1
 

--- a/tests/gateway/test_cron_ticker_resilience.py
+++ b/tests/gateway/test_cron_ticker_resilience.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+import gateway.run as gateway_run
+
+
+class _CronTickFatal(BaseException):
+    pass
+
+
+def test_cron_ticker_survives_baseexception(monkeypatch, caplog):
+    caplog.set_level("WARNING", logger="gateway.run")
+
+    stop_event = gateway_run.threading.Event()
+    calls = {"n": 0}
+
+    def _fake_tick(verbose=False, adapters=None, loop=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _CronTickFatal("boom")
+        stop_event.set()
+
+    monkeypatch.setitem(sys.modules, "cron.scheduler", types.SimpleNamespace(tick=_fake_tick))
+    monkeypatch.setitem(
+        sys.modules,
+        "gateway.platforms.base",
+        types.SimpleNamespace(
+            cleanup_image_cache=lambda max_age_hours=24: 0,
+            cleanup_document_cache=lambda max_age_hours=24: 0,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.debug",
+        types.SimpleNamespace(_sweep_expired_pastes=lambda: (0, 0)),
+    )
+
+    gateway_run._start_cron_ticker(stop_event=stop_event, interval=0)
+
+    assert calls["n"] == 2
+    assert "Cron tick fatal error:" in caplog.text


### PR DESCRIPTION
Prevent a single cron tick failure from silently taking down cron scheduling in a running gateway.

## What changed and why
- `gateway/run.py`: hardened `_start_cron_ticker` exception handling so the background ticker survives both `Exception` and non-`Exception` (`BaseException`) failures from `cron_tick` and continues looping.
- `gateway/run.py`: changed cron tick failure logging from debug-only to warning/error with `exc_info=True` so production operators can see stack traces when a tick fails.
- `tests/gateway/test_cron_ticker_resilience.py`: added a regression test that simulates a fatal tick failure on the first iteration and asserts the ticker runs again instead of dying.

## How to test
- `pytest -q tests/gateway/test_cron_ticker_resilience.py`
- `ruff check gateway/run.py tests/gateway/test_cron_ticker_resilience.py`
- `python scripts/check-windows-footguns.py`
- `git diff --check`
- Optional full-suite check used in this run: `scripts/run_tests.sh` (encountered unrelated pre-existing failures in `tests/agent/lsp/test_client_e2e.py` and `tests/agent/test_anthropic_adapter.py`).

## What platforms tested on
- macOS (darwin-arm64) local worktree environment

Fixes #36854

<!-- autocontrib:worker-id=issue-new-5dcc0f24 kind=pr-open -->