### PR TITLE
fix(gateway): fix Windows /restart chain — WhatsApp bridge force-kill + watcher stdin

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5494,6 +5494,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     time.sleep(0.2)
                 subprocess.Popen(
                     cmd,
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     creationflags=windows_detach_flags_without_breakaway(),
@@ -5529,6 +5530,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
             subprocess.Popen(
                 [watcher_python, "-c", watcher, str(current_pid), str(restart_after_s), *cmd_argv],
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=watcher_env,
@@ -5553,6 +5555,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if setsid_bin:
             subprocess.Popen(
                 [setsid_bin, "bash", "-lc", shell_cmd],
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=watcher_env,
@@ -5561,6 +5564,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             subprocess.Popen(
                 ["bash", "-lc", shell_cmd],
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=watcher_env,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -772,13 +772,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             try:
                 try:
                     _terminate_bridge_process(self._bridge_process, force=False)
-                except (ProcessLookupError, PermissionError):
+                except (ProcessLookupError, PermissionError, OSError):
                     self._bridge_process.terminate()
                 await asyncio.sleep(1)
                 if self._bridge_process.poll() is None:
                     try:
                         _terminate_bridge_process(self._bridge_process, force=True)
-                    except (ProcessLookupError, PermissionError):
+                    except (ProcessLookupError, PermissionError, OSError):
                         self._bridge_process.kill()
             except Exception as e:
                 print(f"[{self.name}] Error stopping bridge: {e}")


### PR DESCRIPTION
## Summary

Fixes two remaining bugs that prevent `/restart` from working on Windows when the gateway is started from a terminal.

> [!NOTE]
> This PR was originally 3 bugs. **Bug 2** (watcher inheriting `_HERMES_GATEWAY` env var, blocking the CLI restart guard) was **solved upstream** and is no longer included. The branch has been rebased onto latest `main`.

### Bug 1: WhatsApp bridge never force-killed (`plugins/platforms/whatsapp/adapter.py:775`)

`_terminate_bridge_process(force=False)` runs `taskkill /PID /T` (no `/F`). When this fails (child process needs force kill), it raises `OSError`. The inner `except (ProcessLookupError, PermissionError)` doesn't catch generic `OSError`, so the `force=True` fallback is never reached. Bridge process survives, port stays held.

**Fix:** Add `OSError` to both `except` clauses (the `force=False` and `force=True` fallback paths).

> **File path update:** This code moved from `gateway/platforms/whatsapp.py` → `plugins/platforms/whatsapp/adapter.py` upstream.

### Bug 3: Missing `stdin=subprocess.DEVNULL` in watcher (`gateway/run.py:5495`)

The 4 `subprocess.Popen` calls in `_launch_detached_restart_command` don't set `stdin=subprocess.DEVNULL`. When the gateway's terminal closes, the inherited stdin handle becomes invalid. The child process may crash silently.

**Fix:** Add `stdin=subprocess.DEVNULL` to all 4 `subprocess.Popen` calls (Windows watcher-internal, Windows watcher-launcher, POSIX setsid, POSIX fallback).

## What was dropped (Bug 2 — solved upstream)

**Watcher respawn blocked by restart-loop guard** — Upstream now strips `_HERMES_GATEWAY` from the watcher environment at `gateway/run.py:5503-5507` (`_launch_detached_restart_command`). This is exactly the fix the original PR proposed, so it has been removed to avoid duplication.

## Testing

Tested on Windows 11 with WhatsApp + LINE platforms:
1. Start gateway: `hermes gateway run`
2. Send `/restart` from WhatsApp
3. Old gateway exits cleanly
4. Watcher detects PID gone, spawns `hermes gateway restart`
5. New gateway starts successfully
6. Messaging platforms reconnect

## References

- `plugins/platforms/whatsapp/adapter.py` lines 771-784 (terminate bridge flow)
- `gateway/run.py` `_launch_detached_restart_command` (lines 5430-5568)
