### PR TITLE
fix(whatsapp): honor dm_policy and group_policy open at the gateway

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1734,8 +1734,8 @@ class BasePlatformAdapter(ABC):
     def enforces_own_access_policy(self) -> bool:
         """Whether this adapter gates inbound access before dispatch.
 
-        Some adapters (WeCom, Weixin, Yuanbao, QQBot) implement a documented
-        config-driven access surface — ``dm_policy`` / ``group_policy`` /
+        Some adapters (WeCom, Weixin, Yuanbao, QQBot, WhatsApp) implement a
+        documented config-driven access surface — ``dm_policy`` / ``group_policy`` /
         ``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra`` — and
         enforce it at intake: a message is dropped inside the adapter and never
         reaches the gateway unless it already passed that policy.

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -379,6 +379,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return True
         return False
 
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """WhatsApp gates DM/group access at intake via dm_policy/group_policy."""
+        return True
+
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
         if self._dm_policy == "disabled":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6820,8 +6820,8 @@ class GatewayRunner:
         """Whether the adapter for *platform* gates access at intake itself.
 
         Mirrors ``BasePlatformAdapter.enforces_own_access_policy``. Adapters
-        such as WeCom, Weixin, Yuanbao, and QQBot evaluate their documented
-        ``dm_policy`` / ``group_policy`` / ``allow_from`` config before a
+        such as WeCom, Weixin, Yuanbao, QQBot, and WhatsApp evaluate their
+        documented ``dm_policy`` / ``group_policy`` / ``allow_from`` config before a
         message is dispatched to the gateway, so a message that reaches
         ``_is_user_authorized`` has already been authorized by the adapter.
         Defaults to ``False`` when the adapter is unknown or doesn't expose

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -1,8 +1,9 @@
 """Tests for config-driven platform access policies at the gateway layer.
 
-Background (#34515): WeCom, Weixin, Yuanbao, and QQBot expose a documented
-config-driven access surface (``dm_policy`` / ``group_policy`` / ``allow_from``
-/ ``group_allow_from`` in ``PlatformConfig.extra``) and enforce it at intake —
+Background (#34515): WeCom, Weixin, Yuanbao, QQBot, and WhatsApp expose a
+documented config-driven access surface (``dm_policy`` / ``group_policy`` /
+``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra``) and enforce
+it at intake —
 a message is dropped inside the adapter and never reaches the gateway unless it
 already passed that policy.
 
@@ -34,6 +35,7 @@ _OWN_POLICY_PLATFORMS = [
     Platform.WEIXIN,
     Platform.YUANBAO,
     Platform.QQBOT,
+    Platform.WHATSAPP,
 ]
 
 
@@ -44,6 +46,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "YUANBAO_ALLOWED_USERS",
         "QQ_ALLOWED_USERS",
         "QQ_GROUP_ALLOWED_USERS",
+        "WHATSAPP_ALLOWED_USERS",
         "TELEGRAM_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
@@ -51,6 +54,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "WEIXIN_ALLOW_ALL_USERS",
         "YUANBAO_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
+        "WHATSAPP_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -103,10 +107,11 @@ def test_base_adapter_defaults_to_not_owning_access_policy():
         ("gateway.platforms.weixin", "WeixinAdapter"),
         ("gateway.platforms.yuanbao", "YuanbaoAdapter"),
         ("gateway.platforms.qqbot.adapter", "QQAdapter"),
+        ("gateway.platforms.whatsapp", "WhatsAppAdapter"),
     ],
 )
 def test_own_policy_adapters_declare_the_flag(module_path, class_name):
-    """The four config-policy adapters override the flag to True."""
+    """The config-policy adapters override the flag to True."""
     import importlib
 
     module = importlib.import_module(module_path)


### PR DESCRIPTION
## What does this PR do?

The WhatsApp adapter gates inbound access at intake via its documented
config surface (`dm_policy` / `group_policy` / `allow_from` / `group_allow_from`),
but it never overrode `enforces_own_access_policy`. As a result the gateway's
`_is_user_authorized()` re-applied its env-only default-deny: when no
`WHATSAPP_ALLOWED_USERS` (or other allowlist) was set, a message the adapter had
**already authorized** (e.g. `dm_policy: open`, the documented default) was
dropped again at the gateway — so `whatsapp.dm_policy: open` and
`whatsapp.group_policy: open` did not actually work, and users saw a silent drop /
unexpected pairing prompt.

The fix declares `enforces_own_access_policy = True` on `WhatsAppAdapter`. This is
the exact drift-proof contract already used by WeCom, Weixin, Yuanbao, and QQBot
(introduced in #34515): the gateway trusts that an own-policy adapter authorized
the sender at intake and skips the env-only default-deny — while an explicit env
allowlist still takes precedence when configured. WhatsApp has the identical
config surface as those adapters and was simply missed when the flag was added.

No gateway logic changes were needed: `_is_user_authorized()` and
`_get_unauthorized_dm_behavior()` already read the flag / `dm_policy` generically,
so this is a one-line behavioral change plus tests and doc-string updates.

## Related Issue

<!-- #34515 is the originating issue/PR that established the
     enforces_own_access_policy contract for WeCom/Weixin/Yuanbao/QQBot; this PR
     extends the same fix to WhatsApp. Link a WhatsApp-specific issue here if one exists. -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/whatsapp.py` — add `enforces_own_access_policy` property
  (`-> True`) to `WhatsAppAdapter`, matching the WeCom/Weixin/Yuanbao/QQBot pattern.
- `gateway/platforms/base.py` — update the `enforces_own_access_policy` doc-string
  to list WhatsApp among the own-policy adapters.
- `gateway/run.py` — update the `_adapter_enforces_own_access_policy` doc-string to
  list WhatsApp.
- `tests/gateway/test_config_driven_access_policy.py` — add WhatsApp to
  `_OWN_POLICY_PLATFORMS`, to the adapter-declares-the-flag parametrization, and to
  the env-clearing helper, so the real adapter's flag and the gateway's
  trust-without-env-allowlist behavior (DM **and** group) are both covered.

## How to Test

1. **Reproduce (before fix):** configure WhatsApp with `dm_policy: open` and no
   `WHATSAPP_ALLOWED_USERS` / `WHATSAPP_ALLOW_ALL_USERS`. A DM that the adapter
   admits at intake is rejected at the gateway (`_is_user_authorized()` returns
   `False` → default-deny), so the user gets a silent drop / pairing prompt
   instead of a reply.
2. **After fix:** the same DM is authorized — the gateway trusts the adapter's
   intake decision. Setting `WHATSAPP_ALLOWED_USERS` still restricts access (env
   allowlist wins), and `dm_policy: allowlist` / `disabled` still gate correctly.
3. **Automated:**

       pytest tests/gateway/test_config_driven_access_policy.py \
              tests/gateway/test_whatsapp_group_gating.py \
              tests/gateway/test_unauthorized_dm_behavior.py -q

   All pass (79), including the new WhatsApp parametrizations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests and they pass (`tests/gateway/test_config_driven_access_policy.py`, `test_whatsapp_group_gating.py`, `test_unauthorized_dm_behavior.py` → 79 passed; full-suite parity is covered by Linux CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated `base.py` / `run.py` docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python property; no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A