### PR TITLE
fix(gateway): avoid stale typing and heal stale session guards

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2075,15 +2075,21 @@ class TelegramAdapter(BasePlatformAdapter):
                         raise
                 message_ids.append(str(msg.message_id))
 
-            # Re-trigger typing indicator after sending a message.
+            # Re-trigger typing indicator after intermediate/progress messages.
             # Telegram clears the typing state when a new message is delivered,
             # so without this the "...typing" bubble disappears mid-response
             # (especially noticeable when the agent sends intermediate progress
             # messages like "Checking:" before running tools).
-            try:
-                await self.send_typing(chat_id, metadata=metadata)
-            except Exception:
-                pass  # Typing failures are non-fatal
+            #
+            # Final user-facing responses are delivered with metadata["notify"]
+            # by BasePlatformAdapter.  Do NOT refresh typing after those sends:
+            # Telegram keeps chat actions visible for a few seconds and JP sees
+            # Alfred stuck as "digitando" even though the answer is already out.
+            if not (metadata or {}).get("notify"):
+                try:
+                    await self.send_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass  # Typing failures are non-fatal
 
             return SendResult(
                 success=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3331,6 +3331,36 @@ class GatewayRunner:
             return False  # let default path handle it
 
         running_agent = self._running_agents.get(session_key)
+        if running_agent is None:
+            # Adapter/session-store split-brain: the platform guard still says
+            # this session is busy, but GatewayRunner has no live AIAgent for it.
+            # If we send a normal busy ack here the user gets stuck in the
+            # "Interrupting current task" / typing loop forever.  Clear the
+            # stale adapter guard and immediately start this event as a fresh
+            # turn instead.
+            logger.warning(
+                "Clearing stale active-session guard for %s: adapter reported busy but no running agent exists",
+                session_key,
+            )
+            try:
+                await adapter.cancel_session_processing(
+                    session_key,
+                    release_guard=True,
+                    discard_pending=True,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to clear stale adapter task for %s; falling back to normal busy handling: %s",
+                    session_key,
+                    exc,
+                )
+                return False
+            try:
+                adapter._start_session_processing(event, session_key)
+            except Exception as exc:
+                logger.error("Failed to restart stale session %s: %s", session_key, exc, exc_info=True)
+                return False
+            return True
 
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "queue")

--- a/tests/gateway/test_telegram_typing_final_response.py
+++ b/tests/gateway/test_telegram_typing_final_response.py
@@ -1,0 +1,132 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_skips_typing_refresh_for_final_notify_response():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=123))
+    )
+    adapter.send_typing = AsyncMock()
+
+    result = await adapter.send("12345", "resposta final", metadata={"notify": True})
+
+    assert result.success is True
+    adapter._bot.send_message.assert_awaited_once()
+    adapter.send_typing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_keeps_typing_refresh_when_metadata_is_none():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=321))
+    )
+    adapter.send_typing = AsyncMock()
+
+    result = await adapter.send("12345", "andamento", metadata=None)
+
+    assert result.success is True
+    adapter._bot.send_message.assert_awaited_once()
+    adapter.send_typing.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_telegram_send_keeps_typing_refresh_for_intermediate_message():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=456))
+    )
+    adapter.send_typing = AsyncMock()
+
+    result = await adapter.send("12345", "andamento", metadata={})
+
+    assert result.success is True
+    adapter._bot.send_message.assert_awaited_once()
+    adapter.send_typing.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_busy_handler_clears_stale_adapter_guard_when_runner_has_no_agent():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner._is_user_authorized = lambda source: True
+
+    adapter = SimpleNamespace(
+        cancel_session_processing=AsyncMock(),
+        _start_session_processing=lambda event, session_key: setattr(
+            adapter, "started", (event, session_key)
+        ),
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    event = MessageEvent(
+        text="nova mensagem",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="8367618544",
+            user_id="8367618544",
+            chat_type="dm",
+        ),
+    )
+
+    handled = await runner._handle_active_session_busy_message(event, "telegram:8367618544")
+
+    assert handled is True
+    adapter.cancel_session_processing.assert_awaited_once_with(
+        "telegram:8367618544",
+        release_guard=True,
+        discard_pending=True,
+    )
+    assert adapter.started == (event, "telegram:8367618544")
+
+
+@pytest.mark.asyncio
+async def test_busy_handler_does_not_restart_if_stale_guard_cancel_fails():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner._is_user_authorized = lambda source: True
+
+    adapter = SimpleNamespace(
+        cancel_session_processing=AsyncMock(side_effect=RuntimeError("boom")),
+        _start_session_processing=AsyncMock(),
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    event = MessageEvent(
+        text="nova mensagem",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="8367618544",
+            user_id="8367618544",
+            chat_type="dm",
+        ),
+    )
+
+    handled = await runner._handle_active_session_busy_message(event, "telegram:8367618544")
+
+    assert handled is False
+    adapter.cancel_session_processing.assert_awaited_once_with(
+        "telegram:8367618544",
+        release_guard=True,
+        discard_pending=True,
+    )
+    adapter._start_session_processing.assert_not_awaited()


### PR DESCRIPTION
## Summary
- stop Telegram typing updates once a final response is ready
- heal stale gateway session typing guards before they wedge future replies
- add regression coverage for final-response typing cleanup

## Validation
- validated locally with tests before handoff

Source branch pushed from JP local checkout; no merge/deploy performed.