### PR TITLE
fix(send_message): add missing wecom branch in _parse_target_ref

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -388,6 +388,11 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    if platform_name == "wecom":
+        # WeCom user IDs are arbitrary strings set by the org admin.
+        # No structural validation needed here; the adapter validates
+        # at send time.
+        return target_ref.strip(), None, True
     if platform_name == "yuanbao":
         match = _YUANBAO_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## What does this PR do?

Fixes WeCom DM routing in `_parse_target_ref()`. When send_message receives a target in `wecom:<user_id>` format, the function returns `(None, None, False)` because no `wecom` branch exists. This causes all WeCom DM targets to fall through to channel-name resolution, ultimately falling back to the home channel.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Added a `wecom` branch in `_parse_target_ref()` at `tools/send_message_tool.py:391-395` that treats the target_ref as a direct user ID and marks it as explicit, so it bypasses channel-name resolution and routes directly to the target user.

This is consistent with how sibling platforms (`weixin`, `yuanbao`) handle their target parsing — the adapter layer at `gateway/platforms/wecom.py` handles any further validation at send time.

## Test Plan

1. Call `send_message(action="send", target="wecom:<valid_user_id>", message="test")` — message should route to the target user instead of falling back to the home channel.
2. Call `send_message(action="send", target="wecom:<invalid_user_id>", message="test")` — should return an error from the adapter layer (no silent fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>