### PR TITLE
transport(chat_completions): strip reasoning echo fields from outgoing assistant messages

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -175,6 +175,10 @@ class ChatCompletionsTransport(ProviderTransport):
             ):
                 needs_sanitize = True
                 break
+            # ``name`` on tool-result messages — see docstring.
+            if msg.get("role") == "tool" and "name" in msg:
+                needs_sanitize = True
+                break
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
@@ -199,6 +203,12 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            # Strip ``name`` ONLY on tool-result messages (``role=tool``) —
+            # leave ``name`` on assistant/function messages alone where the
+            # spec actually expects it. Palantir's OpenAI surface rejects
+            # ``name`` on ``role=tool`` with ``unrecognizedProperty=name``.
+            if msg.get("role") == "tool":
+                msg.pop("name", None)
             # Reasoning echo fields — see docstring above.  Dropping on
             # the OpenAI-wire path is provider-agnostic; the
             # Anthropic-Messages transport reads these from a separate

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -126,6 +126,14 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``name`` on tool-result messages (``role=tool``) — Hermes attaches
+          the function name to tool-results in several places (see
+          conversation_loop.py and tool_executor.py). The OpenAI spec lists
+          ``name`` only on ``role=function`` (legacy 0613 schema) and
+          ``role=tool`` schemas vary across gateways; strict OpenAI-compatible
+          gateways like Palantir LLM-proxy reject it with
+          ``unrecognizedProperty=name``. Drop it on the wire — correlation is
+          already covered by ``tool_call_id``.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -136,6 +144,22 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Reasoning echo fields on assistant messages — ``reasoning``
+          (OpenRouter unified format), ``reasoning_content``
+          (DeepSeek/Moonshot/Kimi), ``reasoning_details`` (OpenRouter
+          structured). These are preserved on the in-memory message dict
+          by ``parse_response`` so downstream code (thinking-prefill
+          retry, ``_extract_reasoning``, the Anthropic-Messages adapter's
+          replay path) can read them back. They must NOT reach the wire
+          on chat_completions providers — strict gateways like Palantir
+          LLM-proxy ``/openai/v1`` reject the assistant message with
+          ``HTTP 400 unrecognizedProperty=reasoning_content`` on the
+          NEXT turn (the field comes back in history). Permissive
+          providers (real OpenAI, OpenRouter) silently ignore them, which
+          masked the bug for months. The Anthropic-Messages transport
+          (``api_mode='anthropic_messages'``) handles its own replay via
+          thinking blocks, so dropping these on the OpenAI-wire path is
+          provider-agnostic and safe.
         """
         needs_sanitize = False
         for msg in messages:
@@ -145,6 +169,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "reasoning" in msg
+                or "reasoning_content" in msg
+                or "reasoning_details" in msg
             ):
                 needs_sanitize = True
                 break
@@ -172,6 +199,13 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            # Reasoning echo fields — see docstring above.  Dropping on
+            # the OpenAI-wire path is provider-agnostic; the
+            # Anthropic-Messages transport reads these from a separate
+            # message-shape branch before convert_messages runs.
+            msg.pop("reasoning", None)
+            msg.pop("reasoning_content", None)
+            msg.pop("reasoning_details", None)
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
             # OpenAI's message schema has no ``_``-prefixed fields, so this
             # is safe and future-proofs against new markers being added.


### PR DESCRIPTION
## What

Strict OpenAI-compatible gateways (Palantir Foundry's LLM-proxy `/openai/v1` surface, and likely others) reject the next-turn assistant message with `HTTP 400 unrecognizedProperty=reasoning_content` when prior assistant turns carry the field in history. Permissive providers (real OpenAI, OpenRouter) silently ignore it, which masked the bug for months.

## Context

`parse_response` preserves three reasoning echo fields on the in-memory assistant message dict so downstream Hermes code can read them back:

- `reasoning` — OpenRouter unified format
- `reasoning_content` — DeepSeek / Moonshot / Kimi
- `reasoning_details` — OpenRouter structured shape

These are consumed by:

- the thinking-prefill retry path
- `_extract_reasoning` (CLI display + telemetry)
- the Anthropic-Messages adapter's replay path (which converts them back to thinking blocks via a separate message-shape branch BEFORE `convert_messages` runs, so dropping them on the OpenAI-wire path doesn't lose information on the Anthropic path)

…but they must not be sent on the wire on chat_completions providers.

## Concrete repro

This user's config has provider `palantir-claude47` with an OpenAI-wire fallback path active. After the first assistant turn returned `reasoning_content`, the second turn 400'd:

```
> /chat hi
→ 400 unrecognizedProperty: ... messages[3].reasoning_content
```

Subsequent turns kept inheriting the field from history and every following call 400'd until the session was reset.

## Fix

Extend the same `needs_sanitize` / `convert_messages` pre-flight that already strips Codex scaffolding and `tool_name` to also drop the three reasoning echo fields. The three are alternative shapes for the same conceptual payload, but providers don't agree on which they emit or accept, so all three are dropped on the wire.

## Verification

Verified live in a fresh CLI session — Palantir-routed `/chat` calls no longer 400 on the second turn; permissive OpenAI/OpenRouter sessions unchanged (they were already silently dropping the field).
