### PR TITLE
fix(cli): prepend turn notes to multimodal messages

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2355,6 +2355,40 @@ def _format_image_attachment_badges(attached_images: list[Path], image_counter: 
     )
 
 
+def _prepend_turn_note_to_message(note: str, message):
+    """Prepend a one-shot CLI note to text or native multimodal content."""
+    note = str(note or "").strip()
+    if not note:
+        return message
+
+    if isinstance(message, str):
+        return f"{note}\n\n{message}" if message else note
+
+    if isinstance(message, list):
+        updated = []
+        inserted = False
+        for part in message:
+            if (
+                not inserted
+                and isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            ):
+                new_part = dict(part)
+                text = new_part.get("text", "")
+                new_part["text"] = f"{note}\n\n{text}" if text else note
+                updated.append(new_part)
+                inserted = True
+            else:
+                updated.append(part)
+
+        if not inserted:
+            return [{"type": "text", "text": note}, *updated]
+        return updated
+
+    return f"{note}\n\n{message}"
+
+
 def _should_auto_attach_clipboard_image_on_paste(pasted_text: str) -> bool:
     """Auto-attach clipboard images only for image-only paste gestures."""
     return not pasted_text.strip()
@@ -12138,14 +12172,14 @@ class HermesCLI:
                 # Prepend pending model switch note so the model knows about the switch
                 _msn = getattr(self, '_pending_model_switch_note', None)
                 if _msn:
-                    agent_message = _msn + "\n\n" + agent_message
+                    agent_message = _prepend_turn_note_to_message(_msn, agent_message)
                     self._pending_model_switch_note = None
                 # Prepend pending /reload-skills note so the model sees which
                 # skills were added/removed before handling this turn. Same
                 # one-shot queue pattern as the model-switch note above.
                 _srn = getattr(self, '_pending_skills_reload_note', None)
                 if _srn:
-                    agent_message = _srn + "\n\n" + agent_message
+                    agent_message = _prepend_turn_note_to_message(_srn, agent_message)
                     self._pending_skills_reload_note = None
                 try:
                     result = self.agent.run_conversation(

--- a/tests/cli/test_cli_image_command.py
+++ b/tests/cli/test_cli_image_command.py
@@ -5,6 +5,7 @@ from cli import (
     HermesCLI,
     _collect_query_images,
     _format_image_attachment_badges,
+    _prepend_turn_note_to_message,
     _termux_example_image_path,
 )
 
@@ -107,3 +108,33 @@ class TestImageBadgeFormatting:
         badges = _format_image_attachment_badges([img1, img2], image_counter=2, width=45)
 
         assert badges == "[📎 2 images attached]"
+
+
+class TestPrependTurnNoteToMessage:
+    def test_prepends_note_to_text_message(self):
+        message = _prepend_turn_note_to_message("[MODEL SWITCHED]", "describe this")
+
+        assert message == "[MODEL SWITCHED]\n\ndescribe this"
+
+    def test_prepends_note_to_native_image_text_part_without_mutating_original(self):
+        original = [
+            {"type": "text", "text": "What do you see?\n\n[Image attached at: /tmp/a.png]"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+
+        message = _prepend_turn_note_to_message("[MODEL SWITCHED]", original)
+
+        assert isinstance(message, list)
+        assert message[0]["text"].startswith("[MODEL SWITCHED]\n\nWhat do you see?")
+        assert message[1] == original[1]
+        assert original[0]["text"].startswith("What do you see?")
+
+    def test_inserts_text_part_when_native_message_has_only_images(self):
+        original = [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+
+        message = _prepend_turn_note_to_message("[MODEL SWITCHED]", original)
+
+        assert message[0] == {"type": "text", "text": "[MODEL SWITCHED]"}
+        assert message[1] == original[0]


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI crash when a user switches model mid-session and then sends an image attachment as the next turn.

The CLI queues one-shot notes after commands such as `/model` and `/reload-skills` so the model sees the updated session state on the next user turn. That path assumed the next message was always a string. Native image attachment routing can instead turn the next message into an OpenAI-style content-parts list, so the CLI crashed while trying to concatenate the note with a list.

This adds a small helper that prepends queued CLI notes to either plain text messages or native multimodal content lists. For content lists, it prefixes the first text part, or inserts a text part before image parts when no text part exists.

## Related Issue

No issue filed. Reported on Discord by privacydied.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: add `_prepend_turn_note_to_message()` for one-shot CLI notes on string and native multimodal messages.
- `cli.py`: use the helper for pending model-switch notes and pending skills-reload notes.
- `tests/cli/test_cli_image_command.py`: add regression coverage for text messages, native image messages with a text part, and image-only content-part lists.

## How to Test

1. Start Hermes on one model, then run `/model gpt-5.5 --provider openai-codex`.
2. Attach or paste an image as the next message.
3. Confirm the CLI does not crash with `TypeError: can only concatenate str (not "list") to str` and the image turn reaches the model.

Focused local validation:

- `scripts/run_tests.sh -j 4 tests/cli/test_cli_image_command.py` — 12 passed
- `scripts/run_tests.sh -j 4 tests/cli/test_cli_reload_skills.py` — 3 passed
- `git diff --check -- cli.py tests/cli/test_cli_image_command.py` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux 6.6.87.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Original crash:

`TypeError: can only concatenate str (not "list") to str`

Crash site was the pending model-switch note prepend path when the next message was a native multimodal content-parts list.
