### PR TITLE
fix(desktop): add @testing-library/dom as explicit dev dependency

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -96,6 +96,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.2",
     "@types/hast": "^3.0.4",
     "@types/node": "^24.12.2",


### PR DESCRIPTION
## Summary

- `apps/desktop` depends on `@testing-library/react@^16.3.2`, which declares `@testing-library/dom` as a **peerDependency** and re-exports `waitFor`/`fireEvent`/`screen`/`within` from it (`@testing-library/react/types/index.d.ts`: `export * from '@testing-library/dom'`).
- Neither root nor `apps/desktop` declares `@testing-library/dom` directly, so npm does not install it and TypeScript cannot resolve those re-exports.
- Result: `tsc -b` fails with ~20 `TS2305: Module '@testing-library/react' has no exported member 'waitFor' / 'fireEvent' / 'screen' / 'within'` errors across `apps/desktop/src/**/*.test.{ts,tsx}`, which blocks `npm run pack` and crashes the macOS bootstrap installer with `INSTALL DIDN'T FINISH` (exit code 1).

The fix declares `@testing-library/dom@^10.4.0` as an explicit `devDependency` in `apps/desktop/package.json`, matching the version range that `@testing-library/react@16` already requires as a peer.

The lockfile is intentionally left out of this PR — regenerating it with the local npm version also cleans up a large amount of unrelated stale entries. Please run `npm install` once after merging so the lockfile is updated alongside the manifest.

## Test plan

- [x] Reproduce the failure: fresh installer on macOS → `~/.hermes/logs/bootstrap-installer.log` shows the `TS2305` errors and `desktop` stage failing with `exit code 1`.
- [x] Apply the fix in `~/.hermes/hermes-agent` (`npm install -D @testing-library/dom@^10 --workspace=apps/desktop`).
- [x] Re-run `cd apps/desktop && npm run build` → passes (`tsc -b` clean, vite build successful).
- [ ] CI green.

## Related

Issue: #36980 ("INSTALL DIDN'T FINISH" on macOS bootstrap installer)

