### PR TITLE
fix(gateway): expire stale restart notification markers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10572,6 +10572,7 @@ class GatewayRunner:
                 "platform": event.source.platform.value if event.source.platform else None,
                 "chat_id": event.source.chat_id,
                 "chat_type": event.source.chat_type,
+                "requested_at": time.time(),
             }
             if event.source.thread_id:
                 notify_data["thread_id"] = event.source.thread_id
@@ -15180,6 +15181,19 @@ class GatewayRunner:
             chat_type = data.get("chat_type")
             thread_id = data.get("thread_id")
             message_id = data.get("message_id")
+
+            requested_at = data.get("requested_at")
+            if isinstance(requested_at, (int, float)):
+                marker_age = time.time() - float(requested_at)
+            else:
+                marker_age = time.time() - notify_path.stat().st_mtime
+            if marker_age > 600:
+                logger.warning(
+                    "Restart notification skipped: stale marker for %s:%s",
+                    platform_str,
+                    chat_id,
+                )
+                return None
 
             if not platform_str or not chat_id:
                 return None

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -74,6 +74,7 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     assert data["chat_id"] == "42"
     assert data["chat_type"] == "dm"
     assert data["message_id"] == "m1"
+    assert isinstance(data["requested_at"], float)
     assert "thread_id" not in data  # no thread → omitted
 
 
@@ -171,7 +172,31 @@ async def test_restart_command_uses_atomic_json_writes_for_marker_files(tmp_path
     names = [name for name, _payload, _kwargs in calls]
     assert names == [".restart_notify.json", ".restart_last_processed.json"]
     assert calls[0][1]["chat_id"] == "42"
+    assert isinstance(calls[0][1]["requested_at"], float)
     assert calls[1][1]["platform"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_skips_stale_marker(tmp_path, monkeypatch):
+    """Old restart markers are discarded instead of notifying stale chats."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run.time, "time", lambda: 1_700_001_000.0)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "stale-42",
+        "requested_at": 1_700_000_000.0,
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="late"))
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    adapter.send.assert_not_called()
+    assert not notify_path.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `requested_at` to `/restart` completion notification markers.
- Skip and delete stale restart notification markers older than 10 minutes.
- Preserve compatibility for old markers by falling back to file mtime.

## Why
`.restart_notify.json` is intended to notify the chat that just requested a gateway restart. If an old marker survives into an unrelated later startup, Hermes can try to notify a stale or invalid chat and log a misleading delivery failure. Expiring old markers keeps restart notifications scoped to the restart that created them.

## Test Plan
- `python -m pytest tests/gateway/test_restart_notification.py::test_restart_command_writes_notify_file tests/gateway/test_restart_notification.py::test_restart_command_uses_atomic_json_writes_for_marker_files tests/gateway/test_restart_notification.py::test_send_restart_notification_skips_stale_marker -q` → 3 passed
- `python -m pytest tests/gateway/test_restart_notification.py -q` → 28 passed
- `python -m pytest tests/gateway/test_restart_notification.py tests/gateway/test_platform_reconnect.py::TestPlatformReconnectWatcher::test_reconnect_never_auto_pauses_retryable_failures tests/gateway/test_platform_reconnect.py::TestPlatformReconnectWatcher::test_reconnect_skips_paused_platforms -q` → 30 passed