### PR TITLE
fix(gateway): honor WECOM_ALLOWED_USERS in env only WeCom DM allowlist

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -161,7 +161,15 @@ class WeComAdapter(BasePlatformAdapter):
         ).strip() or DEFAULT_WS_URL
 
         self._dm_policy = str(extra.get("dm_policy") or os.getenv("WECOM_DM_POLICY", "open")).strip().lower()
-        self._allow_from = _coerce_list(extra.get("allow_from") or extra.get("allowFrom"))
+        # dm_policy already honors WECOM_DM_POLICY, so the allowlist must honor
+        # WECOM_ALLOWED_USERS too. Without the env fallback an env-only setup
+        # (dm_policy=allowlist via env, no config extra) runs with an empty
+        # allowlist and drops every authorized DM at intake.
+        self._allow_from = _coerce_list(
+            extra.get("allow_from")
+            or extra.get("allowFrom")
+            or os.getenv("WECOM_ALLOWED_USERS", "")
+        )
 
         self._group_policy = str(extra.get("group_policy") or os.getenv("WECOM_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -285,6 +285,39 @@ class TestPolicyHelpers:
         assert adapter._is_dm_allowed("user-1") is True
         assert adapter._is_dm_allowed("user-2") is False
 
+    def test_dm_allowlist_honors_env_only_allowed_users(self, monkeypatch):
+        """Env-only setup (WECOM_DM_POLICY + WECOM_ALLOWED_USERS, no config
+        ``extra``) must populate the DM allowlist. Otherwise ``dm_policy:
+        allowlist`` runs with an empty allowlist and drops every listed user
+        at intake — the documented env vars become no-ops."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setenv("WECOM_DM_POLICY", "allowlist")
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "user-1, user-2")
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        assert adapter._dm_policy == "allowlist"
+        assert adapter._allow_from == ["user-1", "user-2"]
+        assert adapter._is_dm_allowed("user-1") is True
+        assert adapter._is_dm_allowed("user-2") is True
+        assert adapter._is_dm_allowed("stranger") is False
+
+    def test_dm_allowlist_extra_takes_precedence_over_env(self, monkeypatch):
+        """Config ``extra`` wins over the env fallback, so an explicit
+        allowlist is never silently widened by a stray WECOM_ALLOWED_USERS."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "env-user")
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "allowlist", "allow_from": ["cfg-user"]})
+        )
+
+        assert adapter._allow_from == ["cfg-user"]
+        assert adapter._is_dm_allowed("cfg-user") is True
+        assert adapter._is_dm_allowed("env-user") is False
+
     def test_group_allowlist_and_per_group_sender_allowlist(self):
         from gateway.platforms.wecom import WeComAdapter
 


### PR DESCRIPTION
## What does this PR do?

Fixes WeCom DM allowlists silently failing in **env-only** setups.

The WeCom adapter resolves `dm_policy` from `WECOM_DM_POLICY` (env) with a
fallback, but resolves `allow_from` **only** from `PlatformConfig.extra` — it
never read `WECOM_ALLOWED_USERS`. The env bootstrap in `gateway/config.py`
also doesn't carry these values into `extra`. So an operator who configures
WeCom purely via env (`WECOM_DM_POLICY=allowlist` + `WECOM_ALLOWED_USERS=...`,
both documented) ends up with `_dm_policy="allowlist"` but `_allow_from=[]`.
Every DM — including from explicitly allowed users — is then dropped at intake
in `_is_dm_allowed()` before it ever reaches the gateway.

This also contradicts the gateway layer, which already reads
`WECOM_ALLOWED_USERS` in `_is_user_authorized()`, and the documented behavior
in `website/docs/user-guide/messaging/wecom.md`.

The fix adds the `WECOM_ALLOWED_USERS` env fallback to `allow_from`, mirroring:
- the `dm_policy`/`_ws_url` resolution idiom already used two lines above in the
  same constructor (`extra(snake) or extra(camel) or os.getenv(...)`), and
- the sibling Weixin adapter (`gateway/platforms/weixin.py`), which reads
  `WEIXIN_ALLOWED_USERS` the same way.

Config `extra` still takes precedence over the env var, so explicit allowlists
are never silently widened. Scope is kept to the documented DM path; no new
(undocumented) env var is introduced.

## Related Issue

<!-- Link an issue if one exists; otherwise remove this line. -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/wecom.py` — `WeComAdapter.__init__` now falls back to
  `WECOM_ALLOWED_USERS` when `allow_from`/`allowFrom` are absent from `extra`,
  matching how `dm_policy` already falls back to `WECOM_DM_POLICY`.
- `tests/gateway/test_wecom.py` — added two `TestPolicyHelpers` cases:
  - `test_dm_allowlist_honors_env_only_allowed_users` (reproduces the bug:
    env-only allowlist now admits listed users and rejects strangers)
  - `test_dm_allowlist_extra_takes_precedence_over_env` (guards the
    config-over-env precedence contract)

## How to Test

**Reproduction (before the fix):** with only env set —
`WECOM_BOT_ID`, `WECOM_SECRET`, `WECOM_DM_POLICY=allowlist`,
`WECOM_ALLOWED_USERS=user-1` — DMs from `user-1` are dropped at intake
(`_is_dm_allowed("user-1")` returns `False` because `_allow_from == []`).

**Proof the fix works:**

1. `WeComAdapter(PlatformConfig(enabled=True))` with the env above now yields
   `_allow_from == ["user-1"]` and `_is_dm_allowed("user-1") is True`,
   `_is_dm_allowed("stranger") is False`.
2. Run the targeted suites:
   ```
   scripts/run_tests.sh tests/gateway/test_wecom.py tests/gateway/test_config_driven_access_policy.py
   ```
  
   `python -m pytest tests/gateway/test_wecom.py tests/gateway/test_config_driven_access_policy.py -m "not integration" --timeout=30 --timeout-method=thread` → **66 passed**;
   `--timeout-method=signal` from `addopts` is skipped on Windows since
   `SIGALRM` is Unix-only.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran targeted gateway suites (66 passed) on Windows; please run the full suite via scripts/run_tests.sh on Linux before merge -->
- [x] I've added tests for my changes


### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (fix aligns code with already-documented `WECOM_ALLOWED_USERS` / `WECOM_DM_POLICY` behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure `os.getenv` resolution, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A