### PR TITLE
i18n(dashboard): translate kanban keys missing from 15 locales

### DIFF
--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -576,6 +576,9 @@ export const af: Translations = {
     createTask: "Skep taak in hierdie kolom",
     noTasks: "— geen take —",
     unassigned: "nie toegewys nie",
+    needsAssignee: "Toegewysde nodig",
+    needsAssigneeHint:
+      "Afhanklikhede is bevredig, maar die dispatcher slaan hierdie taak oor totdat jy 'n profiel toewys.",
     untitled: "(sonder titel)",
     loadingDetail: "Word gelaai…",
     addComment: "Voeg 'n opmerking by… (Enter om in te dien)",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -575,6 +575,9 @@ export const de: Translations = {
     createTask: "Aufgabe in dieser Spalte erstellen",
     noTasks: "— keine Aufgaben —",
     unassigned: "nicht zugewiesen",
+    needsAssignee: "Zuständige Person fehlt",
+    needsAssigneeHint:
+      "Abhängigkeiten sind erfüllt, aber der Dispatcher überspringt diese Aufgabe, bis du ein Profil zuweist.",
     untitled: "(ohne Titel)",
     loadingDetail: "Wird geladen…",
     addComment: "Kommentar hinzufügen… (Enter zum Senden)",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -575,6 +575,9 @@ export const es: Translations = {
     createTask: "Crear tarea en esta columna",
     noTasks: "— sin tareas —",
     unassigned: "sin asignar",
+    needsAssignee: "Falta asignar",
+    needsAssigneeHint:
+      "Las dependencias están satisfechas, pero el dispatcher omite esta tarea hasta que asignes un perfil.",
     untitled: "(sin título)",
     loadingDetail: "Cargando…",
     addComment: "Añadir un comentario… (Enter para enviar)",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -575,6 +575,9 @@ export const fr: Translations = {
     createTask: "Créer une tâche dans cette colonne",
     noTasks: "— aucune tâche —",
     unassigned: "non assigné",
+    needsAssignee: "Assignation requise",
+    needsAssigneeHint:
+      "Les dépendances sont satisfaites, mais le dispatcher ignore cette tâche tant que vous n'assignez pas de profil.",
     untitled: "(sans titre)",
     loadingDetail: "Chargement…",
     addComment: "Ajouter un commentaire… (Enter pour envoyer)",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -576,6 +576,9 @@ export const ga: Translations = {
     createTask: "Cruthaigh tasc sa cholún seo",
     noTasks: "— gan tascanna —",
     unassigned: "gan sannadh",
+    needsAssignee: "Sannaí ag teastáil",
+    needsAssigneeHint:
+      "Tá na spleáchais sásaithe, ach scipeálann an dispatcher an tasc seo go dtí go sannann tú próifíl.",
     untitled: "(gan teideal)",
     loadingDetail: "Á luchtú…",
     addComment: "Cuir nóta tráchta… (Enter chun seoladh)",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -576,6 +576,9 @@ export const hu: Translations = {
     createTask: "Feladat létrehozása ebben az oszlopban",
     noTasks: "— nincsenek feladatok —",
     unassigned: "nincs felelős",
+    needsAssignee: "Felelős szükséges",
+    needsAssigneeHint:
+      "A függőségek teljesültek, de a dispatcher átugorja ezt a feladatot, amíg nem rendel hozzá profilt.",
     untitled: "(névtelen)",
     loadingDetail: "Betöltés…",
     addComment: "Hozzászólás hozzáadása… (Enter a beküldéshez)",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -575,6 +575,9 @@ export const it: Translations = {
     createTask: "Crea attività in questa colonna",
     noTasks: "— nessuna attività —",
     unassigned: "non assegnato",
+    needsAssignee: "Assegnatario mancante",
+    needsAssigneeHint:
+      "Le dipendenze sono soddisfatte, ma il dispatcher salta questa attività finché non assegni un profilo.",
     untitled: "(senza titolo)",
     loadingDetail: "Caricamento…",
     addComment: "Aggiungi un commento… (Enter per inviare)",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -576,6 +576,9 @@ export const ja: Translations = {
     createTask: "この列にタスクを作成",
     noTasks: "— タスクはありません —",
     unassigned: "未割り当て",
+    needsAssignee: "担当者が必要",
+    needsAssigneeHint:
+      "依存関係は満たされていますが、プロファイルを割り当てるまで、ディスパッチャーはこのタスクをスキップします。",
     untitled: "（タイトルなし）",
     loadingDetail: "読み込み中…",
     addComment: "コメントを追加…（Enter で送信）",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -576,6 +576,9 @@ export const ko: Translations = {
     createTask: "이 열에 작업 만들기",
     noTasks: "— 작업 없음 —",
     unassigned: "미지정",
+    needsAssignee: "담당자 필요",
+    needsAssigneeHint:
+      "종속성은 충족되었지만, 프로필을 지정할 때까지 디스패처가 이 작업을 건너뜁니다.",
     untitled: "(제목 없음)",
     loadingDetail: "불러오는 중…",
     addComment: "댓글 추가… (Enter로 전송)",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -576,6 +576,9 @@ export const pt: Translations = {
     createTask: "Criar tarefa nesta coluna",
     noTasks: "— sem tarefas —",
     unassigned: "sem atribuição",
+    needsAssignee: "Falta atribuir responsável",
+    needsAssigneeHint:
+      "As dependências estão satisfeitas, mas o dispatcher ignora esta tarefa até atribuíres um perfil.",
     untitled: "(sem título)",
     loadingDetail: "A carregar…",
     addComment: "Adicionar um comentário… (Enter para submeter)",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -576,6 +576,9 @@ export const ru: Translations = {
     createTask: "Создать задачу в этой колонке",
     noTasks: "— нет задач —",
     unassigned: "без исполнителя",
+    needsAssignee: "Нужен исполнитель",
+    needsAssigneeHint:
+      "Зависимости выполнены, но диспетчер пропускает эту задачу, пока вы не назначите профиль.",
     untitled: "(без названия)",
     loadingDetail: "Загрузка…",
     addComment: "Добавить комментарий… (Enter — отправить)",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -576,6 +576,9 @@ export const tr: Translations = {
     createTask: "Bu sütunda görev oluştur",
     noTasks: "— görev yok —",
     unassigned: "atanmamış",
+    needsAssignee: "Atanan kişi gerekli",
+    needsAssigneeHint:
+      "Bağımlılıklar karşılandı, ancak siz bir profil atayana kadar dispatcher bu görevi atlar.",
     untitled: "(başlıksız)",
     loadingDetail: "Yükleniyor…",
     addComment: "Yorum ekle… (göndermek için Enter)",

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -576,6 +576,9 @@ export const uk: Translations = {
     createTask: "Створити задачу в цьому стовпці",
     noTasks: "— немає задач —",
     unassigned: "не призначено",
+    needsAssignee: "Потрібен виконавець",
+    needsAssigneeHint:
+      "Залежності задоволені, але диспетчер пропускає цю задачу, поки ви не призначите профіль.",
     untitled: "(без назви)",
     loadingDetail: "Завантаження…",
     addComment: "Додати коментар… (Enter для надсилання)",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -576,6 +576,9 @@ export const zhHant: Translations = {
     createTask: "在此欄建立任務",
     noTasks: "— 沒有任務 —",
     unassigned: "未指派",
+    needsAssignee: "需要負責人",
+    needsAssigneeHint:
+      "相依項目已滿足，但在您指派設定檔之前，排程器會略過此任務。",
     untitled: "（無標題）",
     loadingDetail: "載入中…",
     addComment: "新增留言…（按 Enter 送出）",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -572,6 +572,9 @@ export const zh: Translations = {
     createTask: "在此列创建任务",
     noTasks: "— 无任务 —",
     unassigned: "未分配",
+    needsAssignee: "需要负责人",
+    needsAssigneeHint:
+      "依赖项已满足，但在您分配配置文件之前，调度器会跳过此任务。",
     untitled: "（无标题）",
     loadingDetail: "加载中…",
     addComment: "添加评论…（按回车提交）",


### PR DESCRIPTION
## Summary

Adds `needsAssignee` and `needsAssigneeHint` to all 15 non-English locales in `web/src/i18n/`. Both keys are read at runtime by the bundled Kanban plugin dashboard (`plugins/kanban/dashboard/dist/index.js`) via `tx(i18n, key, englishFallback)`. Because `tx()` returns its English fallback argument when a locale lacks the key, non-English users currently see **English fallback copy** (not `undefined`) for the "needs assignee" badge and its tooltip.

Closes #36956.

## What changed

- 15 files modified: `af, de, es, fr, ga, hu, it, ja, ko, pt, ru, tr, uk, zh-hant, zh`
- +45 lines (2 keys × 15 locales), 0 deletions
- Locale data only — no type or code changes

## Scope note (review follow-up)

An earlier revision also added `confirmScheduled`, but that key has **no consumer** in the current dashboard bundle — `DESTRUCTIVE_KEYS` maps only `done`, `archived`, and `blocked`, and a repo-wide search finds no reader for `confirmScheduled`. Translating it has no runtime effect today, so it has been dropped from this PR. It can be added back in a focused change if/when a consumer is introduced.

## Translation notes

- Ukrainian (`uk.ts`) — written by a native speaker; terminology matches the existing file (`виконавець`, `диспетчер`, `Залежності задоволені`).
- Other locales — aligned with each file's established terminology for `dispatcher` and `profile`.
- Irish (`ga.ts`) — best-effort; happy to defer to a native speaker.

## Verification

- `npx tsc -b` passes (no type errors); both keys are declared optional in `types.ts`.
- Confirmed both keys are consumed at `plugins/kanban/dashboard/dist/index.js` via `tx()`.

## Test plan

- [ ] Switch the dashboard to a non-English locale (e.g. `uk`), open the Kanban board, and confirm the translated strings render instead of the English fallback for a task with dependencies satisfied but no assignee (badge + tooltip).
