### PR TITLE
fix(gateway): notify memory providers with rewound=True on /undo

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11661,10 +11661,29 @@ class GatewayRunner:
 
         # Reset stored token count — transcript was truncated.
         session_entry.last_prompt_tokens = 0
-        # Evict the cached agent so the next turn rebuilds from the active-only
-        # transcript and memory providers refresh their per-session caches.
+        # Notify memory providers before evicting so their per-turn document
+        # caches invalidate — mirrors CLI /undo (cli.py). Same
+        # on_session_switch hook /branch uses, with rewound=True (#6672/#21910).
         try:
             session_key = build_session_key(source)
+            _old_agent = None
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            if _cache_lock is not None:
+                with _cache_lock:
+                    _cached = self._agent_cache.get(session_key)
+                    _old_agent = _cached[0] if isinstance(_cached, tuple) else (_cached or None)
+            if _old_agent is not None:
+                _mm = getattr(_old_agent, "_memory_manager", None)
+                if _mm is not None:
+                    try:
+                        _mm.on_session_switch(
+                            session_entry.session_id,
+                            parent_session_id="",
+                            reset=False,
+                            rewound=True,
+                        )
+                    except Exception:
+                        pass
             self._evict_cached_agent(session_key)
         except Exception as e:
             logger.debug("undo: cached-agent eviction skipped: %s", e)

--- a/tests/gateway/test_undo_rewind_session.py
+++ b/tests/gateway/test_undo_rewind_session.py
@@ -80,3 +80,128 @@ def test_rewind_clamps_negative_count_to_one(store):
     res = store.rewind_session(sid, -5)
     assert res["turns_undone"] == 1
     assert res["target_text"] == "q3"
+
+
+# ---------------------------------------------------------------------------
+# _handle_undo_command — memory provider notification parity with CLI /undo
+# ---------------------------------------------------------------------------
+
+def _make_undo_runner(store, session_id="undo-session-1"):
+    """Minimal GatewayRunner fixture wired to the given SessionStore."""
+    import collections
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.session_store = store
+    runner._agent_cache = collections.OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
+    runner._running_agents = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.adapters = {}
+    return runner, session_id
+
+
+def _fake_session_entry(session_id: str):
+    """Build a minimal SessionEntry-like object for test stubs."""
+    from unittest.mock import MagicMock
+    entry = MagicMock()
+    entry.session_id = session_id
+    entry.last_prompt_tokens = 0
+    return entry
+
+
+def test_undo_notifies_memory_manager_with_rewound(store):
+    """_handle_undo_command must call memory_manager.on_session_switch(rewound=True).
+
+    Mirrors CLI /undo which fires the same hook so per-turn document caches
+    in memory providers invalidate after a rewind (#6672, #21910).
+    """
+    import asyncio
+    from unittest.mock import MagicMock, patch
+
+    from gateway.config import Platform
+    from gateway.platforms.base import MessageEvent
+    from gateway.session import SessionSource
+
+    sid = _seed(store, "undo-mm-1", turns=2)
+    runner, _ = _make_undo_runner(store)
+
+    # Fake cached agent with a spy memory_manager.
+    fake_mm = MagicMock()
+    fake_agent = MagicMock()
+    fake_agent._memory_manager = fake_mm
+    runner._agent_cache["telegram:u1:c1:"] = (fake_agent,)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+    event = MessageEvent(text="/undo", source=source, message_id="m1")
+
+    fake_entry = _fake_session_entry(sid)
+
+    with patch("gateway.run.build_session_key", return_value="telegram:u1:c1:"), \
+         patch("gateway.run.t", side_effect=lambda key, **kw: key), \
+         patch.object(runner.session_store, "get_or_create_session", return_value=fake_entry), \
+         patch.object(runner.session_store, "rewind_session",
+                      return_value={"rewound_count": 2, "turns_undone": 1, "target_text": "q2"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            runner._handle_undo_command(event)
+        )
+
+    assert result == "gateway.undo.removed"
+    fake_mm.on_session_switch.assert_called_once_with(
+        sid,
+        parent_session_id="",
+        reset=False,
+        rewound=True,
+    )
+    # Agent must have been evicted from cache.
+    assert "telegram:u1:c1:" not in runner._agent_cache
+
+
+def test_undo_no_cached_agent_still_succeeds(store):
+    """_handle_undo_command works when there is no cached agent (cold session)."""
+    import asyncio
+    from unittest.mock import patch
+
+    from gateway.config import Platform
+    from gateway.platforms.base import MessageEvent
+    from gateway.session import SessionSource
+
+    sid = _seed(store, "undo-cold-1", turns=2)
+    runner, _ = _make_undo_runner(store)
+    # No entry in _agent_cache — cold session.
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u2",
+        chat_id="c2",
+        user_name="tester",
+        chat_type="dm",
+    )
+    event = MessageEvent(text="/undo", source=source, message_id="m2")
+
+    fake_entry = _fake_session_entry(sid)
+
+    with patch("gateway.run.build_session_key", return_value="telegram:u2:c2:"), \
+         patch("gateway.run.t", side_effect=lambda key, **kw: key), \
+         patch.object(runner.session_store, "get_or_create_session", return_value=fake_entry), \
+         patch.object(runner.session_store, "rewind_session",
+                      return_value={"rewound_count": 2, "turns_undone": 1, "target_text": "q2"}):
+        result = asyncio.get_event_loop().run_until_complete(
+            runner._handle_undo_command(event)
+        )
+
+    assert result == "gateway.undo.removed"


### PR DESCRIPTION
## What

`_handle_undo_command` evicted the cached agent but did not call
`memory_manager.on_session_switch(rewound=True)` beforehand.

## Why

Memory providers that cache per-turn document state (mem0, hindsight,
retaindb, etc.) had no signal to invalidate after a gateway `/undo`.
The next agent turn could read stale context containing messages that
were just undone.

CLI `/undo` already fires this hook (`cli.py` — same `on_session_switch`
path `/branch` uses, per #6672 / #21910). Gateway `/undo` was missing
the parity, introduced with the recent `feat(gateway): bring /undo [N]
to messaging platforms` commit.

## Fix

Before evicting the cached agent, read it under the cache lock, call
`on_session_switch(session_id, parent_session_id="", reset=False, rewound=True)`
on its `_memory_manager`, then evict. Guards are symmetric with other
agent-cache reads in the codebase (`getattr` lock check, tuple unpack).

## Testing

- `test_undo_notifies_memory_manager_with_rewound` — verifies
  `on_session_switch(rewound=True)` is called on the cached agent's
  memory manager and the agent is evicted afterwards.
- `test_undo_no_cached_agent_still_succeeds` — verifies `/undo` works
  normally when no agent is cached (cold session, no regression).
- All 8 existing `test_undo_rewind_session` tests pass.

## Checklist

- [x] Symmetric with CLI `/undo` (cli.py:7202-7211)
- [x] No behavior change when no memory providers are active
- [x] No behavior change when no cached agent exists
- [x] 8 tests pass, 0 regressions in targeted gateway suite (92 tests)