### PR TITLE
feat(skills): per-skill model override via config.yaml or SKILL.md frontmatter

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -157,6 +157,62 @@ def _inject_skill_config(loaded_skill: dict[str, Any], parts: list[str]) -> None
         pass  # Non-critical — skill still loads without config injection
 
 
+def resolve_skill_model_override(skill_name: str) -> Optional[Dict[str, str]]:
+    """Resolve a per-skill model override from config or SKILL.md frontmatter.
+
+    Resolution order (highest priority first):
+    1. ``config.yaml`` → ``skills.model_overrides.<skill_name>``
+    2. ``SKILL.md`` frontmatter → ``metadata.hermes.model``
+    3. No override (returns ``None``)
+
+    Returns ``{"model": ..., "provider": ...}`` or ``None``.
+    """
+    # 1. Check user's config.yaml override (highest priority)
+    try:
+        from hermes_constants import get_config_path as _gcfg
+
+        _cp = _gcfg()
+        if _cp.exists():
+            import yaml as _yaml
+
+            _cfg = _yaml.safe_load(_cp.read_text(encoding="utf-8"))
+            if isinstance(_cfg, dict):
+                _overrides = _cfg.get("skills", {}).get("model_overrides", {})
+                if isinstance(_overrides, dict) and skill_name in _overrides:
+                    _ov = _overrides[skill_name]
+                    if isinstance(_ov, dict) and _ov.get("model"):
+                        return {
+                            "model": _ov["model"],
+                            "provider": _ov.get("provider", ""),
+                        }
+    except Exception:
+        pass
+
+    # 2. Check SKILL.md frontmatter (skill author's recommendation)
+    try:
+        from tools.skills_tool import skill_view as _sv
+
+        _loaded = json.loads(_sv(skill_name, preprocess=False))
+        if _loaded.get("success"):
+            _raw = str(_loaded.get("raw_content") or _loaded.get("content") or "")
+            if _raw:
+                from agent.skill_utils import parse_frontmatter as _pf
+
+                _fm, _ = _pf(_raw)
+                _h = _fm.get("metadata", {}).get("hermes", {})
+                if isinstance(_h, dict):
+                    _mc = _h.get("model", {})
+                    if isinstance(_mc, dict) and _mc.get("model"):
+                        return {
+                            "model": _mc["model"],
+                            "provider": _mc.get("provider", ""),
+                        }
+    except Exception:
+        pass
+
+    return None
+
+
 def _build_skill_message(
     loaded_skill: dict[str, Any],
     skill_dir: Path | None,

--- a/cli.py
+++ b/cli.py
@@ -8973,7 +8973,32 @@ class HermesCLI:
                 )
                 if msg:
                     skill_name = skill_commands[base_cmd]["name"]
-                    print(f"\n⚡ Loading skill: {skill_name}")
+                    # ── Per-skill model override ──
+                    _model_override = None
+                    try:
+                        from agent.skill_commands import resolve_skill_model_override
+                        _model_override = resolve_skill_model_override(skill_name)
+                    except Exception:
+                        pass
+                    if _model_override:
+                        from agent.agent_runtime_helpers import switch_model as _sm
+                        self._skill_model_stash = {
+                            "model": self.agent.model,
+                            "provider": self.agent.provider,
+                            "api_key": getattr(self.agent, "api_key", ""),
+                            "base_url": getattr(self.agent, "base_url", ""),
+                            "api_mode": getattr(self.agent, "api_mode", ""),
+                        }
+                        _sm(
+                            self.agent,
+                            _model_override["model"],
+                            _model_override.get("provider", ""),
+                            api_key=_model_override.get("api_key", ""),
+                            base_url=_model_override.get("base_url", ""),
+                        )
+                        print(f"\n⚡ Loading skill: {skill_name} (using {_model_override['model']})")
+                    else:
+                        print(f"\n⚡ Loading skill: {skill_name}")
                     if hasattr(self, '_pending_input'):
                         self._pending_input.put(msg)
                 else:
@@ -11864,6 +11889,25 @@ class HermesCLI:
             buf.cursor_position = min(snapshot.get("cursor_position", 0), len(buf.text))
         except Exception:
             pass
+
+    def _restore_skill_model(self) -> None:
+        """Restore the agent's model after a skill turn that switched models."""
+        stash = getattr(self, "_skill_model_stash", None)
+        if not stash:
+            return
+        try:
+            from agent.agent_runtime_helpers import switch_model as _sm
+            _sm(
+                self.agent,
+                stash["model"],
+                stash["provider"],
+                api_key=stash.get("api_key", ""),
+                base_url=stash.get("base_url", ""),
+                api_mode=stash.get("api_mode", ""),
+            )
+        except Exception as _exc:
+            logging.warning("Failed to restore model after skill: %s", _exc)
+        self._skill_model_stash = None
 
     def _submit_secret_response(self, value: str) -> None:
         if not self._secret_state:
@@ -14880,6 +14924,9 @@ class HermesCLI:
                             self._maybe_continue_goal_after_turn()
                         except Exception as _goal_exc:
                             logging.debug("goal continuation hook failed: %s", _goal_exc)
+
+                        # Restore model after skill turn if we switched for it
+                        self._restore_skill_model()
 
                         # Continuous voice: auto-restart recording after agent responds.
                         # Dispatch to a daemon thread so play_beep (sd.wait) and

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1873,6 +1873,9 @@ class GatewayRunner:
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
         self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        # Stash for per-skill model overrides — holds the session's previous
+        # override so it can be restored after the skill turn completes.
+        self._skill_model_restore: Dict[str, Dict[str, str]] = {}
         # Per-session reasoning effort overrides from /reasoning.
         # Key: session_key, Value: parsed reasoning config dict.
         self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
@@ -8247,6 +8250,22 @@ class GatewayRunner:
                     )
                     if msg:
                         event.text = msg
+                        # ── Per-skill model override (one-shot) ──
+                        if _quick_key and _skill_name:
+                            try:
+                                from agent.skill_commands import resolve_skill_model_override as _resolve_skill_model
+                                _skill_model_ov = _resolve_skill_model(_skill_name)
+                            except Exception:
+                                _skill_model_ov = None
+                            if _skill_model_ov:
+                                # Stash the current override so we can restore after
+                                self._skill_model_restore[_quick_key] = dict(
+                                    self._session_model_overrides.get(_quick_key, {})
+                                )
+                                self._session_model_overrides[_quick_key] = {
+                                    "model": _skill_model_ov["model"],
+                                    "provider": _skill_model_ov.get("provider", ""),
+                                }
                         # Fall through to normal message processing with skill content
                 else:
                     # Not an active skill — check if it's a known-but-disabled or
@@ -8301,7 +8320,20 @@ class GatewayRunner:
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
-            _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            try:
+                _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            finally:
+                # Restore session model after one-shot skill model override
+                _restore = self._skill_model_restore.pop(_quick_key, None) if _quick_key else None
+                if _restore is not None:
+                    if _restore:
+                        self._session_model_overrides[_quick_key] = _restore
+                    else:
+                        self._session_model_overrides.pop(_quick_key, None)
+                    logger.debug(
+                        "Restored session model after skill: session=%s restore=%s",
+                        _quick_key, bool(_restore),
+                    )
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -176,6 +176,7 @@ TIPS = [
     "skills.external_dirs in config.yaml lets you load skills from custom directories.",
     "The agent can create its own skills as procedural memory using skill_manage.",
     "The plan skill saves markdown plans under .hermes/plans/ in the active workspace.",
+    "skills.model_overrides in config.yaml lets you route specific skills to cheaper/faster models — or escalate to stronger ones.",
 
     # --- Cron & Scheduling ---
     "Cron jobs can attach skills: hermes cron add --skill blogwatcher \"Check for new posts\".",

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -177,6 +177,8 @@ TIPS = [
     "The agent can create its own skills as procedural memory using skill_manage.",
     "The plan skill saves markdown plans under .hermes/plans/ in the active workspace.",
     "skills.model_overrides in config.yaml lets you route specific skills to cheaper/faster models — or escalate to stronger ones.",
+    "Use openrouter/auto as a skill model override — OpenRouter picks the best model from 38 candidates per request.",
+    "Set model: openrouter/free for cost-safe auxiliary defaults — it errors if no free model is available.",
 
     # --- Cron & Scheduling ---
     "Cron jobs can attach skills: hermes cron add --skill blogwatcher \"Check for new posts\".",

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -803,3 +803,102 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestResolveSkillModelOverride:
+    """Tests for resolve_skill_model_override()."""
+
+    def test_returns_none_when_no_override(self, tmp_path):
+        """No model override configured — returns None."""
+        from agent.skill_commands import resolve_skill_model_override
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("hermes_constants.get_config_path", return_value=tmp_path / "config.yaml"),
+        ):
+            _make_skill(tmp_path, "no-model-skill", body="Just a skill.")
+            scan_skill_commands()
+            result = resolve_skill_model_override("no-model-skill")
+        assert result is None
+
+    def test_uses_frontmatter_override(self, tmp_path):
+        """Skill declares metadata.hermes.model in SKILL.md."""
+        from agent.skill_commands import resolve_skill_model_override
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("hermes_constants.get_config_path", return_value=tmp_path / "config.yaml"),
+        ):
+            _make_skill(
+                tmp_path, "gif-search",
+                frontmatter_extra="""metadata:
+  hermes:
+    model:
+      provider: openrouter
+      model: google/gemini-2.5-flash
+""",
+            )
+            scan_skill_commands()
+            result = resolve_skill_model_override("gif-search")
+        assert result == {"model": "google/gemini-2.5-flash", "provider": "openrouter"}
+
+    def test_skips_override_when_missing_model_key(self, tmp_path):
+        """metadata.hermes.model exists but has no model key — returns None."""
+        from agent.skill_commands import resolve_skill_model_override
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("hermes_constants.get_config_path", return_value=tmp_path / "config.yaml"),
+        ):
+            _make_skill(
+                tmp_path, "partial-model",
+                frontmatter_extra="""metadata:
+  hermes:
+    model:
+      provider: openrouter
+""",
+            )
+            scan_skill_commands()
+            result = resolve_skill_model_override("partial-model")
+        assert result is None
+
+    def test_config_override_takes_precedence_over_frontmatter(self, tmp_path):
+        """Config.yaml skills.model_overrides wins over SKILL.md."""
+        from agent.skill_commands import resolve_skill_model_override
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "skills:\n  model_overrides:\n    gif-search:\n      model: deepseek-chat\n      provider: deepseek\n",
+            encoding="utf-8",
+        )
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("hermes_constants.get_config_path", return_value=config_path),
+        ):
+            _make_skill(
+                tmp_path, "gif-search",
+                frontmatter_extra="""metadata:
+  hermes:
+    model:
+      provider: openrouter
+      model: google/gemini-2.5-flash
+""",
+            )
+            scan_skill_commands()
+            result = resolve_skill_model_override("gif-search")
+        assert result == {"model": "deepseek-chat", "provider": "deepseek"}
+
+    def test_handles_nonexistent_skill_gracefully(self):
+        """Non-existent skill returns None without error."""
+        from agent.skill_commands import resolve_skill_model_override
+        result = resolve_skill_model_override("this-skill-does-not-exist")
+        assert result is None
+
+    def test_handles_missing_config_gracefully(self, tmp_path):
+        """No config.yaml exists — falls back to frontmatter or None."""
+        from agent.skill_commands import resolve_skill_model_override
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("hermes_constants.get_config_path", return_value=tmp_path / "config.yaml"),
+        ):
+            # No config file written — should not crash
+            _make_skill(tmp_path, "simple-skill", body="Do stuff.")
+            scan_skill_commands()
+            result = resolve_skill_model_override("simple-skill")
+        assert result is None

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -833,12 +833,12 @@ class TestResolveSkillModelOverride:
   hermes:
     model:
       provider: openrouter
-      model: google/gemini-2.5-flash
+      model: google/gemini-3.5-flash
 """,
             )
             scan_skill_commands()
             result = resolve_skill_model_override("gif-search")
-        assert result == {"model": "google/gemini-2.5-flash", "provider": "openrouter"}
+        assert result == {"model": "google/gemini-3.5-flash", "provider": "openrouter"}
 
     def test_skips_override_when_missing_model_key(self, tmp_path):
         """metadata.hermes.model exists but has no model key — returns None."""
@@ -877,7 +877,7 @@ class TestResolveSkillModelOverride:
   hermes:
     model:
       provider: openrouter
-      model: google/gemini-2.5-flash
+      model: google/gemini-3.5-flash
 """,
             )
             scan_skill_commands()


### PR DESCRIPTION
## Summary

- Resolves issue #5997 — allows routing specific skills to different models
- **Resolution order:** `config.yaml` → `skills.model_overrides.<name>` → `SKILL.md` → `metadata.hermes.model` → no override
- **Config example:**
  ```yaml
  skills:
    model_overrides:
      code-review:
        model: deepseek-chat
        provider: deepseek
      blog-writer:
        model: google/gemini-2.5-flash
        provider: openrouter
  ```
- **SKILL.md frontmatter** (skill author's recommendation):
  ```yaml
  metadata:
    hermes:
      model:
        provider: openrouter
        model: google/gemini-2.5-flash
  ```
- CLI (`cli.py`): stashes current model state, switches for the skill turn, restores after via `_restore_skill_model()` in `process_loop`
- Gateway (`gateway/run.py`): uses `_session_model_overrides` dict for one-shot override, with inner `try/finally` for automatic restore after `_handle_message_with_agent`

## Test plan

- [x] New unit test class `TestResolveSkillModelOverride` with 6 test cases:
  - No override → returns None
  - Frontmatter override → returns model/provider
  - Missing model key → returns None
  - Config precedence → config wins over frontmatter
  - Nonexistent skill → returns None gracefully
  - Missing config → returns None gracefully
- [x] All 44 runnable tests in `test_skill_commands.py` pass (3 pre-existing Windows path tests skipped)

Made with Claude Code
