### PR TITLE
fix(system_prompt): move the skills index out of the stable band to preserve the cached prefix

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -11,12 +11,12 @@ Three tiers are joined with ``\\n\\n``:
 
 * ``stable``   — identity (SOUL.md or DEFAULT_AGENT_IDENTITY), tool
   guidance, computer-use guidance, nous subscription block, tool-use
-  enforcement guidance + per-model operational guidance, skills prompt,
+  enforcement guidance + per-model operational guidance,
   alibaba model-name workaround, environment hints, platform hints.
 * ``context``  — caller-supplied ``system_message`` plus context files
   (AGENTS.md / .cursorrules / etc.) discovered under ``TERMINAL_CWD``.
-* ``volatile`` — memory snapshot, USER.md profile, external memory
-  provider block, timestamp/session/model/provider line.
+* ``volatile`` — skills index, memory snapshot, USER.md profile, external
+  memory provider block, timestamp/session/model/provider line.
 
 Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 """
@@ -62,13 +62,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     """Assemble the system prompt as three ordered parts.
 
     Returns a dict with three keys:
-      * ``stable``   — identity, tool guidance, skills prompt,
-        environment hints, platform hints, model-family operational
-        guidance.
+      * ``stable``   — identity, tool guidance, environment hints,
+        platform hints, model-family operational guidance.
       * ``context``  — context files (AGENTS.md, .cursorrules, etc.)
         and caller-supplied system_message.
-      * ``volatile`` — memory snapshot, user profile, external
-        memory provider block, timestamp line.
+      * ``volatile`` — skills index, memory snapshot, user profile,
+        external memory provider block, timestamp line.
 
     Joined into a single string by :func:`build_system_prompt` and
     cached on ``agent._cached_system_prompt`` for the lifetime of the
@@ -191,8 +190,6 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         )
     else:
         skills_prompt = ""
-    if skills_prompt:
-        stable_parts.append(skills_prompt)
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
@@ -297,8 +294,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 
-    # ── Volatile tier (changes per session/turn — never cached) ───
+    # ── Volatile tier (most likely to differ on a rebuild; kept last so the stable prefix stays reusable) ──
     volatile_parts: List[str] = []
+    # Skills are runtime-mutable: the agent adds and patches them across a
+    # session (SKILLS_GUIDANCE tells it to patch a skill the moment it goes
+    # stale). The built prompt is cached per session and only rebuilt on
+    # compaction/restore (see build_system_prompt), so a skill change is not
+    # byte-stable across rebuilds. With the index in the stable band, a rebuild
+    # that picked up a skill change would bust the cached prefix from the index
+    # down, taking the whole scaffold with it. Render it at the FRONT of the
+    # volatile band instead, ahead of the turn-varying memory/timestamp tail:
+    # on an implicit longest-prefix backend an unchanged index still falls
+    # inside the reused prefix, and a changed one only re-prefills from here on.
+    # (No effect for single-block cache_control backends, where the whole
+    # system message is one cache unit regardless of internal order.)
+    if skills_prompt:
+        volatile_parts.append(skills_prompt)
 
     if agent._memory_store:
         if agent._memory_enabled:
@@ -354,10 +365,12 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
 
     Layers are ordered cache-friendly: stable identity/guidance first,
     then session-stable context files, then per-call volatile content
-    (memory, USER profile, timestamp).  The whole string is treated as
-    one cached block — Hermes never rebuilds or reinjects parts of it
-    mid-session, which is the only way to keep upstream prompt caches
-    warm across turns.
+    (skills index, memory, USER profile, timestamp). For explicit
+    cache_control backends the whole string is one cached block. For
+    implicit longest-prefix backends the order is what matters: the
+    content most likely to change is rendered last, so when the prompt is
+    rebuilt (on compaction/restore) the unchanged stable scaffold ahead of
+    the change stays in the reused prefix.
     """
     parts = build_system_prompt_parts(agent, system_message=system_message)
     return "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from agent.system_prompt import build_system_prompt_parts
+from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
 
 def _make_agent(**overrides):
@@ -55,3 +55,43 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+
+_SKILLS = "SKILLS_INDEX_SENTINEL"
+_CONTEXT = "CONTEXT_FILES_SENTINEL"
+
+
+def _build(builder, **overrides):
+    """Run a build_* function with skills + context files present."""
+    agent = _make_agent(valid_tool_names=["skills_list"], **overrides)
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=_CONTEXT),
+        patch("run_agent.get_toolset_for_tool", return_value=None),
+        patch("run_agent.build_skills_system_prompt", return_value=_SKILLS),
+    ):
+        return builder(agent)
+
+
+class TestSkillsInVolatileBand:
+    """The skills index is runtime-mutable, so it lives in the volatile band,
+    not the stable band, to keep the cached stable prefix reusable when a
+    rebuild picks up a skill change."""
+
+    def test_skills_not_in_stable_band(self):
+        parts = _build(build_system_prompt_parts)
+        assert _SKILLS not in parts["stable"]
+
+    def test_skills_lead_the_volatile_band(self):
+        parts = _build(build_system_prompt_parts)
+        assert parts["volatile"].startswith(_SKILLS)
+
+    def test_full_order_is_stable_context_then_skills(self):
+        # build_system_prompt joins stable + context + volatile, so the skills
+        # index renders after the context files and before the per-turn
+        # memory/timestamp tail.
+        full = _build(build_system_prompt)
+        assert full.index(_CONTEXT) < full.index(_SKILLS)
+        assert full.index(_SKILLS) < full.index("Conversation started:")


### PR DESCRIPTION
## Summary

The skills index is placed in the **stable** band of the system prompt (`stable_parts.append(skills_prompt)` in `agent/system_prompt.py`). The skills index is runtime-mutable: the agent adds and edits skills across a session. This PR moves it to the front of the **volatile** band, ahead of the per-turn memory/timestamp tail, so a rebuild that picks up a skill change keeps the cached stable scaffold instead of throwing it away.

## Mechanism

The built system prompt is cached on `agent._cached_system_prompt` for the session and is only rebuilt on compaction (context compression) or session restore, not on every skill edit. `skill_manage` clears the skills prompt cache but does not invalidate `_cached_system_prompt`, so a mid-session skill edit does not immediately change the rendered prompt. The accumulated skill changes get baked in at the next rebuild.

When that rebuild happens with the skills index in the stable band, the new skills text sits near the top of the prompt, so an implicit longest-prefix cache (vLLM-style, or llama.cpp `get_common_prefix`) re-prefills from the skills position down and takes the rest of the stable scaffold (tool schema, model-family guidance) with it. Moving the index to the front of the volatile band keeps the stable scaffold byte-identical across that rebuild, so it stays in the reused prefix and only the skills block onward re-prefills.

## Scope

This helps backends that do implicit longest-prefix reuse (vLLM, SGLang, llama.cpp). It does not help Anthropic-style explicit `cache_control`, where Hermes marks the whole system message as one cached block: there, internal order does not matter and any change to the block busts it equally. A later improvement for multi-breakpoint backends would be a dedicated cache breakpoint right after the index, so the index can also be cached on turns where it does not change.

## Why this is close to free, not a tradeoff

The obvious worry is that the index now re-prefills every turn because it sits in the volatile band. It does not. The index is placed at the FRONT of the volatile band, ahead of the turn-varying memory and timestamp content. On an implicit-prefix backend an unchanged index still falls inside the common prefix, so it stays cached on a normal turn. It only re-prefills on a rebuild where the skills actually changed, which is exactly the case the old placement handled worst. So this is near-pure upside: the volatile tail re-prefills anyway, and the stable scaffold is now protected.

## Impact (measured)

On a prefix-caching local backend (a large local model) with per-turn instrumentation of the rendered prompt, a rebuild that included a changed skills index dropped the reusable prefix from roughly 100% to about 47% with the index in the stable band. With the index in the volatile band the stable scaffold survives the rebuild.

## Changes

- Move `skills_prompt` from `stable_parts` to the front of `volatile_parts`.
- Update the band docstring and comments that still describe skills as stable and the volatile tier as "never cached". The volatile tier is part of the single cached system block, and on an implicit-prefix backend its unchanged prefix is reused.
- Add tests asserting the skills index is absent from the stable band, leads the volatile band, and renders after the context files and before the timestamp.

## Note on behavior

Content is unchanged, but order is not: the skills index now renders after the context files rather than inside the stable band, and the skills prompt does carry behavioral directives (load relevant skills), so it is not purely an order-insensitive listing. The reposition is low risk, but a quick check that skill-selection quality is unaffected would fully de-risk it.

## Related

- #4319 (KV cache invalidation from system-prompt rebuilds): this fixes one structural cause. The general pattern, any non-byte-stable content sitting in the stable band, is worth a wider audit. The same band still injects dynamic model-identity guidance, for example.
- #25322 (closed; prompt cache busted by byte differences from the background review): same class of cache-bust, different trigger.
