### PR TITLE
migration: skip unreadable OpenClaw workspace

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -395,6 +395,13 @@ def backup_existing(path: Path, backup_root: Path) -> Optional[Path]:
     return dest
 
 
+def safe_is_dir(path: Path) -> bool:
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 # ── Brand rewriting ─────────────────────────────────────────
 # Replace OpenClaw brand names with Hermes in migrated text so that
 # memory entries, user profiles, SOUL.md, and workspace instructions
@@ -758,7 +765,7 @@ class Migrator:
             ws_path = Path(ws).expanduser().resolve()
             # Only use it if it exists and is outside the source_root tree
             # (otherwise the standard relative-path logic already covers it).
-            if ws_path.is_dir():
+            if safe_is_dir(ws_path):
                 try:
                     ws_path.relative_to(self.source_root)
                 except ValueError:

--- a/tests/skills/test_openclaw_migration_hardening.py
+++ b/tests/skills/test_openclaw_migration_hardening.py
@@ -172,6 +172,40 @@ def _make_minimal_migrator(mod, tmp_path, **overrides):
     return mod.Migrator(**defaults)
 
 
+def test_configured_workspace_permission_error_is_ignored(tmp_path, monkeypatch):
+    mod = _load()
+    source = tmp_path / "openclaw"
+    source.mkdir()
+    target = tmp_path / "hermes"
+    target.mkdir()
+    unreadable_workspace = (tmp_path / "root-workspace").resolve()
+    (source / "openclaw.json").write_text(
+        json.dumps({"agents": {"defaults": {"workspace": str(unreadable_workspace)}}}),
+        encoding="utf-8",
+    )
+    original_is_dir = mod.Path.is_dir
+
+    def raising_is_dir(path):
+        if path == unreadable_workspace:
+            raise PermissionError("permission denied")
+        return original_is_dir(path)
+
+    monkeypatch.setattr(mod.Path, "is_dir", raising_is_dir)
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=False,
+        workspace_target=None,
+        overwrite=False,
+        migrate_secrets=False,
+        output_dir=None,
+        selected_options=set(),
+    )
+
+    assert migrator._custom_workspace is None
+
+
 def test_dry_run_report_includes_rerun_next_step(tmp_path):
     mod = _load()
     migrator = _make_minimal_migrator(mod, tmp_path)


### PR DESCRIPTION
# Draft PR: OpenClaw migration skips unreadable configured workspace paths

Fixes https://github.com/NousResearch/hermes-agent/issues/36831.

## Summary

- Add a safe directory probe for configured OpenClaw workspace paths.
- Treat `OSError` / `PermissionError` from the configured workspace `is_dir()` check as "not usable" instead of aborting migration startup.
- Add a regression test that simulates an unreadable configured workspace and asserts `Migrator` construction still succeeds with no custom workspace selected.

## Tests

- `python3 -m py_compile optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`
- `uv run --with pytest --with pytest-timeout pytest tests/skills/test_openclaw_migration_hardening.py::test_configured_workspace_permission_error_is_ignored -q --tb=short` - 1 passed
- `uv run --with pytest --with pytest-timeout pytest tests/skills/test_openclaw_migration_hardening.py -q --tb=short` - 27 passed
- `uv run --with pytest --with pytest-timeout pytest tests/skills/test_openclaw_migration.py tests/skills/test_openclaw_migration_hardening.py -q --tb=short` - 68 passed

## Notes

- Prepared by Hermes local contributor lane.
- Opened as a draft PR after explicit approval.
