### PR TITLE
feat(anthropic): opt-in HERMES_PREFER_ENV_ANTHROPIC_TOKEN to keep explicit token authoritative

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1077,6 +1077,27 @@ def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] 
     return None
 
 
+def _env_prefers_static_anthropic_token() -> bool:
+    """Opt-in: keep an explicit env ANTHROPIC_TOKEN (e.g. a long-lived
+    `claude setup-token`) authoritative over any refreshable Claude Code
+    credential found in the macOS Keychain or ~/.claude/.credentials.json.
+
+    Set HERMES_PREFER_ENV_ANTHROPIC_TOKEN=1 (or true/yes/on) in ~/.hermes/.env
+    so Hermes and the interactive Claude Code CLI can coexist: the user may log
+    in / out of `claude` freely (which rewrites the keychain) without Hermes
+    silently falling back to that volatile 8h-expiry session token and
+    deauthing overnight.
+    """
+    raw = os.getenv("HERMES_PREFER_ENV_ANTHROPIC_TOKEN", "")
+    if not raw:
+        try:
+            from hermes_cli.config import get_env_value
+            raw = get_env_value("HERMES_PREFER_ENV_ANTHROPIC_TOKEN") or ""
+        except Exception:
+            raw = ""
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
 def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[str, Any]]) -> Optional[str]:
     """Prefer Claude Code creds when a persisted env OAuth token would shadow refresh.
 
@@ -1084,7 +1105,12 @@ def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[s
     later refresh impossible because the static env token wins before we ever
     inspect Claude Code's refreshable credential file. If we have a refreshable
     Claude Code credential record, prefer it over the static env OAuth token.
+
+    Opt-out: when HERMES_PREFER_ENV_ANTHROPIC_TOKEN is set, the explicit env
+    token is kept authoritative and the refreshable credential is ignored.
     """
+    if _env_prefers_static_anthropic_token():
+        return None
     if not env_token or not _is_oauth_token(env_token) or not isinstance(creds, dict):
         return None
     if not creds.get("refreshToken"):

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -349,6 +349,62 @@ class TestResolveAnthropicToken:
 
         assert resolve_anthropic_token() == "sk-ant-oat01-static-token"
 
+    def test_env_token_overrides_refreshable_creds_when_prefer_flag_set(self, monkeypatch, tmp_path):
+        """With HERMES_PREFER_ENV_ANTHROPIC_TOKEN set, an explicit env token wins
+        over a refreshable Claude Code credential (the inverse of the default
+        shadowing behavior in
+        test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token).
+        """
+        monkeypatch.setenv("HERMES_PREFER_ENV_ANTHROPIC_TOKEN", "1")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        # Mock the macOS Keychain off so the file is the only refreshable source.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert resolve_anthropic_token() == "sk-ant-oat01-static-token"
+
+    def test_prefer_flag_off_preserves_default_shadowing(self, monkeypatch, tmp_path):
+        """Sanity: with the flag unset, default behavior is unchanged — the
+        refreshable Claude Code credential still shadows the static env token.
+        """
+        # Force the flag off explicitly. delenv alone is insufficient because the
+        # resolver falls back to reading ~/.hermes/.env, which may set the flag on
+        # the host running the tests. A non-empty "0" short-circuits that fallback.
+        monkeypatch.setenv("HERMES_PREFER_ENV_ANTHROPIC_TOKEN", "0")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "cc-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert resolve_anthropic_token() == "cc-auto-token"
+
 
 class TestRefreshOauthToken:
     def test_returns_none_without_refresh_token(self):


### PR DESCRIPTION
## Summary

Adds an opt-in env flag, `HERMES_PREFER_ENV_ANTHROPIC_TOKEN`, so an explicitly-set `ANTHROPIC_TOKEN` (e.g. a long-lived `claude setup-token`) takes priority over an auto-detected refreshable Claude Code OAuth credential. **Default behavior is unchanged** (flag off → existing precedence preserved).

## Problem

For headless / always-on Hermes deployments on the `anthropic` provider, `resolve_anthropic_token()` prefers a refreshable Claude Code OAuth credential over a static env token (`_prefer_refreshable_claude_code_token`). On macOS, `read_claude_code_credentials()` reads these from the Keychain (`Claude Code-credentials`) first, then `~/.claude/.credentials.json`.

That credential is an **interactive single-user session**: the access token expires ~8h and refreshes via a single-use rotating refresh token. Under concurrent scheduled jobs, multiple processes hit `_refresh_oauth_token()` simultaneously — and there is no lock around the refresh / `_write_claude_code_credentials()`. The rotating token gets invalidated/clobbered, refresh bricks, and the agent fails with `No Anthropic credentials found` until a human re-runs `claude` interactively.

Observed in production: 9–15h overnight outages, with 2–3 cron jobs failing at the *same minute* (the parallel-refresh signature). Supplying a long-lived `claude setup-token` (~1yr) sidesteps all of this — but it is currently **ignored**, because the volatile keychain credential shadows it. Logging into the Claude Code CLI (which rewrites the keychain) silently re-introduces the deauth.

## Fix

Introduce `HERMES_PREFER_ENV_ANTHROPIC_TOKEN` (default off). When truthy (`1`/`true`/`yes`/`on`), `resolve_anthropic_token()` returns a valid explicit `ANTHROPIC_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` before consulting refreshable Claude Code creds — i.e. it skips the `_prefer_refreshable_claude_code_token` shadowing. The default path is byte-for-byte unchanged.

This lets automation users (a) keep using the Claude Code CLI interactively **and** (b) run Hermes on a stable long-lived token, without the two fighting over the same credential store. The flag is read from the environment, falling back to `~/.hermes/.env` via `get_env_value` (matching the existing pattern used for other provider settings).

## Testing

- `test_env_token_overrides_refreshable_creds_when_prefer_flag_set` — with the flag set + a fresh refreshable cred present, the explicit env token wins.
- `test_prefer_flag_off_preserves_default_shadowing` — with the flag off, the refreshable credential still shadows (default behavior intact).
- Manual: resolver returns the long-lived token, and a live `POST /v1/messages` (Bearer + `anthropic-beta: oauth-2025-04-20`) succeeds.

## Optional follow-up (separate PR)

Add a file lock around `_refresh_oauth_token` / `_write_claude_code_credentials` to make the refresh race-safe even for users who stay on the OAuth path.
