### PR TITLE
Preserve restart resume state until Slack delivery drains

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Dict, Optional, Any, List, Union, Iterable
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -1161,6 +1161,8 @@ logger = logging.getLogger(__name__)
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+_GRACEFUL_SHUTDOWN_DELIVERY_GRACE_SECONDS = 5.0
+_GRACEFUL_SHUTDOWN_DELIVERY_POLL_SECONDS = 0.05
 
 
 def _resolve_runtime_agent_kwargs() -> dict:
@@ -3558,6 +3560,43 @@ class GatewayRunner:
         timed_out = bool(self._running_agents)
         _maybe_update_status(force=True)
         return snapshot, timed_out
+
+    def _pending_session_delivery_keys(self, session_keys: Iterable[str]) -> set[str]:
+        pending: set[str] = set()
+        for session_key in session_keys:
+            for adapter in self.adapters.values():
+                session_tasks = getattr(adapter, "_session_tasks", None)
+                if not hasattr(session_tasks, "get"):
+                    continue
+                task = session_tasks.get(session_key)
+                if task is None:
+                    continue
+                done = getattr(task, "done", None)
+                if callable(done):
+                    if done():
+                        continue
+                pending.add(session_key)
+                break
+        return pending
+
+    async def _drain_session_delivery(
+        self,
+        session_keys: Iterable[str],
+        timeout: float,
+    ) -> tuple[set[str], set[str]]:
+        pending = self._pending_session_delivery_keys(session_keys)
+        initial_pending = set(pending)
+        if not pending or timeout <= 0:
+            return initial_pending, pending
+
+        deadline = asyncio.get_running_loop().time() + timeout
+        while pending:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(_GRACEFUL_SHUTDOWN_DELIVERY_POLL_SECONDS, remaining))
+            pending = self._pending_session_delivery_keys(pending)
+        return initial_pending, pending
 
     def _interrupt_running_agents(self, reason: str) -> None:
         for session_key, agent in list(self._running_agents.items()):
@@ -6350,18 +6389,40 @@ class GatewayRunner:
             )
 
             if not timed_out:
-                # Drain completed gracefully — all running sessions finished.
-                # Clear the pre-drain resume_pending markers so sessions that
-                # completed during the drain window don't carry a stale flag.
+                # Drain completed gracefully — all running agents finished.
+                # Their platform delivery may still be unwinding in adapter
+                # background tasks, so only clear resume_pending after those
+                # per-session tasks drain too. If delivery does not finish
+                # within the short grace window, leave resume_pending armed so
+                # startup auto-resume can recover the stranded turn.
+                delivery_started, delivery_pending = await self._drain_session_delivery(
+                    _pre_drain_keys,
+                    _GRACEFUL_SHUTDOWN_DELIVERY_GRACE_SECONDS,
+                )
+                if delivery_started:
+                    logger.info(
+                        "Shutdown phase: post-turn delivery drain checked %d session(s); pending after %.2fs: %d",
+                        len(delivery_started),
+                        _GRACEFUL_SHUTDOWN_DELIVERY_GRACE_SECONDS,
+                        len(delivery_pending),
+                    )
+                if delivery_pending:
+                    logger.warning(
+                        "Graceful shutdown delivery drain exceeded %.2fs for %d session(s); "
+                        "leaving resume_pending armed for startup recovery.",
+                        _GRACEFUL_SHUTDOWN_DELIVERY_GRACE_SECONDS,
+                        len(delivery_pending),
+                    )
                 for _sk in _pre_drain_keys:
-                    if _sk not in self._running_agents:
-                        try:
-                            self.session_store.clear_resume_pending(_sk)
-                        except Exception as _e:
-                            logger.debug(
-                                "clear_resume_pending after drain failed for %s: %s",
-                                _sk, _e,
-                            )
+                    if _sk in self._running_agents or _sk in delivery_pending:
+                        continue
+                    try:
+                        self.session_store.clear_resume_pending(_sk)
+                    except Exception as _e:
+                        logger.debug(
+                            "clear_resume_pending after drain failed for %s: %s",
+                            _sk, _e,
+                        )
 
             if timed_out:
                 logger.warning(

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -41,7 +41,7 @@ from gateway.run import (
     _last_transcript_timestamp,
     _should_clear_resume_pending_after_turn,
 )
-from gateway.session import SessionEntry, SessionSource, SessionStore
+from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
 from tests.gateway.restart_test_helpers import (
     make_restart_runner,
     make_restart_source,
@@ -170,6 +170,15 @@ def _simulate_note_injection(
             + message
         )
     return message
+
+
+async def _wait_for(predicate, timeout: float = 0.5) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
 
 
 # ---------------------------------------------------------------------------
@@ -852,6 +861,94 @@ async def test_drain_timeout_skips_pending_sentinel_sessions():
     calls = session_store.mark_resume_pending.call_args_list
     marked = {args[0][0] for args in calls}
     assert marked == {session_key_real}
+
+
+@pytest.mark.asyncio
+async def test_graceful_drain_waits_for_delivery_before_clearing_resume_pending(monkeypatch):
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    monkeypatch.setattr("gateway.run._GRACEFUL_SHUTDOWN_DELIVERY_GRACE_SECONDS", 0.2)
+
+    source = make_restart_source(chat_id="delivery-chat")
+    session_key = build_session_key(source)
+    runner._running_agents = {session_key: MagicMock()}
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    session_store.clear_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+
+    release_send = asyncio.Event()
+
+    async def delayed_send(*_args, **_kwargs):
+        await release_send.wait()
+        return SendResult(success=True, message_id="final-1")
+
+    adapter._send_with_retry = AsyncMock(side_effect=delayed_send)
+    adapter.set_message_handler(AsyncMock(return_value="final reply"))
+
+    event = MessageEvent(text="work", source=source, message_id="1")
+    await adapter.handle_message(event)
+    await _wait_for(lambda: adapter._send_with_retry.await_count == 1)
+
+    async def finish_agent_and_delivery():
+        await asyncio.sleep(0.05)
+        runner._running_agents.clear()
+        await asyncio.sleep(0.02)
+        release_send.set()
+
+    asyncio.create_task(finish_agent_and_delivery())
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    session_store.mark_resume_pending.assert_called_once_with(session_key, "shutdown_timeout")
+    session_store.clear_resume_pending.assert_called_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_graceful_drain_keeps_resume_pending_when_delivery_stalls(monkeypatch):
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    monkeypatch.setattr("gateway.run._GRACEFUL_SHUTDOWN_DELIVERY_GRACE_SECONDS", 0.05)
+
+    source = make_restart_source(chat_id="stalled-delivery-chat")
+    session_key = build_session_key(source)
+    runner._running_agents = {session_key: MagicMock()}
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    session_store.clear_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+
+    release_send = asyncio.Event()
+
+    async def stalled_send(*_args, **_kwargs):
+        await release_send.wait()
+        return SendResult(success=True, message_id="final-1")
+
+    adapter._send_with_retry = AsyncMock(side_effect=stalled_send)
+    adapter.set_message_handler(AsyncMock(return_value="final reply"))
+
+    event = MessageEvent(text="work", source=source, message_id="1")
+    await adapter.handle_message(event)
+    await _wait_for(lambda: adapter._send_with_retry.await_count == 1)
+
+    async def finish_agent_only():
+        await asyncio.sleep(0.01)
+        runner._running_agents.clear()
+
+    asyncio.create_task(finish_agent_only())
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    session_store.mark_resume_pending.assert_called_once_with(session_key, "shutdown_timeout")
+    session_store.clear_resume_pending.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep `resume_pending` armed through graceful shutdown until per-session adapter delivery tasks finish
- leave `resume_pending` set when delivery still hangs after the short grace window so startup auto-resume can recover the turn
- add regression coverage for both the successful-delivery and stalled-delivery graceful drain paths

## Verification
- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_clean_shutdown_marker.py`
- `scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py -- -k 'gateway_stop_drains_running_agents_before_disconnect or gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks or gateway_stop_interrupts_after_drain_timeout'`
- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py -- -k 'graceful_drain_waits_for_delivery_before_clearing_resume_pending or graceful_drain_keeps_resume_pending_when_delivery_stalls'`
- live Sawyer Slack DM drill on June 1, 2026: restart during an active turn timed out the 60s drain window, startup logged `Scheduled auto-resume for 1 restart-interrupted session(s)`, and the resumed turn reached `response ready` plus Slack send

## Not Included
- Slack mobile-length tuning
- stale resumed-answer content cleanup
