### PR TITLE
feat(mcp): add Vision-MCP desktop automation integration

### DIFF
--- a/optional-mcps/vision-mcp/manifest.yaml
+++ b/optional-mcps/vision-mcp/manifest.yaml
@@ -9,12 +9,18 @@ source: https://github.com/Haruhiyuki/vision-mcp
 # Vision-MCP is an npm-published stdio MCP server. The apps root is kept
 # outside the Hermes install so learned maps and patches survive package
 # updates and can be shared with other MCP clients.
+#
+# The CLI version is exact-pinned (catalog policy: manifests pin transport
+# details, see hermes_cli/mcp_catalog.py). Bumping it requires a manifest PR
+# that re-validates the release's registered tools against default_enabled
+# below. After a bump, users must re-run `install-helper --force` once to
+# rebuild the native helper.
 transport:
   type: stdio
   command: npx
   args:
     - -y
-    - "@vision-mcp/cli@latest"
+    - "@vision-mcp/cli@0.8.0"
     - serve
     - --apps-root
     - "${HOME}/.vision-mcp/apps"
@@ -52,11 +58,11 @@ post_install: |
   Vision-MCP controls visible desktop applications through screenshots,
   accessibility trees, OCR, and input events. Before running real GUI
   workflows, install the native helper and grant platform permissions:
-    npx -y @vision-mcp/cli@latest doctor
-    npx -y @vision-mcp/cli@latest install-helper
+    npx -y @vision-mcp/cli@0.8.0 doctor
+    npx -y @vision-mcp/cli@0.8.0 install-helper
 
   Copy starter app maps into the default apps root with:
-    npx -y @vision-mcp/cli@latest init-apps
+    npx -y @vision-mcp/cli@0.8.0 init-apps
 
   Install the companion Hermes skill for operating guidance:
     hermes skills install official/mcp/vision-mcp

--- a/optional-mcps/vision-mcp/manifest.yaml
+++ b/optional-mcps/vision-mcp/manifest.yaml
@@ -1,0 +1,64 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: vision-mcp
+description: Reuse desktop GUI workflows through Vision-MCP maps.
+source: https://github.com/Haruhiyuki/vision-mcp
+
+# Vision-MCP is an npm-published stdio MCP server. The apps root is kept
+# outside the Hermes install so learned maps and patches survive package
+# updates and can be shared with other MCP clients.
+transport:
+  type: stdio
+  command: npx
+  args:
+    - -y
+    - "@vision-mcp/cli@latest"
+    - serve
+    - --apps-root
+    - "${HOME}/.vision-mcp/apps"
+
+auth:
+  type: none
+
+# Default to higher-level workflow, state, repair, and capsule tools. Raw
+# coordinate/input tools and map mutation tools are available from the server
+# but require an explicit user opt-in through `hermes mcp configure vision-mcp`.
+tools:
+  default_enabled:
+    - capsule.ensure_display
+    - capsule.attach_window
+    - capsule.migrate_window
+    - capsule.restore_window
+    - capsule.capture
+    - capsule.validate_geometry
+    - capsule.raise
+    - vision_map.snapshot
+    - vision_map.list_apps
+    - vision_map.list_workflows
+    - vision_map.describe_workflow
+    - vision_map.describe
+    - vision_map.detect_state
+    - vision_map.list_actions
+    - vision_map.describe_action
+    - vision_map.perform_action
+    - vision_map.run_workflow
+    - vision_map.verify
+    - vision_map.repair_minimal
+    - vision_map.export_trace
+
+post_install: |
+  Vision-MCP controls visible desktop applications through screenshots,
+  accessibility trees, OCR, and input events. Before running real GUI
+  workflows, install the native helper and grant platform permissions:
+    npx -y @vision-mcp/cli@latest doctor
+    npx -y @vision-mcp/cli@latest install-helper
+
+  Copy starter app maps into the default apps root with:
+    npx -y @vision-mcp/cli@latest init-apps
+
+  Install the companion Hermes skill for operating guidance:
+    hermes skills install official/mcp/vision-mcp
+
+  Start a new Hermes session after setup so the Vision-MCP tools are loaded.

--- a/optional-skills/mcp/vision-mcp/SKILL.md
+++ b/optional-skills/mcp/vision-mcp/SKILL.md
@@ -2,7 +2,7 @@
 name: vision-mcp
 description: Reuse desktop GUI workflows with Vision-MCP maps.
 version: 1.0.0
-author: Hermes Agent
+author: Haruyuki (Haruhiyuki), Hermes Agent
 license: MIT
 platforms: [macos, windows]
 metadata:
@@ -14,7 +14,7 @@ prerequisites:
   commands: [node, npx]
 ---
 
-# Vision-MCP
+# Vision-MCP Skill
 
 Use Vision-MCP to operate visible desktop applications through reusable maps, workflows, screenshots, accessibility trees, OCR, and guarded GUI actions.
 
@@ -37,17 +37,17 @@ Install the optional MCP catalog entry and start a new Hermes session:
 hermes mcp install vision-mcp
 ```
 
-Check the Vision-MCP native helper and platform readiness:
+Check the Vision-MCP native helper and platform readiness (the version matches the pin in the catalog manifest, `optional-mcps/vision-mcp/manifest.yaml`):
 
 ```bash
-npx -y @vision-mcp/cli@latest doctor
-npx -y @vision-mcp/cli@latest install-helper
+npx -y @vision-mcp/cli@0.8.0 doctor
+npx -y @vision-mcp/cli@0.8.0 install-helper
 ```
 
 Copy starter app maps into the default apps root:
 
 ```bash
-npx -y @vision-mcp/cli@latest init-apps
+npx -y @vision-mcp/cli@0.8.0 init-apps
 ```
 
 On macOS, grant Screen Recording and Accessibility permissions to the Vision-MCP helper or the terminal process that launches Hermes. On Windows, use PowerShell 5.1 or newer and run Hermes elevated when controlling elevated target applications.
@@ -86,9 +86,9 @@ Useful starting tools:
 1. Confirm the MCP server is loaded with `mcp_vision_mcp_vision_map_list_apps`. If the tool is unavailable, ask the user to run `hermes mcp install vision-mcp` and restart Hermes.
 2. Prefer saved workflows over raw GUI input. List apps, list workflows, inspect the chosen workflow, then run it with explicit inputs.
 3. Establish or repair the visible window only when needed. Use capsule tools to attach, raise, migrate, or validate geometry before taking screenshots or running actions.
-4. Use `mcp_vision_mcp_vision_map_snapshot` for unknown states, failed postconditions, or user-visible confirmation. Avoid repeated screenshots when workflow and state tools already provide enough context.
+4. Prefer text observations (state detection, accessibility candidates, OCR) over full screenshots. Use `mcp_vision_mcp_vision_map_snapshot` for unknown states, failed postconditions, or user-visible confirmation, and pass `region_norm` to observe only the relevant part of the window. On `mcp_vision_mcp_capsule_capture`, set `only_if_changed: true` when polling for a change, so an unchanged frame returns no new image.
 5. When a known control or postcondition fails, call `mcp_vision_mcp_vision_map_repair_minimal` before escalating to manual coordinates or fresh exploration.
-6. For map-building or low-level control work, get explicit user consent before enabling or using tools such as `vision_map.click_at`, `vision_map.type_text`, `vision_map.press_key`, `vision_map.scroll`, `vision_map.init`, `vision_map.apply_patch`, `vision_map.add_control`, `vision_map.commit_state`, `vision_map.commit_workflow`, or `vision_map.harvest_session`.
+6. For map-building or low-level control work, get explicit user consent before enabling or using tools such as `vision_map.click_at`, `vision_map.type_text`, `vision_map.press_key`, `vision_map.scroll`, `vision_map.init`, `vision_map.apply_patch`, `vision_map.add_control`, `vision_map.propose_controls`, `vision_map.commit_state`, `vision_map.commit_workflow`, or `vision_map.harvest_session`.
 7. Verify the result through the workflow's postcondition, `mcp_vision_mcp_vision_map_verify`, a final state check, or a user-visible screenshot when the task outcome depends on what is on screen.
 
 ## Pitfalls
@@ -97,6 +97,7 @@ Useful starting tools:
 - The default Hermes catalog entry does not enable raw coordinate/input tools or map mutation tools. Use `hermes mcp configure vision-mcp` only when the user explicitly wants that capability.
 - Window geometry matters. A hidden, minimized, off-screen, or partially covered target can make screenshots, OCR, and control locators unreliable.
 - The first `npx` run may download the npm package, so setup and the first MCP probe can take longer than later sessions.
+- When the catalog manifest bumps the pinned CLI version, re-run `npx -y @vision-mcp/cli@<version> install-helper --force` once to rebuild the native helper, and end any old helper processes.
 - Browser and Electron apps often need OCR or bounding-box locators even when accessibility data is incomplete.
 
 ## Verification
@@ -110,5 +111,5 @@ hermes mcp test vision-mcp
 Then start a new Hermes session and call `mcp_vision_mcp_vision_map_list_apps`. For platform diagnostics, run:
 
 ```bash
-npx -y @vision-mcp/cli@latest doctor
+npx -y @vision-mcp/cli@0.8.0 doctor
 ```

--- a/optional-skills/mcp/vision-mcp/SKILL.md
+++ b/optional-skills/mcp/vision-mcp/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: vision-mcp
+description: Reuse desktop GUI workflows with Vision-MCP maps.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [macos, windows]
+metadata:
+  hermes:
+    tags: [MCP, Desktop, GUI, Vision, Automation]
+    homepage: https://github.com/Haruhiyuki/vision-mcp
+    related_skills: [native-mcp, mcporter]
+prerequisites:
+  commands: [node, npx]
+---
+
+# Vision-MCP
+
+Use Vision-MCP to operate visible desktop applications through reusable maps, workflows, screenshots, accessibility trees, OCR, and guarded GUI actions.
+
+## When to Use
+
+Use this skill when the user asks Hermes to:
+
+- run a repeatable workflow in a macOS or Windows desktop application
+- inspect an app window visually before deciding the next action
+- recover when a saved GUI workflow drifts because labels, positions, or states changed
+- turn a successful desktop procedure into a reusable Vision-MCP app map
+
+Use a normal CLI, API, or web integration instead when the same task can be completed without controlling a real desktop session.
+
+## Prerequisites
+
+Install the optional MCP catalog entry and start a new Hermes session:
+
+```bash
+hermes mcp install vision-mcp
+```
+
+Check the Vision-MCP native helper and platform readiness:
+
+```bash
+npx -y @vision-mcp/cli@latest doctor
+npx -y @vision-mcp/cli@latest install-helper
+```
+
+Copy starter app maps into the default apps root:
+
+```bash
+npx -y @vision-mcp/cli@latest init-apps
+```
+
+On macOS, grant Screen Recording and Accessibility permissions to the Vision-MCP helper or the terminal process that launches Hermes. On Windows, use PowerShell 5.1 or newer and run Hermes elevated when controlling elevated target applications.
+
+## How to Run
+
+After `hermes mcp install vision-mcp`, Hermes registers the server's tools with the `mcp_vision_mcp_` prefix. If the server is installed under a different MCP name, replace that prefix with `mcp_<server_name>_`, with hyphens and dots changed to underscores.
+
+Useful starting tools:
+
+- `mcp_vision_mcp_vision_map_list_apps`
+- `mcp_vision_mcp_vision_map_list_workflows`
+- `mcp_vision_mcp_vision_map_describe_workflow`
+- `mcp_vision_mcp_vision_map_run_workflow`
+- `mcp_vision_mcp_vision_map_snapshot`
+- `mcp_vision_mcp_vision_map_detect_state`
+- `mcp_vision_mcp_vision_map_repair_minimal`
+- `mcp_vision_mcp_capsule_attach_window`
+- `mcp_vision_mcp_capsule_validate_geometry`
+
+## Quick Reference
+
+| Goal | Preferred tool |
+| --- | --- |
+| Confirm setup | `mcp_vision_mcp_vision_map_list_apps` |
+| Find reusable automation | `mcp_vision_mcp_vision_map_list_workflows` |
+| Inspect workflow contract | `mcp_vision_mcp_vision_map_describe_workflow` |
+| Execute saved workflow | `mcp_vision_mcp_vision_map_run_workflow` |
+| Inspect current window state | `mcp_vision_mcp_vision_map_snapshot` |
+| Identify current state | `mcp_vision_mcp_vision_map_detect_state` |
+| Recover from drift | `mcp_vision_mcp_vision_map_repair_minimal` |
+| Export debugging evidence | `mcp_vision_mcp_vision_map_export_trace` |
+
+## Procedure
+
+1. Confirm the MCP server is loaded with `mcp_vision_mcp_vision_map_list_apps`. If the tool is unavailable, ask the user to run `hermes mcp install vision-mcp` and restart Hermes.
+2. Prefer saved workflows over raw GUI input. List apps, list workflows, inspect the chosen workflow, then run it with explicit inputs.
+3. Establish or repair the visible window only when needed. Use capsule tools to attach, raise, migrate, or validate geometry before taking screenshots or running actions.
+4. Use `mcp_vision_mcp_vision_map_snapshot` for unknown states, failed postconditions, or user-visible confirmation. Avoid repeated screenshots when workflow and state tools already provide enough context.
+5. When a known control or postcondition fails, call `mcp_vision_mcp_vision_map_repair_minimal` before escalating to manual coordinates or fresh exploration.
+6. For map-building or low-level control work, get explicit user consent before enabling or using tools such as `vision_map.click_at`, `vision_map.type_text`, `vision_map.press_key`, `vision_map.scroll`, `vision_map.init`, `vision_map.apply_patch`, `vision_map.add_control`, `vision_map.commit_state`, `vision_map.commit_workflow`, or `vision_map.harvest_session`.
+7. Verify the result through the workflow's postcondition, `mcp_vision_mcp_vision_map_verify`, a final state check, or a user-visible screenshot when the task outcome depends on what is on screen.
+
+## Pitfalls
+
+- Vision-MCP controls real visible applications. Do not bypass logins, two-factor prompts, CAPTCHAs, consent dialogs, or destructive confirmations.
+- The default Hermes catalog entry does not enable raw coordinate/input tools or map mutation tools. Use `hermes mcp configure vision-mcp` only when the user explicitly wants that capability.
+- Window geometry matters. A hidden, minimized, off-screen, or partially covered target can make screenshots, OCR, and control locators unreliable.
+- The first `npx` run may download the npm package, so setup and the first MCP probe can take longer than later sessions.
+- Browser and Electron apps often need OCR or bounding-box locators even when accessibility data is incomplete.
+
+## Verification
+
+Run the catalog connection check:
+
+```bash
+hermes mcp test vision-mcp
+```
+
+Then start a new Hermes session and call `mcp_vision_mcp_vision_map_list_apps`. For platform diagnostics, run:
+
+```bash
+npx -y @vision-mcp/cli@latest doctor
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,8 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/unreal-engine" = ["optional-mcps/unreal-engine/manifest.yaml"]
+"optional-mcps/vision-mcp" = ["optional-mcps/vision-mcp/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -536,6 +536,43 @@ class TestToolSelection:
         assert list_catalog() == []
 
 
+class TestShippedVisionMcpManifest:
+    def test_manifest_uses_stdio_npx_and_safe_default_tools(self, monkeypatch):
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import get_entry
+
+        entry = get_entry("vision-mcp")
+        assert entry is not None
+        assert entry.auth.type == "none"
+        assert entry.transport.type == "stdio"
+        assert entry.transport.command == "npx"
+        assert entry.transport.args == [
+            "-y",
+            "@vision-mcp/cli@latest",
+            "serve",
+            "--apps-root",
+            "${HOME}/.vision-mcp/apps",
+        ]
+
+        defaults = set(entry.tools.default_enabled or [])
+        assert "vision_map.run_workflow" in defaults
+        assert "vision_map.perform_action" in defaults
+        assert "vision_map.repair_minimal" in defaults
+        assert "capsule.attach_window" in defaults
+
+        for raw_or_mutating_tool in {
+            "vision_map.click_at",
+            "vision_map.type_text",
+            "vision_map.press_key",
+            "vision_map.scroll",
+            "vision_map.init",
+            "vision_map.apply_patch",
+            "vision_map.add_control",
+            "vision_map.commit_state",
+            "vision_map.commit_workflow",
+            "vision_map.harvest_session",
+        }:
+            assert raw_or_mutating_tool not in defaults
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -7,6 +7,7 @@ launch an MCP is mocked.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -548,7 +549,7 @@ class TestShippedVisionMcpManifest:
         assert entry.transport.command == "npx"
         assert entry.transport.args == [
             "-y",
-            "@vision-mcp/cli@latest",
+            "@vision-mcp/cli@0.8.0",
             "serve",
             "--apps-root",
             "${HOME}/.vision-mcp/apps",
@@ -568,11 +569,41 @@ class TestShippedVisionMcpManifest:
             "vision_map.init",
             "vision_map.apply_patch",
             "vision_map.add_control",
+            "vision_map.propose_controls",
             "vision_map.commit_state",
             "vision_map.commit_workflow",
             "vision_map.harvest_session",
         }:
             assert raw_or_mutating_tool not in defaults
+
+    def test_manifest_exact_pins_the_cli_release(self, monkeypatch):
+        """Catalog policy (hermes_cli/mcp_catalog.py): manifests pin transport
+        details. A floating ref (`@latest`, a dist-tag, or a range) would let a
+        future npm publish silently change the spawned subprocess and its tool
+        surface without a manifest review — the exact regression this pin
+        prevents. The same pinned version must be used everywhere the manifest
+        invokes the CLI (serve args and post_install setup commands).
+        """
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import get_entry
+
+        entry = get_entry("vision-mcp")
+        assert entry is not None
+
+        cli_refs = [a for a in entry.transport.args if a.startswith("@vision-mcp/cli@")]
+        assert len(cli_refs) == 1
+        version = cli_refs[0].removeprefix("@vision-mcp/cli@")
+        assert re.fullmatch(r"\d+\.\d+\.\d+", version), (
+            f"@vision-mcp/cli must be pinned to an exact semver release, "
+            f"got {cli_refs[0]!r}"
+        )
+
+        post_install_refs = re.findall(r"@vision-mcp/cli@(\S+)", entry.post_install)
+        assert post_install_refs, "post_install should show pinned setup commands"
+        assert set(post_install_refs) == {version}, (
+            "post_install commands must use the same pinned CLI version as "
+            "transport.args"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_vision_mcp_skill.py
+++ b/tests/skills/test_vision_mcp_skill.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "mcp" / "vision-mcp"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+
+
+def _frontmatter_text() -> str:
+    src = SKILL_PATH.read_text(encoding="utf-8")
+    match = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert match, "SKILL.md missing YAML frontmatter"
+    return match.group(1)
+
+
+def _frontmatter_value(key: str) -> str:
+    match = re.search(rf"^{re.escape(key)}:\s*(.+)$", _frontmatter_text(), re.MULTILINE)
+    assert match, f"missing frontmatter key: {key}"
+    return match.group(1).strip().strip('"')
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert SKILL_PATH.is_file()
+
+
+def test_frontmatter_matches_optional_skill_standards() -> None:
+    assert _frontmatter_value("name") == "vision-mcp"
+    description = _frontmatter_value("description")
+    assert description.endswith(".")
+    assert len(description) <= 60
+    assert _frontmatter_value("license") == "MIT"
+
+
+def test_platforms_gate_real_supported_desktops() -> None:
+    platforms = _frontmatter_value("platforms")
+    assert "macos" in platforms
+    assert "windows" in platforms
+    assert "linux" not in platforms
+
+
+def test_modern_sections_are_present_in_order() -> None:
+    src = SKILL_PATH.read_text(encoding="utf-8")
+    sections = [
+        "# Vision-MCP",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [src.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_skill_names_hermes_mcp_tools_and_setup_commands() -> None:
+    src = SKILL_PATH.read_text(encoding="utf-8")
+    required = [
+        "hermes mcp install vision-mcp",
+        "hermes mcp configure vision-mcp",
+        "mcp_vision_mcp_vision_map_list_apps",
+        "mcp_vision_mcp_vision_map_run_workflow",
+        "mcp_vision_mcp_vision_map_repair_minimal",
+        "mcp_vision_mcp_capsule_attach_window",
+    ]
+    for text in required:
+        assert text in src
+
+
+def test_skill_calls_out_low_level_and_mutating_tool_consent() -> None:
+    src = SKILL_PATH.read_text(encoding="utf-8")
+    for tool in [
+        "vision_map.click_at",
+        "vision_map.type_text",
+        "vision_map.apply_patch",
+        "vision_map.commit_state",
+        "vision_map.commit_workflow",
+    ]:
+        assert tool in src
+    assert "explicit user consent" in src

--- a/tests/skills/test_vision_mcp_skill.py
+++ b/tests/skills/test_vision_mcp_skill.py
@@ -37,6 +37,14 @@ def test_frontmatter_matches_optional_skill_standards() -> None:
     assert _frontmatter_value("license") == "MIT"
 
 
+def test_author_credits_human_contributor_first() -> None:
+    # AGENTS.md contributed-skill standard: the external contributor's real
+    # name + GitHub handle come first; "Hermes Agent" is the secondary
+    # collaborator, never the primary author.
+    author = _frontmatter_value("author")
+    assert author == "Haruyuki (Haruhiyuki), Hermes Agent"
+
+
 def test_platforms_gate_real_supported_desktops() -> None:
     platforms = _frontmatter_value("platforms")
     assert "macos" in platforms
@@ -46,8 +54,10 @@ def test_platforms_gate_real_supported_desktops() -> None:
 
 def test_modern_sections_are_present_in_order() -> None:
     src = SKILL_PATH.read_text(encoding="utf-8")
+    # AGENTS.md skill standard: modern `# <Skill> Skill` title form.
+    assert re.search(r"^# Vision-MCP Skill$", src, re.MULTILINE)
     sections = [
-        "# Vision-MCP",
+        "# Vision-MCP Skill",
         "## When to Use",
         "## Prerequisites",
         "## How to Run",
@@ -85,3 +95,25 @@ def test_skill_calls_out_low_level_and_mutating_tool_consent() -> None:
     ]:
         assert tool in src
     assert "explicit user consent" in src
+
+
+def test_setup_commands_match_the_catalog_manifest_pin() -> None:
+    # The skill duplicates the manifest's npx setup commands. Catalog policy
+    # pins the CLI release in the manifest; the skill must reference the same
+    # exact version so the two files cannot drift (and never float `@latest`).
+    manifest = (
+        SKILL_DIR.parents[2] / "optional-mcps" / "vision-mcp" / "manifest.yaml"
+    ).read_text(encoding="utf-8")
+    manifest_refs = set(re.findall(r"@vision-mcp/cli@(\S+?)[\"\s]", manifest))
+    assert len(manifest_refs) == 1, f"manifest pins one CLI version: {manifest_refs}"
+    version = manifest_refs.pop()
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version)
+
+    src = SKILL_PATH.read_text(encoding="utf-8")
+    skill_refs = set(re.findall(r"@vision-mcp/cli@([\w.<>-]+)", src))
+    # `@<version>` placeholders in upgrade guidance are allowed; every literal
+    # version must equal the manifest pin.
+    literal_refs = {r for r in skill_refs if r != "<version>"}
+    assert literal_refs == {version}, (
+        f"SKILL.md references {literal_refs}, manifest pins {version}"
+    )

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -267,6 +267,43 @@ def test_locale_catalogs_ship_in_both_wheel_and_sdist():
     assert on_disk, "expected locales/*.yaml catalogs on disk"
 
 
+def test_every_mcp_catalog_manifest_ships_in_both_wheel_and_sdist():
+    """Regression test for the bug class behind #39859.
+
+    optional-mcps/ is a bare data directory like locales/, but it is nested
+    (optional-mcps/<name>/manifest.yaml) and setuptools data-files flattens
+    every glob match into its single target dir — a shared glob would collapse
+    all manifests into one colliding path. Each catalog entry therefore needs
+    its OWN data-files target, which is easy to forget when adding an entry:
+    the repo checkout keeps working while packaged installs silently drop the
+    new entry from `hermes mcp catalog` (list_catalog() iterates the packaged
+    dir). Enforce one exact data-files entry per on-disk manifest.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    data_files = data["tool"]["setuptools"].get("data-files", {})
+
+    on_disk = sorted((REPO_ROOT / "optional-mcps").glob("*/manifest.yaml"))
+    assert on_disk, "expected optional-mcps/<name>/manifest.yaml manifests on disk"
+
+    problems = []
+    for manifest in on_disk:
+        name = manifest.parent.name
+        target = f"optional-mcps/{name}"
+        expected = [f"optional-mcps/{name}/manifest.yaml"]
+        if data_files.get(target) != expected:
+            problems.append(
+                f"pyproject [tool.setuptools.data-files] must declare "
+                f'"{target}" = {expected} so the wheel ships this catalog entry'
+            )
+    assert not problems, "\n".join(problems)
+
+    # Sdist channel: MANIFEST.in grafts the whole directory.
+    manifest_in = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "graft optional-mcps" in manifest_in, (
+        "MANIFEST.in must `graft optional-mcps` so the sdist ships the catalog"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Dependency-pin consistency: pyproject extras <-> tools/lazy_deps.py
 #


### PR DESCRIPTION
## Summary
- add Vision-MCP to the optional MCP catalog so Hermes can connect to its npm stdio server for reusable desktop GUI workflows
- add the companion `optional-skills/mcp/vision-mcp` skill explaining what Vision-MCP is, when to use it, setup, Hermes MCP tool names, workflow-first operation, repair flow, and verification
- keep defaults conservative: enable workflow, state, capsule, verification, repair, and trace tools while leaving raw coordinate/input tools and map mutation tools opt-in via `hermes mcp configure vision-mcp`
- add focused tests for the shipped manifest transport/default tool selection and the skill frontmatter/section structure

## Why
Vision-MCP gives agents a visual desktop software control layer using screenshots, accessibility trees, OCR, reusable maps, workflows, and repair. Shipping it as an optional MCP plus optional skill brings that capability into Hermes without changing the core runtime or enabling high-risk GUI input tools by default.

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_mcp_catalog.py tests/skills/test_vision_mcp_skill.py`
- `.venv/bin/ruff check tests/hermes_cli/test_mcp_catalog.py tests/skills/test_vision_mcp_skill.py`
- local consistency check: manifest default tool names match the Vision-MCP server registered tools (`defaults 20`, `registered 31`, `missing []`)
