### PR TITLE
fix(whatsapp): handle locationMessage, liveLocationMessage, and contactMessage in bridge

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -393,6 +393,40 @@ async function startSocket() {
         } catch (err) {
           console.error('[bridge] Failed to download document:', err.message);
         }
+      } else if (messageContent.locationMessage) {
+        hasMedia = true;
+        mediaType = 'location';
+        const loc = messageContent.locationMessage;
+        const lat = loc.degreesLatitude;
+        const lng = loc.degreesLongitude;
+        const lines = [];
+        if (loc.name) lines.push(`📍 ${loc.name}`);
+        if (loc.address) lines.push(loc.address);
+        lines.push(`🗺 https://maps.google.com/?q=${lat},${lng}`);
+        lines.push(`📍 ${lat}, ${lng}`);
+        body = lines.join('\n');
+      } else if (messageContent.liveLocationMessage) {
+        hasMedia = true;
+        mediaType = 'location';
+        const loc = messageContent.liveLocationMessage;
+        const lat = loc.degreesLatitude;
+        const lng = loc.degreesLongitude;
+        const lines = [];
+        if (loc.caption) lines.push(`📍 Live: ${loc.caption}`);
+        lines.push(`🗺 https://maps.google.com/?q=${lat},${lng}`);
+        lines.push(`📍 ${lat}, ${lng} (live)`);
+        body = lines.join('\n');
+      } else if (messageContent.contactMessage) {
+        hasMedia = true;
+        mediaType = 'contact';
+        const ct = messageContent.contactMessage;
+        const lines = ['👤 Contact shared'];
+        if (ct.displayName) lines.push(`Name: ${ct.displayName}`);
+        if (ct.vcard) {
+          const telMatch = ct.vcard.match(/TEL[^:]*:([^\n]+)/i);
+          if (telMatch) lines.push(`Phone: ${telMatch[1].trim()}`);
+        }
+        body = lines.join('\n');
       }
 
       // For media without caption, use a placeholder so the API message is never empty


### PR DESCRIPTION
# WhatsApp Bridge — Location & Contact Message Fix

The bridge only parsed conversation, extendedTextMessage, imageMessage, videoMessage, audioMessage, and documentMessage. Location messages (locationMessage, liveLocationMessage) and shared contacts (contactMessage) had no handler, resulting in empty body text that was silently dropped before reaching the agent.

Add three new handlers that extract coordinates, address, name, and Google Maps links from location and live location messages, and displayName/phone from contact messages.

This patch was generated by Hermes Agent using the Deepseek-v4-pro model.

## What does this PR do?

Adds support for parsing incoming WhatsApp Location (`locationMessage`, `liveLocationMessage`) and Contact (`contactMessage`) messages. Currently, these message types are silently dropped by the bridge because there is no matching `else if` block in the Baileys parsing chain. 

By extracting coords, names, addresses, Google Maps URLs, and phone details from the VCARD, this approach ensures the agent receives rich and contextual incoming text instead of an empty body that gets silently filtered out before reaching the gateway.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js`: Added explicit `else if` branches for `locationMessage`, `liveLocationMessage`, and `contactMessage` inside Baileys `messages.upsert` socket handler to format them into descriptive plain text.

## How to Test

1. Connect the WhatsApp bridge in `self-chat` mode.
2. Send a static location pin and a live location pin from your phone. Verify the agent receives the Google Maps URLs and exact coordinates successfully.
3. Share a contact card to the chat. Verify that the agent receives the name and phone number extracted from the VCARD payload.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (N/A — JS bridge parser behavior; integration checked manually in production)
- [x] I've tested on my platform: Windows (WSL / Native Windows Node environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
Testing location message
*(Você pode opcionalmente colar aqui um log ou print demonstrando a recepção da mensagem formatada no seu agente!)*
<img width="1264" height="473" alt="image" src="https://github.com/user-attachments/assets/ef86f688-b17d-4d4e-b402-ff7f1bb22ba9" />

Testing contact message
<img width="1143" height="327" alt="image" src="https://github.com/user-attachments/assets/bf7a9761-b65d-4646-ace7-7e9c400ad7ec" />
