### PR TITLE
fix: bridge WhatsApp gateway settings from config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -896,6 +896,20 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                # WhatsApp bridge settings — without these keys the shared-key loop
+                # skips the whatsapp: block entirely when enabled is not explicit,
+                # so bridge_port / bridge_script / session_path never reach extra.
+                if plat == Platform.WHATSAPP:
+                    if "bridge_port" in platform_cfg:
+                        bridged["bridge_port"] = platform_cfg["bridge_port"]
+                    if "bridge_script" in platform_cfg:
+                        bridged["bridge_script"] = platform_cfg["bridge_script"]
+                    if "session_path" in platform_cfg:
+                        bridged["session_path"] = platform_cfg["session_path"]
+                    if "text_batch_delay_seconds" in platform_cfg:
+                        bridged["text_batch_delay_seconds"] = platform_cfg["text_batch_delay_seconds"]
+                    if "text_batch_split_delay_seconds" in platform_cfg:
+                        bridged["text_batch_split_delay_seconds"] = platform_cfg["text_batch_split_delay_seconds"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -648,6 +648,30 @@ class TestLoadGatewayConfig:
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
 
+    def test_bridges_whatsapp_bridge_settings_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  bridge_port: 18791\n"
+            "  bridge_script: /tmp/whatsapp-bridge.js\n"
+            "  session_path: /tmp/whatsapp-session\n"
+            "  text_batch_delay_seconds: 1.5\n"
+            "  text_batch_split_delay_seconds: 0.25\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.WHATSAPP].extra["bridge_port"] == 18791
+        assert config.platforms[Platform.WHATSAPP].extra["bridge_script"] == "/tmp/whatsapp-bridge.js"
+        assert config.platforms[Platform.WHATSAPP].extra["session_path"] == "/tmp/whatsapp-session"
+        assert config.platforms[Platform.WHATSAPP].extra["text_batch_delay_seconds"] == 1.5
+        assert config.platforms[Platform.WHATSAPP].extra["text_batch_split_delay_seconds"] == 0.25
+
     def test_bridges_telegram_disable_link_previews_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- Bridge WhatsApp adapter settings from `config.yaml` into platform `extra` when `enabled` is not explicitly set.
- Add regression coverage for `bridge_port`, `bridge_script`, `session_path`, and text batching delay keys.

## Test plan
- `venv/bin/python -m pytest tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_whatsapp_bridge_settings_from_config_yaml -q -o 'addopts='`
- `venv/bin/python -m pytest tests/gateway/test_config.py -q -o 'addopts='`

## Notes
- Direct push to upstream was denied, so this PR is opened from the authenticated fork.
