### PR TITLE
fix(agent): skip anthropic auto fallback without explicit key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1414,8 +1414,18 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             # Without this gate, Claude Code credentials get silently used
             # as auxiliary fallback when the user's primary provider fails.
             try:
-                from hermes_cli.auth import is_provider_explicitly_configured
+                from hermes_cli.auth import is_provider_explicitly_configured, has_usable_secret
                 if not is_provider_explicitly_configured("anthropic"):
+                    continue
+                # In the auto-provider chain, skip Anthropic unless an
+                # explicit Anthropic credential is present. This prevents
+                # implicit Claude Code OAuth discovery from hijacking
+                # auxiliary fallback when ANTHROPIC_API_KEY is unset.
+                has_explicit_anthropic_key = any(
+                    has_usable_secret(os.getenv(var, ""))
+                    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN")
+                )
+                if not has_explicit_anthropic_key:
                     continue
             except ImportError:
                 pass

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1675,6 +1675,43 @@ def test_resolve_api_key_provider_skips_unconfigured_anthropic(monkeypatch):
         "_try_anthropic() should not be called when anthropic is not explicitly configured"
 
 
+def test_resolve_api_key_provider_skips_anthropic_without_explicit_key(monkeypatch):
+    """Auto provider chain should not try anthropic without explicit env credentials."""
+    from collections import OrderedDict
+    from hermes_cli.auth import ProviderConfig
+
+    fake_registry = OrderedDict({
+        "anthropic": ProviderConfig(
+            id="anthropic",
+            name="Anthropic",
+            auth_type="api_key",
+            inference_base_url="https://api.anthropic.com",
+            api_key_env_vars=("ANTHROPIC_API_KEY",),
+        ),
+    })
+
+    called = []
+
+    def mock_try_anthropic():
+        called.append("anthropic")
+        return None, None
+
+    monkeypatch.setattr("agent.auxiliary_client._try_anthropic", mock_try_anthropic)
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry)
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_provider_explicitly_configured",
+        lambda pid: True,
+    )
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+
+    from agent.auxiliary_client import _resolve_api_key_provider
+    _resolve_api_key_provider()
+
+    assert "anthropic" not in called, \
+        "_try_anthropic() should not be called when no explicit Anthropic env key is set"
+
+
 # ---------------------------------------------------------------------------
 # model="default" elimination (#7512)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Prevents the auxiliary `provider: auto` chain from attempting Anthropic unless an explicit Anthropic env credential is present. This avoids unintended Anthropic fallback attempts when `ANTHROPIC_API_KEY` is unset, which can otherwise lead to long retry/hang behavior in auxiliary flows.

## Related Issue

Fixes #7104

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py`: In `_resolve_api_key_provider()`, Anthropic auto-fallback now requires both: (1) Anthropic explicitly configured, and (2) explicit Anthropic env credential present (`ANTHROPIC_API_KEY` or `ANTHROPIC_TOKEN`).
- `tests/agent/test_auxiliary_client.py`: Added regression test `test_resolve_api_key_provider_skips_anthropic_without_explicit_key` to ensure `_try_anthropic()` is not called when Anthropic is configured but explicit Anthropic env keys are absent.

## How to Test

1. Run targeted regression tests:
   - `pytest tests/agent/test_auxiliary_client.py -q -k "skips_anthropic_without_explicit_key or skips_unconfigured_anthropic"`
2. Verify lint for changed code path:
   - `ruff check .`
3. Run broad project checks:
   - `scripts/run_tests.sh`
   - `pytest tests/ -q -x --timeout=60`

## What platforms tested on

- macOS (darwin-arm64)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted tests for this fix passed: `2 passed, 190 deselected` in `tests/agent/test_auxiliary_client.py`.
- `scripts/run_tests.sh` reports multiple pre-existing unrelated failures in this environment (e.g. `tests/agent/lsp/test_client_e2e.py`, `tests/agent/test_anthropic_adapter.py`, `tests/agent/test_codex_ttfb_watchdog.py`, `tests/cli/test_cli_context_warning.py`).

<!-- autocontrib:worker-id=issue-new-a4b04017 kind=pr-open -->