### PR TITLE
feat: add life ops brief helper

### DIFF
--- a/docs/plans/nightly-life-ops-brief.md
+++ b/docs/plans/nightly-life-ops-brief.md
@@ -1,0 +1,45 @@
+# Life Ops Brief Helper Implementation Plan
+
+> **For Hermes:** Use test-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a small local-first script that turns simple YAML/JSON life-ops items into a Joe-style Traditional Chinese morning brief, with exact `[SILENT]` support when nothing needs attention.
+
+**Architecture:** A standalone script under `scripts/` parses a user-owned backlog file without touching external systems. It classifies overdue/due-soon/scheduled items from dates or recurring intervals, formats compact Traditional Chinese output, and supports deterministic tests with `--today`.
+
+**Tech Stack:** Python stdlib + optional PyYAML already used in project tests. Focused pytest coverage via `scripts/run_tests.sh`.
+
+---
+
+### Task 1: Add failing tests for overdue/due-soon/SILENT behavior
+
+**Files:**
+- Create: `tests/scripts/test_life_ops_brief.py`
+- Create: `scripts/life_ops_brief.py`
+
+**Steps:**
+1. Write tests that import the script module and exercise:
+   - overdue date items are reported
+   - recurring tasks compute next due date from `last_done` + `every_days`
+   - no relevant items returns exactly `[SILENT]`
+2. Run the focused tests and confirm failure because the script does not exist or behavior is missing.
+
+### Task 2: Implement minimal parser/classifier/formatter
+
+**Files:**
+- Modify: `scripts/life_ops_brief.py`
+
+**Steps:**
+1. Implement `load_items`, `build_brief`, and CLI `main` with `--input`, `--today`, `--soon-days`.
+2. Support JSON and YAML based on file extension.
+3. Return exact `[SILENT]` when no due/soon/overdue items exist.
+4. Run focused tests and confirm pass.
+
+### Task 3: Add smoke/CLI coverage and verify
+
+**Files:**
+- Modify: `tests/scripts/test_life_ops_brief.py`
+
+**Steps:**
+1. Add CLI smoke test for JSON input.
+2. Run focused tests through `scripts/run_tests.sh`.
+3. Commit, push branch, open PR.

--- a/scripts/life_ops_brief.py
+++ b/scripts/life_ops_brief.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Build a local-first Joe-style life-ops morning brief.
+
+Input is a JSON/YAML list of items. Example item shapes:
+
+    {"title": "clean fridge", "area": "household", "due": "2026-06-01"}
+    {"title": "aircon cleaning", "last_done": "2026-03-10", "every_days": 90}
+
+The script prints exactly ``[SILENT]`` when no item is overdue or due soon,
+which lets cron jobs suppress delivery without special wrapper logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Iterable
+
+try:  # PyYAML is optional for JSON-only users.
+    import yaml
+except Exception:  # pragma: no cover - exercised only when PyYAML unavailable.
+    yaml = None
+
+
+@dataclass(frozen=True)
+class ActionableItem:
+    title: str
+    area: str
+    due: date
+    status: str
+    days_delta: int
+    notes: str = ""
+
+
+def _parse_date(value: Any, field_name: str) -> date | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be YYYY-MM-DD, got {value!r}")
+    return date.fromisoformat(value)
+
+
+def _today(value: str | date | None) -> date:
+    if value is None:
+        return date.today()
+    if isinstance(value, date):
+        return value
+    return date.fromisoformat(value)
+
+
+def _item_due_date(item: dict[str, Any]) -> date | None:
+    explicit_due = _parse_date(item.get("due"), "due")
+    if explicit_due is not None:
+        return explicit_due
+
+    if item.get("last_done") in (None, "") or item.get("every_days") in (None, ""):
+        return None
+
+    last_done = _parse_date(item.get("last_done"), "last_done")
+    if last_done is None:
+        return None
+    try:
+        every_days = int(item["every_days"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"every_days must be an integer, got {item.get('every_days')!r}") from exc
+    if every_days <= 0:
+        raise ValueError("every_days must be positive")
+    return last_done + timedelta(days=every_days)
+
+
+def load_items(path: str | Path) -> list[dict[str, Any]]:
+    """Load life-ops items from JSON or YAML."""
+    source = Path(path)
+    text = source.read_text(encoding="utf-8")
+    if not text.strip():
+        return []
+
+    if source.suffix.lower() == ".json":
+        data = json.loads(text)
+    else:
+        if yaml is None:
+            raise RuntimeError("YAML input requires PyYAML; use .json or install pyyaml")
+        data = yaml.safe_load(text)
+
+    if data is None:
+        return []
+    if not isinstance(data, list):
+        raise ValueError("life-ops input must be a list of items")
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"item {index} must be an object")
+    return data
+
+
+def classify_items(
+    items: Iterable[dict[str, Any]], *, today: str | date | None = None, soon_days: int = 7
+) -> list[ActionableItem]:
+    """Return only overdue or due-soon items, sorted by urgency."""
+    anchor = _today(today)
+    horizon = anchor + timedelta(days=soon_days)
+    actionable: list[ActionableItem] = []
+
+    for item in items:
+        if item.get("done") is True or item.get("status") in {"done", "completed", "cancelled"}:
+            continue
+        due = _item_due_date(item)
+        if due is None or due > horizon:
+            continue
+
+        days_delta = (due - anchor).days
+        status = "overdue" if days_delta < 0 else "soon"
+        if days_delta == 0:
+            status = "today"
+        actionable.append(
+            ActionableItem(
+                title=str(item.get("title") or item.get("name") or "Untitled"),
+                area=str(item.get("area") or "life"),
+                due=due,
+                status=status,
+                days_delta=days_delta,
+                notes=str(item.get("notes") or item.get("note") or ""),
+            )
+        )
+
+    return sorted(actionable, key=lambda row: (row.due, row.area.lower(), row.title.lower()))
+
+
+def _status_label(item: ActionableItem) -> str:
+    if item.status == "overdue":
+        return f"逾期 {abs(item.days_delta)} 天"
+    if item.status == "today":
+        return "今天到期"
+    return f"{item.days_delta} 天內到期"
+
+
+def build_brief(
+    items: Iterable[dict[str, Any]], *, today: str | date | None = None, soon_days: int = 7
+) -> str:
+    """Build a Traditional Chinese morning brief or exact ``[SILENT]``."""
+    actionable = classify_items(items, today=today, soon_days=soon_days)
+    if not actionable:
+        return "[SILENT]"
+
+    overdue_count = sum(1 for item in actionable if item.status == "overdue")
+    today_count = sum(1 for item in actionable if item.status == "today")
+    soon_count = sum(1 for item in actionable if item.status == "soon")
+
+    lines = [
+        f"TL;DR：生活營運有 {len(actionable)} 個項目需要注意（逾期 {overdue_count}、今天 {today_count}、即將到期 {soon_count}）。",
+        "",
+        "- 事實 / 待處理：",
+    ]
+    for item in actionable:
+        note = f" — {item.notes}" if item.notes else ""
+        lines.append(
+            f"  - [{item.area}] {item.title}：{_status_label(item)}（due {item.due.isoformat()}）{note}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "- 建議：先處理逾期項；若已完成，更新 `last_done` 或 `due`，下次 cron 會自動安靜。",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="JSON/YAML life-ops backlog path")
+    parser.add_argument("--today", help="Override today's date as YYYY-MM-DD for deterministic cron/tests")
+    parser.add_argument("--soon-days", type=int, default=7, help="Include items due within N days")
+    args = parser.parse_args(argv)
+
+    print(build_brief(load_items(args.input), today=args.today, soon_days=args.soon_days))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_life_ops_brief.py
+++ b/tests/scripts/test_life_ops_brief.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "life_ops_brief.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("life_ops_brief", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_brief_surfaces_overdue_and_due_soon_life_ops_items():
+    mod = _load_module()
+    items = [
+        {
+            "title": "clean fridge",
+            "area": "household",
+            "due": "2026-06-01",
+            "notes": "monthly reset",
+        },
+        {
+            "title": "aircon cleaning",
+            "area": "household",
+            "last_done": "2026-03-10",
+            "every_days": 90,
+        },
+        {
+            "title": "review portfolio thesis",
+            "area": "investment",
+            "due": "2026-06-20",
+        },
+    ]
+
+    brief = mod.build_brief(items, today="2026-06-10", soon_days=7)
+
+    assert brief.startswith("TL;DR")
+    assert "逾期 2" in brief
+    assert "clean fridge" in brief
+    assert "2026-06-01" in brief
+    assert "aircon cleaning" in brief
+    assert "2026-06-08" in brief
+    assert "review portfolio thesis" not in brief
+
+
+def test_brief_returns_exact_silent_when_nothing_actionable():
+    mod = _load_module()
+    items = [
+        {"title": "future trip planning", "area": "life", "due": "2026-07-01"},
+        {"title": "quarterly body check", "area": "health", "last_done": "2026-06-01", "every_days": 30},
+    ]
+
+    assert mod.build_brief(items, today="2026-06-10", soon_days=7) == "[SILENT]"
+
+
+def test_json_cli_smoke_outputs_silent_for_empty_backlog(tmp_path, capsys):
+    mod = _load_module()
+    backlog = tmp_path / "life_ops.json"
+    backlog.write_text("[]", encoding="utf-8")
+
+    code = mod.main(["--input", str(backlog), "--today", "2026-06-10"])
+
+    assert code == 0
+    assert capsys.readouterr().out.strip() == "[SILENT]"


### PR DESCRIPTION
## Summary
- Add `scripts/life_ops_brief.py`, a local-first JSON/YAML helper that formats Joe-style Traditional Chinese life-ops morning briefs.
- Supports one-off `due` dates and recurring `last_done` + `every_days` items.
- Returns exact `[SILENT]` when nothing is overdue or due soon, so cron delivery can suppress noise.
- Include a small implementation plan under `docs/plans/` and focused tests.

## Test Plan
- [x] RED: `source /Users/hyc/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/scripts/test_life_ops_brief.py -q -o 'addopts='` failed with `FileNotFoundError` before implementation.
- [x] GREEN: `source /Users/hyc/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/scripts/test_life_ops_brief.py -q -o 'addopts='` → `3 passed`.
- [x] Smoke: `source /Users/hyc/.hermes/hermes-agent/venv/bin/activate && python scripts/life_ops_brief.py --input /dev/null --today 2026-06-10` → `[SILENT]`.
- [ ] Wrapper note: `scripts/run_tests.sh tests/scripts/test_life_ops_brief.py` currently cannot start in this local shared venv because pytest-timeout is unavailable (`unrecognized arguments: --timeout=30 --timeout-method=signal`); the shared venv also has no `pip`, so I used the documented direct-pytest fallback.
