### PR TITLE
fix: suppress shared-channel empty model status noise

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -85,6 +85,16 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+_SHARED_CHANNEL_NOISY_STATUS_RE = re.compile(
+    r"("  # transient model status that should stay in logs, not shared chats
+    r"empty\s+response\s+from\s+model\s+[-—]\s+retrying"
+    r"|model\s+returned\s+no\s+content\s+after\s+all\s+retries"
+    r"|model\s+returned\s+no\s+response\s+after\s+processing\s+tool\s+results"
+    r"|model\s+produced\s+reasoning\s+but\s+no\s+visible\s+response"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -306,6 +316,12 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
     if not text:
+        return None
+    # Empty-model retry/failure chatter is useful in logs but too noisy in
+    # shared messaging rooms (Discord HQ/team channels, Telegram DMs, etc.).
+    # Keep the final response path separate so real user-facing failures still
+    # surface through the normal assistant reply when appropriate.
+    if _SHARED_CHANNEL_NOISY_STATUS_RE.search(text):
         return None
     if _gateway_platform_value(platform) != "telegram":
         return text

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -22,12 +22,26 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
 
 
-def test_non_telegram_status_is_unchanged():
-    """The Telegram quieting policy must not hide CLI/Discord diagnostics."""
+def test_non_telegram_status_is_unchanged_for_general_diagnostics():
+    """The Telegram-only quieting policy must not hide general CLI/Discord diagnostics."""
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."
 
     assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
+def test_shared_channel_status_suppresses_empty_model_chatter():
+    """Transient empty-model status chatter should stay out of shared channels."""
+    noisy_messages = [
+        "⚠️ Empty response from model — retrying (1/3)",
+        "❌ Model returned no content after all retries. No fallback providers configured.",
+        "⚠️ Model produced reasoning but no visible response after all retries. Returning empty.",
+        "Model returned no response after processing tool results; try again or rephrase.",
+    ]
+
+    for message in noisy_messages:
+        assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) is None
+        assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) is None
 
 
 def test_telegram_status_sanitizes_raw_provider_security_errors():


### PR DESCRIPTION
## Summary
- Suppress known transient empty-model retry/failure status messages before delivery to shared messaging channels.
- Preserve general non-Telegram diagnostics, including ordinary retry lifecycle messages.
- Add regression coverage for Discord/shared-channel empty-model chatter while keeping Telegram quieting behavior intact.

## Test plan
- `pytest -q tests/gateway/test_telegram_noise_filter.py`

## Notes
- This only filters gateway status-message delivery for specific empty-model chatter; logs and final assistant responses remain separate.
- Local unrelated change in `agent/codex_runtime.py` was intentionally excluded from this PR.
