### PR TITLE
chore(release): add whyhkzk to AUTHOR_MAP for PR #32407

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1420,6 +1420,7 @@ AUTHOR_MAP = {
     "me@simontaggart.com": "SiTaggart",  # PR #35583 (docker_forward_env empty-secret .env fallback)
     "2663402852@qq.com": "x1am1",  # PR #35098 (chown root-owned top-level HERMES_HOME state files)
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
+    "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
 }
 
 


### PR DESCRIPTION
Adds `wasdhkzk@gmail.com` → `whyhkzk` to `AUTHOR_MAP` in `scripts/release.py`.

## Why
PR #32407 (sandbox-mirror inner-container guard, follow-up to #32049 / sibling of the just-merged #32213) is blocked by the `check-attribution` CI gate because the contributor's commit-author email isn't mapped. Their commits are authored under two names (`whyhkzk` and `zhukun`) but the same email `wasdhkzk@gmail.com`, so one entry covers both (the gate keys on `git log %ae`).

## Note
This PR's own `check-attribution` passes because it's authored by a maintainer whose email is whitelisted. Once merged, #32407's attribution requirement is factually satisfied on `main`.

Type of change: chore (CI/release tooling, no runtime impact).