### PR TITLE
fix: repair malformed cron jobs storage

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -423,6 +423,18 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 # Job CRUD Operations
 # =============================================================================
 
+def _jobs_from_loaded_data(data: Any) -> List[Dict[str, Any]]:
+    if isinstance(data, list):
+        save_jobs(data)
+        logger.warning("Auto-repaired jobs.json (top-level list; wrapped in jobs object)")
+        return data
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"Cron database corrupted: expected top-level object or list, got {type(data).__name__}"
+        )
+    return data.get("jobs", [])
+
+
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
@@ -432,13 +444,13 @@ def load_jobs() -> List[Dict[str, Any]]:
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            return data.get("jobs", [])
+            return _jobs_from_loaded_data(data)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
-                jobs = data.get("jobs", [])
+                jobs = _jobs_from_loaded_data(data)
                 if jobs:
                     # Auto-repair: rewrite with proper escaping
                     save_jobs(jobs)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1,9 +1,11 @@
 """Tests for cron/jobs.py — schedule parsing, job CRUD, and due-job detection."""
 
+import json
 import threading
 import pytest
 from datetime import datetime, timedelta, timezone
 
+import cron.jobs as cron_jobs
 from cron.jobs import (
     parse_duration,
     parse_schedule,
@@ -223,6 +225,43 @@ class TestJobCRUD:
         assert jobs[0]["prompt"] == ""
         assert jobs[0]["schedule_display"] == "every 60m"
         assert jobs[0]["state"] == "scheduled"
+
+    def test_load_jobs_repairs_bare_list_database(self, tmp_cron_dir, caplog):
+        bare_jobs = [
+            {
+                "id": "abc123deadbe",
+                "name": "Legacy list job",
+                "prompt": "run from old list shape",
+                "schedule": {"kind": "interval", "minutes": 60},
+                "enabled": True,
+            }
+        ]
+        cron_jobs.ensure_dirs()
+        cron_jobs.JOBS_FILE.write_text(json.dumps(bare_jobs), encoding="utf-8")
+
+        with caplog.at_level("WARNING", logger="cron.jobs"):
+            jobs = load_jobs()
+
+        assert jobs == bare_jobs
+        repaired = json.loads(cron_jobs.JOBS_FILE.read_text(encoding="utf-8"))
+        assert repaired["jobs"] == bare_jobs
+        assert any("Auto-repaired jobs.json" in rec.message and "top-level list" in rec.message for rec in caplog.records)
+
+    @pytest.mark.parametrize(
+        ("payload", "type_name"),
+        [
+            ("not a job database", "str"),
+            (123, "int"),
+            (True, "bool"),
+            (None, "NoneType"),
+        ],
+    )
+    def test_load_jobs_rejects_non_dict_non_list_database(self, tmp_cron_dir, payload, type_name):
+        cron_jobs.ensure_dirs()
+        cron_jobs.JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match=f"Cron database corrupted.*{type_name}"):
+            load_jobs()
 
     def test_remove_job(self, tmp_cron_dir):
         job = create_job(prompt="Temp job", schedule="30m")


### PR DESCRIPTION
## Summary
- Repair bare-list cron/jobs.json files by wrapping them back into canonical jobs storage
- Reject other valid but malformed top-level JSON values with a graceful RuntimeError instead of AttributeError
- Add regression coverage for issue #36867

Closes #36867

## Test Plan
- python -m pytest tests/cron/test_jobs.py -q
- python -m pytest tests/cron -q