### PR TITLE
feat(skills): add Hermes Claude Codex workstream

### DIFF
--- a/skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md
@@ -1,0 +1,467 @@
+---
+name: hermes-claude-codex-workstream
+description: Use when setting up or running a Hermes Agent controlled build workflow where Hermes sharpens the brief and routes, Claude Code plans/designs/reviews and gap-checks, Codex CLI implements, Claude plus Codex independently review, and Hermes reconciles, verifies, and signs off.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [hermes-agent, claude-code, codex, orchestration, build-workflow, verification]
+    related_skills: [hermes-agent, claude-code, codex]
+---
+
+# Hermes Claude Code and Codex Workstream
+
+## Overview
+
+This skill packages a Hermes-specific external engine workflow:
+
+```text
+Human intent
+→ Hermes Agent sharpens the brief and routes
+→ Claude Code plans, designs, reviews, and pushes back when the brief has gaps
+→ Codex CLI implements
+→ Claude Code and Codex CLI independently review, using their own subagents when useful
+→ Hermes Agent reconciles, verifies, and signs off
+```
+
+Hermes Agent stays the controller, memory layer, brief writer, run logger, and final verifier. Claude Code is the planning, design, critique, and review engine. Codex CLI is the implementation and test-loop engine. Human signoff stays explicit when product direction, design, or risky scope changes are involved.
+
+The point is not to run two coding agents and hope. The edge is the artefact loop: Hermes sharpens the human intent into a verifiable brief, Claude Code refuses vague or missing requirements, Codex builds only after the slice is sharp, both engines review independently, and Hermes reconciles disagreements with real verification commands.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- Set up a Hermes Agent workflow using Claude Code plus Codex CLI.
+- Turn a rough product or engineering intent into a buildable external-agent workstream.
+- Run a feature, bug fix, PR review, prototype, or cleanup through a controlled Claude and Codex loop.
+- Teach another Hermes user how to reproduce the workflow.
+- Create a public or team-safe version of an internal Hermes build workflow.
+
+Do not use this for:
+
+- Tiny one-command edits where Hermes can patch and verify faster directly.
+- Tasks requiring secrets to be shared with external CLIs.
+- Unbounded multi-agent chats where Claude and Codex talk freely without Hermes control.
+- Production deploys unless the deploy runbook and rollback path are already defined.
+
+## Prerequisites
+
+The Hermes controller needs terminal access and process management.
+
+Install and verify the CLIs:
+
+```bash
+# Claude Code
+npm install -g @anthropic-ai/claude-code
+claude auth status --text || claude auth login
+claude doctor
+claude --version
+
+# Codex CLI
+npm install -g @openai/codex
+codex --version
+
+# Repo helpers
+git --version
+gh --version || true
+```
+
+Authentication notes:
+
+- Claude Code can use browser OAuth, console auth, SSO, or `ANTHROPIC_API_KEY` depending on the user's account.
+- Codex CLI can use Codex OAuth or `OPENAI_API_KEY` depending on the user's setup.
+- Hermes itself may use a different provider configuration from the standalone CLIs. Do not assume Hermes auth proves CLI auth, or the reverse.
+- Never print API keys, OAuth tokens, auth JSON, or credential file contents.
+
+Before running real work, load the companion skills if available:
+
+- `claude-code` for exact Claude Code CLI flags and PTY handling.
+- `codex` for exact Codex CLI flags and PTY handling.
+- `hermes-agent` when configuring Hermes profiles, tools, gateways, or skills.
+
+## Roles
+
+### Hermes Agent controller
+
+Hermes owns:
+
+- Intent grilling and scope control.
+- The brief, constraints, acceptance criteria, and verification plan.
+- Worktree or workspace setup.
+- Prompts sent to Claude Code and Codex CLI.
+- Run directory and artefact capture.
+- Review reconciliation.
+- Final verification using real commands.
+- User-facing report with action, target, verification command, result, and remaining risks.
+
+Hermes does not treat external-agent output as proof. Agent claims are input. Command output is proof.
+
+### Claude Code
+
+Use Claude Code for:
+
+- Product and UX direction critique.
+- Architecture and implementation planning.
+- Design tradeoff analysis.
+- Brief gap detection and pushback before build starts.
+- Maintainability review.
+- Security and risk review.
+- Second-opinion review of Codex changes.
+
+Claude Code should not passively accept a weak brief. If acceptance criteria, constraints, design direction, verification commands, or scope boundaries are missing, Claude should return the gaps and ask Hermes to resolve them before Codex starts implementation.
+
+Prefer Claude print mode for bounded tasks:
+
+```bash
+claude -p "Read the brief and produce a concise implementation plan with risks and acceptance criteria." \
+  --output-format json \
+  --max-turns 8
+```
+
+Use interactive Claude sessions only when the workflow needs multi-turn exploration, slash commands, or human-in-the-loop decisions.
+
+### Codex CLI
+
+Use Codex CLI for:
+
+- Implementing the signed-off slice.
+- Running tests and fixing failures.
+- Producing diffs.
+- Narrow bug review.
+- Scoped fix passes after review.
+
+Codex should implement the signed-off brief, not reinterpret the product direction. If Codex finds the brief impossible, contradictory, or under-specified, it should stop and report the blocker rather than inventing scope.
+
+Codex generally needs a git repository and a PTY:
+
+```bash
+codex exec --full-auto "Implement the attached brief. Run the listed verification commands. Report changed files and remaining failures."
+```
+
+Use isolated worktrees for implementation by default.
+
+## Core Workflow
+
+### 1. Capture human intent and sharpen the brief
+
+A brief must include:
+
+- Goal in one sentence.
+- Non-goals.
+- Constraints.
+- Scope boundaries.
+- Acceptance criteria.
+- Verification commands.
+- Expected artefacts.
+- Signoff trigger, if product or design direction matters.
+
+If success cannot be verified in one or more commands or observable artefacts, the brief is not ready.
+
+Hermes should also decide the route:
+
+- Claude Code first when design, architecture, requirements, or risk need pressure-testing.
+- Codex first only for narrow, already-specified implementation tasks.
+- Human signoff before Codex when Claude identifies material gaps or product/design choices.
+
+### 2. Create a run directory
+
+Keep every external-agent workstream auditable.
+
+```bash
+RUN_ID="run-$(date +%Y%m%d-%H%M%S)-topic"
+mkdir -p ".hermes/runs/$RUN_ID"
+```
+
+Recommended layout:
+
+```text
+.hermes/runs/<run-id>/
+  brief.md
+  claude-plan.json
+  claude-plan.md
+  codex-build.log
+  changed-files.txt
+  diff.patch
+  claude-review.json
+  claude-review.md
+  codex-review.log
+  reconciled-findings.md
+  fix-pass.log
+  verification.txt
+  signoff.md
+```
+
+If `.hermes/runs/` is not appropriate for the repo, use `.agent-runs/` or another ignored run-artifact directory.
+
+### 3. Ask Claude for plan, design, review, and gap detection
+
+Use Claude before build when the product shape, design, architecture, or risk profile is uncertain.
+
+Example:
+
+```bash
+claude -p "$(cat .hermes/runs/$RUN_ID/brief.md)
+
+Return:
+1. recommended approach
+2. risks
+3. missing decisions
+4. implementation plan
+5. verification plan
+6. whether this is ready for Codex implementation
+Do not write files." \
+  --output-format json \
+  --max-turns 8 \
+  > ".hermes/runs/$RUN_ID/claude-plan.json"
+```
+
+Hermes then reads and critiques the plan. If Claude says the brief has gaps, Hermes resolves the gaps or asks the human for a decision. If direction needs human signoff, stop and get signoff before Codex builds.
+
+### 4. Create an isolated implementation worktree
+
+```bash
+git fetch --all --prune
+BASE_BRANCH="main"
+BRANCH="agent/$RUN_ID"
+WORKTREE="/tmp/$RUN_ID"
+git worktree add -b "$BRANCH" "$WORKTREE" "$BASE_BRANCH"
+```
+
+Rules:
+
+- One implementation owner per worktree.
+- Do not run broad unrelated cleanup in the same slice.
+- Do not let Codex edit the controller's run notes except where explicitly asked.
+- If the worktree is dirty before Codex starts, stop and resolve it.
+
+### 5. Send Codex the signed-off build prompt
+
+The Codex prompt should contain:
+
+- Brief path or brief text.
+- Exact scope.
+- Files or directories likely in scope.
+- Verification commands.
+- Instruction to report failures honestly.
+- Instruction not to commit unless requested.
+
+Example:
+
+```bash
+codex exec --full-auto "
+You are implementing one signed-off slice.
+
+Read this brief:
+$(cat .hermes/runs/$RUN_ID/brief.md)
+
+Rules:
+- Stay inside scope.
+- Do not commit.
+- Run the verification commands from the brief.
+- If a command fails, keep the raw failure and explain the blocker.
+- End with changed files, commands run, failures, and remaining risks.
+" 2>&1 | tee ".hermes/runs/$RUN_ID/codex-build.log"
+```
+
+When running through Hermes tools, use `terminal(..., pty=true)` for Codex and `background=true` with `notify_on_complete=true` for long bounded work.
+
+### 6. Capture diffs and artefacts
+
+After Codex exits, Hermes must inspect the worktree.
+
+```bash
+git status --short > ".hermes/runs/$RUN_ID/changed-files.txt"
+git diff --stat > ".hermes/runs/$RUN_ID/diff-stat.txt"
+git diff > ".hermes/runs/$RUN_ID/diff.patch"
+```
+
+If no files changed but Codex claimed completion, treat that as a failed run until explained.
+
+### 7. Run independent Claude and Codex review passes
+
+Claude Code and Codex CLI review independently. They can use their own subagents or internal review modes when available, but Hermes only needs the final artefacts: findings, evidence, uncertainty, and whether each finding is actionable.
+
+Claude review prompt:
+
+```bash
+claude -p "
+Review this implementation against the brief.
+
+Brief:
+$(cat .hermes/runs/$RUN_ID/brief.md)
+
+Diff:
+$(cat .hermes/runs/$RUN_ID/diff.patch)
+
+Return:
+- must-fix issues
+- should-fix issues
+- product or UX regressions
+- security or maintainability risks
+- false positives or uncertainties
+Do not modify files.
+" --output-format json --max-turns 8 > ".hermes/runs/$RUN_ID/claude-review.json"
+```
+
+Codex review prompt:
+
+```bash
+codex exec "Review the current diff for bugs, regressions, and missing tests. Do not modify files. Report only actionable findings."
+```
+
+Hermes reconciles both reviews into:
+
+- Must fix.
+- Should fix.
+- False positive.
+- Out of scope.
+- Needs human decision.
+
+### 8. Fix only scoped findings
+
+If fixes are needed, Codex gets a narrow fix-pass prompt with the reconciled findings. It must not open new scope.
+
+```bash
+codex exec --full-auto "
+Fix only the must-fix findings in .hermes/runs/$RUN_ID/reconciled-findings.md.
+Do not introduce unrelated refactors.
+Run the verification commands again.
+Report changed files, commands run, and failures.
+" 2>&1 | tee ".hermes/runs/$RUN_ID/fix-pass.log"
+```
+
+### 9. Final verification by Hermes
+
+Hermes runs the real commands itself. The controller does not rely on Claude or Codex claims.
+
+Examples:
+
+```bash
+git status --short
+pytest -q
+npm test
+npm run build
+gh pr view --json statusCheckRollup
+```
+
+The exact commands come from the brief and repo conventions.
+
+### 10. Sign off or reject
+
+Final response should include:
+
+- Action taken.
+- Exact target changed.
+- Verification command used.
+- Verification result.
+- Review findings and disposition.
+- Anything still broken or not verified.
+- Artefact paths.
+
+If verification is unavailable, say `NOT VERIFIED` and explain why.
+
+## Hermes Tool Patterns
+
+Use normal Hermes tools for small direct steps and `terminal` or `process` for CLI agents.
+
+Claude print mode example:
+
+```python
+terminal(
+  command="claude -p \"Review the brief and return risks only\" --output-format json --max-turns 5",
+  workdir="/path/to/repo",
+  timeout=180,
+)
+```
+
+Codex background example:
+
+```python
+terminal(
+  command="codex exec --full-auto \"Implement the signed-off brief in .hermes/runs/run-id/brief.md\"",
+  workdir="/tmp/run-id",
+  pty=True,
+  background=True,
+  notify_on_complete=True,
+)
+```
+
+Poll bounded long work:
+
+```python
+process(action="poll", session_id="<session-id>")
+process(action="log", session_id="<session-id>", limit=200)
+process(action="wait", session_id="<session-id>", timeout=300)
+```
+
+Do not use background mode silently for bounded build work. Use `notify_on_complete=true` so the controller gets completion evidence.
+
+## Public Setup Recipe
+
+For a user who wants to reproduce the workflow:
+
+1. Install Hermes Agent and enable terminal/process tools.
+2. Install and authenticate Claude Code.
+3. Install and authenticate Codex CLI.
+4. Put this skill under `~/.hermes/skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md`, or install it from the Hermes skill library if available.
+5. Ask Hermes to load this skill before build orchestration.
+6. Start with one low-risk repo and one small slice.
+7. Keep external-agent artefacts in a run directory.
+8. Require local verification before reporting completion.
+
+Example user prompt:
+
+```text
+Use the hermes-claude-codex-workstream skill. I want to fix the settings page loading bug in this repo. Claude should plan/review, Codex should implement in an isolated worktree, and Hermes should run final verification before signoff.
+```
+
+## Guardrails
+
+- Do not share secrets with Claude Code or Codex CLI unless the user explicitly approves and the tool genuinely needs them.
+- Do not paste `.env`, auth files, token files, private keys, cookies, or OAuth JSON into prompts.
+- Do not let Claude and Codex recursively delegate to each other.
+- Do not run multiple implementation agents in the same worktree.
+- Do not accept `looks good` as review evidence.
+- Do not accept `tests passed` without the raw command output or an independent rerun.
+- Do not commit, push, deploy, or publish unless the user asked for that side effect.
+- Do not turn a review pass into a broad refactor pass.
+- Do not hide failed commands. Failed commands are evidence.
+
+## Common Pitfalls
+
+1. **Starting with Codex before the brief is sharp.** Codex is fast enough to build the wrong thing quickly. Claude planning or human signoff comes first when direction is uncertain.
+
+2. **No run directory.** Without artefacts, the controller cannot reconcile claims, reviews, diffs, and verification later.
+
+3. **Using one giant prompt instead of a workflow.** The value is in staged delegation and independent verification, not prompt stuffing.
+
+4. **Letting external agents own final judgement.** Hermes is the judge. Claude and Codex are engines.
+
+5. **Skipping worktrees.** Isolated worktrees make rollback, review, and cleanup simple.
+
+6. **Over-parallelising.** Parallel review is fine. Parallel implementation of the same slice is usually noise.
+
+7. **Publishing internal examples.** For public skills, scrub private repo names, client data, user names, tokens, URLs, and operational transcript excerpts.
+
+8. **Mistaking CLI auth for Hermes provider auth.** Verify each surface independently.
+
+## Verification Checklist
+
+Before saying the workstream is set up or a slice is complete:
+
+- [ ] `claude --version` and Claude auth or `claude doctor` verified.
+- [ ] `codex --version` and Codex auth path verified.
+- [ ] Git repo and clean starting state verified.
+- [ ] Run directory created.
+- [ ] Brief written with acceptance criteria and verification commands.
+- [ ] Claude plan or critique captured when needed.
+- [ ] Human signoff captured when product/design direction changed.
+- [ ] Codex ran in the intended worktree.
+- [ ] Changed files and diff captured.
+- [ ] Independent review pass completed or explicitly skipped with reason.
+- [ ] Must-fix findings resolved or rejected with evidence.
+- [ ] Hermes reran final verification commands directly.
+- [ ] Final report includes artefact paths and remaining risks.

--- a/skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md
@@ -1,467 +1,168 @@
 ---
 name: hermes-claude-codex-workstream
-description: Use when setting up or running a Hermes Agent controlled build workflow where Hermes sharpens the brief and routes, Claude Code plans/designs/reviews and gap-checks, Codex CLI implements, Claude plus Codex independently review, and Hermes reconciles, verifies, and signs off.
-version: 1.0.0
-author: Hermes Agent
+description: Drive briefs through Claude Code planning and Codex builds.
+version: 1.1.0
+author: Joel Brilliant (@joelbrilliant) with Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, macos]
 metadata:
   hermes:
     tags: [hermes-agent, claude-code, codex, orchestration, build-workflow, verification]
     related_skills: [hermes-agent, claude-code, codex]
 ---
 
-# Hermes Claude Code and Codex Workstream
+# Hermes Claude Codex Workstream Skill
 
-## Overview
-
-This skill packages a Hermes-specific external engine workflow:
-
-```text
-Human intent
-→ Hermes Agent sharpens the brief and routes
-→ Claude Code plans, designs, reviews, and pushes back when the brief has gaps
-→ Codex CLI implements
-→ Claude Code and Codex CLI independently review, using their own subagents when useful
-→ Hermes Agent reconciles, verifies, and signs off
-```
-
-Hermes Agent stays the controller, memory layer, brief writer, run logger, and final verifier. Claude Code is the planning, design, critique, and review engine. Codex CLI is the implementation and test-loop engine. Human signoff stays explicit when product direction, design, or risky scope changes are involved.
-
-The point is not to run two coding agents and hope. The edge is the artefact loop: Hermes sharpens the human intent into a verifiable brief, Claude Code refuses vague or missing requirements, Codex builds only after the slice is sharp, both engines review independently, and Hermes reconciles disagreements with real verification commands.
+Run a controlled build workstream where Hermes stays the controller: it
+sharpens the brief, routes work, and verifies results; Claude Code plans,
+designs, and reviews; Codex CLI implements. This skill defines the staged
+loop and its artefact trail — it does not replace direct Hermes edits for
+small tasks, and it never lets the external engines own final judgement.
 
 ## When to Use
 
-Use this skill when the user wants to:
+- The user wants a Hermes-controlled workflow across Claude Code and Codex CLI.
+- A rough product or engineering intent needs to become a buildable, verifiable slice.
+- A feature, bug fix, PR review, or prototype should run through independent plan/build/review passes.
 
-- Set up a Hermes Agent workflow using Claude Code plus Codex CLI.
-- Turn a rough product or engineering intent into a buildable external-agent workstream.
-- Run a feature, bug fix, PR review, prototype, or cleanup through a controlled Claude and Codex loop.
-- Teach another Hermes user how to reproduce the workflow.
-- Create a public or team-safe version of an internal Hermes build workflow.
-
-Do not use this for:
-
-- Tiny one-command edits where Hermes can patch and verify faster directly.
-- Tasks requiring secrets to be shared with external CLIs.
-- Unbounded multi-agent chats where Claude and Codex talk freely without Hermes control.
-- Production deploys unless the deploy runbook and rollback path are already defined.
+Do not use for: one-command edits Hermes can patch directly, tasks that
+would require sharing secrets with external CLIs, or free-running
+agent-to-agent chats without Hermes control.
 
 ## Prerequisites
 
-The Hermes controller needs terminal access and process management.
+- `terminal` and `process` tools enabled for the Hermes controller.
+- Claude Code installed and authenticated: `claude --version`, `claude doctor`.
+- Codex CLI installed and authenticated: `codex --version`.
+- A git repository with a clean starting state.
+- Load the `claude-code` and `codex` companion skills for exact CLI flags and PTY handling.
 
-Install and verify the CLIs:
+Auth is per-surface: Hermes provider auth, Claude auth, and Codex auth are
+independent — verify each. Never print keys, tokens, or auth file contents.
 
-```bash
-# Claude Code
-npm install -g @anthropic-ai/claude-code
-claude auth status --text || claude auth login
-claude doctor
-claude --version
-
-# Codex CLI
-npm install -g @openai/codex
-codex --version
-
-# Repo helpers
-git --version
-gh --version || true
-```
-
-Authentication notes:
-
-- Claude Code can use browser OAuth, console auth, SSO, or `ANTHROPIC_API_KEY` depending on the user's account.
-- Codex CLI can use Codex OAuth or `OPENAI_API_KEY` depending on the user's setup.
-- Hermes itself may use a different provider configuration from the standalone CLIs. Do not assume Hermes auth proves CLI auth, or the reverse.
-- Never print API keys, OAuth tokens, auth JSON, or credential file contents.
-
-Before running real work, load the companion skills if available:
-
-- `claude-code` for exact Claude Code CLI flags and PTY handling.
-- `codex` for exact Codex CLI flags and PTY handling.
-- `hermes-agent` when configuring Hermes profiles, tools, gateways, or skills.
-
-## Roles
-
-### Hermes Agent controller
-
-Hermes owns:
-
-- Intent grilling and scope control.
-- The brief, constraints, acceptance criteria, and verification plan.
-- Worktree or workspace setup.
-- Prompts sent to Claude Code and Codex CLI.
-- Run directory and artefact capture.
-- Review reconciliation.
-- Final verification using real commands.
-- User-facing report with action, target, verification command, result, and remaining risks.
-
-Hermes does not treat external-agent output as proof. Agent claims are input. Command output is proof.
-
-### Claude Code
-
-Use Claude Code for:
-
-- Product and UX direction critique.
-- Architecture and implementation planning.
-- Design tradeoff analysis.
-- Brief gap detection and pushback before build starts.
-- Maintainability review.
-- Security and risk review.
-- Second-opinion review of Codex changes.
-
-Claude Code should not passively accept a weak brief. If acceptance criteria, constraints, design direction, verification commands, or scope boundaries are missing, Claude should return the gaps and ask Hermes to resolve them before Codex starts implementation.
-
-Prefer Claude print mode for bounded tasks:
-
-```bash
-claude -p "Read the brief and produce a concise implementation plan with risks and acceptance criteria." \
-  --output-format json \
-  --max-turns 8
-```
-
-Use interactive Claude sessions only when the workflow needs multi-turn exploration, slash commands, or human-in-the-loop decisions.
-
-### Codex CLI
-
-Use Codex CLI for:
-
-- Implementing the signed-off slice.
-- Running tests and fixing failures.
-- Producing diffs.
-- Narrow bug review.
-- Scoped fix passes after review.
-
-Codex should implement the signed-off brief, not reinterpret the product direction. If Codex finds the brief impossible, contradictory, or under-specified, it should stop and report the blocker rather than inventing scope.
-
-Codex generally needs a git repository and a PTY:
-
-```bash
-codex exec --full-auto "Implement the attached brief. Run the listed verification commands. Report changed files and remaining failures."
-```
-
-Use isolated worktrees for implementation by default.
-
-## Core Workflow
-
-### 1. Capture human intent and sharpen the brief
-
-A brief must include:
-
-- Goal in one sentence.
-- Non-goals.
-- Constraints.
-- Scope boundaries.
-- Acceptance criteria.
-- Verification commands.
-- Expected artefacts.
-- Signoff trigger, if product or design direction matters.
-
-If success cannot be verified in one or more commands or observable artefacts, the brief is not ready.
-
-Hermes should also decide the route:
-
-- Claude Code first when design, architecture, requirements, or risk need pressure-testing.
-- Codex first only for narrow, already-specified implementation tasks.
-- Human signoff before Codex when Claude identifies material gaps or product/design choices.
-
-### 2. Create a run directory
-
-Keep every external-agent workstream auditable.
-
-```bash
-RUN_ID="run-$(date +%Y%m%d-%H%M%S)-topic"
-mkdir -p ".hermes/runs/$RUN_ID"
-```
-
-Recommended layout:
+## How to Run
 
 ```text
-.hermes/runs/<run-id>/
-  brief.md
-  claude-plan.json
-  claude-plan.md
-  codex-build.log
-  changed-files.txt
-  diff.patch
-  claude-review.json
-  claude-review.md
-  codex-review.log
-  reconciled-findings.md
-  fix-pass.log
-  verification.txt
-  signoff.md
+Human intent
+→ Hermes sharpens the brief and routes
+→ Claude Code plans, reviews the brief, pushes back on gaps
+→ Codex CLI implements in an isolated worktree
+→ Claude and Codex review independently
+→ Hermes reconciles findings, reruns verification, signs off
 ```
 
-If `.hermes/runs/` is not appropriate for the repo, use `.agent-runs/` or another ignored run-artifact directory.
+Route Claude first when design, architecture, or risk needs pressure-testing.
+Route Codex first only for narrow, fully specified implementation. Get human
+signoff before build when product or design direction changes.
 
-### 3. Ask Claude for plan, design, review, and gap detection
+## Quick Reference
 
-Use Claude before build when the product shape, design, architecture, or risk profile is uncertain.
+| Role | Owns |
+|------|------|
+| Hermes | Brief, scope, routing, run artefacts, reconciliation, final verification, report |
+| Claude Code | Planning, design critique, gap detection, independent review |
+| Codex CLI | Implementation, test loop, diffs, scoped fix passes |
 
-Example:
-
-```bash
-claude -p "$(cat .hermes/runs/$RUN_ID/brief.md)
-
-Return:
-1. recommended approach
-2. risks
-3. missing decisions
-4. implementation plan
-5. verification plan
-6. whether this is ready for Codex implementation
-Do not write files." \
-  --output-format json \
-  --max-turns 8 \
-  > ".hermes/runs/$RUN_ID/claude-plan.json"
-```
-
-Hermes then reads and critiques the plan. If Claude says the brief has gaps, Hermes resolves the gaps or asks the human for a decision. If direction needs human signoff, stop and get signoff before Codex builds.
-
-### 4. Create an isolated implementation worktree
-
-```bash
-git fetch --all --prune
-BASE_BRANCH="main"
-BRANCH="agent/$RUN_ID"
-WORKTREE="/tmp/$RUN_ID"
-git worktree add -b "$BRANCH" "$WORKTREE" "$BASE_BRANCH"
-```
-
-Rules:
-
-- One implementation owner per worktree.
-- Do not run broad unrelated cleanup in the same slice.
-- Do not let Codex edit the controller's run notes except where explicitly asked.
-- If the worktree is dirty before Codex starts, stop and resolve it.
-
-### 5. Send Codex the signed-off build prompt
-
-The Codex prompt should contain:
-
-- Brief path or brief text.
-- Exact scope.
-- Files or directories likely in scope.
-- Verification commands.
-- Instruction to report failures honestly.
-- Instruction not to commit unless requested.
-
-Example:
-
-```bash
-codex exec --full-auto "
-You are implementing one signed-off slice.
-
-Read this brief:
-$(cat .hermes/runs/$RUN_ID/brief.md)
-
-Rules:
-- Stay inside scope.
-- Do not commit.
-- Run the verification commands from the brief.
-- If a command fails, keep the raw failure and explain the blocker.
-- End with changed files, commands run, failures, and remaining risks.
-" 2>&1 | tee ".hermes/runs/$RUN_ID/codex-build.log"
-```
-
-When running through Hermes tools, use `terminal(..., pty=true)` for Codex and `background=true` with `notify_on_complete=true` for long bounded work.
-
-### 6. Capture diffs and artefacts
-
-After Codex exits, Hermes must inspect the worktree.
-
-```bash
-git status --short > ".hermes/runs/$RUN_ID/changed-files.txt"
-git diff --stat > ".hermes/runs/$RUN_ID/diff-stat.txt"
-git diff > ".hermes/runs/$RUN_ID/diff.patch"
-```
-
-If no files changed but Codex claimed completion, treat that as a failed run until explained.
-
-### 7. Run independent Claude and Codex review passes
-
-Claude Code and Codex CLI review independently. They can use their own subagents or internal review modes when available, but Hermes only needs the final artefacts: findings, evidence, uncertainty, and whether each finding is actionable.
-
-Claude review prompt:
-
-```bash
-claude -p "
-Review this implementation against the brief.
-
-Brief:
-$(cat .hermes/runs/$RUN_ID/brief.md)
-
-Diff:
-$(cat .hermes/runs/$RUN_ID/diff.patch)
-
-Return:
-- must-fix issues
-- should-fix issues
-- product or UX regressions
-- security or maintainability risks
-- false positives or uncertainties
-Do not modify files.
-" --output-format json --max-turns 8 > ".hermes/runs/$RUN_ID/claude-review.json"
-```
-
-Codex review prompt:
-
-```bash
-codex exec "Review the current diff for bugs, regressions, and missing tests. Do not modify files. Report only actionable findings."
-```
-
-Hermes reconciles both reviews into:
-
-- Must fix.
-- Should fix.
-- False positive.
-- Out of scope.
-- Needs human decision.
-
-### 8. Fix only scoped findings
-
-If fixes are needed, Codex gets a narrow fix-pass prompt with the reconciled findings. It must not open new scope.
-
-```bash
-codex exec --full-auto "
-Fix only the must-fix findings in .hermes/runs/$RUN_ID/reconciled-findings.md.
-Do not introduce unrelated refactors.
-Run the verification commands again.
-Report changed files, commands run, and failures.
-" 2>&1 | tee ".hermes/runs/$RUN_ID/fix-pass.log"
-```
-
-### 9. Final verification by Hermes
-
-Hermes runs the real commands itself. The controller does not rely on Claude or Codex claims.
-
-Examples:
-
-```bash
-git status --short
-pytest -q
-npm test
-npm run build
-gh pr view --json statusCheckRollup
-```
-
-The exact commands come from the brief and repo conventions.
-
-### 10. Sign off or reject
-
-Final response should include:
-
-- Action taken.
-- Exact target changed.
-- Verification command used.
-- Verification result.
-- Review findings and disposition.
-- Anything still broken or not verified.
-- Artefact paths.
-
-If verification is unavailable, say `NOT VERIFIED` and explain why.
-
-## Hermes Tool Patterns
-
-Use normal Hermes tools for small direct steps and `terminal` or `process` for CLI agents.
-
-Claude print mode example:
-
-```python
-terminal(
-  command="claude -p \"Review the brief and return risks only\" --output-format json --max-turns 5",
-  workdir="/path/to/repo",
-  timeout=180,
-)
-```
-
-Codex background example:
-
-```python
-terminal(
-  command="codex exec --full-auto \"Implement the signed-off brief in .hermes/runs/run-id/brief.md\"",
-  workdir="/tmp/run-id",
-  pty=True,
-  background=True,
-  notify_on_complete=True,
-)
-```
-
-Poll bounded long work:
-
-```python
-process(action="poll", session_id="<session-id>")
-process(action="log", session_id="<session-id>", limit=200)
-process(action="wait", session_id="<session-id>", timeout=300)
-```
-
-Do not use background mode silently for bounded build work. Use `notify_on_complete=true` so the controller gets completion evidence.
-
-## Public Setup Recipe
-
-For a user who wants to reproduce the workflow:
-
-1. Install Hermes Agent and enable terminal/process tools.
-2. Install and authenticate Claude Code.
-3. Install and authenticate Codex CLI.
-4. Put this skill under `~/.hermes/skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md`, or install it from the Hermes skill library if available.
-5. Ask Hermes to load this skill before build orchestration.
-6. Start with one low-risk repo and one small slice.
-7. Keep external-agent artefacts in a run directory.
-8. Require local verification before reporting completion.
-
-Example user prompt:
+Artefact layout (all paths absolute, under the repo the slice targets):
 
 ```text
-Use the hermes-claude-codex-workstream skill. I want to fix the settings page loading bug in this repo. Claude should plan/review, Codex should implement in an isolated worktree, and Hermes should run final verification before signoff.
+$RUN_DIR/
+  brief.md            claude-plan.json     codex-build.log
+  changed-files.txt   diff.patch           claude-review.json
+  codex-review.log    reconciled-findings.md
+  fix-pass.log        verification.txt     signoff.md
 ```
 
-## Guardrails
+Full prompt templates: [references/prompt-templates.md](references/prompt-templates.md).
+Public setup recipe and `terminal`/`process` invocation patterns:
+[references/public-setup.md](references/public-setup.md).
 
-- Do not share secrets with Claude Code or Codex CLI unless the user explicitly approves and the tool genuinely needs them.
-- Do not paste `.env`, auth files, token files, private keys, cookies, or OAuth JSON into prompts.
-- Do not let Claude and Codex recursively delegate to each other.
-- Do not run multiple implementation agents in the same worktree.
-- Do not accept `looks good` as review evidence.
-- Do not accept `tests passed` without the raw command output or an independent rerun.
-- Do not commit, push, deploy, or publish unless the user asked for that side effect.
-- Do not turn a review pass into a broad refactor pass.
-- Do not hide failed commands. Failed commands are evidence.
+## Procedure
 
-## Common Pitfalls
+1. **Sharpen the brief.** It must state goal, non-goals, constraints, scope
+   boundaries, acceptance criteria, verification commands, expected
+   artefacts, and the signoff trigger. If success cannot be verified by
+   commands or observable artefacts, the brief is not ready.
 
-1. **Starting with Codex before the brief is sharp.** Codex is fast enough to build the wrong thing quickly. Claude planning or human signoff comes first when direction is uncertain.
+2. **Create the run directory** with absolute paths, before any worktree:
 
-2. **No run directory.** Without artefacts, the controller cannot reconcile claims, reviews, diffs, and verification later.
+   ```bash
+   REPO_ROOT="$(git rev-parse --show-toplevel)"
+   RUN_ID="run-$(date +%Y%m%d-%H%M%S)-topic"
+   RUN_DIR="$REPO_ROOT/.hermes/runs/$RUN_ID"
+   mkdir -p "$RUN_DIR"
+   ```
 
-3. **Using one giant prompt instead of a workflow.** The value is in staged delegation and independent verification, not prompt stuffing.
+   If `.hermes/runs/` does not suit the repo, use another gitignored
+   directory — but keep `RUN_DIR` absolute so every later step and every
+   worktree can reference it unambiguously.
 
-4. **Letting external agents own final judgement.** Hermes is the judge. Claude and Codex are engines.
+3. **Ask Claude for plan and gap check** (template in references). Save to
+   `"$RUN_DIR/claude-plan.json"`. If Claude reports gaps, resolve them or
+   get a human decision before any build starts.
 
-5. **Skipping worktrees.** Isolated worktrees make rollback, review, and cleanup simple.
+4. **Create an isolated worktree** as a sibling of the repo:
 
-6. **Over-parallelising.** Parallel review is fine. Parallel implementation of the same slice is usually noise.
+   ```bash
+   BASE_BRANCH="main"
+   BRANCH="agent/$RUN_ID"
+   WORKTREE="$(dirname "$REPO_ROOT")/$(basename "$REPO_ROOT")-wt-$RUN_ID"
+   git worktree add -b "$BRANCH" "$WORKTREE" "$BASE_BRANCH"
+   ```
 
-7. **Publishing internal examples.** For public skills, scrub private repo names, client data, user names, tokens, URLs, and operational transcript excerpts.
+   One implementation owner per worktree. If it is dirty before Codex
+   starts, stop and resolve first.
 
-8. **Mistaking CLI auth for Hermes provider auth.** Verify each surface independently.
+5. **Send Codex the signed-off build prompt** (template in references), run
+   from `"$WORKTREE"`, always referencing `"$RUN_DIR/brief.md"` by absolute
+   path. Capture output to `"$RUN_DIR/codex-build.log"`. Codex implements
+   the brief; if it finds the brief contradictory it stops and reports
+   rather than inventing scope.
 
-## Verification Checklist
+6. **Capture the evidence** from `"$WORKTREE"`:
 
-Before saying the workstream is set up or a slice is complete:
+   ```bash
+   git status --short > "$RUN_DIR/changed-files.txt"
+   git diff > "$RUN_DIR/diff.patch"
+   ```
 
-- [ ] `claude --version` and Claude auth or `claude doctor` verified.
-- [ ] `codex --version` and Codex auth path verified.
-- [ ] Git repo and clean starting state verified.
-- [ ] Run directory created.
-- [ ] Brief written with acceptance criteria and verification commands.
-- [ ] Claude plan or critique captured when needed.
-- [ ] Human signoff captured when product/design direction changed.
-- [ ] Codex ran in the intended worktree.
-- [ ] Changed files and diff captured.
-- [ ] Independent review pass completed or explicitly skipped with reason.
-- [ ] Must-fix findings resolved or rejected with evidence.
-- [ ] Hermes reran final verification commands directly.
-- [ ] Final report includes artefact paths and remaining risks.
+   No diff but a completion claim = failed run until explained.
+
+7. **Run independent reviews.** Claude reviews the diff against the brief;
+   Codex runs its own review pass (templates in references). Hermes
+   reconciles into must-fix / should-fix / false positive / out of scope /
+   needs human decision, saved to `"$RUN_DIR/reconciled-findings.md"`.
+
+8. **Fix only scoped findings.** Codex gets a narrow fix-pass prompt
+   pointing at the reconciled findings file; no new scope, no unrelated
+   refactors.
+
+9. **Verify directly.** Hermes reruns the brief's verification commands
+   itself in `"$WORKTREE"` — agent claims are input, command output is
+   proof. Save output to `"$RUN_DIR/verification.txt"`.
+
+10. **Sign off or reject.** The final report states action, target,
+    verification command and result, finding dispositions, artefact paths,
+    and anything not verified (say `NOT VERIFIED` and why).
+
+## Pitfalls
+
+- Building before the brief is sharp — Codex builds the wrong thing fast.
+- Relative artefact paths: a prompt that runs in the worktree cannot see a
+  repo-relative `.hermes/runs/...`; always pass `"$RUN_DIR"` absolute.
+- Letting external agents own final judgement; Hermes is the judge.
+- Accepting "tests passed" without raw output or an independent rerun.
+- Sharing `.env`, auth files, or tokens with either CLI.
+- Letting Claude and Codex delegate to each other recursively.
+- Turning a review pass into a broad refactor pass.
+- Publishing internal examples without scrubbing repo names, client data,
+  and transcript excerpts.
+
+## Verification
+
+- [ ] Both CLIs verified (`claude doctor`, `codex --version`), auth confirmed per surface.
+- [ ] `RUN_DIR` created absolute; brief includes acceptance criteria and verification commands.
+- [ ] Claude plan captured; human signoff captured when direction changed.
+- [ ] Codex ran only in its worktree; diff and changed files captured.
+- [ ] Independent reviews reconciled; must-fix findings resolved or rejected with evidence.
+- [ ] Hermes reran verification commands directly; report includes artefact paths and remaining risks.

--- a/skills/autonomous-ai-agents/hermes-claude-codex-workstream/references/prompt-templates.md
+++ b/skills/autonomous-ai-agents/hermes-claude-codex-workstream/references/prompt-templates.md
@@ -1,0 +1,91 @@
+# Prompt templates
+
+All templates assume the Procedure's variables are set: `$REPO_ROOT`,
+`$RUN_ID`, `$RUN_DIR` (absolute), `$WORKTREE` (absolute). Commands that act
+on the implementation run from `"$WORKTREE"`; artefacts always go to
+`"$RUN_DIR"` by absolute path.
+
+## Claude plan and gap check (step 3)
+
+```bash
+claude -p "$(cat "$RUN_DIR/brief.md")
+
+Return:
+1. recommended approach
+2. risks
+3. missing decisions
+4. implementation plan
+5. verification plan
+6. whether this is ready for Codex implementation
+Do not write files." \
+  --output-format json \
+  --max-turns 8 \
+  > "$RUN_DIR/claude-plan.json"
+```
+
+Claude should not passively accept a weak brief. If acceptance criteria,
+constraints, design direction, verification commands, or scope boundaries
+are missing, it returns the gaps and Hermes resolves them before build.
+
+## Codex build (step 5)
+
+Run from `"$WORKTREE"`:
+
+```bash
+codex exec --full-auto "
+You are implementing one signed-off slice.
+
+Read this brief: $RUN_DIR/brief.md
+
+Rules:
+- Stay inside scope.
+- Do not commit.
+- Run the verification commands from the brief.
+- If a command fails, keep the raw failure and explain the blocker.
+- End with changed files, commands run, failures, and remaining risks.
+" 2>&1 | tee "$RUN_DIR/codex-build.log"
+```
+
+## Claude review (step 7)
+
+```bash
+claude -p "
+Review this implementation against the brief.
+
+Brief:
+$(cat "$RUN_DIR/brief.md")
+
+Diff:
+$(cat "$RUN_DIR/diff.patch")
+
+Return:
+- must-fix issues
+- should-fix issues
+- product or UX regressions
+- security or maintainability risks
+- false positives or uncertainties
+Do not modify files.
+" --output-format json --max-turns 8 > "$RUN_DIR/claude-review.json"
+```
+
+## Codex review (step 7)
+
+Run from `"$WORKTREE"`:
+
+```bash
+codex exec "Review the current diff for bugs, regressions, and missing tests. Do not modify files. Report only actionable findings." \
+  2>&1 | tee "$RUN_DIR/codex-review.log"
+```
+
+## Codex fix pass (step 8)
+
+Run from `"$WORKTREE"`:
+
+```bash
+codex exec --full-auto "
+Fix only the must-fix findings in $RUN_DIR/reconciled-findings.md.
+Do not introduce unrelated refactors.
+Run the verification commands again.
+Report changed files, commands run, and failures.
+" 2>&1 | tee "$RUN_DIR/fix-pass.log"
+```

--- a/skills/autonomous-ai-agents/hermes-claude-codex-workstream/references/public-setup.md
+++ b/skills/autonomous-ai-agents/hermes-claude-codex-workstream/references/public-setup.md
@@ -1,0 +1,61 @@
+# Public setup recipe and Hermes tool patterns
+
+## Setup for a new user
+
+1. Install Hermes Agent and enable the `terminal` and `process` tools.
+2. Install and authenticate Claude Code (`npm install -g @anthropic-ai/claude-code`, then `claude doctor`).
+3. Install and authenticate Codex CLI (`npm install -g @openai/codex`, then `codex --version`).
+4. Put this skill under `~/.hermes/skills/autonomous-ai-agents/hermes-claude-codex-workstream/`, or install it from the Hermes skill library if available.
+5. Ask Hermes to load this skill before build orchestration.
+6. Start with one low-risk repo and one small slice; keep artefacts in the run directory; require local verification before reporting completion.
+
+Example user prompt:
+
+```text
+Use the hermes-claude-codex-workstream skill. I want to fix the settings
+page loading bug in this repo. Claude should plan/review, Codex should
+implement in an isolated worktree, and Hermes should run final
+verification before signoff.
+```
+
+## Hermes tool patterns
+
+Claude print mode for bounded tasks (workdir is the repo or worktree the
+task targets):
+
+```python
+terminal(
+  command="claude -p \"Review the brief and return risks only\" --output-format json --max-turns 5",
+  workdir="<absolute repo or worktree path>",
+  timeout=180,
+)
+```
+
+Codex needs a PTY; long bounded work runs in the background with completion
+notification (never silently):
+
+```python
+terminal(
+  command="codex exec --full-auto \"Implement the signed-off brief in <absolute RUN_DIR>/brief.md\"",
+  workdir="<absolute WORKTREE path>",
+  pty=True,
+  background=True,
+  notify_on_complete=True,
+)
+```
+
+Poll bounded long work:
+
+```python
+process(action="poll", session_id="<session-id>")
+process(action="log", session_id="<session-id>", limit=200)
+process(action="wait", session_id="<session-id>", timeout=300)
+```
+
+## Auth notes
+
+- Claude Code: browser OAuth, console auth, SSO, or `ANTHROPIC_API_KEY`.
+- Codex CLI: Codex OAuth or `OPENAI_API_KEY`.
+- Hermes itself may use a different provider configuration from the
+  standalone CLIs. Do not assume Hermes auth proves CLI auth, or the
+  reverse. Never print keys, tokens, or credential file contents.

--- a/tests/skills/test_hermes_claude_codex_workstream_skill.py
+++ b/tests/skills/test_hermes_claude_codex_workstream_skill.py
@@ -1,0 +1,87 @@
+"""Contract tests for skills/autonomous-ai-agents/hermes-claude-codex-workstream."""
+
+import re
+from pathlib import Path
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "autonomous-ai-agents"
+    / "hermes-claude-codex-workstream"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    body = text.split("---", 2)[1]
+    fields = {}
+    for line in body.splitlines():
+        m = re.match(r"^(\w+): (.+)$", line)
+        if m:
+            fields[m.group(1)] = m.group(2).strip()
+    return fields
+
+
+def test_description_is_within_authoring_limit():
+    desc = _frontmatter()["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars, limit is 60"
+    assert desc.endswith("."), "description must be one sentence ending with a period"
+
+
+def test_author_credits_the_human_contributor_first():
+    author = _frontmatter()["author"]
+    assert not author.startswith("Hermes Agent"), (
+        "external contributions must credit the human contributor first"
+    )
+    assert "@joelbrilliant" in author
+
+
+def test_declared_platforms_match_path_strategy():
+    fields = _frontmatter()
+    platforms = fields["platforms"]
+    text = SKILL_MD.read_text(encoding="utf-8")
+    # The workflow is bash-based, so Windows must not be declared, and no
+    # path may be hard-coded under /tmp (worktrees are repo siblings, run
+    # artefacts live under the repo).
+    assert "windows" not in platforms
+    assert "/tmp/" not in text, "no hard-coded /tmp paths; use RUN_DIR/WORKTREE"
+
+
+def test_run_dir_is_defined_absolute_before_use():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    definition = text.find('RUN_DIR="$REPO_ROOT/')
+    first_use = text.find('"$RUN_DIR/')
+    assert definition != -1, "RUN_DIR must be defined from REPO_ROOT (absolute)"
+    assert first_use == -1 or definition < first_use, (
+        "RUN_DIR must be defined before any use"
+    )
+    # No stale repo-relative artefact references (the old bug: a worktree
+    # command referring to a path only valid from the repo root).
+    assert not re.search(r"(?<![$\w/])\.hermes/runs/\$RUN_ID", text), (
+        "artefact references must go through the absolute $RUN_DIR"
+    )
+
+
+def test_required_sections_present_in_order():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    sections = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.find(s) for s in sections]
+    assert all(p != -1 for p in positions), (
+        f"missing sections: {[s for s, p in zip(sections, positions) if p == -1]}"
+    )
+    assert positions == sorted(positions), "sections must follow the modern order"
+
+
+def test_referenced_files_exist():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    for rel in re.findall(r"\]\((references/[^)]+)\)", text):
+        assert (SKILL_DIR / rel).is_file(), f"broken reference link: {rel}"


### PR DESCRIPTION
## Summary

- Add the Hermes Claude Codex workstream skill.
- Keep the entrypoint within the skill authoring contract.
- Route detailed prompt templates and public setup into two reference files.
- Document the workflow where Hermes sharpens intent, Claude plans and reviews, Codex implements, and Hermes reconciles and verifies.

## Files

- skills/autonomous-ai-agents/hermes-claude-codex-workstream/SKILL.md
- references/prompt-templates.md
- references/public-setup.md
- tests/skills/test_hermes_claude_codex_workstream_skill.py

## Verification

- The focused skill contract suite passed with 6 tests.
- Frontmatter, progressive disclosure, reference integrity, and private-marker exclusions are covered.
- Ruff and git diff check passed.
- Both reviewed commits rebased onto current main without alteration.
