### PR TITLE
fix(model_metadata): drop stale ≤256,000 cache entries for Grok-4.3

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1140,6 +1140,18 @@ def _model_name_suggests_minimax_m3(model: str) -> bool:
     return "minimax-m3" in model.lower()
 
 
+def _model_name_suggests_grok_4_3(model: str) -> bool:
+    """Return True if the model name looks like a Grok 4.3 variant.
+
+    Catches ``grok-4.3``, ``grok-4.3-latest``, and similar slugs.
+    Used as a guard against stale cache entries seeded by pre-catalog builds
+    that resolved grok-4.3 via the generic ``grok-4`` catch-all (256,000)
+    before the ``grok-4.3`` (1M) entry was added to DEFAULT_CONTEXT_LENGTHS
+    on 2026-05-15.
+    """
+    return "grok-4.3" in model.lower()
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length."""
     import httpx
@@ -1560,6 +1572,19 @@ def get_model_context_length(
             elif cached <= 204_800 and _model_name_suggests_minimax_m3(model):
                 logger.info(
                     "Dropping stale MiniMax-M3 cache entry %s@%s -> %s (pre-catalog value); "
+                    "re-resolving via hardcoded defaults",
+                    model, base_url, f"{cached:,}",
+                )
+                _invalidate_cached_context_length(model, base_url)
+            # Invalidate stale ≤256,000 cache entries for Grok-4.3.  The
+            # ``grok-4.3`` (1M) entry was added to DEFAULT_CONTEXT_LENGTHS on
+            # 2026-05-15; prior to that, grok-4.3 slugs resolved via the
+            # ``grok-4`` catch-all (256,000) and that value was persisted.
+            # grok-4.3 is 1M, so any sub-262K cached value is a pre-catalog
+            # leftover — drop it and fall through to the hardcoded default.
+            elif cached <= 256_000 and _model_name_suggests_grok_4_3(model):
+                logger.info(
+                    "Dropping stale Grok-4.3 cache entry %s@%s -> %s (pre-catalog value); "
                     "re-resolving via hardcoded defaults",
                     model, base_url, f"{cached:,}",
                 )

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1247,3 +1247,59 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+class TestGrok43StaleCacheGuard:
+    """Pre-catalog builds resolved grok-4.3 via the generic 'grok-4' catch-all
+    (256,000) and persisted it before the 'grok-4.3' (1M) catalog entry was
+    added on 2026-05-15.  The step-1 cache guard must drop that stale value
+    and re-resolve to 1M, while leaving correct grok-4 entries (256,000)
+    untouched.
+    """
+
+    def test_suggests_grok_4_3(self):
+        from agent.model_metadata import _model_name_suggests_grok_4_3
+        assert _model_name_suggests_grok_4_3("grok-4.3")
+        assert _model_name_suggests_grok_4_3("grok-4.3-latest")
+        assert _model_name_suggests_grok_4_3("xai/grok-4.3")
+        assert not _model_name_suggests_grok_4_3("grok-4")
+        assert not _model_name_suggests_grok_4_3("grok-4-fast")
+        assert not _model_name_suggests_grok_4_3("grok-4.20")
+
+    def test_stale_grok_4_3_dropped_and_reresolves_to_1m(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.x.ai/v1"
+        mm.save_context_length("grok-4.3", base, 256_000)
+        ctx = mm.get_model_context_length(
+            "grok-4.3", base_url=base, api_key="", provider="xai"
+        )
+        assert ctx == 1_000_000
+
+    def test_correct_grok_4_3_cache_preserved(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.x.ai/v1"
+        mm.save_context_length("grok-4.3", base, 1_000_000)
+        ctx = mm.get_model_context_length(
+            "grok-4.3", base_url=base, api_key="", provider="xai"
+        )
+        assert ctx == 1_000_000
+
+    def test_grok_4_not_clobbered(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.x.ai/v1"
+        # 256,000 is the CORRECT value for plain grok-4 — guard must not touch it.
+        for slug in ("grok-4", "grok-4-0709"):
+            mm.save_context_length(slug, base, 256_000)
+            ctx = mm.get_model_context_length(
+                slug, base_url=base, api_key="", provider="xai"
+            )
+            assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"


### PR DESCRIPTION
## Root Cause

`grok-4.3` (1M context) was added to `DEFAULT_CONTEXT_LENGTHS` on 2026-05-15
(`ce0e189d3`). The generic `grok-4` entry (256,000) was added earlier on
2026-04-10 (`b57769718`). In the 35-day window between those two commits,
any lookup of a `grok-4.3` slug hit `DEFAULT_CONTEXT_LENGTHS` via the
`"grok-4" in model_lower` substring match and cached **256,000** to disk.

`get_model_context_length()` reads the persistent cache at step 1 before
reaching the hardcoded defaults in step 8, so those stale 256K entries are
returned indefinitely — users see `"Context: 256K tokens (detected)"` when
the real limit is 1M.

## Fix

Mirror the existing Kimi / Codex / MiniMax-M3 stale-cache guards:

- Add `_model_name_suggests_grok_4_3()` (matches `grok-4.3`, `grok-4.3-latest`,
  `xai/grok-4.3`, etc.)
- Add an `elif cached <= 256_000 and _model_name_suggests_grok_4_3(model)` branch
  in `get_model_context_length()` that drops the stale entry so the next lookup
  falls through to the 1M hardcoded default.

The threshold 256,000 is exact: it is the value that `"grok-4"` resolves to and
the only value that could have been cached for a grok-4.3 slug during the gap
period. Correct 1M entries and unrelated grok-4 / grok-4-fast entries are
untouched.

## Tests

4 new tests in `TestGrok43StaleCacheGuard`:

- `test_suggests_grok_4_3` — unit-tests the helper (positive and negative cases)
- `test_stale_grok_4_3_dropped_and_reresolves_to_1m` — stale 256K entry is
  dropped and re-resolved to 1M
- `test_correct_grok_4_3_cache_preserved` — a correct 1M entry is not touched
- `test_grok_4_not_clobbered` — plain `grok-4` / `grok-4-0709` at 256K (correct
  for those slugs) is not clobbered

```
tests/agent/test_model_metadata.py::TestGrok43StaleCacheGuard - 4 passed
tests/agent/test_minimax_provider.py                           - 88 passed (no regression)
tests/agent/test_model_metadata.py                             - 144 passed total
```