### PR TITLE
fix(whatsapp): honor dm_policy and group_policy open at the gateway

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1750,8 +1750,8 @@ class BasePlatformAdapter(ABC):
     def enforces_own_access_policy(self) -> bool:
         """Whether this adapter gates inbound access before dispatch.
 
-        Some adapters (WeCom, Weixin, Yuanbao, QQBot) implement a documented
-        config-driven access surface — ``dm_policy`` / ``group_policy`` /
+        Some adapters (WeCom, Weixin, Yuanbao, QQBot, WhatsApp) implement a
+        documented config-driven access surface — ``dm_policy`` / ``group_policy`` /
         ``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra`` — and
         enforce it at intake: a message is dropped inside the adapter and never
         reaches the gateway unless it already passed that policy.

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -379,6 +379,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return True
         return False
 
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """WhatsApp gates DM/group access at intake via dm_policy/group_policy."""
+        return True
+
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
         if self._dm_policy == "disabled":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6820,8 +6820,8 @@ class GatewayRunner:
         """Whether the adapter for *platform* gates access at intake itself.
 
         Mirrors ``BasePlatformAdapter.enforces_own_access_policy``. Adapters
-        such as WeCom, Weixin, Yuanbao, and QQBot evaluate their documented
-        ``dm_policy`` / ``group_policy`` / ``allow_from`` config before a
+        such as WeCom, Weixin, Yuanbao, QQBot, and WhatsApp evaluate their
+        documented ``dm_policy`` / ``group_policy`` / ``allow_from`` config before a
         message is dispatched to the gateway, so a message that reaches
         ``_is_user_authorized`` has already been authorized by the adapter.
         Defaults to ``False`` when the adapter is unknown or doesn't expose

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -1,8 +1,9 @@
 """Tests for config-driven platform access policies at the gateway layer.
 
-Background (#34515): WeCom, Weixin, Yuanbao, and QQBot expose a documented
-config-driven access surface (``dm_policy`` / ``group_policy`` / ``allow_from``
-/ ``group_allow_from`` in ``PlatformConfig.extra``) and enforce it at intake —
+Background (#34515): WeCom, Weixin, Yuanbao, QQBot, and WhatsApp expose a
+documented config-driven access surface (``dm_policy`` / ``group_policy`` /
+``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra``) and enforce
+it at intake —
 a message is dropped inside the adapter and never reaches the gateway unless it
 already passed that policy.
 
@@ -34,6 +35,7 @@ _OWN_POLICY_PLATFORMS = [
     Platform.WEIXIN,
     Platform.YUANBAO,
     Platform.QQBOT,
+    Platform.WHATSAPP,
 ]
 
 
@@ -44,6 +46,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "YUANBAO_ALLOWED_USERS",
         "QQ_ALLOWED_USERS",
         "QQ_GROUP_ALLOWED_USERS",
+        "WHATSAPP_ALLOWED_USERS",
         "TELEGRAM_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
@@ -51,6 +54,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "WEIXIN_ALLOW_ALL_USERS",
         "YUANBAO_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
+        "WHATSAPP_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -103,10 +107,11 @@ def test_base_adapter_defaults_to_not_owning_access_policy():
         ("gateway.platforms.weixin", "WeixinAdapter"),
         ("gateway.platforms.yuanbao", "YuanbaoAdapter"),
         ("gateway.platforms.qqbot.adapter", "QQAdapter"),
+        ("gateway.platforms.whatsapp", "WhatsAppAdapter"),
     ],
 )
 def test_own_policy_adapters_declare_the_flag(module_path, class_name):
-    """The four config-policy adapters override the flag to True."""
+    """The config-policy adapters override the flag to True."""
     import importlib
 
     module = importlib.import_module(module_path)


### PR DESCRIPTION
## Summary
`whatsapp.dm_policy: open` / `group_policy: open` now actually work — the WhatsApp adapter declares `enforces_own_access_policy = True`, so the gateway trusts the intake authorization it already performed instead of re-applying its env-only default-deny.

Root cause: the adapter gates inbound access at intake (`_is_dm_allowed` / `_is_group_allowed` via `dm_policy` / `group_policy` / `allow_from`), but never overrode `enforces_own_access_policy`. With no `WHATSAPP_ALLOWED_USERS` set, `_is_user_authorized()` dropped messages the adapter had already admitted — silent drop / unexpected pairing prompt. Same contract WeCom/Weixin/Yuanbao/QQBot adopted in #34515; WhatsApp was missed.

## Changes
- `gateway/platforms/whatsapp.py`: add `enforces_own_access_policy` property (`-> True`).
- `gateway/platforms/base.py`, `gateway/run.py`: docstrings list WhatsApp among own-policy adapters.
- `tests/gateway/test_config_driven_access_policy.py`: WhatsApp added to own-policy platform list, flag-declaration parametrization, and env-clearing helper.

## Validation
| | Before | After |
|---|---|---|
| `dm_policy: open`, no env allowlist | dropped at gateway | authorized (adapter trusted) |
| `WHATSAPP_ALLOWED_USERS` set | restricts | restricts (env wins) |

Targeted tests: 79/79 pass (`test_config_driven_access_policy`, `test_whatsapp_group_gating`, `test_unauthorized_dm_behavior`). E2E: wired adapter into a runner — `_adapter_enforces_own_access_policy(WHATSAPP)` returns True, control platform returns False.

Salvaged from #37066 by @Zyrixtrex (authorship preserved via cherry-pick).

## Infographic

![whatsapp-dm-policy-fix](https://v3b.fal.media/files/b/0a9c9f77/r0e7wJA1VA4-SXCh0be-6_NaUzkZhv.png)
