### PR TITLE
feat(caching): add deepseek/deepseek-v4-flash to OpenRouter explicit cache_control allowlist

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1610,6 +1610,14 @@ def dump_api_request_debug(
         return None
 
 
+# OpenRouter model IDs that require explicit `cache_control` markers for prompt
+# caching (verified on production Hermes). Kept intentionally minimal.
+_OPENROUTER_EXPLICIT_CACHE_CONTROL_MODEL_IDS: frozenset[str] = frozenset({
+    # DeepSeek V4-Flash: verified on prod 2026-05-31 (0% -> 98% cache hits).
+    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash-20260423",
+})
+
 
 def anthropic_prompt_cache_policy(
     agent,
@@ -1717,6 +1725,8 @@ def anthropic_prompt_cache_policy(
     if is_native_anthropic:
         return True, True
     if (is_openrouter or is_nous_portal) and (is_claude or is_kimi):
+        return True, False
+    if is_openrouter and model_lower in _OPENROUTER_EXPLICIT_CACHE_CONTROL_MODEL_IDS:
         return True, False
     # Nous Portal Qwen (e.g. qwen3.6-plus) takes the same envelope-layout
     # cache_control path as Portal Claude. Portal proxies to OpenRouter

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -377,6 +377,45 @@ class TestExplicitOverrides:
         assert (should, native) == (True, False)
 
 
+class TestOpenRouterExplicitCacheControlAllowlist:
+    """DeepSeek V4-Flash on OpenRouter needs explicit cache_control markers.
+
+    Verified on production 2026-05-31: enabling markers moved cache-hit
+    rate from 0% to 98%.  Only the two canonical V4-Flash slugs are in the
+    allowlist; Qwen on OpenRouter is deliberately excluded (falls through
+    to the existing (False, False) path).
+    """
+
+    def test_deepseek_v4_flash_on_openrouter_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="deepseek/deepseek-v4-flash",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_deepseek_v4_flash_dated_slug_on_openrouter_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="deepseek/deepseek-v4-flash-20260423",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_deepseek_v4_flash_on_non_openrouter_gateway_does_not_cache(self):
+        # Allowlist is scoped to OpenRouter only; same slug on another
+        # gateway falls through to (False, False).
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://api.deepseek.com/v1",
+            api_mode="chat_completions",
+            model="deepseek/deepseek-v4-flash",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Long-lived prefix cache policy (cross-session 1h tier)
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds **only** `deepseek/deepseek-v4-flash` (and its dated pin `deepseek/deepseek-v4-flash-20260423`) to the OpenRouter explicit `cache_control` allowlist in `anthropic_prompt_cache_policy()`.

A minimal `_OPENROUTER_EXPLICIT_CACHE_CONTROL_MODEL_IDS` frozenset plus one guard branch returns `(True, False)` for those slugs when the gateway is OpenRouter. Insert point is directly after the existing Claude/Kimi OpenRouter enablement.

## Why

On current `main`, OpenRouter cache markers are enabled only for Claude and Kimi. DeepSeek V4-Flash therefore reaches the `(False, False)` fallback and never caches — re-billing the full prompt every turn. Verified on production Hermes 2026-05-31: enabling explicit markers moved the cache-hit rate from ~0% to ~98%.

## Scope (narrowed)

- Touches **only** the two verified V4-Flash slugs.
- Does **not** add Qwen IDs or `deepseek/deepseek-v3.2`, and does **not** revive the closed #20945 allowlist. Those were removed from this PR.
- **Qwen-on-OpenRouter behavior is unchanged**: it is handled via the separate Portal/OpenCode/Alibaba paths and still falls through to `(False, False)` on plain OpenRouter, as covered by the pre-existing `test_qwen_on_openrouter_not_affected`.

## Tests

```bash
pytest tests/run_agent/test_anthropic_prompt_cache_policy.py -q
```

- V4-Flash on OpenRouter → `(True, False)` (base slug + dated pin).
- Same V4-Flash slug on a non-OpenRouter gateway → `(False, False)` (allowlist is OpenRouter-scoped).
- Full file: 32 passed, including the preserved `test_qwen_on_openrouter_not_affected`.
- Guard check: with the allowlist emptied, the two positive V4-Flash tests fail with `(False, False)`, confirming they guard real behavior.

Rebased onto current `upstream/main` (clean, no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)