### PR TITLE
docs: agent validation commands and validate.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1038,38 +1038,45 @@ def profile_env(tmp_path, monkeypatch):
 
 **ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
 hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
-on a 16+ core developer machine with API keys set diverges from CI in ways
-that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+and PYTHONHASHSEED=0) and delegates to `scripts/run_tests_parallel.py`. That
+runner discovers files, then runs each test file in its own fresh
+`python -m pytest <file>` subprocess with bounded parallelism. Direct `pytest`
+on a developer machine with API keys set diverges from CI in ways that have
+caused multiple "works locally, fails in CI" incidents (and the reverse).
+
+Run the fast pre-PR validation gate before opening a PR:
+
+```bash
+scripts/validate.sh                                # ruff + Windows footguns
+```
 
 ```bash
 scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
-scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
-scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
-scripts/run_tests.sh --no-isolate tests/foo/          # disable subprocess isolation (faster, for debugging)
+scripts/run_tests.sh tests/agent/test_foo.py          # one file
+scripts/run_tests.sh tests/agent/test_foo.py -- -q    # one file + pytest args
+scripts/run_tests.sh -- -v --tb=long                  # pytest args only
 ```
 
-### Subprocess-per-test isolation
+### Per-file subprocess isolation
 
-Every test runs in a freshly-spawned Python subprocess via the in-tree plugin
-at `tests/_isolate_plugin.py`. This means module-level dicts/sets and
-ContextVars from one test cannot leak into the next — the historic
-`_reset_module_state` autouse fixture is gone.
+Every test file runs in a freshly-spawned Python subprocess via
+`scripts/run_tests_parallel.py`. This means module-level dicts/sets and
+ContextVars from one file cannot leak into the next — the historic
+`_reset_module_state` autouse fixture and the older per-test isolation plugin
+are gone.
 
 Implementation notes:
 
-- The plugin uses `multiprocessing.get_context("spawn")`, which works on
-  Linux, macOS, and Windows alike (POSIX `fork` is not used).
-- Per-test overhead is ~0.5–1.0s (Python startup + pytest collection). xdist
-  parallelism amortizes this across cores; on a 20-core box the full suite
-  finishes in roughly the same wall time as before, but flake-free.
-- `isolate_timeout` (configured in `pyproject.toml`) caps each test at 30s.
-  Hangs are killed and surfaced as a failure report.
-- Pass `--no-isolate` to disable isolation — useful when debugging a single
-  test interactively, or when you specifically want to verify state leakage.
-- The plugin disables itself in child processes (sentinel envvar
-  `HERMES_ISOLATE_CHILD=1`), so there's no fork-bomb risk.
+- `scripts/run_tests_parallel.py` uses a bounded `subprocess.Popen` pool, not
+  pytest-xdist workers.
+- Per-file overhead is much lower than per-test process spawning while still
+  preventing cross-file module-level state leakage.
+- `pytest-timeout` (configured in `pyproject.toml`) caps individual tests at
+  30s inside each file subprocess. The runner also has an outer per-file wall
+  clock cap.
+- Path arguments before `--` select files or directories. Arguments after
+  `--` pass through to each pytest invocation.
 
 ### Why the wrapper (and why the old "just call pytest" doesn't work)
 
@@ -1081,7 +1088,7 @@ Five real sources of local-vs-CI drift the script closes:
 | HOME / `~/.hermes/` | Your real config+auth.json | Temp dir per test |
 | Timezone | Local TZ (PDT etc.) | UTC |
 | Locale | Whatever is set | C.UTF-8 |
-| xdist workers | `-n auto` = all cores | `-n auto` (safe — subprocess isolation prevents cross-worker flakes) |
+| Test process lifetime | One long-lived pytest process | Fresh subprocess per test file |
 
 `tests/conftest.py` also enforces points 1-4 as an autouse fixture so ANY pytest
 invocation (including IDE integrations) gets hermetic behavior — but the wrapper
@@ -1090,9 +1097,9 @@ is belt-and-suspenders.
 ### Running without the wrapper (only if you must)
 
 If you can't use the wrapper (e.g. inside an IDE that shells pytest directly),
-at minimum activate the venv. The isolation plugin loads automatically from
-`addopts` in `pyproject.toml`, so you get the same per-test process isolation
-either way.
+at minimum activate the venv and mirror the deterministic environment. You do
+not get the per-file fresh-process boundary unless you use `scripts/run_tests.sh`
+or call `scripts/run_tests_parallel.py`.
 
 ```bash
 source .venv/bin/activate   # or: source venv/bin/activate
@@ -1102,7 +1109,7 @@ python -m pytest tests/ -q
 If you need to bypass isolation for fast feedback while debugging:
 
 ```bash
-python -m pytest tests/agent/test_foo.py -q --no-isolate
+python -m pytest tests/agent/test_foo.py -q
 ```
 
 Always run the full suite before pushing changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,12 +121,14 @@ hermes chat -q "Hello"
 ### Run tests
 
 ```bash
-# Preferred — matches CI (hermetic env, 4 xdist workers); see AGENTS.md
+# Fast pre-PR gate: ruff plus the Windows footgun scanner
+scripts/validate.sh
+
+# Full suite — per-file subprocess runner, hermetic env; see AGENTS.md
 scripts/run_tests.sh
 
-# Alternative (activate the venv first). The wrapper is still recommended
-# for parity with GitHub Actions before you open a PR:
-pytest tests/ -v
+# Scoped tests for fast feedback
+scripts/run_tests.sh tests/hermes_cli/test_tips.py -- -q
 ```
 
 ---
@@ -593,7 +595,7 @@ that touches the OS, assume *any* platform can hit your code path.
 
 > **Before you PR:** run `scripts/check-windows-footguns.py` to catch the
 > common Windows-unsafe patterns in your diff. It's grep-based and cheap;
-> CI runs it on every PR too.
+> CI runs it on every PR too. `scripts/validate.sh` includes this check.
 
 ### Critical rules
 
@@ -857,10 +859,11 @@ refactor/description   # Code restructuring
 
 ### Before submitting
 
-1. **Run tests**: `scripts/run_tests.sh` (recommended; same as CI) or `pytest tests/ -v` with the project venv activated
-2. **Test manually**: Run `hermes` and exercise the code path you changed
-3. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
-4. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.
+1. **Run validation**: `scripts/validate.sh` (blocking ruff + Windows footgun scanner)
+2. **Run tests**: `scripts/run_tests.sh` for the full suite, or scope to one file with `scripts/run_tests.sh tests/hermes_cli/test_tips.py -- -q`
+3. **Test manually**: Run `hermes` and exercise the code path you changed
+4. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
+5. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.
 
 ### PR description
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv .venv --python 3.11
 source .venv/bin/activate
 uv pip install -e ".[all,dev]"
+scripts/validate.sh
 scripts/run_tests.sh
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "apps/*"
   ],
   "scripts": {
-    "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'"
+    "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'",
+    "validate": "scripts/validate.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Fast pre-PR validation for agent/developer workflows.
+#
+# This intentionally stays cheap: run the blocking lint/footgun checks before
+# opening a PR, then use scripts/run_tests.sh for full or scoped pytest runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VENV=""
+for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+  if [ -f "$candidate/bin/python" ]; then
+    VENV="$candidate"
+    break
+  fi
+done
+
+if [ -z "$VENV" ]; then
+  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  exit 1
+fi
+
+PYTHON="$VENV/bin/python"
+
+cd "$REPO_ROOT"
+
+echo "==> ruff"
+"$PYTHON" -m ruff check .
+
+echo "==> windows footguns"
+FOOTGUN_BASE="${HERMES_VALIDATE_BASE:-}"
+if [ -z "$FOOTGUN_BASE" ]; then
+  for candidate in upstream/main origin/main main; do
+    if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+      FOOTGUN_BASE="$candidate"
+      break
+    fi
+  done
+fi
+
+FOOTGUN_PATHS=()
+if [ -n "$FOOTGUN_BASE" ] && git merge-base "$FOOTGUN_BASE" HEAD >/dev/null 2>&1; then
+  while IFS= read -r -d '' path; do
+    FOOTGUN_PATHS+=("$path")
+  done < <(git diff -z --name-only --diff-filter=ACMR "$FOOTGUN_BASE"...HEAD)
+fi
+while IFS= read -r -d '' path; do
+  FOOTGUN_PATHS+=("$path")
+done < <(git diff -z --name-only --diff-filter=ACMR)
+while IFS= read -r -d '' path; do
+  FOOTGUN_PATHS+=("$path")
+done < <(git ls-files -z --others --exclude-standard)
+
+if [ "${#FOOTGUN_PATHS[@]}" -eq 0 ]; then
+  echo "No changed files to scan."
+else
+  "$PYTHON" scripts/check-windows-footguns.py "${FOOTGUN_PATHS[@]}"
+fi
+
+echo "ok: validation passed"


### PR DESCRIPTION
## Summary
- Add scripts/validate.sh as a fast pre-PR gate for ruff plus the Windows footgun scanner.
- Expose the gate as npm run validate for tool discovery.
- Document validation and scoped test commands in README/CONTRIBUTING.
- Fix AGENTS.md Testing to match per-file scripts/run_tests_parallel.py behavior and remove stale xdist/--no-isolate guidance.

## Test plan
- [x] scripts/validate.sh
- [x] npm run validate
- [x] scripts/run_tests.sh tests/hermes_cli/test_tips.py -- -q
- [ ] After merge: check-agent-compatibility vs 85 baseline