### PR TITLE
fix(skills): prevent indefinite hang when skill source stalls during parallel search

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2201,3 +2201,54 @@ class TestInstallPathSafety:
 
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
+
+
+def test_parallel_search_sources_does_not_hang_on_stalled_source():
+    """Regression: parallel_search_sources must not block indefinitely when a
+    source stalls past the overall_timeout (issue #37008)."""
+    import time
+    from tools.skills_hub import parallel_search_sources, SkillSource, SkillMeta
+
+    class _StalledSource(SkillSource):
+        def source_id(self):
+            return "stalled"
+
+        def search(self, query, limit=50):
+            # Simulate a source that never returns (e.g. hung HTTP connection)
+            time.sleep(300)
+            return []
+
+        def fetch(self, identifier):
+            return None, None
+
+        def inspect(self, identifier):
+            return None
+
+    class _FastSource(SkillSource):
+        def source_id(self):
+            return "fast"
+
+        def search(self, query, limit=50):
+            return [SkillMeta(
+                identifier="fast/skill", name="skill",
+                description="ok", source="fast", trust_level="community",
+            )]
+
+        def fetch(self, identifier):
+            return None, None
+
+        def inspect(self, identifier):
+            return None
+
+    start = time.monotonic()
+    results, counts, timed_out = parallel_search_sources(
+        [_StalledSource(), _FastSource()],
+        query="test",
+        overall_timeout=1.0,
+    )
+    elapsed = time.monotonic() - start
+
+    # Must return within ~2s (1s timeout + small overhead), not 300s
+    assert elapsed < 5.0, f"parallel_search_sources hung for {elapsed:.1f}s"
+    assert "stalled" in timed_out
+    assert counts.get("fast") == 1

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3692,32 +3692,38 @@ def parallel_search_sources(
     if not active:
         return all_results, source_counts, timed_out_ids
 
-    with ThreadPoolExecutor(max_workers=min(len(active), 8)) as pool:
-        futures = {}
-        for src in active:
-            lim = per_source_limits.get(src.source_id(), 50)
-            fut = pool.submit(_search_one_source, src, query, lim)
-            futures[fut] = src.source_id()
+    pool = ThreadPoolExecutor(max_workers=min(len(active), 8))
+    futures = {}
+    for src in active:
+        lim = per_source_limits.get(src.source_id(), 50)
+        fut = pool.submit(_search_one_source, src, query, lim)
+        futures[fut] = src.source_id()
 
-        try:
-            for fut in as_completed(futures, timeout=overall_timeout):
-                try:
-                    sid, results = fut.result(timeout=0)
-                    source_counts[sid] = len(results)
-                    all_results.extend(results)
-                    if on_source_done:
-                        on_source_done(sid, len(results))
-                except Exception:
-                    pass
-        except TimeoutError:
-            timed_out_ids = [
-                futures[f] for f in futures if not f.done()
-            ]
-            if timed_out_ids:
-                logger.debug(
-                    "Skills browse timed out waiting for: %s",
-                    ", ".join(timed_out_ids),
-                )
+    try:
+        for fut in as_completed(futures, timeout=overall_timeout):
+            try:
+                sid, results = fut.result(timeout=0)
+                source_counts[sid] = len(results)
+                all_results.extend(results)
+                if on_source_done:
+                    on_source_done(sid, len(results))
+            except Exception:
+                pass
+    except TimeoutError:
+        timed_out_ids = [
+            futures[f] for f in futures if not f.done()
+        ]
+        if timed_out_ids:
+            logger.debug(
+                "Skills browse timed out waiting for: %s",
+                ", ".join(timed_out_ids),
+            )
+    finally:
+        # Use wait=False + cancel_futures=True so we never block on threads
+        # stuck in slow/stalled source requests (fixes #37008).
+        # Without this, the ThreadPoolExecutor context manager's __exit__
+        # calls shutdown(wait=True), which joins all threads indefinitely.
+        pool.shutdown(wait=False, cancel_futures=True)
 
     return all_results, source_counts, timed_out_ids
 


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes skills install <short-name>` (and `unified_search`) from hanging indefinitely when a skill source stalls during parallel search. Previously, the `ThreadPoolExecutor` context manager's `__exit__` called `shutdown(wait=True)`, which blocked forever on threads stuck in slow/stalled source requests.

## Related Issue

Fixes #37008

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py`: Replace `with ThreadPoolExecutor(...) as pool:` context manager with explicit `pool.shutdown(wait=False, cancel_futures=True)` in a `finally` clause. This ensures the function returns promptly after `overall_timeout`, even when individual sources hang indefinitely.
- `tests/tools/test_skills_hub.py`: Add `test_parallel_search_sources_does_not_hang_on_stalled_source` — creates a source that sleeps 300s (simulating a stalled HTTP connection) and verifies the function returns within 5s.

## How to Test

1. Run the new regression test: `pytest tests/tools/test_skills_hub.py::test_parallel_search_sources_does_not_hang_on_stalled_source -xvs`
2. Verify the test completes in ~1.3s (1s timeout + overhead), not 300s
3. Run the broader skills_hub tests: `pytest tests/tools/test_skills_hub.py -k "parallel or timeout" -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skills_hub.py -k "parallel or timeout" -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `parallel_search_sources` in `tools/skills_hub.py` (callers: `unified_search`, `hermes_cli/skills_hub.py:do_browse`, CLI skill commands)
- Blast radius: LOW — only affects the timeout handling path; normal fast-path behavior unchanged
- Related patterns: `ThreadPoolExecutor` + `cancel_futures=True` already used in `cron/scheduler.py` and `tui_gateway/server.py`
