### PR TITLE
fix(agent): strip shared mcp_<server>_ prefix before fuzzy tool-name match

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -28,6 +28,7 @@ import logging
 import re
 import time
 from datetime import datetime
+from difflib import SequenceMatcher, get_close_matches
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -2477,6 +2478,32 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
 
 
+def _repair_op_suffix(name: str, other: str) -> str:
+    """Strip the longest shared leading ``_``-segment run from ``name``.
+
+    Why: MCP tools share a long namespace prefix (e.g. ``mcp__knowledge__``)
+    that inflates whole-name similarity between semantically unrelated
+    operations.  Stripping the shared prefix isolates the operation token
+    so suffix-level comparison is meaningful.
+    What: Splits both ``name`` and ``other`` on ``"_"``, advances past
+    identical leading segments (including the empty strings produced by
+    ``__`` delimiters, so ``"mcp__svc__op".split("_")`` yields
+    ``["mcp", "", "svc", "", "op"]`` and the shared ``mcp / / svc / ``
+    segments are consumed), then returns the remainder of ``name`` joined
+    back with ``"_"``.  Falls back to the full ``name`` when no suffix
+    remains (i.e. ``name`` is a strict prefix of ``other`` in segment space).
+    Test: ``_repair_op_suffix("mcp__svc__kb_search", "mcp__svc__kb_add")``
+    returns ``"search"`` (the ``"kb"`` segment is shared between ``kb_search``
+    and ``kb_add``); ``_repair_op_suffix("terminal", "read_file")``
+    returns ``"terminal"`` (no shared prefix, full name returned).
+    """
+    a, b = name.split("_"), other.split("_")
+    i = 0
+    while i < len(a) and i < len(b) and a[i] == b[i]:
+        i += 1
+    return "_".join(a[i:]) or name
+
+
 def repair_tool_call(agent, tool_name: str) -> str | None:
     """Attempt to repair a mismatched tool name before aborting.
 
@@ -2498,9 +2525,6 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
     Returns the repaired name if found in valid_tool_names, else None.
     """
-    import re
-    from difflib import get_close_matches
-
     if not tool_name:
         return None
 
@@ -2564,10 +2588,83 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
             return c
 
     # Fuzzy match as last resort.
-    matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
-    if matches:
-        return matches[0]
+    #
+    # For namespaced MCP tools the shared ``mcp__<server>__`` prefix can push
+    # two semantically-opposite operations (e.g. ``mcp__knowledge__kb_search``
+    # vs ``mcp__knowledge__kb_add``) over the whole-name 0.7 cutoff, so a
+    # missing read tool could be silently repaired into a write tool — a
+    # dangerous remap (BUG-8).
+    #
+    # Fix: gather up to 5 plausible candidates via ``get_close_matches``.  For
+    # same-namespace pools, the shared prefix keeps all sibling operations above
+    # 0.7 so the correct one is included in the candidate list.  Each candidate
+    # is then scored by its *operation-suffix* similarity: ``_repair_op_suffix``
+    # strips the longest common leading ``_``-segment run (which covers the
+    # shared namespace prefix) from both the emitted name and the candidate,
+    # leaving only the operation token for comparison.  The candidate with the
+    # highest op-suffix ratio is selected.
+    #
+    # NOTE: for same-namespace candidate pools, whole-name similarity and
+    # op-suffix similarity rank candidates in the SAME order (the shared prefix
+    # contributes equally to both ratios).  The selection step therefore does
+    # NOT produce a different winner than ``get_close_matches`` would for
+    # same-namespace pools; its value is entirely in the acceptance gate below.
+    #
+    # Acceptance gate (the real BUG-8 fix): the winning op-suffix ratio must
+    # be >= 0.7.  This is a conservative rejection guard: it blocks repairs
+    # where the emitted operation token diverges too much from every registered
+    # operation (e.g. a typo that maps closer to ``kb_add`` than ``kb_search``
+    # is blocked outright rather than silently remapping a read to a write).
+    # Legitimate operation-level typos (``kb_serach`` -> ``kb_search``,
+    # ratio ~0.91) pass the gate.
+    #
+    # Non-namespaced tools: when there is no shared prefix ``_repair_op_suffix``
+    # returns the full name unchanged, so the gate degrades to a plain
+    # whole-name ratio check — identical to the old unconditional behaviour
+    # for ordinary tools (e.g. ``terminall`` -> ``terminal``).
+    #
+    # Tie-breaking: on equal op-suffix ratio prefer the earlier position in
+    # the ``get_close_matches`` result list (better whole-name match), which
+    # is deterministic and stable.
 
+    # Collect up to 5 plausible whole-name candidates.  Same-namespace siblings
+    # all score above 0.7 due to the shared prefix, so the correct operation is
+    # always included in the list when it exists.
+    candidates = get_close_matches(lowered, agent.valid_tool_names, n=5, cutoff=0.7)
+    if not candidates:
+        return None
+
+    # Score each candidate by operation-suffix similarity.
+    best_candidate: str | None = None
+    best_op_ratio: float = -1.0
+    for candidate in candidates:
+        op_emitted = _repair_op_suffix(lowered, candidate)
+        op_candidate = _repair_op_suffix(candidate, lowered)
+        shared_prefix = op_emitted != lowered or op_candidate != candidate
+        if not shared_prefix:
+            # No shared namespace prefix: this is a plain (non-namespaced)
+            # tool.  The whole-name ratio already captures the full similarity;
+            # use it directly so non-namespaced candidates compete fairly with
+            # namespaced candidates ranked by op-suffix (avoids inflating
+            # non-namespaced tools to 1.0 which would let a lower whole-name
+            # match beat a high-confidence op-suffix match).
+            op_ratio = SequenceMatcher(None, lowered, candidate).ratio()
+        else:
+            op_ratio = SequenceMatcher(None, op_emitted, op_candidate).ratio()
+
+        # Prefer strictly higher op-ratio; ties fall back to whole-name rank
+        # (earlier position in the ``get_close_matches`` result = better
+        # whole-name match, so the first candidate seen wins on equal score).
+        if op_ratio > best_op_ratio:
+            best_op_ratio = op_ratio
+            best_candidate = candidate
+
+    # Conservative rejection guard (BUG-8 fix): accept only when the winning
+    # operation suffix is a plausible typo (ratio >= 0.7).  Blocks cross-op
+    # remaps like kb_search -> kb_add; allows legitimate typos like
+    # kb_serach -> kb_search.
+    if best_candidate is not None and best_op_ratio >= 0.7:
+        return best_candidate
     return None
 
 

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -8,12 +8,25 @@ snake_case name. The repair routine now normalizes CamelCase,
 strips trailing ``_tool`` / ``-tool`` / ``tool`` suffixes (up to
 twice to handle double-tacked suffixes like ``TodoTool_tool``), and
 falls back to fuzzy match.
+
+BUG-8 regression guard: the namespace-prefix guard prevents a shared
+``mcp__knowledge__kb_`` prefix from inflating the SequenceMatcher ratio
+enough to allow silent read-to-write repairs (e.g. ``kb_search`` ->
+``kb_add``).  The fix is a conservative acceptance gate: the fuzzy
+candidate is accepted ONLY when its operation-suffix similarity ratio
+(computed after stripping the shared namespace prefix) is >= 0.7.  This
+blocks cross-operation remaps while allowing legitimate operation-level
+typos.  For same-namespace candidate pools the op-suffix and whole-name
+orderings coincide, so n=5 does NOT select a different winner than n=1
+would — the value is entirely in the gate that rejects diverging ops.
 """
 from __future__ import annotations
 
 from types import SimpleNamespace
 
 import pytest
+
+from tools.mcp_tool import mcp_prefixed_tool_name
 
 
 VALID = {
@@ -28,6 +41,30 @@ VALID = {
     "execute_code",
     "session_search",
 }
+
+# Extended VALID set used by TestNamespacePrefixGuard.  Uses the
+# production double-underscore MCP naming (``mcp__<server>__<tool>``)
+# produced by ``mcp_prefixed_tool_name`` so all guard tests exercise the
+# real registration format rather than synthetic single-underscore names.
+# Includes sibling operations so both the blocking and allow paths are
+# covered.
+_MCP_NS_SEARCH = mcp_prefixed_tool_name("knowledge", "kb_search")   # mcp__knowledge__kb_search
+_MCP_NS_GET = mcp_prefixed_tool_name("knowledge", "kb_get")          # mcp__knowledge__kb_get
+_MCP_NS_ADD = mcp_prefixed_tool_name("knowledge", "kb_add")          # mcp__knowledge__kb_add
+
+VALID_NS = VALID | {_MCP_NS_SEARCH, _MCP_NS_GET, _MCP_NS_ADD}
+
+# Production double-underscore MCP tool names built via the same helper
+# Hermes uses at registration time (``mcp__<server>__<tool>``).  These
+# cover the format produced by ``mcp_prefixed_tool_name`` in
+# ``tools/mcp_tool.py``.
+_MCP_KB_SEARCH = mcp_prefixed_tool_name("knowledge", "kb_search")  # mcp__knowledge__kb_search
+_MCP_KB_ADD = mcp_prefixed_tool_name("knowledge", "kb_add")        # mcp__knowledge__kb_add
+_MCP_KB_GET = mcp_prefixed_tool_name("knowledge", "kb_get")        # mcp__knowledge__kb_get
+
+# Valid tool set containing the production double-underscore MCP tools alongside
+# the existing non-namespaced tools so both code paths are exercised.
+VALID_MCP_DD = VALID | {_MCP_KB_SEARCH, _MCP_KB_ADD, _MCP_KB_GET}
 
 
 @pytest.fixture
@@ -186,3 +223,293 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+@pytest.fixture
+def repair_ns():
+    """Bound _repair_tool_call using VALID_NS — the extended tool set.
+
+    Why: The base ``repair`` fixture uses VALID which lacks the
+    ``mcp__knowledge__kb_*`` sibling operations needed to exercise both
+    the blocking and allow paths of the namespace-prefix guard.
+    What: Returns a bound method identical in structure to ``repair`` but
+    backed by VALID_NS, which contains production double-underscore MCP
+    names alongside the base non-namespaced tools.
+    Test: Instantiate and call with a known-blocked pair; assert None is
+    returned to confirm the fixture is wired correctly.
+    """
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=VALID_NS)
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
+class TestNamespacePrefixGuard:
+    """BUG-8 regression: namespace-prefix guard prevents read->write repairs.
+
+    All tool names here use the production double-underscore format
+    (``mcp__<server>__<tool>``) via ``mcp_prefixed_tool_name``.
+
+    The acceptance gate strips the shared leading ``_``-segment prefix from
+    both the emitted name and any fuzzy-match candidate, then requires the
+    operation suffixes to score >= 0.7.  This blocks ``mcp__knowledge__kb_search``
+    from silently repairing to ``mcp__knowledge__kb_add`` just because the
+    shared ``mcp__knowledge__`` prefix pushes the whole-name SequenceMatcher
+    ratio above the 0.7 cutoff.
+
+    For same-namespace candidate pools, whole-name and op-suffix orderings
+    coincide.  The guard's value is entirely in the acceptance gate that
+    blocks diverging operations.
+    """
+
+    def test_direct_match_fast_path(self, repair_ns):
+        # Exact name in VALID_NS — fast-path returns before fuzzy even runs.
+        # Confirms the guard does not break the trivial case.
+        assert repair_ns(_MCP_NS_SEARCH) == _MCP_NS_SEARCH
+
+    def test_op_typo_repaired_to_search(self, repair_ns):
+        # Pathological transposition ``kb_saerch`` in the op portion.
+        # Op suffixes: ``kb_saerch`` vs ``kb_search`` — ratio ~0.88 >= 0.7.
+        # The gate must allow this repair.
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_saerch")
+        assert repair_ns(emitted) == _MCP_NS_SEARCH
+
+    def test_direct_match_get_fast_path(self, repair_ns):
+        # ``mcp__knowledge__kb_get`` is in VALID_NS — fast-path, no fuzzy.
+        # Confirms it does not accidentally map to kb_add or kb_search.
+        assert repair_ns(_MCP_NS_GET) == _MCP_NS_GET
+
+    def test_guard_blocks_cross_op_fuzzy_match(self, repair_ns):
+        # ``mcp__knowledge__kb_aed``: op suffix ``kb_aed`` vs ``kb_add``
+        # ratio is ``aed`` vs ``add`` ~0.67 < 0.7, so the gate blocks it.
+        # Without the gate, the shared prefix would push the whole-name
+        # ratio above 0.7 and fuzzy would silently return kb_add.
+        # This test FAILS against the old unconditional ``return matches[0]``
+        # because that code returns the closest whole-name match (kb_add)
+        # rather than None — making this the authoritative behavior-changing
+        # regression test.
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_aed")
+        result = repair_ns(emitted)
+        assert result is None
+
+    def test_legitimate_typo_same_op_allowed(self, repair_ns):
+        # One-character truncation ``kb_searc`` of ``kb_search``.
+        # Op suffixes: ``kb_searc`` vs ``kb_search`` — ratio ~0.93 >= 0.7.
+        # The gate must allow this repair.
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_searc")
+        assert repair_ns(emitted) == _MCP_NS_SEARCH
+
+    def test_non_namespaced_typo_still_works(self, repair_ns):
+        # ``terminall`` has no shared namespace prefix with any candidate.
+        # ``_repair_op_suffix`` returns the full name unchanged, so the
+        # gate degrades to a plain whole-name ratio check — identical to
+        # old fuzzy behaviour.
+        assert repair_ns("terminall") == "terminal"
+
+    def test_mcp_namespaced_op_typo_allowed(self, repair_ns):
+        # Transposition ``kb_serach`` in the op portion of the full MCP name.
+        # Shared prefix: ``mcp__knowledge__``; op suffix: ``kb_serach``
+        # vs ``kb_search`` — ratio ~0.91 >= 0.7, so the gate allows it.
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_serach")
+        assert repair_ns(emitted) == _MCP_NS_SEARCH
+
+    def test_mcp_namespaced_cross_op_blocked(self, repair_ns):
+        # ``mcp__knowledge__kb_aet``: op suffix ``kb_aet`` vs ``kb_add``
+        # is ``aet`` vs ``add`` ~0.67 < 0.7, so the gate blocks it.
+        # Like test_guard_blocks_cross_op_fuzzy_match, this FAILS against
+        # the old unconditional ``return matches[0]`` code.
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_aet")
+        result = repair_ns(emitted)
+        assert result is None
+
+
+@pytest.fixture
+def repair_mcp_dd():
+    """Bound _repair_tool_call backed by VALID_MCP_DD (double-underscore MCP tools).
+
+    Why: The existing ``repair_ns`` fixture uses the single-underscore form
+    ``mcp_knowledge_kb_search``.  Hermes registers native MCP tools as
+    ``mcp__<server>__<tool>`` (double-underscore, via ``mcp_prefixed_tool_name``
+    in ``tools/mcp_tool.py``).  This fixture exercises that production format.
+    What: Returns a bound method identical to ``repair`` but backed by
+    VALID_MCP_DD, which includes ``mcp__knowledge__kb_search``,
+    ``mcp__knowledge__kb_add``, and ``mcp__knowledge__kb_get``.
+    Test: Call with a known-blocked pair and assert None is returned.
+    """
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=VALID_MCP_DD)
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
+class TestMcpDoubleUnderscoreNaming:
+    """BUG-8 + naming-format coverage for Hermes-native MCP tool names.
+
+    Hermes registers MCP tools as ``mcp__<server>__<tool>`` (double-underscore
+    delimiter, produced by ``mcp_prefixed_tool_name``).  The ``_repair_op_suffix``
+    helper splits on ``"_"`` and compares segment-by-segment, so the empty
+    strings produced by ``__`` (e.g. ``"mcp__svc__op".split("_")`` yields
+    ``["mcp", "", "svc", "", "op"]``) participate in the shared-prefix walk as
+    equal segments.  These tests verify that:
+
+    1. The double-underscore prefix is stripped correctly so only the operation
+       token (e.g. ``"kb_search"``) is compared.
+    2. A typo in the operation is allowed (ALLOW case).
+    3. A diverging operation is blocked even when the shared prefix is long (BLOCK
+       case — this is the behavior-changing test that FAILS against old code).
+    4. The correct operation is selected from the candidate list with the op-suffix
+       gate applied (selection case — note: same-namespace orderings coincide for
+       whole-name and op-suffix; see test docstring for details).
+    5. Non-namespaced tools in the same valid set are unaffected.
+    """
+
+    def test_double_underscore_op_typo_allowed(self, repair_mcp_dd):
+        """ALLOW: typo of ``kb_search`` repairs to ``mcp__knowledge__kb_search``.
+
+        Why: Demonstrates that the double-underscore prefix is stripped
+        correctly and the operation suffix ``kb_serch`` is compared to
+        ``kb_search`` (ratio ~0.91 >= 0.7), allowing the repair.
+        What: Both ``mcp__knowledge__kb_search`` and ``mcp__knowledge__kb_add``
+        are valid; the emitted name's op suffix must unambiguously resolve to
+        the search operation.
+        Test: Assert repair returns ``mcp__knowledge__kb_search``.
+        """
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_serch")
+        assert repair_mcp_dd(emitted) == _MCP_KB_SEARCH
+
+    def test_double_underscore_cross_op_blocked(self, repair_mcp_dd):
+        """BLOCK: diverging op suffix is rejected by the acceptance gate.
+
+        Why: Without the op-suffix acceptance gate (i.e. the old code that
+        unconditionally returned ``matches[0]``), the shared ``mcp__knowledge__``
+        prefix would push ``mcp__knowledge__kb_aet`` close enough to
+        ``mcp__knowledge__kb_add`` in whole-name similarity that fuzzy match
+        returns ``kb_add`` — silently remapping a read operation to a write.
+        With the gate, op suffix ``kb_aet`` vs ``kb_add`` scores ``aet``/``add``
+        ~0.67 < 0.7 and the repair is blocked (returns None).
+
+        This is the BEHAVIOR-CHANGING regression test: it FAILS against the old
+        unconditional ``return matches[0]`` code (which returns ``kb_add``) and
+        PASSES with the acceptance gate.  It is the authoritative guard for BUG-8.
+        Test: Assert repair returns None.
+        """
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_aet")
+        result = repair_mcp_dd(emitted)
+        assert result is None
+
+    def test_double_underscore_op_typo_selects_correct_operation(self, repair_mcp_dd):
+        """ALLOW: transposition typo in op suffix selects the correct operation.
+
+        Why: Verifies that the op-suffix scoring selects ``kb_search`` (the
+        correct operation) and that the acceptance gate passes it through
+        (ratio ~0.91 >= 0.7).
+
+        Context on same-namespace ordering: for tools sharing an identical long
+        prefix (``mcp__knowledge__``), whole-name similarity and op-suffix
+        similarity rank candidates in the SAME order — the prefix term
+        contributes equally to both ratios.  This means the n=5 op-suffix
+        selection does NOT produce a different winner than n=1 whole-name
+        matching would for same-namespace pools.  This test verifies that the
+        correct operation is chosen and accepted; it does NOT demonstrate a
+        whole-name/op-suffix ranking inversion (which is mathematically
+        impossible for same-prefix pairs and would require cross-namespace
+        scenarios).  The behavior-changing regression test is
+        ``test_double_underscore_cross_op_blocked``, which exercises the
+        acceptance gate that the old code lacked entirely.
+
+        Test: Assert repair returns ``mcp__knowledge__kb_search``.
+        """
+        emitted = mcp_prefixed_tool_name("knowledge", "kb_serach")
+        result = repair_mcp_dd(emitted)
+        assert result == _MCP_KB_SEARCH
+
+    def test_double_underscore_direct_match_fast_path(self, repair_mcp_dd):
+        """Direct match: exact ``mcp__knowledge__kb_search`` skips fuzzy path.
+
+        Why: Verifies the fast-path returns before the fuzzy/ranking step.
+        What: Emitting the exact registered name should return immediately.
+        Test: Assert repair returns ``mcp__knowledge__kb_search``.
+        """
+        assert repair_mcp_dd(_MCP_KB_SEARCH) == _MCP_KB_SEARCH
+
+    def test_double_underscore_non_namespaced_unaffected(self, repair_mcp_dd):
+        """Non-namespaced tools in VALID_MCP_DD must still repair correctly.
+
+        Why: Ensures the ranking change does not regress non-MCP tools that
+        share the same valid-tool set.
+        What: ``terminall`` has no shared namespace prefix with any candidate;
+        the op-suffix falls back to the full name, preserving ordinary fuzzy
+        behaviour.
+        Test: Assert repair returns ``terminal``.
+        """
+        assert repair_mcp_dd("terminall") == "terminal"
+
+
+class TestRepairOpSuffixHelper:
+    """Unit tests for ``_repair_op_suffix`` — the module-level suffix-stripping helper.
+
+    Why: ``_repair_op_suffix`` is extracted from the nested function so it can
+    be unit-tested independently and is allocated once rather than on every
+    ``repair_tool_call`` invocation.  These tests verify isolation of the
+    operation token across both single- and double-underscore MCP prefixes, and
+    the no-shared-prefix fallback.
+    """
+
+    def setup_method(self):
+        from agent.agent_runtime_helpers import _repair_op_suffix
+        self.fn = _repair_op_suffix
+
+    def test_double_underscore_strips_namespace_and_shared_op_prefix(self):
+        """Strip shared prefix from ``mcp__knowledge__kb_search`` vs ``mcp__knowledge__kb_add``.
+
+        Why: Core case — long shared prefix including the shared ``kb`` segment
+        must be fully consumed, leaving only the distinguishing token.
+        What: ``"mcp__knowledge__kb_search".split("_")`` yields
+        ``["mcp", "", "knowledge", "", "kb", "search"]`` and
+        ``"mcp__knowledge__kb_add".split("_")`` yields
+        ``["mcp", "", "knowledge", "", "kb", "add"]``.  The shared leading
+        segments are ``["mcp", "", "knowledge", "", "kb"]``, so the remainder
+        of ``name`` is ``["search"]`` -> ``"search"``.
+        Test: Direct call; assert return value equals ``"search"``.
+        """
+        result = self.fn(
+            mcp_prefixed_tool_name("knowledge", "kb_search"),
+            mcp_prefixed_tool_name("knowledge", "kb_add"),
+        )
+        assert result == "search"
+
+    def test_no_shared_prefix_returns_full_name(self):
+        """No shared leading segments — return the full name unchanged.
+
+        Why: Non-namespaced tools have no common prefix; the helper must
+        fall back to the full name so the caller's ratio check uses the
+        complete string (preserving old fuzzy behaviour).
+        What: ``"terminal"`` and ``"read_file"`` share no ``_``-split
+        segments; ``"terminal"`` is returned as-is.
+        Test: Direct call; assert return value equals ``"terminal"``.
+        """
+        result = self.fn("terminal", "read_file")
+        assert result == "terminal"
+
+    def test_single_shared_prefix_segment(self):
+        """Strips a single shared leading segment (e.g. ``kb_``).
+
+        Why: Covers the non-MCP (no double-underscore) namespaced case where
+        two tools share a short prefix like ``kb_``.
+        What: ``"kb_search"`` and ``"kb_add"`` share segment ``"kb"`` (after
+        splitting on ``"_"``); the helper returns ``"search"``.
+        Test: Direct call; assert return value equals ``"search"``.
+        """
+        result = self.fn("kb_search", "kb_add")
+        assert result == "search"
+
+    def test_name_is_prefix_of_other_returns_full_name(self):
+        """Fallback when ``name`` is exhausted before ``other``.
+
+        Why: Guards against returning an empty string when ``name`` is a
+        strict segment-prefix of ``other``; the fallback preserves ``name``.
+        What: ``"mcp"`` (1 segment) vs ``"mcp__svc__op"`` (5 segments) —
+        the walk exhausts ``a`` at i=1, leaving ``"_".join([])`` == ``""``,
+        so the ``or name`` fallback kicks in.
+        Test: Direct call; assert return value equals ``"mcp"``.
+        """
+        result = self.fn("mcp", mcp_prefixed_tool_name("svc", "op"))
+        assert result == "mcp"


### PR DESCRIPTION
## What
Hardens `repair_tool_call()` against dangerous cross-operation remaps for namespaced MCP tools. When two tools share a long common `mcp__<server>__` prefix (e.g. `mcp__knowledge__kb_search` vs `mcp__knowledge__kb_add`), that shared prefix inflates whole-name fuzzy similarity above the 0.7 cutoff, so a missing READ tool could be silently repaired into a WRITE tool (BUG-8).

Adds a module-level `_repair_op_suffix()` helper that strips the longest shared leading namespace segment run and scores close candidates on their operation suffix. A candidate is accepted only if its operation-suffix ratio is >= 0.7 -- a conservative rejection guard: a legitimate operation-level typo (`kb_serch` -> `kb_search`) is repaired, while a divergent operation (`kb_search` when only `kb_add` exists) returns `None` instead of remapping across operations.

**Note on framing:** for a same-namespace candidate pool, whole-name and operation-suffix similarity rank candidates in the same order (the shared prefix contributes equally to both), so the selection step does not choose a different winner than whole-name matching would. The behavioral value is entirely in the acceptance gate. Non-namespaced names have no shared prefix and fall back to ordinary whole-name fuzzy behavior, unchanged.

**Files modified:** `agent/agent_runtime_helpers.py` (module-level `_repair_op_suffix` + gate in `repair_tool_call`), `tests/run_agent/test_repair_tool_call_name.py`.

## Tests
Uses the production double-underscore `mcp__<server>__<tool>` registration form via `mcp_prefixed_tool_name()`: allow cases (legit op typo repaired), block cases (divergent op returns `None` -- fails against the prior unconditional return, passes with the gate), non-namespaced regression, and direct unit tests for `_repair_op_suffix`. 46 tests pass; ruff clean.