### PR TITLE
fix(gateway): relaunch macOS launchd gateway after /restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10623,8 +10623,17 @@ class GatewayRunner:
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # launchd doesn't set INVOCATION_ID; it sets XPC_SERVICE_NAME to the job
+        # label (e.g. "ai.hermes.gateway-alex") for managed jobs, and "0" for
+        # shell-launched processes.  Without this, macOS LaunchAgents take the
+        # detached self-restart path, exit 0, and KeepAlive{SuccessfulExit=false}
+        # never relaunches them — the gateway stays dead until manual recovery.
+        # (NousResearch/hermes-agent #29180 / #9659 / #35043)
+        _under_launchd = sys.platform == "darwin" and os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_service or _under_launchd or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -11,6 +11,7 @@ Tests are parametrized over platforms via the ``platform`` fixture in conftest.
 """
 
 import asyncio
+import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -113,6 +114,43 @@ class TestSlashCommands:
         response_text = send.call_args[1].get("content") or send.call_args[0][1]
         assert response_text == "agent-handled"
         runner.request_restart.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plaintext_restart_gateway_uses_service_path_under_launchd(self, adapter, runner, platform, monkeypatch):
+        if platform != Platform.TELEGRAM:
+            pytest.skip("Plaintext restart shortcut is intentionally DM/Telegram-focused")
+
+        # macOS launchd sets XPC_SERVICE_NAME (not INVOCATION_ID).  The gateway
+        # must take the service-restart path (exit 75) so KeepAlive relaunches
+        # it; the detached path would exit 0 and the job would stay dead.
+        # (NousResearch/hermes-agent #29180 / #9659 / #35043)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway-test")
+        runner.request_restart = MagicMock(return_value=True)
+
+        send = await send_and_capture(adapter, "restart gateway", platform)
+
+        send.assert_called_once()
+        runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+    @pytest.mark.asyncio
+    async def test_plaintext_restart_gateway_bare_process_uses_detached_path(self, adapter, runner, platform, monkeypatch):
+        if platform != Platform.TELEGRAM:
+            pytest.skip("Plaintext restart shortcut is intentionally DM/Telegram-focused")
+
+        # No service manager: a shell-launched macOS process reports
+        # XPC_SERVICE_NAME="0" and no INVOCATION_ID, so the detached
+        # self-restart path must be kept (nothing else would relaunch it).
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+        runner.request_restart = MagicMock(return_value=True)
+
+        send = await send_and_capture(adapter, "restart gateway", platform)
+
+        send.assert_called_once()
+        runner.request_restart.assert_called_once_with(detached=True, via_service=False)
 
     @pytest.mark.asyncio
     async def test_personality_lists_options(self, adapter, platform):


### PR DESCRIPTION
## Problem

On macOS, sending `/restart` to a launchd-managed gateway can leave it **dead until manual recovery**.

`_handle_restart_command` selects its restart strategy from `INVOCATION_ID` (systemd) and `/.dockerenv` (container) only:

```python
_under_service = bool(os.environ.get("INVOCATION_ID"))   # systemd sets this
_in_container  = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
if _under_service or _in_container:
    self.request_restart(detached=False, via_service=True)   # exit 75 -> supervisor relaunches
else:
    self.request_restart(detached=True,  via_service=False)  # detached helper + clean exit 0
```

launchd sets **neither** variable, so a LaunchAgent-managed gateway takes the `else` branch: it spawns a detached helper and exits **0**. The generated plist uses `KeepAlive{SuccessfulExit: false}`, which treats a clean exit as success and does **not** relaunch — and the detached helper does not reliably survive under launchd. Net: `/restart` silently kills the gateway.

This is the macOS manifestation behind #29180, #9659, and #35043.

## Fix

Detect launchd via `XPC_SERVICE_NAME` — the launchd analog of systemd's `INVOCATION_ID` (set to the job label for managed jobs, `"0"` for shell-launched processes) — and route those restarts through the existing `via_service=True` path, which already exits `75` on darwin so `KeepAlive` relaunches:

```python
_under_launchd = sys.platform == "darwin" and os.environ.get("XPC_SERVICE_NAME", "0") not in ("", "0")
if _under_service or _under_launchd or _in_container:
    ...
```

No plist change required — the macOS exit-75 path already exists; this just lets launchd-managed gateways reach it.

### Preserved behavior
- Intentional `gateway stop` (clean exit 0) still stays down.
- Bare-process restarts (no `XPC_SERVICE_NAME`) still use the detached path.
- systemd / container behavior unchanged.

## Testing

Adds two cases to `tests/e2e/test_platform_commands.py`:
- launchd env → `request_restart(detached=False, via_service=True)`
- bare process (`XPC_SERVICE_NAME="0"`) → `request_restart(detached=True, via_service=False)`

Refs #29180, #9659, #35043
