### PR TITLE
fix(gateway): warn about duplicate gateway supervisors

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -836,6 +836,99 @@ def _systemd_main_pid(system: bool = False) -> int | None:
     return _systemd_main_pid_from_props(_read_systemd_unit_properties(system=system))
 
 
+def _systemctl_user_env() -> dict[str, str]:
+    """Return an environment that can reach the user systemd bus when present."""
+    env = os.environ.copy()
+    uid = os.getuid()  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    runtime_dir = env.get("XDG_RUNTIME_DIR") or f"/run/user/{uid}"
+    env.setdefault("XDG_RUNTIME_DIR", runtime_dir)
+    bus_path = Path(runtime_dir) / "bus"
+    if "DBUS_SESSION_BUS_ADDRESS" not in env and bus_path.exists():
+        env["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
+    return env
+
+
+def _systemd_gateway_unit_names(*, system: bool) -> tuple[list[str], str | None]:
+    """Read-only discovery of installed/loaded Hermes gateway systemd units."""
+    if shutil.which("systemctl") is None:
+        return [], "systemctl is not available"
+    names: set[str] = set()
+    errors: list[str] = []
+    env = _systemctl_user_env() if not system else None
+    commands = (
+        ["list-unit-files", "hermes-gateway*.service", "--no-legend", "--no-pager"],
+        ["list-units", "hermes-gateway*.service", "--all", "--no-legend", "--no-pager"],
+    )
+    for args in commands:
+        try:
+            result = subprocess.run(
+                _systemctl_cmd(system) + args,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+        except (RuntimeError, OSError, subprocess.TimeoutExpired) as exc:
+            errors.append(str(exc))
+            continue
+        if result.returncode != 0:
+            text = (result.stderr or result.stdout or "").strip()
+            if text:
+                errors.append(text)
+            continue
+        for line in (result.stdout or "").splitlines():
+            parts = line.split(None, 1)
+            first = parts[0] if parts else ""
+            if first.startswith("hermes-gateway") and first.endswith(".service"):
+                names.add(first)
+    error = "; ".join(dict.fromkeys(errors)) or None
+    return sorted(names), error
+
+
+def _duplicate_gateway_process_pids() -> list[int]:
+    try:
+        return sorted(find_gateway_pids(all_profiles=False))
+    except Exception:
+        return []
+
+
+def _print_duplicate_gateway_diagnostics() -> None:
+    """Print read-only hints for duplicate gateway supervisors/processes."""
+    if is_linux():
+        system_units, _system_err = _systemd_gateway_unit_names(system=True)
+        user_units, user_err = _systemd_gateway_unit_names(system=False)
+        if system_units and user_units:
+            print()
+            print("⚠ Duplicate gateway supervisors detected for this host")
+            print(f"  System units: {', '.join(system_units)}")
+            print(f"  User units:   {', '.join(user_units)}")
+            print(f"  HERMES_HOME:   {get_hermes_home().resolve()}")
+            print("  Choose one supervisor lane (system or user) before editing model/provider config.")
+            print("  This check is read-only; it did not stop, disable, or delete any service.")
+        elif user_err and "connect to bus" in user_err.lower():
+            print()
+            print("⚠ Could not inspect user-scope gateway services")
+            print(f"  systemctl --user: {user_err.splitlines()[0]}")
+            print("  This is different from no user services existing; try a login shell or linger-enabled user bus.")
+    elif is_macos():
+        plist = get_launchd_plist_path()
+        label = get_launchd_label()
+        if plist.exists():
+            print()
+            print("Gateway supervisor check:")
+            print(f"  launchd label: {label}")
+            print(f"  plist:         {plist}")
+            print("  If another foreground/tmux gateway is also running, choose one supervisor lane.")
+
+    pids = _duplicate_gateway_process_pids()
+    if len(pids) > 1:
+        print()
+        print("⚠ Multiple gateway processes detected for this profile")
+        print(f"  PIDs: {', '.join(str(p) for p in pids)}")
+        print(f"  HERMES_HOME: {get_hermes_home().resolve()}")
+        print("  Duplicate processes using `gateway run --replace` can take turns replacing each other.")
+
+
 def _read_gateway_runtime_status() -> dict | None:
     try:
         from gateway.status import read_runtime_status
@@ -2940,6 +3033,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         for line in runtime_lines:
             print(f"  {line}")
 
+    _print_duplicate_gateway_diagnostics()
+
     unit_props = _read_systemd_unit_properties(system=system)
     active_state = unit_props.get("ActiveState", "")
     sub_state = unit_props.get("SubState", "")
@@ -3386,6 +3481,8 @@ def launchd_status(deep: bool = False):
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
         print("  Run: hermes gateway start")
+
+    _print_duplicate_gateway_diagnostics()
 
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -341,6 +341,7 @@ def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys
 
     monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
     monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (False, ""))
+    monkeypatch.setattr(gateway, "_print_duplicate_gateway_diagnostics", lambda: None)
 
     def fake_run(cmd, capture_output=False, text=False, check=False, **kwargs):
         if cmd[:4] == ["systemctl", "--user", "status", gateway.get_service_name()]:
@@ -718,6 +719,112 @@ class TestStopProfileGateway:
         assert calls["kill"] == 1          # one SIGTERM
         assert calls["alive_probes"] == 20 # 20 liveness polls over the 2s window
         assert calls["remove"] == 0
+
+
+def test_systemd_gateway_unit_names_discovers_system_units_read_only(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "/bin/systemctl" if name == "systemctl" else None)
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        assert "start" not in cmd
+        assert "stop" not in cmd
+        assert "disable" not in cmd
+        if "list-unit-files" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="hermes-gateway.service enabled\nhermes-gateway-default.service disabled\n",
+                stderr="",
+            )
+        if "list-units" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="hermes-gateway-extra.service loaded active running Hermes\n",
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    units, error = gateway._systemd_gateway_unit_names(system=True)
+
+    assert units == [
+        "hermes-gateway-default.service",
+        "hermes-gateway-extra.service",
+        "hermes-gateway.service",
+    ]
+    assert error is None
+    assert all(call[1]["env"] is None for call in calls)
+
+
+def test_systemd_gateway_unit_names_reports_user_bus_inspection_failure(monkeypatch):
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "/bin/systemctl" if name == "systemctl" else None)
+    monkeypatch.setattr(gateway, "_systemctl_user_env", lambda: {"XDG_RUNTIME_DIR": "/run/user/123"})
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[:2] == ["systemctl", "--user"]
+        assert kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/123"}
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="Failed to connect to bus: No medium found\n",
+        )
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    units, error = gateway._systemd_gateway_unit_names(system=False)
+
+    assert units == []
+    assert error == "Failed to connect to bus: No medium found"
+
+
+def test_duplicate_gateway_diagnostics_warns_for_system_and_user_units(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "_duplicate_gateway_process_pids", lambda: [])
+
+    def fake_units(*, system):
+        return (["hermes-gateway.service"], None) if system else (["hermes-gateway-default.service"], None)
+
+    monkeypatch.setattr(gateway, "_systemd_gateway_unit_names", fake_units)
+
+    gateway._print_duplicate_gateway_diagnostics()
+
+    out = capsys.readouterr().out
+    assert "Duplicate gateway supervisors detected" in out
+    assert "System units: hermes-gateway.service" in out
+    assert "User units:   hermes-gateway-default.service" in out
+    assert "read-only" in out
+
+
+def test_duplicate_gateway_diagnostics_warns_for_user_bus_failure(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "_duplicate_gateway_process_pids", lambda: [])
+
+    def fake_units(*, system):
+        return (["hermes-gateway.service"], None) if system else ([], "Failed to connect to bus: No medium found")
+
+    monkeypatch.setattr(gateway, "_systemd_gateway_unit_names", fake_units)
+
+    gateway._print_duplicate_gateway_diagnostics()
+
+    out = capsys.readouterr().out
+    assert "Could not inspect user-scope gateway services" in out
+    assert "systemctl --user: Failed to connect to bus: No medium found" in out
+
+
+def test_duplicate_gateway_diagnostics_warns_for_multiple_gateway_pids(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "is_linux", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "_duplicate_gateway_process_pids", lambda: [111, 222])
+
+    gateway._print_duplicate_gateway_diagnostics()
+
+    out = capsys.readouterr().out
+    assert "Multiple gateway processes detected" in out
+    assert "PIDs: 111, 222" in out
 
 
 def test_module_has_logger():


### PR DESCRIPTION
## Summary
- add read-only gateway supervisor diagnostics to status output
- warn when both system and user systemd gateway services are discoverable
- distinguish user-bus inspection failures from absence of user services
- warn when multiple gateway processes are running for the current profile
- add targeted tests for duplicate supervisor/process detection

Fixes #32952
Related #32951

## Test plan
- \All checks passed!
- \