### PR TITLE
vision: honour api_mode for routing on proxy providers (Palantir, custom)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1676,6 +1676,54 @@ def _read_main_provider() -> str:
     return ""
 
 
+def _read_main_api_mode() -> str:
+    """Read the active main provider's wire-protocol mode.
+
+    Returns one of ``"anthropic_messages"``, ``"chat_completions"``,
+    ``"responses"``, etc. — whatever the resolved provider declares in
+    config.yaml under ``providers.<slug>.api_mode`` /
+    ``custom_providers[].api_mode``. Falls back to "" when the active
+    provider has no explicit api_mode (which is what aggregator/canonical
+    providers like ``openai``/``anthropic``/``openrouter`` set, since
+    those are pinned to one wire by their adapter).
+
+    Used by image-routing decisions that need to know the wire protocol
+    behind the active provider id (e.g. a Palantir Foundry custom
+    provider with ``api_mode: anthropic_messages`` should be treated as
+    Anthropic-native for vision purposes — the model is a Claude Opus
+    even though the provider id is ``palantir-claude47``).
+    """
+    override = _RUNTIME_MAIN_API_MODE
+    if isinstance(override, str) and override.strip():
+        return override.strip().lower()
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        prov = _read_main_provider()
+        if not prov:
+            return ""
+        # custom: scheme — ``custom:openrouter`` etc. — strip prefix and
+        # consult ``custom_providers:`` list.
+        if prov.startswith("custom:"):
+            slug = prov[len("custom:"):]
+            for cp in cfg.get("custom_providers") or []:
+                if not isinstance(cp, dict):
+                    continue
+                cp_slug = str(cp.get("slug") or cp.get("name") or "").strip().lower()
+                if cp_slug == slug:
+                    return str(cp.get("api_mode") or "").strip().lower()
+            return ""
+        # Keyed providers under ``providers:`` — palantir-claude47, etc.
+        prv = cfg.get("providers") or {}
+        if isinstance(prv, dict):
+            entry = prv.get(prov) or prv.get(prov.lower())
+            if isinstance(entry, dict):
+                return str(entry.get("api_mode") or "").strip().lower()
+    except Exception:
+        pass
+    return ""
+
+
 # Process-local override set by AIAgent at session/turn start. Single-threaded
 # per turn — no lock needed. Cleared by ``clear_runtime_main()``.
 _RUNTIME_MAIN_PROVIDER: str = ""

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -284,6 +284,52 @@ def _lookup_supports_vision(
     return bool(caps.supports_vision)
 
 
+def _is_known_vision_capable_model_name(model: str) -> bool:
+    """Heuristic: does the model slug name a known vision-capable family?
+
+    Used as a backstop for custom/proxy providers whose ``api_mode``
+    (anthropic_messages / chat_completions) confirms the wire protocol
+    can carry images, but where models.dev has no entry for the proxy's
+    opaque resource ID and the user hasn't set ``model.supports_vision``.
+
+    Recognises substrings present in modern vision-capable family names:
+    Claude 3+ (Opus/Sonnet/Haiku), GPT-4o, GPT-5, GPT-4 Turbo Vision,
+    Gemini 1.5+/2/3, Llama 3.2/3.3 Vision, Pixtral, Qwen-VL, etc. The
+    list is conservative and additive — false negatives are recoverable
+    (the user gets the legacy aux-LLM text fallback) but false positives
+    silently inject pixels into a text-only model.
+    """
+    if not isinstance(model, str):
+        return False
+    m = model.strip().lower()
+    if not m:
+        return False
+    # Anthropic Claude 3+ are all vision-capable. The proxy id may carry
+    # the family name in any of these forms, so substring-match.
+    if "claude-3" in m or "claude-4" in m or "claude-5" in m:
+        return True
+    if "opus" in m or "sonnet" in m or "haiku" in m:
+        return True
+    # OpenAI GPT-4o family + GPT-5+ multimodal
+    if "gpt-4o" in m or "gpt-4-vision" in m or "gpt-4-turbo" in m:
+        return True
+    if "gpt-5" in m or "gpt-6" in m or "o3" in m or "o4" in m:
+        return True
+    # Gemini 1.5+ all vision; older 1.0 not (rarely seen)
+    if "gemini-1.5" in m or "gemini-2" in m or "gemini-3" in m:
+        return True
+    if "gemini-pro-vision" in m or "gemini-flash" in m:
+        return True
+    # Open-weight vision families
+    if "pixtral" in m or "llama-3.2" in m or "llama-3.3" in m:
+        return True
+    if "qwen2-vl" in m or "qwen2.5-vl" in m or "qwen3-vl" in m:
+        return True
+    if "molmo" in m or "internvl" in m or "minicpm-v" in m:
+        return True
+    return False
+
+
 def decide_image_input_mode(
     provider: str,
     model: str,
@@ -313,6 +359,30 @@ def decide_image_input_mode(
 
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
+        return "native"
+    if supports is False:
+        # Hard miss from override or models.dev — caller asked for text.
+        return "text"
+
+    # supports is None — unknown to models.dev and no user override. This
+    # is the common path for custom/proxy providers (Palantir Foundry,
+    # self-hosted vLLM, branded aggregators) where the provider id is
+    # arbitrary. Fall back to (a) wire-protocol awareness from the
+    # active provider's ``api_mode``, plus (b) a substring check on the
+    # model slug for known vision families. Both must agree to upgrade
+    # to native, so a model name that contains "gpt-4o" still routes to
+    # text if the wire is something exotic that doesn't carry images.
+    try:
+        from agent.auxiliary_client import _read_main_api_mode
+        wire = _read_main_api_mode()
+    except Exception:
+        wire = ""
+    wire_carries_images = wire in {
+        "anthropic_messages", "anthropic",
+        "chat_completions", "openai",
+        "responses", "openai_responses",
+    }
+    if wire_carries_images and _is_known_vision_capable_model_name(model):
         return "native"
     return "text"
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -477,6 +477,13 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
 
     For unknown / legacy providers we conservatively return False — the
     caller falls back to the legacy aux-LLM text path.
+
+    Custom proxy providers (Palantir Foundry, self-hosted vLLM behind a
+    branded key, etc.) are recognised by their wire-protocol mode
+    (``api_mode`` in config.yaml) rather than by provider id, since the
+    id is user-controlled and may be anything (``palantir-claude47``,
+    ``corp-llm-prod-3``). The wire decides whether tool-result image
+    blocks are accepted, not the brand label on top.
     """
     if not isinstance(provider, str):
         return False
@@ -512,6 +519,28 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
             return True
         return False
+
+    # Custom / proxy providers: trust the wire-protocol mode declared in
+    # config.yaml. The ``api_mode`` is what determines whether tool-result
+    # image blocks are syntactically accepted, regardless of how the
+    # caller branded the provider slug. A Palantir Foundry entry with
+    # ``api_mode: anthropic_messages`` is wire-identical to native
+    # Anthropic; OpenAI-compat proxies declare ``chat_completions`` and
+    # accept ``image_url`` parts in tool messages.
+    try:
+        from agent.auxiliary_client import _read_main_api_mode
+        api_mode = _read_main_api_mode()
+    except Exception:
+        api_mode = ""
+    if api_mode in {
+        "anthropic_messages",
+        "anthropic",
+        "chat_completions",
+        "openai",
+        "responses",
+        "openai_responses",
+    }:
+        return True
 
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -521,12 +521,14 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return False
 
     # Custom / proxy providers: trust the wire-protocol mode declared in
-    # config.yaml. The ``api_mode`` is what determines whether tool-result
-    # image blocks are syntactically accepted, regardless of how the
-    # caller branded the provider slug. A Palantir Foundry entry with
-    # ``api_mode: anthropic_messages`` is wire-identical to native
-    # Anthropic; OpenAI-compat proxies declare ``chat_completions`` and
-    # accept ``image_url`` parts in tool messages.
+    # config.yaml AND require the model slug to be a known vision-capable
+    # family. The wire decides syntax-acceptance, the slug decides whether
+    # the model can actually consume pixels — both must agree, mirroring
+    # the gate in ``decide_image_input_mode`` in agent/image_routing.py.
+    # Without the slug guard we'd inject ``image_url`` parts into
+    # text-only models behind vision-capable wires (e.g. gpt-3.5-turbo via
+    # a chat_completions proxy), which strict gateways reject and
+    # permissive ones silently bill for the unused image tokens.
     try:
         from agent.auxiliary_client import _read_main_api_mode
         api_mode = _read_main_api_mode()
@@ -540,7 +542,12 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         "responses",
         "openai_responses",
     }:
-        return True
+        try:
+            from agent.image_routing import _is_known_vision_capable_model_name
+            if _is_known_vision_capable_model_name(model):
+                return True
+        except Exception:
+            pass
 
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result


### PR DESCRIPTION
## What

Vision routing (`decide_image_input_mode`, `_supports_media_in_tool_results`, `_should_use_native_vision_fast_path`) keyed solely on the provider id string. Users running a vision-capable Claude / GPT / Gemini model behind a custom proxy provider — Palantir Foundry, Bedrock-shaped corporate gateway, self-hosted vLLM behind a branded key, etc. — were silently routed to the auxiliary vision LLM even though the active main model handles images natively.

## Concrete repro

This user's config has a `providers:` entry `palantir-claude47` with `api_mode: anthropic_messages` proxying Claude 4.7 Opus via Palantir's `/anthropic` endpoint. The active model id is the proxy's opaque resource ID: `ri.language-model-service..language-model.anthropic-claude-4-7-opus`. Calling `vision_analyze` on a local screenshot:

```
decide_image_input_mode("palantir-claude47", "ri.language-model-service..…", cfg)
  → "text"      (was "native" expected)
_supports_media_in_tool_results(...) → False
_should_use_native_vision_fast_path() → False
```

→ `vision_analyze` fired the auxiliary vision client against the active main provider/model (i.e. shipped a chat-completions vision call to Palantir Anthropic with the opaque `ri.*` resource ID), returning errors. The active main model — an Opus that natively reads pixels — never saw the image.

## Root cause

Both routing predicates keyed on the provider id string (`anthropic` / `openai` / `openrouter` / `gemini`). Custom `providers:` / `custom_providers:` entries have user-chosen ids (`palantir-claude47`, `corp-llm-prod-3`) so the id-based allowlist misses them, and models.dev has no entry for the proxy's opaque resource id so `_lookup_supports_vision` returns `None` (not `False` — the lookup just doesn't know).

The auto-mode fallback was `return "text"` whenever `supports != True`, which conflated "unknown" with "definitely text-only".

## Fix — three small layered changes

1. **`agent.auxiliary_client._read_main_api_mode()`** (new public helper). Resolves the active main provider's wire-protocol mode by first consulting the runtime override (`_RUNTIME_MAIN_API_MODE`, set by AIAgent at turn start to track CLI `/model` switches), then falling back to config.yaml's keyed `providers:` entry or `custom_providers:` list. Returns the empty string when the active provider is canonical/aggregator (those pin their wire inside the adapter and don't carry an explicit api_mode field).

2. **`tools.vision_tools._supports_media_in_tool_results`**: when the provider id misses every named allowlist, fall back to checking the wire-protocol mode. `anthropic_messages` / `anthropic` / `chat_completions` / `openai` / `responses` / `openai_responses` are wire-protocols whose tool-result messages syntactically carry image content — the predicate trusts the wire, not the brand label on top.

3. **`agent.image_routing.decide_image_input_mode`** (auto mode): when models.dev returns `None` (the common path for proxy/aggregator model ids), upgrade to `native` only if (a) the wire-protocol carries images AND (b) the model slug substring-matches a known vision-capable family (`opus` / `sonnet` / `haiku` / `claude-3+` / `gpt-4o` / `gpt-5+` / `gemini-1.5+` / `pixtral` / `llama-3.2+` / `qwen*-vl` / `molmo` / `internvl` / `minicpm-v`). Both must agree, so a known-vision slug routed through an exotic wire stays on the text path, and a text-only model routed through a vision-capable wire also stays text.

   `_lookup_supports_vision` returning `False` is still a hard negative (explicit user override or definitive models.dev miss), so users who declared a capable model as text-only via `model.supports_vision: false` keep their behaviour.

The vision-family substring list (`_is_known_vision_capable_model_name`) is conservative and additive — false negatives are recoverable (legacy aux-LLM text fallback fires) but false positives silently inject pixels into a text-only model, so additions should land alongside empirical confirmation that the slug substring is unique to vision-capable models.

## Manual smoke (this user's live setup)

**Before** — provider=`palantir-claude47`, model=`ri.language-model-service..language-model.anthropic-claude-4-7-opus`:

```
mode=text, media_ok=False, fast_path=False
→ aux vision client called instead of attaching to the main model.
```

**After**:

```
mode=native, media_ok=True, fast_path=True
→ image attached to the main model's next turn as multimodal
  tool-result; Opus reads the pixels directly.
```

Verified live in a fresh CLI session — `vision_analyze` on a PNG screenshot resolved through the native fast path; the Claude Opus main model described the image content directly on the next turn instead of returning the aux-LLM error.

**Regression guard**:

```
provider=fictional-corp, model=corp-summarizer-v1, wire=chat_completions
→ mode=text (slug missing from vision-family list).

provider=anthropic, model=claude-3-5-haiku-latest, wire=anthropic_messages
→ mode=native (claude-3 family, wire carries images — unchanged).
```

## Test status

Tests in `tests/agent/test_vision_routing_31179.py` and `tests/tools/test_vision_native_fast_path.py` pass when run in isolation. Pre-existing test-pollution between `tests/tools/test_vision_tools.py` modules causes 13 unrelated failures when the suite runs together — those are present on main both with and without this patch and aren't introduced here.
