### PR TITLE
fix(security): denylist plaintext-credential home dotfiles for media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -898,6 +898,14 @@ _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     ".azure",
     ".gcloud",
     "Library/Keychains",  # macOS
+    # Plaintext-credential dotfiles (single files, matched by exact path):
+    # ~/.netrc holds curl/git/ftp login passwords, ~/.git-credentials holds
+    # https://user:token@host git creds, ~/.npmrc / ~/.pypirc hold registry
+    # auth tokens. Same exfiltration class as ~/.aws/credentials above.
+    ".netrc",
+    ".git-credentials",
+    ".npmrc",
+    ".pypirc",
 )
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -740,6 +740,33 @@ class TestMediaDeliveryPathValidation:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
+    @pytest.mark.parametrize(
+        "rel_path",
+        [".netrc", ".git-credentials", ".npmrc", ".pypirc"],
+    )
+    def test_recency_trust_denies_home_credential_dotfiles_even_when_fresh(
+        self, tmp_path, monkeypatch, rel_path
+    ):
+        """Plaintext-credential home dotfiles must never be delivered.
+
+        Sibling of the ~/.ssh case: ~/.netrc, ~/.git-credentials, ~/.npmrc
+        and ~/.pypirc hold cleartext tokens/passwords. Even freshly touched
+        (mtime within the recency window), prompt injection must not be able
+        to exfiltrate them as a native attachment.
+        """
+        self._patch_roots(monkeypatch)
+        monkeypatch.delenv("HERMES_MEDIA_ALLOW_DIRS", raising=False)
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_SECONDS", "600")
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir(parents=True)
+        secret = fake_home / rel_path
+        secret.write_text("machine example.com login bob password s3cr3t")
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
     def test_recency_trust_allows_pdf_in_project_dir(self, tmp_path, monkeypatch):
         """The motivating case: agent produces a PDF in a project directory.
 


### PR DESCRIPTION
## This is a sibling follow-up to commit 4ec0adebe (fix(gateway): denylist config.yaml for media delivery)

- `4ec0adebe` / `02d1da49d` covered: `~/.hermes/{.env,auth.json,credentials,config.yaml}` in the media-delivery denylist, plus the `$HOME` cloud-credential *directories* (`.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`, `.gcloud`, `Library/Keychains`).
- It did NOT touch: the plaintext-credential *dotfiles* in `$HOME` — `~/.netrc`, `~/.git-credentials`, `~/.npmrc`, `~/.pypirc`. Same exfiltration class (`~/.aws/credentials` is already blocked; `~/.netrc` is its single-file twin), reaching a different resource the existing entries miss.
- This PR adds those four files to `_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS`, so native media delivery can never attach them even under recency-trust.

## What does this PR do?

Widens the gateway media-delivery credential denylist to cover the common plaintext-credential home dotfiles (`.netrc`, `.git-credentials`, `.npmrc`, `.pypirc`). Defense-in-depth against prompt-injection exfiltrating host secrets as a native attachment. The exact-path matcher in `_path_under_denied_prefix` (`_path_is_within(...) or resolved == resolved_denied`) already handles single-file denylist entries, so this is a pure data widening with no plumbing change and no behavioral change for legitimate media paths.

## Related Issue

(none — sibling follow-up to commit 4ec0adebe)

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/base.py`: add 4 credential dotfiles (`.netrc`, `.git-credentials`, `.npmrc`, `.pypirc`) to `_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS`.
- `tests/gateway/test_platform_base.py`: parametrized regression proving each dotfile is denied even when freshly produced (recency-trust on).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_platform_base.py::TestMediaDeliveryPathValidation -v`
2. Confirmed regression guard: the 4 new parametrized cases FAIL on current `main` (delivery allowed) and PASS with the production hunk applied.
3. Full class: 15 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite `pytest tests/gateway/test_platform_base.py::TestMediaDeliveryPathValidation -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — these are POSIX home dotfiles; the matcher resolves against the live `$HOME` so it is correct on all platforms — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

> Sibling code paths that may need the same fix: the file-tool *read* denylist and the *write*/approval denylist already cover `.netrc`-class files separately (#16851 / #27217); this PR only addresses the gateway media-delivery surface. Happy to widen if preferred.