### PR TITLE
Add Home Assistant MCP skill (optional-skills/mcp/home-assistant)

### DIFF
--- a/optional-skills/mcp/home-assistant/SKILL.md
+++ b/optional-skills/mcp/home-assistant/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: home-assistant
+description: Control Home Assistant — lights, switches, climate, scenes, scripts, and automations — via MCP, with natural-language YAML automation creation and risk assessment. Auth is OAuth 2.0 through Selora Connect.
+version: 1.0.0
+author: Selora Homes
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [HomeAssistant, SmartHome, IoT, HomeAutomation, MCP, OAuth]
+    homepage: https://selorahomes.com/docs/selora-ai/
+    related_skills: [mcporter]
+---
+
+# Home Assistant
+
+Control your smart home from Hermes — lights, switches, climate, scenes, scripts, and automations. Describe new automations in plain English; the skill returns validated Home Assistant YAML with a risk assessment for review before deployment. Auth is OAuth 2.0 via Selora Connect; no long-lived tokens or copy-pasted secrets.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- inspect or change device state in Home Assistant (lights, switches, climate, covers, media players)
+- create or modify automations from a natural-language description
+- validate hand-written automation YAML and check its risk profile before deploying
+- list, accept, or dismiss proactive suggestions surfaced by the Home Assistant integration
+- inspect existing automations, recent chat sessions, or detected behavior patterns
+
+## Prerequisites
+
+1. **Home Assistant** 2025.1+ with the [Selora AI integration](https://selorahomes.com/docs/selora-ai/installation/) installed and enabled.
+2. A **Selora Connect** account with the HA installation linked.
+3. The **MCP URL** for this installation. Find it in Selora Connect after enabling MCP remote access:
+   - Local: `http://homeassistant.local:8123/api/selora_ai/mcp`
+   - Remote: `https://mcp-<id>.selorabox.com/api/selora_ai/mcp`
+
+## How to Run
+
+Register the MCP server with Hermes:
+
+```bash
+hermes mcp add home-assistant \
+  --url https://mcp-<id>.selorabox.com/api/selora_ai/mcp \
+  --auth oauth
+```
+
+This writes the server into `~/.hermes/config.yaml` under `mcp_servers`:
+
+```yaml
+mcp_servers:
+  home-assistant:
+    url: https://mcp-<id>.selorabox.com/api/selora_ai/mcp
+    auth: oauth
+```
+
+For LAN-only access, substitute `http://homeassistant.local:8123/api/selora_ai/mcp` (or the HA IP if mDNS is slow).
+
+Confirm the connection with `hermes mcp test home-assistant`. On first tool invocation, Hermes performs an OAuth 2.0 authorization code + PKCE flow against Selora Connect:
+
+1. Hermes reads `.well-known/oauth-authorization-server` from the MCP endpoint.
+2. Hermes registers itself dynamically (`POST /oauth/register`).
+3. Hermes surfaces an authorization URL — open it, approve access on the Selora Connect consent screen.
+4. The browser callback completes the token exchange; tokens refresh silently from then on.
+
+Verify with: *"Get a snapshot of my home"*. The `selora_get_home_snapshot` tool returns entities grouped by area.
+
+## Quick Reference
+
+**Read tools** (no admin role required):
+
+| Tool | Description |
+|------|-------------|
+| `selora_get_home_snapshot` | Entity states grouped by area — call this first |
+| `selora_list_automations` | Selora automations with status and risk (filterable) |
+| `selora_get_automation` | Full detail: YAML, versions, risk |
+| `selora_validate_automation` | Validate and risk-assess YAML without creating it |
+| `selora_list_sessions` | Recent chat sessions |
+| `selora_list_patterns` | Detected behavior patterns |
+| `selora_get_pattern` | Pattern detail with linked suggestions |
+| `selora_list_suggestions` | Proactive suggestions with YAML previews |
+
+**Mutating tools** (🔒 require `owner` or `member` role on Selora Connect):
+
+| Tool | Description |
+|------|-------------|
+| `selora_chat` 🔒 | Natural-language chat — proposes automations with YAML and risk |
+| `selora_create_automation` 🔒 | Create automation from YAML (disabled by default) |
+| `selora_accept_automation` 🔒 | Enable a pending automation |
+| `selora_delete_automation` 🔒 | Delete permanently |
+| `selora_accept_suggestion` 🔒 | Create automation from a suggestion |
+| `selora_dismiss_suggestion` 🔒 | Dismiss a suggestion |
+| `selora_trigger_scan` 🔒 | Trigger immediate suggestion scan (rate-limited 60s) |
+
+## Procedure
+
+### Inspect the home
+
+1. `selora_get_home_snapshot` to learn entities and areas.
+2. `selora_list_automations` / `selora_get_automation` for existing automations.
+
+### Create an automation from YAML
+
+1. `selora_validate_automation` — check YAML and surface risk.
+2. Show normalized YAML + risk; ask the user to confirm.
+3. `selora_create_automation` with `enabled=false`.
+4. `selora_accept_automation` after explicit approval.
+
+### Create an automation from natural language
+
+1. `selora_chat` — describe the automation; Selora returns YAML + risk.
+2. Summarize risk; ask the user to confirm.
+3. `selora_create_automation`, then `selora_accept_automation`.
+
+### Act on a proactive suggestion
+
+1. `selora_list_suggestions` (optionally `selora_trigger_scan` first).
+2. Show suggestion details; ask the user to confirm.
+3. `selora_accept_suggestion` or `selora_dismiss_suggestion`.
+
+## Pitfalls
+
+- **Never invent entity IDs**. Resolve them from tool output only.
+- **Always surface `risk_assessment`** before any mutation. `high` or missing risk requires a second confirmation.
+- **Create automations disabled by default**; enable only after explicit approval.
+- **Do not skip validation** for externally provided YAML.
+- **Cross-device OAuth callback**: the redirect targets `localhost` on the machine running Hermes. If the browser runs on a different machine, the callback can't reach Hermes' listener. As a fallback, ask the user to copy the full callback URL (including `code` and `state`) from the browser and paste it back for manual exchange.
+- **`401 Unauthorized` loop** without an auth URL surfaced usually means the OAuth flow is not reaching Hermes' listener. Check gateway logs for `401`, auth URL emission, and MCP startup failures. `npx -y mcp-remote <url>` can isolate whether the endpoint or the client is at fault.
+- **Admin tools rejected** when the Selora Connect role is `viewer`. Promote to `member` or `owner`.
+
+## Verification
+
+```bash
+# Sanity-check the MCP endpoint exposes OAuth metadata.
+curl -sS https://mcp-<id>.selorabox.com/api/selora_ai/mcp/.well-known/oauth-authorization-server | jq .
+```
+
+Then ask the agent: *"Get a snapshot of my home"*. Expected: a list of areas with entity states from `selora_get_home_snapshot`. Failure modes: `401 Unauthorized` with an authorization URL surfaced (expected on first use), connection refused (HA not running or URL wrong), or empty tool list (Selora AI integration not enabled in HA).

--- a/optional-skills/mcp/home-assistant/SKILL.md
+++ b/optional-skills/mcp/home-assistant/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: home-assistant
-description: Control Home Assistant — lights, switches, climate, scenes, scripts, and automations — via MCP, with natural-language YAML automation creation and risk assessment. Auth is OAuth 2.0 through Selora Connect.
+description: Control lights, climate, scenes and automations via MCP.
 version: 1.0.0
-author: Selora Homes
+author: Gunnar Beck Nelson (@GChief117)
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -12,7 +12,7 @@ metadata:
     related_skills: [mcporter]
 ---
 
-# Home Assistant
+# Home Assistant Skill
 
 Control your smart home from Hermes — lights, switches, climate, scenes, scripts, and automations. Describe new automations in plain English; the skill returns validated Home Assistant YAML with a risk assessment for review before deployment. Auth is OAuth 2.0 via Selora Connect; no long-lived tokens or copy-pasted secrets.
 
@@ -62,63 +62,70 @@ Confirm the connection with `hermes mcp test home-assistant`. On first tool invo
 3. Hermes surfaces an authorization URL — open it, approve access on the Selora Connect consent screen.
 4. The browser callback completes the token exchange; tokens refresh silently from then on.
 
-Verify with: *"Get a snapshot of my home"*. The `selora_get_home_snapshot` tool returns entities grouped by area.
+Verify with: *"Get a snapshot of my home"*. The `mcp__home_assistant__selora_get_home_snapshot` tool returns entities grouped by area.
 
 ## Quick Reference
+
+Hermes registers MCP tools as `mcp__<server>__<tool>`, so the names below assume the server was
+added as `home-assistant` per [How to Run](#how-to-run). Confirm the exact set with
+`hermes mcp test home-assistant`.
 
 **Read tools** (no admin role required):
 
 | Tool | Description |
 |------|-------------|
-| `selora_get_home_snapshot` | Entity states grouped by area — call this first |
-| `selora_list_automations` | Selora automations with status and risk (filterable) |
-| `selora_get_automation` | Full detail: YAML, versions, risk |
-| `selora_validate_automation` | Validate and risk-assess YAML without creating it |
-| `selora_list_sessions` | Recent chat sessions |
-| `selora_list_patterns` | Detected behavior patterns |
-| `selora_get_pattern` | Pattern detail with linked suggestions |
-| `selora_list_suggestions` | Proactive suggestions with YAML previews |
+| `mcp__home_assistant__selora_get_home_snapshot` | Entity states grouped by area — call this first |
+| `mcp__home_assistant__selora_list_automations` | Selora automations with status and risk (filterable) |
+| `mcp__home_assistant__selora_get_automation` | Full detail: YAML, versions, risk |
+| `mcp__home_assistant__selora_validate_automation` | Validate and risk-assess YAML without creating it |
+| `mcp__home_assistant__selora_list_sessions` | Recent chat sessions |
+| `mcp__home_assistant__selora_list_patterns` | Detected behavior patterns |
+| `mcp__home_assistant__selora_get_pattern` | Pattern detail with linked suggestions |
+| `mcp__home_assistant__selora_list_suggestions` | Proactive suggestions with YAML previews |
 
 **Mutating tools** (🔒 require `owner` or `member` role on Selora Connect):
 
 | Tool | Description |
 |------|-------------|
-| `selora_chat` 🔒 | Natural-language chat — proposes automations with YAML and risk |
-| `selora_create_automation` 🔒 | Create automation from YAML (disabled by default) |
-| `selora_accept_automation` 🔒 | Enable a pending automation |
-| `selora_delete_automation` 🔒 | Delete permanently |
-| `selora_accept_suggestion` 🔒 | Create automation from a suggestion |
-| `selora_dismiss_suggestion` 🔒 | Dismiss a suggestion |
-| `selora_trigger_scan` 🔒 | Trigger immediate suggestion scan (rate-limited 60s) |
+| `mcp__home_assistant__selora_chat` 🔒 | Natural-language chat — proposes automations with YAML and risk |
+| `mcp__home_assistant__selora_create_automation` 🔒 | Create automation from YAML (disabled by default) |
+| `mcp__home_assistant__selora_accept_automation` 🔒 | Enable a pending automation |
+| `mcp__home_assistant__selora_delete_automation` 🔒 | Delete permanently |
+| `mcp__home_assistant__selora_accept_suggestion` 🔒 | Create automation from a suggestion |
+| `mcp__home_assistant__selora_dismiss_suggestion` 🔒 | Dismiss a suggestion |
+| `mcp__home_assistant__selora_trigger_scan` 🔒 | Trigger immediate suggestion scan (rate-limited 60s) |
 
 ## Procedure
 
 ### Inspect the home
 
-1. `selora_get_home_snapshot` to learn entities and areas.
-2. `selora_list_automations` / `selora_get_automation` for existing automations.
+1. `mcp__home_assistant__selora_get_home_snapshot` to learn entities and areas.
+2. `mcp__home_assistant__selora_list_automations` / `mcp__home_assistant__selora_get_automation` for existing automations.
 
 ### Create an automation from YAML
 
-1. `selora_validate_automation` — check YAML and surface risk.
+1. `mcp__home_assistant__selora_validate_automation` — check YAML and surface risk.
 2. Show normalized YAML + risk; ask the user to confirm.
-3. `selora_create_automation` with `enabled=false`.
-4. `selora_accept_automation` after explicit approval.
+3. `mcp__home_assistant__selora_create_automation` with `enabled=false`.
+4. `mcp__home_assistant__selora_accept_automation` after explicit approval.
 
 ### Create an automation from natural language
 
-1. `selora_chat` — describe the automation; Selora returns YAML + risk.
+1. `mcp__home_assistant__selora_chat` — describe the automation; Selora returns YAML + risk.
 2. Summarize risk; ask the user to confirm.
-3. `selora_create_automation`, then `selora_accept_automation`.
+3. `mcp__home_assistant__selora_create_automation`, then `mcp__home_assistant__selora_accept_automation`.
 
 ### Act on a proactive suggestion
 
-1. `selora_list_suggestions` (optionally `selora_trigger_scan` first).
+1. `mcp__home_assistant__selora_list_suggestions` (optionally `mcp__home_assistant__selora_trigger_scan` first).
 2. Show suggestion details; ask the user to confirm.
-3. `selora_accept_suggestion` or `selora_dismiss_suggestion`.
+3. `mcp__home_assistant__selora_accept_suggestion` or `mcp__home_assistant__selora_dismiss_suggestion`.
 
 ## Pitfalls
 
+- **Tool names follow the registered server name.** Registering the server as anything other than
+  `home-assistant` changes the prefix (`hermes mcp add ha ...` yields `mcp__ha__selora_*`). Take the
+  names from `hermes mcp test <server>` rather than assuming the ones documented here.
 - **Never invent entity IDs**. Resolve them from tool output only.
 - **Always surface `risk_assessment`** before any mutation. `high` or missing risk requires a second confirmation.
 - **Create automations disabled by default**; enable only after explicit approval.
@@ -134,4 +141,4 @@ Verify with: *"Get a snapshot of my home"*. The `selora_get_home_snapshot` tool 
 curl -sS https://mcp-<id>.selorabox.com/api/selora_ai/mcp/.well-known/oauth-authorization-server | jq .
 ```
 
-Then ask the agent: *"Get a snapshot of my home"*. Expected: a list of areas with entity states from `selora_get_home_snapshot`. Failure modes: `401 Unauthorized` with an authorization URL surfaced (expected on first use), connection refused (HA not running or URL wrong), or empty tool list (Selora AI integration not enabled in HA).
+Then ask the agent: *"Get a snapshot of my home"*. Expected: a list of areas with entity states from `mcp__home_assistant__selora_get_home_snapshot`. Failure modes: `401 Unauthorized` with an authorization URL surfaced (expected on first use), connection refused (HA not running or URL wrong), or empty tool list (Selora AI integration not enabled in HA).

--- a/tests/skills/test_home_assistant_skill.py
+++ b/tests/skills/test_home_assistant_skill.py
@@ -1,0 +1,117 @@
+"""
+Smoke tests for the home-assistant optional MCP skill.
+
+The skill talks to a live Home Assistant install over MCP behind OAuth, so none
+of that is exercisable in CI. These tests instead pin the things that silently
+rot:
+  - SKILL.md frontmatter conforms to the hardline format
+  - documented tool names match how Hermes actually registers MCP tools
+  - the MCP endpoint URL is not mangled by a tool-name rename
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "mcp" / "home-assistant"
+
+# Mirrors tools/mcp_tool.py: sanitize_mcp_name_component() + mcp_prefixed_tool_name().
+# The skill documents `hermes mcp add home-assistant`, which sanitizes to home_assistant.
+TOOL_PREFIX = "mcp__home_assistant__"
+
+# The Home Assistant route the MCP server is mounted at. It is not a tool, so it
+# must survive any prefixing of the selora_* tool names.
+ENDPOINT_PATH = "/api/selora_ai/mcp"
+
+
+@pytest.fixture(scope="module")
+def skill_md() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text()
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_md: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_md, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+
+
+def test_description_is_one_terminated_sentence(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert desc.endswith("."), f"description must end with a period: {desc!r}"
+    assert desc.count(".") == 1, f"description must be a single sentence: {desc!r}"
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "home-assistant"
+
+
+def test_author_credits_human_contributor(frontmatter) -> None:
+    # AGENTS.md: the human contributor comes first, not the org or the tooling.
+    author = frontmatter["author"]
+    assert "Gunnar Beck Nelson" in author, f"author should credit the contributor: {author!r}"
+    assert "GChief117" in author, f"author should carry the GitHub handle: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_title_has_skill_suffix(skill_md: str) -> None:
+    m = re.search(r"^# (.+)$", skill_md, re.MULTILINE)
+    assert m, "SKILL.md has no H1 title"
+    assert m.group(1).endswith(" Skill"), f"title must use '# <Skill> Skill': {m.group(1)!r}"
+
+
+def test_section_order_matches_hardline(skill_md: str) -> None:
+    expected = [
+        "When to Use",
+        "Prerequisites",
+        "How to Run",
+        "Quick Reference",
+        "Procedure",
+        "Pitfalls",
+        "Verification",
+    ]
+    assert re.findall(r"^## (.+)$", skill_md, re.MULTILINE) == expected
+
+
+def test_tool_references_are_mcp_prefixed(skill_md: str) -> None:
+    """Hermes exposes MCP tools as mcp__<server>__<tool>; bare selora_* names are not callable."""
+    body = skill_md.replace(ENDPOINT_PATH, "")  # endpoint URL is not a tool reference
+    bare = re.findall(r"(?<!__)\bselora_(?!ai\b)[a-z_]+", body)
+    assert not bare, f"bare tool names are not callable, prefix with {TOOL_PREFIX}: {sorted(set(bare))}"
+
+
+def test_documented_tools_all_carry_prefix(skill_md: str) -> None:
+    tools = re.findall(r"`" + re.escape(TOOL_PREFIX) + r"(selora_[a-z_]+)`", skill_md)
+    assert tools, "expected the Quick Reference to document prefixed tool names"
+    assert "selora_get_home_snapshot" in tools, "snapshot tool should stay documented"
+
+
+def test_endpoint_url_not_prefixed(skill_md: str) -> None:
+    """Guards the obvious bad fix: a blind selora_* rename would corrupt the MCP URL."""
+    assert ENDPOINT_PATH in skill_md, "MCP endpoint path should remain documented"
+    assert f"{TOOL_PREFIX}selora_ai" not in skill_md, "endpoint URL must not be tool-prefixed"
+
+
+def test_mutating_tools_flagged(skill_md: str) -> None:
+    # Mutations are gated on a Selora Connect role; the skill must keep saying so.
+    assert f"`{TOOL_PREFIX}selora_create_automation` 🔒" in skill_md
+    assert f"`{TOOL_PREFIX}selora_delete_automation` 🔒" in skill_md


### PR DESCRIPTION
## Summary

Adds an optional skill at `optional-skills/mcp/home-assistant/SKILL.md` that connects Hermes to a Home Assistant installation via MCP, with OAuth 2.0 handled by Selora Connect.

Capabilities surfaced to the agent:

- **Control** — lights, switches, climate, scenes, scripts, covers
- **Automation creation** from natural language with risk assessment (YAML returned for review)
- **YAML validation** before create
- **Proactive suggestions** based on detected behavior patterns

The underlying MCP server (`selora_ai_*` tools, `.well-known/oauth-authorization-server` metadata, dynamic client registration via `POST /oauth/register`, authorization code + PKCE) is production-validated through the [ClawHub](https://clawhub.ai/lafoush/homeassistant-selora) integration today; this PR ports that same skill content to Hermes' format.

## Why a skill, not a tool

Per `CONTRIBUTING.md`: the integration is "instructions + an MCP server already supported by Hermes' OAuth runtime", with no custom Python or API key management. The answer was a skill.

## Category

Placed under `optional-skills/mcp/` alongside `fastmcp` and `mcporter` — `mcporter` is generic MCP-tool calling; `fastmcp` is for building MCP servers; this is the canonical Home Assistant MCP integration. `related_skills: [mcporter]` in the frontmatter for cross-referencing.

## Skill metadata

- **Author**: Selora Homes
- **License**: MIT
- **Platforms**: linux, macos, windows
- **Tags**: `HomeAssistant`, `SmartHome`, `IoT`, `HomeAutomation`, `MCP`, `OAuth`
- **Homepage**: https://selorahomes.com/docs/selora-ai/

## Test plan / local verification

Ran locally on macOS 25.5 with Python 3.11 + uv:

- [x] `python website/scripts/generate-skill-docs.py` discovers the skill (177 skills, was 176), writes `website/docs/user-guide/skills/optional/mcp/mcp-home-assistant.md`, updates `optional-skills-catalog.md` and the Docusaurus sidebar. Per-skill page renders with all frontmatter fields parsed.
- [x] `hermes mcp add home-assistant --url https://mcp-<id>.selorabox.com/api/selora_ai/mcp --auth oauth` accepts the URL and writes a well-formed `mcp_servers.home-assistant` block to `~/.hermes/config.yaml`. `hermes mcp list` shows the server.
- [x] `python scripts/check-windows-footguns.py optional-skills/mcp/home-assistant/SKILL.md` clean.
- [ ] Live OAuth handshake against a reachable HA MCP endpoint — requires a SeloraBox tunnel ID; not exercised in this PR. The same flow is in continuous production use via the ClawHub integration.

## Section order

Follows the modern order from `CONTRIBUTING.md`: title → intro → When to Use → Prerequisites → How to Run → Quick Reference → Procedure → Pitfalls → Verification.

## Not included in this PR

The auto-generated docs page (`mcp-home-assistant.md`), `optional-skills-catalog.md` update, and sidebar entry are not committed here — they regenerate cleanly from `website/scripts/generate-skill-docs.py` and I didn't want to fight ordering churn in unrelated catalog entries. Happy to add them in a follow-up commit if maintainers prefer.