### PR TITLE
fix(google_meet): use real Chrome for auth flow to bypass Google sign…

### DIFF
--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -351,8 +351,20 @@ def _cmd_auth() -> int:
     print(f"saving storage state to: {path}")
     try:
         with sync_playwright() as pw:
-            browser = pw.chromium.launch(headless=False)
+            # Launch real Chrome (not Chromium for Testing) and strip the
+            # --enable-automation flag so Google's sign-in flow doesn't
+            # block us with "Couldn't sign you in / browser may not be secure".
+            browser = pw.chromium.launch(
+                headless=False,
+                channel="chrome",
+                ignore_default_args=["--enable-automation"],
+                args=["--disable-blink-features=AutomationControlled"],
+            )
             context = browser.new_context()
+            # Hide navigator.webdriver — another tell Google sniffs.
+            context.add_init_script(
+                "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+            )
             page = context.new_page()
             page.goto("https://accounts.google.com/", wait_until="domcontentloaded")
             try:


### PR DESCRIPTION
 Summary
    
    hermes meet auth currently launches Playwright's bundled Chromium ("Chrome for Testing"), which Google's sign-in flow rejects with "Couldn't sign you in / This browser or app may not be secure." This blocks the entire google_meet plugin onboarding on a fresh install — users can't save a storage_state and end up stuck in the guest lobby on every join.
    
    Reproduced on macOS 26.5 with a fresh hermes meet install + hermes meet auth.
    
    Fix
    
    Only the auth path (cli._cmd_auth) is changed. Four targeted tweaks to the Playwright launch:
    
    - channel="chrome" — uses the user's installed Google Chrome (a real channel build) instead of Chrome for Testing.
    - ignore_default_args=["--enable-automation"] — strips the flag that triggers Google's secure-browser check.
    - args=["--disable-blink-features=AutomationControlled"]
    - add_init_script hiding navigator.webdriver
    
    After the fix, sign-in completes normally and storage_state is saved to ~/.hermes/workspace/meetings/auth.json.
    
    Scope
    
    The actual meeting bot in meet_bot.py is not touched. Google Meet itself accepts the bundled Chromium once the user is signed in via the saved storage_state cookie, so there's no need to require a full Chrome install for meeting attendance — only for the one-time auth.
    
    Test plan
    
    - [x] On macOS with Google Chrome installed: hermes meet auth opens real Chrome, sign-in completes, auth.json is saved.
    - [x] hermes meet setup reports google auth : saved after.
    - [x] Existing hermes meet join flow unaffected (bot still uses bundled Chromium + saved storage_state).
    
    Caveat
    
    Requires the user to have Google Chrome installed (very common on macOS/Windows; less universal on Linux). If channel="chrome" can't find Chrome, Playwright will raise a clear error directing the user to install it — that's a better failure mode than the current silent "Couldn't sign you in" page that gives the user no actionable signal.
    
    A future improvement could fall back to channel="msedge" or channel="chromium" and surface a friendlier error, but that's out of scope for this fix.
