### PR TITLE
fix(gateway): collapse Telegram DM topics when topic mode is off

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2343,6 +2343,29 @@ class GatewayRunner:
         # opt into topic mode) means topic mode is off for this chat.
         return raw is True
 
+    def _normalize_telegram_disabled_topic_source(self, source: SessionSource) -> SessionSource:
+        """Collapse Telegram DM topic metadata when Hermes topic mode is disabled.
+
+        Telegram can keep sending ``message_thread_id`` after the operator turns
+        Hermes topic mode off. Normalize that stale client-side topic metadata
+        before deriving any session key so commands, locks, queues, clarify,
+        approvals, and the agent path all agree on the root DM session.
+        """
+        if (
+            source.platform == Platform.TELEGRAM
+            and source.chat_type == "dm"
+            and source.thread_id
+            and not self._telegram_topic_mode_enabled(source)
+        ):
+            logger.info(
+                "telegram topic mode off: ignoring DM thread_id for session routing chat=%s user=%s thread=%s",
+                source.chat_id,
+                source.user_id,
+                source.thread_id,
+            )
+            return dataclasses.replace(source, thread_id=None)
+        return source
+
     # Telegram's General (pinned top) topic in forum-enabled private chats.
     # Bot API behavior varies: some clients omit message_thread_id for
     # General, others send "1". Treat both as "root" for lobby/lane purposes.
@@ -7194,6 +7217,15 @@ class GatewayRunner:
         7. Return response
         """
         source = event.source
+        normalized_source = source
+        if event.get_command() != "topic":
+            normalized_source = self._normalize_telegram_disabled_topic_source(source)
+        if normalized_source is not source:
+            source = normalized_source
+            try:
+                event.source = source
+            except Exception:
+                event = dataclasses.replace(event, source=source)
 
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
@@ -8636,6 +8668,17 @@ class GatewayRunner:
         )
 
         # Get or create session
+        # Disabled Telegram DM topic metadata is normalized at the top of
+        # _handle_message(), before _quick_key and command/session handlers.
+        # Keep this guard for direct unit callers of _handle_message_with_agent.
+        normalized_source = self._normalize_telegram_disabled_topic_source(source)
+        if normalized_source is not source:
+            source = normalized_source
+            try:
+                event.source = source
+            except Exception:
+                pass
+
         # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
         # last-active topic so a cross-topic Reply or stripped plain reply
         # doesn't fragment the conversation across sessions.

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -99,6 +99,7 @@ def _make_runner(session_db=None):
     runner.session_store.append_to_transcript = MagicMock()
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
+    runner.session_store._entries = {}
     runner.session_store.reset_session = MagicMock(return_value=None)
 
     # Default switch_session impl: returns a SessionEntry carrying the target
@@ -219,6 +220,80 @@ async def test_telegram_topic_prompt_still_runs_agent_when_topic_mode_enabled(mo
 
     assert result == "agent response"
     runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disabled_topic_mode_ignores_telegram_dm_thread_for_session_key(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: False
+    captured = {}
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["session_id"] = kwargs.get("session_id")
+        captured["session_key"] = kwargs.get("session_key")
+        return {
+            "success": True,
+            "final_response": "plain dm response",
+            "session_id": kwargs.get("session_id"),
+            "messages": [],
+        }
+
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("plain dm despite telegram thread", thread_id="763"))
+
+    assert result == "plain dm response"
+    assert captured["session_id"] == "sess-root"
+    assert captured["session_key"] == "agent:main:telegram:dm:208214988"
+    assert "763" not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_disabled_topic_mode_new_resets_root_dm_session(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = lambda source: False
+    reset_keys = []
+    created_sources = []
+
+    def fake_reset(session_key):
+        reset_keys.append(session_key)
+        return None
+
+    def fake_get_or_create(source, force_new=False):
+        created_sources.append((source, force_new))
+        return SessionEntry(
+            session_key=build_session_key(source),
+            session_id="sess-root-new" if not source.thread_id else "sess-topic-new",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            origin=source,
+        )
+
+    runner.session_store.reset_session = MagicMock(side_effect=fake_reset)
+    runner.session_store.get_or_create_session = MagicMock(side_effect=fake_get_or_create)
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/new", thread_id="763"))
+
+    assert isinstance(result, str)
+    assert "New session started" in result
+    assert reset_keys == ["agent:main:telegram:dm:208214988"]
+    assert created_sources
+    assert created_sources[0][0].thread_id is None
+    assert created_sources[0][1] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- normalize stale Telegram DM thread IDs before session-key routing when Hermes topic mode is disabled
- preserve /topic command thread context for topic status/linking flows
- add regression coverage for plain prompt routing and /new reset behavior after /topic off

## Reviews
- Destro: approved product behavior after early-normalization update
- Buzzer: approved technical placement, edge cases, and coverage after blocker fix

## Test Plan
- ./scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py
- git diff --check