### PR TITLE
fix(gateway): remove --replace from systemd unit templates

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2371,7 +2371,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2381,8 +2381,6 @@ Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
@@ -2409,15 +2407,13 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM


### PR DESCRIPTION
## Problem

`hermes gateway service install` generates systemd unit files with `--replace` in the `ExecStart` line. Under systemd's `Restart=always`, this creates an infinite self-kill loop:

1. Gateway starts, reads `gateway.pid`, kills the previous process
2. Gateway writes its own PID to `gateway.pid`
3. Gateway exits (SIGTERM from the replace lifecycle)
4. Systemd restarts it (`Restart=always`)
5. New instance reads `gateway.pid`, kills the previous instance
6. Repeat until systemd hits its restart limit

Also removes `RestartMaxDelaySec` and `RestartSteps` which require systemd v255+ and are silently ignored on older versions (generating warning noise in the journal).

## Fix

- Remove `--replace` from both systemd unit templates (system-level and user-level)
- Remove `RestartMaxDelaySec=300` and `RestartSteps=5` from both templates

`--replace` is designed for manual one-shot starts where you want to take over from an existing process. Under a process supervisor, the supervisor owns the lifecycle — `--replace` fights it.

## Impact

- `hermes gateway service install` will now generate units without `--replace`
- Existing installations need to re-run `hermes gateway service install` to regenerate the clean unit
- `--replace` remains available as a CLI flag for manual `hermes gateway run --replace` — this only affects the generated service files

## Discovery

Found during MonkeyProof cross-agent gateway restart testing. Direction 2 (Skippy → Bilby systemd restart) triggered the crash loop on CT271. Root cause traced to `hermes_cli/gateway.py` lines 2374 and 2412.