### PR TITLE
Add webhook http_callback delivery

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -36,6 +36,9 @@ import logging
 import re
 import subprocess
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import Any, Dict, List, Optional
 
 try:
@@ -244,6 +247,9 @@ class WebhookAdapter(BasePlatformAdapter):
 
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
+
+        if deliver_type == "http_callback":
+            return await self._deliver_http_callback(content, delivery)
 
         # Cross-platform delivery — any platform with a gateway adapter.
         # Check both built-in names and plugin-registered platforms.
@@ -819,11 +825,110 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        if deliver_type == "http_callback":
+            return await self._deliver_http_callback(content, delivery)
+
         # Fall through to the cross-platform dispatcher, which validates the
         # target name and routes via the gateway runner.
         return await self._deliver_cross_platform(
             deliver_type, content, delivery
         )
+
+    def _format_http_callback_body(
+        self, template: Any, content: str
+    ) -> Any:
+        """Substitute agent response tokens in an HTTP callback body template."""
+        escaped = (
+            content.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&#x27;")
+            .replace("\n", "<br>")
+        )
+        replacements = {
+            "{content}": content,
+            "{content_html}": escaped,
+            "{content_json}": json.dumps(content)[1:-1],
+        }
+        if isinstance(template, str):
+            result = template
+            for token, value in replacements.items():
+                result = result.replace(token, value)
+            return result
+        if isinstance(template, dict):
+            return {
+                key: self._format_http_callback_body(value, content)
+                for key, value in template.items()
+            }
+        if isinstance(template, list):
+            return [self._format_http_callback_body(value, content) for value in template]
+        return template
+
+    async def _deliver_http_callback(
+        self, content: str, delivery: dict
+    ) -> SendResult:
+        """POST the agent response to a templated HTTP callback URL."""
+        extra = delivery.get("deliver_extra", {})
+        url = extra.get("url", "")
+        if not isinstance(url, str) or not url:
+            logger.error("[webhook] http_callback delivery missing deliver_extra.url")
+            return SendResult(success=False, error="Missing deliver_extra.url")
+
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            logger.error("[webhook] http_callback delivery invalid URL")
+            return SendResult(success=False, error="Invalid callback URL")
+        if parsed.scheme == "http" and not extra.get("allow_insecure_http"):
+            host = parsed.hostname or ""
+            if host not in _LOOPBACK_HOSTS:
+                logger.error("[webhook] http_callback refuses non-HTTPS URL")
+                return SendResult(success=False, error="HTTPS required for callback URL")
+
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "Hermes Webhook HTTP Callback",
+        }
+        extra_headers = extra.get("headers", {})
+        if isinstance(extra_headers, dict):
+            headers.update({str(k): str(v) for k, v in extra_headers.items()})
+        bearer_token = extra.get("bearer_token") or extra.get("secret")
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+
+        body_template = extra.get("body_template", {"content": "{content}"})
+        body_obj = self._format_http_callback_body(body_template, content)
+
+        def _post() -> tuple[int, str]:
+            if headers.get("Content-Type", "").startswith("application/json"):
+                body = json.dumps(body_obj, ensure_ascii=False).encode("utf-8")
+            elif isinstance(body_obj, str):
+                body = body_obj.encode("utf-8")
+            else:
+                body = json.dumps(body_obj, ensure_ascii=False).encode("utf-8")
+            req = urllib.request.Request(
+                url,
+                data=body,
+                method="POST",
+                headers=headers,
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    return resp.status, resp.read(1000).decode("utf-8", "replace")
+            except urllib.error.HTTPError as e:
+                return e.code, e.read(1000).decode("utf-8", "replace")
+
+        try:
+            status, response_text = await asyncio.to_thread(_post)
+        except Exception as e:
+            logger.error("[webhook] http_callback delivery error: %s", e)
+            return SendResult(success=False, error=str(e))
+        if 200 <= status < 300:
+            logger.info("[webhook] Posted HTTP callback status=%s", status)
+            return SendResult(success=True)
+        logger.error("[webhook] HTTP callback failed status=%s response=%s", status, response_text[:300])
+        return SendResult(success=False, error=f"HTTP {status}")
 
     async def _deliver_github_comment(
         self, content: str, delivery: dict

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -31,9 +31,11 @@ import base64
 import binascii
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import re
+import socket
 import subprocess
 import time
 import urllib.error
@@ -93,6 +95,89 @@ def _is_loopback_host(host: str) -> bool:
     if not host:
         return False
     return host.strip().lower() in _LOOPBACK_HOSTS
+
+
+def _is_public_callback_ip(ip: Any) -> bool:
+    """Return True only for globally routable callback destinations.
+
+    ``ip_address.is_global`` is intentionally stricter than checking only
+    RFC1918/private ranges: it also rejects loopback, link-local, multicast,
+    unspecified, reserved/documentation ranges, and cloud metadata addresses
+    such as 169.254.169.254.  For callback delivery, fail-closed is safer
+    than trying to enumerate every non-public network.
+    """
+    return ip.is_global
+
+
+def _resolve_callback_host(host: str) -> list[ipaddress._BaseAddress]:
+    """Resolve a callback hostname to IP addresses for SSRF filtering."""
+    try:
+        literal = ipaddress.ip_address(host)
+        return [literal]
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve callback host: {host}") from exc
+
+    addresses: list[ipaddress._BaseAddress] = []
+    seen: set[str] = set()
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        raw_ip = str(sockaddr[0])
+        # IPv6 link-local addresses may include a scope id (fe80::1%lo0).
+        ip_text = raw_ip.split("%", 1)[0]
+        try:
+            ip = ipaddress.ip_address(ip_text)
+        except ValueError:
+            continue
+        if str(ip) not in seen:
+            addresses.append(ip)
+            seen.add(str(ip))
+    if not addresses:
+        raise ValueError(f"Cannot resolve callback host: {host}")
+    return addresses
+
+
+def _validate_http_callback_url(url: str, *, allow_insecure_http: bool = False) -> None:
+    """Validate an outbound http_callback URL before making the request.
+
+    The webhook payload can render into ``deliver_extra.url`` (for example via
+    ``{callback_url}``), so this must defend the gateway host against SSRF.
+    HTTPS is required by default.  HTTP is allowed only for explicit local
+    testing and only to loopback hosts.  HTTPS targets must resolve solely to
+    globally routable IPs.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Invalid callback URL")
+
+    host = parsed.hostname or ""
+    if not host:
+        raise ValueError("Invalid callback URL")
+
+    if parsed.scheme == "http":
+        if not allow_insecure_http:
+            raise ValueError("HTTPS required for callback URL")
+        if not _is_loopback_host(host):
+            raise ValueError("HTTP callback URL is only allowed for loopback hosts")
+        return
+
+    ips = _resolve_callback_host(host)
+    blocked = [str(ip) for ip in ips if not _is_public_callback_ip(ip)]
+    if blocked:
+        raise ValueError("Callback URL resolves to a non-public IP address")
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Disable urllib's default redirect following for callback delivery."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[override]
+        return None
 
 
 def check_webhook_requirements() -> bool:
@@ -875,15 +960,15 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.error("[webhook] http_callback delivery missing deliver_extra.url")
             return SendResult(success=False, error="Missing deliver_extra.url")
 
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            logger.error("[webhook] http_callback delivery invalid URL")
-            return SendResult(success=False, error="Invalid callback URL")
-        if parsed.scheme == "http" and not extra.get("allow_insecure_http"):
-            host = parsed.hostname or ""
-            if host not in _LOOPBACK_HOSTS:
-                logger.error("[webhook] http_callback refuses non-HTTPS URL")
-                return SendResult(success=False, error="HTTPS required for callback URL")
+        try:
+            _validate_http_callback_url(
+                url,
+                allow_insecure_http=bool(extra.get("allow_insecure_http")),
+            )
+        except ValueError as exc:
+            error = str(exc)
+            logger.error("[webhook] http_callback delivery rejected URL: %s", error)
+            return SendResult(success=False, error=error)
 
         headers = {
             "Content-Type": "application/json",
@@ -913,8 +998,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 method="POST",
                 headers=headers,
             )
+            opener = urllib.request.build_opener(_NoRedirectHandler)
             try:
-                with urllib.request.urlopen(req, timeout=30) as resp:
+                with opener.open(req, timeout=30) as resp:
                     return resp.status, resp.read(1000).decode("utf-8", "replace")
             except urllib.error.HTTPError as e:
                 return e.code, e.read(1000).decode("utf-8", "replace")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -16,10 +16,13 @@ Covers:
 
 import asyncio
 import base64
+import email.message
 import hashlib
 import hmac
+import io
 import json
 import time
+import urllib.error
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,6 +34,7 @@ from gateway.platforms.base import SendResult
 from gateway.platforms.webhook import (
     WebhookAdapter,
     _INSECURE_NO_AUTH,
+    _validate_http_callback_url,
     check_webhook_requirements,
 )
 
@@ -839,6 +843,50 @@ class TestDeliveryCleanup:
         assert "webhook:test:new" in adapter._delivery_info_created
 
 
+# ===================================================================
+# http_callback URL validation
+# ===================================================================
+
+
+class TestHttpCallbackUrlValidation:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://169.254.169.254/latest/meta-data/",
+            "https://127.0.0.1:8080/admin",
+            "https://10.0.0.5/internal-api",
+            "https://[::1]/",
+        ],
+    )
+    def test_rejects_private_loopback_and_link_local_literals(self, url):
+        with pytest.raises(ValueError, match="non-public IP"):
+            _validate_http_callback_url(url)
+
+    def test_rejects_hostname_that_resolves_to_private_ip(self):
+        def _fake_getaddrinfo(*_args, **_kwargs):
+            return [(None, None, None, "", ("10.0.0.5", 443))]
+
+        with patch("gateway.platforms.webhook.socket.getaddrinfo", _fake_getaddrinfo):
+            with pytest.raises(ValueError, match="non-public IP"):
+                _validate_http_callback_url("https://callback.example.test/hook")
+
+    def test_allows_hostname_that_resolves_to_public_ip(self):
+        def _fake_getaddrinfo(*_args, **_kwargs):
+            return [(None, None, None, "", ("93.184.216.34", 443))]
+
+        with patch("gateway.platforms.webhook.socket.getaddrinfo", _fake_getaddrinfo):
+            _validate_http_callback_url("https://callback.example.test/hook")
+
+    def test_http_requires_explicit_loopback_test_escape_hatch(self):
+        with pytest.raises(ValueError, match="HTTPS required"):
+            _validate_http_callback_url("http://127.0.0.1:8080/hook")
+
+        _validate_http_callback_url(
+            "http://127.0.0.1:8080/hook",
+            allow_insecure_http=True,
+        )
+
+
 class TestHttpCallbackDelivery:
 
     @pytest.mark.asyncio
@@ -848,7 +896,7 @@ class TestHttpCallbackDelivery:
         delivery = {
             "deliver": "http_callback",
             "deliver_extra": {
-                "url": "https://example.test/callback",
+                "url": "https://93.184.216.34/callback",
                 "body_template": {"content": "<p>{content_html}</p>"},
             },
         }
@@ -866,21 +914,30 @@ class TestHttpCallbackDelivery:
             def read(self, *_args):
                 return b"{}"
 
-        def _fake_urlopen(req, timeout):
-            captured["url"] = req.full_url
-            captured["timeout"] = timeout
-            captured["headers"] = dict(req.header_items())
-            captured["body"] = req.data.decode("utf-8")
-            return _Response()
+        class _Opener:
+            def open(self, req, timeout):
+                captured["url"] = req.full_url
+                captured["timeout"] = timeout
+                captured["headers"] = dict(req.header_items())
+                captured["body"] = req.data.decode("utf-8")
+                return _Response()
+
+        def _fake_build_opener(*handlers):
+            captured["redirect_handler"] = [
+                getattr(handler, "__name__", type(handler).__name__)
+                for handler in handlers
+            ]
+            return _Opener()
 
         chat_id = "webhook:test:1"
         adapter._delivery_info[chat_id] = delivery
-        with patch("gateway.platforms.webhook.urllib.request.urlopen", _fake_urlopen):
+        with patch("gateway.platforms.webhook.urllib.request.build_opener", _fake_build_opener):
             result = await adapter.send(chat_id, "Hello <Rob>\nDone")
 
         assert result.success is True
-        assert captured["url"] == "https://example.test/callback"
+        assert captured["url"] == "https://93.184.216.34/callback"
         assert captured["timeout"] == 30
+        assert "_NoRedirectHandler" in captured["redirect_handler"]
         assert json.loads(captured["body"]) == {"content": "<p>Hello &lt;Rob&gt;<br>Done</p>"}
         assert captured["headers"]["Content-type"] == "application/json"
 
@@ -890,7 +947,7 @@ class TestHttpCallbackDelivery:
         delivery = {
             "deliver": "http_callback",
             "deliver_extra": {
-                "url": "https://example.test/callback",
+                "url": "https://93.184.216.34/callback",
                 "bearer_token": "secret-token",
             },
         }
@@ -908,17 +965,62 @@ class TestHttpCallbackDelivery:
             def read(self, *_args):
                 return b"{}"
 
-        def _fake_urlopen(req, timeout):
-            captured["headers"] = dict(req.header_items())
-            return _Response()
+        class _Opener:
+            def open(self, req, timeout):
+                captured["headers"] = dict(req.header_items())
+                return _Response()
 
         chat_id = "webhook:test:1"
         adapter._delivery_info[chat_id] = delivery
-        with patch("gateway.platforms.webhook.urllib.request.urlopen", _fake_urlopen):
+        with patch("gateway.platforms.webhook.urllib.request.build_opener", lambda *_handlers: _Opener()):
             result = await adapter.send(chat_id, "Done")
 
         assert result.success is True
         assert captured["headers"]["Authorization"] == "Bearer secret-token"
+
+    @pytest.mark.asyncio
+    async def test_http_callback_rejects_private_ip_before_network_call(self):
+        adapter = _make_adapter()
+        delivery = {
+            "deliver": "http_callback",
+            "deliver_extra": {"url": "https://169.254.169.254/latest/meta-data/"},
+        }
+
+        adapter._delivery_info["webhook:test:1"] = delivery
+        with patch("gateway.platforms.webhook.urllib.request.build_opener") as build_opener:
+            result = await adapter.send("webhook:test:1", "Done")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "non-public IP" in result.error
+        build_opener.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_callback_does_not_follow_redirects(self):
+        adapter = _make_adapter()
+        delivery = {
+            "deliver": "http_callback",
+            "deliver_extra": {"url": "https://93.184.216.34/callback"},
+        }
+
+        class _Opener:
+            def open(self, req, timeout):
+                headers = email.message.Message()
+                headers["Location"] = "https://127.0.0.1/admin"
+                raise urllib.error.HTTPError(
+                    req.full_url,
+                    302,
+                    "Found",
+                    headers,
+                    io.BytesIO(b"redirect"),
+                )
+
+        adapter._delivery_info["webhook:test:1"] = delivery
+        with patch("gateway.platforms.webhook.urllib.request.build_opener", lambda *_handlers: _Opener()):
+            result = await adapter.send("webhook:test:1", "Done")
+
+        assert result.success is False
+        assert result.error == "HTTP 302"
 
     @pytest.mark.asyncio
     async def test_http_callback_rejects_missing_url(self):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -839,6 +839,101 @@ class TestDeliveryCleanup:
         assert "webhook:test:new" in adapter._delivery_info_created
 
 
+class TestHttpCallbackDelivery:
+
+    @pytest.mark.asyncio
+    async def test_http_callback_posts_templated_json_body(self):
+        """http_callback POSTs the agent response to deliver_extra.url."""
+        adapter = _make_adapter()
+        delivery = {
+            "deliver": "http_callback",
+            "deliver_extra": {
+                "url": "https://example.test/callback",
+                "body_template": {"content": "<p>{content_html}</p>"},
+            },
+        }
+        captured = {}
+
+        class _Response:
+            status = 201
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self, *_args):
+                return b"{}"
+
+        def _fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["timeout"] = timeout
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = req.data.decode("utf-8")
+            return _Response()
+
+        chat_id = "webhook:test:1"
+        adapter._delivery_info[chat_id] = delivery
+        with patch("gateway.platforms.webhook.urllib.request.urlopen", _fake_urlopen):
+            result = await adapter.send(chat_id, "Hello <Rob>\nDone")
+
+        assert result.success is True
+        assert captured["url"] == "https://example.test/callback"
+        assert captured["timeout"] == 30
+        assert json.loads(captured["body"]) == {"content": "<p>Hello &lt;Rob&gt;<br>Done</p>"}
+        assert captured["headers"]["Content-type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_http_callback_supports_bearer_token(self):
+        adapter = _make_adapter()
+        delivery = {
+            "deliver": "http_callback",
+            "deliver_extra": {
+                "url": "https://example.test/callback",
+                "bearer_token": "secret-token",
+            },
+        }
+        captured = {}
+
+        class _Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self, *_args):
+                return b"{}"
+
+        def _fake_urlopen(req, timeout):
+            captured["headers"] = dict(req.header_items())
+            return _Response()
+
+        chat_id = "webhook:test:1"
+        adapter._delivery_info[chat_id] = delivery
+        with patch("gateway.platforms.webhook.urllib.request.urlopen", _fake_urlopen):
+            result = await adapter.send(chat_id, "Done")
+
+        assert result.success is True
+        assert captured["headers"]["Authorization"] == "Bearer secret-token"
+
+    @pytest.mark.asyncio
+    async def test_http_callback_rejects_missing_url(self):
+        adapter = _make_adapter()
+        delivery = {"deliver": "http_callback", "deliver_extra": {}}
+
+        adapter._delivery_info["webhook:test:1"] = delivery
+
+        result = await adapter.send("webhook:test:1", "Done")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "url" in result.error
+
+
 # ===================================================================
 # check_webhook_requirements
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -279,7 +279,7 @@ platforms:
 - `{content_html}` — HTML-escaped response text with newlines converted to `<br>`
 - `{content_json}` — JSON-string-escaped response text without surrounding quotes
 
-By default, Hermes sends `{"content": "{content}"}` as JSON. Callback URLs must be HTTPS unless they target a loopback host or `allow_insecure_http: true` is explicitly set for local testing.
+By default, Hermes sends `{"content": "{content}"}` as JSON. Callback URLs must be HTTPS and resolve only to public, globally routable IP addresses; loopback, private, link-local, metadata-service, reserved, and other non-public destinations are rejected. Automatic redirects are disabled so a public callback URL cannot redirect Hermes to an internal host. For local testing only, set `allow_insecure_http: true` with an HTTP loopback URL.
 
 ---
 

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -82,7 +82,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. |
 | `skills` | No | List of skill names to load for the agent run. |
-| `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
+| `deliver` | No | Where to send the response: `github_comment`, `http_callback`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
@@ -233,6 +233,7 @@ The `deliver` field controls where the agent's response goes after processing th
 |-------------|-------------|
 | `log` | Logs the response to the gateway log output. This is the default and is useful for testing. |
 | `github_comment` | Posts the response as a PR/issue comment via the `gh` CLI. Requires `deliver_extra.repo` and `deliver_extra.pr_number`. The `gh` CLI must be installed and authenticated on the gateway host (`gh auth login`). |
+| `http_callback` | POSTs the response to a templated HTTP endpoint. Requires `deliver_extra.url`. Supports optional `bearer_token`/`secret`, custom `headers`, and `body_template`. Useful for services that provide per-request callback URLs, like custom chatbots. |
 | `telegram` | Routes the response to Telegram. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `discord` | Routes the response to Discord. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `slack` | Routes the response to Slack. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
@@ -250,6 +251,35 @@ The `deliver` field controls where the agent's response goes after processing th
 | `bluebubbles` | Routes the response to BlueBubbles (iMessage). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 
 For cross-platform delivery, the target platform must also be enabled and connected in the gateway. If no `chat_id` is provided in `deliver_extra`, the response is sent to that platform's configured home channel.
+
+### HTTP callback delivery
+
+Use `deliver: "http_callback"` when the webhook payload includes a reply URL, or when you want Hermes to POST the agent response to a custom service instead of a built-in messaging platform.
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        my-chatbot:
+          secret: "chatbot-hmac-secret"
+          prompt: "{command}"
+          deliver: "http_callback"
+          deliver_extra:
+            url: "{callback_url}"
+            bearer_token: "optional-shared-secret"
+            body_template:
+              content: "<p>{content_html}</p>"
+```
+
+`deliver_extra.url`, headers, and other string values are first rendered against the incoming webhook payload, so callback URLs supplied by the source can be used directly. `body_template` is rendered later against the agent response and supports:
+
+- `{content}` — raw agent response text
+- `{content_html}` — HTML-escaped response text with newlines converted to `<br>`
+- `{content_json}` — JSON-string-escaped response text without surrounding quotes
+
+By default, Hermes sends `{"content": "{content}"}` as JSON. Callback URLs must be HTTPS unless they target a loopback host or `allow_insecure_http: true` is explicitly set for local testing.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a generic `http_callback` delivery mode to the webhook gateway adapter so an agent response can be POSTed back to a templated HTTP endpoint.

This addresses the use case described in #4386: services like custom chatbots often invoke Hermes with a per-request callback/reply URL, then expect the final agent response to be sent back to that URL rather than to a built-in platform.

## What changed

- Adds `deliver: "http_callback"` handling in the webhook adapter.
- Requires `deliver_extra.url`, rendered from the incoming webhook payload like existing `deliver_extra` fields.
- Supports optional `bearer_token`/`secret`, custom headers, and templated response bodies.
- Adds response-body tokens:
  - `{content}` raw agent response
  - `{content_html}` HTML-escaped response with newlines converted to `<br>`
  - `{content_json}` JSON-string-escaped response without surrounding quotes
- Requires HTTPS callback URLs by default, while allowing loopback HTTP for local testing.
- Documents the new delivery mode in the webhooks guide.
- Adds focused tests for JSON body templating, bearer-token auth, and missing URL validation.

## Example

```yaml
routes:
  my-chatbot:
    secret: "chatbot-hmac-secret"
    prompt: "{command}"
    deliver: "http_callback"
    deliver_extra:
      url: "{callback_url}"
      bearer_token: "optional-shared-secret"
      body_template:
        content: "<p>{content_html}</p>"
```

## Tests

- `python -m py_compile gateway/platforms/webhook.py`
- `python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='`

Both pass locally: `68 passed`.

Closes #4386.
