### PR TITLE
fix(kanban): flag run/status desync when a Ready task has an open running run (#36910)

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1006,13 +1006,25 @@ def _rule_run_status_desync(task, events, runs, now, cfg) -> list[Diagnostic]:
     if not runs:
         return []
     # Newest run = highest id (runs are created monotonically per task).
-    newest = max(runs, key=lambda r: int(_task_field(r, "id", 0) or 0))
+    # ``id`` is normally an int, but a malformed row (string id, unexpected
+    # shape) must not raise ValueError here — ``compute_task_diagnostics``
+    # swallows rule exceptions, so an unguarded ``int()`` would silently drop
+    # the entire diagnostic for this rule. ``_positive_int`` coerces safely
+    # and falls back to 0 for the odd row instead of crashing the whole rule.
+    newest = max(runs, key=lambda r: _positive_int(_task_field(r, "id", 0), 0))
     if _task_field(newest, "status") != "running":
         return []
     if _task_field(newest, "ended_at") is not None:
         return []
 
     run_id = _task_field(newest, "id")
+    # Normalize the id once so the ``run_id`` field, ``data["run_id"]`` and the
+    # detail text all expose the same int contract to consumers (UI/CLI). A
+    # non-numeric id falls back to None rather than raising.
+    run_id_int = _positive_int(run_id, 0) if run_id is not None else None
+    if run_id_int == 0:
+        run_id_int = None
+    run_id_display = run_id_int if run_id_int is not None else run_id
     run_profile = _task_field(newest, "profile")
     assignee = _task_field(task, "assignee") or ""
     # Note: a server-side ``reclaim`` action is intentionally NOT offered
@@ -1034,20 +1046,21 @@ def _rule_run_status_desync(task, events, runs, now, cfg) -> list[Diagnostic]:
         severity="error",
         title="Board lane out of sync with active run",
         detail=(
-            f"This task is in the Ready lane but run #{run_id} is still "
-            f"flagged running (no end time recorded). The board derives "
-            f"lane placement from the task status, so active work is "
-            f"showing as available. Reclaim the task to close the stale "
-            f"run and resync, or confirm the worker for run #{run_id} "
-            f"has actually stopped."
+            f"This task is in the Ready lane but run #{run_id_display} is "
+            f"still flagged running (no end time recorded). The board derives "
+            f"lane placement from the task status, so active work is showing "
+            f"as available. Inspect the open run and confirm the worker for "
+            f"run #{run_id_display} has actually stopped, then re-dispatch the "
+            f"task or close the stale run via admin tooling. (A reclaim won't "
+            f"help here — that path only acts on tasks already in 'running'.)"
         ),
         actions=actions,
         first_seen_at=now,
         last_seen_at=now,
         count=1,
-        run_id=int(run_id) if run_id is not None else None,
+        run_id=run_id_int,
         data={
-            "run_id": run_id,
+            "run_id": run_id_int,
             "run_profile": run_profile,
             "assignee": assignee,
         },

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -974,6 +974,86 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_run_status_desync(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """Task lane disagrees with its active run: the task sits in ``ready``
+    (no live claim) while its latest ``task_run`` is still open and
+    ``running``.
+
+    This is the run/status desync seen after a worker crash + reclaim
+    (#36910): ``detect_crashed_workers`` / ``release_stale_claims`` drop
+    the task back to ``ready`` and close the run on the normal path, but
+    if a run row is ever left open while the task is reset — a host that
+    died mid-transaction, an out-of-band SQL edit, a non-host reclaim
+    that couldn't close the remote run — the board (which derives lanes
+    from ``tasks.status``) shows the work in *Ready* even though a run is
+    still flagged ``running``. Operators can't trust board state, and the
+    dispatcher may treat the active work as available.
+
+    Fire only on the unambiguous desync: ``status == 'ready'``, no
+    ``claim_lock`` (a live claim means the task is genuinely being
+    worked — that's the normal in-flight state, not a desync), and the
+    newest run is ``status == 'running'`` with no ``ended_at``. A
+    correctly-reclaimed task has its run closed (``ended_at`` set,
+    ``status`` in crashed/reclaimed/...), so it never trips this.
+    """
+    if _task_field(task, "status") != "ready":
+        return []
+    # A live claim_lock means the dispatcher considers this task in
+    # flight; ``_rule_stranded_in_ready`` already skips those too. Only
+    # the unclaimed-but-running-run case is a true desync.
+    if _task_field(task, "claim_lock"):
+        return []
+    if not runs:
+        return []
+    # Newest run = highest id (runs are created monotonically per task).
+    newest = max(runs, key=lambda r: int(_task_field(r, "id", 0) or 0))
+    if _task_field(newest, "status") != "running":
+        return []
+    if _task_field(newest, "ended_at") is not None:
+        return []
+
+    run_id = _task_field(newest, "id")
+    run_profile = _task_field(newest, "profile")
+    assignee = _task_field(task, "assignee") or ""
+    # Note: a server-side ``reclaim`` action is intentionally NOT offered
+    # here — ``kanban_db.reclaim_task`` only acts on tasks already in
+    # ``running`` state, and this task is ``ready``. The operator path is
+    # to inspect the open run and re-dispatch (or stop the worker).
+    actions: list[DiagnosticAction] = []
+    task_id = _task_field(task, "id")
+    if task_id:
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label=f"Inspect runs: hermes kanban runs {task_id}",
+            payload={"command": f"hermes kanban runs {task_id}"},
+            suggested=True,
+        ))
+
+    return [Diagnostic(
+        kind="run_status_desync",
+        severity="error",
+        title="Board lane out of sync with active run",
+        detail=(
+            f"This task is in the Ready lane but run #{run_id} is still "
+            f"flagged running (no end time recorded). The board derives "
+            f"lane placement from the task status, so active work is "
+            f"showing as available. Reclaim the task to close the stale "
+            f"run and resync, or confirm the worker for run #{run_id} "
+            f"has actually stopped."
+        ),
+        actions=actions,
+        first_seen_at=now,
+        last_seen_at=now,
+        count=1,
+        run_id=int(run_id) if run_id is not None else None,
+        data={
+            "run_id": run_id,
+            "run_profile": run_profile,
+            "assignee": assignee,
+        },
+    )]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
@@ -985,6 +1065,7 @@ _RULES: list[RuleFn] = [
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
+    _rule_run_status_desync,
 ]
 
 
@@ -999,6 +1080,7 @@ DIAGNOSTIC_KINDS = (
     "stuck_in_blocked",
     "block_unblock_cycling",
     "stranded_in_ready",
+    "run_status_desync",
 )
 
 

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -820,3 +820,38 @@ def test_run_status_desync_silent_when_not_ready():
     runs = [_open_run(run_id=5, status="running", ended_at=None)]
     diags = kd.compute_task_diagnostics(task, [], runs)
     assert [d for d in diags if d.kind == "run_status_desync"] == []
+
+
+def test_run_status_desync_survives_non_numeric_run_id():
+    """A malformed run row with a non-numeric id must not crash the rule.
+
+    ``compute_task_diagnostics`` swallows rule exceptions, so an unguarded
+    ``int()`` on the id (in the newest-run ``max`` key) would silently drop
+    the entire diagnostic. The safe coercion must skip the bad id and still
+    surface the desync from the valid newest run.
+    """
+    task = _task(status="ready", assignee="x", claim_lock=None)
+    runs = [
+        _open_run(run_id="not-an-int", status="running", ended_at=None),
+        _open_run(run_id=9, status="running", ended_at=None),
+    ]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    desync = [d for d in diags if d.kind == "run_status_desync"]
+    assert len(desync) == 1
+    d = desync[0]
+    # run_id is normalized to the same int contract everywhere.
+    assert d.run_id == 9
+    assert d.data["run_id"] == 9
+    assert "#9" in d.detail
+
+
+def test_run_status_desync_detail_does_not_misdirect_to_reclaim():
+    """The detail must not tell operators to 'Reclaim the task' — reclaim
+    only acts on tasks already in 'running' and cannot resolve a ready-lane
+    desync (#36910 Copilot review)."""
+    task = _task(status="ready", assignee="x", claim_lock=None)
+    runs = [_open_run(run_id=11, status="running", ended_at=None)]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    desync = [d for d in diags if d.kind == "run_status_desync"]
+    assert len(desync) == 1
+    assert "Reclaim the task to close the stale run" not in desync[0].detail

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -748,3 +748,75 @@ def test_severity_at_or_above_uses_threshold_semantics():
     assert kd.severity_at_or_above("error", "critical") is False
     assert kd.severity_at_or_above("mystery", "warning") is False
     assert kd.severity_at_or_above("warning", None) is True
+
+
+# ---------------------------------------------------------------------------
+# run_status_desync (#36910) — task in Ready while its newest run is still
+# flagged running with no ended_at (post-crash/reclaim board desync).
+# ---------------------------------------------------------------------------
+
+
+def _open_run(run_id=1, status="running", ended_at=None, profile="dev"):
+    return {
+        "id": run_id,
+        "status": status,
+        "ended_at": ended_at,
+        "profile": profile,
+        "outcome": None,
+    }
+
+
+def test_run_status_desync_fires_when_ready_with_open_running_run():
+    """Reproduces #36910: tasks.status=ready, no claim, newest task_run is
+    running with no ended_at → the board shows active work in Ready."""
+    task = _task(status="ready", assignee="lucca-senior-dev", claim_lock=None)
+    runs = [_open_run(run_id=7, status="running", ended_at=None,
+                      profile="lucca-senior-dev")]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    desync = [d for d in diags if d.kind == "run_status_desync"]
+    assert len(desync) == 1
+    d = desync[0]
+    assert d.severity == "error"
+    assert d.run_id == 7
+    assert d.data["run_id"] == 7
+    assert "#7" in d.detail
+
+
+def test_run_status_desync_silent_when_run_closed():
+    """A correctly-reclaimed task has its run closed (ended_at set) — the
+    normal recovery path must NOT trip this rule."""
+    task = _task(status="ready", assignee="x", claim_lock=None)
+    runs = [_open_run(run_id=3, status="reclaimed", ended_at=1000)]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert [d for d in diags if d.kind == "run_status_desync"] == []
+
+
+def test_run_status_desync_silent_when_claim_lock_held():
+    """A live claim_lock means the task is genuinely in flight (the
+    dispatcher just set running on the run + lock on the task between our
+    two reads); that's not a desync."""
+    task = _task(status="ready", assignee="x", claim_lock="host:abc")
+    runs = [_open_run(run_id=4, status="running", ended_at=None)]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert [d for d in diags if d.kind == "run_status_desync"] == []
+
+
+def test_run_status_desync_uses_newest_run_only():
+    """An older open run must not fire if the newest run is properly
+    closed — only the latest attempt defines the current lane."""
+    task = _task(status="ready", assignee="x", claim_lock=None)
+    runs = [
+        _open_run(run_id=1, status="running", ended_at=None),
+        _open_run(run_id=2, status="crashed", ended_at=2000),
+    ]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert [d for d in diags if d.kind == "run_status_desync"] == []
+
+
+def test_run_status_desync_silent_when_not_ready():
+    """A genuinely running task (status=running) is the expected state,
+    not a desync."""
+    task = _task(status="running", assignee="x", claim_lock=None)
+    runs = [_open_run(run_id=5, status="running", ended_at=None)]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert [d for d in diags if d.kind == "run_status_desync"] == []


### PR DESCRIPTION
## What does this PR do?

Surfaces the kanban run/status desynchronization reported in #36910. After a worker crash and reclaim, the normal recovery path (`detect_crashed_workers` / `release_stale_claims` in `hermes_cli/kanban_db.py`) drops the task back to `ready` **and** closes the open run. But if a `task_run` is ever left open (`status='running'`, `ended_at IS NULL`) while the parent task sits in `ready` with no live `claim_lock`, the board — which derives lane placement from `tasks.status` — shows the work in the **Ready** lane even though a run is still flagged running.

As the issue notes: operators cannot trust board state, the dispatcher may treat active work as available, and `tasks`/`task_runs` disagreeing makes troubleshooting hard. This adds a read-only diagnostic rule that detects exactly that state so it shows up in `hermes kanban diagnostics` and the dashboard distress signals instead of silently misleading the operator.

## Related Issue

Fixes #36910

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_diagnostics.py`: add `_rule_run_status_desync` — a read-only rule that fires (`severity=error`) when a task is `status='ready'`, has no `claim_lock`, and its newest `task_run` is still `status='running'` with `ended_at IS NULL`. It emits an inspect-runs CLI hint and scopes the diagnostic to the stale run id. Registered in `_RULES` and added to `DIAGNOSTIC_KINDS`.
- `tests/hermes_cli/test_kanban_diagnostics.py`: positive + four negative regression tests.

The rule fires only on the unambiguous desync. A live `claim_lock` (the normal in-flight state, where the dispatcher set the run running between two reads) is skipped, and a correctly-reclaimed task has its run closed (`ended_at` set), so it never trips. No state is mutated — the rule is read-only, consistent with every other rule in this module.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_kanban_diagnostics.py -v` → 51 passed.
2. Regression direction: remove `_rule_run_status_desync` from the `_RULES` registry and re-run `-k run_status_desync` → the positive test fails (`assert 0 == 1`); restore it → green.
3. Reproduces #36910's state: `_task(status="ready", claim_lock=None)` + a run `{"status": "running", "ended_at": None}` now yields a `run_status_desync` diagnostic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A