### PR TITLE
fix(gateway): close adapter resources on failed reconnect to prevent fd leak

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4204,6 +4204,15 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._app = None
+        # Close the ResponseStore sqlite3 connection so the db + WAL file
+        # descriptors are released.  Without this, every disconnect leaks 2
+        # fds, which adds up to gateway exhaustion on long-running deployments.
+        if self._response_store is not None:
+            try:
+                self._response_store.close()
+            except Exception:
+                pass
+            self._response_store = None
         logger.info("[%s] API server stopped", self.name)
 
     async def send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6200,6 +6200,7 @@ class GatewayRunner:
                             "Reconnect %s: non-retryable error (%s), removing from retry queue",
                             platform.value, adapter.fatal_error_message,
                         )
+                        await self._dispose_failed_adapter(adapter, platform)
                         del self._failed_platforms[platform]
                     else:
                         self._update_platform_runtime_status(
@@ -6208,6 +6209,7 @@ class GatewayRunner:
                             error_code=adapter.fatal_error_code,
                             error_message=adapter.fatal_error_message or "failed to reconnect",
                         )
+                        await self._dispose_failed_adapter(adapter, platform)
                         backoff = min(30 * (2 ** (attempt - 1)), _BACKOFF_CAP)
                         info["attempts"] = attempt
                         info["next_retry"] = time.monotonic() + backoff
@@ -6240,6 +6242,9 @@ class GatewayRunner:
                     # A raised exception during reconnect (connect timeout, DNS
                     # resolution failure, etc.) is inherently transient — keep
                     # retrying at the backoff cap rather than auto-pausing.
+                    # Clean up the newly created adapter to release any fds it
+                    # opened (e.g. APIServerAdapter sqlite3 db + WAL).
+                    await self._dispose_failed_adapter(adapter, platform)
 
             # Check every 10 seconds for platforms that need reconnection
             for _ in range(10):
@@ -6605,6 +6610,30 @@ class GatewayRunner:
     async def wait_for_shutdown(self) -> None:
         """Wait for shutdown signal."""
         await self._shutdown_event.wait()
+
+    async def _dispose_failed_adapter(
+        self,
+        adapter: "Optional[BasePlatformAdapter]",
+        platform: "Platform",
+    ) -> None:
+        """Disconnect and clean up a newly created adapter that failed to connect.
+
+        Called in all three reconnect-loop failure paths so that any resources
+        the adapter opened during __init__ (e.g. APIServerAdapter sqlite3
+        ResponseStore connection — 2 fds per instance) are released before the
+        adapter reference is dropped.  Without this, each failed reconnect
+        attempt leaks file descriptors until the process hits the OS fd limit
+        and becomes non-functional (~12-26 hours on a 300s backoff cycle).
+        """
+        if adapter is None:
+            return
+        try:
+            await adapter.disconnect()
+        except Exception as exc:
+            logger.debug(
+                "Ignoring error while disposing failed %s adapter: %s",
+                platform.value, exc,
+            )
 
     def _create_adapter(
         self, 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6151,6 +6151,7 @@ class GatewayRunner:
                     platform.value, attempt,
                 )
 
+                adapter = None  # ensure adapter is always bound for exception-path cleanup
                 try:
                     adapter = self._create_adapter(platform, platform_config)
                     if not adapter:


### PR DESCRIPTION
## What does this PR do?

Fixes a file descriptor leak in the platform reconnect loop that causes the gateway to exhaust the OS fd limit (~2560) after 12–26 hours of uptime, making it completely non-functional.

**Root cause:** When a platform fails to connect and is queued for reconnect, the loop creates a fresh adapter on every retry. For `APIServerAdapter`, `__init__` opens a `sqlite3.connect()` (db + WAL = 2 fds). On all three failure paths the new adapter was simply dropped — never disconnected, never cleaned up leaking 2 fds per attempt. At the 300s backoff cap that's ~12 leaked fds/hour. After ~26h the gateway hits the 2560 fd limit causing `OSError: [Errno 24] Too many open files` on every file operation, silently killing all platform connections.

**Note:** The initial connection path already calls `_safe_adapter_disconnect()` on failure this PR only fixes the reconnect loop which was missing cleanup.

**Three-part fix:**
- `_dispose_failed_adapter()` new helper that calls `adapter.disconnect()` in a try/except so cleanup errors never crash the reconnect watcher
- Called in all three failure paths in the reconnect loop: non-retryable error, retryable failure, and exception during connect
- `adapter = None` initialized before the try block so exception-path cleanup never raises `NameError`
- `APIServerAdapter.disconnect()` now also closes the `ResponseStore` sqlite3 connection previously only the aiohttp server was stopped, leaving the db connection open even on clean shutdown

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## References
Fixes #37011

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix