### PR TITLE
fix(website): bump path-to-regexp — CVE-2026-4867

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9907,9 +9907,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {

--- a/website/package.json
+++ b/website/package.json
@@ -36,7 +36,10 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "express": {
+      "path-to-regexp": "0.1.13"
+    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
Scoped npm override forces path-to-regexp@0.1.13 (patched for CVE-2026-4867 / GHSA-37ch-88jc-xwx2) only within the express dependency subtree.

## Details
- CVE-2026-4867: path-to-regexp < 0.1.13 is vulnerable to ReDoS via catastrophic backtracking from malformed URL parameters
- Added scoped override in `website/package.json` under `express.path-to-regexp`: `0.1.13`
- react-router (1.9.0) and serve-handler (3.3.0) use different major versions and are not affected
- `npm audit` confirms path-to-regexp no longer appears in vulnerability list

## VIPER
- Hash: 6b30ac69a7cd83e4
- Severity: HIGH
- EPSS: 0.00017
- KEV listed: false

## Verification
```
npm audit after fix:
- path-to-regexp: NOT in vulnerabilities (PASS)
- Remaining vulns: body-parser (moderate), brace-expansion (moderate), express (moderate), picomatch (high), postcss (moderate), qs (moderate), undici (high), ws (moderate)
```

## Changed files
- `website/package.json` — added scoped override
- `website/package-lock.json` — regenerated with path-to-regexp@0.1.13 in express subtree