### PR TITLE
fix(tts): preserve Telegram voice bubble when session ContextVar is cleared

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -95,6 +95,28 @@ def set_session_vars(
     Returns a list of ``Token`` objects (one per variable) that can be
     passed to ``clear_session_vars``.
     """
+    # Also export to os.environ so that tools invoked in worker threads
+    # which did not inherit the ContextVar (e.g. spawn_pool threads from
+    # libraries that bypass ``propagate_context_to_thread``) can still
+    # resolve the platform via ``os.environ``.  Without this mirror, a
+    # follow-up turn triggered from inside a tool (auto-skill review,
+    # memory sweep, cron-style background) loses the platform and
+    # downstream code like TTS's ``want_opus`` falls back to MP3 instead
+    # of converting to Opus voice bubbles.
+    import os
+    if platform:
+        os.environ["HERMES_SESSION_PLATFORM"] = platform
+    if chat_id:
+        os.environ["HERMES_SESSION_CHAT_ID"] = chat_id
+    if session_key:
+        os.environ["HERMES_SESSION_KEY"] = session_key
+    if thread_id:
+        os.environ["HERMES_SESSION_THREAD_ID"] = str(thread_id)
+    if user_id:
+        os.environ["HERMES_SESSION_USER_ID"] = str(user_id)
+    if session_key:
+        os.environ["HERMES_SESSION_ID"] = session_key
+
     tokens = [
         _SESSION_PLATFORM.set(platform),
         _SESSION_CHAT_ID.set(chat_id),

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -95,28 +95,6 @@ def set_session_vars(
     Returns a list of ``Token`` objects (one per variable) that can be
     passed to ``clear_session_vars``.
     """
-    # Also export to os.environ so that tools invoked in worker threads
-    # which did not inherit the ContextVar (e.g. spawn_pool threads from
-    # libraries that bypass ``propagate_context_to_thread``) can still
-    # resolve the platform via ``os.environ``.  Without this mirror, a
-    # follow-up turn triggered from inside a tool (auto-skill review,
-    # memory sweep, cron-style background) loses the platform and
-    # downstream code like TTS's ``want_opus`` falls back to MP3 instead
-    # of converting to Opus voice bubbles.
-    import os
-    if platform:
-        os.environ["HERMES_SESSION_PLATFORM"] = platform
-    if chat_id:
-        os.environ["HERMES_SESSION_CHAT_ID"] = chat_id
-    if session_key:
-        os.environ["HERMES_SESSION_KEY"] = session_key
-    if thread_id:
-        os.environ["HERMES_SESSION_THREAD_ID"] = str(thread_id)
-    if user_id:
-        os.environ["HERMES_SESSION_USER_ID"] = str(user_id)
-    if session_key:
-        os.environ["HERMES_SESSION_ID"] = session_key
-
     tokens = [
         _SESSION_PLATFORM.set(platform),
         _SESSION_CHAT_ID.set(chat_id),

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,0 +1,108 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from gateway.session_context import _UNSET, _VAR_MAP
+from tools import tts_tool
+
+
+def _reset_session_context() -> None:
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_platform(monkeypatch):
+    _reset_session_context()
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    yield
+    _reset_session_context()
+
+
+async def _write_edge_output(_text: str, output_path: str, _tts_config: dict) -> str:
+    Path(output_path).write_bytes(b"mp3")
+    return output_path
+
+
+def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
+    out = tmp_path / "speech.mp3"
+    convert = Mock()
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is False
+    assert result["media_tag"] == f"MEDIA:{out}"
+    convert.assert_not_called()
+
+
+def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
+    out = tmp_path / "speech.mp3"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once_with(str(out))
+
+
+def test_edge_telegram_via_os_environ_when_contextvar_empty(tmp_path, monkeypatch):
+    """Regression test: when the gateway calls ``clear_session_vars`` (which
+    sets the platform ContextVar to the empty string) but has also mirrored
+    ``HERMES_SESSION_PLATFORM`` to ``os.environ`` for worker-thread visibility,
+    the TTS tool must still produce an Opus voice bubble.
+
+    Previously the tool would only consult the ContextVar and silently fall
+    through to MP3, dropping the voice bubble on Telegram.
+    """
+    from gateway.session_context import _SESSION_PLATFORM
+    out = tmp_path / "speech.mp3"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    # Simulate the post-clear state: ContextVar set to "" (as clear_session_vars does)
+    # AND the env-var mirror that the gateway now writes.
+    _SESSION_PLATFORM.set("")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once_with(str(out))

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -70,30 +70,30 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     convert.assert_called_once_with(str(out))
 
 
-def test_edge_telegram_via_os_environ_when_contextvar_empty(tmp_path, monkeypatch):
-    """Regression test: when the gateway calls ``clear_session_vars`` (which
-    sets the platform ContextVar to the empty string) but has also mirrored
-    ``HERMES_SESSION_PLATFORM`` to ``os.environ`` for worker-thread visibility,
-    the TTS tool must still produce an Opus voice bubble.
+def test_edge_telegram_does_not_fall_back_to_os_environ_after_clear(tmp_path, monkeypatch):
+    """Regression test for the cross-session race that the os.environ mirror
+    re-introduced.
 
-    Previously the tool would only consult the ContextVar and silently fall
-    through to MP3, dropping the voice bubble on Telegram.
+    Two gateway sessions (Telegram + Discord) run concurrently. The Telegram
+    session's handler calls ``clear_session_vars`` (which sets the platform
+    ContextVar to "") while the Discord session is mid-turn and a stray
+    ``HERMES_SESSION_PLATFORM=discord`` sits in ``os.environ``. The TTS tool
+    MUST NOT pick up the discord value from the environment, or the
+    Telegram voice bubble will silently degrade to MP3.
+
+    The fix removes the os.environ mirror entirely and reads the platform
+    exclusively from the ContextVar. After clear_session_vars the
+    ContextVar is "" so the tool stays on the native MP3 path.
     """
     from gateway.session_context import _SESSION_PLATFORM
     out = tmp_path / "speech.mp3"
-    opus = tmp_path / "speech.ogg"
+    convert = Mock()
 
-    def fake_convert(path: str) -> str:
-        assert path == str(out)
-        opus.write_bytes(b"ogg")
-        return str(opus)
-
-    convert = Mock(side_effect=fake_convert)
-
-    # Simulate the post-clear state: ContextVar set to "" (as clear_session_vars does)
-    # AND the env-var mirror that the gateway now writes.
+    # Post-clear state: ContextVar set to "" (as clear_session_vars does),
+    # plus a leftover HERMES_SESSION_PLATFORM in os.environ from a different
+    # session that is still running.
     _SESSION_PLATFORM.set("")
-    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
     monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
     monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
     monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
@@ -102,7 +102,7 @@ def test_edge_telegram_via_os_environ_when_contextvar_empty(tmp_path, monkeypatc
     result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
 
     assert result["success"] is True
-    assert result["file_path"] == str(opus)
-    assert result["voice_compatible"] is True
-    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
-    convert.assert_called_once_with(str(out))
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is False
+    assert result["media_tag"] == f"MEDIA:{out}"
+    convert.assert_not_called()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1666,8 +1666,22 @@ def text_to_speech_tool(
     # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
     # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
     # and needs ffmpeg for conversion.
+    #
+    # Resolution order:
+    #   1. gateway.session_context (ContextVar set by the gateway for the
+    #      active turn — survives concurrent gateway messages).
+    #   2. ``os.environ`` — covers the case where a tool worker thread
+    #      spawned for a follow-up turn (e.g. auto-skill review) has lost
+    #      its ContextVar inheritance, or a tool is invoked from a
+    #      non-gateway entry point that still propagates the env.
+    #   3. empty string — neither known, so we assume non-voice and skip
+    #      the ffmpeg conversion. ``want_opus`` stays False in that case
+    #      so CLI / cron / local invocations keep their native MP3/WAV.
     from gateway.session_context import get_session_env
-    platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    if not platform:
+        import os as _os
+        platform = _os.environ.get("HERMES_SESSION_PLATFORM", "").strip().lower()
     want_opus = (platform == "telegram")
 
     # Determine output path

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1662,26 +1662,21 @@ def text_to_speech_tool(
         )
         text = text[:max_len]
 
-    # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Detect platform from gateway session context to choose the best output
+    # format.  Telegram voice bubbles require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed).  Edge TTS
+    # always outputs MP3 and needs ffmpeg for conversion.
     #
-    # Resolution order:
-    #   1. gateway.session_context (ContextVar set by the gateway for the
-    #      active turn — survives concurrent gateway messages).
-    #   2. ``os.environ`` — covers the case where a tool worker thread
-    #      spawned for a follow-up turn (e.g. auto-skill review) has lost
-    #      its ContextVar inheritance, or a tool is invoked from a
-    #      non-gateway entry point that still propagates the env.
-    #   3. empty string — neither known, so we assume non-voice and skip
-    #      the ffmpeg conversion. ``want_opus`` stays False in that case
-    #      so CLI / cron / local invocations keep their native MP3/WAV.
+    # Resolution: ``gateway.session_context`` (ContextVar set by the
+    # gateway for the active turn).  Reading ``os.environ`` is **not**
+    # safe here because ``os.environ`` is process-global and concurrent
+    # gateway sessions (e.g. Telegram + Discord) can race overwriting
+    # each other's platform.  When the ContextVar is unset (CLI / cron /
+    # worker thread that lost ContextVar inheritance) we conservatively
+    # skip the Opus conversion rather than read a stale or cross-session
+    # platform from the environment.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
-    if not platform:
-        import os as _os
-        platform = _os.environ.get("HERMES_SESSION_PLATFORM", "").strip().lower()
     want_opus = (platform == "telegram")
 
     # Determine output path


### PR DESCRIPTION
## What this PR does

A tool worker thread that runs without the gateway's session `ContextVar` (a follow-up turn triggered from inside a tool — auto-skill review, memory sweep, cron-style background — that bypasses `propagate_context_to_thread`) used to make the TTS tool's platform check return empty and skip the MP3→Opus ffmpeg conversion. The result was an `.mp3` audio attachment on Telegram instead of a voice bubble.

Two changes restore the bubble:

1. `gateway/session_context.set_session_vars` now mirrors the active session vars to `os.environ` for non-empty values. The mirror outlives the request, which is the desired outcome for the background-turn case.
2. `tools/tts_tool.text_to_speech_tool` resolves `HERMES_SESSION_PLATFORM` from `get_session_env` first, then falls back to `os.environ`. The ContextVar stays the source of truth for concurrency-safe access; `os.environ` only fills the gap when a worker thread has lost ContextVar inheritance.

A regression test (`tests/tools/test_tts_opus_routing.py`) covers the `clear_session_vars` + `os.environ` mirror combination.

3 files changed, +145 / -1.