### PR TITLE
fix(hindsight): flush buffered turns on session end to prevent silent data loss

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1711,6 +1711,78 @@ class HindsightMemoryProvider(MemoryProvider):
             self._session_id, self._parent_session_id, reset, self._document_id,
         )
 
+    def on_session_end(self, messages: list) -> None:
+        """Flush any buffered turns when the session ends.
+
+        Called by MemoryManager at actual session boundaries (CLI exit,
+        /reset, gateway session expiry) *before* shutdown(). Without this
+        override, ``retain_every_n_turns > 1`` silently drops whatever is
+        in ``_session_turns`` if the session ends before hitting the modulo
+        boundary — the same data-loss class that ``on_session_switch`` already
+        handles for mid-session rotations.
+
+        The flush mirrors the retain logic in ``on_session_switch`` but does
+        not reset session state — the session is ending, so there is nothing
+        to rotate to.
+        """
+        if not self._session_turns:
+            return
+
+        # Snapshot state before enqueuing — the writer thread may run
+        # after _session_turns is cleared by a concurrent call.
+        old_turns = list(self._session_turns)
+        old_session_id = self._session_id
+        old_parent_session_id = self._parent_session_id
+        old_turn_index = self._turn_index
+        old_metadata = self._build_metadata(
+            message_count=len(old_turns) * 2,
+            turn_index=old_turn_index,
+        )
+        old_lineage_tags: list[str] = []
+        if old_session_id:
+            old_lineage_tags.append(f"session:{old_session_id}")
+        if old_parent_session_id:
+            old_lineage_tags.append(f"parent:{old_parent_session_id}")
+        old_content = "[" + ",".join(old_turns) + "]"
+        old_document_id, old_update_mode = self._resolve_retain_target(
+            self._document_id
+        )
+
+        def _flush():
+            try:
+                item = self._build_retain_kwargs(
+                    old_content,
+                    context=self._retain_context,
+                    metadata=old_metadata,
+                    tags=old_lineage_tags or None,
+                )
+                item.pop("bank_id", None)
+                item.pop("retain_async", None)
+                if old_update_mode is not None:
+                    item["update_mode"] = old_update_mode
+                logger.debug(
+                    "Hindsight flush-on-end: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                    self._bank_id, old_document_id, old_update_mode, len(old_turns),
+                )
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                        document_id=old_document_id,
+                        retain_async=self._retain_async,
+                    )
+                )
+            except Exception as e:
+                logger.warning("Hindsight flush-on-end failed: %s", e, exc_info=True)
+
+        # Route through the writer queue to serialize with any still-queued
+        # retains from the same session. Skip if shutdown already fired —
+        # the writer is draining/gone.
+        if not self._shutting_down.is_set():
+            self._ensure_writer()
+            self._register_atexit()
+            self._retain_queue.put(_flush)
+
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
         # Stop accepting new retain jobs first so anyone still calling

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1096,6 +1096,79 @@ class TestSessionSwitchBufferFlush:
 
 
 # ---------------------------------------------------------------------------
+# on_session_end — flush partial buffers at session teardown
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEndBufferFlush:
+    def test_buffered_turns_flushed_on_session_end(self, provider_with_config):
+        """retain_every_n_turns > 1 must not silently drop partial buffers
+        when a session ends (CLI exit, idle timeout, /reset). Whatever's in
+        _session_turns at session-end time should be flushed to Hindsight."""
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+        old_doc = p._document_id
+
+        # Three turns buffered, no retain yet (boundary is at turn 5).
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p.sync_turn("turn3-user", "turn3-asst")
+        assert p._sync_thread is None  # writer not started yet
+        p._client.aretain_batch.assert_not_called()
+
+        # Session end — flush should fire under the current document_id.
+        p.on_session_end([{"role": "user", "content": "dummy"}])
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_called_once()
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == old_doc
+        item = kw["items"][0]
+        content = json.loads(item["content"])
+        flat = json.dumps(content)
+        assert "turn1-user" in flat
+        assert "turn2-user" in flat
+        assert "turn3-user" in flat
+        # Session id must appear in lineage tags / metadata.
+        assert "session:test-session" in item["tags"]
+        assert item["metadata"]["session_id"] == "test-session"
+
+    def test_no_flush_when_buffer_empty_on_session_end(self, provider):
+        """Session end with no buffered turns must not fire a spurious retain."""
+        provider.on_session_end([{"role": "user", "content": "dummy"}])
+        provider._retain_queue.join()
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_on_session_end_does_not_reset_state(self, provider_with_config):
+        """on_session_end should flush but NOT clear session state — the
+        session is ending, not rotating. Clearing would race with shutdown."""
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+        p.sync_turn("turn1-user", "turn1-asst")
+        old_session_id = p._session_id
+        old_counter = p._turn_counter
+
+        p.on_session_end([{"role": "user", "content": "dummy"}])
+        p._retain_queue.join()
+
+        # State should be preserved — on_session_end doesn't rotate.
+        assert p._session_id == old_session_id
+        assert p._turn_counter == old_counter
+
+    def test_on_session_end_skipped_during_shutdown(self, provider_with_config):
+        """If shutdown() has already fired, on_session_end must not enqueue
+        new work — the writer is draining/gone."""
+        p = provider_with_config(retain_every_n_turns=5, retain_async=False)
+        p.sync_turn("turn1-user", "turn1-asst")
+
+        # Simulate shutdown already happened.
+        p._shutting_down.set()
+
+        p.on_session_end([{"role": "user", "content": "dummy"}])
+        # Queue should be empty — nothing was enqueued.
+        assert p._retain_queue.empty()
+        p._client.aretain_batch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # update_mode='append' capability probe + retain dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Flushes buffered turns in `HindsightMemoryProvider.on_session_end()` to prevent silent data loss when a session ends before hitting the `retain_every_n_turns` modulo boundary.

## Related Issue

Fixes #36216

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: Added `on_session_end()` method that flushes `_session_turns` via the writer queue before session teardown. Mirrors the existing flush logic in `on_session_switch()` but without resetting session state (the session is ending, not rotating).
- `tests/plugins/memory/test_hindsight_provider.py`: Added `TestSessionEndBufferFlush` with 4 tests: buffered turns flushed, empty buffer no-op, state preservation during flush, skip during shutdown.

## How to Test

1. Set `retain_every_n_turns: 12` in Hindsight config
2. Start a conversation and exchange 8 turns (fewer than 12)
3. Exit the CLI or let the session expire via gateway idle timeout
4. Check Hindsight bank — the 8 turns should now be retained (previously they were silently dropped)
5. Run `pytest tests/plugins/memory/test_hindsight_provider.py::TestSessionEndBufferFlush -xvs` to verify the regression tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/memory/test_hindsight_provider.py -x` and all 105 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/hindsight/__init__.py` — `HindsightMemoryProvider.on_session_end` (new method), `on_session_switch` (reference pattern), `sync_turn` (buffer logic), `shutdown` (teardown sequence)
- Blast radius: LOW — single new method on a plugin provider, no changes to existing methods or base class
- Related patterns: `on_session_switch` (lines 1586-1712) uses identical flush logic; `shutdown` (line 1714) drains the same writer queue; `MemoryManager.on_session_end` (agent/memory_manager.py:477) is the caller
