### PR TITLE
docs(sidebar): wire up local-ollama-setup guide in navigation

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -693,6 +693,7 @@ const sidebars: SidebarsConfig = {
         'guides/run-hermes-with-nous-portal',
         'guides/tips',
         'guides/local-llm-on-mac',
+        'guides/local-ollama-setup',
         'guides/daily-briefing-bot',
         'guides/team-telegram-assistant',
         'guides/python-library',


### PR DESCRIPTION
## Summary

Adds `'guides/local-ollama-setup'` to the Guides sidebar block in `website/sidebars.ts`. The doc was authored with `sidebar_position: 9` in its own frontmatter (meant to be in a sidebar) and is published at https://hermes-agent.nousresearch.com/docs/guides/local-ollama-setup, but no nav path reaches it.

Complementary to `local-llm-on-mac` (llama.cpp / MLX on Apple Silicon) — this one covers the cross-platform Ollama backend.

Closes #36985.

## Verification

- Doc file exists at HEAD ✓
- `cd website && npm run build` (Docusaurus) succeeds with the new entry ✓
- Single-line change to `website/sidebars.ts`

## Test plan

- [ ] `cd website && npm install && npm run start` and confirm "Run Hermes Locally with Ollama — Zero API Cost" appears in the Guides sidebar between "Run Local LLMs on Mac" and "Tutorial: Daily Briefing Bot"