### PR TITLE
fix(file_safety): extend write denylist to cover ~/.hermes/hooks/

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -140,6 +140,16 @@ def is_write_denied(path: str) -> bool:
                 return True
         except Exception:
             pass
+        # hooks/: gateway Python hooks — writing here lets an agent install a
+        # persistent handler that runs with full Python privileges outside the
+        # approval sandbox on every gateway startup. Same threat model as
+        # pairing/ and mcp-tokens/.
+        try:
+            hooks_real = os.path.realpath(os.path.join(base_real, "hooks"))
+            if resolved == hooks_real or resolved.startswith(hooks_real + os.sep):
+                return True
+        except Exception:
+            pass
 
     safe_root = get_safe_write_root()
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -166,6 +166,29 @@ class TestIsWriteDenied:
         assert _is_write_denied(str(root / "pairing" / "telegram-approved.json")) is True
         assert _is_write_denied(str(root / "pairing")) is True
 
+    def test_hooks_dir_denied(self, tmp_path, monkeypatch):
+        """Regression: hooks/ must be write-denied under both profile and root.
+
+        gateway/hooks.py loads and exec_modules every handler.py found under
+        ~/.hermes/hooks/*/handler.py on gateway startup. Without this block, a
+        prompt-injected write_file can install a persistent Python handler that
+        runs with full privileges outside the approval sandbox — the same threat
+        class that motivated protecting pairing/ and mcp-tokens/.
+        """
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        # Active profile hook files
+        assert _is_write_denied(str(profile / "hooks" / "evil" / "handler.py")) is True
+        assert _is_write_denied(str(profile / "hooks" / "evil" / "HOOK.yaml")) is True
+        # The hooks directory itself
+        assert _is_write_denied(str(profile / "hooks")) is True
+        # Root hooks entries (profile mode)
+        assert _is_write_denied(str(root / "hooks" / "evil" / "handler.py")) is True
+        assert _is_write_denied(str(root / "hooks")) is True
+
 
 
 # =========================================================================


### PR DESCRIPTION
## What

Add `~/.hermes/hooks/` to the `is_write_denied()` write denylist in
`agent/file_safety.py`, covering both the active-profile and root Hermes
home paths.

## Why

`gateway/hooks.py` discovers and `exec_module`s every `handler.py` found
under `~/.hermes/hooks/*/` at gateway startup. Before this fix, that
directory was absent from the write denylist, so a prompt-injected
`write_file` call could plant a malicious `handler.py` that executes
with **full Python privileges outside the approval sandbox** on every
subsequent gateway restart — persistent, unapproved code execution.

The threat model is identical to `pairing/` (PR #30412) and `mcp-tokens/`:
all three directories let a write into them escalate from agent-level
access to something that permanently affects the gateway. User-authored
hooks are still fully supported — the gate only applies to the
**agent's** write path, not to the user writing directly.

## Fix

Extend the `hermes_dirs` loop in `is_write_denied()` with the same
prefix check already applied to `pairing/` and `mcp-tokens/`:

```python
hooks_real = os.path.realpath(os.path.join(base_real, "hooks"))
if resolved == hooks_real or resolved.startswith(hooks_real + os.sep):
    return True
```

## Testing

`test_hooks_dir_denied` mirrors `test_pairing_dir_denied` exactly:
checks that files inside `hooks/` and the directory itself are
write-denied under both profile and root Hermes home.

All 132 file-safety tests pass.

## Checklist

- [x] Symmetric with `pairing/` and `mcp-tokens/` protection in `is_write_denied()`
- [x] No change to read access (hooks remain readable/executable by the gateway)
- [x] No change to user's ability to create/edit hooks directly
- [x] 132 file-safety tests pass, 0 regressions