### PR TITLE
anthropic_adapter: route Palantir Foundry /anthropic surface through Bearer auth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -476,9 +476,10 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
     Some third-party /anthropic endpoints implement Anthropic's Messages API but
-    require Authorization: Bearer instead of Anthropic's native x-api-key header.
-    MiniMax's global and China Anthropic-compatible endpoints, and Azure AI
-    Foundry's Anthropic-style endpoint follow this pattern.
+    require Authorization: Bearer *** of Anthropic's native x-api-key header.
+    MiniMax's global and China Anthropic-compatible endpoints, Azure AI
+    Foundry's Anthropic-style endpoint, and Palantir Foundry's AIP LLM-proxy
+    Anthropic-Messages endpoint all follow this pattern.
     """
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
@@ -487,6 +488,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     return (
         normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
         or "azure.com" in normalized
+        or ("palantirfoundry." in normalized and "/llm/proxy/anthropic" in normalized)
     )
 
 


### PR DESCRIPTION
## What

Palantir Foundry's AIP LLM-proxy publishes an Anthropic-Messages API at `/llm/proxy/anthropic` that requires `Authorization: Bearer <token>` instead of Anthropic's native `x-api-key` header. Without this entry in `_requires_bearer_auth`, the SDK falls through to `x-api-key` and Foundry returns:

```
401 Authentication failed: missing or invalid Bearer token
```

## Context

Foundry's surface is structurally the same case already covered for **MiniMax** and **Azure AI Foundry**: an Anthropic-shaped Messages endpoint fronted by a corporate identity layer that won't accept the native `x-api-key` header.

## Fix

Extend the host substring allow-list in `_requires_bearer_auth` to also match `palantirfoundry.` hosts whose path contains `/llm/proxy/anthropic` (region/tenant subdomain agnostic, path-scoped so the OpenAI-wire surface at `/llm/proxy/openai/v1` is unaffected — that one already authenticates correctly via the OpenAI-wire bearer path).

## Verification

Verified live: `palantir-claude47` (api_mode=anthropic_messages, base_url=`https://...palantirfoundry.com/llm/proxy/anthropic`) connects cleanly with the Bearer header set; SDK doesn't fall back to x-api-key. MiniMax and Azure paths unchanged.
