### PR TITLE
feat(models): add grok-composer-2.5-fast to xAI model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -47,6 +47,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("google/gemini-3.5-flash",                ""),
     # xAI
     ("x-ai/grok-4.3",                          ""),
+    ("x-ai/grok-composer-2.5-fast",            ""),
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
     ("deepseek/deepseek-v4-flash",             ""),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-01T08:20:18Z",
+  "updated_at": "2026-06-01T19:36:45Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -54,6 +54,10 @@
         },
         {
           "id": "x-ai/grok-4.3",
+          "description": ""
+        },
+        {
+          "id": "x-ai/grok-composer-2.5-fast",
           "description": ""
         },
         {


### PR DESCRIPTION
## Summary
- Adds `x-ai/grok-composer-2.5-fast` to the xAI model list in `hermes_cli/models.py`
- This model is live on xAI `/v1/chat/completions` with `reasoning_content` support
- It is Grok Build's composer model for agentic code composition
- Not yet listed in `/v1/models` or `/v1/language-models` but responds to direct calls

## Test plan
- [ ] Verify `hermes auth add xai-oauth` → `hermes run --model x-ai/grok-composer-2.5-fast` works
- [ ] Confirm model appears in `hermes models` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)