### PR TITLE
docs(sidebar): add local-ollama-setup to navigation

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -715,6 +715,7 @@ const sidebars: SidebarsConfig = {
         'guides/oauth-over-ssh',
         'guides/microsoft-graph-app-registration',
         'guides/operate-teams-meeting-pipeline',
+        'guides/local-ollama-setup',
       ],
     },
     {


### PR DESCRIPTION
## Summary
Fixes #36985 — the docs guide `website/docs/guides/local-ollama-setup.md` was unreachable from site navigation because it was missing from `website/sidebars.ts`, despite declaring `sidebar_position: 9` in its frontmatter.

## Change
Added the missing `'guides/local-ollama-setup'` entry to the `Guides & Tutorials` category in `website/sidebars.ts`.

## Diff
```
website/sidebars.ts | 1 +
1 file changed, 1 insertion(+)
```

## Verification
- [x] Verified the guide file exists and declares `sidebar_position: 9`
- [x] Verified the entry is in the correct `Guides & Tutorials` category
- [x] Syntax sanity check on `sidebars.ts` passed
- [ ] Docusaurus build (deferred to upstream CI)

## Risk
Minimal — 1-line string addition to a sidebar config array. No behavior change beyond restoring the intended navigation entry.

## Note on prior PR
Supersedes #37049 (which was auto-closed when the head branch was force-pushed during rebase cleanup). The underlying change is identical: this PR is from the cleanly-rebased branch containing only the docs fix.

Closes #36985
