### PR TITLE
fix(tools): enforce bundled/hub guard for skill writes (#20273)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -19,6 +19,7 @@ from tools.skill_manager_tool import (
     _write_file,
     _remove_file,
     skill_manage,
+    _bundled_hub_guard,
     MAX_NAME_LENGTH,
 )
 
@@ -939,3 +940,174 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Bundled/hub-installed guard — issue #20273.
+# skill_manage refuses to mutate bundled (shipped with Hermes) or
+# hub-installed (via 'hermes skills install') skills. Unlike the pin guard,
+# this is **enforced** with no opt-out — it is defense-in-depth against a
+# confused background review or a poisoned community skill that injects
+# instructions to overwrite upstream-owned content.
+# ---------------------------------------------------------------------------
+
+
+class TestBundledHubGuard:
+    """All write paths (edit, patch, delete, write_file, remove_file) refuse
+    bundled and hub-installed skills. Create is intentionally unguarded —
+    you can't "create" a name that already exists upstream, and the
+    existing duplicate-name check catches the real risk there.
+    """
+
+    @staticmethod
+    def _make_bundled(name: str):
+        """Patch skill_usage.is_agent_created to mark *name* as bundled."""
+        def _fake(name_, bundled_name=name):
+            return name_ != bundled_name
+        return patch("tools.skill_usage.is_agent_created", side_effect=_fake)
+
+    @staticmethod
+    def _make_hub(name: str):
+        """Mark *name* as hub-installed via _read_hub_installed_names
+        (the public is_agent_created path uses both bundled AND hub sets)."""
+        hub_set = {name}
+        bundled_set: set = set()
+        return (
+            patch("tools.skill_usage.is_agent_created",
+                  side_effect=lambda n: n not in hub_set),
+            patch("tools.skill_usage._read_bundled_manifest_names",
+                  return_value=bundled_set),
+            patch("tools.skill_usage._read_hub_installed_names",
+                  return_value=hub_set),
+        )
+
+    # ---- guard function direct tests ---------------------------------
+
+    def test_bundled_guard_returns_error_for_bundled(self):
+        name = "hermes-agent"
+        with self._make_bundled(name):
+            err = _bundled_hub_guard(name)
+        assert err is not None
+        assert "bundled" in err.lower()
+        assert name in err
+
+    def test_bundled_guard_returns_error_for_hub_installed(self):
+        name = "community-skill"
+        patches = self._make_hub(name)
+        with patches[0], patches[1], patches[2]:
+            err = _bundled_hub_guard(name)
+        assert err is not None
+        assert "hub-installed" in err.lower()
+        assert name in err
+
+    def test_bundled_guard_returns_none_for_agent_created(self):
+        with patch("tools.skill_usage.is_agent_created", return_value=True):
+            err = _bundled_hub_guard("my-personal-skill")
+        assert err is None
+
+    def test_bundled_guard_fails_open_on_lookup_error(self):
+        """If provenance lookup raises, allow the write (best-effort)."""
+        with patch("tools.skill_usage.is_agent_created",
+                   side_effect=RuntimeError("manifest broken")):
+            err = _bundled_hub_guard("some-skill")
+        assert err is None
+
+    # ---- write-path integration tests --------------------------------
+
+    def test_edit_refuses_bundled(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("hermes-agent", VALID_SKILL_CONTENT)
+            with self._make_bundled("hermes-agent"):
+                result = _edit_skill("hermes-agent", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        # File untouched
+        content = (tmp_path / "hermes-agent" / "SKILL.md").read_text()
+        assert "A test skill" in content
+        assert "Updated description" not in content
+
+    def test_patch_refuses_bundled(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("hermes-agent", VALID_SKILL_CONTENT)
+            with self._make_bundled("hermes-agent"):
+                result = _patch_skill("hermes-agent", "Do the thing.", "Hijacked.")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        content = (tmp_path / "hermes-agent" / "SKILL.md").read_text()
+        assert "Do the thing." in content
+        assert "Hijacked." not in content
+
+    def test_delete_refuses_bundled(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("hermes-agent", VALID_SKILL_CONTENT)
+            with self._make_bundled("hermes-agent"):
+                result = _delete_skill("hermes-agent")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        # Skill still exists
+        assert (tmp_path / "hermes-agent" / "SKILL.md").exists()
+
+    def test_delete_refuses_hub_installed(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("community-skill", VALID_SKILL_CONTENT)
+            patches = self._make_hub("community-skill")
+            with patches[0], patches[1], patches[2]:
+                result = _delete_skill("community-skill")
+        assert result["success"] is False
+        assert "hub-installed" in result["error"].lower()
+        assert (tmp_path / "community-skill" / "SKILL.md").exists()
+
+    def test_write_file_refuses_bundled(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("hermes-agent", VALID_SKILL_CONTENT)
+            with self._make_bundled("hermes-agent"):
+                result = _write_file("hermes-agent", "references/api.md", "x")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        assert not (tmp_path / "hermes-agent" / "references" / "api.md").exists()
+
+    def test_remove_file_refuses_bundled(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("hermes-agent", VALID_SKILL_CONTENT)
+            _write_file("hermes-agent", "references/api.md", "x")
+            with self._make_bundled("hermes-agent"):
+                result = _remove_file("hermes-agent", "references/api.md")
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        # File still there
+        assert (tmp_path / "hermes-agent" / "references" / "api.md").exists()
+
+    def test_agent_created_skill_still_editable(self, tmp_path):
+        """Sanity check: the guard doesn't fire for normal agent skills."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-personal-skill", VALID_SKILL_CONTENT)
+            with patch("tools.skill_usage.is_agent_created", return_value=True):
+                result = _edit_skill("my-personal-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True, result
+        content = (tmp_path / "my-personal-skill" / "SKILL.md").read_text()
+        assert "Updated description" in content
+
+    def test_bundled_guard_fails_open_during_write(self, tmp_path):
+        """If provenance lookup raises, write goes through (best-effort)."""
+        with _skill_dir(tmp_path):
+            _create_skill("some-skill", VALID_SKILL_CONTENT)
+            with patch("tools.skill_usage.is_agent_created",
+                       side_effect=RuntimeError("manifest broken")):
+                result = _edit_skill("some-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True
+        content = (tmp_path / "some-skill" / "SKILL.md").read_text()
+        assert "Updated description" in content
+
+    def test_via_dispatcher_delete_refuses_bundled(self, tmp_path):
+        """The skill_manage dispatcher route also honors the guard."""
+        with _skill_dir(tmp_path):
+            _create_skill("hermes-agent", VALID_SKILL_CONTENT)
+            with self._make_bundled("hermes-agent"):
+                raw = skill_manage(
+                    action="delete",
+                    name="hermes-agent",
+                )
+        result = json.loads(raw) if isinstance(raw, str) else raw
+        assert result["success"] is False
+        assert "bundled" in result["error"].lower()
+        assert (tmp_path / "hermes-agent" / "SKILL.md").exists()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -161,6 +161,60 @@ def _pinned_guard(name: str) -> Optional[str]:
     return None
 
 
+def _bundled_hub_guard(name: str) -> Optional[str]:
+    """Refuse to mutate bundled or hub-installed skills (issue #20273).
+
+    Bundled skills ship with Hermes (``hermes-agent/skills/`` and synced to
+    ``~/.hermes/skills/`` by ``tools/skills_sync.py``); hub-installed skills
+    arrive via ``hermes skills install`` and are tracked in
+    ``~/.hermes/skills/.hub/lock.json``. Both are owned by their upstream
+    source — overwriting them is overwritten again on the next
+    ``hermes update`` and, worse, can be triggered autonomously by the
+    background review fork or the curator without a conscious user decision.
+
+    The background review prompt already instructs the agent to leave them
+    alone, but a code-level guard is needed as defense-in-depth so a
+    poisoned community skill (prompt-injection) or a confused background
+    review can still be stopped. This guard is **enforced**, not a flag:
+    no opt-out.
+
+    Best-effort: if the provenance lookup fails (missing manifest, broken
+    lock file) we let the write through rather than block on a metadata
+    read — the same posture as ``_pinned_guard``. The protected *bundled*
+    list is the one shipped with the running Hermes install, so a
+    missing-manifest case should be rare.
+    """
+    try:
+        from tools import skill_usage
+        # ``is_agent_created`` returns False for bundled + hub skills.
+        # We only want to *block* on bundled/hub, not silently pass on
+        # genuine agent-created skills.
+        if not skill_usage.is_agent_created(name):
+            # Distinguish bundled vs hub for a clearer error message.
+            bundled = skill_usage._read_bundled_manifest_names()  # noqa: SLF001
+            hub = skill_usage._read_hub_installed_names()  # noqa: SLF001
+            if name in bundled:
+                source = "bundled (shipped with Hermes)"
+            elif name in hub:
+                source = "hub-installed (via 'hermes skills install')"
+            else:
+                source = "not agent-created (bundled or hub-installed)"
+            return (
+                f"Skill '{name}' is {source} and cannot be edited, patched, "
+                f"deleted, or have files written/removed via skill_manage. "
+                f"Upstream owns this skill and any local change will be "
+                f"overwritten on `hermes update` or `hermes skills sync`. "
+                f"To capture a personal variant, create a new skill with a "
+                f"different name instead."
+            )
+    except Exception:
+        # Best-effort: never block legitimate writes on a metadata-read
+        # failure. The background review prompt is the second line of
+        # defense; this is the first.
+        logger.debug("bundled-hub-guard lookup failed for %s", name, exc_info=True)
+    return None
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -544,6 +598,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
 
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -583,6 +641,10 @@ def _patch_skill(
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
 
     skill_dir = existing["path"]
 
@@ -673,6 +735,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
 
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     pinned_err = _pinned_guard(name)
     if pinned_err:
         return {"success": False, "error": pinned_err}
@@ -742,6 +808,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name, " Create it first with action='create'.")}
 
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -775,6 +845,10 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
+
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
 
     skill_dir = existing["path"]
 


### PR DESCRIPTION
## Summary

Fix for issue #20273 (open). Adds a code-level `_bundled_hub_guard()` function to `tools/skill_manager_tool.py` that refuses write operations (edit, patch, delete, write_file, remove_file) on bundled and hub-installed skills.

Previously the only protection was prompt-level instructions (\"DO NOT touch bundled skills\"). This closes a vector where a confused background review agent or a poisoned community skill could overwrite upstream-owned content via `skill_manage`.

## Changes

- **`tools/skill_manager_tool.py`**: Added `_bundled_hub_guard()` that checks `skill_usage.is_agent_created()` and returns an error message for bundled/hub-installed skills. Inserted guard calls into every write path: `_edit_skill`, `_patch_skill`, `_delete_skill`, `_write_file`, `_remove_file`.
- **`tests/tools/test_skill_manager_tool.py`**: 13 new tests covering:
  - Guard returns error for bundled and hub-installed skills
  - Guard returns None for agent-created skills
  - Guard fails open on provenance lookup error
  - Every write path (edit, patch, delete, write_file, remove_file) refuses bundled skills
  - Agent-created skills still editable after guard
  - Delete refuses hub-installed skills
  - `skill_manage` dispatcher route honors the guard

## Testing

```
python -m pytest tests/tools/test_skill_manager_tool.py::TestBundledHubGuard -v  # 13/13 passed
python -m pytest tests/tools/ tests/run_agent/ --tb=short -q  # 163/163 passed
```

## Related

- Issue: #20273
- Also affects background review safety (related to #15204)