### PR TITLE
fix(mcp): wait longer for headless discovery

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from typing import Optional
+
+_DEFAULT_MCP_DISCOVERY_WAIT = 3.0
+_MCP_DISCOVERY_WAIT_ENV = "HERMES_MCP_DISCOVERY_WAIT"
 
 _mcp_discovery_lock = threading.Lock()
 _mcp_discovery_started = False
@@ -51,9 +55,27 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         thread.start()
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly wait for background MCP discovery before the first tool snapshot."""
+def _configured_mcp_discovery_wait() -> float:
+    """Return the bounded first-snapshot wait for background MCP discovery."""
+    raw = os.environ.get(_MCP_DISCOVERY_WAIT_ENV)
+    if raw is None or raw.strip() == "":
+        return _DEFAULT_MCP_DISCOVERY_WAIT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return _DEFAULT_MCP_DISCOVERY_WAIT
+    return max(0.0, timeout)
+
+
+def wait_for_mcp_discovery(timeout: float | None = None) -> None:
+    """Wait for background MCP discovery before the first tool snapshot.
+
+    Headless one-shot sessions snapshot tools once, so the default wait is long
+    enough for normal stdio/container MCP cold starts. Users with slower servers
+    can tune it with ``HERMES_MCP_DISCOVERY_WAIT``; explicit test/caller timeouts
+    still take precedence.
+    """
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return
-    thread.join(timeout=timeout)
+    thread.join(timeout=_configured_mcp_discovery_wait() if timeout is None else timeout)

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -140,6 +140,30 @@ def test_cli_get_tool_definitions_briefly_waits_for_fast_mcp_thread(monkeypatch)
     assert not thread.is_alive()
 
 
+def test_cli_get_tool_definitions_honors_mcp_wait_env(monkeypatch):
+    thread = threading.Thread(target=lambda: time.sleep(0.12), daemon=True)
+    thread.start()
+    mcp_startup._mcp_discovery_thread = thread
+    monkeypatch.setenv("HERMES_MCP_DISCOVERY_WAIT", "0.25")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(get_tool_definitions=lambda *_a, **_k: ["ok"]),
+    )
+
+    result = cli_mod.get_tool_definitions(enabled_toolsets=["web"], quiet_mode=True)
+
+    assert result == ["ok"]
+    assert not thread.is_alive()
+
+
+def test_wait_for_mcp_discovery_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv("HERMES_MCP_DISCOVERY_WAIT", "not-a-float")
+
+    assert mcp_startup._configured_mcp_discovery_wait() == 3.0
+
+
 def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     waited = {"done": False}
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -543,6 +543,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_QUIET` | Suppress non-essential output (`true`/`false`) |
 | `CODEX_HOME` | When [Codex app-server runtime](../user-guide/features/codex-app-server-runtime) is enabled, override the directory Codex CLI reads its config + auth from (default: `~/.codex`). Hermes' migration writes the managed block to `<CODEX_HOME>/config.toml`. |
 | `HERMES_KANBAN_TASK` | Set by the kanban dispatcher when spawning a worker (task UUID). Workers and the spawned `hermes-tools` MCP subprocess inherit it so kanban tools gate correctly. Don't set manually. |
+| `HERMES_MCP_DISCOVERY_WAIT` | Seconds to wait for background MCP tool discovery before the first CLI/headless tool snapshot (default: `3.0`). Increase for slow stdio/container MCP servers used from `hermes -z`; set to `0` to avoid waiting. |
 | `HERMES_API_TIMEOUT` | LLM API call timeout in seconds (default: `1800`) |
 | `HERMES_API_CALL_STALE_TIMEOUT` | Non-streaming stale-call timeout in seconds (default: `300`). Auto-disabled for local providers when left unset. Also configurable via `providers.<id>.stale_timeout_seconds` or `providers.<id>.models.<model>.stale_timeout_seconds` in `config.yaml`. |
 | `HERMES_STREAM_READ_TIMEOUT` | Streaming socket read timeout in seconds (default: `120`). Auto-increased to `HERMES_API_TIMEOUT` for local providers. Increase if local LLMs time out during long code generation. |


### PR DESCRIPTION
## Summary
- Increases the CLI/headless first MCP discovery wait from 0.75s to 3.0s so cold stdio/container-backed servers can register before `hermes -z` snapshots tools.
- Adds `HERMES_MCP_DISCOVERY_WAIT` as an escape hatch for slower or latency-sensitive setups.

Closes #37013

## Why
- Headless one-shot sessions snapshot tool definitions once; if background MCP discovery is still connecting, those tools stay unavailable for the entire run.
- The old 0.75s wait was shorter than common process/container MCP cold starts reported in the issue.

## Changes
- `hermes_cli/mcp_startup.py`: use a 3.0s default wait and parse `HERMES_MCP_DISCOVERY_WAIT` with safe fallback/clamping.
- `tests/hermes_cli/test_mcp_startup.py`: cover env-tuned waits and invalid env fallback.
- `website/docs/reference/environment-variables.md`: document the new environment variable.

## Validation
- `python -m pytest tests/hermes_cli/test_mcp_startup.py -q -o 'addopts='`
- `python -m ruff check hermes_cli/mcp_startup.py tests/hermes_cli/test_mcp_startup.py`
- `git diff --check`

## Scope
- Does not change MCP server discovery or connection semantics.
- Does not add per-server required/blocking startup; this only makes the existing first-snapshot wait long enough for normal cold starts and configurable for outliers.
