### PR TITLE
[codex] Add runtime clock prompt and oMLX doctor validation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.model_metadata import is_local_endpoint
+from agent.system_prompt import build_runtime_clock_prompt
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1302,6 +1303,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         effective_system = agent._cached_system_prompt or ""
         if agent.ephemeral_system_prompt:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        runtime_clock_prompt = build_runtime_clock_prompt()
+        if runtime_clock_prompt:
+            effective_system = (effective_system + "\n\n" + runtime_clock_prompt).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
         if agent.prefill_messages:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -54,6 +54,7 @@ from agent.model_metadata import (
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import jittered_backoff
+from agent.system_prompt import build_runtime_clock_prompt
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -1000,6 +1001,9 @@ def run_conversation(
         effective_system = active_system_prompt or ""
         if agent.ephemeral_system_prompt:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        runtime_clock_prompt = build_runtime_clock_prompt()
+        if runtime_clock_prompt:
+            effective_system = (effective_system + "\n\n" + runtime_clock_prompt).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -364,6 +364,29 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     return "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)
 
 
+def build_runtime_clock_prompt() -> str:
+    """Return a tiny API-call-time clock block.
+
+    The full system prompt is cached for session/prefix-cache stability, so
+    its ``Conversation started`` line intentionally stays date-only. This
+    block is appended at request time and is not persisted to session DB.
+    """
+    from hermes_time import now as _hermes_now
+
+    current = _hermes_now()
+    offset = current.strftime("%z")
+    offset_display = f"UTC{offset[:3]}:{offset[3:]}" if offset else "local timezone"
+    zone_name = current.tzname() or "local time"
+    return (
+        "## Current Date and Time\n"
+        f"Current local date/time: {current.strftime('%A, %B %d, %Y at %I:%M %p')} "
+        f"{zone_name} ({offset_display}); ISO: {current.isoformat(timespec='seconds')}.\n"
+        "Use this timestamp for all relative date phrases. Treat 'today' as this "
+        "date and 'this week' as the current calendar week containing this date; "
+        "do not assume 'this week' means 'weekend' unless the user says weekend."
+    )
+
+
 def invalidate_system_prompt(agent: Any) -> None:
     """Invalidate the cached system prompt, forcing a rebuild on the next turn.
 
@@ -402,6 +425,7 @@ def format_tools_for_system_message(agent: Any) -> str:
 __all__ = [
     "build_system_prompt_parts",
     "build_system_prompt",
+    "build_runtime_clock_prompt",
     "invalidate_system_prompt",
     "format_tools_for_system_message",
 ]

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -690,6 +690,11 @@ def run_doctor(args):
                     known_providers.add("custom:" + name.lower().replace(" ", "-"))
 
             valid_provider_ids = set(known_providers)
+            valid_provider_ids.update(
+                str(known_provider).strip().lower()
+                for known_provider in known_providers
+                if str(known_provider).strip()
+            )
             provider_ids_to_accept = {provider} if provider else set()
             if _normalize_catalog_provider is not None:
                 for known_provider in known_providers:
@@ -707,6 +712,7 @@ def run_doctor(args):
                 try:
                     runtime_provider = _resolve_auth_provider(provider)
                     provider_ids_to_accept.add(runtime_provider)
+                    provider_ids_to_accept.add(str(runtime_provider).strip().lower())
                 except Exception:
                     runtime_provider = provider
 
@@ -720,12 +726,11 @@ def run_doctor(args):
                 catalog_provider = provider_def.id if provider_def is not None else None
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
+                    provider_ids_to_accept.add(str(catalog_provider).strip().lower())
 
             if provider and provider != "auto":
-                if catalog_provider is None or (
-                    known_providers
-                    and not (provider_ids_to_accept & valid_provider_ids)
-                ):
+                provider_known = bool(provider_ids_to_accept & valid_provider_ids)
+                if catalog_provider is None and not provider_known:
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     _fail_and_issue(
                         f"model.provider '{provider_raw}' is not a recognised provider",

--- a/tests/agent/test_runtime_clock_prompt.py
+++ b/tests/agent/test_runtime_clock_prompt.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def test_runtime_clock_prompt_includes_fresh_time_and_relative_date_guidance(monkeypatch):
+    import hermes_time
+    from agent.system_prompt import build_runtime_clock_prompt
+
+    monkeypatch.setattr(
+        hermes_time,
+        "now",
+        lambda: datetime(2026, 6, 1, 13, 4, 5, tzinfo=ZoneInfo("America/Chicago")),
+    )
+
+    prompt = build_runtime_clock_prompt()
+
+    assert "## Current Date and Time" in prompt
+    assert "Monday, June 01, 2026 at 01:04 PM" in prompt
+    assert "UTC-05:00" in prompt
+    assert "2026-06-01T13:04:05-05:00" in prompt
+    assert "this week" in prompt
+    assert "do not assume 'this week' means 'weekend'" in prompt

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -445,6 +445,50 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+def test_run_doctor_accepts_auth_registry_provider_without_catalog_entry(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: omlx\n"
+        "  default: qwen3-30b-a3b-instruct-2507-4bit\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import providers as providers_mod
+
+    monkeypatch.setitem(auth_mod.PROVIDER_REGISTRY, "oMLX", object())
+    monkeypatch.setattr(auth_mod, "resolve_provider", lambda provider: "oMLX")
+    monkeypatch.setattr(providers_mod, "resolve_provider_full", lambda *a, **kw: None)
+
+    try:
+        monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'omlx' is not a recognised provider" not in out
+    assert "model.provider 'omlx' is unknown" not in out
+
+
 def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- Add a fresh runtime clock prompt for API calls so gateway/CLI turns resolve relative dates from the current local timestamp, not only the cached date-only system prompt.
- Preserve prompt-cache stability by keeping the base `Conversation started:` line date-only and appending volatile clock context outside that cached base prompt.
- Accept registered provider names such as `omlx`/`oMLX` in doctor validation when they are supplied by the provider/auth registry rather than the catalog.
- Add regression coverage for the runtime clock prompt and provider validation path.

## Why

Studio Hermes exposed two local issues while migrating gateway usage to an always-on Mac Studio:

- The model could misinterpret relative date phrases such as `this week` because the stable system prompt only carried a date-only `Conversation started:` line.
- `hermes doctor` could flag `model.provider: omlx` even though the provider was registered and connectivity worked.

## Validation

```bash
./scripts/run_tests.sh tests/agent/test_runtime_clock_prompt.py tests/hermes_cli/test_doctor.py tests/run_agent/test_run_agent.py -- -k "runtime_clock_prompt or doctor or includes_datetime or datetime_is_date_only"
```

Result: 63 passed, 0 failed.
