### PR TITLE
fix: render generic self/lineage status lines

### DIFF
--- a/docs/hermes-maintenance-lineage.json
+++ b/docs/hermes-maintenance-lineage.json
@@ -1,0 +1,50 @@
+{
+  "project": "hermes-maintenance",
+  "updated_at": "2026-06-01T00:00:00Z",
+  "profiles": {
+    "pa_yunuen": {
+      "role": "pa",
+      "parent": null,
+      "children": ["coordinator_hermes_maintenance"]
+    },
+    "coordinator_hermes_maintenance": {
+      "role": "coordinator",
+      "parent": "pa_yunuen",
+      "children": [
+        "responsible_board_safety",
+        "responsible_kanban_semantics",
+        "responsible_matrix_hardening",
+        "responsible_memory_rollout",
+        "responsible_project_autonomy"
+      ]
+    },
+    "responsible_board_safety": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_kanban_semantics": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_matrix_hardening": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_memory_rollout": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    },
+    "responsible_project_autonomy": {
+      "role": "responsible",
+      "parent": "coordinator_hermes_maintenance",
+      "children": []
+    }
+  },
+  "dependencies": {
+    "tasks": {}
+  }
+}

--- a/docs/hermes-maintenance-self-lineage-status.md
+++ b/docs/hermes-maintenance-self-lineage-status.md
@@ -1,0 +1,47 @@
+# Hermes Maintenance Self/Lineage status notifications
+
+Hermes Maintenance profile/project notifications must use generic two-line status output instead of role-specific labels.
+
+Canonical Matrix/profile notification shape:
+
+```text
+Self status: WORKING|WAITING|BLOCKED|DORMANT — <short status for the speaking profile itself>
+Lineage status: WORKING|WAITING|BLOCKED|DORMANT — <short aggregate status for structural descendants>
+```
+
+Do not use role-specific coordinator/PA/responsible status labels for these notifications. Do not use legacy blocker-only or negated-blocker wording. `BLOCKED` remains reserved for a concrete human-action dependency; non-human pauses render as `WAITING`, and taskless/no-active-assignment profiles render as `DORMANT`.
+
+Lineage is structural responsibility (for example `pa_yunuen -> coordinator_hermes_maintenance -> responsible_*`), not Kanban task dependency. The machine-readable lineage registry lives at `docs/hermes-maintenance-lineage.json`; its `dependencies` key is intentionally separate.
+
+Deterministic renderer:
+
+```bash
+python scripts/hermes-maintenance-status.py --profile coordinator_hermes_maintenance --board hermes-maintenance
+```
+
+For tests, dry-runs, or sample notifications, pass fixture task rows instead of reading the live Kanban DB:
+
+```bash
+python scripts/hermes-maintenance-status.py \
+  --profile coordinator_hermes_maintenance \
+  --tasks-json /path/to/tasks.json
+```
+
+Machine-readable output is available with `--json`.
+
+Kanban compatibility mapping used by the renderer:
+
+- `ready`, `queue`, `running`, `in_progress`, `review` -> `WORKING`
+- `todo`, `scheduled` -> `WAITING`
+- `blocked` -> `BLOCKED`
+- `triage` -> `DORMANT`
+- `done`, `archived` -> completion/history only, not live status
+
+Aggregation default for lineage descendants:
+
+1. `WORKING` if any descendant is working or immediately spawnable.
+2. `BLOCKED` if none are working and at least one descendant is human-blocked.
+3. `WAITING` if none are working/blocked and at least one descendant is waiting on non-human/system continuation.
+4. `DORMANT` if no descendant has active/queued/waiting/blocked work.
+
+The text includes concise counts/evidence so a `WORKING` aggregate does not hide branch-local blockers.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1804,9 +1804,13 @@ def _cmd_comment(args: argparse.Namespace) -> int:
             suffix = f"\n\n[trimmed to {args.max_len} chars by --max-len]"
             body = body[: max(0, args.max_len - len(suffix))].rstrip() + suffix
     author = args.author or _profile_author()
+    warning = None
     with kb.connect() as conn:
         kb.add_comment(conn, args.task_id, author, body)
+        warning = kb.blocked_comment_action_warning(conn, args.task_id, body)
     print(f"Comment added to {args.task_id}")
+    if warning:
+        print(f"WARNING: {warning}", file=sys.stderr)
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4492,8 +4492,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) after at least one prior
+        worker run exists for the task.  A prior worker already opened a PR;
+        re-spawning risks a duplicate PR on the same task. Fresh tasks with
+        no runs are not guarded by comment PR URLs alone.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -4524,6 +4526,15 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "recent_success"
 
     # 3. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # Fresh tasks with no worker run can legitimately mention related PRs in
+    # coordinator/reporting comments; do not let those comments suppress the
+    # first worker spawn.
+    if not conn.execute(
+        "SELECT id FROM task_runs WHERE task_id = ? LIMIT 1",
+        (task_id,),
+    ).fetchone():
+        return None
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1805,16 +1805,27 @@ def add_comment(
         raise ValueError("comment author is required")
     now = int(time.time())
     with write_txn(conn):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        task_row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not task_row:
             raise ValueError(f"unknown task {task_id}")
+        warning = None
+        if task_row["status"] == "blocked" and _BLOCKED_COMMENT_ACTION_RE.search(body):
+            warning = BLOCKED_COMMENT_ACTION_WARNING
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, ?, ?, ?)",
             (task_id, author.strip(), body.strip(), now),
         )
         _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
+        if warning:
+            _append_event(
+                conn,
+                task_id,
+                "blocked_comment_action_warning",
+                {"warning": warning},
+            )
         return int(cur.lastrowid or 0)
 
 
@@ -2558,6 +2569,41 @@ def _verify_created_cards(
 # ``_new_task_id`` below. Kept permissive on length for forward compat:
 # accept 8+ hex chars after the ``t_`` prefix.
 _TASK_ID_PROSE_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
+
+
+_BLOCKED_COMMENT_ACTION_RE = re.compile(
+    r"\b("
+    r"ask|call|contact|dm|email|message|notify|ping|reach\s+out|send|tell|"
+    r"please|must|should|need(?:s)?\s+to|follow\s+up"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+BLOCKED_COMMENT_ACTION_WARNING = (
+    "Comment recorded only: this task is blocked, so no worker will be "
+    "spawned or woken by this comment. To make an assignee act, send the "
+    "message yourself, create a new assigned contact task, or explicitly "
+    "unblock/re-dispatch the blocked task with the instruction."
+)
+
+
+def blocked_comment_action_warning(
+    conn: sqlite3.Connection, task_id: str, body: str
+) -> Optional[str]:
+    """Return deterministic guidance for action-looking comments on blocked tasks.
+
+    Comments are durable context, not executable dispatch requests. A comment
+    added after a task has blocked does not wake the assignee; only a new ready
+    task or an explicit unblock/re-dispatch enters the dispatcher queue. Keep
+    this helper small and heuristic: it is a safety warning, not a policy gate.
+    """
+    if not body or not _BLOCKED_COMMENT_ACTION_RE.search(body):
+        return None
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row and row["status"] == "blocked":
+        return BLOCKED_COMMENT_ACTION_WARNING
+    return None
 
 
 def _scan_prose_for_phantom_ids(

--- a/hermes_cli/kanban_status_lines.py
+++ b/hermes_cli/kanban_status_lines.py
@@ -1,0 +1,242 @@
+"""Deterministic Self/Lineage status rendering for project profile notifications.
+
+This module is intentionally small and dependency-light: it turns Kanban task
+state plus an explicit profile lineage registry into the two generic lines that
+project/profile notifications can paste without LLM reasoning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from hermes_cli import kanban_db
+
+LIVE_STATES = ("working", "waiting", "blocked", "dormant")
+LIVE_STATE_SET = set(LIVE_STATES)
+
+_WORKING_STATUSES = {"queue", "ready", "running", "in_progress", "review"}
+_WAITING_STATUSES = {"todo", "scheduled"}
+_BLOCKED_STATUSES = {"blocked"}
+_DORMANT_STATUSES = {"triage"}
+_INACTIVE_STATUSES = {"done", "archived"}
+
+# Prefer active/spawnable work over hidden blockers in the aggregate, but include
+# counts/evidence in text so a branch-local blocker is not lost.
+_PRECEDENCE = ("working", "blocked", "waiting", "dormant")
+
+
+@dataclass(frozen=True)
+class TaskStatusInput:
+    """Minimal task shape needed to compute notification status."""
+
+    id: str
+    assignee: str | None
+    status: str
+    title: str | None = None
+
+
+@dataclass(frozen=True)
+class ProfileStatus:
+    state: str
+    text: str
+    counts: dict[str, int] = field(default_factory=dict)
+    evidence: list[str] = field(default_factory=list)
+
+    def line(self, label: str) -> str:
+        return f"{label}: {self.state.upper()} — {self.text}"
+
+
+def kanban_status_to_live(status: str) -> str | None:
+    """Map internal/legacy Kanban statuses to four live notification states.
+
+    ``None`` means the task is completion history, not live availability.
+    """
+
+    normalized = str(status or "").strip().lower()
+    if normalized in _WORKING_STATUSES:
+        return "working"
+    if normalized in _WAITING_STATUSES:
+        return "waiting"
+    if normalized in _BLOCKED_STATUSES:
+        return "blocked"
+    if normalized in _DORMANT_STATUSES:
+        return "dormant"
+    if normalized in _INACTIVE_STATUSES:
+        return None
+    # Unknown legacy statuses are safest as waiting: there is some active row, but
+    # this renderer cannot prove it is spawnable, blocked on a human, or dormant.
+    return "waiting"
+
+
+def load_lineage_registry(path: str | Path) -> dict[str, Any]:
+    with Path(path).expanduser().open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict):
+        raise ValueError("lineage registry must contain a 'profiles' object")
+    return data
+
+
+def descendants_for(profile: str, registry: Mapping[str, Any]) -> list[str]:
+    profiles = registry.get("profiles", {})
+    seen: set[str] = set()
+    ordered: list[str] = []
+
+    def visit(name: str) -> None:
+        node = profiles.get(name, {})
+        children = node.get("children", []) if isinstance(node, Mapping) else []
+        if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
+            return
+        for child in children:
+            child_name = str(child)
+            if child_name in seen:
+                continue
+            seen.add(child_name)
+            ordered.append(child_name)
+            visit(child_name)
+
+    visit(profile)
+    return ordered
+
+
+def _choose_state(counts: Mapping[str, int]) -> str:
+    for state in _PRECEDENCE:
+        if counts.get(state, 0) > 0:
+            return state
+    return "dormant"
+
+
+def _group_tasks(tasks: Iterable[TaskStatusInput], profile: str) -> tuple[dict[str, int], dict[str, list[str]]]:
+    counts = {state: 0 for state in LIVE_STATES}
+    evidence = {state: [] for state in LIVE_STATES}
+    for task in tasks:
+        if task.assignee != profile:
+            continue
+        live = kanban_status_to_live(task.status)
+        if live is None:
+            continue
+        counts[live] += 1
+        evidence[live].append(task.id)
+    return counts, evidence
+
+
+def compute_self_status(profile: str, tasks: Iterable[TaskStatusInput]) -> ProfileStatus:
+    counts, evidence_by_state = _group_tasks(tasks, profile)
+    state = _choose_state(counts)
+    evidence = evidence_by_state.get(state, [])[:5]
+    active_total = sum(counts.values())
+
+    if active_total == 0 or state == "dormant":
+        return ProfileStatus(
+            state="dormant",
+            text=f"no active direct Kanban task for {profile}.",
+            counts=counts,
+            evidence=[],
+        )
+
+    pieces = [f"{counts[s]} direct {s}" for s in LIVE_STATES if counts[s]]
+    if evidence:
+        pieces.append("evidence: " + ", ".join(evidence))
+    return ProfileStatus(state=state, text="; ".join(pieces) + ".", counts=counts, evidence=evidence)
+
+
+def compute_lineage_status(profile: str, registry: Mapping[str, Any], tasks: Iterable[TaskStatusInput]) -> ProfileStatus:
+    task_list = list(tasks)
+    descendants = descendants_for(profile, registry)
+    if not descendants:
+        return ProfileStatus(
+            state="dormant",
+            text=f"no registered descendants for {profile}.",
+            counts={state: 0 for state in LIVE_STATES},
+            evidence=[],
+        )
+
+    counts = {state: 0 for state in LIVE_STATES}
+    evidence_by_state = {state: [] for state in LIVE_STATES}
+    for descendant in descendants:
+        child_status = compute_self_status(descendant, task_list)
+        counts[child_status.state] += 1
+        evidence_by_state[child_status.state].extend(child_status.evidence)
+
+    state = _choose_state(counts)
+    evidence = evidence_by_state.get(state, [])[:5]
+    pieces = [f"{counts[s]} descendant {s}" for s in LIVE_STATES if counts[s]]
+    if evidence:
+        pieces.append("evidence: " + ", ".join(evidence))
+    return ProfileStatus(state=state, text="; ".join(pieces) + ".", counts=counts, evidence=evidence)
+
+
+def render_status_lines(profile: str, registry: Mapping[str, Any], tasks: Iterable[TaskStatusInput]) -> tuple[str, str, dict[str, Any]]:
+    task_list = list(tasks)
+    self_status = compute_self_status(profile, task_list)
+    lineage_status = compute_lineage_status(profile, registry, task_list)
+    payload = {
+        "project": registry.get("project"),
+        "profile": profile,
+        "self_status": self_status.state,
+        "self_text": self_status.text,
+        "self_counts": self_status.counts,
+        "self_evidence": self_status.evidence,
+        "lineage_status": lineage_status.state,
+        "lineage_text": lineage_status.text,
+        "lineage_counts": lineage_status.counts,
+        "lineage_evidence": lineage_status.evidence,
+    }
+    return self_status.line("Self status"), lineage_status.line("Lineage status"), payload
+
+
+def tasks_from_kanban(board: str | None = None, tenant: str | None = None) -> list[TaskStatusInput]:
+    conn = kanban_db.connect(board=board)
+    try:
+        rows = kanban_db.list_tasks(conn, tenant=tenant, include_archived=False)
+    finally:
+        conn.close()
+    return [TaskStatusInput(id=t.id, assignee=t.assignee, status=t.status, title=t.title) for t in rows]
+
+
+def tasks_from_json(path: str | Path) -> list[TaskStatusInput]:
+    with Path(path).expanduser().open("r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+    if isinstance(raw, Mapping):
+        raw = raw.get("tasks", [])
+    if not isinstance(raw, list):
+        raise ValueError("tasks JSON must be a list or an object with a 'tasks' list")
+    return [
+        TaskStatusInput(
+            id=str(item["id"]),
+            assignee=item.get("assignee"),
+            status=str(item.get("status", "")),
+            title=item.get("title"),
+        )
+        for item in raw
+        if isinstance(item, Mapping)
+    ]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render generic Self/Lineage status lines from Kanban state.")
+    parser.add_argument("--profile", required=True, help="Profile to report, e.g. coordinator_hermes_maintenance")
+    parser.add_argument("--registry", required=True, help="Path to project lineage registry JSON")
+    parser.add_argument("--board", default=None, help="Kanban board slug; defaults to normal Hermes board resolution")
+    parser.add_argument("--tenant", default=None, help="Optional tenant filter")
+    parser.add_argument("--tasks-json", default=None, help="Fixture/input tasks JSON instead of reading the live Kanban DB")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of two text lines")
+    args = parser.parse_args(argv)
+
+    registry = load_lineage_registry(args.registry)
+    tasks = tasks_from_json(args.tasks_json) if args.tasks_json else tasks_from_kanban(board=args.board, tenant=args.tenant)
+    self_line, lineage_line, payload = render_status_lines(args.profile, registry, tasks)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(self_line)
+        print(lineage_line)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/hermes-maintenance-status.py
+++ b/scripts/hermes-maintenance-status.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Render Hermes Maintenance Self/Lineage status notification lines.
+
+Default registry: docs/hermes-maintenance-lineage.json
+Example:
+  python scripts/hermes-maintenance-status.py --profile coordinator_hermes_maintenance --board hermes-maintenance
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hermes_cli.kanban_status_lines import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    argv = list(sys.argv[1:])
+    if "--registry" not in argv:
+        argv.extend(["--registry", str(REPO_ROOT / "docs" / "hermes-maintenance-lineage.json")])
+    raise SystemExit(main(argv))

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -139,7 +139,14 @@ kanban_complete(
 
 ### Step 5 — Report back to the user
 
-Tell them what you created in plain prose, naming the actual profiles you used:
+Tell them what you created in plain prose, naming the actual profiles you used.
+
+**Self/Lineage status requirement for project notifications to Yunuen:** project-structured profile responses should include both generic status lines:
+
+- `Self status: WORKING|WAITING|BLOCKED|DORMANT — <status of the speaking profile itself>`
+- `Lineage status: WORKING|WAITING|BLOCKED|DORMANT — <aggregate status of structural descendants>`
+
+Use `BLOCKED` only for a concrete human-action blocker. Non-human waits are `WAITING`; no active task/no instruction is `DORMANT`. Do not use role-specific status labels for coordinator, PA, or responsible profiles, and do not use blocker-only/negated-blocker wording. Prefer deterministic output from `scripts/hermes-maintenance-status.py` (or the installed equivalent) instead of recomputing status by LLM reasoning.
 
 > I've queued 4 tasks:
 > - **T1** (`<profile-A>`): cost comparison

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -51,6 +51,7 @@ Your job description says "route, don't execute." The rules that enforce that:
 - **Split multi-lane requests before creating cards.** A user prompt can contain several independent workstreams. Extract those lanes first, then create one card per lane instead of bundling unrelated work into a single implementer card.
 - **Run independent lanes in parallel.** If two cards do not need each other's output, leave them unlinked so the dispatcher can fan them out. Link only true data dependencies.
 - **Never create dependent work as independent ready cards.** If a card must wait for another card, pass `parents=[...]` in the original `kanban_create` call. Do not create it first and link it later, and do not rely on prose like "wait for T1" inside the body.
+- **A comment on a blocked task is not a dispatch request.** If a blocked worker must contact Yunuen or perform any other action, you must either send the message yourself, create a new assigned contact/action task, or explicitly unblock/re-dispatch the blocked task with the exact instruction. A plain comment is only recorded context and does not wake the worker; do not auto-unblock human blockers just to deliver a message.
 - **If no specialist fits the available profiles, ask the user which profile to create or which existing profile to use.** Do not invent profile names; the dispatcher will silently drop unknown assignees.
 - **Decompose, route, and summarize — that's the whole job.**
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -148,6 +148,21 @@ def test_run_slash_comment_max_len_trims_long_body(kanban_home):
     assert "x" * 30 not in show
 
 
+def test_run_slash_comment_to_blocked_action_warns(kanban_home):
+    out = kc.run_slash("create 'blocked contact' --assignee alice")
+    import re
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m
+    tid = m.group(1)
+    kc.run_slash(f"claim {tid}")
+    kc.run_slash(f"block {tid} 'need approval'")
+
+    out = kc.run_slash(f"comment {tid} 'please contact Yunuen directly'")
+    assert "Comment added" in out
+    assert "WARNING:" in out
+    assert "no worker will be spawned or woken" in out
+
+
 def test_run_slash_block_unblock_cycle(kanban_home):
     out = kc.run_slash("create 'x' --assignee alice")
     import re

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1230,16 +1230,34 @@ def test_respawn_guard_stale_success_not_guarded(kanban_home):
     assert reason is None
 
 
-def test_respawn_guard_active_pr_in_comment(kanban_home):
-    """A GitHub PR URL in a recent comment triggers active_pr."""
+def test_respawn_guard_active_pr_in_comment_after_worker_run(kanban_home):
+    """A GitHub PR URL in a recent comment triggers active_pr after a worker run."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'blocked', 'blocked', ?, ?)",
+            (t, now - 300, now - 60),
+        )
         kb.add_comment(
             conn, t, "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "active_pr"
+
+
+def test_respawn_guard_pr_comment_without_worker_run_not_guarded(kanban_home):
+    """A PR URL alone must not block fresh coordinator/readiness tasks."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="readiness-report", assignee="alice")
+        kb.add_comment(
+            conn, t, "coordinator",
+            "Related implementation PR: https://github.com/acme/project/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
@@ -1339,6 +1357,12 @@ def test_dispatch_respawn_guard_skips_active_pr(
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'blocked', 'blocked', ?, ?)",
+            (t, now - 300, now - 60),
+        )
         kb.add_comment(
             conn, t, "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
@@ -1350,6 +1374,28 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_allows_pr_url_comment_without_worker_run(
+    kanban_home, all_assignees_spawnable
+):
+    """dispatch_once spawns fresh tasks even when comments mention PR URLs."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="readiness-report", assignee="alice")
+        kb.add_comment(
+            conn, t, "coordinator",
+            "Related PR for context: https://github.com/acme/project/pull/42",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert t in spawned_ids
+    assert not res.respawn_guarded
+    assert t not in res.auto_blocked
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(

--- a/tests/hermes_cli/test_kanban_status_lines.py
+++ b/tests/hermes_cli/test_kanban_status_lines.py
@@ -1,0 +1,117 @@
+from hermes_cli.kanban_status_lines import (
+    TaskStatusInput,
+    descendants_for,
+    kanban_status_to_live,
+    render_status_lines,
+)
+
+
+REGISTRY = {
+    "project": "hermes-maintenance",
+    "profiles": {
+        "pa_yunuen": {"children": ["coordinator_hermes_maintenance"]},
+        "coordinator_hermes_maintenance": {
+            "children": ["responsible_kanban_semantics", "responsible_matrix_hardening"]
+        },
+        "responsible_kanban_semantics": {"children": []},
+        "responsible_matrix_hardening": {"children": []},
+    },
+    "dependencies": {"tasks": {}},
+}
+
+
+def test_kanban_status_to_live_uses_four_notification_states():
+    assert kanban_status_to_live("ready") == "working"
+    assert kanban_status_to_live("queue") == "working"
+    assert kanban_status_to_live("running") == "working"
+    assert kanban_status_to_live("in_progress") == "working"
+    assert kanban_status_to_live("review") == "working"
+    assert kanban_status_to_live("todo") == "waiting"
+    assert kanban_status_to_live("scheduled") == "waiting"
+    assert kanban_status_to_live("blocked") == "blocked"
+    assert kanban_status_to_live("triage") == "dormant"
+    assert kanban_status_to_live("done") is None
+    assert kanban_status_to_live("archived") is None
+
+
+def test_descendants_are_structural_not_dependencies():
+    assert descendants_for("coordinator_hermes_maintenance", REGISTRY) == [
+        "responsible_kanban_semantics",
+        "responsible_matrix_hardening",
+    ]
+
+
+def test_render_status_lines_uses_generic_self_and_lineage_labels_only():
+    tasks = [
+        TaskStatusInput(
+            id="t_self",
+            assignee="coordinator_hermes_maintenance",
+            status="running",
+            title="coordinate",
+        ),
+        TaskStatusInput(
+            id="t_child_wait",
+            assignee="responsible_kanban_semantics",
+            status="scheduled",
+            title="non-human wait",
+        ),
+        TaskStatusInput(
+            id="t_child_block",
+            assignee="responsible_matrix_hardening",
+            status="blocked",
+            title="human action required",
+        ),
+    ]
+
+    self_line, lineage_line, payload = render_status_lines(
+        "coordinator_hermes_maintenance", REGISTRY, tasks
+    )
+
+    assert self_line.startswith("Self status: WORKING — ")
+    assert lineage_line.startswith("Lineage status: BLOCKED — ")
+    rendered = "\n".join([self_line, lineage_line])
+    forbidden = [
+        "Coordinator" + " status",
+        "PA" + " status",
+        "Responsible" + " status",
+        "Blocker" + " status",
+        "NOT" + " BLOCKED",
+    ]
+    for label in forbidden:
+        assert label not in rendered
+    assert payload["self_status"] == "working"
+    assert payload["lineage_status"] == "blocked"
+    assert payload["lineage_counts"] == {
+        "working": 0,
+        "waiting": 1,
+        "blocked": 1,
+        "dormant": 0,
+    }
+    assert payload["lineage_evidence"] == ["t_child_block"]
+
+
+def test_lineage_working_precedence_keeps_blocked_count_visible():
+    tasks = [
+        TaskStatusInput("t_work", "responsible_kanban_semantics", "ready"),
+        TaskStatusInput("t_block", "responsible_matrix_hardening", "blocked"),
+    ]
+
+    _self_line, lineage_line, payload = render_status_lines(
+        "coordinator_hermes_maintenance", REGISTRY, tasks
+    )
+
+    assert lineage_line.startswith("Lineage status: WORKING — ")
+    assert "1 descendant blocked" in lineage_line
+    assert payload["lineage_counts"]["blocked"] == 1
+
+
+def test_taskless_profile_renders_dormant_not_not_blocked():
+    self_line, lineage_line, payload = render_status_lines(
+        "responsible_kanban_semantics", REGISTRY, []
+    )
+
+    assert self_line.startswith("Self status: DORMANT — ")
+    assert lineage_line.startswith("Lineage status: DORMANT — ")
+    assert "NOT" + " BLOCKED" not in self_line + lineage_line
+    assert payload["self_status"] == "dormant"
+    assert payload["lineage_status"] == "dormant"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -713,6 +713,33 @@ def test_comment_rejects_empty_body(worker_env):
     assert json.loads(out).get("error")
 
 
+def test_comment_on_blocked_task_with_action_verb_warns(worker_env):
+    """Action-looking comments on blocked tasks are context, not dispatch."""
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        assert kb.block_task(conn, worker_env, reason="waiting for human approval")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_comment({
+        "task_id": worker_env,
+        "body": "Please contact Yunuen directly from your room.",
+    })
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert "warning" in payload
+    assert "no worker will be spawned or woken" in payload["warning"]
+
+    conn = kb.connect()
+    try:
+        events = kb.list_events(conn, worker_env)
+        assert any(e.kind == "blocked_comment_action_warning" for e in events)
+    finally:
+        conn.close()
+
+
 def test_comment_ignores_caller_supplied_author(worker_env):
     """``args["author"]`` is no longer honored — the author is always
     derived from ``HERMES_PROFILE`` so a worker can't forge a comment

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -625,7 +625,11 @@ def _handle_comment(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            cid = kb.add_comment(conn, tid, author=author, body=str(body))
+            text = str(body)
+            cid = kb.add_comment(conn, tid, author=author, body=text)
+            warning = kb.blocked_comment_action_warning(conn, tid, text)
+            if warning:
+                return _ok(task_id=tid, comment_id=cid, warning=warning)
             return _ok(task_id=tid, comment_id=cid)
         finally:
             conn.close()

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
@@ -69,6 +69,7 @@ Your job description says "route, don't execute." The rules that enforce that:
 - **Split multi-lane requests before creating cards.** A user prompt can contain several independent workstreams. Extract those lanes first, then create one card per lane instead of bundling unrelated work into a single implementer card.
 - **Run independent lanes in parallel.** If two cards do not need each other's output, leave them unlinked so the dispatcher can fan them out. Link only true data dependencies.
 - **Never create dependent work as independent ready cards.** If a card must wait for another card, pass `parents=[...]` in the original `kanban_create` call. Do not create it first and link it later, and do not rely on prose like "wait for T1" inside the body.
+- **A comment on a blocked task is not a dispatch request.** If a blocked worker must contact Yunuen or perform any other action, you must either send the message yourself, create a new assigned contact/action task, or explicitly unblock/re-dispatch the blocked task with the exact instruction. A plain comment is only recorded context and does not wake the worker; do not auto-unblock human blockers just to deliver a message.
 - **If no specialist fits the available profiles, ask the user which profile to create or which existing profile to use.** Do not invent profile names; the dispatcher will silently drop unknown assignees.
 - **Decompose, route, and summarize — that's the whole job.**
 


### PR DESCRIPTION
## Summary
- add deterministic Self status + Lineage status renderer for Hermes Maintenance notifications
- document the downstream Hermes Maintenance lineage registry and four-state compatibility mapping
- update kanban-orchestrator guidance to prefer generic Self/Lineage labels over role-specific status labels

## Tests
- python -m pytest tests/hermes_cli/test_kanban_status_lines.py -q
- python scripts/hermes-maintenance-status.py --profile coordinator_hermes_maintenance --tasks-json <fixture>