### PR TITLE
feat(background_review): make review-fork toolsets config-overridable

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -399,6 +399,27 @@ def _run_review_in_thread(
             # Match parent's toolset config so ``tools[]`` is byte-identical
             # in the request body — Anthropic's cache key includes it.
             # (The runtime whitelist below still restricts dispatch.)
+            #
+            # Override seam: deployments under a provider tool-count cap can
+            # pin the review fork's toolsets via config instead of inheriting
+            # the parent's full set. Inheriting can exceed e.g. xAI's hard
+            # 200-tool limit (the request 400s with "N tools provided, maximum
+            # is 200") once enough MCP servers are enabled, and since the
+            # whitelist below restricts dispatch to memory/skills anyway, a
+            # narrower request set is lossless. Default (key absent): inherit
+            # the parent — byte-identical behavior, no change for Anthropic.
+            _review_cfg: dict = {}
+            try:
+                from hermes_cli.config import load_config
+                _review_cfg = (load_config() or {}).get("background_review") or {}
+            except Exception:
+                _review_cfg = {}
+            _review_enabled_toolsets = _review_cfg.get("enabled_toolsets")
+            if _review_enabled_toolsets is None:
+                _review_enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+            _review_disabled_toolsets = _review_cfg.get("disabled_toolsets")
+            if _review_disabled_toolsets is None:
+                _review_disabled_toolsets = getattr(agent, "disabled_toolsets", None)
             review_agent = AIAgent(
                 model=agent.model,
                 max_iterations=16,
@@ -410,8 +431,8 @@ def _run_review_in_thread(
                 api_key=_parent_runtime.get("api_key") or None,
                 credential_pool=getattr(agent, "_credential_pool", None),
                 parent_session_id=agent.session_id,
-                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                enabled_toolsets=_review_enabled_toolsets,
+                disabled_toolsets=_review_disabled_toolsets,
                 skip_memory=True,
             )
             review_agent._memory_write_origin = "background_review"


### PR DESCRIPTION
## What

Makes the background skill-review fork's toolsets config-overridable via `background_review.enabled_toolsets` (and `.disabled_toolsets`) in `agent/background_review.py`.

**Default behavior is unchanged**: when the config keys are absent, the fork inherits the parent agent's toolsets exactly as before (so the request `tools[]` stays byte-identical for Anthropic prefix-caching).

## Why

The review fork inherits the parent's full toolset so `tools[]` is byte-identical for cache parity. But on a provider with a hard tool-count cap — e.g. xAI/Grok's 200-tool limit — once enough MCP servers are enabled, the inherited set **exceeds the cap and the review request 400s** (`N tools provided, maximum is 200`), so the fork never runs and no skill is produced.

Since the runtime whitelist already restricts review dispatch to `memory`/`skills`, a narrower **request** set is lossless. This adds an opt-in escape hatch for capped providers without changing anything for Anthropic.

## Behavior change

None unless `background_review.enabled_toolsets` is set in config. The config read is wrapped in try/except and falls back to the previous `getattr(agent, "enabled_toolsets", None)` inheritance.

## Example config

```yaml
background_review:
  enabled_toolsets: [memory, skills]   # pin the fork under a provider tool cap
```
