### PR TITLE
fix(gateway): drop _HERMES_GATEWAY blanket guard for legit internal restarts

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6147,16 +6147,6 @@ def _gateway_command_inner(args):
             sys.exit(1)
 
     elif subcmd == "stop":
-        # Defense: refuse self-targeting gateway stop from inside the gateway.
-        # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
-            print_error(
-                "Refusing to stop the gateway from inside the gateway process.\n"
-                "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway stop` from a shell outside the running gateway."
-            )
-            sys.exit(1)
-
         stop_all = getattr(args, "all", False)
         system = getattr(args, "system", False)
 
@@ -6240,16 +6230,6 @@ def _gateway_command_inner(args):
                 print(f"✓ Stopped {get_service_name()} service")
 
     elif subcmd == "restart":
-        # Defense: refuse self-targeting gateway restart from inside the gateway.
-        # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
-            print_error(
-                "Refusing to restart the gateway from inside the gateway process.\n"
-                "This command was blocked to prevent restart loops.\n"
-                "Use `hermes gateway restart` from a shell outside the running gateway."
-            )
-            sys.exit(1)
-
         # Try service first, fall back to killing and restarting
         service_available = False
         system = getattr(args, "system", False)


### PR DESCRIPTION
## Problem

PR #35679 added a blanket guard that refuses all `stop`/`restart` commands from inside the gateway process (via the `_HERMES_GATEWAY` env var). The intent was to prevent the cron+KeepAlive respawn loop from #30719 — but it has the side effect of blocking **legitimate** manual restarts from WeChat/Telegram/etc., forcing users to SSH in or use an external terminal.

Additionally, the guard does not actually prevent the original #30719 loop: cron jobs run as subprocesses that inherit `_HERMES_GATEWAY=1`, but the guard triggers on the **first** attempt, not on the loop pattern itself.

## Solution

**Drop the guard entirely.** Trust launchd KeepAlive (or systemd Restart=always / container restart policy) as the only respawn policy. With #35668 (KeepAlive unconditional) merged, the supervisor handles respawn correctly — no agent-side guard needed.

### Behavior comparison

| Scenario | Old guard | No guard (this PR) |
|---|---|---|
| Manual restart from WeChat/Telegram | ❌ Blocked | ✅ Allowed |
| cron fires restart once an hour | ❌ Blocked (if inside gateway) | ✅ Allowed |
| cron fires restart every 10s + KeepAlive (original #30719 loop) | ❌ Blocks 1st attempt (breaks the loop but also breaks valid use) | ✅ KeepAlive ensures stable respawn; the macOS race is fixed in companion PR |

## Companion PRs

- #35668 — KeepAlive unconditional (lands first, this PR depends on it being in)
- macOS via_service race fix (companion PR, incoming) — prevents SIGTERM ping-pong at the source

## Supersedes

- #35815 (loop-detector variant) — closed in favor of this simpler approach

## Test plan

- [x] From inside the gateway (WeChat DM): `hermes gateway restart` now succeeds
- [x] launchd plist shows KeepAlive unconditional after #35668
- [x] Manual restart from terminal still works (was always OK)
- [x] No infinite-loop regression observed