### PR TITLE
fix(cron): handle non-dict jobs.json gracefully instead of crashing #36867

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -429,27 +429,42 @@ def load_jobs() -> List[Dict[str, Any]]:
     if not JOBS_FILE.exists():
         return []
     
+    _strict_retry = False  # track whether we used the strict=False fallback
+    
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            return data.get("jobs", [])
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
+        _strict_retry = True
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
-                jobs = data.get("jobs", [])
-                if jobs:
-                    # Auto-repair: rewrite with proper escaping
-                    save_jobs(jobs)
-                    logger.warning("Auto-repaired jobs.json (had invalid control characters)")
-                return jobs
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
             raise RuntimeError(f"Cron database corrupted and unrepairable: {e}") from e
     except IOError as e:
         logger.error("IOError reading jobs.json: %s", e)
         raise RuntimeError(f"Failed to read cron database: {e}") from e
+
+    # Validate top-level JSON shape: accept dict (expected) or bare list (auto-repair).
+    if isinstance(data, dict):
+        jobs = data.get("jobs", [])
+        if _strict_retry and jobs:
+            # We hit control-character corruption; rewrite with proper escaping
+            save_jobs(jobs)
+            logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+        return jobs
+    if isinstance(data, list):
+        # Bare array — likely saved/edited outside save_jobs(). Auto-repair.
+        if data:
+            save_jobs(data)
+            logger.warning("Auto-repaired jobs.json (bare list → wrapped as dict)")
+        return data
+
+    raise RuntimeError(
+        f"Cron database corrupted: expected {{'jobs': [...]}}, got {type(data).__name__}"
+    )
 
 
 def save_jobs(jobs: List[Dict[str, Any]]):


### PR DESCRIPTION
## Problem

When `cron/jobs.json` contains a top-level JSON value that isn't a dict (e.g. a bare array `[...]`), `load_jobs()` raises an uncaught `AttributeError` because `.get("jobs", [])` is called on a `list`. This takes down the entire cron subsystem — scheduler ticks fail, the `cronjob` agent tool returns errors — until the file is repaired manually.

## Fix

After `json.load()` succeeds (on either the normal or the `strict=False` retry path), `load_jobs()` now validates the top-level JSON shape:

- **dict** (expected): `data.get("jobs", [])` as before.
- **list** (bare array): auto-repairs by calling `save_jobs()` to wrap it in the expected `{"jobs": [...], "updated_at": ...}` dict structure, then returns the list.
- **anything else** (str, number, null, etc.): raises `RuntimeError("Cron database corrupted: expected {'jobs': [...]}, got <type>")`.

The auto-repair for control-character corruption in the `strict=False` path is preserved via a `_strict_retry` flag.

## Related issue

Closes #36867