### PR TITLE
fix(cron): guard load_jobs() against non-dict top-level JSON shapes (#36867)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -423,6 +423,25 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 # Job CRUD Operations
 # =============================================================================
 
+def _extract_jobs(data: Any) -> List[Dict[str, Any]]:
+    """Normalize top-level JSON data into a jobs list.
+
+    Accepts the expected ``{"jobs": [...]}`` dict, a bare ``[...]`` list
+    (auto-repairs by re-wrapping via :func:`save_jobs`), and raises
+    :class:`RuntimeError` for any other top-level shape.
+    """
+    if isinstance(data, list):
+        save_jobs(data)
+        logger.warning("Auto-repaired jobs.json (top-level was a list, expected object)")
+        return data
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"Cron database corrupted: top-level is {type(data).__name__}, "
+            f"expected object"
+        )
+    return data.get("jobs", [])
+
+
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
@@ -432,13 +451,13 @@ def load_jobs() -> List[Dict[str, Any]]:
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            return data.get("jobs", [])
+            return _extract_jobs(data)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
-                jobs = data.get("jobs", [])
+                jobs = _extract_jobs(data)
                 if jobs:
                     # Auto-repair: rewrite with proper escaping
                     save_jobs(jobs)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -585,6 +585,84 @@ class TestMarkJobRun:
         assert updated["state"] == "completed"
 
 
+class TestLoadJobsShapeGuard:
+    """load_jobs() must handle malformed top-level JSON shapes gracefully."""
+
+    def test_tolerates_bare_list(self, tmp_cron_dir, monkeypatch):
+        """A bare-list jobs.json (valid JSON, wrong shape) should be
+        auto-repaired and the list returned as the jobs array."""
+        import json
+        jobs = [
+            {
+                "id": "bare-list-job",
+                "prompt": "hello",
+                "schedule": {"kind": "once", "run_at": "2020-01-01T00:00:00+00:00", "display": "once"},
+                "repeat": {"times": None, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+                "next_run_at": "2020-01-01T00:00:00+00:00",
+                "last_run_at": None,
+                "last_status": None,
+                "last_error": None,
+                "last_delivery_error": None,
+                "created_at": "2020-01-01T00:00:00+00:00",
+            }
+        ]
+        # Write a bare list — the exact scenario that caused the AttributeError
+        tmp_cron_dir.joinpath("cron").mkdir(parents=True, exist_ok=True)
+        with open(tmp_cron_dir / "cron" / "jobs.json", "w", encoding="utf-8") as f:
+            json.dump(jobs, f)
+
+        result = load_jobs()
+        assert result == jobs, "bare list should be returned as the jobs array"
+
+        # Verify on-disk repair: file now has the object wrapper
+        with open(tmp_cron_dir / "cron" / "jobs.json", "r", encoding="utf-8") as f:
+            repaired = json.load(f)
+        assert isinstance(repaired, dict), "auto-repair should wrap in an object"
+        assert "jobs" in repaired
+        assert repaired["jobs"] == jobs
+
+    def test_bare_list_in_strict_false_path(self, tmp_cron_dir, monkeypatch):
+        """Bare list detected inside the strict=False fallback path also
+        auto-repairs and returns cleanly."""
+        import json
+        jobs = [{"id": "strict-path", "prompt": "test", "enabled": True}]
+        # Embed a raw control character inside the JSON so json.load()
+        # raises JSONDecodeError, triggering the strict=False retry path.
+        payload = json.dumps(jobs)
+        payload = payload.replace('"test"', '"test\x01payload"')
+        tmp_cron_dir.joinpath("cron").mkdir(parents=True, exist_ok=True)
+        with open(tmp_cron_dir / "cron" / "jobs.json", "w", encoding="utf-8") as f:
+            f.write(payload)
+
+        result = load_jobs()
+        # The prompt value changes because strict=False preserves it
+        assert len(result) == 1
+        assert result[0]["id"] == "strict-path"
+
+    def test_raises_on_scalar_top_level(self, tmp_cron_dir):
+        """A non-dict, non-list top-level value (e.g. a plain string)
+        should raise RuntimeError with a descriptive message."""
+        import json
+        tmp_cron_dir.joinpath("cron").mkdir(parents=True, exist_ok=True)
+        with open(tmp_cron_dir / "cron" / "jobs.json", "w", encoding="utf-8") as f:
+            json.dump("just a string", f)
+
+        with pytest.raises(RuntimeError, match="top-level is str"):
+            load_jobs()
+
+    def test_raises_on_number_top_level(self, tmp_cron_dir):
+        """A numeric top-level should also raise RuntimeError."""
+        import json
+        tmp_cron_dir.joinpath("cron").mkdir(parents=True, exist_ok=True)
+        with open(tmp_cron_dir / "cron" / "jobs.json", "w", encoding="utf-8") as f:
+            json.dump(42, f)
+
+        with pytest.raises(RuntimeError, match="top-level is int"):
+            load_jobs()
+
+
 class TestAdvanceNextRun:
     """Tests for advance_next_run() — crash-safety for recurring jobs."""
 


### PR DESCRIPTION
When `jobs.json` is a bare JSON list (valid JSON, wrong shape), `load_jobs()` crashes with `AttributeError` because `data.get()` fails on a list. This happens when the scheduler process crashes mid-write, leaving a partial file.

**Fix**: Extracts an `_extract_jobs()` helper that normalizes any top-level shape:
- `dict` with `"jobs"` key → returns the jobs array (happy path)
- Bare `list` → auto-repairs by re-wrapping via `save_jobs()` and returns the list
- Anything else (string, number) → raises `RuntimeError` with a descriptive message

Applied to both the `json.load()` path and the `strict=False` fallback path.

4 regression tests: bare list, bare list in strict=False, string top-level, int top-level. 91/91 existing tests pass.