### PR TITLE
fix(models,doctor): add opencode-go deepseek models + warn on shell/.env key mismatch

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -105,6 +105,100 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+# Curated base of provider env-var names the gateway reads from ~/.hermes/.env
+# at startup (see gateway/run.py).  A key set in the user's interactive shell
+# but never written to .env causes /model to switch successfully (the /v1/models
+# probe on opencode-go does not require auth) while the next chat call returns
+# 401 -- the failure mode in #36915.  This tuple is the seed for
+# _dotenv_required_provider_keys(), which unions it with the API-key names
+# declared in hermes_cli.auth.PROVIDER_REGISTRY so first-party providers added
+# there (e.g. Google AI Studio's GOOGLE_API_KEY / GEMINI_API_KEY) are covered
+# without editing this list.  It is kept as an explicit fallback (and to retain
+# non-*_API_KEY names like ANTHROPIC_TOKEN / HF_TOKEN that the registry filter
+# drops).  Not covered: providers a user defines only in config via
+# providers.*.key_env -- those live in config.yaml, not the registry.
+_DOTENV_REQUIRED_PROVIDER_KEYS: tuple[str, ...] = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "OPENROUTER_API_KEY",
+    "OPENCODE_ZEN_API_KEY",
+    "OPENCODE_GO_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GLM_API_KEY",
+    "ZAI_API_KEY",
+    "Z_AI_API_KEY",
+    "KIMI_API_KEY",
+    "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "KILOCODE_API_KEY",
+    "GMI_API_KEY",
+    "ARCEEAI_API_KEY",
+    "STEPFUN_API_KEY",
+    "HF_TOKEN",
+    "AI_GATEWAY_API_KEY",
+    "NVIDIA_API_KEY",
+    "XIAOMI_API_KEY",
+    "TOKENHUB_API_KEY",
+)
+
+
+def _dotenv_required_provider_keys() -> tuple[str, ...]:
+    """Return the provider API-key env-var names to check for shell/.env drift.
+
+    Derived from hermes_cli.auth.PROVIDER_REGISTRY so first-party providers are
+    covered without maintaining a parallel list: the *_API_KEY names declared by
+    each provider are unioned with the curated
+    _DOTENV_REQUIRED_PROVIDER_KEYS base.  The *_API_KEY suffix filter keeps the
+    derivation to provider credentials and excludes shared git/OAuth tokens
+    (GITHUB_TOKEN, GH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN) that are commonly exported
+    in the shell for unrelated reasons; the curated base still carries the
+    non-suffixed provider keys (ANTHROPIC_TOKEN, HF_TOKEN).  Falls back to the
+    curated base alone if the registry import fails.
+    """
+    keys = set(_DOTENV_REQUIRED_PROVIDER_KEYS)
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        for provider in PROVIDER_REGISTRY.values():
+            for name in getattr(provider, "api_key_env_vars", ()):
+                if name.endswith("_API_KEY"):
+                    keys.add(name)
+    except Exception:
+        pass
+    return tuple(sorted(keys))
+
+
+def _shell_env_dotenv_mismatches() -> list[str]:
+    """Return provider env vars set in the shell but missing from ~/.hermes/.env.
+
+    The gateway (launchd / systemd unit) does not inherit the user's
+    interactive shell env; it reads ~/.hermes/.env instead.  A key
+    exported in the shell but never written to .env is invisible to the
+    gateway and produces HTTP 401 on the first chat call after /model
+    switches providers (the symptom in #36915).
+
+    Returns a list of env var names where os.environ is non-empty but
+    load_env() does not contain the same name.  Comparison is
+    case-sensitive (env var names are conventionally uppercase).
+    """
+    try:
+        from hermes_cli.config import load_env
+        dotenv_vars = load_env()
+    except Exception:
+        return []
+    mismatches: list[str] = []
+    for name in _dotenv_required_provider_keys():
+        shell_val = os.environ.get(name, "").strip()
+        if not shell_val:
+            continue
+        dotenv_val = str(dotenv_vars.get(name, "") or "").strip()
+        if not dotenv_val:
+            mismatches.append(name)
+    return mismatches
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -730,7 +824,33 @@ def run_doctor(args):
             else:
                 check_info("Run 'hermes setup' to create one")
                 issues.append("Run 'hermes setup' to create .env")
-    
+
+    # Surface provider keys set in the user's interactive shell but
+    # missing from .env.  The gateway process (launchd / systemd)
+    # does not inherit shell env, so any key only in the shell is
+    # invisible to the gateway and produces HTTP 401 on the first
+    # chat call after a /model switch.  See #36915.  Fires
+    # regardless of whether .env exists; if it doesn't, every
+    # shell-set provider key is a mismatch.
+    try:
+        mismatches = _shell_env_dotenv_mismatches()
+    except Exception:
+        mismatches = []
+    if mismatches:
+        _shown = ", ".join(mismatches[:5])
+        _extra = f" (+{len(mismatches) - 5} more)" if len(mismatches) > 5 else ""
+        check_warn(
+            f"{len(mismatches)} provider key(s) set in shell but missing from .env: {_shown}{_extra}",
+            "(the gateway process won't see these keys)",
+        )
+        issues.append(
+            "Provider API keys are set in your shell but not in "
+            f"{_DHH}/.env.  The gateway (launchd / systemd) reads .env, "
+            "not the shell env, so it will return HTTP 401 on chat calls.  "
+            "Run 'hermes setup' to write the missing keys to .env, or "
+            "append them manually."
+        )
+
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'
     if config_path.exists():

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -126,6 +126,85 @@ class TestDoctorEnvFileEncoding:
             doctor_mod.run_doctor(Namespace(fix=False))
 
 
+class TestShellEnvDotenvMismatches:
+    """Verifies the opencode-go / .env 401 surface in #36915 is caught by doctor."""
+
+    def test_no_mismatch_when_nothing_set(self, monkeypatch, tmp_path):
+        # No shell keys, no .env file → empty list.
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: tmp_path / ".env")
+        for name in doctor._DOTENV_REQUIRED_PROVIDER_KEYS:
+            monkeypatch.delenv(name, raising=False)
+        assert doctor._shell_env_dotenv_mismatches() == []
+
+    def test_no_mismatch_when_keys_match(self, monkeypatch, tmp_path):
+        from hermes_cli import config as cfg_mod
+        env_path = tmp_path / ".env"
+        env_path.write_text("OPENCODE_GO_API_KEY=sk-abc\nOPENAI_API_KEY=sk-openai\n")
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: env_path)
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-abc")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        assert doctor._shell_env_dotenv_mismatches() == []
+
+    def test_mismatch_when_key_in_shell_only(self, monkeypatch, tmp_path):
+        from hermes_cli import config as cfg_mod
+        env_path = tmp_path / ".env"
+        env_path.write_text("# empty .env\n")
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: env_path)
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-shell-only")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        result = doctor._shell_env_dotenv_mismatches()
+        assert "OPENCODE_GO_API_KEY" in result
+        assert "OPENAI_API_KEY" not in result
+
+    def test_mismatch_when_dotenv_missing_but_keys_in_shell(self, monkeypatch, tmp_path):
+        # The user case in #36915: shell has the key, ~/.hermes/.env doesn't exist.
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: tmp_path / "nonexistent.env")
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-shell-only")
+        result = doctor._shell_env_dotenv_mismatches()
+        assert "OPENCODE_GO_API_KEY" in result
+
+    def test_ignores_empty_values(self, monkeypatch, tmp_path):
+        from hermes_cli import config as cfg_mod
+        env_path = tmp_path / ".env"
+        env_path.write_text("OPENCODE_GO_API_KEY=sk-abc\n")
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: env_path)
+        # Empty string in shell is not a real key, should not be flagged.
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert doctor._shell_env_dotenv_mismatches() == []
+
+    def test_returns_empty_list_on_load_error(self, monkeypatch):
+        from hermes_cli import config as cfg_mod
+        def _boom():
+            raise RuntimeError("corrupt .env")
+        monkeypatch.setattr(cfg_mod, "load_env", _boom)
+        monkeypatch.setenv("OPENCODE_GO_API_KEY", "sk-abc")
+        assert doctor._shell_env_dotenv_mismatches() == []
+
+    def test_covers_google_gemini_provider_keys(self, monkeypatch, tmp_path):
+        # GOOGLE_API_KEY / GEMINI_API_KEY (Google AI Studio) must be covered;
+        # a hardcoded list omitting them was the gap flagged in review. The set
+        # is derived from the provider registry so these are included.
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: tmp_path / "nonexistent.env")
+        monkeypatch.setenv("GOOGLE_API_KEY", "sk-google-shell-only")
+        assert "GOOGLE_API_KEY" in doctor._shell_env_dotenv_mismatches()
+
+    def test_excludes_shared_git_oauth_tokens(self, monkeypatch, tmp_path):
+        # Shared git/OAuth tokens (GITHUB_TOKEN, GH_TOKEN) are commonly exported
+        # in the shell for non-provider reasons; deriving from the registry must
+        # not flag them as provider mismatches (only *_API_KEY names are taken).
+        from hermes_cli import config as cfg_mod
+        monkeypatch.setattr(cfg_mod, "get_env_path", lambda: tmp_path / "nonexistent.env")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_shellonly")
+        monkeypatch.setenv("GH_TOKEN", "ghp_shellonly")
+        result = doctor._shell_env_dotenv_mismatches()
+        assert "GITHUB_TOKEN" not in result
+        assert "GH_TOKEN" not in result
+
+
 class TestDoctorToolAvailabilityOverrides:
     def test_marks_honcho_available_when_configured(self, monkeypatch):
         monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: True)


### PR DESCRIPTION
## What does this PR do?

Addresses the 401 reported in #36915 and improves diagnosis of the same class of failure for every other shell-vs-`.env` provider key mismatch. Note: neither change silently auto-fixes a live 401. In the reported online scenario the `/v1/models` probe already authenticates (it does not require a key), so the catalog change matters only on the offline / probe-failure path; the doctor change surfaces the root cause (a key set in the shell but missing from `.env`) and points the user at the remediation. The actual fix on the user's side is running `hermes setup` (or writing the key to `.env`).

Two related changes:

1. **`hermes_cli/models.py`** — Add `deepseek-v4-pro` and `deepseek-v4-flash` to `_PROVIDER_MODELS["opencode-go"]`. The live `https://opencode.ai/zen/go/v1/models` endpoint lists both; they are first-class opencode-go models but were absent from the curated list, so the static-catalog fallback in `validate_requested_model()` would reject the `/model` switch whenever the live probe failed (offline, transient, or — most relevant to #36915 — the probe not actually authenticating because `/v1/models` on opencode-go does not require auth while `/v1/chat/completions` does).

2. **`hermes_cli/doctor.py`** — New `_shell_env_dotenv_mismatches()` check. The gateway process (launchd / systemd unit) does not inherit the user's interactive shell environment; it reads `~/.hermes/.env` instead. Users who export `OPENCODE_GO_API_KEY` in their shell but never wrote it to `.env` (because they skipped `hermes setup` and just hand-edited shell rc files) hit the 401 above with no diagnostic. `hermes doctor` now emits a clear warning when shell-set provider keys are missing from `.env`, with a remediation hint pointing at `hermes setup`.

The reason the 401 fires on chat but not on the `/model` probe: opencode-go's `GET /v1/models` does not require auth, so the probe always succeeds and the switch "works." `POST /v1/chat/completions` does require auth, so the next chat turn after the switch returns 401. The catalog fix makes the offline/probe-failure path also succeed; the doctor check catches the underlying setup gap before the user hits it.

## Related Issue

Refs #36915 (improves diagnosis and the offline-probe path; does not auto-resolve the user's 401 — see the note above)

Related context — PR #36756 (`feat(pricing): add opencode-go provider pricing for all Go models`, opened earlier today by `kirikatiya`) is adding pricing entries for the same two models in `agent/usage_pricing.py`. That PR is complementary, not conflicting: it adds the pricing rows, this PR adds the catalog rows. They are safe to merge independently in either order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/models.py` — added `deepseek-v4-pro`, `deepseek-v4-flash` to `_PROVIDER_MODELS["opencode-go"]` with a comment explaining the `#36915` rationale and the cross-reference to the static-catalog fallback in `validate_requested_model()` (the curated-catalog branch near the end of the function, ~L3387-3443).
- `hermes_cli/doctor.py` — added `_DOTENV_REQUIRED_PROVIDER_KEYS` (24-entry tuple of known provider env-var names), `_shell_env_dotenv_mismatches()` (returns the list of env vars set in `os.environ` but missing from `load_env()`), and an inline call site in `run_doctor()` that emits a `check_warn` and appends to `issues` when any mismatches are found. The check fires whether or not `~/.hermes/.env` exists; if it doesn't, every shell-set provider key is a mismatch.
- `tests/hermes_cli/test_doctor.py` — added 9 new tests across two classes:
  - `TestShellEnvDotenvMismatches` (6 tests): no mismatch when nothing set, no mismatch when keys match, mismatch when key in shell only, mismatch when `.env` doesn't exist, empty shell value is ignored, load error returns empty list.
  - `TestOpencodeGoCatalogIncludesDeepseek` (3 tests): `deepseek-v4-pro` / `deepseek-v4-flash` present in the catalog, and `provider_model_ids("opencode-go")` returns them even when `models_dev.list_agentic_models` is empty (the offline / probe-failure path that was the regression case).

## How to Test

### Reproduce the bug (pre-fix)

```bash
# 1. Set up an opencode-go key in shell, but NOT in ~/.hermes/.env
export OPENCODE_GO_API_KEY="sk-your-real-key"
# 2. Ensure ~/.hermes/.env does not contain it
grep OPENCODE_GO_API_KEY ~/.hermes/.env || echo "not in .env"

# 3. Start a session on opencode-go/deepseek-v4-flash, then /model deepseek-v4-pro
# Result: 401 "Invalid API key" on first chat turn after the switch.
```

### Verify the doctor fix

```bash
# With the same setup (key in shell, not in .env):
hermes doctor
# Expected: a new warning line under "Configuration Files":
#   ⚠ N provider key(s) set in shell but missing from .env: OPENCODE_GO_API_KEY
#     (the gateway process won't see these keys)
# Plus an issues entry with the remediation hint to run 'hermes setup'.
```

### Verify the catalog fix

```bash
# Direct catalog check (works in any state, no API calls):
python -c "from hermes_cli.models import _PROVIDER_MODELS; assert 'deepseek-v4-pro' in _PROVIDER_MODELS['opencode-go']; assert 'deepseek-v4-flash' in _PROVIDER_MODELS['opencode-go']; print('ok')"
```

### Test run

```
$ pytest tests/hermes_cli/test_doctor.py -q
68 passed, 1 warning in 8.36s

$ pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_command_install.py -q
78 passed, 1 warning in 9.35s

$ pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_switch_variant_tags.py tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/hermes_cli/test_model_switch_opencode_anthropic.py -q
291 passed, 1 warning in 7.68s
```

Combined: 369/369 pass in the touched scope, measured after rebasing this branch onto current `main`. (Counts are higher than an earlier revision of this description because `main` has since added more tests in `test_doctor.py`; this PR itself adds 9.) Unrelated pre-existing failures elsewhere in the wider `tests/hermes_cli/` sweep reproduce on a clean `main` without this change and are not caused by this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(models,doctor): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (within the scope I touched — 78 doctor + 291 model-switch = 369/369; pre-existing failures in other files are unaffected)
- [x] I've added tests for my changes (9 new tests in `TestShellEnvDotenvMismatches` and `TestOpencodeGoCatalogIncludesDeepseek`)
- [x] I've tested on my platform: Linux (Ubuntu 24.04, hermes-agent main @ `f8744dfca` + this branch)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing docs change; the doctor output IS the user-facing surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (the doctor change is OS-agnostic; the catalog change is data-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Sample doctor output (post-fix, with the user's shell having `OPENCODE_GO_API_KEY` set and `~/.hermes/.env` not containing it):

```
◆ Configuration Files
  ✓ /home/ubuntu/.hermes/.env file exists
  ✓ API key or custom endpoint configured
  ⚠ 1 provider key(s) set in shell but missing from .env: OPENCODE_GO_API_KEY
    (the gateway process won't see these keys)
```

The corresponding `issues` list entry tells the user to run `hermes setup` or append the key to `.env` manually.

