### PR TITLE
docs(user-guide): add prompt caching to user guide

### DIFF
--- a/website/docs/user-guide/features/prompt-caching.md
+++ b/website/docs/user-guide/features/prompt-caching.md
@@ -28,33 +28,49 @@ Hermes handles the rest: it sends the provider's `cache_control` markers automat
 
 ## Supported Providers
 
-`cache_ttl` only takes effect for providers where Hermes injects `cache_control` markers. That's **Claude models** and **Qwen/Alibaba models**:
+`cache_ttl` takes effect for providers where Hermes injects `cache_control` markers:
 
-| Provider | `cache_ttl` effect |
-|----------|--------------------|
-| **Anthropic Claude** — native API, or via OpenRouter / Nous Portal | Yes — Hermes injects `cache_control` markers controlled by `cache_ttl` |
-| **Qwen / Alibaba** — on OpenCode / DashScope | Yes — Hermes injects `cache_control` markers controlled by `cache_ttl` |
-| **Other providers** (DeepSeek, Llama, etc.) | No effect — caching, if any, is handled by the provider's own infrastructure |
-| **Cerebras** | No effect — automatic server-side KV caching, independent of this config |
+| Provider / Model | `cache_ttl` effect | Notes |
+|------------------|--------------------|-------|
+| **Anthropic Claude** — native API, or via OpenRouter / Nous Portal | Yes | Default path; no extra config |
+| **Qwen / Alibaba** — on OpenCode / DashScope | Yes | |
+| **DeepSeek** — `deepseek-v3.2`, `deepseek-v4-flash` via OpenRouter | Yes | Requires [#20945](https://github.com/NousResearch/hermes-agent/pull/20945) — see below |
+| **Other providers** (Llama, Mistral, etc.) | No effect | Provider-side caching only |
+| **Cerebras** | No effect | Automatic server-side KV caching, independent of this config |
 
-For Claude and Qwen, Hermes attaches the markers automatically and the CLI confirms it at startup:
+For supported providers, the CLI confirms caching at startup:
 
 ```
 💾 Prompt caching: ENABLED (Claude via OpenRouter, 5m TTL)
 ```
 
-This message only appears for supported providers (Claude / Qwen). You won't see it for DeepSeek, Cerebras, or other providers — that's expected, and `cache_ttl` is safe to leave in your config either way.
+This message only appears for Claude and Qwen paths. Cerebras and DeepSeek don't emit it — that's expected.
 
-DeepSeek and Cerebras still get caching — DeepSeek via OpenRouter's infrastructure, Cerebras via automatic server-side KV caching of repeated system-prompt prefixes — but neither is driven by `cache_ttl`, and Hermes sends no `cache_control` markers to them.
+### DeepSeek via OpenRouter
+
+`deepseek/deepseek-v4-flash` and `deepseek/deepseek-v3.2` accept `cache_control` markers on OpenRouter and return real cache hits when they are present. Without them, the full prompt is re-billed on every turn.
+
+This requires the models to be in `_OPENROUTER_EXPLICIT_CACHE_CONTROL_MODEL_IDS` in `agent/agent_runtime_helpers.py`. [PR #20945](https://github.com/NousResearch/hermes-agent/pull/20945) (open, pending merge) adds these models. Once merged, `cache_ttl` controls DeepSeek caching the same way it does Claude.
+
+**Measured on production Hermes (2026-05-31, `deepseek/deepseek-v4-flash` via OpenRouter):**
+
+| Scenario | Cache hit rate |
+|----------|---------------|
+| Warmup → identical repeat | 98% |
+| Realistic 5-turn growing conversation | 87–89% (warm turns) |
+| Aggregate over multi-turn session | ~64% |
+| Baseline before patch | ~1% |
+
+### Cerebras
+
+Cerebras caches KV state of repeated system-prompt prefixes automatically at the infrastructure level. No `cache_control` markers are sent and `cache_ttl` has no effect — the caching happens regardless. An orchestrator with a stable `SOUL.md` typically sees a **91–99% cache hit rate** with **1–4 seconds** of latency savings per request.
 
 ## Why It Helps
 
-The biggest win is on the parts of the prompt that never change between turns — your system prompt and `SOUL.md`. As long as those stay stable, the model reads them from cache instead of reprocessing them every request.
-
-In practice, the orchestrator running on Cerebras sees a **91–99% cache hit rate** when the system prompt is stable, saving roughly **1–4 seconds per request**. The savings compound over a long session: every turn that hits the cache is cheaper and faster than the one before it would have been.
+The biggest win is on the parts of the prompt that never change between turns — your system prompt and `SOUL.md`. As long as those stay stable, the model reads them from cache instead of reprocessing them every request. The savings compound over a long session.
 
 ## Tips
 
 - **Leave it on.** There's no downside on unsupported models, and no per-model setup.
 - **Keep your system prompt stable.** Editing `SOUL.md` or the system prompt mid-session invalidates the cached prefix, and the cache rebuilds over the next turn or two.
-- **Use `"1h"` for slow conversations.** If you take long breaks between messages (e.g. a chat assistant you ping a few times an hour), `cache_ttl: "1h"` keeps the prefix warm past the 5-minute default.
+- **Use `"1h"` for slow conversations.** If you take long breaks between messages, `cache_ttl: "1h"` keeps the prefix warm past the 5-minute default.

--- a/website/docs/user-guide/features/prompt-caching.md
+++ b/website/docs/user-guide/features/prompt-caching.md
@@ -34,7 +34,7 @@ Hermes handles the rest: it sends the provider's `cache_control` markers automat
 |------------------|--------------------|-------|
 | **Anthropic Claude** — native API, or via OpenRouter / Nous Portal | Yes | Default path; no extra config |
 | **Qwen / Alibaba** — on OpenCode / DashScope | Yes | |
-| **DeepSeek** — `deepseek-v3.2`, `deepseek-v4-flash` via OpenRouter | Yes | Requires [#20945](https://github.com/NousResearch/hermes-agent/pull/20945) — see below |
+| **DeepSeek** — `deepseek-v3.2`, `deepseek-v4-flash` via OpenRouter | Yes | Requires [#36984](https://github.com/NousResearch/hermes-agent/pull/36984) — see below |
 | **Other providers** (Llama, Mistral, etc.) | No effect | Provider-side caching only |
 | **Cerebras** | No effect | Automatic server-side KV caching, independent of this config |
 
@@ -50,7 +50,7 @@ This message only appears for Claude and Qwen paths. Cerebras and DeepSeek don't
 
 `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v3.2` accept `cache_control` markers on OpenRouter and return real cache hits when they are present. Without them, the full prompt is re-billed on every turn.
 
-This requires the models to be in `_OPENROUTER_EXPLICIT_CACHE_CONTROL_MODEL_IDS` in `agent/agent_runtime_helpers.py`. [PR #20945](https://github.com/NousResearch/hermes-agent/pull/20945) (open, pending merge) adds these models. Once merged, `cache_ttl` controls DeepSeek caching the same way it does Claude.
+This requires the models to be in `_OPENROUTER_EXPLICIT_CACHE_CONTROL_MODEL_IDS` in `agent/agent_runtime_helpers.py`. [PR #36984](https://github.com/NousResearch/hermes-agent/pull/36984) (open, pending merge) adds `deepseek-v4-flash` and `deepseek-v4-flash-20260423`, building on [#20945](https://github.com/NousResearch/hermes-agent/pull/20945) which covers `deepseek-v3.2` and the Qwen family. Once either is merged, `cache_ttl` controls DeepSeek caching the same way it does Claude.
 
 **Measured on production Hermes (2026-05-31, `deepseek/deepseek-v4-flash` via OpenRouter):**
 

--- a/website/docs/user-guide/features/prompt-caching.md
+++ b/website/docs/user-guide/features/prompt-caching.md
@@ -20,27 +20,32 @@ prompt_caching:
   cache_ttl: "5m"   # use "1h" for long sessions with pauses between turns
 ```
 
+> **Config path:** `~/.hermes/config.yaml` is the default. If `HERMES_HOME` is set (e.g. on a server install), the file is at `$HERMES_HOME/config.yaml` instead.
+
 `cache_ttl` is the only setting. The cache prefix is reused for this long after each request; subsequent requests within the window get a cache hit. Only `"5m"` and `"1h"` are valid — any other value falls back to `"5m"`.
 
 Hermes handles the rest: it sends the provider's `cache_control` markers automatically and only when the active model supports caching. You don't configure anything per model.
 
 ## Supported Providers
 
-Caching activates automatically when your model and provider support it:
+`cache_ttl` only takes effect for providers where Hermes injects `cache_control` markers. That's **Claude models** and **Qwen/Alibaba models**:
 
-| Provider | Caching |
-|----------|---------|
-| **Anthropic Claude** (native API or via OpenRouter) | Yes — controlled by `cache_ttl` |
-| **DeepSeek** | Yes |
-| **Cerebras** | Yes — automatic, no config needed |
+| Provider | `cache_ttl` effect |
+|----------|--------------------|
+| **Anthropic Claude** — native API, or via OpenRouter / Nous Portal | Yes — Hermes injects `cache_control` markers controlled by `cache_ttl` |
+| **Qwen / Alibaba** — on OpenCode / DashScope | Yes — Hermes injects `cache_control` markers controlled by `cache_ttl` |
+| **Other providers** (DeepSeek, Llama, etc.) | No effect — caching, if any, is handled by the provider's own infrastructure |
+| **Cerebras** | No effect — automatic server-side KV caching, independent of this config |
 
-When caching is active, the CLI shows it at startup:
+For Claude and Qwen, Hermes attaches the markers automatically and the CLI confirms it at startup:
 
 ```
 💾 Prompt caching: ENABLED (Claude via OpenRouter, 5m TTL)
 ```
 
-If your model doesn't support caching, the setting is simply ignored — it's safe to leave in your config.
+This message only appears for supported providers (Claude / Qwen). You won't see it for DeepSeek, Cerebras, or other providers — that's expected, and `cache_ttl` is safe to leave in your config either way.
+
+DeepSeek and Cerebras still get caching — DeepSeek via OpenRouter's infrastructure, Cerebras via automatic server-side KV caching of repeated system-prompt prefixes — but neither is driven by `cache_ttl`, and Hermes sends no `cache_control` markers to them.
 
 ## Why It Helps
 

--- a/website/docs/user-guide/features/prompt-caching.md
+++ b/website/docs/user-guide/features/prompt-caching.md
@@ -1,0 +1,55 @@
+---
+title: Prompt Caching
+description: Reuse your stable system prompt across requests to cut input token cost and latency.
+sidebar_label: Prompt Caching
+sidebar_position: 9
+---
+
+# Prompt Caching
+
+Prompt caching lets the model reuse your stable conversation prefix — most importantly your system prompt and `SOUL.md` — across requests instead of re-reading it every turn, cutting input token cost and shaving latency off each reply.
+
+It's set-and-forget: enable it with a single config line, and Hermes attaches the right cache markers automatically. There's no per-model tuning to do.
+
+## Enabling It
+
+Add a `prompt_caching` section to your `~/.hermes/config.yaml`:
+
+```yaml
+prompt_caching:
+  cache_ttl: "5m"   # use "1h" for long sessions with pauses between turns
+```
+
+`cache_ttl` is the only setting. The cache prefix is reused for this long after each request; subsequent requests within the window get a cache hit. Only `"5m"` and `"1h"` are valid — any other value falls back to `"5m"`.
+
+Hermes handles the rest: it sends the provider's `cache_control` markers automatically and only when the active model supports caching. You don't configure anything per model.
+
+## Supported Providers
+
+Caching activates automatically when your model and provider support it:
+
+| Provider | Caching |
+|----------|---------|
+| **Anthropic Claude** (native API or via OpenRouter) | Yes — controlled by `cache_ttl` |
+| **DeepSeek** | Yes |
+| **Cerebras** | Yes — automatic, no config needed |
+
+When caching is active, the CLI shows it at startup:
+
+```
+💾 Prompt caching: ENABLED (Claude via OpenRouter, 5m TTL)
+```
+
+If your model doesn't support caching, the setting is simply ignored — it's safe to leave in your config.
+
+## Why It Helps
+
+The biggest win is on the parts of the prompt that never change between turns — your system prompt and `SOUL.md`. As long as those stay stable, the model reads them from cache instead of reprocessing them every request.
+
+In practice, the orchestrator running on Cerebras sees a **91–99% cache hit rate** when the system prompt is stable, saving roughly **1–4 seconds per request**. The savings compound over a long session: every turn that hits the cache is cheaper and faster than the one before it would have been.
+
+## Tips
+
+- **Leave it on.** There's no downside on unsupported models, and no per-model setup.
+- **Keep your system prompt stable.** Editing `SOUL.md` or the system prompt mid-session invalidates the cached prefix, and the cache rebuilds over the next turn or two.
+- **Use `"1h"` for slow conversations.** If you take long breaks between messages (e.g. a chat assistant you ping a few times an hour), `cache_ttl: "1h"` keeps the prefix warm past the 5-minute default.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -673,6 +673,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/features/acp',
         'user-guide/features/provider-routing',
         'user-guide/features/fallback-providers',
+        'user-guide/features/prompt-caching',
         'user-guide/features/credential-pools',
       ],
     },


### PR DESCRIPTION
## What
Adds a new user-facing documentation page (`website/docs/user-guide/features/prompt-caching.md`) explaining prompt caching for operators and end-users. Covers what caching is (system-prompt/SOUL.md reuse), which providers support it (Anthropic Claude, DeepSeek via OpenRouter, Cerebras), the single config line to enable it (`prompt_caching.cache_ttl: "5m"`), and performance impact (91-99% cache hit rates on stable system prompts, saving 1-4s per request).

**Files modified:** `website/docs/user-guide/features/prompt-caching.md` (new), `website/sidebars.ts` (adds page to Integrations category).

## Why
Prompt caching documentation exists only in the developer guide and example config. New users read the user guide, miss the feature entirely, and never enable a setting that meaningfully cuts input token cost and latency. This page surfaces caching where users actually look.

## Platforms tested
Linux (CT/LXC environment, Python 3.13) — docs rendered locally via Docusaurus dev server