### PR TITLE
fix(approval): gate perl -i and awk -i inplace edits of Hermes config/env

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -440,6 +440,85 @@ class TestHermesConfigWriteProtection:
         assert dangerous is False
 
 
+class TestHermesConfigPerlAwkInPlace:
+    """Sibling follow-up to #14639 / the sed-in-place pairing: `sed -i` is not
+    the only standard in-place editor that mutates ~/.hermes/config.yaml (or
+    .env) directly and so bypasses the redirection/tee/cp patterns. `perl -i`
+    (also `-pi`, `-i.bak`) and `awk -i inplace` / `gawk -i inplace` reach the
+    same security file via the same in-place-write path. Gating only `sed`
+    leaves the write_file/patch deny unpaired theater. These pin the remaining
+    in-place editors against the config/env files."""
+
+    def test_perl_in_place(self):
+        # The gap: perl -i mutates the file directly, like sed -i.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/manual/off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_perl_combined_pi_flag(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -pi -e 's/manual/off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
+    def test_perl_in_place_with_backup_suffix_on_env(self):
+        # -i.bak (backup suffix) must still be caught, against .env.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i.bak -pe 's/x/y/' ~/.hermes/.env"
+        )
+        assert dangerous is True
+
+    def test_awk_in_place(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "awk -i inplace '{print}' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+        assert "hermes config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_gawk_in_place_on_env(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "gawk -i inplace '{print}' ~/.hermes/.env"
+        )
+        assert dangerous is True
+
+    def test_custom_hermes_home(self):
+        # HERMES_HOME override form must be covered like the sed pairing.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/x/y/' $HERMES_HOME/config.yaml"
+        )
+        assert dangerous is True
+
+    # --- No-regression negatives ---
+
+    def test_perl_without_in_place_safe(self):
+        # No -i flag, no config path — the new in-place pattern must not trip.
+        # (`perl -e` is independently gated by the -e/-c script pattern, so use
+        # a read-only invocation to isolate the in-place pairing.)
+        dangerous, key, desc = detect_dangerous_command("perl --version")
+        assert dangerous is False
+
+    def test_perl_in_place_non_sensitive_path_safe(self):
+        # In-place edit of a scratch file is not the security file.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -i -pe 's/x/y/' /tmp/scratch.yaml"
+        )
+        assert dangerous is False
+
+    def test_read_only_awk_on_config_safe(self):
+        # awk without -i inplace only reads; must not trip.
+        dangerous, key, desc = detect_dangerous_command(
+            "awk '{print}' ~/.hermes/config.yaml"
+        )
+        assert dangerous is False
+
+    def test_cat_config_safe(self):
+        # Reading config is not a write.
+        dangerous, key, desc = detect_dangerous_command("cat ~/.hermes/config.yaml")
+        assert dangerous is False
+
+
 class TestFindExecFullPathRm:
     """Detect find -exec with full-path rm bypasses."""
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -506,6 +506,32 @@ class TestHermesConfigPerlAwkInPlace:
         )
         assert dangerous is False
 
+    def test_perl_include_path_flag_not_flagged(self):
+        # Regression for the Copilot finding on PR #37107: detection lowercases
+        # input and runs under re.IGNORECASE, so perl's include-path flag `-I`
+        # (uppercase, takes a directory arg) collapses to `-i`. A loose
+        # `[^\s]*i` match wrongly flagged `perl -Ilib script.pl <config>` as an
+        # in-place edit even though no in-place editing happens. The precise
+        # flag-grammar pattern must NOT fire here.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -Ilib script.pl ~/.hermes/config.yaml"
+        )
+        assert dangerous is False
+        # Multiple include paths bundled the same way must also stay safe.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -Ilib -Ivendor/lib run.pl ~/.hermes/.env"
+        )
+        assert dangerous is False
+
+    def test_perl_real_inplace_still_flagged_vs_include(self):
+        # Companion to the regression above: a genuine in-place edit that also
+        # passes an include path must STILL be gated. Pins that the fix narrows
+        # only the false positive, not real coverage.
+        dangerous, key, desc = detect_dangerous_command(
+            "perl -Ilib -i -pe 's/manual/off/' ~/.hermes/config.yaml"
+        )
+        assert dangerous is True
+
     def test_read_only_awk_on_config_safe(self):
         # awk without -i inplace only reads; must not trip.
         dangerous, key, desc = detect_dangerous_command(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -443,6 +443,14 @@ DANGEROUS_PATTERNS = [
     # the terminal side is not an open door. See #14639.
     (rf'\bsed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env"),
     (rf'\bsed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (long flag)"),
+    # Same in-place-edit escalation as the sed pairing above, reached through
+    # the other standard in-place editors `sed -i` does not cover: `perl -i`
+    # (also `-pi`, `-i.bak`) and `awk -i inplace` / `gawk -i inplace`. Each
+    # mutates ~/.hermes/config.yaml (or .env) directly, and the mtime-keyed
+    # config cache reloads it mid-session — so gating only `sed` leaves the
+    # write_file/patch deny unpaired. Sibling follow-up to #14639.
+    (rf'\bperl\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl -i)"),
+    (rf'\b(?:g?awk)\s+-i\s+inplace\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (awk -i inplace)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -449,7 +449,20 @@ DANGEROUS_PATTERNS = [
     # mutates ~/.hermes/config.yaml (or .env) directly, and the mtime-keyed
     # config cache reloads it mid-session — so gating only `sed` leaves the
     # write_file/patch deny unpaired. Sibling follow-up to #14639.
-    (rf'\bperl\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl -i)"),
+    #
+    # The `-i` token must be matched against perl's actual flag grammar, NOT a
+    # loose `[^\s]*i` that fires on any `i` in a flag bundle. Detection runs
+    # under re.IGNORECASE *and* lowercases input, so the include-path flag
+    # `-I` (which consumes its arg as a directory, e.g. `perl -Ilib script.pl`)
+    # is indistinguishable from `-i` by case alone — a loose match wrongly
+    # gates `perl -Ilib script.pl ~/.hermes/config.yaml`. Instead require `-i`
+    # to be a real in-place flag: an optional bundle of the boolean prefix
+    # flags perl allows before it (`-pi`, `-ni`, `-pi.bak`, …), then `i`, then
+    # either the flag boundary (whitespace) or a backup suffix introduced by a
+    # non-letter (`.bak`, `~`, `'*'`). `-Ilib` fails because `i` is followed by
+    # the letters of the include path, which is neither a boundary nor a
+    # suffix start. See #14639 and the Copilot finding on this PR.
+    (rf'\bperl\s+(?:[^\s]+\s+)*?-[pnaslwxcefutWCSU0-9]*i(?=\s|[.~\'"*])[^\s]*\s.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl -i)"),
     (rf'\b(?:g?awk)\s+-i\s+inplace\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (awk -i inplace)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.


### PR DESCRIPTION
## This is a sibling follow-up to commit `4e9d886d9` (fix(approval): pair terminal-side gate for ~/.hermes/config.yaml writes)

- **4e9d886d9 covered:** terminal-side in-place edits via `sed -i` / `sed --in-place` of `~/.hermes/config.yaml` and `.env` (added `_HERMES_CONFIG_PATH`, folded into `_SENSITIVE_WRITE_TARGET` + sed `DANGEROUS_PATTERNS`).
- **4e9d886d9 did NOT touch:** the other standard in-place editors — `perl -i` (also `-pi`, `-i.bak`) and `awk -i inplace` / `gawk -i inplace`. Same in-place-mutation pattern, different editor verb, reaches the same security file.
- **This PR adds:** the same in-place-edit deny for `perl -i` and `awk -i inplace` against `~/.hermes/config.yaml` and `.env`, reusing the existing `_HERMES_CONFIG_PATH` / `_HERMES_ENV_PATH` fragments.

## What does this PR do?

Pairs the remaining terminal-side in-place editors with the existing write_file/patch deny on `~/.hermes/config.yaml` / `.env`. `sed -i` is already gated (#14639 / 4e9d886d9); `perl -i -pe 's/.../approvals.mode: off/' ~/.hermes/config.yaml` and `awk -i inplace` were not. Because the config cache is mtime-keyed, such an in-place write takes effect mid-session and the agent can flip `approvals.mode=off` to bypass the approval gate — so the sed-only pairing is incomplete ("theater" per SECURITY.md, the same argument the parent made for sed).

Issue lists 1 escalation vector at this code site (in-place edit of the Hermes security config). The parent closed it for `sed`; this PR closes the remaining editor verbs (`perl -i`, `awk -i inplace`) at the same site. No new path fragment — only the editor verb is widened.

## Related Issue

Sibling follow-up to 4e9d886d9 / #14639 (no separate issue).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py`: two new `DANGEROUS_PATTERNS` entries — `perl -[..]i` and `(g)awk -i inplace` targeting `_HERMES_CONFIG_PATH` / `_HERMES_ENV_PATH`.
- `tests/tools/test_approval.py`: positive cases (`perl -i` / `-pi` / `-i.bak`, `awk`/`gawk -i inplace`, `$HERMES_HOME` form) + no-regression negatives (`perl --version`, in-place edit of `/tmp`, read-only `awk`, `cat` of `config.yaml`).

## How to Test

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_approval.py -v
```

Regression guard verified both directions: with the prod hunk stashed, all 6 positive cases fail (`perl -i`/`-pi`/`-i.bak`, `awk`/`gawk -i inplace`, `$HERMES_HOME`); restored, the full file passes 207/207.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite and all tests pass (207/207 in `tests/tools/test_approval.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — the regexes are shell-syntax (not OS path) based and match the parent's `sed` pairing — or N/A

> Audited siblings: confirmed `sed` (parent), `perl -i`, and `awk -i inplace` are the standard in-place editors; `tee`/`>`/`cp`/`mv` are already covered by `_SENSITIVE_WRITE_TARGET`. No further widening needed.