### PR TITLE
fix(gateway): keep cron alive on non-conflict startup auth failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2264,6 +2264,19 @@ class GatewayRunner:
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
+    @staticmethod
+    def _is_startup_conflict_error_code(error_code: Optional[str]) -> bool:
+        """Return True when startup should exit cleanly for a hard conflict.
+
+        Conflict-like failures (duplicate app/session locks, polling conflict)
+        are not recoverable in-process and should stop startup. Other fatal
+        startup errors should degrade so cron can continue running.
+        """
+        if not error_code:
+            return False
+        code = str(error_code).strip().lower()
+        return code.endswith("_lock") or code == "telegram_polling_conflict"
+
     def _platform_connect_timeout_secs(self) -> float:
         """Return the per-platform connect timeout used during startup/retry."""
         raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
@@ -4420,6 +4433,7 @@ class GatewayRunner:
         connected_count = 0
         enabled_platform_count = 0
         startup_nonretryable_errors: list[str] = []
+        startup_conflict_errors: list[str] = []
         startup_retryable_errors: list[str] = []
         
         # Initialize and connect each configured platform
@@ -4495,9 +4509,10 @@ class GatewayRunner:
                             if adapter.fatal_error_retryable
                             else startup_nonretryable_errors
                         )
-                        target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
-                        )
+                        error_text = f"{platform.value}: {adapter.fatal_error_message}"
+                        target.append(error_text)
+                        if self._is_startup_conflict_error_code(adapter.fatal_error_code):
+                            startup_conflict_errors.append(error_text)
                         # Queue for reconnection if the error is retryable
                         if adapter.fatal_error_retryable:
                             self._failed_platforms[platform] = {
@@ -4542,8 +4557,8 @@ class GatewayRunner:
                 }
         
         if connected_count == 0:
-            if startup_nonretryable_errors:
-                reason = "; ".join(startup_nonretryable_errors)
+            if startup_conflict_errors:
+                reason = "; ".join(startup_conflict_errors)
                 logger.error("Gateway hit a non-retryable startup conflict: %s", reason)
                 try:
                     from gateway.status import write_runtime_status
@@ -4580,6 +4595,12 @@ class GatewayRunner:
                         pass
                     # Fall through to the normal "running" state — reconnect
                     # watcher takes it from here.
+                if startup_nonretryable_errors:
+                    reason = "; ".join(startup_nonretryable_errors)
+                    logger.warning(
+                        "Gateway started with non-retryable platform errors (degrading for cron): %s",
+                        reason,
+                    )
                 # All enabled platforms had no adapter (missing library or credentials).
                 # In fleet deployments the same config.yaml is shared across nodes that
                 # may only have credentials for a subset of platforms.  Rather than

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -46,6 +46,28 @@ class _DisabledAdapter(BasePlatformAdapter):
         return {"id": chat_id}
 
 
+class _NonRetryableAuthFailureAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+
+    async def connect(self) -> bool:
+        self._set_fatal_error(
+            "telegram_auth_invalid",
+            "Telegram startup failed: invalid bot token.",
+            retryable=False,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
 class _SuccessfulAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.DISCORD)
@@ -94,6 +116,44 @@ async def test_runner_stays_alive_for_retryable_startup_errors(monkeypatch, tmp_
     assert Platform.TELEGRAM in runner._failed_platforms
     assert state["platforms"]["telegram"]["state"] == "retrying"
     assert state["platforms"]["telegram"]["error_code"] == "telegram_connect_error"
+
+
+@pytest.mark.asyncio
+async def test_runner_stays_alive_for_nonretryable_nonconflict_startup_errors(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _NonRetryableAuthFailureAdapter(),
+    )
+
+    import logging
+    with caplog.at_level(logging.WARNING):
+        ok = await runner.start()
+
+    # Non-retryable auth-like startup failures should degrade instead of
+    # exiting the process, so cron-only workloads keep running.
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner._failed_platforms == {}
+    state = read_runtime_status()
+    assert state["gateway_state"] in {"degraded", "running"}
+    assert state["platforms"]["telegram"]["state"] == "fatal"
+    assert state["platforms"]["telegram"]["error_code"] == "telegram_auth_invalid"
+    # The specific error text must appear in the log stream for operator debugging.
+    assert any(
+        "non-retryable platform errors" in record.message
+        and "invalid bot token" in record.message
+        for record in caplog.records
+    ), "Expected non-retryable error log with specific error details"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Prevent gateway restart loops from killing cron when a platform has a non-retryable startup error (for example invalid auth), while preserving clean-exit behavior for true startup conflicts.

## What changed and why
- Updated `GatewayRunner.start()` in `gateway/run.py` to classify startup failures by error code semantics.
- Added `_is_startup_conflict_error_code()` and now only request clean exit for hard conflict conditions (`*_lock` and `telegram_polling_conflict`).
- For non-retryable but non-conflict startup failures, gateway now stays alive in degraded/running mode instead of exiting, so cron jobs keep running and the process does not enter a systemd restart loop.
- Added `test_runner_stays_alive_for_nonretryable_nonconflict_startup_errors` in `tests/gateway/test_runner_startup_failures.py` to lock this behavior.

## How to test
- Run targeted regression tests:
  - `pytest tests/gateway/test_runner_startup_failures.py tests/gateway/test_runner_fatal_adapter.py -q`
- Run lint/static checks on touched files:
  - `ruff check gateway/run.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_runner_fatal_adapter.py`
- Run safety/format checks:
  - `python scripts/check-windows-footguns.py`
  - `git diff --check`
- Optional full suite entrypoint:
  - `scripts/run_tests.sh` (in this environment it reported unrelated pre-existing failures in `tests/agent/lsp/test_client_e2e.py`).

## What platforms tested on
- macOS 15 (darwin-arm64) local worker environment

Fixes #21831

<!-- autocontrib:worker-id=issue-new-9fca909e kind=pr-open -->