### PR TITLE
fix(mattermost): keep thread root and replies in one session

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -787,7 +787,20 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
         # Thread support: if the post is in a thread, use root_id.
+        #
+        # A root post (the first message of a thread) has an empty root_id in
+        # Mattermost, while its replies carry root_id = <root post id>.  When
+        # reply_mode is "thread" the bot nests its replies under this root
+        # post, so every later reply in the thread will arrive with
+        # root_id = <this post's id>.  To keep the root message and all of its
+        # threaded replies in the SAME session, fall back to the post's own id
+        # as the thread_id for root posts.  Without this, the first message
+        # lands in session "...:<chat>" while every follow-up lands in
+        # "...:<chat>:<root_id>", so the agent loses all context on the first
+        # threaded reply.
         thread_id = post.get("root_id") or None
+        if thread_id is None and self._reply_mode == "thread":
+            thread_id = post.get("id") or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -406,6 +406,101 @@ class TestMattermostWebSocketParsing:
 
 
 # ---------------------------------------------------------------------------
+# Thread session continuity (root post + replies share one session)
+# ---------------------------------------------------------------------------
+
+class TestMattermostThreadSessionContinuity:
+    """A thread's root post and its later replies must resolve to the SAME
+    gateway session, so the agent keeps context when the user follows up.
+
+    In Mattermost a root post has an empty ``root_id`` while its replies carry
+    ``root_id=<root post id>``.  Under ``reply_mode='thread'`` the bot nests
+    its replies under the root post, so every later reply arrives with
+    ``root_id=<root post id>``.  The adapter therefore seeds ``thread_id``
+    from the post's own id for root posts in thread mode — keeping the root
+    message and all of its replies on a single session key.
+    """
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+
+    def _make_event(self, post_id, root_id="", channel_type="D"):
+        post_data = {
+            "id": post_id,
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id hello",
+        }
+        if root_id:
+            post_data["root_id"] = root_id
+        return {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": channel_type,
+                "sender_name": "@alice",
+            },
+        }
+
+    async def _thread_id_for(self, **kwargs):
+        self.adapter.handle_message.reset_mock()
+        await self.adapter._handle_ws_event(self._make_event(**kwargs))
+        assert self.adapter.handle_message.called
+        return self.adapter.handle_message.call_args[0][0].source.thread_id
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_root_post_seeds_thread_id_from_own_id(self):
+        """In thread mode a root post (empty root_id) uses its own id."""
+        self.adapter._reply_mode = "thread"
+        tid = await self._thread_id_for(post_id="root_post_123", root_id="")
+        assert tid == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_reply_keeps_root_id(self):
+        """A reply still threads off the existing root_id, not its own id."""
+        self.adapter._reply_mode = "thread"
+        tid = await self._thread_id_for(post_id="reply_456", root_id="root_post_123")
+        assert tid == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_off_mode_root_post_has_no_thread_id(self):
+        """With reply_mode='off' a root post must NOT be forced into a thread,
+        otherwise every flat top-level message would get its own session."""
+        self.adapter._reply_mode = "off"
+        tid = await self._thread_id_for(post_id="root_post_123", root_id="")
+        assert tid is None
+
+    @pytest.mark.asyncio
+    async def test_root_and_reply_share_session_key_in_thread_mode(self):
+        """End-to-end regression: the opening message and a follow-up reply in
+        the bot's thread must produce the SAME session key — the original
+        "forgets context on every threaded reply" bug."""
+        from gateway.session import SessionSource, build_session_key
+
+        self.adapter._reply_mode = "thread"
+
+        # 1) User's first message — a root post with an empty root_id.
+        root_tid = await self._thread_id_for(post_id="root_post_123", root_id="")
+        # 2) User's follow-up inside the bot's thread (root_id = original post).
+        reply_tid = await self._thread_id_for(post_id="reply_456", root_id="root_post_123")
+
+        def session_key(thread_id):
+            src = SessionSource(
+                platform=Platform.MATTERMOST,
+                chat_id="chan_456",
+                chat_type="dm",
+                user_id="user_123",
+                thread_id=thread_id,
+            )
+            return build_session_key(src)
+
+        assert session_key(root_tid) == session_key(reply_tid)
+
+
+# ---------------------------------------------------------------------------
 # Mention behavior (require_mention + free_response_channels)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes a context-loss bug in the Mattermost adapter when `MATTERMOST_REPLY_MODE=thread`.

In thread mode, the agent lost all conversation context the moment a user
followed up inside a thread — every threaded reply was treated as a brand-new
conversation.

Root cause: in Mattermost the root post of a thread has an empty `root_id`,
while its replies carry `root_id=<root post id>`. The adapter derived the
gateway `thread_id` straight from `root_id`, so the opening message produced
session key `…:dm:<chat>` (no thread suffix) while every reply in the bot's
thread produced `…:dm:<chat>:<root_id>`. The two keys never matched, so the
first follow-up always started a fresh, empty session.

When `reply_mode` is `"thread"` the bot nests its replies under the user's
original post, so every later reply arrives with `root_id=<that post id>`. The
fix seeds `thread_id` from the post's own id for root posts in thread mode, so
the root message and all of its replies resolve to a single session key. The
fallback is guarded on `reply_mode == "thread"`; under `"off"` the bot posts
flat replies and root posts intentionally stay un-threaded, so we don't spawn a
stray per-post session.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #18279

#18279 ("Mattermost root threads share one session and block parallel
conversations") identifies the same root cause this PR fixes — root posts enter
the gateway with `thread_id = post.get("root_id") or None`, so for a root post
(empty `root_id`) `thread_id` is `None` and `build_session_key()` keys by
channel only, splitting the root message and its threaded replies across
different sessions.

Scope note vs. #18279: that issue proposes setting `thread_id = post.id` for
**non-DM** top-level posts and explicitly keeps DM behavior unchanged. This PR
instead guards the fallback on `reply_mode == "thread"` and applies it to all
chat types **including DMs**, because the reported failure occurred in a DM
(observed session keys were `…:mattermost:dm:…`) — the non-DM-only fix would not
resolve it. The `reply_mode == "thread"` form still satisfies #18279's
parallel-conversation goal: distinct root posts get distinct `post.id` values,
hence distinct sessions.

Related (not fixed here):
- #25181 — outbound `400 Invalid RootId` when posting thread replies (handled
  separately by `_resolve_root_id`). Different bug.
- #4221 — older report covering ignored thread follow-ups *and* tool output
  leaking to the main channel. This PR addresses the ignored-follow-up
  (context-loss) half only.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `plugins/platforms/mattermost/adapter.py` — in `_handle_ws_event`, seed
  `thread_id` from the post's own id for root posts (empty `root_id`) when
  `reply_mode == "thread"`, so a thread's root and replies share one session
  key. Behavior under `reply_mode == "off"` is unchanged.
- `tests/gateway/test_mattermost.py` — add `TestMattermostThreadSessionContinuity`
  covering root/reply `thread_id` derivation in both reply modes, plus an
  end-to-end assertion that the root post and a threaded reply build the same
  `build_session_key`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the adapter's test suite — all pass, including the 4 new continuity tests:
   `pytest tests/gateway/test_mattermost.py -q` → `47 passed`.
2. Prove the tests guard the bug: temporarily revert the two added lines in
   `adapter.py` and re-run — `test_thread_mode_root_post_seeds_thread_id_from_own_id`
   and `test_root_and_reply_share_session_key_in_thread_mode` fail, with the diff
   showing `…:dm:<chat>` vs `…:dm:<chat>:<root_id>` (the two mismatched keys).
3. Manual repro (optional): with `MATTERMOST_REPLY_MODE=thread`, DM/mention the
   bot, then reply inside the thread it creates. Before the fix the follow-up
   starts a fresh session (no memory of the first message); after the fix the
   thread retains context across replies.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- `tests/gateway/test_mattermost.py` passes (47/47). Note: a full `tests/gateway/` run shows 21 failures in unrelated modules (Matrix e2ee, Telegram MarkdownV2 escaping) that are pre-existing on `main` and untouched by this change. -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 7.0.0-22-generic), Python 3.11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: code-comment explaining the root-post thread_id fallback added inline -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A: no new config keys -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- N/A: platform-agnostic string/session-key logic -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

The mismatched session keys that caused the bug, surfaced by the regression
test when the fix is reverted:

```
- agent:main:mattermost:dm:chan_456:root_post_123   (a threaded reply)
+ agent:main:mattermost:dm:chan_456                  (the opening message)
```

With the fix applied, both resolve to `agent:main:mattermost:dm:chan_456:root_post_123`.