### PR TITLE
feat(approval): add register_dangerous_pattern() runtime extension seam

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -479,6 +479,40 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
 
 
 # =========================================================================
+# Extension seam — downstream-registered dangerous patterns
+# =========================================================================
+
+_REGISTERED_DANGEROUS_PATTERNS: list[tuple[str, str]] = []
+
+
+def register_dangerous_pattern(pattern: str, description: str) -> None:
+    """Register an additional approval-gated command pattern at runtime.
+
+    Lets a deployment add command patterns to the approval gate WITHOUT
+    editing the built-in ``DANGEROUS_PATTERNS`` list — e.g. a plugin or a
+    site security policy that wants to flag an extra shape. The registered
+    pattern joins the same approve once/session/permanent flow as the
+    built-ins (it is an ASK gate, not a hard block) and is picked up by
+    :func:`detect_dangerous_command` immediately.
+
+    Idempotent: re-registering the same ``(pattern, description)`` is a no-op.
+
+    Args:
+        pattern: regex matched (case-insensitively, via ``_RE_FLAGS``)
+            against the normalized command string.
+        description: human-readable reason; also used as the approval key.
+    """
+    entry = (pattern, description)
+    if entry in _REGISTERED_DANGEROUS_PATTERNS:
+        return
+    _REGISTERED_DANGEROUS_PATTERNS.append(entry)
+    DANGEROUS_PATTERNS_COMPILED.append((re.compile(pattern, _RE_FLAGS), description))
+    _legacy_key = _legacy_pattern_key(pattern)
+    _PATTERN_KEY_ALIASES.setdefault(description, set()).update({description, _legacy_key})
+    _PATTERN_KEY_ALIASES.setdefault(_legacy_key, set()).update({_legacy_key, description})
+
+
+# =========================================================================
 # Detection
 # =========================================================================
 


### PR DESCRIPTION
## What

Adds a small public extension seam, `register_dangerous_pattern(pattern, description)`, to `tools/approval.py`. It lets a deployment add approval-gated command patterns at runtime **without editing the built-in `DANGEROUS_PATTERNS` list**.

Registered patterns:
- join the same **approve once / session / permanent** flow as the built-ins (an ASK gate, not a hard block),
- are picked up by `detect_dangerous_command()` immediately (appended to `DANGEROUS_PATTERNS_COMPILED`),
- get the same approval-key aliasing as built-ins (`_PATTERN_KEY_ALIASES`),
- registration is **idempotent** (re-registering the same `(pattern, description)` is a no-op).

## Why

Downstream operators who want to flag an extra command shape (e.g. a site security policy gating "a credential file referenced together with a network tool in one command") currently have to monkeypatch the module or fork the file — both fragile across upgrades. A tiny public seam keeps such customizations out of the vendored source.

## Behavior change

None by default. The built-in list and matcher are unchanged; this only adds an opt-in registration entry point. No new dependencies.

## Test

```python
import tools.approval as ap
n0 = len(ap.DANGEROUS_PATTERNS_COMPILED)
ap.register_dangerous_pattern(r'\bzzdanger_test\b', "unit test pattern")
ap.register_dangerous_pattern(r'\bzzdanger_test\b', "unit test pattern")   # idempotent
assert len(ap.DANGEROUS_PATTERNS_COMPILED) == n0 + 1
assert ap.detect_dangerous_command("echo zzdanger_test")[0] is True
assert ap.detect_dangerous_command("echo hello")[0] is False
```
