### PR TITLE
fix(gateway): honor WECOM_ALLOWED_USERS in env-only WeCom DM allowlist

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -161,7 +161,15 @@ class WeComAdapter(BasePlatformAdapter):
         ).strip() or DEFAULT_WS_URL
 
         self._dm_policy = str(extra.get("dm_policy") or os.getenv("WECOM_DM_POLICY", "open")).strip().lower()
-        self._allow_from = _coerce_list(extra.get("allow_from") or extra.get("allowFrom"))
+        # dm_policy already honors WECOM_DM_POLICY, so the allowlist must honor
+        # WECOM_ALLOWED_USERS too. Without the env fallback an env-only setup
+        # (dm_policy=allowlist via env, no config extra) runs with an empty
+        # allowlist and drops every authorized DM at intake.
+        self._allow_from = _coerce_list(
+            extra.get("allow_from")
+            or extra.get("allowFrom")
+            or os.getenv("WECOM_ALLOWED_USERS", "")
+        )
 
         self._group_policy = str(extra.get("group_policy") or os.getenv("WECOM_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -285,6 +285,39 @@ class TestPolicyHelpers:
         assert adapter._is_dm_allowed("user-1") is True
         assert adapter._is_dm_allowed("user-2") is False
 
+    def test_dm_allowlist_honors_env_only_allowed_users(self, monkeypatch):
+        """Env-only setup (WECOM_DM_POLICY + WECOM_ALLOWED_USERS, no config
+        ``extra``) must populate the DM allowlist. Otherwise ``dm_policy:
+        allowlist`` runs with an empty allowlist and drops every listed user
+        at intake — the documented env vars become no-ops."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setenv("WECOM_DM_POLICY", "allowlist")
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "user-1, user-2")
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        assert adapter._dm_policy == "allowlist"
+        assert adapter._allow_from == ["user-1", "user-2"]
+        assert adapter._is_dm_allowed("user-1") is True
+        assert adapter._is_dm_allowed("user-2") is True
+        assert adapter._is_dm_allowed("stranger") is False
+
+    def test_dm_allowlist_extra_takes_precedence_over_env(self, monkeypatch):
+        """Config ``extra`` wins over the env fallback, so an explicit
+        allowlist is never silently widened by a stray WECOM_ALLOWED_USERS."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "env-user")
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"dm_policy": "allowlist", "allow_from": ["cfg-user"]})
+        )
+
+        assert adapter._allow_from == ["cfg-user"]
+        assert adapter._is_dm_allowed("cfg-user") is True
+        assert adapter._is_dm_allowed("env-user") is False
+
     def test_group_allowlist_and_per_group_sender_allowlist(self):
         from gateway.platforms.wecom import WeComAdapter
 


### PR DESCRIPTION
## Summary
WeCom DM allowlists now work in env-only setups — `WECOM_ALLOWED_USERS` is honored at the adapter intake gate, not just config `extra`.

Root cause: `WeComAdapter.__init__` resolved `dm_policy` from `WECOM_DM_POLICY` (env) but resolved `allow_from` **only** from `PlatformConfig.extra`. An operator configuring WeCom purely via the documented env vars (`WECOM_DM_POLICY=allowlist` + `WECOM_ALLOWED_USERS=...`) ended up with `_dm_policy="allowlist"` and `_allow_from=[]`, so every DM — including from explicitly allowed users — was dropped at intake in `_is_dm_allowed()`.

## Changes
- `gateway/platforms/wecom.py`: `allow_from` now falls back to `os.getenv("WECOM_ALLOWED_USERS")`, mirroring the `dm_policy` resolution on the line directly above and the sibling `weixin.py` adapter (`WEIXIN_ALLOWED_USERS`). Config `extra` keeps precedence — explicit allowlists are never silently widened. No new env var introduced.
- `tests/gateway/test_wecom.py`: +2 cases — env-only allowlist admits listed users / rejects strangers; config `extra` wins over env.

## Validation
| | Before | After |
|---|---|---|
| env-only `WECOM_ALLOWED_USERS=alice,bob`, `_is_dm_allowed("alice")` | `False` (dropped) | `True` |
| env-only, `_is_dm_allowed("stranger")` | `False` | `False` |
| config `allow_from=[cfg-only]` + env `alice`, `_is_dm_allowed("alice")` | — | `False` (extra wins) |

`tests/gateway/test_wecom.py` → 46/46 passing. E2E verified with real imports + isolated HERMES_HOME.

Salvage of #37069 by @Zyrixtrex onto current `main`; original commit cherry-picked with authorship preserved.

## Infographic

![wecom-dm-allowlist-env-fix](https://v3b.fal.media/files/b/0a9c9f73/WRg3UKpb76L248b4B0acb_O0NABqp3.png)
