### PR TITLE
Add Discord busy Stop button

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Callable, Dict, Optional, Any, List, Union, cast
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -3511,19 +3511,46 @@ class GatewayRunner:
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
-        try:
-            await adapter._send_with_retry(
-                chat_id=event.source.chat_id,
-                content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
-                metadata=thread_meta,
+        reply_to = (
+            reply_anchor
+            if event.source.platform == Platform.TELEGRAM
+            and event.source.chat_type == "dm"
+            and event.source.thread_id
+            else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
+        )
+
+        async def _stop_from_busy_ack(stop_session_key: str) -> str:
+            await self._interrupt_and_clear_session(
+                stop_session_key,
+                event.source,
+                interrupt_reason=_INTERRUPT_REASON_STOP,
+                invalidation_reason="busy_ack_stop_button",
             )
+            logger.info(
+                "STOP (busy ack button) for session %s — agent interrupted, session lock released",
+                stop_session_key,
+            )
+            return t("gateway.stop.stopped")
+
+        try:
+            send_busy_ack_with_stop = getattr(adapter, "send_busy_ack_with_stop", None)
+            if event.source.platform == Platform.DISCORD and callable(send_busy_ack_with_stop):
+                send_busy_ack_with_stop = cast(Callable[..., Any], send_busy_ack_with_stop)
+                await send_busy_ack_with_stop(
+                    chat_id=event.source.chat_id,
+                    content=message,
+                    session_key=session_key,
+                    stop_callback=_stop_from_busy_ack,
+                    reply_to=reply_to,
+                    metadata=thread_meta,
+                )
+            else:
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=message,
+                    reply_to=reply_to,
+                    metadata=thread_meta,
+                )
         except Exception as e:
             logger.debug("Failed to send busy-ack: %s", e)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1448,6 +1448,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            discord_view = metadata.get("discord_view") if isinstance(metadata, dict) else None
 
             message_ids = []
             reference = None
@@ -1468,10 +1469,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    send_kwargs = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    if discord_view is not None and i == 0:
+                        send_kwargs["view"] = discord_view
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -1490,10 +1494,13 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        retry_kwargs = {
+                            "content": chunk,
+                            "reference": None,
+                        }
+                        if discord_view is not None and i == 0:
+                            retry_kwargs["view"] = discord_view
+                        msg = await channel.send(**retry_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))
@@ -1513,6 +1520,45 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    async def send_busy_ack_with_stop(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        session_key: str,
+        stop_callback: Callable[[str], Any],
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a busy acknowledgement with a Discord Stop button.
+
+        The button is UI sugar for the gateway's existing `/stop` path.  The
+        adapter owns only Discord component rendering/auth; the gateway-owned
+        callback performs the actual session interruption.
+        """
+        if not DISCORD_AVAILABLE:
+            return await self._send_with_retry(
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+
+        view = StopTaskView(
+            session_key=session_key,
+            stop_callback=stop_callback,
+            allowed_user_ids=self._allowed_user_ids,
+            allowed_role_ids=self._allowed_role_ids,
+        )
+        view_metadata: Dict[str, Any] = dict(metadata or {})
+        view_metadata["discord_view"] = view
+        return await self._send_with_retry(
+            chat_id=chat_id,
+            content=content,
+            reply_to=reply_to,
+            metadata=view_metadata,
+        )
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
@@ -5040,7 +5086,75 @@ def _define_discord_view_classes() -> None:
     lazy install sets DISCORD_AVAILABLE=True but leaves the classes
     undefined, causing NameError on the first button interaction.
     """
-    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, StopTaskView
+
+    class StopTaskView(discord.ui.View):  # type: ignore[union-attr]
+        """Single-button view that maps Discord busy-ack clicks to `/stop`."""
+
+        def __init__(
+            self,
+            session_key: str,
+            stop_callback: Callable[[str], Any],
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            super().__init__(timeout=3600)
+            self.session_key = session_key
+            self.stop_callback = stop_callback
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+
+            button = discord.ui.Button(  # type: ignore[union-attr]
+                label="Stop",
+                style=getattr(discord.ButtonStyle, "red"),  # type: ignore[union-attr]
+                custom_id=f"busy-stop:{hashlib.sha256(session_key.encode()).hexdigest()[:16]}",
+            )
+            button.callback = self._on_stop
+            self.add_item(button)
+
+        def _check_auth(self, interaction: Any) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        async def _on_stop(self, interaction: Any) -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This task has already been stopped~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to stop this task~", ephemeral=True,
+                )
+                return
+
+            self.resolved = True
+            for child in self.children:
+                setattr(child, "disabled", True)
+
+            try:
+                callback_result = self.stop_callback(self.session_key)
+                if asyncio.iscoroutine(callback_result):
+                    callback_result = await callback_result
+                text = str(callback_result or "Stop requested — current task cancelled.")
+            except Exception as exc:
+                logger.error("Discord busy-stop callback failed for %s: %s", self.session_key, exc, exc_info=True)
+                text = "Stop failed — please send /stop."
+
+            try:
+                await interaction.response.edit_message(content=f"🛑 {text}", view=self)
+            except Exception:
+                try:
+                    await interaction.response.send_message(f"🛑 {text}", ephemeral=True)
+                except Exception:
+                    pass
+
+        async def on_timeout(self):
+            self.resolved = True
+            for child in self.children:
+                setattr(child, "disabled", True)
 
     class ExecApprovalView(discord.ui.View):
         """

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -30,6 +30,7 @@ from gateway.platforms.base import (
     SessionSource,
     build_session_key,
 )
+from gateway.config import Platform
 
 
 # ---------------------------------------------------------------------------
@@ -86,6 +87,34 @@ def _make_adapter(platform_val="telegram"):
     adapter._text_debounce = {}
     adapter._busy_text_debounce_seconds = 0.6
     return adapter
+
+
+def _make_discord_event(text="hello", chat_id="123"):
+    """Build a minimal Discord MessageEvent with the real Platform enum."""
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type="channel",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg1",
+    )
+
+
+class _DiscordBusyAckAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+        self.send_busy_ack_with_stop = AsyncMock()
+        self._send_with_retry = AsyncMock()
+        self.config = MagicMock()
+        self.config.extra = {}
+        self.platform = Platform.DISCORD
+        self._text_debounce = {}
+        self._busy_text_debounce_seconds = 0.6
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +187,61 @@ class TestBusySessionAck:
 
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
+
+    @pytest.mark.asyncio
+    async def test_discord_busy_ack_uses_stop_button_sender(self):
+        """Discord busy acks should use the adapter Stop-button path."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _DiscordBusyAckAdapter()
+
+        event = _make_discord_event(text="queue this")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[Platform.DISCORD] = adapter  # type: ignore[assignment]
+
+        with patch("gateway.run.merge_pending_message_event"):
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter.send_busy_ack_with_stop.assert_called_once()
+        adapter._send_with_retry.assert_not_called()
+        call_kwargs = adapter.send_busy_ack_with_stop.call_args.kwargs
+        assert call_kwargs["chat_id"] == "123"
+        assert call_kwargs["session_key"] == sk
+        assert callable(call_kwargs["stop_callback"])
+        assert "Queued for the next turn" in call_kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_discord_busy_stop_callback_interrupts_and_clears_session(self):
+        """The Stop button callback is wired to the gateway interrupt path."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _DiscordBusyAckAdapter()
+
+        event = _make_discord_event(text="queue this")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[Platform.DISCORD] = adapter  # type: ignore[assignment]
+
+        runner._interrupt_and_clear_session = AsyncMock(return_value=None)
+
+        with patch("gateway.run.merge_pending_message_event"), patch(
+            "gateway.run.t", lambda key: "Stopped."
+        ):
+            await runner._handle_active_session_busy_message(event, sk)
+            stop_callback = adapter.send_busy_ack_with_stop.call_args.kwargs["stop_callback"]
+            text = await stop_callback(sk)
+
+        assert text == "Stopped."
+        runner._interrupt_and_clear_session.assert_awaited_once_with(
+            sk,
+            event.source,
+            interrupt_reason="Stop requested",
+            invalidation_reason="busy_ack_stop_button",
+        )
 
     @pytest.mark.asyncio
     async def test_queue_mode_suppresses_interrupt_and_updates_ack(self):

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -28,6 +28,7 @@ if _repo not in sys.path:
 from plugins.platforms.discord.adapter import (  # noqa: E402
     ClarifyChoiceView,
     DiscordAdapter,
+    StopTaskView,
 )
 from gateway.config import PlatformConfig  # noqa: E402
 
@@ -404,3 +405,73 @@ class TestDiscordSendClarify:
         # Only 1 real choice + 1 Other = 2 children
         assert len(view.children) == 2
         assert "real-choice" in view.children[0].label
+
+
+class TestDiscordBusyStopButton:
+    @pytest.mark.asyncio
+    async def test_send_busy_ack_with_stop_attaches_view(self):
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 555
+        channel.send = AsyncMock(return_value=sent_msg)
+        client = MagicMock()
+        client.get_channel = MagicMock(return_value=channel)
+        adapter._client = client
+
+        metadata = {"thread_id": "7777", "kept": "yes"}
+        await adapter.send_busy_ack_with_stop(
+            chat_id="9001",
+            content="busy",
+            session_key="discord:9001:user1",
+            stop_callback=AsyncMock(return_value="Stopped."),
+            metadata=metadata,
+        )
+
+        client.get_channel.assert_called_once_with(7777)
+        kwargs = channel.send.call_args.kwargs
+        assert kwargs["content"] == "busy"
+        view = kwargs["view"]
+        assert isinstance(view, StopTaskView)
+        assert len(view.children) == 1
+        button = view.children[0]
+        assert getattr(button, "label") == "Stop"
+        assert getattr(button, "custom_id").startswith("busy-stop:")
+        # Caller metadata is copied before injecting the view.
+        assert "discord_view" not in metadata
+
+    @pytest.mark.asyncio
+    async def test_stop_view_authorizes_and_invokes_callback(self):
+        callback = AsyncMock(return_value="Stopped.")
+        view = StopTaskView(
+            session_key="sk-1",
+            stop_callback=callback,
+            allowed_user_ids={"42"},
+        )
+        interaction = _make_interaction(user_id="42")
+        button = view.children[0]
+
+        await getattr(button, "callback")(interaction)
+
+        callback.assert_awaited_once_with("sk-1")
+        interaction.response.edit_message.assert_awaited_once()
+        assert view.resolved is True
+        assert getattr(button, "disabled") is True
+
+    @pytest.mark.asyncio
+    async def test_stop_view_rejects_unauthorized_user(self):
+        callback = AsyncMock(return_value="Stopped.")
+        view = StopTaskView(
+            session_key="sk-1",
+            stop_callback=callback,
+            allowed_user_ids={"42"},
+        )
+        interaction = _make_interaction(user_id="99")
+        button = view.children[0]
+
+        await getattr(button, "callback")(interaction)
+
+        callback.assert_not_awaited()
+        interaction.response.send_message.assert_awaited_once()
+        assert view.resolved is False
+        assert getattr(button, "disabled") is False


### PR DESCRIPTION
## Summary
- add Discord busy-ack Stop button wired to the gateway session interrupt path
- allow Discord adapter sends to attach a view to the first message chunk
- cover gateway routing, callback wiring, view attachment, auth, and rejection paths

## Tests
- uv run --extra dev --extra messaging pytest tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_busy_session_ack.py -q
- python3 -m py_compile gateway/run.py plugins/platforms/discord/adapter.py tests/gateway/test_busy_session_ack.py tests/gateway/test_discord_clarify_buttons.py /Users/macintosh/archive-pipeline/collect_browser_history.py
- archive-pipeline build_collection_summary smoke: default stdout omits sample_visits, opt-in sample_limit includes it