### PR TITLE
fix: always redact API keys in hermes status --all

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,16 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # `--all` should expand component coverage, not print raw secrets.
+        # This command is commonly copied into diagnostics and agent snapshots;
+        # leaking provider keys here turns routine status collection into a
+        # credential-rotation incident.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -27,6 +27,39 @@ def _patch_common_status_deps(monkeypatch, status_mod, tmp_path, *, openai_base_
     )
 
 
+def test_show_status_all_redacts_api_keys(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+
+    raw_openrouter = "openrouter-test-key-abcdefghijklmnopqrstuvwxyz1234567890"
+    raw_anthropic = "anthropic-test-key-abcdefghijklmnopqrstuvwxyz1234567890"
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+
+    def _get_env_value(name: str):
+        if name == "OPENROUTER_API_KEY":
+            return raw_openrouter
+        return ""
+
+    monkeypatch.setattr(status_mod, "get_env_value", _get_env_value, raising=False)
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: raw_anthropic, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": {"default": "gpt-5"}}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenRouter", raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    out = capsys.readouterr().out
+    assert raw_openrouter not in out
+    assert raw_anthropic not in out
+    assert "open...7890" in out
+    assert "anth...7890" in out
+    assert "OpenRouter" in out
+    assert "Anthropic" in out
+
+
+
 def test_show_status_displays_configured_dict_model_and_provider_label(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
 


### PR DESCRIPTION
## Summary
- keep `hermes status --all` on the redacted path for provider API keys
- add a regression test covering OpenRouter and Anthropic key display under `--all`

## Test Plan
- `/Users/chas-studio/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_status_model_provider.py tests/hermes_cli/test_status.py -q`
- `git diff --check -- hermes_cli/status.py tests/hermes_cli/test_status_model_provider.py`
