### PR TITLE
fix(gateway): rename Telegram topic to session title on /topic restore

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19261,6 +19261,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raise
 
         title = await self._session_db.get_session_title(session_id) or session_id
+        # Restored sessions already carry a title, so the auto-title path
+        # (which only fires for newly generated titles) never renames the
+        # topic. Rename it here so the restored topic reflects the session
+        # title instead of keeping Telegram's default name (the raw
+        # "/topic <id>" command text that created the topic).
+        await self._rename_telegram_topic_for_session_title(source, session_id, title)
         last_assistant = None
         try:
             for message in reversed(await self._session_db.get_messages(session_id)):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21193,6 +21193,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raise
 
         title = await self._session_db.get_session_title(session_id) or session_id
+        # Restored sessions already carry a title, so the auto-title path
+        # (which only fires for newly generated titles) never renames the
+        # topic. Rename it here so the restored topic reflects the session
+        # title instead of keeping Telegram's default name (the raw
+        # "/topic <id>" command text that created the topic).
+        await self._rename_telegram_topic_for_session_title(source, session_id, title)
         last_assistant = None
         try:
             for message in reversed(await self._session_db.get_messages(session_id)):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -518,6 +518,46 @@ async def test_topic_root_command_lists_unlinked_sessions_for_restore(tmp_path, 
 
 
 @pytest.mark.asyncio
+async def test_topic_restore_renames_topic_to_restored_session_title(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.set_session_title("old-session", "Quarterly Tax Planning")
+    session_db.append_message("old-session", "user", "help with taxes")
+    session_db.append_message("old-session", "assistant", "Sure, happy to help.")
+    runner = _make_runner(session_db=session_db)
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/topic restore must not enter the agent loop")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/topic old-session", thread_id="17585")
+    )
+
+    # The restored topic must be renamed to the session title rather than
+    # keeping Telegram's default (the raw "/topic <id>" command text).
+    assert "Session restored: Quarterly Tax Planning" in result
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="17585",
+        name="Quarterly Tax Planning",
+    )
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_first_message_inside_topic_records_topic_binding(tmp_path, monkeypatch):
     import gateway.run as gateway_run
 


### PR DESCRIPTION
## What does this PR do?

Restoring a previous session into a Telegram DM topic via `/topic <session-id>` left the topic with Telegram's **default name** — the literal `/topic <id>` command text that created the topic — instead of the restored session's title. Freshly created topics rename correctly; only the restore path was broken.

**Why this approach:** `_restore_telegram_topic_session` already fetches the session title for its confirmation message. The smallest correct fix is to stamp that title onto the topic using the **existing** `_rename_telegram_topic_for_session_title` helper, which already enforces every relevant guard (topic-lane check, operator-declared `dm_topics`, the `disable_topic_auto_rename` extra, and binding ownership). No new rename logic, no new config surface.

**Root cause:** topic auto-rename only ever fires through the auto-title callback (`maybe_auto_title` → `title_callback` → `_schedule_telegram_topic_title_rename`). `auto_title_session` early-returns when a title already exists:

```python
existing = session_db.get_session_title(session_id)
if existing:
    return
```

A restored session is always already-titled, so the callback never runs and the topic is never renamed.

## Related Issue

Fixes #36992

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — in `_restore_telegram_topic_session`, after binding the topic and resolving `title`, call `await self._rename_telegram_topic_for_session_title(source, session_id, title)` so the restored topic reflects the session title. (6 lines incl. comment.)
- `tests/gateway/test_telegram_topic_mode.py` — add `test_topic_restore_renames_topic_to_restored_session_title` regression test.

## How to Test

**Reproduction (before the fix):**

1. Enable Telegram DM topic mode for a bot (BotFather Threaded Mode on; run `/topic` in the DM).
2. Have at least one prior titled session (e.g. titled "Asking for the Time").
3. In the topic root, send `/topic <that-session-id>`.
4. The new topic is named after the raw command, e.g. **`/topic 20260601_124920_a9576f50`** — not the session title.

**Proof the fix works (after):** step 3 renames the topic to **"Asking for the Time"**.

**Automated:**

```
scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py
# => 45 tests passed
```

The new test was confirmed to **fail without the fix** (`rename_dm_topic` awaited 0 times) and **pass with it** — i.e. it genuinely pins the regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest is #36990 — collapsing DM topics when topic mode is *off* — a distinct concern)
- [x] My PR contains **only** changes related to this fix (one focused commit)
- [x] I've run the affected suite via `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py` — 45 passed
- [x] I've added tests for my changes (RED/GREEN verified)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Telegram polling-mode gateway

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal gateway behavior; no user-facing docs or docstring change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure async/string logic, no OS calls; `scripts/check-windows-footguns.py --diff origin/main` reports clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change)

## Screenshots / Logs

Before — restored topic kept the raw command as its name:

```
Topic list:  All Messages | System | /topic 20260601_124920_a9576f50
```

After — restored topic carries the session title:

```
Topic list:  All Messages | System | Asking for the Time
```
