### PR TITLE
fix(model_normalize): don't dot-hyphenate non-Anthropic models for the anthropic provider

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -409,11 +409,20 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         return name
 
     # --- Anthropic: strip matching provider prefix, dots -> hyphens ---
+    #     The hyphenated naming convention (claude-sonnet-4.6 ->
+    #     claude-sonnet-4-6) is Anthropic-specific.  Only apply it to
+    #     Anthropic-native (claude) models.  A foreign-vendor model that
+    #     reaches the anthropic provider — e.g. via auto-resolution
+    #     fallthrough when an aggregator is down — must pass through
+    #     unchanged: mangling "gpt-5.5" -> "gpt-5-5" yields a misleading
+    #     HTTP 404 "model: gpt-5-5" instead of the honest "model: gpt-5.5".
     if provider in _DOT_TO_HYPHEN_PROVIDERS:
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:
             return bare
-        return _dots_to_hyphens(bare)
+        if detect_vendor(bare) == "anthropic":
+            return _dots_to_hyphens(bare)
+        return bare
 
     # --- Copilot / Copilot ACP: delegate to the Copilot-specific
     #     normalizer.  It knows about the alias table (vendor-prefix

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -51,6 +51,22 @@ class TestAnthropicDotToHyphen:
         result = normalize_model_for_provider("anthropic/claude-sonnet-4.6", "anthropic")
         assert result == "claude-sonnet-4-6"
 
+    @pytest.mark.parametrize("model", [
+        "gpt-5.5",
+        "gpt-5.4-mini",
+        "gemini-3.0-pro",
+        "minimax-m2.7",
+    ])
+    def test_anthropic_does_not_mangle_foreign_vendor_models(self, model):
+        """Foreign-vendor models that reach the anthropic provider (e.g. via
+        auto-resolution fallthrough when an aggregator is down) must NOT be
+        dot-hyphenated.  Mangling ``gpt-5.5`` -> ``gpt-5-5`` produced a
+        misleading HTTP 404 ``model: gpt-5-5``.  Only Anthropic-native
+        (claude) models use the hyphenated naming.
+        """
+        result = normalize_model_for_provider(model, "anthropic")
+        assert result == model, f"Expected {model!r} unchanged, got {result!r}"
+
 
 # ── OpenCode Zen regression ────────────────────────────────────────────
 


### PR DESCRIPTION
### Problem
`normalize_model_for_provider(model, "anthropic")` applies `_dots_to_hyphens()` to **any** model, not just Claude models, so a foreign-vendor model that reaches the `anthropic` provider gets silently mangled:

```python
>>> normalize_model_for_provider("gpt-5.5", "anthropic")
'gpt-5-5'        # ← sent to Anthropic's API verbatim
```

Anthropic then returns `HTTP 404: model: gpt-5-5` — an identifier that matches nothing the user configured, making the failure hard to diagnose.

### How it triggers
The hyphenation is only meant for Claude's native naming (`claude-sonnet-4.6` → `claude-sonnet-4-6`). But a non-Claude model can legitimately land on the `anthropic` provider via auto-resolution / fallback fallthrough — e.g. a config default of `model: gpt-5.5` + `provider: auto` where the primary aggregator is unavailable and resolution falls through to the first credentialed provider. The name should pass through untouched so the error is honest (`model: gpt-5.5`) and failover logic can reason about it. In practice this silently broke scheduled (cron) jobs running on a `gpt-5.5` default — they failed with `HTTP 404: model: gpt-5-5` instead of a legible error.

### Fix
Guard the dot→hyphen conversion with `detect_vendor()` (already in this module) so only Anthropic-native models are hyphenated; everything else passes through unchanged.

### Test
Adds a regression covering `gpt-5.5`, `gpt-5.4-mini`, `gemini-3.0-pro`, `minimax-m2.7` → unchanged for `anthropic`, while existing Claude hyphenation cases still pass.

### Risk
Minimal. Anthropic's API only serves Claude models, so hyphenating a non-Claude name was never correct — this strictly removes a harmful transformation and improves error legibility. No change to Claude-model behavior.