### PR TITLE
docs: add reuse-before-build guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,14 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+## Reuse Before Build
+
+Before implementing new behavior, scan for existing Hermes mechanisms, docs,
+and nearby tests that already solve or partially solve the problem. Prefer
+existing routing, fallback, config, tool, MCP, and provider abstractions over
+bespoke systems. Do not design a new subsystem until you have reported the reuse
+scan.
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,14 @@ Also keep issue labels current: add the best existing label for the work
 being done, and create a new label only when the existing taxonomy does not
 fit.
 
+For Linear workspace administration, use the Linear connector first. If the
+connector lacks the required admin surface, the Studio Linear desktop app can
+be used as a UI fallback. If Linear is running with no accessible window, open
+one with `open linear://`, then navigate directly, for example:
+`open -a /Applications/Linear.app 'https://linear.app/agents-n-such/settings/teams'`.
+Stop before final create/save actions that change workspace structure unless
+the user has explicitly approved that specific action.
+
 ## Worktree Hygiene
 
 Use isolated git worktrees for issue/PR work by default when the main checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,24 @@ Instructions for AI coding assistants and developers working on the hermes-agent
 
 **Never give up on the right solution.**
 
+## Linear Tracking
+
+Treat Linear updates as part of the work, not as an optional closeout task.
+When working a tracked issue, update the relevant Linear ticket as you make
+meaningful progress, uncover blockers, change scope, or finish verification.
+Do not wait for a separate prompt to keep Linear current.
+Also keep issue labels current: add the best existing label for the work
+being done, and create a new label only when the existing taxonomy does not
+fit.
+
+## Worktree Hygiene
+
+Use isolated git worktrees for issue/PR work by default when the main checkout
+is dirty, when the change belongs to a different Linear issue, or when runtime
+experiments should not contaminate an existing branch. Keep each branch scoped
+to one issue whenever practical, and avoid stacking unrelated commits into an
+active PR.
+
 ## Development Environment
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a concise Reuse Before Build section to AGENTS.md
- Require reporting the reuse scan before designing new subsystems

## Tests
- git diff --check -- AGENTS.md