### PR TITLE
fix(gateway): close ResponseStore on disconnect and clean up failed reconnect adapters

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4195,7 +4195,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
     async def disconnect(self) -> None:
-        """Stop the aiohttp web server."""
+        """Stop the aiohttp web server and release the response store."""
         self._mark_disconnected()
         if self._site:
             await self._site.stop()
@@ -4203,6 +4203,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
+        if self._response_store is not None:
+            self._response_store.close()
+            self._response_store = None
         self._app = None
         logger.info("[%s] API server stopped", self.name)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6151,6 +6151,7 @@ class GatewayRunner:
                     platform.value, attempt,
                 )
 
+                adapter = None
                 try:
                     adapter = self._create_adapter(platform, platform_config)
                     if not adapter:
@@ -6228,7 +6229,7 @@ class GatewayRunner:
                 except Exception as e:
                     # Clean up adapter if it was created before the exception.
                     # _safe_adapter_disconnect swallows all errors.
-                    if "adapter" in locals():
+                    if adapter is not None:
                         await self._safe_adapter_disconnect(adapter, platform)
                     self._update_platform_runtime_status(
                         platform.value,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6190,6 +6190,7 @@ class GatewayRunner:
                             pass
                     # Check if the failure is non-retryable
                     elif adapter.has_fatal_error and not adapter.fatal_error_retryable:
+                        await self._safe_adapter_disconnect(adapter, platform)
                         self._update_platform_runtime_status(
                             platform.value,
                             platform_state="fatal",
@@ -6202,6 +6203,7 @@ class GatewayRunner:
                         )
                         del self._failed_platforms[platform]
                     else:
+                        await self._safe_adapter_disconnect(adapter, platform)
                         self._update_platform_runtime_status(
                             platform.value,
                             platform_state="retrying",
@@ -6224,6 +6226,10 @@ class GatewayRunner:
                         # `not fatal_error_retryable` branch above, so anything
                         # reaching here is by definition retryable.
                 except Exception as e:
+                    # Clean up adapter if it was created before the exception.
+                    # _safe_adapter_disconnect swallows all errors.
+                    if "adapter" in locals():
+                        await self._safe_adapter_disconnect(adapter, platform)
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -338,6 +338,39 @@ class TestAdapterInit:
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
 
+class TestAdapterDisconnect:
+    """Verify that disconnect() releases all resources including ResponseStore."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_response_store(self):
+        """disconnect() must close the sqlite3 connection in _response_store."""
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        # _response_store is created during __init__
+        assert adapter._response_store is not None
+        conn = adapter._response_store._conn
+
+        await adapter.disconnect()
+
+        # After disconnect, _response_store should be None
+        assert adapter._response_store is None
+        # The underlying sqlite3 connection should be closed
+        # (operations on a closed connection raise ProgrammingError)
+        import sqlite3 as _sqlite3
+        with pytest.raises(_sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_disconnect_idempotent(self):
+        """Calling disconnect() twice should not raise."""
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        await adapter.disconnect()
+        # Second call should be a no-op
+        await adapter.disconnect()
+        assert adapter._response_store is None
+
+
 # ---------------------------------------------------------------------------
 # Auth checking
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -718,3 +718,179 @@ class TestPlatformSlashCommand:
         out = await runner._handle_platform_command(self._make_event("/platform"))
         assert "Gateway platforms" in out
 
+
+
+class TestReconnectDisconnectCleanup:
+    """Verify _safe_adapter_disconnect is called on every reconnect failure path.
+
+    Regression tests for PR #37018 — without these disconnect calls,
+    failed reconnect adapters leak sqlite3 connections, aiohttp sessions,
+    and other resources until the process hits [Errno 24] Too many open files.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retryable_failure_disconnects_adapter(self):
+        """When connect() fails with a retryable error, adapter must be disconnected."""
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        fail_adapter = StubAdapter(
+            succeed=False, fatal_error="DNS timeout", fatal_retryable=True
+        )
+        disconnect_spy = AsyncMock(wrapping=fail_adapter.disconnect)
+        fail_adapter.disconnect = disconnect_spy
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter):
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        disconnect_spy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_nonretryable_fatal_disconnects_adapter(self):
+        """When adapter reports non-retryable fatal error, adapter must be disconnected."""
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        fail_adapter = StubAdapter(
+            succeed=False, fatal_error="bad token", fatal_retryable=False
+        )
+        disconnect_spy = AsyncMock(wrapping=fail_adapter.disconnect)
+        fail_adapter.disconnect = disconnect_spy
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter):
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        disconnect_spy.assert_called_once()
+        assert Platform.TELEGRAM not in runner._failed_platforms
+
+    @pytest.mark.asyncio
+    async def test_exception_during_connect_disconnects_adapter(self):
+        """When _connect_adapter_with_timeout raises, adapter must be disconnected."""
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        # Create a real adapter to verify disconnect is called
+        adapter = StubAdapter(succeed=True)
+        disconnect_spy = AsyncMock(wrapping=adapter.disconnect)
+        adapter.disconnect = disconnect_spy
+
+        # Make _connect_adapter_with_timeout raise an exception
+        async def raise_connect(adapt, plat):
+            raise RuntimeError("simulated connect failure")
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=adapter):
+            with patch.object(runner, "_connect_adapter_with_timeout", side_effect=raise_connect):
+                async def run_one_iteration():
+                    runner._running = True
+                    call_count = 0
+
+                    async def fake_sleep(n):
+                        nonlocal call_count
+                        call_count += 1
+                        if call_count > 1:
+                            runner._running = False
+                        await real_sleep(0)
+
+                    with patch("asyncio.sleep", side_effect=fake_sleep):
+                        await runner._platform_reconnect_watcher()
+
+                await run_one_iteration()
+
+        # disconnect must have been called even though connect raised
+        disconnect_spy.assert_called_once()
+        # Platform should stay in retry queue (exception = transient)
+        assert Platform.TELEGRAM in runner._failed_platforms
+
+    @pytest.mark.asyncio
+    async def test_exception_before_adapter_creation_no_disconnect(self):
+        """When _create_adapter itself raises, no disconnect should be attempted."""
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        # _create_adapter raises before adapter is created
+        def raise_create(platform, config):
+            raise RuntimeError("adapter factory exploded")
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", side_effect=raise_create):
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        # Platform should stay in retry queue
+        assert Platform.TELEGRAM in runner._failed_platforms


### PR DESCRIPTION
## What does this PR do?

Fixes a file descriptor leak in the gateway platform reconnect loop where `APIServerAdapter` sqlite3 connections were never closed on failed reconnect attempts, causing the gateway to exhaust the 2560 fd limit after ~12-15 hours of uptime.

## Related Issue

Fixes #37011

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: `disconnect()` now closes `self._response_store` and sets it to `None`, releasing the sqlite3 connection (2 fds). Uses `is not None` check because `ResponseStore.__len__` returns 0 for empty stores, making `bool(store)` falsely evaluate to False.
- `gateway/run.py`: Added `await self._safe_adapter_disconnect(adapter, platform)` at all three failure paths in `_run_reconnect_loop()`: non-retryable fatal error (line 6193), retryable failure (line 6206), and exception during reconnect (line 6231, guarded by `if "adapter" in locals()`).
- `tests/gateway/test_api_server.py`: Added `TestAdapterDisconnect` class with two regression tests: `test_disconnect_closes_response_store` (verifies sqlite3 connection is closed and `_response_store` is `None`) and `test_disconnect_idempotent` (verifies double-disconnect is safe).

## How to Test

1. Configure a platform (e.g., API_SERVER) with an intentionally failing config (missing API_SERVER_KEY)
2. Start the gateway and wait for the reconnect loop to run multiple attempts
3. Check fd count: `lsof -p <pid> | grep response_store | wc -l` — should stay stable, not grow
4. Run `pytest tests/gateway/test_api_server.py::TestAdapterDisconnect -xvs` to verify the regression tests pass
5. Run `pytest tests/gateway/test_api_server.py -x` to verify no existing tests regressed (158 tests)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_api_server.py -q` and all 158 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/api_server.py:APIServerAdapter.disconnect` (callers: `_safe_adapter_disconnect` in gateway shutdown + reconnect loop)
- Analyzed: `gateway/run.py:GatewayRunner._run_reconnect_loop` (3 failure paths that leaked adapters)
- Blast radius: LOW — changes are isolated to the API server adapter lifecycle and reconnect cleanup
- Related patterns: `_safe_adapter_disconnect()` already existed as a defensive wrapper; this fix ensures it's called on all failure paths. The `ResponseStore.__len__` truthiness pitfall (`bool(empty_store)` is `False`) is a known Python gotcha when `__len__` is defined.
