### PR TITLE
fix: preserve Hermes runtime reliability customizations

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -25,6 +25,64 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _synthesized_message_item(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+def _backfill_response_output(
+    response: Any,
+    output_items: List[Any],
+    text_deltas: List[str],
+) -> bool:
+    """Fill a Responses object whose final event omitted ``output``.
+
+    The ChatGPT Codex backend can stream valid ``response.output_item.done``
+    events and then send ``response.completed`` with ``response.output = null``.
+    The OpenAI SDK currently crashes while parsing that final event, and the raw
+    ``responses.create(stream=True)`` fallback exposes the same null output. Use
+    the already-streamed items as the authoritative output.
+    """
+    if response is None:
+        return False
+
+    output = getattr(response, "output", None)
+    if isinstance(output, list) and output:
+        return True
+
+    if output_items:
+        response.output = list(output_items)
+        return True
+
+    if text_deltas:
+        response.output = [_synthesized_message_item("".join(text_deltas))]
+        return True
+
+    return False
+
+
+def _synthesize_codex_response(
+    api_kwargs: Dict[str, Any],
+    output_items: List[Any],
+    text_deltas: List[str],
+) -> SimpleNamespace:
+    text = "".join(text_deltas)
+    output = list(output_items)
+    if not output and text:
+        output = [_synthesized_message_item(text)]
+    return SimpleNamespace(
+        output=output,
+        output_text=text or None,
+        status="completed",
+        model=api_kwargs.get("model"),
+        usage=None,
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -516,15 +574,105 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
 
 def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None):
-    """Backward-compatible alias for the unified event-driven path.
+    """Fallback path for stream completion edge cases on Codex-style Responses backends."""
+    active_client = client or agent._ensure_primary_openai_client(reason="codex_create_stream_fallback")
+    fallback_kwargs = dict(api_kwargs)
+    fallback_kwargs["stream"] = True
+    fallback_kwargs = agent._get_transport().preflight_kwargs(fallback_kwargs, allow_stream=True)
+    stream_or_response = active_client.responses.create(**fallback_kwargs)
 
-    Historically this was the fallback when the SDK's high-level
-    ``responses.stream(...)`` helper raised on shape drift.  The primary
-    path now does exactly what the fallback did, so this just forwards.
-    Kept as a public symbol because tests and a small number of call sites
-    still reference it by name.
-    """
-    return run_codex_stream(agent, api_kwargs, client=client)
+    # Compatibility shim for mocks or providers that still return a concrete response.
+    if hasattr(stream_or_response, "output"):
+        return stream_or_response
+    if not hasattr(stream_or_response, "__iter__"):
+        return stream_or_response
+
+    terminal_response = None
+    collected_output_items: list = []
+    collected_text_deltas: list = []
+    try:
+        for event in stream_or_response:
+            agent._touch_activity("receiving stream response")
+            event_type = getattr(event, "type", None)
+            if not event_type and isinstance(event, dict):
+                event_type = event.get("type")
+
+            # ``error`` SSE frames carry the provider's real failure
+            # reason (subscription / quota / model-not-available /
+            # rejected-reasoning-replay) but never appear in the
+            # ``{completed, incomplete, failed}`` terminal set, so the
+            # raw loop below would silently consume them and end with
+            # "did not emit a terminal response".  xAI in particular
+            # emits ``type=error`` as the FIRST frame for OAuth
+            # accounts whose Grok subscription is missing/exhausted —
+            # the SDK's stream helper raises ``RuntimeError(Expected
+            # to have received response.created before error)`` which
+            # the caller catches and routes here, expecting this
+            # fallback to surface the message.  Synthesize an
+            # APIError-shaped exception so ``_summarize_api_error``
+            # and the credential-pool entitlement detector see the
+            # real text instead of a generic RuntimeError.
+            if event_type == "error":
+                err_message = getattr(event, "message", None)
+                if not err_message and isinstance(event, dict):
+                    err_message = event.get("message")
+                err_code = getattr(event, "code", None)
+                if not err_code and isinstance(event, dict):
+                    err_code = event.get("code")
+                err_param = getattr(event, "param", None)
+                if not err_param and isinstance(event, dict):
+                    err_param = event.get("param")
+                err_message = (err_message or "stream emitted error event").strip()
+                from run_agent import _StreamErrorEvent
+                raise _StreamErrorEvent(err_message, code=err_code, param=err_param)
+
+            # Collect output items and text deltas for backfill
+            if event_type == "response.output_item.done":
+                done_item = getattr(event, "item", None)
+                if done_item is None and isinstance(event, dict):
+                    done_item = event.get("item")
+                if done_item is not None:
+                    collected_output_items.append(done_item)
+            elif event_type in {"response.output_text.delta",}:
+                delta = getattr(event, "delta", "")
+                if not delta and isinstance(event, dict):
+                    delta = event.get("delta", "")
+                if delta:
+                    collected_text_deltas.append(delta)
+
+            if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
+                continue
+
+            terminal_response = getattr(event, "response", None)
+            if terminal_response is None and isinstance(event, dict):
+                terminal_response = event.get("response")
+            if terminal_response is not None:
+                # Backfill empty output from collected stream events
+                _out = getattr(terminal_response, "output", None)
+                if not isinstance(_out, list) or not _out:
+                    if _backfill_response_output(
+                        terminal_response,
+                        collected_output_items,
+                        collected_text_deltas,
+                    ):
+                        logger.debug(
+                            "Codex fallback stream: backfilled output from stream events "
+                            "(items=%d, text_parts=%d)",
+                            len(collected_output_items),
+                            len(collected_text_deltas),
+                        )
+                return terminal_response
+    finally:
+        close_fn = getattr(stream_or_response, "close", None)
+        if callable(close_fn):
+            try:
+                close_fn()
+            except Exception:
+                pass
+
+    if terminal_response is not None:
+        return terminal_response
+    raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
 
 
 __all__ = [

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1028,7 +1028,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if getattr(self.config, "extra", None):
             raw = self.config.extra.get("concurrent_updates")
         if raw is None:
-            raw = os.getenv("HERMES_TELEGRAM_CONCURRENT_UPDATES", "32")
+            raw = 32
         if isinstance(raw, bool):
             return raw
         if isinstance(raw, int):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,6 +11,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import mimetypes
 import os
 import tempfile
 import html as _html
@@ -405,6 +406,13 @@ class TelegramAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.TELEGRAM)
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
+        # Optional secondary Bot client used only for media downloads. This enables
+        # hybrid mode: official Telegram cloud Bot API for polling/sending, local
+        # telegram-bot-api for getFile/file bytes.
+        self._download_bot: Optional[Any] = None
+        self._download_base_url: Optional[str] = self.config.extra.get("download_base_url") or None
+        self._download_base_file_url: Optional[str] = self.config.extra.get("download_base_file_url") or None
+        self._download_local_mode: bool = self._coerce_bool_extra("download_local_mode", False)
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -460,12 +468,13 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topic_chat_ids: Set[str] = {
             str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
         }
-        # Document size cap. Telegram's public Bot API caps getFile at 20MB; a
-        # locally-hosted telegram-bot-api server (configured via extra.base_url)
-        # raises that to 2GB, so the presence of base_url is the opt-in.
+        # Document size cap. Telegram's public Bot API caps getFile at 20MB. A
+        # locally-hosted telegram-bot-api server raises that to 2GB. Treat either
+        # full local mode (extra.base_url) or hybrid download mode
+        # (extra.download_base_url) as opting into the larger media-download path.
         self._max_doc_bytes: int = (
             2 * 1024 * 1024 * 1024
-            if self.config.extra.get("base_url")
+            if (self.config.extra.get("base_url") or self._download_base_url)
             else 20 * 1024 * 1024
         )
         # Interactive model picker state per chat
@@ -491,6 +500,122 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+
+    def _telegram_download_limit_note(self, media_label: str) -> str:
+        """Human-readable Telegram file-download cap note for failed media caching."""
+        limit_mb = self._max_doc_bytes // (1024 * 1024)
+        api_mode = (
+            "hybrid local Telegram Bot API download path"
+            if self._download_base_url else
+            "local Telegram Bot API" if self.config.extra.get("base_url") else
+            "Telegram cloud Bot API"
+        )
+        return (
+            f"I received your {media_label}, but Telegram's {api_mode} couldn't download it "
+            f"for the bot. The current download limit is {limit_mb} MB. "
+            "Please send a smaller file or use another upload path."
+        )
+
+    def _is_telegram_file_too_big_error(self, exc: Exception) -> bool:
+        """Return True for Telegram/PTB download-size failures."""
+        text = str(exc).lower()
+        return "file is too big" in text or "file too big" in text or "too large" in text
+
+    def _media_file_size_exceeds_download_limit(self, media_obj: Any) -> bool:
+        """Pre-check Telegram media objects when file_size is available."""
+        file_size = getattr(media_obj, "file_size", None)
+        return isinstance(file_size, int) and file_size > self._max_doc_bytes
+
+    def _media_file_extension(self, file_obj: Any, candidates: Dict[str, str], default: str) -> str:
+        """Infer a cached extension from Telegram's file_path using an allowed map."""
+        file_path = str(getattr(file_obj, "file_path", "") or "").lower()
+        for candidate in candidates:
+            if file_path.endswith(candidate):
+                return candidate
+        return default
+
+    async def _get_download_file(self, media_obj: Any) -> Any:
+        """Return a Telegram File for media downloads, using hybrid local API if configured.
+
+        The main Telegram application can stay on Telegram's official cloud Bot API
+        for polling/sending while this secondary Bot is used only for getFile and
+        subsequent file-byte downloads.
+        """
+        file_id = getattr(media_obj, "file_id", None)
+        if self._download_bot is not None and file_id:
+            try:
+                return await self._download_bot.get_file(file_id)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Hybrid Telegram local download getFile failed; falling back to primary Bot API: %s",
+                    self.name,
+                    exc,
+                )
+        return await media_obj.get_file()
+
+    def _format_telegram_contact_summary(self, contact: Any) -> str:
+        """Convert a Telegram contact payload into model-readable text."""
+        name = " ".join(
+            part for part in [
+                str(getattr(contact, "first_name", "") or "").strip(),
+                str(getattr(contact, "last_name", "") or "").strip(),
+            ] if part
+        )
+        lines = ["[User sent a Telegram contact]"]
+        if name:
+            lines.append(f"Name: {name}")
+        phone = str(getattr(contact, "phone_number", "") or "").strip()
+        if phone:
+            lines.append(f"Phone: {phone}")
+        user_id = getattr(contact, "user_id", None)
+        if user_id:
+            lines.append(f"Telegram user ID: {user_id}")
+        vcard = str(getattr(contact, "vcard", "") or "").strip()
+        if vcard:
+            lines.append(f"vCard: {vcard[:2000]}")
+        return "\n".join(lines)
+
+    def _format_telegram_poll_summary(self, poll: Any) -> str:
+        """Convert a Telegram poll payload into model-readable text."""
+        question = str(getattr(poll, "question", "") or "").strip()
+        lines = ["[User sent a Telegram poll]"]
+        if question:
+            lines.append(f"Question: {question}")
+        options = getattr(poll, "options", None) or []
+        if options:
+            lines.append("Options:")
+            for option in options:
+                text = str(getattr(option, "text", "") or "").strip() or "(blank)"
+                votes = getattr(option, "voter_count", None)
+                if votes is None:
+                    lines.append(f"- {text}")
+                else:
+                    lines.append(f"- {text} — {votes}")
+        total_votes = getattr(poll, "total_voter_count", None)
+        if total_votes is not None:
+            lines.append(f"total votes: {total_votes}")
+        lines.append(f"closed: {bool(getattr(poll, 'is_closed', False))}")
+        if getattr(poll, "type", None):
+            lines.append(f"type: {getattr(poll, 'type')}")
+        lines.append(f"anonymous: {bool(getattr(poll, 'is_anonymous', False))}")
+        lines.append(f"multiple answers: {bool(getattr(poll, 'allows_multiple_answers', False))}")
+        return "\n".join(lines)
+
+    def _telegram_media_filter(self):
+        """Build the Telegram media filter, including optional PTB media types."""
+        media_filter = (
+            filters.PHOTO
+            | filters.VIDEO
+            | filters.AUDIO
+            | filters.VOICE
+            | filters.Document.ALL
+            | filters.Sticker.ALL
+        )
+        for optional_name in ("VIDEO_NOTE", "ANIMATION", "CONTACT", "POLL"):
+            optional_filter = getattr(filters, optional_name, None)
+            if optional_filter is not None:
+                media_filter = media_filter | optional_filter
+        return media_filter
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -891,6 +1016,33 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
             return default
         return bool(value)
+
+    def _resolve_concurrent_updates(self) -> bool | int:
+        """Resolve PTB concurrent update count for Telegram polling/webhooks.
+
+        Default to parallel Telegram update handling so slow media/file work in
+        one forum topic cannot block unrelated topics.  Per-session guards still
+        serialize same-topic agent turns.
+        """
+        raw = None
+        if getattr(self.config, "extra", None):
+            raw = self.config.extra.get("concurrent_updates")
+        if raw is None:
+            raw = os.getenv("HERMES_TELEGRAM_CONCURRENT_UPDATES", "32")
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, int):
+            return raw if raw > 0 else False
+        lowered = str(raw).strip().lower()
+        if lowered in {"", "false", "0", "no", "off", "disabled", "disable"}:
+            return False
+        if lowered in {"true", "yes", "on", "enabled", "enable"}:
+            return True
+        try:
+            count = int(lowered)
+        except (TypeError, ValueError):
+            return 32
+        return count if count > 0 else False
 
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
@@ -1515,8 +1667,20 @@ class TelegramAdapter(BasePlatformAdapter):
             if not self._acquire_platform_lock('telegram-bot-token', self.config.token, 'Telegram bot token'):
                 return False
 
-            # Build the application
+            # Build the application.  Enable PTB's concurrent update
+            # processing by default so a slow media download or long handler in
+            # one Telegram forum topic cannot starve text updates from another
+            # topic in the same supergroup.  Hermes already has per-session
+            # guards in BasePlatformAdapter, so same-topic serialization stays
+            # intact while different topics remain independent.
             builder = Application.builder().token(self.config.token)
+            concurrent_updates = self._resolve_concurrent_updates()
+            builder = builder.concurrent_updates(concurrent_updates)
+            logger.info(
+                "[%s] Telegram concurrent update processing: %s",
+                self.name,
+                concurrent_updates,
+            )
             custom_base_url = self.config.extra.get("base_url")
             if custom_base_url:
                 builder = builder.base_url(custom_base_url)
@@ -1600,6 +1764,25 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
+
+            self._download_bot = None
+            if self._download_base_url:
+                download_file_url = self._download_base_file_url or self._download_base_url
+                download_request = HTTPXRequest(**request_kwargs)  # type: ignore[operator]
+                self._download_bot = Bot(  # type: ignore[operator]
+                    token=self.config.token,
+                    base_url=self._download_base_url,
+                    base_file_url=download_file_url,
+                    request=download_request,
+                    local_mode=self._download_local_mode,
+                )
+                logger.info(
+                    "[%s] Hybrid Telegram mode: primary Bot API=%s, media downloads=%s (local_mode=%s)",
+                    self.name,
+                    custom_base_url or "official Telegram cloud",
+                    self._download_base_url,
+                    self._download_local_mode,
+                )
             
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
@@ -1615,8 +1798,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._handle_location_message
             ))
             self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
+                self._telegram_media_filter(),
+                self._handle_media_message,
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
@@ -1626,7 +1809,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 from telegram.error import NetworkError, TimedOut
             except ImportError:
                 NetworkError = TimedOut = OSError  # type: ignore[misc,assignment]
-            _max_connect = 8
+            _max_connect = max(1, _env_int("HERMES_TELEGRAM_CONNECT_ATTEMPTS", 8))
             for _attempt in range(_max_connect):
                 try:
                     await self._app.initialize()
@@ -1807,6 +1990,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._app.shutdown()
             except Exception as e:
                 logger.warning("[%s] Error during Telegram disconnect: %s", self.name, e, exc_info=True)
+        if self._download_bot:
+            try:
+                shutdown = getattr(self._download_bot, "shutdown", None)
+                if callable(shutdown):
+                    result = shutdown()
+                    if hasattr(result, "__await__"):
+                        await result  # type: ignore[misc]
+            except Exception as e:
+                logger.debug("[%s] Error during Telegram hybrid download bot shutdown: %s", self.name, e, exc_info=True)
+        self._download_bot = None
         self._release_platform_lock()
 
         for task in self._pending_photo_batch_tasks.values():
@@ -2143,6 +2336,16 @@ class TelegramAdapter(BasePlatformAdapter):
             if result.success:
                 if result.message_id:
                     self._status_message_ids[key] = str(result.message_id)
+                return result
+            err = (getattr(result, "error", "") or "").lower()
+            if "flood_control" in err or "retry after" in err or "flood" in err:
+                # Status/progress bubbles are lower priority than final
+                # replies.  If Telegram tells us to slow down while editing a
+                # status bubble, do not immediately create a fresh status
+                # message; that competes with final sends across sibling forum
+                # topics in the same supergroup and prolongs the flood window.
+                # Keep the cached id so a later, calmer status update can edit
+                # the same bubble.
                 return result
             # Edit failed — clear the cached id and fall through to a fresh send.
             self._status_message_ids.pop(key, None)
@@ -5289,12 +5492,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     _observe_type = MessageType.STICKER
                 elif _m.photo:
                     _observe_type = MessageType.PHOTO
-                elif _m.video:
+                elif _m.video or getattr(_m, "video_note", None) or getattr(_m, "animation", None):
                     _observe_type = MessageType.VIDEO
                 elif _m.audio:
                     _observe_type = MessageType.AUDIO
                 elif _m.voice:
                     _observe_type = MessageType.VOICE
+                elif getattr(_m, "contact", None) or getattr(_m, "poll", None):
+                    _observe_type = MessageType.TEXT
                 else:
                     _observe_type = MessageType.DOCUMENT
                 self._observe_unmentioned_group_message(_m, _observe_type, update_id=update.update_id)
@@ -5307,12 +5512,14 @@ class TelegramAdapter(BasePlatformAdapter):
             msg_type = MessageType.STICKER
         elif msg.photo:
             msg_type = MessageType.PHOTO
-        elif msg.video:
+        elif msg.video or getattr(msg, "video_note", None) or getattr(msg, "animation", None):
             msg_type = MessageType.VIDEO
         elif msg.audio:
             msg_type = MessageType.AUDIO
         elif msg.voice:
             msg_type = MessageType.VOICE
+        elif getattr(msg, "contact", None) or getattr(msg, "poll", None):
+            msg_type = MessageType.TEXT
         elif msg.document:
             msg_type = MessageType.DOCUMENT
         else:
@@ -5323,6 +5530,18 @@ class TelegramAdapter(BasePlatformAdapter):
         # Add caption as text
         if msg.caption:
             event.text = self._clean_bot_trigger_text(msg.caption)
+        if getattr(msg, "contact", None):
+            contact_summary = self._format_telegram_contact_summary(msg.contact)
+            event.text = self._merge_caption(event.text, contact_summary) if event.text else contact_summary
+            event = self._apply_telegram_group_observe_attribution(event)
+            await self.handle_message(event)
+            return
+        if getattr(msg, "poll", None):
+            poll_summary = self._format_telegram_poll_summary(msg.poll)
+            event.text = self._merge_caption(event.text, poll_summary) if event.text else poll_summary
+            event = self._apply_telegram_group_observe_attribution(event)
+            await self.handle_message(event)
+            return
         
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:
@@ -5341,7 +5560,7 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 # msg.photo is a list of PhotoSize sorted by size; take the largest
                 photo = msg.photo[-1]
-                file_obj = await photo.get_file()
+                file_obj = await self._get_download_file(photo)
                 # Download the image bytes directly into memory
                 image_bytes = await file_obj.download_as_bytearray()
                 # Determine extension from the file path if available
@@ -5370,41 +5589,66 @@ class TelegramAdapter(BasePlatformAdapter):
         # Download voice/audio messages to cache for STT transcription
         if msg.voice:
             try:
-                file_obj = await msg.voice.get_file()
-                audio_bytes = await file_obj.download_as_bytearray()
-                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
-                event.media_urls = [cached_path]
-                event.media_types = ["audio/ogg"]
-                logger.info("[Telegram] Cached user voice at %s", cached_path)
+                if self._media_file_size_exceeds_download_limit(msg.voice):
+                    event.text = self._telegram_download_limit_note("voice message")
+                else:
+                    file_obj = await self._get_download_file(msg.voice)
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
+                    event.media_urls = [cached_path]
+                    event.media_types = ["audio/ogg"]
+                    logger.info("[Telegram] Cached user voice at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache voice: %s", e, exc_info=True)
+                if self._is_telegram_file_too_big_error(e):
+                    event.text = self._telegram_download_limit_note("voice message")
         elif msg.audio:
             try:
-                file_obj = await msg.audio.get_file()
-                audio_bytes = await file_obj.download_as_bytearray()
-                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
-                event.media_urls = [cached_path]
-                event.media_types = ["audio/mp3"]
-                logger.info("[Telegram] Cached user audio at %s", cached_path)
+                if self._media_file_size_exceeds_download_limit(msg.audio):
+                    event.text = self._telegram_download_limit_note("audio file")
+                else:
+                    file_obj = await self._get_download_file(msg.audio)
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    ext = ".mp3"
+                    file_name = str(getattr(msg.audio, "file_name", "") or "").lower()
+                    if file_name:
+                        _, name_ext = os.path.splitext(file_name)
+                        if name_ext in {".mp3", ".m4a", ".wav", ".ogg", ".aac", ".flac", ".webm", ".mp4", ".mpeg", ".mpga"}:
+                            ext = name_ext
+                    if getattr(file_obj, "file_path", None):
+                        for candidate in [".mp3", ".m4a", ".wav", ".ogg", ".aac", ".flac", ".webm", ".mp4", ".mpeg", ".mpga"]:
+                            if str(file_obj.file_path).lower().endswith(candidate):
+                                ext = candidate
+                                break
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [getattr(msg.audio, "mime_type", None) or mimetypes.guess_type(f"audio{ext}")[0] or "audio/mpeg"]
+                    logger.info("[Telegram] Cached user audio at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
+                if self._is_telegram_file_too_big_error(e):
+                    event.text = self._telegram_download_limit_note("audio file")
 
-        elif msg.video:
+        elif msg.video or getattr(msg, "video_note", None) or getattr(msg, "animation", None):
+            video_payload = msg.video or getattr(msg, "video_note", None) or getattr(msg, "animation", None)
+            if video_payload is None:
+                video_payload = msg.video
+            assert video_payload is not None
             try:
-                file_obj = await msg.video.get_file()
-                video_bytes = await file_obj.download_as_bytearray()
-                ext = ".mp4"
-                if getattr(file_obj, "file_path", None):
-                    for candidate in SUPPORTED_VIDEO_TYPES:
-                        if file_obj.file_path.lower().endswith(candidate):
-                            ext = candidate
-                            break
-                cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
-                event.media_urls = [cached_path]
-                event.media_types = [SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4")]
-                logger.info("[Telegram] Cached user video at %s", cached_path)
+                if self._media_file_size_exceeds_download_limit(video_payload):
+                    event.text = self._telegram_download_limit_note("video")
+                else:
+                    file_obj = await self._get_download_file(video_payload)
+                    video_bytes = await file_obj.download_as_bytearray()
+                    ext = self._media_file_extension(file_obj, SUPPORTED_VIDEO_TYPES, ".mp4")
+                    cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4")]
+                    logger.info("[Telegram] Cached user video at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
+                if self._is_telegram_file_too_big_error(e):
+                    event.text = self._telegram_download_limit_note("video")
 
         # Download document files to cache for agent processing
         elif msg.document:
@@ -5444,7 +5688,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # payload is actually an image, route it through the image cache
                 # and batching path instead of rejecting it as a document.
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
-                    file_obj = await doc.get_file()
+                    file_obj = await self._get_download_file(doc)
                     image_bytes = await file_obj.download_as_bytearray()
                     image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
                     try:
@@ -5484,7 +5728,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     ext = image_mime_to_ext.get(doc.mime_type, "")
 
                 if ext in SUPPORTED_VIDEO_TYPES:
-                    file_obj = await doc.get_file()
+                    file_obj = await self._get_download_file(doc)
                     video_bytes = await file_obj.download_as_bytearray()
                     cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
                     event.media_urls = [cached_path]
@@ -5500,19 +5744,33 @@ class TelegramAdapter(BasePlatformAdapter):
                 # ext-in-SUPPORTED_IMAGE_DOCUMENT_TYPES branch would be dead
                 # code — the extension sets are identical.
 
-                # Check if supported
+                # Unknown document extensions are still useful to the agent: cache
+                # them generically instead of rejecting, so the user can ask for
+                # extraction/conversion or a tool can inspect the bytes.
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
-                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
-                        f"Supported types: {supported_list}"
+                    guessed_mime = None
+                    if original_filename:
+                        guessed_mime = mimetypes.guess_type(original_filename)[0]
+                    if not guessed_mime and doc_mime:
+                        guessed_mime = doc_mime
+                    mime_type = guessed_mime or "application/octet-stream"
+                    cache_name = original_filename or (f"document{ext}" if ext else "document.bin")
+                    file_obj = await self._get_download_file(doc)
+                    doc_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_document_from_bytes(bytes(doc_bytes), cache_name)
+                    event.media_urls = [cached_path]
+                    event.media_types = [mime_type]
+                    event.message_type = MessageType.DOCUMENT
+                    logger.info(
+                        "[Telegram] Cached generic document type %s at %s",
+                        ext or "unknown",
+                        cached_path,
                     )
-                    logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
                     await self.handle_message(event)
                     return
 
                 # Download and cache
-                file_obj = await doc.get_file()
+                file_obj = await self._get_download_file(doc)
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
                 cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
@@ -5521,23 +5779,31 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s", cached_path)
 
-                # For text files, inject content into event.text (capped at 100 KB)
+                # For text files, inject content into event.text (capped at 100 KB).
+                # Telegram clients sometimes export .txt as UTF-16/UTF-16-LE (BOM 0xff/0xfe),
+                # so try common encodings before giving up.  If none match, inject a
+                # replacement-decoded preview instead of dropping the file context entirely.
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
                 if ext in {".md", ".txt"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
-                    try:
-                        text_content = raw_bytes.decode("utf-8")
-                        display_name = original_filename or f"document{ext}"
-                        display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                        injection = f"[Content of {display_name}]:\n{text_content}"
-                        if event.text:
-                            event.text = f"{injection}\n\n{event.text}"
-                        else:
-                            event.text = injection
-                    except UnicodeDecodeError:
+                    text_content = None
+                    for encoding in ("utf-8-sig", "utf-16", "utf-16-le", "utf-16-be"):
+                        try:
+                            text_content = raw_bytes.decode(encoding)
+                            break
+                        except UnicodeDecodeError:
+                            continue
+                    if text_content is None:
+                        text_content = raw_bytes.decode("utf-8", errors="replace")
                         logger.warning(
-                            "[Telegram] Could not decode text file as UTF-8, skipping content injection",
-                            exc_info=True,
+                            "[Telegram] Text file was not UTF-8/UTF-16; injected replacement-decoded preview"
                         )
+                    display_name = original_filename or f"document{ext}"
+                    display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+                    injection = f"[Content of {display_name}]:\n{text_content}"
+                    if event.text:
+                        event.text = f"{injection}\n\n{event.text}"
+                    else:
+                        event.text = injection
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
@@ -5621,7 +5887,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Cache miss -- download and analyze
         try:
-            file_obj = await sticker.get_file()
+            file_obj = await self._get_download_file(sticker)
             image_bytes = await file_obj.download_as_bytearray()
             cached_path = cache_image_from_bytes(bytes(image_bytes), ext=".webp")
             logger.info("[Telegram] Analyzing sticker at %s", cached_path)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1282,6 +1282,8 @@ def _build_media_placeholder(event) -> str:
             parts.append(f"[User sent an image: {url}]")
         elif mtype.startswith("audio/"):
             parts.append(f"[User sent audio: {url}]")
+        elif mtype.startswith("video/") or getattr(event, "message_type", None) == MessageType.VIDEO:
+            parts.append(f"[User sent a video: {url}]")
         else:
             parts.append(f"[User sent a file: {url}]")
     return "\n".join(parts)
@@ -3143,6 +3145,8 @@ class GatewayRunner:
         if not mode:
             cfg = _load_gateway_runtime_config()
             mode = str(cfg_get(cfg, "display", "busy_text_mode", default="") or "").strip().lower()
+        if mode == "steer":
+            return "steer"
         if mode == "interrupt":
             return "interrupt"
         return "queue"
@@ -4244,7 +4248,14 @@ class GatewayRunner:
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            write_runtime_status(
+                gateway_state="starting",
+                exit_reason=None,
+                secret_redaction_enabled=(
+                    os.getenv("HERMES_REDACT_SECRETS", "true").lower()
+                    in {"1", "true", "yes", "on"}
+                ),
+            )
         except Exception:
             pass
 
@@ -8383,10 +8394,16 @@ class GatewayRunner:
             thread_sessions_per_user=_thread_sessions_per_user,
         )
         if _is_shared_multi_user and source.user_name:
-            message_text = f"[{source.user_name}] {message_text}"
+            # Keep sender attribution as explicit metadata instead of a
+            # bracket-prefix tag.  Bracket prefixes like ``[Stale Mate]`` look
+            # exactly like user-authored task labels/topics and can cause the
+            # agent to route a normal Life/general request into a content
+            # workflow.  The actual message text should remain the primary
+            # intent signal; the display name is only attribution.
+            message_text = f"Sender: {source.user_name}\n\n{message_text}"
 
         # Prepend channel context from history backfill (if any).  This
-        # happens after sender-prefix so the prefix only applies to the
+        # happens after sender metadata so the attribution only applies to the
         # trigger message, not the backfill block.
         if getattr(event, "channel_context", None):
             message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
@@ -8394,6 +8411,7 @@ class GatewayRunner:
         # Declare at outer scope so the audio-file-paths handling block below
         # remains safe when ``event.media_urls`` is empty (no inner block runs).
         audio_file_paths: list[str] = []
+        video_paths: list[str] = []
 
         if event.media_urls:
             image_paths = []
@@ -8402,15 +8420,36 @@ class GatewayRunner:
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
-                # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
-                # MessageType.VOICE = voice message (Opus/OGG) — always STT
+                # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a).
+                # By default it stays a file note; Telegram can opt into STT
+                # for recorder-app uploads via extra.auto_transcribe_audio_attachments.
+                # MessageType.VOICE = native voice message (Opus/OGG) — always STT.
+                _auto_transcribe_audio_attachments = False
                 if event.message_type == MessageType.AUDIO:
-                    audio_file_paths.append(path)
+                    try:
+                        _platform_cfg = self.config.platforms.get(source.platform)
+                        _raw_auto_audio = (
+                            _platform_cfg.extra.get("auto_transcribe_audio_attachments")
+                            if _platform_cfg is not None
+                            else False
+                        )
+                        if isinstance(_raw_auto_audio, str):
+                            _auto_transcribe_audio_attachments = _raw_auto_audio.strip().lower() in {"1", "true", "yes", "on"}
+                        else:
+                            _auto_transcribe_audio_attachments = bool(_raw_auto_audio)
+                    except Exception:
+                        _auto_transcribe_audio_attachments = False
+                    if _auto_transcribe_audio_attachments:
+                        audio_paths.append(path)
+                    else:
+                        audio_file_paths.append(path)
                 elif event.message_type == MessageType.VOICE or (
                     mtype.startswith("audio/")
                     and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
                 ):
                     audio_paths.append(path)
+                if mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
+                    video_paths.append(path)
 
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
@@ -8486,6 +8525,23 @@ class GatewayRunner:
                     f"Ask the user what they'd like you to do with it, or pass the path to a transcription or media tool.]"
                 )
                 message_text = f"{_note}\n\n{message_text}"
+
+        if video_paths:
+            from tools.credential_files import to_agent_visible_cache_path as _to_agent_path
+            notes = []
+            for _vpath in video_paths:
+                _basename = os.path.basename(_vpath)
+                _parts = _basename.split("_", 2)
+                _display = _parts[2] if len(_parts) >= 3 else _basename
+                _display = re.sub(r'[^\w.\- ]', '_', _display)
+                _agent_path = _to_agent_path(_vpath)
+                notes.append(
+                    f"[The user sent a video: '{_display}'. The file is saved at: {_agent_path}. "
+                    "For video-specific requests, inspect this exact file first "
+                    "(ffprobe/contact sheet/vision/audio as needed) before answering.]"
+                )
+            video_note = "\n".join(notes)
+            message_text = f"{video_note}\n\n{message_text}" if message_text else video_note
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
@@ -10564,6 +10620,24 @@ class GatewayRunner:
             if count:
                 return t("gateway.draining", count=count)
             return EphemeralReply(t("gateway.restart.in_progress"))
+
+        force_restart = False
+        try:
+            import shlex
+            _tokens = shlex.split(str(event.text or "").replace("—", "--"))
+            force_restart = "--force" in _tokens
+        except Exception:
+            force_restart = "--force" in str(event.text or "")
+
+        active_agents = self._running_agent_count()
+        if active_agents and not force_restart:
+            return (
+                "✗ Gateway restart refused: active agent run(s) are still in progress.\n"
+                f"Active agents: {active_agents}\n\n"
+                "This avoids interrupting Telegram tasks and losing in-memory run state. "
+                "Use `/reload-mcp` for MCP/tool changes, wait for the task to finish, "
+                "or run `/restart --force` if you intentionally want to interrupt active work."
+            )
 
         # Save the requester's routing info so the new gateway process can
         # notify them once it comes back online.
@@ -17151,13 +17225,19 @@ class GatewayRunner:
                                 )
                                 continue
                             if "flood" in _err or "retry after" in _err:
-                                # Flood control hit — backoff but keep editing.
-                                # Only disable edits for non-recoverable errors.
+                                # Flood control hit — back off and DROP this
+                                # non-essential progress frame.  Do NOT fall
+                                # back to a fresh progress send here: Telegram
+                                # flood limits are chat/bot scoped, so sending
+                                # a new bubble immediately after an edit 429
+                                # extends the same flood window and can delay
+                                # final answers in sibling forum topics.
                                 logger.info(
                                     "[%s] Progress edit flood control, backing off",
                                     adapter.name,
                                 )
                                 _last_edit_ts = time.monotonic()
+                                continue
                             else:
                                 can_edit = False
                             _flood_result = await adapter.send(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -297,14 +297,16 @@ def build_session_context_prompt(
     # In shared multi-user sessions (shared threads OR shared non-thread groups
     # when group_sessions_per_user=False), multiple users contribute to the same
     # conversation.  Don't pin a single user name in the system prompt — it
-    # changes per-turn and would bust the prompt cache.  Instead, note that
-    # this is a multi-user session; individual sender names are prefixed on
-    # each user message by the gateway.
+    # changes per-turn and would bust the prompt cache.  Instead, the gateway
+    # adds explicit sender metadata to each user message.  Sender display names
+    # are attribution only; they are not channel topics, task labels, or intent
+    # signals.
     if context.shared_multi_user_session:
         session_label = "Multi-user thread" if context.source.thread_id else "Multi-user session"
         lines.append(
-            f"**Session type:** {session_label} — messages are prefixed "
-            "with [sender name]. Multiple users may participate."
+            f"**Session type:** {session_label} — user messages may include "
+            "a `Sender:` metadata line. Treat sender names as attribution only, "
+            "not as topic tags or task instructions. Multiple users may participate."
         )
     elif context.source.user_name:
         lines.append(f"**User:** {context.source.user_name}")

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,6 +216,7 @@ def _build_runtime_status_record() -> dict[str, Any]:
         "exit_reason": None,
         "restart_requested": False,
         "active_agents": 0,
+        "secret_redaction_enabled": None,
         "platforms": {},
         "updated_at": _utc_now_iso(),
     })
@@ -507,6 +508,7 @@ def write_runtime_status(
     exit_reason: Any = _UNSET,
     restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET,
+    secret_redaction_enabled: Any = _UNSET,
     platform: Any = _UNSET,
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
@@ -531,6 +533,8 @@ def write_runtime_status(
         payload["restart_requested"] = bool(restart_requested)
     if active_agents is not _UNSET:
         payload["active_agents"] = max(0, int(active_agents))
+    if secret_redaction_enabled is not _UNSET:
+        payload["secret_redaction_enabled"] = bool(secret_redaction_enabled)
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -210,6 +210,38 @@ def check_via_pypi() -> Optional[int]:
         return 1 if latest != VERSION else 0
 
 
+def _git_ref(repo_dir: Path, ref: str) -> Optional[str]:
+    """Resolve a git ref without network access, returning None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            rev = result.stdout.strip()
+            return rev or None
+    except Exception:
+        pass
+    return None
+
+
+def _local_git_cache_rev(repo_dir: Path) -> Optional[str]:
+    """Return a cache key for the local checkout state.
+
+    The update badge is cached for several hours.  If ``hermes update`` or a
+    manual git pull moves HEAD, a cache keyed only by embedded build revision
+    can keep reporting an old "N commits behind" value even though the checkout
+    is already current.  Include the current checkout and local origin/main refs
+    so local updates invalidate stale cache entries without requiring network.
+    """
+    head = _git_ref(repo_dir, "HEAD")
+    if not head:
+        return None
+    origin_main = _git_ref(repo_dir, "refs/remotes/origin/main") or _git_ref(repo_dir, "origin/main")
+    return f"git:{repo_dir}:{head}:{origin_main or ''}"
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -224,19 +256,36 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check. The version guard matters for pip installs:
-    # `check_via_pypi()` compares against VERSION, so a `pip install --upgrade`
-    # changes VERSION but leaves rev unchanged (both None), and without this
-    # the stale "behind" count would survive the upgrade for up to 6h. See #34491.
+    if embedded_rev:
+        cache_rev = embedded_rev
+    else:
+        # Prefer the running code's location over the profile-scoped path.
+        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
+        # Path(__file__) always resolves to the actual installed checkout.
+        repo_candidate = Path(__file__).parent.parent.resolve()
+        if not (repo_candidate / ".git").exists():
+            repo_candidate = hermes_home / "hermes-agent"
+        if (repo_candidate / ".git").exists():
+            repo_dir = repo_candidate
+            cache_rev = _local_git_cache_rev(repo_dir)
+        else:
+            cache_rev = f"pypi:{VERSION}"
+
+    # Read cache — invalidate if the embedded build revision, local git state,
+    # or installed version changed since the last check. The version guard
+    # matters for pip installs: `check_via_pypi()` compares against VERSION, so
+    # a package upgrade changes VERSION even when no git revision is present.
+    # The richer git-state rev also prevents a successful git update from
+    # leaving a stale "commits behind" badge around for the full cache TTL.
     now = time.time()
     try:
-        if cache_file.exists():
+        if cache_rev and cache_file.exists():
             cached = json.loads(cache_file.read_text())
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
+                and cached.get("rev") == cache_rev
                 and cached.get("ver") == VERSION
             ):
                 return cached.get("behind")
@@ -246,20 +295,17 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             behind = check_via_pypi()
         else:
             behind = _check_via_local_git(repo_dir)
+            # Fetching may advance origin/main; store the post-fetch state so the
+            # next invocation can use cache when nothing local has moved.
+            cache_rev = _local_git_cache_rev(repo_dir) or cache_rev
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
+            json.dumps({"ts": now, "behind": behind, "rev": cache_rev, "ver": VERSION})
         )
     except Exception:
         pass

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3387,6 +3387,12 @@ def launchd_status(deep: bool = False):
         print("  Service definition exists locally but launchd has not loaded it.")
         print("  Run: hermes gateway start")
 
+    runtime_lines = _runtime_health_lines()
+    if runtime_lines:
+        print()
+        print("Recent gateway health:")
+        for line in runtime_lines:
+            print(f"  {line}")
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
         if log_file.exists():
@@ -4347,7 +4353,13 @@ def _runtime_health_lines() -> list[str]:
     exit_reason = state.get("exit_reason")
     active_agents = state.get("active_agents")
     restart_requested = state.get("restart_requested")
+    secret_redaction_enabled = state.get("secret_redaction_enabled")
     platforms = state.get("platforms", {}) or {}
+
+    if secret_redaction_enabled is True:
+        lines.append("✓ Secret redaction enabled")
+    elif secret_redaction_enabled is False:
+        lines.append("⚠ Secret redaction disabled")
 
     for platform, pdata in platforms.items():
         if pdata.get("state") == "fatal":
@@ -6216,7 +6228,24 @@ def _gateway_command_inner(args):
         service_available = False
         system = getattr(args, "system", False)
         restart_all = getattr(args, "all", False)
+        force_restart = getattr(args, "force", False)
         service_configured = False
+
+        if not restart_all and not force_restart:
+            try:
+                from gateway.status import read_runtime_status
+                status = read_runtime_status() or {}
+                active_agents = int(status.get("active_agents") or 0)
+            except Exception:
+                active_agents = 0
+            if active_agents > 0:
+                print("✗ Gateway restart refused: active agent run(s) are in progress.")
+                print(f"  Active agents: {active_agents}")
+                print("  This avoids interrupting Telegram tasks and losing in-memory run state.")
+                print("  Prefer an in-chat /reload-mcp for MCP/tool changes, or wait for the task to finish.")
+                print("  If you intentionally want to interrupt active work, run:")
+                print("    hermes gateway restart --force")
+                return
 
         # Phase 4: inside a container with s6, dispatch via the service
         # manager (s6-svc -t restarts the supervised process). ``--all``

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12065,6 +12065,11 @@ def main():
         action="store_true",
         help="Kill ALL gateway processes across all profiles before restarting",
     )
+    gateway_restart.add_argument(
+        "--force",
+        action="store_true",
+        help="Restart even if active gateway agent runs are in progress",
+    )
 
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,15 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # `--all` means show all status sections, not raw secrets. Never echo
+        # provider keys verbatim in CLI/status output because that output is
+        # commonly pasted into chats, logs, and support tickets.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -363,7 +363,8 @@ class TestBuildSessionContextPrompt:
         prompt = build_session_context_prompt(ctx)
 
         assert "Multi-user thread" in prompt
-        assert "[sender name]" in prompt
+        assert "Sender:" in prompt
+        assert "not as topic tags" in prompt
         # Should NOT show a specific **User:** line (would bust cache)
         assert "**User:** Alice" not in prompt
 
@@ -406,7 +407,8 @@ class TestBuildSessionContextPrompt:
         prompt = build_session_context_prompt(ctx)
 
         assert "Multi-user session" in prompt
-        assert "[sender name]" in prompt
+        assert "Sender:" in prompt
+        assert "not as topic tags" in prompt
         assert "**User:** Alice" not in prompt
 
     def test_dm_thread_shows_user_not_multi(self):
@@ -430,11 +432,11 @@ class TestBuildSessionContextPrompt:
         assert "Multi-user thread" not in prompt
 
 
-class TestSenderPrefixWithBackfill:
-    """Regression: sender prefix must not wrap the backfill context block.
+class TestSenderMetadataWithBackfill:
+    """Regression: sender metadata must not wrap the backfill context block.
 
     Tests exercise the real GatewayRunner._prepare_inbound_message_text()
-    method to ensure the [sender_name] prefix applies only to the trigger
+    method to ensure sender metadata applies only to the trigger
     message, not the channel_context backfill block.
     """
 
@@ -460,17 +462,17 @@ class TestSenderPrefixWithBackfill:
         )
 
     @pytest.mark.asyncio
-    async def test_plain_message_gets_prefix(self, runner, source):
-        """Normal message without backfill gets [sender] prefix."""
+    async def test_plain_message_gets_sender_metadata(self, runner, source):
+        """Normal message without backfill gets explicit sender metadata."""
         event = MessageEvent(text="hello world", source=source)
         result = await runner._prepare_inbound_message_text(
             event=event, source=source, history=[],
         )
-        assert result == "[Alice] hello world"
+        assert result == "Sender: Alice\n\nhello world"
 
     @pytest.mark.asyncio
-    async def test_backfill_prefix_only_on_trigger(self, runner, source):
-        """Backfill context must NOT get the sender prefix."""
+    async def test_backfill_sender_metadata_only_on_trigger(self, runner, source):
+        """Backfill context must NOT get the sender metadata."""
         event = MessageEvent(
             text="hello world",
             source=source,
@@ -480,8 +482,8 @@ class TestSenderPrefixWithBackfill:
             event=event, source=source, history=[],
         )
         assert result.startswith("[Recent channel messages]")
-        assert "[Alice] [Recent channel messages]" not in result
-        assert "[New message]\n[Alice] hello world" in result
+        assert "Sender: Alice\n\n[Recent channel messages]" not in result
+        assert "[New message]\nSender: Alice\n\nhello world" in result
 
     @pytest.mark.asyncio
     async def test_backfill_preserves_context_block(self, runner, source):
@@ -494,7 +496,7 @@ class TestSenderPrefixWithBackfill:
             event=event, source=source, history=[],
         )
         assert result.startswith(context)
-        assert "[Alice] hey everyone" in result
+        assert "Sender: Alice\n\nhey everyone" in result
         assert "[Alice] [Bob]" not in result
         assert "[Alice] [Charlie" not in result
         assert "[Alice] [Recent" not in result

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -16,16 +16,31 @@ from unittest.mock import patch
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
-def _make_runner(stt_enabled: bool = True) -> "GatewayRunner":  # type: ignore[name-defined]
+def _make_runner(
+    stt_enabled: bool = True,
+    *,
+    auto_transcribe_audio_attachments: bool = False,
+) -> "GatewayRunner":  # type: ignore[name-defined]
     from gateway.run import GatewayRunner
 
     runner = GatewayRunner.__new__(GatewayRunner)
-    runner.config = GatewayConfig(stt_enabled=stt_enabled)
+    runner.config = GatewayConfig(
+        stt_enabled=stt_enabled,
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={
+                    "auto_transcribe_audio_attachments": auto_transcribe_audio_attachments,
+                },
+            )
+        },
+    )
     runner.adapters = {}
     runner._model = "test-model"
     runner._base_url = ""
@@ -134,6 +149,28 @@ async def test_audio_attachment_context_note_format():
     assert "audio file attachment" in result.lower()
     # Should NOT contain the voice-message transcription wrapper text
     assert "voice message" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_audio_attachment_transcribed_when_config_enabled():
+    """Telegram audio attachments should be STT-capable when explicitly opted in."""
+    runner = _make_runner(stt_enabled=True, auto_transcribe_audio_attachments=True)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm")
+    event = _audio_event("/tmp/meeting.m4a")
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "meeting notes", "provider": "whisper"},
+    ) as mock_transcribe:
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    mock_transcribe.assert_called_once_with("/tmp/meeting.m4a")
+    assert "meeting notes" in result
+    assert "audio file attachment" not in result.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -91,9 +91,13 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     # Media flags — all None except explicit payload
     msg.photo = photo
     msg.video = None
+    msg.video_note = None
+    msg.animation = None
     msg.audio = None
     msg.voice = None
     msg.sticker = None
+    msg.contact = None
+    msg.poll = None
     msg.document = document
     msg.media_group_id = media_group_id
     # Chat / user
@@ -118,8 +122,18 @@ def _make_update(msg):
 
 def _make_video(file_obj=None):
     video = MagicMock()
+    video.file_size = 1024
     video.get_file = AsyncMock(return_value=file_obj or _make_file_obj(b"video-bytes"))
     return video
+
+
+def _make_audio(file_obj=None):
+    audio = MagicMock()
+    audio.file_size = 1024
+    audio.file_name = "clip.mp3"
+    audio.mime_type = "audio/mpeg"
+    audio.get_file = AsyncMock(return_value=file_obj or _make_file_obj(b"audio-bytes"))
+    return audio
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +188,56 @@ class TestDocumentTypeDetection:
         await adapter._handle_media_message(update, MagicMock())
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
+
+
+class TestTelegramStructuredMediaSummaries:
+    @pytest.mark.asyncio
+    async def test_contact_message_is_summarized_as_text(self, adapter):
+        msg = _make_message()
+        msg.contact = SimpleNamespace(
+            first_name="Ada",
+            last_name="Lovelace",
+            phone_number="+155****4567",
+            user_id=4242,
+            vcard=None,
+        )
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.TEXT
+        assert "Telegram contact" in event.text
+        assert "Ada Lovelace" in event.text
+        assert "+155****4567" in event.text
+        assert "4242" in event.text
+
+    @pytest.mark.asyncio
+    async def test_poll_message_is_summarized_as_text(self, adapter):
+        msg = _make_message()
+        msg.poll = SimpleNamespace(
+            question="Pick lunch",
+            options=[
+                SimpleNamespace(text="Pizza", voter_count=2),
+                SimpleNamespace(text="Sushi", voter_count=1),
+            ],
+            total_voter_count=3,
+            is_closed=False,
+            is_anonymous=True,
+            type="regular",
+            allows_multiple_answers=False,
+        )
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.TEXT
+        assert "Telegram poll" in event.text
+        assert "Pick lunch" in event.text
+        assert "Pizza — 2" in event.text
+        assert "Sushi — 1" in event.text
+        assert "total votes: 3" in event.text
 
 
 # ---------------------------------------------------------------------------
@@ -336,18 +400,35 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/pdf"]
 
     @pytest.mark.asyncio
-    async def test_missing_filename_and_mime_rejected(self, adapter):
+    async def test_missing_filename_and_mime_cached_as_generic_document(self, adapter):
         doc = _make_document(file_name=None, mime_type=None, file_size=100)
         msg = _make_message(document=doc)
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
         event = adapter.handle_message.call_args[0][0]
-        assert "Unsupported" in event.text
+        assert event.message_type == MessageType.DOCUMENT
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["application/octet-stream"]
+        assert "Unsupported" not in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_unknown_extension_cached_as_generic_document(self, adapter):
+        doc = _make_document(file_name="mystery.xyzzy", mime_type=None, file_size=100)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_urls and event.media_urls[0].endswith("mystery.xyzzy")
+        assert event.media_types == ["application/octet-stream"]
+        assert "Unsupported" not in (event.text or "")
 
     @pytest.mark.asyncio
     async def test_unicode_decode_error_handled(self, adapter):
-        """Binary bytes that aren't valid UTF-8 in a .txt — content not injected but file still cached."""
+        """Binary-ish .txt bytes get a replacement-decoded preview and the file is cached."""
         binary = bytes(range(128, 256))  # not valid UTF-8
         file_obj = _make_file_obj(binary)
         doc = _make_document(
@@ -362,8 +443,9 @@ class TestDocumentDownloadBlock:
         # File should still be cached
         assert len(event.media_urls) == 1
         assert os.path.exists(event.media_urls[0])
-        # Content NOT injected — text should be empty (no caption set)
-        assert "[Content of" not in (event.text or "")
+        # Invalid UTF-8/UTF-16 should still give the model visible context.
+        assert "[Content of binary.txt]" in (event.text or "")
+        assert "�" in (event.text or "")
 
     @pytest.mark.asyncio
     async def test_text_injection_capped(self, adapter):
@@ -413,6 +495,64 @@ class TestVideoDownloadBlock:
         assert len(event.media_urls) == 1
         assert os.path.exists(event.media_urls[0])
         assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+    @pytest.mark.asyncio
+    async def test_video_note_is_cached_as_video(self, adapter):
+        file_obj = _make_file_obj(b"fake-round-video")
+        file_obj.file_path = "videos/round.mp4"
+        msg = _make_message()
+        msg.video_note = _make_video(file_obj)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VIDEO
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+    @pytest.mark.asyncio
+    async def test_animation_is_cached_as_video(self, adapter):
+        file_obj = _make_file_obj(b"fake-gif-video")
+        file_obj.file_path = "animations/dance.mp4"
+        msg = _make_message()
+        msg.animation = _make_video(file_obj)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VIDEO
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+    @pytest.mark.asyncio
+    async def test_audio_file_too_big_gets_clear_user_message(self, adapter):
+        audio = _make_audio()
+        audio.get_file = AsyncMock(side_effect=RuntimeError("File is too big"))
+        msg = _make_message()
+        msg.audio = audio
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "couldn't download" in event.text
+        assert "20 MB" in event.text
+        assert event.media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_video_file_too_big_gets_clear_user_message(self, adapter):
+        video = _make_video()
+        video.get_file = AsyncMock(side_effect=RuntimeError("File is too big"))
+        msg = _make_message()
+        msg.video = video
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "couldn't download" in event.text
+        assert "20 MB" in event.text
+        assert event.media_urls == []
 
     @pytest.mark.asyncio
     async def test_mp4_document_is_treated_as_video(self, adapter):

--- a/tests/gateway/test_telegram_max_doc_bytes.py
+++ b/tests/gateway/test_telegram_max_doc_bytes.py
@@ -54,3 +54,24 @@ def test_max_doc_bytes_empty_base_url_keeps_default():
         PlatformConfig(enabled=True, token="***", extra={"base_url": ""}),
     )
     assert adapter._max_doc_bytes == 20 * 1024 * 1024
+
+
+def test_concurrent_updates_defaults_to_parallel_processing(monkeypatch):
+    monkeypatch.delenv("HERMES_TELEGRAM_CONCURRENT_UPDATES", raising=False)
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+    assert adapter._resolve_concurrent_updates() == 32
+
+
+def test_concurrent_updates_can_be_disabled():
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"concurrent_updates": "off"})
+    )
+    assert adapter._resolve_concurrent_updates() is False
+
+
+def test_concurrent_updates_prefers_explicit_extra_over_env(monkeypatch):
+    monkeypatch.setenv("HERMES_TELEGRAM_CONCURRENT_UPDATES", "64")
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"concurrent_updates": "7"})
+    )
+    assert adapter._resolve_concurrent_updates() == 7

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -129,6 +129,25 @@ async def test_edit_failure_falls_back_to_fresh_send(adapter):
 
 
 @pytest.mark.asyncio
+async def test_edit_flood_control_does_not_send_fresh_status(adapter):
+    """Flooded status edits must not create fresh bubbles that extend flood wait."""
+    adapter.send.return_value = SendResult(success=True, message_id="100")
+    adapter.edit_message.return_value = SendResult(
+        success=False, error="flood_control:13", retryable=True,
+    )
+
+    await adapter.send_or_update_status("chat-1", "lifecycle", "step 1")
+    result = await adapter.send_or_update_status("chat-1", "lifecycle", "step 2")
+
+    assert result.success is False
+    assert "flood_control" in result.error
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once()
+    # Keep the cached id so the next calm update edits the same bubble.
+    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
+
+
+@pytest.mark.asyncio
 async def test_distinct_status_keys_do_not_collide(adapter):
     """A different status_key gets its own message; the original isn't touched."""
     adapter.send.side_effect = [

--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -20,3 +20,27 @@ def test_runtime_health_lines_include_fatal_platform_and_startup_reason(monkeypa
 
     assert "⚠ telegram: another poller is active" in lines
     assert "⚠ Last startup issue: telegram conflict" in lines
+
+
+def test_runtime_health_lines_include_secret_redaction_status(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "secret_redaction_enabled": True,
+            "platforms": {},
+        },
+    )
+
+    assert "✓ Secret redaction enabled" in _runtime_health_lines()
+
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "secret_redaction_enabled": False,
+            "platforms": {},
+        },
+    )
+
+    assert "⚠ Secret redaction disabled" in _runtime_health_lines()

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -5,13 +5,30 @@ from hermes_cli.status import show_status
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_all_still_redacts_api_keys(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.gateway as gateway_mod
+
+    raw_key = "tvly-dev-this-is-a-realistic-looking-secret-value"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TAVILY_API_KEY", raw_key)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert raw_key not in output
+    assert "tvly" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,9 +17,8 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
-    from hermes_cli import __version__
+    """When cache is fresh for the current git state, return cached value."""
+    import hermes_cli.banner as banner
 
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
@@ -27,14 +26,38 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "rev": "git-state", "ver": banner.VERSION})
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+    with patch.object(banner, "_local_git_cache_rev", return_value="git-state"), \
+         patch.object(banner, "_check_via_local_git") as mock_check:
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    mock_check.assert_not_called()
+
+
+def test_check_for_updates_ignores_stale_git_cache(tmp_path, monkeypatch):
+    """A fresh cache from an older HEAD must not survive a local git update."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 283, "rev": "old-git-state"}))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch.object(banner, "_local_git_cache_rev", return_value="new-git-state"), \
+         patch.object(banner, "_check_via_local_git", return_value=0) as mock_check:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_check.assert_called_once()
+    assert json.loads(cache_file.read_text())["rev"] == "new-git-state"
 
 
 def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
@@ -93,7 +116,7 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count >= 2  # cache key rev-parse(s), git fetch, git rev-list
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -674,6 +674,73 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.usage.total_tokens == 11
 
 
+def test_run_codex_stream_uses_low_level_create_stream(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    streamed_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream recovered")],
+    )
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.output_item.done", item=streamed_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(id="resp_low_level", status="completed", output=None),
+            ),
+        ]
+    )
+
+    def _unexpected_stream(**kwargs):
+        raise AssertionError("run_codex_stream should not use the SDK high-level responses.stream helper")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_unexpected_stream,
+            create=lambda **kwargs: create_stream,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "stream recovered"
+    assert create_stream.closed is True
+
+
+def test_codex_create_stream_fallback_backfills_null_completed_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    streamed_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="fallback recovered")],
+    )
+    terminal_response = SimpleNamespace(output=None, status="completed")
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.output_item.done", item=streamed_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=terminal_response,
+            ),
+        ]
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream)
+    )
+
+    response = agent._run_codex_create_stream_fallback(
+        _codex_request_kwargs(),
+        client=agent.client,
+    )
+
+    assert response is terminal_response
+    assert response.output[0].content[0].text == "fallback recovered"
+    assert create_stream.closed is True
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))
@@ -1089,7 +1156,7 @@ def test_run_conversation_codex_tool_round_trip(monkeypatch):
     responses = [_codex_tool_call_response(), _codex_message_response("done")]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1280,7 +1347,7 @@ def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
 
     monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1315,7 +1382,7 @@ def test_run_conversation_codex_continues_after_incomplete_interim_message(monke
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1667,7 +1734,7 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1703,7 +1770,7 @@ def test_run_conversation_codex_continues_after_ack_stop_message(monkeypatch):
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1744,7 +1811,7 @@ def test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
         for call in assistant_message.tool_calls:
             messages.append(
                 {

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -163,6 +163,36 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+    def test_bare_home_channel_preserves_thread_id(self):
+        """Bare platform targets should route to the configured home thread/topic."""
+        home = SimpleNamespace(chat_id="-1001", thread_id="1582")
+        config, _telegram_cfg = _make_config()
+        config.get_home_channel = lambda _platform: home
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert "thread_id: 1582" in result["note"]
+        send_mock.assert_awaited_once()
+        send_args = send_mock.await_args
+        assert send_args is not None
+        assert send_args.kwargs["thread_id"] == "1582"
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.kwargs["thread_id"] == "1582"
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -947,7 +947,8 @@ class TestTranscribeAudioDispatch:
         large_audio = tmp_path / "long.ogg"
         large_audio.write_bytes(b"x" * 20)
 
-        def fake_ffmpeg_run(command, check, capture_output, text):
+        def fake_ffmpeg_run(command, check, capture_output, text, timeout):
+            assert timeout == 300
             output_pattern = next(arg for arg in command if "%03d" in str(arg))
             for idx in range(2):
                 Path(str(output_pattern).replace("%03d", f"{idx:03d}")).write_bytes(b"chunk")
@@ -971,6 +972,21 @@ class TestTranscribeAudioDispatch:
         assert result["provider"] == "local"
         assert result["transcript"] == "first chunk\n\nsecond chunk"
         assert mock_local.call_count == 2
+
+    def test_large_audio_chunking_reports_ffmpeg_timeout(self, tmp_path):
+        large_audio = tmp_path / "long.ogg"
+        large_audio.write_bytes(b"x" * 20)
+
+        with patch("tools.transcription_tools.MAX_FILE_SIZE", 10), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"provider": "local"}), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._find_ffmpeg_binary", return_value="ffmpeg"), \
+             patch("tools.transcription_tools.subprocess.run", side_effect=subprocess.TimeoutExpired(["ffmpeg"], 300)):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(large_audio))
+
+        assert result["success"] is False
+        assert "Timed out while splitting audio" in result["error"]
 
 
 # ============================================================================

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -11,7 +11,9 @@ import struct
 import subprocess
 import types
 import wave
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
 
 import pytest
 
@@ -940,6 +942,35 @@ class TestTranscribeAudioDispatch:
             transcribe_audio(sample_ogg, model=None)
 
         assert mock_openai.call_args[0][1] == "gpt-4o-transcribe"
+
+    def test_large_audio_is_split_into_ffmpeg_chunks(self, tmp_path):
+        large_audio = tmp_path / "long.ogg"
+        large_audio.write_bytes(b"x" * 20)
+
+        def fake_ffmpeg_run(command, check, capture_output, text):
+            output_pattern = next(arg for arg in command if "%03d" in str(arg))
+            for idx in range(2):
+                Path(str(output_pattern).replace("%03d", f"{idx:03d}")).write_bytes(b"chunk")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        transcripts = [
+            {"success": True, "transcript": "first chunk", "provider": "local"},
+            {"success": True, "transcript": "second chunk", "provider": "local"},
+        ]
+        with patch("tools.transcription_tools.MAX_FILE_SIZE", 10), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"provider": "local"}), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._find_ffmpeg_binary", return_value="ffmpeg"), \
+             patch("tools.transcription_tools.subprocess.run", side_effect=fake_ffmpeg_run), \
+             patch("tools.transcription_tools._transcribe_local", side_effect=transcripts) as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(large_audio))
+
+        assert result["success"] is True
+        assert result["chunked"] is True
+        assert result["provider"] == "local"
+        assert result["transcript"] == "first chunk\n\nsecond chunk"
+        assert mock_local.call_count == 2
 
 
 # ============================================================================

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -396,6 +396,15 @@ class TestBackendSelection:
              patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             assert _get_backend() == "parallel"
 
+    def test_extract_results_have_content_helper(self):
+        """Fallback extraction detects content-bearing provider results."""
+        from tools.web_tools import _extract_results_have_content
+
+        assert _extract_results_have_content([{"url": "https://x.test", "content": "hello"}]) is True
+        assert _extract_results_have_content({"results": [{"url": "https://x.test", "markdown": "# hi"}]}) is True
+        assert _extract_results_have_content([{"url": "https://x.test", "content": "", "error": "empty"}]) is False
+        assert _extract_results_have_content({"success": False, "error": "failed"}) is False
+
 
 class TestParallelClientConfig:
     """Test suite for Parallel client initialization."""

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -300,17 +300,17 @@ class MemoryStore:
         Hard limits keep files from exceeding absolute prompt budget. The soft
         guard is a hygiene layer: when enabled, new append-only entries are
         refused once they would push core memory above the target percentage.
-        Agents can still consolidate with replace/remove, or the user can
-        intentionally bypass via HERMES_MEMORY_SOFT_GUARD_BYPASS=1.
+        Agents can still consolidate with replace/remove, or an operator can
+        intentionally bypass via ``memory.soft_guard_bypass`` in config.yaml.
         """
-        if os.environ.get("HERMES_MEMORY_SOFT_GUARD_BYPASS") == "1":
-            return {"enabled": False}
         try:
             from hermes_cli.config import read_raw_config
 
             cfg = read_raw_config() or {}
             mem_cfg = cfg.get("memory", {}) if isinstance(cfg, dict) else {}
             if not isinstance(mem_cfg, dict):
+                return {"enabled": False}
+            if bool(mem_cfg.get("soft_guard_bypass", False)):
                 return {"enabled": False}
             enabled = bool(mem_cfg.get("soft_guard_enabled", False))
             target_pct = float(mem_cfg.get("soft_target_pct", 50))
@@ -378,7 +378,7 @@ class MemoryStore:
                             f"above the configured {target_pct:.1f}% target. "
                             "Use replace/remove to consolidate, save procedures as skills, "
                             "or store detailed facts in fact_store/session/project docs. "
-                            "Set HERMES_MEMORY_SOFT_GUARD_BYPASS=1 only for an intentional override."
+                            "Set memory.soft_guard_bypass in config.yaml only for an intentional override."
                         ),
                         "current_entries": entries,
                         "usage": f"{current:,}/{limit:,}",

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -294,6 +294,32 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
+    def _soft_guard_config(self, target: str) -> Dict[str, Any]:
+        """Return optional soft-budget settings for append-only writes.
+
+        Hard limits keep files from exceeding absolute prompt budget. The soft
+        guard is a hygiene layer: when enabled, new append-only entries are
+        refused once they would push core memory above the target percentage.
+        Agents can still consolidate with replace/remove, or the user can
+        intentionally bypass via HERMES_MEMORY_SOFT_GUARD_BYPASS=1.
+        """
+        if os.environ.get("HERMES_MEMORY_SOFT_GUARD_BYPASS") == "1":
+            return {"enabled": False}
+        try:
+            from hermes_cli.config import read_raw_config
+
+            cfg = read_raw_config() or {}
+            mem_cfg = cfg.get("memory", {}) if isinstance(cfg, dict) else {}
+            if not isinstance(mem_cfg, dict):
+                return {"enabled": False}
+            enabled = bool(mem_cfg.get("soft_guard_enabled", False))
+            target_pct = float(mem_cfg.get("soft_target_pct", 50))
+            if target_pct <= 0 or target_pct >= 100:
+                target_pct = 50.0
+            return {"enabled": enabled, "target_pct": target_pct}
+        except Exception:
+            return {"enabled": False}
+
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
@@ -337,6 +363,27 @@ class MemoryStore:
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
+
+            soft = self._soft_guard_config(target)
+            if soft.get("enabled"):
+                target_pct = float(soft.get("target_pct", 50.0))
+                soft_limit = int(limit * target_pct / 100.0)
+                if new_total > soft_limit:
+                    current = self._char_count(target)
+                    return {
+                        "success": False,
+                        "error": (
+                            f"Memory soft guard: adding this entry would put {target} memory at "
+                            f"{new_total:,}/{limit:,} chars ({new_total / limit * 100:.1f}%), "
+                            f"above the configured {target_pct:.1f}% target. "
+                            "Use replace/remove to consolidate, save procedures as skills, "
+                            "or store detailed facts in fact_store/session/project docs. "
+                            "Set HERMES_MEMORY_SOFT_GUARD_BYPASS=1 only for an intentional override."
+                        ),
+                        "current_entries": entries,
+                        "usage": f"{current:,}/{limit:,}",
+                        "soft_limit": f"{soft_limit:,}/{limit:,}",
+                    }
 
             entries.append(content)
             self._set_entries(target, entries)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -272,6 +272,8 @@ def _handle_send(args):
                 home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
         if home:
             chat_id = home.chat_id
+            if not thread_id and getattr(home, "thread_id", None):
+                thread_id = str(home.thread_id)
             used_home_channel = True
         else:
             home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
@@ -324,6 +326,8 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+            if thread_id:
+                result["note"] += f" thread_id: {thread_id}"
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1646,7 +1646,11 @@ def _split_audio_with_ffmpeg(file_path: str, output_dir: str, *, segment_seconds
         output_pattern,
     ]
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300)
+    except subprocess.TimeoutExpired as e:
+        details = (e.stderr or e.stdout or "").strip() if isinstance(e.stderr or e.stdout, str) else ""
+        logger.error("ffmpeg audio chunking timed out for %s: %s", file_path, details)
+        return [], "Timed out while splitting audio for STT"
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
         logger.error("ffmpeg audio chunking failed for %s: %s", file_path, details)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1013,7 +1013,7 @@ def _dispatch_to_plugin_provider(
 # ---------------------------------------------------------------------------
 
 
-def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
+def _validate_audio_file(file_path: str, *, allow_oversize: bool = False) -> Optional[Dict[str, Any]]:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
@@ -1031,7 +1031,7 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
         }
     try:
         file_size = audio_path.stat().st_size
-        if file_size > MAX_FILE_SIZE:
+        if file_size > MAX_FILE_SIZE and not allow_oversize:
             return {
                 "success": False,
                 "transcript": "",
@@ -1521,7 +1521,6 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"xAI STT transcription failed: {e}"}
 
 
-# ---------------------------------------------------------------------------
 # Provider: ElevenLabs (Scribe STT API)
 # ---------------------------------------------------------------------------
 
@@ -1608,45 +1607,65 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Public API
+# Large-file chunking
 # ---------------------------------------------------------------------------
 
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
-    """
-    Transcribe an audio file using the configured STT provider.
+def _audio_file_size(file_path: str) -> int:
+    try:
+        return Path(file_path).stat().st_size
+    except OSError:
+        return 0
 
-    Provider priority:
-      1. User config (``stt.provider`` in config.yaml)
-      2. Auto-detect: local > Groq > OpenAI > Mistral > xAI > ElevenLabs
 
-    Args:
-        file_path: Absolute path to the audio file to transcribe.
-        model:     Override the model. If None, uses config or provider default.
+def _split_audio_with_ffmpeg(file_path: str, output_dir: str, *, segment_seconds: int = 600) -> tuple[list[str], Optional[str]]:
+    """Transcode/split audio into small MP3 chunks suitable for STT APIs."""
+    ffmpeg = _find_ffmpeg_binary()
+    if not ffmpeg:
+        return [], "Audio is larger than the STT per-file limit and ffmpeg was not found for chunking"
 
-    Returns:
-        dict with keys:
-          - "success" (bool): Whether transcription succeeded
-          - "transcript" (str): The transcribed text (empty on failure)
-          - "error" (str, optional): Error message if success is False
-          - "provider" (str, optional): Which provider was used
-    """
-    # Validate input
-    error = _validate_audio_file(file_path)
-    if error:
-        return error
+    output_pattern = os.path.join(output_dir, "chunk_%03d.mp3")
+    command = [
+        ffmpeg,
+        "-y",
+        "-i",
+        file_path,
+        "-vn",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-b:a",
+        "64k",
+        "-f",
+        "segment",
+        "-segment_time",
+        str(segment_seconds),
+        "-reset_timestamps",
+        "1",
+        output_pattern,
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        details = e.stderr.strip() or e.stdout.strip() or str(e)
+        logger.error("ffmpeg audio chunking failed for %s: %s", file_path, details)
+        return [], f"Failed to split audio for STT: {details}"
 
-    # Load config and determine provider
-    stt_config = _load_stt_config()
-    if not is_stt_enabled(stt_config):
-        return {
-            "success": False,
-            "transcript": "",
-            "error": "STT is disabled in config.yaml (stt.enabled: false).",
-        }
+    chunks = sorted(str(path) for path in Path(output_dir).glob("chunk_*.mp3"))
+    if not chunks:
+        return [], "ffmpeg completed but produced no audio chunks"
+    oversized = [path for path in chunks if _audio_file_size(path) > MAX_FILE_SIZE]
+    if oversized:
+        return [], (
+            "ffmpeg produced a chunk larger than the STT per-file limit; "
+            "try a shorter recording or lower bitrate"
+        )
+    return chunks, None
 
-    provider = _get_provider(stt_config)
 
+def _transcribe_with_provider(file_path: str, provider: str, stt_config: Dict[str, Any], model: Optional[str] = None) -> Dict[str, Any]:
+    """Dispatch to the selected STT provider after validation/chunking."""
     if provider == "local":
         local_cfg = stt_config.get("local", {})
         model_name = _normalize_local_model(
@@ -1676,7 +1695,6 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_mistral(file_path, model_name)
 
     if provider == "xai":
-        # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
@@ -1701,19 +1719,6 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             model_override=model,
         )
 
-    # Plugin-registered STT backend (e.g. OpenRouter, SenseAudio,
-    # Gemini-STT). Fires only when ``provider`` is neither a built-in
-    # nor ``"none"`` AND there is no same-name command provider. The
-    # dispatcher enforces built-ins-always-win + command-wins-over-plugin
-    # defensively. Returns None when no plugin is registered for the
-    # configured name, falling through to the legacy "No STT provider"
-    # error message below.
-    #
-    # Plugin-scoped config namespace mirrors the built-in pattern
-    # (``stt.openai.model``, ``stt.mistral.model``): plugins read their
-    # per-provider config under ``stt.<provider>`` and the dispatcher
-    # forwards ``language`` from there. Top-level ``model`` argument
-    # overrides any config-set model.
     plugin_cfg = stt_config.get(provider, {}) if isinstance(stt_config.get(provider), dict) else {}
     plugin_language = plugin_cfg.get("language")
     plugin_model = model or plugin_cfg.get("model")
@@ -1727,7 +1732,6 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     if plugin_result is not None:
         return plugin_result
 
-    # No provider available
     return {
         "success": False,
         "transcript": "",
@@ -1740,6 +1744,90 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
+
+
+def _transcribe_large_audio_in_chunks(file_path: str, provider: str, stt_config: Dict[str, Any], model: Optional[str] = None) -> Dict[str, Any]:
+    """Split oversized audio and transcribe chunks sequentially."""
+    with tempfile.TemporaryDirectory(prefix="hermes-stt-chunks-") as chunk_dir:
+        chunks, error = _split_audio_with_ffmpeg(file_path, chunk_dir)
+        if error:
+            return {"success": False, "transcript": "", "error": error}
+
+        transcripts: list[str] = []
+        chunk_provider = provider
+        for index, chunk_path in enumerate(chunks, start=1):
+            validation_error = _validate_audio_file(chunk_path)
+            if validation_error:
+                validation_error["error"] = f"Chunk {index} validation failed: {validation_error['error']}"
+                return validation_error
+            result = _transcribe_with_provider(chunk_path, provider, stt_config, model=model)
+            if not result.get("success"):
+                return {
+                    "success": False,
+                    "transcript": "\n\n".join(transcripts),
+                    "error": f"Chunk {index}/{len(chunks)} failed: {result.get('error', 'unknown STT error')}",
+                    "provider": result.get("provider", provider),
+                    "chunked": True,
+                    "chunks": len(chunks),
+                }
+            chunk_provider = result.get("provider", chunk_provider)
+            text = str(result.get("transcript") or "").strip()
+            if text:
+                transcripts.append(text)
+
+    return {
+        "success": True,
+        "transcript": "\n\n".join(transcripts),
+        "provider": chunk_provider,
+        "chunked": True,
+        "chunks": len(chunks),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Transcribe an audio file using the configured STT provider.
+
+    Provider priority:
+      1. User config (``stt.provider`` in config.yaml)
+      2. Auto-detect: local faster-whisper (free) > Groq (free tier) > OpenAI (paid)
+
+    Args:
+        file_path: Absolute path to the audio file to transcribe.
+        model:     Override the model. If None, uses config or provider default.
+
+    Returns:
+        dict with keys:
+          - "success" (bool): Whether transcription succeeded
+          - "transcript" (str): The transcribed text (empty on failure)
+          - "error" (str, optional): Error message if success is False
+          - "provider" (str, optional): Which provider was used
+    """
+    # Validate input.  Oversized audio is allowed through here so it can be
+    # split/transcoded into provider-safe chunks below.
+    error = _validate_audio_file(file_path, allow_oversize=True)
+    if error:
+        return error
+
+    # Load config and determine provider
+    stt_config = _load_stt_config()
+    if not is_stt_enabled(stt_config):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "STT is disabled in config.yaml (stt.enabled: false).",
+        }
+
+    provider = _get_provider(stt_config)
+    if _audio_file_size(file_path) > MAX_FILE_SIZE:
+        return _transcribe_large_audio_in_chunks(file_path, provider, stt_config, model=model)
+
+    return _transcribe_with_provider(file_path, provider, stt_config, model=model)
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -148,8 +148,8 @@ def _parse_backend_order(value: Any) -> List[str]:
 def _get_backend_order() -> List[str]:
     """Return the ordered backend preference list.
 
-    ``web.backend_order`` or ``HERMES_WEB_BACKEND_ORDER`` enables runtime
-    fallback across multiple configured providers. If no order is configured,
+    ``web.backend_order`` enables runtime fallback across multiple configured
+    providers. If no order is configured,
     preserve the historical single-backend behavior for explicit
     ``web.backend`` values and the legacy auto-discovery order otherwise.
     """
@@ -157,7 +157,7 @@ def _get_backend_order() -> List[str]:
     configured_order = _parse_backend_order(
         web_config.get("backend_order")
         or web_config.get("fallback_order")
-        or os.getenv("HERMES_WEB_BACKEND_ORDER", "")
+        or ""
     )
     if configured_order:
         return configured_order

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -122,36 +122,64 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
-def _get_backend() -> str:
-    """Determine which web backend to use (shared fallback).
+_SUPPORTED_WEB_BACKENDS = ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai")
+_LEGACY_BACKEND_ORDER = ("firecrawl", "parallel", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai")
 
-    Reads ``web.backend`` from config.yaml (set by ``hermes tools``).
-    Falls back to whichever API key is present for users who configured
-    keys manually without running setup.
+
+def _parse_backend_order(value: Any) -> List[str]:
+    """Parse a configured backend order from a list or comma-separated string."""
+    if isinstance(value, str):
+        raw_items = re.split(r"[,\s]+", value)
+    elif isinstance(value, (list, tuple)):
+        raw_items = value
+    else:
+        raw_items = []
+
+    order: List[str] = []
+    seen = set()
+    for item in raw_items:
+        backend = str(item or "").lower().strip()
+        if backend in _SUPPORTED_WEB_BACKENDS and backend not in seen:
+            order.append(backend)
+            seen.add(backend)
+    return order
+
+
+def _get_backend_order() -> List[str]:
+    """Return the ordered backend preference list.
+
+    ``web.backend_order`` or ``HERMES_WEB_BACKEND_ORDER`` enables runtime
+    fallback across multiple configured providers. If no order is configured,
+    preserve the historical single-backend behavior for explicit
+    ``web.backend`` values and the legacy auto-discovery order otherwise.
     """
-    configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
-        return configured
-
-    # Fallback for manual / legacy config — pick the highest-priority
-    # available backend. Firecrawl also counts as available when the managed
-    # tool gateway is configured for Nous subscribers.
-    # Free-tier backends (searxng / brave-free / ddgs) trail the paid ones so
-    # existing paid setups are unaffected.
-    backend_candidates = (
-        ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
-        ("parallel", _has_env("PARALLEL_API_KEY")),
-        ("tavily", _has_env("TAVILY_API_KEY")),
-        ("exa", _has_env("EXA_API_KEY")),
-        ("searxng", _has_env("SEARXNG_URL")),
-        ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
-        ("ddgs", _ddgs_package_importable()),
+    web_config = _load_web_config()
+    configured_order = _parse_backend_order(
+        web_config.get("backend_order")
+        or web_config.get("fallback_order")
+        or os.getenv("HERMES_WEB_BACKEND_ORDER", "")
     )
-    for backend, available in backend_candidates:
-        if available:
-            return backend
+    if configured_order:
+        return configured_order
 
-    return "firecrawl"  # default (backward compat)
+    configured = (web_config.get("backend") or "").lower().strip()
+    if configured in _SUPPORTED_WEB_BACKENDS:
+        return [configured]
+
+    return list(_LEGACY_BACKEND_ORDER)
+
+
+def _get_available_backend_order() -> List[str]:
+    """Return configured backend order filtered to currently configured backends."""
+    return [backend for backend in _get_backend_order() if _is_backend_available(backend)]
+
+
+def _get_backend() -> str:
+    """Determine the first currently usable web backend."""
+    for backend in _get_available_backend_order():
+        return backend
+    order = _get_backend_order()
+    return order[0] if order else "firecrawl"
 
 
 def _get_search_backend() -> str:
@@ -724,6 +752,28 @@ def clean_base64_images(text: str) -> str:
     return cleaned_text
 
 
+
+def _extract_results_have_content(results: Any) -> bool:
+    """Return True if an extract provider produced any non-empty page content."""
+    if isinstance(results, dict):
+        if results.get("success") is False:
+            return False
+        candidate_results = results.get("results")
+        if candidate_results is None:
+            candidate_results = results.get("data")
+        return _extract_results_have_content(candidate_results)
+    if not isinstance(results, list):
+        return False
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        for key in ("content", "markdown", "text", "html", "raw_content"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return True
+    return False
+
+
 # ─── Exa / Parallel inline helpers — moved into plugins ──────────────────────
 # After PR #25182, the exa client + search/extract and parallel client +
 # search/extract helpers all live in their respective plugins:
@@ -818,40 +868,90 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
+        # Dispatch through the web search registry, but preserve this user's
+        # configured runtime fallback order (for example Tavily → Exa →
+        # local Firecrawl). Providers now live in plugins; the fallback loop
+        # resolves providers by name instead of calling old inline helpers.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
             get_provider as _wsp_get_provider,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
+        fallback_errors = []
+        preferred_backend = _get_search_backend()
+        available_backend_order = _get_available_backend_order()
+        backend_order = []
+        if preferred_backend:
+            backend_order.append(preferred_backend)
+        backend_order.extend(
+            backend for backend in available_backend_order
+            if backend not in backend_order
+        )
+        if not backend_order:
+            backend_order = [_get_backend()]
+        debug_call_data["backend_order"] = backend_order
 
-        if provider is None:
-            response_data = {
-                "success": False,
-                "error": (
-                    "No web search provider configured. "
-                    "Run `hermes tools` to set one up."
-                ),
-            }
-        else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
+        tried_providers = set()
+        for backend in backend_order:
+            provider = _wsp_get_provider(backend) if backend else None
+            if provider is None or not provider.supports_search():
+                fallback_errors.append(f"{backend}: no registered search provider")
+                continue
+            if provider.name in tried_providers:
+                continue
+            tried_providers.add(provider.name)
+            try:
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    provider.name, query, limit,
+                )
+                response_data = provider.search(query, limit)
+                if response_data.get("success") is False:
+                    raise RuntimeError(response_data.get("error") or f"{provider.name} search failed")
+
+                results_count = len(response_data.get("data", {}).get("web", []))
+                logger.info("Web search backend=%s returned %d result(s)", provider.name, results_count)
+                debug_call_data["backend"] = provider.name
+                debug_call_data["fallback_errors"] = fallback_errors
+                debug_call_data["results_count"] = results_count
+                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+                debug_call_data["final_response_size"] = len(result_json)
+                _debug.log_call("web_search_tool", debug_call_data)
+                _debug.save()
+                return result_json
+            except Exception as backend_error:
+                if len(backend_order) == 1:
+                    raise
+                message = f"{provider.name}: {backend_error}"
+                logger.warning("Web search backend failed; trying next backend if available: %s", message)
+                fallback_errors.append(message)
+
+        # Last resort: preserve upstream's active-provider resolution path for
+        # typo/unregistered backend names where an available provider exists.
+        provider = get_active_search_provider()
+        if provider is not None and provider.name not in tried_providers and provider.supports_search():
+            logger.info("Web search via fallback active provider %s: '%s' (limit: %d)", provider.name, query, limit)
             response_data = provider.search(query, limit)
+            if response_data.get("success") is False:
+                raise RuntimeError(response_data.get("error") or f"{provider.name} search failed")
+            debug_call_data["backend"] = provider.name
+            debug_call_data["fallback_errors"] = fallback_errors
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
 
-        debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+        response_data = {
+            "success": False,
+            "error": (
+                "No web search provider configured. "
+                "Run `hermes tools` to set one up."
+                + ((" Fallback errors: " + "; ".join(fallback_errors)) if fallback_errors else "")
+            ),
+        }
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
         debug_call_data["final_response_size"] = len(result_json)
         _debug.log_call("web_search_tool", debug_call_data)
@@ -942,75 +1042,93 @@ async def web_extract_tool(
             else:
                 safe_urls.append(url)
 
-        # Dispatch only safe URLs to the configured backend
+        extract_backend = _get_extract_backend()
+        if extract_backend in ("searxng", "brave-free", "ddgs"):
+            label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)"}[extract_backend]
+            return json.dumps({
+                "success": False,
+                "error": f"{label} is a search-only backend and cannot extract URL content. "
+                         "Set web.extract_backend to firecrawl, tavily, exa, or parallel.",
+            }, ensure_ascii=False)
+
+        # Dispatch only safe URLs to the configured backends, in preference order.
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # Dispatch through plugin providers while preserving configured
+            # runtime fallback order. Some providers' extract() is async
+            # (parallel, firecrawl), others sync (exa, tavily), so dispatch
+            # adapts per provider.
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,
             )
-
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
-                provider = get_active_extract_provider()
-                if provider is None:
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
-
-            logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
-            )
-
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
             import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
+
+            fallback_errors = []
+            available_backend_order = _get_available_backend_order()
+            backend_order = []
+            if extract_backend:
+                backend_order.append(extract_backend)
+            backend_order.extend(
+                backend for backend in available_backend_order
+                if backend not in backend_order
+            )
+            if not backend_order:
+                backend_order = [_get_backend()]
+            debug_call_data["backend_order"] = backend_order
+            results = []
+
+            tried_providers = set()
+            for backend in backend_order:
+                provider = _wsp_get_provider(backend) if backend else None
+                if provider is None:
+                    fallback_errors.append(f"{backend}: no registered extract provider")
+                    continue
+                if not provider.supports_extract():
+                    fallback_errors.append(f"{provider.name}: does not support extract")
+                    continue
+                if provider.name in tried_providers:
+                    continue
+                tried_providers.add(provider.name)
+                try:
+                    logger.info("Web extract via %s: %d URL(s)", provider.name, len(safe_urls))
+                    if inspect.iscoroutinefunction(provider.extract):
+                        candidate_results = await provider.extract(safe_urls, format=format)
+                    else:
+                        candidate_results = await asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        )
+                    if not _extract_results_have_content(candidate_results):
+                        raise RuntimeError(f"{provider.name} returned no extracted content")
+                    results = candidate_results
+                    debug_call_data["backend"] = provider.name
+                    debug_call_data["fallback_errors"] = fallback_errors
+                    break
+                except Exception as backend_error:
+                    if len(backend_order) == 1:
+                        raise
+                    message = f"{provider.name}: {backend_error}"
+                    logger.warning("Web extract backend failed; trying next backend if available: %s", message)
+                    fallback_errors.append(message)
             else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
-                )
+                provider = get_active_extract_provider()
+                if provider is not None and provider.name not in tried_providers and provider.supports_extract():
+                    logger.info("Web extract via fallback active provider %s: %d URL(s)", provider.name, len(safe_urls))
+                    if inspect.iscoroutinefunction(provider.extract):
+                        results = await provider.extract(safe_urls, format=format)
+                    else:
+                        results = await asyncio.to_thread(provider.extract, safe_urls, format=format)
+                    if not _extract_results_have_content(results):
+                        raise RuntimeError(f"{provider.name} returned no extracted content")
+                    debug_call_data["backend"] = provider.name
+                    debug_call_data["fallback_errors"] = fallback_errors
+                else:
+                    raise RuntimeError(
+                        "All configured web extraction backends failed: "
+                        + ("; ".join(fallback_errors) if fallback_errors else "no extract provider configured")
+                    )
 
         # Merge any SSRF-blocked results back in
         if ssrf_blocked:
@@ -1153,14 +1271,8 @@ async def web_extract_tool(
 
 # Convenience function to check Firecrawl credentials
 def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
-        return _is_backend_available(configured)
-    return any(
-        _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
-    )
+    """Check whether at least one configured web backend is available."""
+    return bool(_get_available_backend_order())
 
 
 def check_auxiliary_model() -> bool:


### PR DESCRIPTION
## Summary

Tracks local Hermes runtime reliability fixes that have been repeatedly preserved across this install's safe-update flow.

Patch families included:
- Codex Responses streaming/output backfill resilience
- Telegram large media/download handling and structured media summaries
- Gateway runtime/status and active-agent restart safety
- Sender metadata attribution behavior for gateway session context
- Git-aware update-check cache correctness
- Ordered web backend fallback
- Memory soft guard for core memory bloat
- Telegram home thread preservation
- Oversized audio transcription chunking

This is intentionally opened as a draft because the branch bundles several local reliability patches. It may be better split into focused PRs before maintainer review.

## Test plan

Ran locally on macOS with Hermes venv Python:

```bash
python -m compileall agent gateway hermes_cli tools -q
python -m pytest \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/gateway/test_telegram_documents.py \
  tests/gateway/test_telegram_audio_vs_voice.py \
  tests/gateway/test_telegram_max_doc_bytes.py \
  tests/gateway/test_telegram_status_update.py \
  tests/hermes_cli/test_gateway_runtime_health.py \
  tests/hermes_cli/test_status.py \
  tests/gateway/test_session.py \
  tests/hermes_cli/test_update_check.py \
  tests/tools/test_web_tools_config.py \
  tests/tools/test_send_message_tool.py \
  tests/tools/test_transcription_tools.py \
  -q -o 'addopts='
```

Result:

```text
532 passed, 3 warnings
```
