### PR TITLE
fix(gateway): cap direct tool exposure for large MCP surfaces

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -45,6 +45,7 @@ class TestConfigParsing:
         cfg = ToolSearchConfig.from_raw(None)
         assert cfg.enabled == "auto"
         assert cfg.threshold_pct == 10.0
+        assert cfg.max_visible_tools == 180
 
     def test_bool_true_maps_to_auto(self):
         from tools.tool_search import ToolSearchConfig
@@ -81,6 +82,11 @@ class TestConfigParsing:
         })
         assert cfg.max_search_limit == 50
         assert cfg.search_default_limit <= cfg.max_search_limit
+
+    def test_max_visible_tools_clamps_to_disable_at_zero(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({"max_visible_tools": -10})
+        assert cfg.max_visible_tools == 0
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +160,20 @@ class TestThresholdGate:
         cfg = ToolSearchConfig.from_raw({"enabled": "auto", "threshold_pct": 10})
         # 5% of 200K = below 10% threshold
         assert not should_activate(cfg, deferrable_tokens=10_000, context_length=200_000)
+
+    def test_auto_activates_above_visible_tool_cap(self):
+        from tools.tool_search import ToolSearchConfig, should_activate
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "auto",
+            "threshold_pct": 100,
+            "max_visible_tools": 200,
+        })
+        assert should_activate(
+            cfg,
+            deferrable_tokens=100,
+            context_length=200_000,
+            visible_tool_count=201,
+        )
 
     def test_auto_at_or_above_threshold_activates(self):
         from tools.tool_search import ToolSearchConfig, should_activate
@@ -264,6 +284,38 @@ class TestAssembly:
         assert not result.activated
         names = {(t.get("function") or {}).get("name") for t in result.tool_defs}
         assert "tool_search" not in names
+
+    def test_auto_activates_when_tool_count_exceeds_cap(self, monkeypatch):
+        """Large MCP surfaces must collapse even when schema tokens are below
+        a large-context model's threshold. Some providers cap tool count."""
+        import tools.tool_search as tool_search
+        from tools.tool_search import BRIDGE_TOOL_NAMES, ToolSearchConfig, assemble_tool_defs
+
+        monkeypatch.setattr(
+            tool_search,
+            "is_deferrable_tool_name",
+            lambda name: str(name).startswith("mcp_big_"),
+        )
+        defs = [_td("terminal", "Run shell")] + [
+            _td(f"mcp_big_{i}", "Small schema") for i in range(205)
+        ]
+
+        result = assemble_tool_defs(
+            defs,
+            context_length=2_000_000,
+            config=ToolSearchConfig.from_raw({
+                "enabled": "auto",
+                "threshold_pct": 100,
+                "max_visible_tools": 200,
+            }),
+        )
+
+        assert result.activated
+        names = {(t.get("function") or {}).get("name") for t in result.tool_defs}
+        assert "terminal" in names
+        assert BRIDGE_TOOL_NAMES <= names
+        assert "mcp_big_0" not in names
+        assert len(result.tool_defs) == 4
 
     def test_idempotent_when_bridge_already_present(self):
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES
@@ -535,4 +587,3 @@ class TestRegression_ToolsetScoping:
         assert "mcp_helper_op" in names
         # core tools are never deferrable
         assert "terminal" not in names
-

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -66,6 +66,7 @@ class ToolSearchConfig:
 
     enabled: str  # "auto" | "on" | "off"
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
+    max_visible_tools: int  # 0 disables count-based activation
     search_default_limit: int
     max_search_limit: int
 
@@ -81,12 +82,15 @@ class ToolSearchConfig:
         """
         if raw is True:
             return cls(enabled="auto", threshold_pct=10.0,
+                       max_visible_tools=180,
                        search_default_limit=5, max_search_limit=20)
         if raw is False:
             return cls(enabled="off", threshold_pct=10.0,
+                       max_visible_tools=180,
                        search_default_limit=5, max_search_limit=20)
         if not isinstance(raw, dict):
             return cls(enabled="auto", threshold_pct=10.0,
+                       max_visible_tools=180,
                        search_default_limit=5, max_search_limit=20)
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
@@ -102,6 +106,12 @@ class ToolSearchConfig:
         threshold_pct = _safe_float(raw.get("threshold_pct"), 10.0)
         threshold_pct = max(0.0, min(100.0, threshold_pct))
 
+        # Some providers enforce a hard function/tool count independent of
+        # schema token cost. Keep a little headroom below common 200-tool caps
+        # because agent init may append memory/context-engine tools after this
+        # assembly step. Set to 0 to disable this activation trigger.
+        max_visible_tools = max(0, _safe_int(raw.get("max_visible_tools"), 180))
+
         max_search_limit = max(1, min(50, _safe_int(raw.get("max_search_limit"), 20)))
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
@@ -109,6 +119,7 @@ class ToolSearchConfig:
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
+            max_visible_tools=max_visible_tools,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
         )
@@ -235,19 +246,27 @@ def should_activate(
     config: ToolSearchConfig,
     deferrable_tokens: int,
     context_length: Optional[int],
+    visible_tool_count: Optional[int] = None,
 ) -> bool:
     """Decide whether tool search should activate for the current assembly.
 
     ``"off"`` skips unconditionally. ``"on"`` activates unconditionally
     (as long as there is at least one deferrable tool — there's no point
-    swapping a no-op). ``"auto"`` activates when the deferrable schemas
-    would consume ``threshold_pct`` of context or more.
+    swapping a no-op). ``"auto"`` activates when the direct tool list would
+    exceed ``max_visible_tools`` or when the deferrable schemas would consume
+    ``threshold_pct`` of context or more.
     """
     if config.enabled == "off":
         return False
     if deferrable_tokens <= 0:
         return False
     if config.enabled == "on":
+        return True
+    if (
+        config.max_visible_tools > 0
+        and visible_tool_count is not None
+        and visible_tool_count > config.max_visible_tools
+    ):
         return True
     # auto
     if not context_length or context_length <= 0:
@@ -556,7 +575,12 @@ def assemble_tool_defs(
         return AssemblyResult(tool_defs=incoming, activated=False)
 
     deferrable_tokens = estimate_tokens_from_schemas(deferrable)
-    if not should_activate(config, deferrable_tokens, context_length):
+    if not should_activate(
+        config,
+        deferrable_tokens,
+        context_length,
+        visible_tool_count=len(incoming),
+    ):
         return AssemblyResult(
             tool_defs=incoming,
             activated=False,


### PR DESCRIPTION
## Summary
- cap direct tool exposure when MCP discovery returns a provider-breaking tool count
- keep progressive disclosure active for large tool surfaces even when token pressure is otherwise acceptable
- fixes xAI/Grok 4.3 HTTP 400 failures from more than 200 exposed tools

## Verification
- venv/bin/python -m pytest tests/tools/test_tool_search.py tests/test_get_tool_definitions_cache_isolation.py -q
- hermes -z 'Reply with exactly: HERMES_PROVIDER_OK'