### PR TITLE
fix(gateway): classify each attachment by its own mimetype, not message type

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1278,7 +1278,7 @@ def _build_media_placeholder(event) -> str:
     media_types = getattr(event, "media_types", None) or []
     for i, url in enumerate(media_urls):
         mtype = media_types[i] if i < len(media_types) else ""
-        if mtype.startswith("image/") or getattr(event, "message_type", None) == MessageType.PHOTO:
+        if mtype.startswith("image/") or (not mtype and getattr(event, "message_type", None) == MessageType.PHOTO):
             parts.append(f"[User sent an image: {url}]")
         elif mtype.startswith("audio/"):
             parts.append(f"[User sent audio: {url}]")
@@ -8400,7 +8400,7 @@ class GatewayRunner:
             audio_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
-                if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
+                if mtype.startswith("image/") or (not mtype and event.message_type == MessageType.PHOTO):
                     image_paths.append(path)
                 # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
                 # MessageType.VOICE = voice message (Opus/OGG) — always STT

--- a/tests/gateway/test_media_placeholder_mixed_attachments.py
+++ b/tests/gateway/test_media_placeholder_mixed_attachments.py
@@ -1,0 +1,53 @@
+"""Regression tests for _build_media_placeholder mixed-attachment routing.
+
+When a message mixes a real image with a document (e.g. a .md brief), the
+whole message is typed MessageType.PHOTO. The per-file loop must classify
+each attachment by its OWN mimetype — a document must not be labelled an
+image just because the message-level type is PHOTO. Mislabelling a non-image
+file as an image caused its bytes to be sent to the vision endpoint, which
+rejected them with a non-retryable HTTP 400 and killed the whole turn.
+
+The message-level PHOTO fallback is preserved only for attachments whose
+per-file mimetype is unknown (empty) — i.e. platforms that don't populate
+media_types.
+"""
+
+from types import SimpleNamespace
+
+from gateway.platforms.base import MessageType
+from gateway.run import _build_media_placeholder
+
+
+def test_document_in_photo_message_is_not_labelled_an_image():
+    event = SimpleNamespace(
+        media_urls=["/cache/product.png", "/cache/brief.md"],
+        media_types=["image/png", "text/markdown"],
+        message_type=MessageType.PHOTO,
+    )
+    out = _build_media_placeholder(event)
+    assert "[User sent an image: /cache/product.png]" in out
+    # The document must NOT be promoted to an image by the PHOTO fallback.
+    assert "[User sent an image: /cache/brief.md]" not in out
+    assert "[User sent a file: /cache/brief.md]" in out
+
+
+def test_image_with_unknown_mimetype_still_uses_photo_fallback():
+    # Platforms that don't populate media_types rely on the message-level type.
+    event = SimpleNamespace(
+        media_urls=["/cache/photo.jpg"],
+        media_types=[""],
+        message_type=MessageType.PHOTO,
+    )
+    out = _build_media_placeholder(event)
+    assert "[User sent an image: /cache/photo.jpg]" in out
+
+
+def test_audio_and_image_classified_by_own_mimetype():
+    event = SimpleNamespace(
+        media_urls=["/cache/clip.ogg", "/cache/shot.png"],
+        media_types=["audio/ogg", "image/png"],
+        message_type=MessageType.PHOTO,
+    )
+    out = _build_media_placeholder(event)
+    assert "[User sent audio: /cache/clip.ogg]" in out
+    assert "[User sent an image: /cache/shot.png]" in out


### PR DESCRIPTION
## What does this PR do?

When an inbound message mixes an image with a non-image document (e.g. a photo plus a `.md` brief), the whole message is typed `MessageType.PHOTO`. The per-file attachment loops in `gateway/run.py` then classified each file with `mtype.startswith("image/") or message_type == MessageType.PHOTO` — so the message-level `PHOTO` fallback fired for **every** attachment, including the document. The document's bytes were attached to the model as an inline image, and the vision endpoint rejected them with a non-retryable HTTP 400 (`The image data you provided does not represent a valid image`), killing the whole turn before the agent could read anything.

This is a gateway-level bug in the shared routing, independent of platform. It reproduces on Slack (a photo plus a Markdown brief in one message) and matches the Discord reports in the related issues.

The fix gates the message-level `PHOTO` fallback on an **unknown (empty)** per-file mimetype, so a file carrying a real non-image mimetype is never treated as an image. The fallback is preserved for platforms that don't populate `media_types`.

## Related Issue

Related to #29711 and #25935. Both are filed under `platform/discord`, but the root cause is in the shared gateway routing in `gateway/run.py`, so this also covers Slack and other platforms. Not using "Fixes" because the Discord adapter may have an additional attachment path worth confirming before those issues are closed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: in `_build_media_placeholder()` and the `GatewayRunner` image-routing loop, only fall back to the message-level `MessageType.PHOTO` classification when the per-file mimetype is empty (`image/* OR (not mtype AND message_type == PHOTO)`).
- `tests/gateway/test_media_placeholder_mixed_attachments.py`: new regression tests — a document in a `PHOTO` message is not labelled an image; an image with an unknown mimetype still uses the `PHOTO` fallback; audio + image are each classified by their own mimetype.

## How to Test

1. Send a message to any vision-capable gateway with both an image **and** a `.md`/`.txt`/`.pdf` document attached.
2. Before: the turn dies with non-retryable `HTTP 400: The image data you provided does not represent a valid image`.
3. After: only the image is attached to the model; the document flows through the document path.
4. `pytest tests/gateway/test_media_placeholder_mixed_attachments.py -q` passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and all pass (focused + adjacent media-routing suites via `scripts/run_tests.sh`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Sequoia)

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — considered (pure mimetype/string logic, no OS-specific calls)
- [x] Tool descriptions/schemas — N/A