### PR TITLE
fix(packaging): tolerate missing optional data roots

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ REPO_ROOT = Path(__file__).parent.resolve()
 
 def _data_file_tree(root_name: str) -> list[tuple[str, list[str]]]:
     root = REPO_ROOT / root_name
+    if not root.exists():
+        return []
     grouped: defaultdict[str, list[str]] = defaultdict(list)
     for path in sorted(root.rglob("*")):
         if not path.is_file():

--- a/tests/test_setup_py.py
+++ b/tests/test_setup_py.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+SETUP_PATH = Path(__file__).resolve().parents[1] / "setup.py"
+
+
+def _load_setup_module():
+    spec = importlib.util.spec_from_file_location("hermes_setup_py_test", SETUP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    setuptools_stub = types.ModuleType("setuptools")
+    setuptools_stub.setup = lambda *args, **kwargs: None
+    sys.modules["setuptools"] = setuptools_stub
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop("setuptools", None)
+    return module
+
+
+def test_data_file_tree_tolerates_missing_root(tmp_path):
+    setup_mod = _load_setup_module()
+    setup_mod.REPO_ROOT = tmp_path
+
+    assert setup_mod._data_file_tree("optional-skills") == []


### PR DESCRIPTION
## Summary

Fixes a packaging edge case where `setup.py` assumes `skills/` and `optional-skills/` always exist during metadata evaluation. Minimal source distributions or downstream repacks can omit one of those roots, which currently raises before setuptools can finish building metadata.

## Changes

- return `[]` from `_data_file_tree()` when the requested root is missing
- add a regression test that imports `setup.py` with a stubbed `setuptools` module and verifies missing roots are tolerated

Fixes #36619

## Testing

- `source /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/activate && pytest -o addopts='' tests/test_setup_py.py`
- `source /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/activate && ruff check setup.py tests/test_setup_py.py`
- `python3 -m py_compile setup.py tests/test_setup_py.py`
- `git diff --check HEAD~1 HEAD`

## CI note

Recent company PRs do not show a broad shared-red baseline for this surface. `#36170` and `#36173` were fully green; `#37111` had one isolated `test (2)` failure that does not look like a shared packaging baseline.
