### PR TITLE
feat(cron): add configurable pre-flight gate chain for cron jobs

### DIFF
--- a/cron/cron_gates.py
+++ b/cron/cron_gates.py
@@ -1,0 +1,136 @@
+"""
+Cron Gate Chain — configurable pre-flight checks for cron jobs.
+
+Each gate is a pure function ``(job, now) → (passed: bool, reason: str)``.
+Gates run sequentially; the first failure blocks the job.
+
+Configured per-job via the ``gates`` dict in the job's config::
+
+    gates:
+      cooldown_minutes: 30       # minimum gap since last run
+      max_daily: 12              # max runs in rolling 24h window
+      active_hours: "09:00-18:00"  # only run within this time range
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from hermes_time import now as _hermes_now
+
+logger = logging.getLogger(__name__)
+
+
+def gate_cooldown(job: dict, now: datetime) -> tuple[bool, str]:
+    """Skip if last run was within ``cooldown_minutes``.
+
+    Returns ``(True, "")`` if the gate passes,
+    ``(False, "reason")`` if it blocks.
+    """
+    minutes = (job.get("gates") or {}).get("cooldown_minutes")
+    if not minutes:
+        return True, ""
+    last_run = job.get("last_run_at")
+    if not last_run:
+        return True, ""
+    try:
+        last_dt = datetime.fromisoformat(last_run)
+        if hasattr(last_dt, "tzinfo") and last_dt.tzinfo is None:
+            last_dt = last_dt.replace(tzinfo=now.tzinfo)
+    except Exception:
+        return True, ""
+    elapsed = (now - last_dt).total_seconds() / 60
+    if elapsed < float(minutes):
+        return False, f"cooldown: last run was {elapsed:.0f}m ago (minimum {minutes}m)"
+    return True, ""
+
+
+def gate_max_daily(job: dict, now: datetime) -> tuple[bool, str]:
+    """Skip if run count in the last 24 hours exceeds ``max_daily``.
+
+    Returns ``(True, "")`` if the gate passes,
+    ``(False, "reason")`` if it blocks.
+    """
+    max_count = (job.get("gates") or {}).get("max_daily")
+    if not max_count:
+        return True, ""
+    run_history = job.get("run_history")
+    if not isinstance(run_history, list) or not run_history:
+        return True, ""
+    cutoff = now - timedelta(hours=24)
+    recent = 0
+    for entry in run_history:
+        ts = entry.get("timestamp") if isinstance(entry, dict) else entry
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(ts)
+            if hasattr(dt, "tzinfo") and dt.tzinfo is None:
+                dt = dt.replace(tzinfo=now.tzinfo)
+            if dt >= cutoff:
+                recent += 1
+        except Exception:
+            continue
+    if recent >= int(max_count):
+        return False, f"max_daily: {recent} runs in last 24h (limit {max_count})"
+    return True, ""
+
+
+def gate_active_hours(job: dict, now: datetime) -> tuple[bool, str]:
+    """Skip if current time is outside the configured window.
+
+    Format: ``"HH:MM-HH:MM"`` (24h, e.g. ``"09:00-18:00"``).
+    Supports ranges that cross midnight (e.g. ``"22:00-06:00"``).
+
+    Returns ``(True, "")`` if the gate passes,
+    ``(False, "reason")`` if it blocks.
+    """
+    window = (job.get("gates") or {}).get("active_hours")
+    if not window or not isinstance(window, str) or "-" not in window:
+        return True, ""
+    try:
+        start_str, end_str = window.split("-", 1)
+        start_h, start_m = int(start_str.split(":")[0]), int(start_str.split(":")[1])
+        end_h, end_m = int(end_str.split(":")[0]), int(end_str.split(":")[1])
+    except (ValueError, IndexError):
+        logger.warning("Job '%s': invalid active_hours format '%s'", job.get("id"), window)
+        return True, ""
+    current_minutes = now.hour * 60 + now.minute
+    start_total = start_h * 60 + start_m
+    end_total = end_h * 60 + end_m
+    if start_total <= end_total:
+        # Normal range (e.g. 09:00-18:00)
+        if start_total <= current_minutes < end_total:
+            return True, ""
+    else:
+        # Crosses midnight (e.g. 22:00-06:00)
+        if current_minutes >= start_total or current_minutes < end_total:
+            return True, ""
+    return False, f"active_hours: current time {now.hour:02d}:{now.minute:02d} outside window {window}"
+
+
+_GATES = [
+    gate_cooldown,
+    gate_max_daily,
+    gate_active_hours,
+]
+
+
+def check_job_gates(job: dict) -> tuple[bool, str]:
+    """Run the gate chain for a cron job.
+
+    Iterates over all configured gates in order. The first gate that
+    blocks short-circuits and returns the reason.
+
+    Returns:
+        ``(True, "")`` if all gates pass.
+        ``(False, "reason")`` if a gate blocks.
+    """
+    gates_config = job.get("gates")
+    if not gates_config or not isinstance(gates_config, dict):
+        return True, ""  # no gates configured — always pass
+    now = _hermes_now()
+    for gate_fn in _GATES:
+        passed, reason = gate_fn(job, now)
+        if not passed:
+            return False, reason
+    return True, ""

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -41,6 +41,9 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
+# Gate chain — pre-flight checks for cron jobs
+from cron.cron_gates import check_job_gates
+
 logger = logging.getLogger(__name__)
 
 
@@ -1930,6 +1933,25 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
+            # ── Gate chain: pre-flight checks before running the agent ──────
+            gate_ok, gate_reason = check_job_gates(job)
+            if not gate_ok:
+                job_id = job.get("id", "?")
+                job_name = job.get("name", "?")
+                logger.info(
+                    "Job '%s' (%s): gate blocked — %s",
+                    job_id, job_name, gate_reason,
+                )
+                _silent_doc = (
+                    "# Cron Job: " + str(job_name) + "\n\n"
+                    "**Job ID:** " + str(job_id) + "\n"
+                    "**Run Time:** " + _hermes_now().strftime("%Y-%m-%d %H:%M:%S") + "\n\n"
+                    "Gate blocked: " + gate_reason + "\n"
+                )
+                save_job_output(job["id"], _silent_doc)
+                if verbose:
+                    logger.info("Job '%s': gate blocked — %s", job_id, gate_reason)
+                return True
             try:
                 success, output, final_response, error = run_job(job)
 

--- a/tests/cron/test_cron_gates.py
+++ b/tests/cron/test_cron_gates.py
@@ -1,0 +1,225 @@
+"""Tests for cron/cron_gates.py — pre-flight gate chain for cron jobs."""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from cron.cron_gates import (
+    check_job_gates,
+    gate_cooldown,
+    gate_max_daily,
+    gate_active_hours,
+)
+
+
+def _now() -> datetime:
+    """Return a fixed reference time for deterministic tests."""
+    return datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestGateCooldown:
+    """cooldown_minutes: minimum gap since last run."""
+
+    def test_no_gate_config(self):
+        """No cooldown configured → always pass."""
+        assert gate_cooldown({"gates": {}, "last_run_at": None}, _now()) == (True, "")
+
+    def test_no_last_run(self):
+        """First-time run → pass."""
+        assert gate_cooldown(
+            {"gates": {"cooldown_minutes": 30}, "last_run_at": None}, _now()
+        ) == (True, "")
+
+    def test_within_cooldown(self):
+        """Job ran 5 minutes ago → block."""
+        now = _now()
+        last_run = now - timedelta(minutes=5)
+        ok, reason = gate_cooldown(
+            {"gates": {"cooldown_minutes": 30}, "last_run_at": last_run.isoformat()}, now
+        )
+        assert not ok
+        assert "cooldown" in reason
+        assert "5m ago" in reason
+
+    def test_after_cooldown(self):
+        """Job ran 45 minutes ago with 30min cooldown → pass."""
+        now = _now()
+        last_run = now - timedelta(minutes=45)
+        assert gate_cooldown(
+            {"gates": {"cooldown_minutes": 30}, "last_run_at": last_run.isoformat()}, now
+        ) == (True, "")
+
+    def test_exactly_at_boundary(self):
+        """Job ran exactly 30 minutes ago with 30min cooldown → pass (check is <, not <=)."""
+        now = _now()
+        last_run = now - timedelta(minutes=30)
+        assert gate_cooldown(
+            {"gates": {"cooldown_minutes": 30}, "last_run_at": last_run.isoformat()}, now
+        ) == (True, "")
+
+    def test_missing_timezone_last_run(self):
+        """last_run_at without tzinfo is treated as UTC (same zone as now)."""
+        now = _now()
+        last_run_naive = datetime(2026, 6, 1, 11, 55, 0)  # naive → default UTC
+        ok, reason = gate_cooldown(
+            {"gates": {"cooldown_minutes": 30}, "last_run_at": last_run_naive.isoformat()}, now
+        )
+        assert not ok
+        assert "5m ago" in reason
+
+
+class TestGateMaxDaily:
+    """max_daily: max runs in rolling 24h window."""
+
+    def test_no_gate_config(self):
+        assert gate_max_daily({"gates": {}, "run_history": []}, _now()) == (True, "")
+
+    def test_no_history(self):
+        assert gate_max_daily(
+            {"gates": {"max_daily": 5}, "run_history": []}, _now()
+        ) == (True, "")
+
+    def test_under_limit(self):
+        now = _now()
+        history = [{"timestamp": (now - timedelta(hours=i)).isoformat()} for i in range(3)]
+        assert gate_max_daily(
+            {"gates": {"max_daily": 5}, "run_history": history}, now
+        ) == (True, "")
+
+    def test_over_limit(self):
+        now = _now()
+        history = [{"timestamp": (now - timedelta(hours=i)).isoformat()} for i in range(10)]
+        ok, reason = gate_max_daily(
+            {"gates": {"max_daily": 5}, "run_history": history}, now
+        )
+        assert not ok
+        assert "max_daily" in reason
+        assert "10 runs" in reason
+
+    def test_old_entries_dont_count(self):
+        """Entries older than 24h are excluded."""
+        now = _now()
+        history = [
+            {"timestamp": (now - timedelta(hours=25)).isoformat()},  # too old
+            {"timestamp": (now - timedelta(hours=2)).isoformat()},   # recent
+        ]
+        assert gate_max_daily(
+            {"gates": {"max_daily": 5}, "run_history": history}, now
+        ) == (True, "")
+
+    def test_plain_string_history(self):
+        """run_history entries can be plain ISO strings (not dicts)."""
+        now = _now()
+        history = [now.isoformat()] * 5
+        ok, reason = gate_max_daily(
+            {"gates": {"max_daily": 3}, "run_history": history}, now
+        )
+        assert not ok
+        assert "5 runs" in reason
+
+
+class TestGateActiveHours:
+    """active_hours: time window restriction."""
+
+    def test_no_gate_config(self):
+        assert gate_active_hours({"gates": {}}, _now()) == (True, "")
+
+    def test_inside_window(self):
+        now = datetime(2026, 6, 1, 14, 30, 0, tzinfo=timezone.utc)
+        assert gate_active_hours(
+            {"gates": {"active_hours": "09:00-18:00"}}, now
+        ) == (True, "")
+
+    def test_outside_window(self):
+        now = datetime(2026, 6, 1, 20, 0, 0, tzinfo=timezone.utc)
+        ok, reason = gate_active_hours(
+            {"gates": {"active_hours": "09:00-18:00"}}, now
+        )
+        assert not ok
+        assert "outside window" in reason
+
+    def test_exactly_at_boundary_open(self):
+        """At 09:00 exactly → inside window (start is inclusive)."""
+        now = datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+        assert gate_active_hours(
+            {"gates": {"active_hours": "09:00-18:00"}}, now
+        ) == (True, "")
+
+    def test_exactly_at_boundary_close(self):
+        """At 18:00 exactly → outside window (end is exclusive)."""
+        now = datetime(2026, 6, 1, 18, 0, 0, tzinfo=timezone.utc)
+        ok, reason = gate_active_hours(
+            {"gates": {"active_hours": "09:00-18:00"}}, now
+        )
+        assert not ok
+
+    def test_crosses_midnight_inside(self):
+        """Window 22:00-06:00, current time 02:00 → pass."""
+        now = datetime(2026, 6, 1, 2, 0, 0, tzinfo=timezone.utc)
+        assert gate_active_hours(
+            {"gates": {"active_hours": "22:00-06:00"}}, now
+        ) == (True, "")
+
+    def test_crosses_midnight_outside(self):
+        """Window 22:00-06:00, current time 12:00 → block."""
+        now = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        ok, reason = gate_active_hours(
+            {"gates": {"active_hours": "22:00-06:00"}}, now
+        )
+        assert not ok
+
+    def test_invalid_format(self):
+        """Malformed window string → pass (logged as warning)."""
+        assert gate_active_hours(
+            {"gates": {"active_hours": "not-a-valid-format"}}, _now()
+        ) == (True, "")
+
+
+class TestCheckJobGates:
+    """Integration: check_job_gates runs the full gate chain."""
+
+    def test_no_gates_configured(self):
+        """No gates dict → always pass."""
+        assert check_job_gates({"id": "test"}) == (True, "")
+
+    def test_empty_gates(self):
+        assert check_job_gates({"id": "test", "gates": {}}) == (True, "")
+
+    def test_all_gates_pass(self):
+        """Job with cooldown met + daily under limit + inside window → pass."""
+        assert check_job_gates({
+            "id": "test",
+            "gates": {"cooldown_minutes": 30, "max_daily": 10, "active_hours": "00:00-23:59"},
+        }) == (True, "")
+
+    def test_cooldown_blocks(self):
+        """cooldown gate fires first."""
+        from hermes_time import now as _hn
+        now = _hn()
+        ok, reason = check_job_gates({
+            "id": "test",
+            "gates": {"cooldown_minutes": 30},
+            "last_run_at": now.isoformat(),
+        })
+        assert not ok
+        assert "cooldown" in reason
+
+    def test_max_daily_blocks(self):
+        from hermes_time import now as _hn
+        now = _hn()
+        ok, reason = check_job_gates({
+            "id": "test",
+            "gates": {"max_daily": 1},
+            "run_history": [{"timestamp": now.isoformat()}, {"timestamp": now.isoformat()}],
+        })
+        assert not ok
+        assert "max_daily" in reason
+
+    def test_active_hours_blocks(self):
+        """Active hours fires when cooldown and max_daily pass."""
+        ok, reason = check_job_gates({
+            "id": "test",
+            "gates": {"active_hours": "01:00-01:01"},
+        })
+        assert not ok
+        assert "outside window" in reason


### PR DESCRIPTION
Three configurable gates for cron job scheduling:
- cooldown_minutes: minimum gap since last run
- max_daily: cap on runs per 24h
- active_hours: time window restriction (e.g. 09:00-18:00)

Gates configured per-job via cron tool. 364 cron tests pass.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

