### PR TITLE
fix(feishu): allow DM approval button callbacks

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2581,8 +2581,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -524,6 +524,33 @@ class TestCardActionCallbackResponse:
         assert card["header"]["template"] == "red"
         assert "Denied" in card["header"]["title"]["content"]
 
+    def test_dm_approval_click_does_not_require_group_allowlist(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
+        adapter._allowed_group_users = set()
+        adapter._admins = set()
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg-7",
+            "chat_id": "oc_dm",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            chat_id="oc_dm",
+            open_id="ou_paired_dm_user",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Approved once" in card["header"]["title"]["content"]
+
     def test_ignores_missing_approval_id(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()


### PR DESCRIPTION
## Summary
- allow Feishu DM approval card callbacks to use interactive-operator authorization instead of group message allowlist checks
- add regression coverage for DM approval clicks when group allowlist policy is enabled

## Problem
After the Feishu approval button auth hardening, approval card clicks in a DM could be rejected as unauthorized when group allowlist policy was enabled. The command approval still worked via `/approve`, but the inline card button callback was dropped before resolving the pending approval.

## Test plan
- `python -m pytest tests/gateway/test_feishu_approval_buttons.py -q`
- `python -m py_compile gateway/platforms/feishu.py`
