### PR TITLE
Guard private memory artifacts from delivery

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1990,26 +1990,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         _merge_summary_into_tail = False
-        last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
-        # Pick a role that avoids consecutive same-role with both neighbors.
-        # Priority: avoid colliding with head (already committed), then tail.
-        if last_head_role in {"assistant", "tool"}:
-            summary_role = "user"
-        else:
-            summary_role = "assistant"
-        # If the chosen role collides with the tail AND flipping wouldn't
-        # collide with the head, flip it.
-        if summary_role == first_tail_role:
-            flipped = "assistant" if summary_role == "user" else "user"
-            if flipped != last_head_role:
-                summary_role = flipped
-            else:
-                # Both roles would create consecutive same-role messages
-                # (e.g. head=assistant, tail=user — neither role works).
-                # Merge the summary into the first tail message instead
-                # of inserting a standalone message that breaks alternation.
-                _merge_summary_into_tail = True
+        # Context handoffs are internal instructions for the *next* model. Never
+        # serialize them as assistant-role turns: assistant messages are the
+        # same channel that gateways persist/deliver as user-visible output, so
+        # a compaction handoff there can leak into transcripts or messaging
+        # adapters. Prefer a user-role handoff with explicit reference-only
+        # framing; if the protected tail already starts with a user message,
+        # merge the handoff into that user turn to avoid adjacent user messages.
+        summary_role = "user"
+        if first_tail_role == "user":
+            _merge_summary_into_tail = True
 
         # When the summary lands as a standalone role="user" message,
         # weak models read the verbatim "## Active Task" quote of a past

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -963,6 +963,14 @@ def _media_delivery_denied_paths() -> List[Path]:
         denied.append(hermes_root / "auth.json")
         denied.append(hermes_root / "credentials")
         denied.append(hermes_root / "config.yaml")
+        # Built-in and plugin memory stores are profile-private state. They may
+        # be Markdown/JSON and therefore look like ordinary deliverables, but a
+        # model-emitted MEDIA: tag or bare path must never upload them to a
+        # messaging platform. Cache roots under the profile remain allowlisted
+        # above before the denylist is applied.
+        denied.append(hermes_root / "MEMORY.md")
+        denied.append(hermes_root / "USER.md")
+        denied.append(hermes_root / "memories")
     return denied
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -912,6 +912,35 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(config_file)) is None
 
+
+    def test_denylist_blocks_builtin_memory_files_in_active_profile(self, tmp_path, monkeypatch):
+        """MEMORY.md/USER.md are profile-private state, never outbound documents."""
+        self._patch_roots(monkeypatch)
+
+        profile_home = tmp_path / "home" / ".hermes" / "profiles" / "booksignal"
+        profile_home.mkdir(parents=True)
+        memory_file = profile_home / "MEMORY.md"
+        user_file = profile_home / "USER.md"
+        memory_file.write_text("private agent memory")
+        user_file.write_text("private user profile")
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", profile_home)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(memory_file)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(user_file)) is None
+
+    def test_denylist_blocks_memory_store_directory(self, tmp_path, monkeypatch):
+        """Deep memory stores under the profile are also private state."""
+        self._patch_roots(monkeypatch)
+
+        profile_home = tmp_path / "home" / ".hermes" / "profiles" / "booksignal"
+        memories_dir = profile_home / "memories"
+        memories_dir.mkdir(parents=True)
+        fact_db = memories_dir / "facts.json"
+        fact_db.write_text('{"private": true}')
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", profile_home)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(fact_db)) is None
+
     def test_strict_mode_envvar_restores_legacy_behavior(self, tmp_path, monkeypatch):
         """Setting HERMES_MEDIA_DELIVERY_STRICT=1 reactivates the older
         allowlist+recency logic. A stale file outside the allowlist is

--- a/tests/run_agent/test_compression_boundary.py
+++ b/tests/run_agent/test_compression_boundary.py
@@ -196,3 +196,27 @@ class TestCompressionToolResultPreservation:
             if msg.get("role") == "tool":
                 assert msg["content"] != "[Result from earlier conversation — see context summary above]", \
                     f"Stub result found for {msg.get('tool_call_id')} — real result was lost"
+
+
+class TestSummaryRoleSafety:
+    def test_compression_summary_is_never_inserted_as_assistant_turn(self):
+        comp = _make_compressor(protect_first_n=2, protect_last_n=1)
+        comp._generate_summary = lambda *_args, **_kwargs: "compressed handoff"
+        comp._find_tail_cut_by_tokens = lambda messages, head_end, token_budget=None: len(messages) - 1
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "head user"},
+            {"role": "assistant", "content": "middle assistant 1"},
+            {"role": "user", "content": "middle user 1"},
+            {"role": "assistant", "content": "middle assistant 2"},
+            {"role": "user", "content": "middle user 2"},
+            {"role": "assistant", "content": "middle assistant 3"},
+            {"role": "assistant", "content": "tail assistant"},
+        ]
+
+        compressed = comp.compress(messages, current_tokens=7000, force=True)
+
+        summary_msgs = [m for m in compressed if "compressed handoff" in str(m.get("content"))]
+        assert summary_msgs, compressed
+        assert all(m.get("role") != "assistant" for m in summary_msgs)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -246,6 +246,42 @@ class TestRoleFilter:
             assert result["results"][0]["matched_role"] == "tool"
 
 
+
+
+class TestCompactionHygiene:
+    def test_discovery_hides_context_compaction_messages(self, db):
+        db.create_session("s_compacted", source="cli")
+        db.append_message(
+            "s_compacted",
+            role="assistant",
+            content="[CONTEXT COMPACTION — REFERENCE ONLY] secret needle summary",
+        )
+        db.append_message("s_compacted", role="user", content="ordinary needle request")
+
+        result = json.loads(session_search(query="needle", limit=5, db=db))
+
+        payload = json.dumps(result, ensure_ascii=False)
+        assert "CONTEXT COMPACTION" not in payload
+        assert "ordinary needle request" in payload
+
+    def test_scroll_hides_context_compaction_messages(self, db):
+        db.create_session("s_scroll", source="cli")
+        db.append_message(
+            "s_scroll",
+            role="assistant",
+            content="[CONTEXT COMPACTION — REFERENCE ONLY] hidden handoff",
+        )
+        anchor_id = db.append_message("s_scroll", role="user", content="visible anchor")
+
+        result = json.loads(session_search(session_id="s_scroll", around_message_id=anchor_id, window=2, db=db))
+
+        assert result["success"] is True
+        payload = json.dumps(result, ensure_ascii=False)
+        assert "CONTEXT COMPACTION" not in payload
+        assert "hidden handoff" not in payload
+        assert "visible anchor" in payload
+
+
 # =========================================================================
 # Scroll shape (session_id + around_message_id)
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -33,6 +33,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from agent.context_compressor import ContextCompressor
+
 # Sources that are excluded from session browsing/searching by default.
 # Third-party integrations tag their sessions with HERMES_SESSION_SOURCE=tool
 # so they don't clutter the user's session history.
@@ -84,6 +86,22 @@ def _resolve_to_parent(db, session_id: str) -> str:
             logging.debug("Error resolving parent for %s: %s", cur, e, exc_info=True)
             break
     return cur
+
+
+def _is_compaction_handoff_message(m: Dict[str, Any]) -> bool:
+    """Return True for internal context-compression handoff turns.
+
+    These are implementation details injected into the model context, not user
+    transcript. They must not be surfaced by session_search discovery/scroll or
+    they can be mistaken for fresh user-visible chat content.
+    """
+    try:
+        if ContextCompressor._is_context_summary_content(m.get("content")):
+            return True
+    except Exception:
+        pass
+    content = m.get("content")
+    return isinstance(content, str) and content.lstrip().startswith("[CONTEXT COMPACTION")
 
 
 def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
@@ -207,7 +225,7 @@ def _scroll(
         logging.error("get_messages_around failed: %s", e, exc_info=True)
         return tool_error(f"failed to load messages: {e}", success=False)
 
-    messages = view.get("window") or []
+    messages = [m for m in (view.get("window") or []) if not _is_compaction_handoff_message(m)]
 
     # Lineage rebind: caller may have paired a parent session_id with a
     # message id that lives in a descendant (compaction / delegation creates
@@ -316,6 +334,8 @@ def _discover(
     seen_sessions = {}
     for r in raw_results:
         raw_sid = r["session_id"]
+        if _is_compaction_handoff_message(r):
+            continue
         resolved_sid = _resolve_to_parent(db, raw_sid)
         # Skip the current session lineage
         if current_lineage_root and resolved_sid == current_lineage_root:
@@ -355,9 +375,21 @@ def _discover(
             "matched_role": match_info.get("role"),
             "match_message_id": msg_id,
             "snippet": match_info.get("snippet") or "",
-            "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or [])],
-            "messages": [_shape_message(m, anchor_id=msg_id) for m in (view.get("window") or [])],
-            "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or [])],
+            "bookend_start": [
+                _shape_message(m)
+                for m in (view.get("bookend_start") or [])
+                if not _is_compaction_handoff_message(m)
+            ],
+            "messages": [
+                _shape_message(m, anchor_id=msg_id)
+                for m in (view.get("window") or [])
+                if not _is_compaction_handoff_message(m)
+            ],
+            "bookend_end": [
+                _shape_message(m)
+                for m in (view.get("bookend_end") or [])
+                if not _is_compaction_handoff_message(m)
+            ],
             "messages_before": view.get("messages_before", 0),
             "messages_after": view.get("messages_after", 0),
         }


### PR DESCRIPTION
## Summary
- keep context compaction handoff summaries out of assistant-role transcript turns
- filter context compaction handoffs from session_search discovery/scroll output
- deny media delivery of profile MEMORY.md, USER.md, and memories/ artifacts
- add regression coverage for compression, session_search hygiene, and gateway media path validation

## Test Plan
- `python3 -m pytest tests/gateway/test_platform_base.py tests/tools/test_session_search.py tests/run_agent/test_compression_boundary.py -q`
- `python3 -m ruff check agent/context_compressor.py gateway/platforms/base.py tools/session_search_tool.py tests/gateway/test_platform_base.py tests/tools/test_session_search.py tests/run_agent/test_compression_boundary.py`
