### PR TITLE
docs: add Hermes MCP registry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Hermes Agent ☤
 
+<!-- mcp-name: io.github.NousResearch/hermes-agent -->
+
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>

--- a/server.json
+++ b/server.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.NousResearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Bridge Hermes Agent messaging conversations to MCP clients.",
+  "version": "0.15.1",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent",
+      "version": "0.15.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_server_registry_metadata.py
+++ b/tests/test_server_registry_metadata.py
@@ -1,0 +1,40 @@
+import json
+import re
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_server_json_registry_metadata_matches_project_version():
+    server_path = ROOT / "server.json"
+    assert server_path.is_file()
+
+    metadata = json.loads(server_path.read_text())
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    version = pyproject["project"]["version"]
+
+    assert metadata["$schema"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    assert metadata["name"] == "io.github.NousResearch/hermes-agent"
+    assert re.fullmatch(r"[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+", metadata["name"])
+    assert metadata["description"]
+    assert metadata["version"] == version
+
+    repository = metadata["repository"]
+    assert repository["url"] == "https://github.com/NousResearch/hermes-agent"
+    assert repository["source"] == "github"
+
+    packages = metadata["packages"]
+    assert len(packages) == 1
+    package = packages[0]
+    assert package["registryType"] == "pypi"
+    assert package["registryBaseUrl"] == "https://pypi.org"
+    assert package["identifier"] == "hermes-agent"
+    assert package["version"] == version
+    assert package["transport"] == {"type": "stdio"}
+    assert [arg["value"] for arg in package["packageArguments"]] == ["mcp", "serve"]
+    assert all(arg["type"] == "positional" for arg in package["packageArguments"])
+
+    readme = (ROOT / "README.md").read_text()
+    assert f"mcp-name: {metadata['name']}" in readme

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -660,7 +660,9 @@ This starts a stdio MCP server. The MCP client (not you) manages the process lif
 
 ### MCP client configuration
 
-Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:
+Hermes publishes root-level MCP registry metadata in [`server.json`](https://github.com/NousResearch/hermes-agent/blob/main/server.json). The metadata points at the official PyPI package, includes the registry-required `mcp-name` ownership marker in the package README, and fixes the stdio arguments to `mcp serve` so clients launch the MCP server instead of plain `hermes`.
+
+Some clients install the base PyPI distribution from registry metadata but do not request optional extras. If your client does not install the `mcp` extra automatically, configure Hermes manually. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -668,6 +670,19 @@ Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/c
     "hermes": {
       "command": "hermes",
       "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+If you want the client to run Hermes through `uvx` with the MCP extra instead of relying on an existing install:
+
+```json
+{
+  "mcpServers": {
+    "hermes": {
+      "command": "uvx",
+      "args": ["--from", "hermes-agent[mcp]", "hermes", "mcp", "serve"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add root-level `server.json` metadata for publishing Hermes Agent's own `hermes mcp serve` bridge to MCP registries/directories
- Add the PyPI README ownership marker required by the official MCP registry (`mcp-name: io.github.NousResearch/hermes-agent`)
- Document registry metadata plus manual fallback configs, including `uvx --from hermes-agent[mcp] hermes mcp serve` for clients that do not install optional extras automatically
- Add a focused regression test to keep `server.json` in sync with `pyproject.toml` and verify the fixed `mcp serve` launch args

## Notes
- The official MCP registry's PyPI validator looks up `identifier` directly via PyPI, so `server.json` uses `hermes-agent` as the package identifier and documents the `hermes-agent[mcp]` extra as the manual fallback path for clients that need it.
- One remaining ecosystem/client behavior to verify during registry submission: whether a registry client running from PyPI metadata selects the `hermes` console script or needs an explicit executable override. The documented fallback is known to use the intended executable.

## Test Plan
- [x] `python -m pytest tests/test_server_registry_metadata.py -q`
- [x] Validate `server.json` against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [x] Confirm official-validator-style PyPI lookup succeeds for `https://pypi.org/pypi/hermes-agent/0.15.1/json`
