### PR TITLE
fix(discord): render markdown tables as aligned code blocks

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -170,6 +170,75 @@ def _build_allowed_mentions():
     )
 
 
+# --- Markdown table detection for Discord code-fence wrapping ---
+
+_TABLE_SEPARATOR_RE = re.compile(
+    r'^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$'
+)
+
+
+def _is_table_row(line: str) -> bool:
+    """Return True if *line* could plausibly be a table data row."""
+    stripped = line.strip()
+    return bool(stripped) and '|' in stripped
+
+
+def _wrap_tables_in_code_fence(text: str) -> str:
+    """Wrap GFM-style pipe tables in fenced code blocks for Discord.
+
+    Discord does not render markdown tables natively — raw pipe characters
+    display as garbage.  Wrapping the table in triple-backtick fences
+    produces a readable monospaced rendering.
+
+    Tables that are already inside fenced code blocks are left alone.
+    """
+    if '|' not in text or '-' not in text:
+        return text
+
+    lines = text.split('\n')
+    out: list[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+
+        # Track existing fenced code blocks — never touch content inside.
+        if stripped.startswith('```'):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+
+        # Look for a header row (contains '|') immediately followed by a
+        # delimiter row matching the separator regex.
+        if (
+            '|' in line
+            and i + 1 < len(lines)
+            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            table_block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and _is_table_row(lines[j]):
+                table_block.append(lines[j])
+                j += 1
+            # Wrap the detected table in code fences
+            out.append('```')
+            out.extend(table_block)
+            out.append('```')
+            i = j
+            continue
+
+        out.append(line)
+        i += 1
+
+    return '\n'.join(out)
+
+
 class VoiceReceiver:
     """Captures and decodes voice audio from a Discord voice channel.
 
@@ -2908,10 +2977,12 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         Format message for Discord.
 
-        Discord uses its own markdown variant.
+        Discord uses its own markdown variant.  In particular, Discord does
+        not render GFM pipe tables — the raw pipe characters display as
+        garbage.  Detected tables are wrapped in triple-backtick code fences
+        so they render as readable monospaced text.
         """
-        # Discord markdown is fairly standard, no special escaping needed
-        return content
+        return _wrap_tables_in_code_fence(content)
 
     async def _run_simple_slash(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -170,25 +170,64 @@ def _build_allowed_mentions():
     )
 
 
-# --- Markdown table detection for Discord code-fence wrapping ---
+# --- Markdown table detection for Discord code-fence formatting ---
 
 _TABLE_SEPARATOR_RE = re.compile(
     r'^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$'
 )
 
 
+def _split_table_row(line: str) -> list[str]:
+    """Split a GFM pipe-table row into stripped cell strings."""
+    stripped = line.strip()
+    if stripped.startswith('|'):
+        stripped = stripped[1:]
+    if stripped.endswith('|'):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split('|')]
+
+
 def _is_table_row(line: str) -> bool:
     """Return True if *line* could plausibly be a table data row."""
-    stripped = line.strip()
-    return bool(stripped) and '|' in stripped
+    if '|' not in line:
+        return False
+    return len(_split_table_row(line)) >= 2
+
+
+def _format_plaintext_table(table_lines: list[str]) -> list[str]:
+    """Render markdown table lines as aligned plaintext rows."""
+    if len(table_lines) < 2:
+        return table_lines
+
+    rows = [_split_table_row(table_lines[0])]
+    rows.extend(_split_table_row(line) for line in table_lines[2:])
+    column_count = max((len(row) for row in rows), default=0)
+    if column_count < 2:
+        return table_lines
+
+    normalized = [row + [''] * (column_count - len(row)) for row in rows]
+    widths = [
+        max(len(row[index]) for row in normalized)
+        for index in range(column_count)
+    ]
+
+    def render_row(row: list[str]) -> str:
+        return ' | '.join(
+            cell.ljust(widths[index]) for index, cell in enumerate(row)
+        ).rstrip()
+
+    separator = ' | '.join('-' * max(3, width) for width in widths)
+    rendered = [render_row(normalized[0]), separator]
+    rendered.extend(render_row(row) for row in normalized[1:])
+    return rendered
 
 
 def _wrap_tables_in_code_fence(text: str) -> str:
-    """Wrap GFM-style pipe tables in fenced code blocks for Discord.
+    """Convert GFM-style pipe tables to aligned code blocks for Discord.
 
-    Discord does not render markdown tables natively — raw pipe characters
-    display as garbage.  Wrapping the table in triple-backtick fences
-    produces a readable monospaced rendering.
+    Discord does not render markdown tables natively. Raw markdown tables
+    are hard to read in proportional chat text, so detected tables are
+    converted to aligned plaintext and wrapped in triple-backtick fences.
 
     Tables that are already inside fenced code blocks are left alone.
     """
@@ -203,7 +242,7 @@ def _wrap_tables_in_code_fence(text: str) -> str:
         line = lines[i]
         stripped = line.lstrip()
 
-        # Track existing fenced code blocks — never touch content inside.
+        # Track existing fenced code blocks, never touch content inside.
         if stripped.startswith('```'):
             in_fence = not in_fence
             out.append(line)
@@ -214,10 +253,9 @@ def _wrap_tables_in_code_fence(text: str) -> str:
             i += 1
             continue
 
-        # Look for a header row (contains '|') immediately followed by a
-        # delimiter row matching the separator regex.
+        # Look for a header row immediately followed by a GFM separator row.
         if (
-            '|' in line
+            _is_table_row(line)
             and i + 1 < len(lines)
             and _TABLE_SEPARATOR_RE.match(lines[i + 1])
         ):
@@ -226,9 +264,8 @@ def _wrap_tables_in_code_fence(text: str) -> str:
             while j < len(lines) and _is_table_row(lines[j]):
                 table_block.append(lines[j])
                 j += 1
-            # Wrap the detected table in code fences
             out.append('```')
-            out.extend(table_block)
+            out.extend(_format_plaintext_table(table_block))
             out.append('```')
             i = j
             continue

--- a/tests/gateway/test_discord_table_wrap.py
+++ b/tests/gateway/test_discord_table_wrap.py
@@ -1,0 +1,128 @@
+"""Tests for Discord markdown table code-fence wrapping (issue #21168).
+
+Discord does not render GFM pipe tables — raw pipe characters display as
+garbage.  ``_wrap_tables_in_code_fence`` detects tables and wraps them in
+triple-backtick fences so they render as readable monospaced text.
+"""
+
+import pytest
+
+from plugins.platforms.discord.adapter import _wrap_tables_in_code_fence
+
+
+class TestWrapTablesInCodeFence:
+    """Unit tests for the table-wrapping helper."""
+
+    def test_basic_table_is_wrapped(self):
+        text = (
+            "| Name | Value |\n"
+            "|------|-------|\n"
+            "| foo  | 1     |\n"
+            "| bar  | 2     |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")
+        # Original table lines are preserved inside the fences
+        assert "| Name | Value |" in result
+        assert "| foo  | 1     |" in result
+
+    def test_table_with_surrounding_text(self):
+        text = (
+            "Here is a comparison:\n"
+            "\n"
+            "| Model | Speed |\n"
+            "|-------|-------|\n"
+            "| A     | fast  |\n"
+            "| B     | slow  |\n"
+            "\n"
+            "Hope that helps!"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        # Surrounding text is untouched
+        assert result.startswith("Here is a comparison:\n")
+        assert result.endswith("\nHope that helps!")
+        # Table is wrapped
+        assert "```\n| Model | Speed |" in result
+        assert "| B     | slow  |\n```" in result
+
+    def test_table_inside_code_fence_is_untouched(self):
+        text = (
+            "```\n"
+            "| A | B |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+            "```"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result == text  # unchanged
+
+    def test_no_table_passthrough(self):
+        text = "Just a regular message with no pipes or tables."
+        assert _wrap_tables_in_code_fence(text) == text
+
+    def test_pipe_without_separator_is_untouched(self):
+        # A line with '|' but no separator row below is NOT a table
+        text = "Use the | operator in bash for piping."
+        assert _wrap_tables_in_code_fence(text) == text
+
+    def test_empty_input(self):
+        assert _wrap_tables_in_code_fence("") == ""
+
+    def test_table_without_leading_pipe(self):
+        # GFM tables can omit leading/trailing pipes
+        text = (
+            "Name | Value\n"
+            "------|-------\n"
+            "foo  | 1\n"
+            "bar  | 2"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")
+
+    def test_multiple_tables(self):
+        text = (
+            "| A | B |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+            "\n"
+            "Some text\n"
+            "\n"
+            "| C | D |\n"
+            "|---|---|\n"
+            "| 3 | 4 |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        # Both tables should be wrapped
+        assert result.count("```") == 4  # 2 opening + 2 closing fences
+
+    def test_table_with_alignment_row(self):
+        text = (
+            "| Left | Center | Right |\n"
+            "|:-----|:------:|------:|\n"
+            "| a    | b      | c     |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")
+
+    def test_single_column_separator_not_matched(self):
+        # A separator with only one column (no '|') should not match
+        text = "-----\nnot a table"
+        assert _wrap_tables_in_code_fence(text) == text
+
+    def test_format_message_integration(self):
+        """Verify format_message calls the wrapping function."""
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        # Create adapter instance bypassing __init__
+        adapter = DiscordAdapter.__new__(DiscordAdapter)
+        text = (
+            "| X | Y |\n"
+            "|---|---|\n"
+            "| 1 | 2 |"
+        )
+        result = adapter.format_message(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")

--- a/tests/gateway/test_discord_table_wrap.py
+++ b/tests/gateway/test_discord_table_wrap.py
@@ -1,19 +1,17 @@
-"""Tests for Discord markdown table code-fence wrapping (issue #21168).
+"""Tests for Discord markdown table formatting (issue #21168).
 
-Discord does not render GFM pipe tables — raw pipe characters display as
-garbage.  ``_wrap_tables_in_code_fence`` detects tables and wraps them in
-triple-backtick fences so they render as readable monospaced text.
+Discord does not render GFM pipe tables. ``_wrap_tables_in_code_fence``
+detects tables, converts them to aligned plaintext, and wraps them in
+triple-backtick fences so they render readably in Discord.
 """
-
-import pytest
 
 from plugins.platforms.discord.adapter import _wrap_tables_in_code_fence
 
 
 class TestWrapTablesInCodeFence:
-    """Unit tests for the table-wrapping helper."""
+    """Unit tests for the table-formatting helper."""
 
-    def test_basic_table_is_wrapped(self):
+    def test_basic_table_is_aligned_and_wrapped(self):
         text = (
             "| Name | Value |\n"
             "|------|-------|\n"
@@ -21,11 +19,31 @@ class TestWrapTablesInCodeFence:
             "| bar  | 2     |"
         )
         result = _wrap_tables_in_code_fence(text)
-        assert result.startswith("```\n")
-        assert result.endswith("\n```")
-        # Original table lines are preserved inside the fences
-        assert "| Name | Value |" in result
-        assert "| foo  | 1     |" in result
+        assert result == (
+            "```\n"
+            "Name | Value\n"
+            "---- | -----\n"
+            "foo  | 1\n"
+            "bar  | 2\n"
+            "```"
+        )
+
+    def test_unaligned_markdown_table_becomes_readable_plaintext(self):
+        text = (
+            "Model | Latency | Notes\n"
+            "---|---|---\n"
+            "GPT-5.5 | 120ms | fast\n"
+            "Mini | 9ms | cheap"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result == (
+            "```\n"
+            "Model   | Latency | Notes\n"
+            "------- | ------- | -----\n"
+            "GPT-5.5 | 120ms   | fast\n"
+            "Mini    | 9ms     | cheap\n"
+            "```"
+        )
 
     def test_table_with_surrounding_text(self):
         text = (
@@ -39,12 +57,10 @@ class TestWrapTablesInCodeFence:
             "Hope that helps!"
         )
         result = _wrap_tables_in_code_fence(text)
-        # Surrounding text is untouched
         assert result.startswith("Here is a comparison:\n")
         assert result.endswith("\nHope that helps!")
-        # Table is wrapped
-        assert "```\n| Model | Speed |" in result
-        assert "| B     | slow  |\n```" in result
+        assert "```\nModel | Speed" in result
+        assert "B     | slow\n```" in result
 
     def test_table_inside_code_fence_is_untouched(self):
         text = (
@@ -55,14 +71,13 @@ class TestWrapTablesInCodeFence:
             "```"
         )
         result = _wrap_tables_in_code_fence(text)
-        assert result == text  # unchanged
+        assert result == text
 
     def test_no_table_passthrough(self):
         text = "Just a regular message with no pipes or tables."
         assert _wrap_tables_in_code_fence(text) == text
 
     def test_pipe_without_separator_is_untouched(self):
-        # A line with '|' but no separator row below is NOT a table
         text = "Use the | operator in bash for piping."
         assert _wrap_tables_in_code_fence(text) == text
 
@@ -70,7 +85,6 @@ class TestWrapTablesInCodeFence:
         assert _wrap_tables_in_code_fence("") == ""
 
     def test_table_without_leading_pipe(self):
-        # GFM tables can omit leading/trailing pipes
         text = (
             "Name | Value\n"
             "------|-------\n"
@@ -78,8 +92,14 @@ class TestWrapTablesInCodeFence:
             "bar  | 2"
         )
         result = _wrap_tables_in_code_fence(text)
-        assert result.startswith("```\n")
-        assert result.endswith("\n```")
+        assert result == (
+            "```\n"
+            "Name | Value\n"
+            "---- | -----\n"
+            "foo  | 1\n"
+            "bar  | 2\n"
+            "```"
+        )
 
     def test_multiple_tables(self):
         text = (
@@ -94,8 +114,9 @@ class TestWrapTablesInCodeFence:
             "| 3 | 4 |"
         )
         result = _wrap_tables_in_code_fence(text)
-        # Both tables should be wrapped
-        assert result.count("```") == 4  # 2 opening + 2 closing fences
+        assert result.count("```") == 4
+        assert "A | B\n--- | ---\n1 | 2" in result
+        assert "C | D\n--- | ---\n3 | 4" in result
 
     def test_table_with_alignment_row(self):
         text = (
@@ -104,19 +125,39 @@ class TestWrapTablesInCodeFence:
             "| a    | b      | c     |"
         )
         result = _wrap_tables_in_code_fence(text)
-        assert result.startswith("```\n")
-        assert result.endswith("\n```")
+        assert result == (
+            "```\n"
+            "Left | Center | Right\n"
+            "---- | ------ | -----\n"
+            "a    | b      | c\n"
+            "```"
+        )
 
     def test_single_column_separator_not_matched(self):
-        # A separator with only one column (no '|') should not match
         text = "-----\nnot a table"
         assert _wrap_tables_in_code_fence(text) == text
+
+    def test_ragged_rows_are_padded(self):
+        text = (
+            "| A | B | C |\n"
+            "|---|---|---|\n"
+            "| 1 | 2 |\n"
+            "| 3 | 4 | 5 |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result == (
+            "```\n"
+            "A | B | C\n"
+            "--- | --- | ---\n"
+            "1 | 2 |\n"
+            "3 | 4 | 5\n"
+            "```"
+        )
 
     def test_format_message_integration(self):
         """Verify format_message calls the wrapping function."""
         from plugins.platforms.discord.adapter import DiscordAdapter
 
-        # Create adapter instance bypassing __init__
         adapter = DiscordAdapter.__new__(DiscordAdapter)
         text = (
             "| X | Y |\n"
@@ -124,5 +165,10 @@ class TestWrapTablesInCodeFence:
             "| 1 | 2 |"
         )
         result = adapter.format_message(text)
-        assert result.startswith("```\n")
-        assert result.endswith("\n```")
+        assert result == (
+            "```\n"
+            "X | Y\n"
+            "--- | ---\n"
+            "1 | 2\n"
+            "```"
+        )


### PR DESCRIPTION
## Summary
- Builds on #35707's Discord table detection
- Converts detected GFM pipe tables to aligned plaintext before wrapping in code fences
- Keeps existing fenced code blocks untouched
- Adds regression coverage for unaligned and ragged markdown tables

## Why
Discord does not render GFM tables. Wrapping raw markdown in a code block is better than proportional text, but unaligned pipe tables are still hard to read. This renders a readable monospaced table instead.

## Test Plan
- python3 -m pytest tests/gateway/test_discord_table_wrap.py -q
- env -u DISCORD_ALLOW_BOTS python3 -m pytest tests/gateway/test_discord_system_messages.py tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_connect.py -q
- python3 -m ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_table_wrap.py

Related: #35707, #21168