### PR TITLE
fix(scripts): add explicit utf-8 encodings

### DIFF
--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -30,7 +30,7 @@ def _load_json(path: Path | None) -> list[dict]:
     if path is None or not path.exists() or path.stat().st_size == 0:
         return []
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         print(f"warning: could not parse {path}: {exc}", file=sys.stderr)
         return []
@@ -197,7 +197,7 @@ def main() -> int:
 
     summary = "\n".join(buf)
     if args.output:
-        args.output.write_text(summary)
+        args.output.write_text(summary, encoding="utf-8")
     else:
         print(summary)
     return 0

--- a/scripts/profile-tui.py
+++ b/scripts/profile-tui.py
@@ -516,7 +516,7 @@ def main() -> int:
         if not path.exists():
             print(f"\n⚠ no baseline at {path} — run with --save {args.compare} first")
         else:
-            before = json.loads(path.read_text())
+            before = json.loads(path.read_text(encoding="utf-8"))
             print(f"\n═══ A/B diff vs /tmp/perf-{args.compare}.json ═══")
             print(format_diff(before, metrics))
 

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -508,7 +508,7 @@ def _load_durations(repo_root: Path) -> dict[str, float]:
     if not path.is_file():
         return {}
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
 
@@ -529,7 +529,10 @@ def _save_durations(
         key = _format_file(f, repo_root)
         data[key] = round(t, 3)
     path = repo_root / _DURATIONS_FILE
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    path.write_text(
+        json.dumps(data, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _slice_files(


### PR DESCRIPTION
## Summary
- add explicit `encoding="utf-8"` to text reads/writes in `scripts/lint_diff.py`
- add explicit `encoding="utf-8"` to the compare path in `scripts/profile-tui.py`
- add explicit `encoding="utf-8"` to duration cache reads/writes in `scripts/run_tests_parallel.py`

## Verification
- `ruff check --select PLW1514 scripts/lint_diff.py scripts/profile-tui.py scripts/run_tests_parallel.py`
- `python -m py_compile scripts/lint_diff.py scripts/profile-tui.py scripts/run_tests_parallel.py`
- `git diff --check`

Fixes #36649