### PR TITLE
fix(dashboard): surface Docker update guidance instead of generic failure (#34347)

### DIFF
--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -71,10 +71,28 @@ export function SystemActionsProvider({
       try {
         if (action === "restart") {
           await api.restartGateway();
+          setActiveAction(action);
         } else {
-          await api.updateHermes();
+          const resp = await api.updateHermes();
+          // In a Docker install the image is immutable, so `hermes update`
+          // can't apply — the endpoint returns 200 with a structured
+          // {ok:false, error:"docker_update_unsupported", message, update_command}
+          // envelope instead of spawning the action (see #34347 / #36263).
+          // Surface that guidance to the user rather than starting the poll,
+          // which would otherwise report a generic "failed (exit 1)".
+          if (!resp.ok && resp.error === "docker_update_unsupported") {
+            const cmd = resp.update_command ? `  ${resp.update_command}` : "";
+            setToast({
+              type: "success",
+              message:
+                (resp.message ??
+                  "Updates don't apply inside Docker — re-pull the image instead.") +
+                cmd,
+            });
+            return;
+          }
+          setActiveAction(action);
         }
-        setActiveAction(action);
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         setToast({


### PR DESCRIPTION
## Summary

Closes #34347 — the dashboard "Update" button's frontend half.

The backend guard for this landed in #36263: `/api/hermes/update` detects a Docker install and returns a structured `{ok:false, error:"docker_update_unsupported", message, update_command}` envelope (HTTP 200) instead of surfacing a raw `SystemExit`. That fixed the crash, but the **frontend never consumed the envelope**: `runAction()` in `SystemActions.tsx` only branched on a *thrown* error, so the 200 response fell through to the action-status poll, which reported a generic `"Action failed (exit 1)"` toast — the guidance message and re-pull command were only visible if the user dug into the action log.

This wires the frontend to inspect the update response: on the `docker_update_unsupported` case it surfaces the backend's guidance `message` plus the recommended `update_command` directly (success-styled, since it's actionable guidance rather than a failure) and skips the poll.

## Verification

- `tsc --noEmit` clean.
- `eslint src/contexts/SystemActions.tsx` clean.
- Frontend matches the backend contract (`ok` / `error` / `message` / `update_command`) confirmed against `hermes_cli/web_server.py`.

No new i18n key or UI-library change required: the backend always supplies `message` on this path (a literal fallback covers the defensive `??`), and the existing `success`-typed toast is reused.

Closes #34347.
