### PR TITLE
fix: resolve doctor command home lookup

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -77,6 +77,25 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _real_user_home() -> Path:
+    """Return the OS login home directory, ignoring Hermes HOME overrides.
+
+    Hermes can remap ``Path.home()`` / ``$HOME`` to a profile-scoped directory
+    at runtime. The command-installation check needs the real shell home,
+    because ``~/.local/bin/hermes`` is installed for the OS user, not for the
+    Hermes profile.
+    """
+    if sys.platform == "win32":
+        return Path.home()
+
+    try:
+        import pwd
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        return Path.home()
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -1135,7 +1154,7 @@ def run_doctor(args):
             _cmd_link_dir = Path(_prefix) / "bin"
             _cmd_link_display = "$PREFIX/bin"
         else:
-            _cmd_link_dir = Path.home() / ".local" / "bin"
+            _cmd_link_dir = _real_user_home() / ".local" / "bin"
             _cmd_link_display = "~/.local/bin"
         _cmd_link = _cmd_link_dir / "hermes"
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -96,6 +96,37 @@ def _real_user_home() -> Path:
         return Path.home()
 
 
+def _current_launcher_bin() -> Path | None:
+    """Return the active Hermes launcher entry point for this runtime."""
+    launcher_name = "hermes.exe" if sys.platform == "win32" else "hermes"
+    candidates = []
+
+    try:
+        argv0 = Path(sys.argv[0] or "")
+        if argv0.name in {"hermes", "hermes.exe"}:
+            candidates.append(argv0.resolve())
+    except Exception:
+        pass
+
+    try:
+        executable = Path(sys.executable or "").resolve()
+        candidates.append(executable.parent / launcher_name)
+    except Exception:
+        pass
+
+    for _venv_name in ("venv", ".venv"):
+        candidates.append(PROJECT_ROOT / _venv_name / "bin" / launcher_name)
+
+    for candidate in candidates:
+        try:
+            if candidate.exists():
+                return candidate
+        except Exception:
+            continue
+
+    return None
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -1139,13 +1170,8 @@ def run_doctor(args):
 
     if sys.platform != "win32":
         _section("Command Installation")
-        # Determine the venv entry point location
-        _venv_bin = None
-        for _venv_name in ("venv", ".venv"):
-            _candidate = PROJECT_ROOT / _venv_name / "bin" / "hermes"
-            if _candidate.exists():
-                _venv_bin = _candidate
-                break
+        # Determine the current launcher entry point for this runtime.
+        _launcher_bin = _current_launcher_bin()
 
         # Determine the expected command link directory (mirrors install.sh logic)
         _prefix = os.environ.get("PREFIX", "")
@@ -1158,21 +1184,26 @@ def run_doctor(args):
             _cmd_link_display = "~/.local/bin"
         _cmd_link = _cmd_link_dir / "hermes"
 
-        if _venv_bin is None:
+        if _launcher_bin is None:
             check_warn(
                 "Venv entry point not found",
-                "(hermes not in venv/bin/ or .venv/bin/ — reinstall with pip install -e '.[all]')"
+                "(hermes not in current env/bin/ or repo venv/bin/ — reinstall with pip install -e '.[all]')"
             )
             manual_issues.append(
                 f"Reinstall entry point: cd {PROJECT_ROOT} && source venv/bin/activate && pip install -e '.[all]'"
             )
         else:
-            check_ok(f"Venv entry point exists ({_venv_bin.relative_to(PROJECT_ROOT)})")
+            _launcher_display = str(_launcher_bin)
+            try:
+                _launcher_display = str(_launcher_bin.relative_to(PROJECT_ROOT))
+            except Exception:
+                pass
+            check_ok(f"Venv entry point exists ({_launcher_display})")
 
             # Check the symlink at the command link location
             if _cmd_link.is_symlink():
                 _target = _cmd_link.resolve()
-                _expected = _venv_bin.resolve()
+                _expected = _launcher_bin.resolve()
                 if _target == _expected:
                     check_ok(f"{_cmd_link_display}/hermes → correct target")
                 else:
@@ -1182,8 +1213,8 @@ def run_doctor(args):
                     )
                     if should_fix:
                         _cmd_link.unlink()
-                        _cmd_link.symlink_to(_venv_bin)
-                        check_ok(f"Fixed symlink: {_cmd_link_display}/hermes → {_venv_bin}")
+                        _cmd_link.symlink_to(_launcher_bin)
+                        check_ok(f"Fixed symlink: {_cmd_link_display}/hermes → {_launcher_bin}")
                         fixed_count += 1
                     else:
                         issues.append(f"Broken symlink at {_cmd_link_display}/hermes — run 'hermes doctor --fix'")
@@ -1193,12 +1224,12 @@ def run_doctor(args):
             else:
                 check_fail(
                     f"{_cmd_link_display}/hermes not found",
-                    "(hermes command may not work outside the venv)"
+                    "(hermes command may not work outside the current env)"
                 )
                 if should_fix:
                     _cmd_link_dir.mkdir(parents=True, exist_ok=True)
-                    _cmd_link.symlink_to(_venv_bin)
-                    check_ok(f"Created symlink: {_cmd_link_display}/hermes → {_venv_bin}")
+                    _cmd_link.symlink_to(_launcher_bin)
+                    check_ok(f"Created symlink: {_cmd_link_display}/hermes → {_launcher_bin}")
                     fixed_count += 1
 
                     # Check if the link dir is on PATH

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -10,6 +10,17 @@ import pytest
 import hermes_cli.doctor as doctor_mod
 
 
+def _set_real_user_home(monkeypatch, tmp_path):
+    """Point the doctor at tmp_path as the OS login home."""
+    import pwd
+
+    monkeypatch.setattr(
+        pwd,
+        "getpwuid",
+        lambda uid: types.SimpleNamespace(pw_dir=str(tmp_path)),
+    )
+
+
 def _setup_doctor_env(monkeypatch, tmp_path, venv_name="venv"):
     """Create a minimal HERMES_HOME + PROJECT_ROOT for doctor tests."""
     home = tmp_path / ".hermes"
@@ -79,7 +90,8 @@ class TestDoctorCommandInstallation:
         cmd_link = cmd_link_dir / "hermes"
         cmd_link.symlink_to(hermes_bin)
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / ".hermes" / "home")
 
         out = _run_doctor(fix=False)
         assert "Command Installation" in out
@@ -90,7 +102,7 @@ class TestDoctorCommandInstallation:
     def test_missing_symlink_shows_fail(self, monkeypatch, tmp_path):
         home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
         # Don't create the symlink — it should be missing
 
         out = _run_doctor(fix=False)
@@ -103,7 +115,7 @@ class TestDoctorCommandInstallation:
     def test_fix_creates_missing_symlink(self, monkeypatch, tmp_path):
         home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path)
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         out = _run_doctor(fix=True)
         assert "Command Installation" in out
@@ -126,7 +138,7 @@ class TestDoctorCommandInstallation:
         wrong_target.write_text("#!/usr/bin/env python\n")
         cmd_link.symlink_to(wrong_target)
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         out = _run_doctor(fix=False)
         assert "Command Installation" in out
@@ -144,7 +156,7 @@ class TestDoctorCommandInstallation:
         wrong_target.write_text("#!/usr/bin/env python\n")
         cmd_link.symlink_to(wrong_target)
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         out = _run_doctor(fix=True)
         assert "Fixed symlink" in out
@@ -166,7 +178,7 @@ class TestDoctorCommandInstallation:
         monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         fake_model_tools = types.SimpleNamespace(
             check_tool_availability=lambda *a, **kw: ([], []),
@@ -201,7 +213,7 @@ class TestDoctorCommandInstallation:
         cmd_link = cmd_link_dir / "hermes"
         cmd_link.symlink_to(hermes_bin)
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         out = _run_doctor(fix=False)
         assert "Venv entry point exists" in out
@@ -217,7 +229,7 @@ class TestDoctorCommandInstallation:
         cmd_link = cmd_link_dir / "hermes"
         cmd_link.write_text("#!/bin/sh\nexec python -m hermes_cli.main \"$@\"\n")
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         out = _run_doctor(fix=False)
         assert "non-symlink" in out
@@ -233,7 +245,7 @@ class TestDoctorCommandInstallation:
 
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", str(prefix_dir))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        _set_real_user_home(monkeypatch, tmp_path)
 
         out = _run_doctor(fix=False)
         assert "Command Installation" in out

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -21,7 +21,7 @@ def _set_real_user_home(monkeypatch, tmp_path):
     )
 
 
-def _setup_doctor_env(monkeypatch, tmp_path, venv_name="venv"):
+def _setup_doctor_env(monkeypatch, tmp_path, venv_name="venv", create_launcher=True):
     """Create a minimal HERMES_HOME + PROJECT_ROOT for doctor tests."""
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)
@@ -30,12 +30,19 @@ def _setup_doctor_env(monkeypatch, tmp_path, venv_name="venv"):
     project = tmp_path / "project"
     project.mkdir(exist_ok=True)
 
-    # Create a fake venv entry point
+    # Create a fake launcher entry point
     venv_bin_dir = project / venv_name / "bin"
     venv_bin_dir.mkdir(parents=True, exist_ok=True)
+    python_bin = venv_bin_dir / "python"
+    python_bin.write_text("#!/usr/bin/env python\n# python entry point\n")
+    python_bin.chmod(0o755)
+    monkeypatch.setattr(doctor_mod.sys, "executable", str(python_bin))
+
     hermes_bin = venv_bin_dir / "hermes"
-    hermes_bin.write_text("#!/usr/bin/env python\n# entry point\n")
-    hermes_bin.chmod(0o755)
+    if create_launcher:
+        hermes_bin.write_text("#!/usr/bin/env python\n# entry point\n")
+        hermes_bin.chmod(0o755)
+    monkeypatch.setattr(doctor_mod.sys, "argv", [str(hermes_bin)])
 
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
@@ -167,35 +174,9 @@ class TestDoctorCommandInstallation:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
     def test_missing_venv_entry_point_shows_warn(self, monkeypatch, tmp_path):
-        home = tmp_path / ".hermes"
-        home.mkdir(parents=True, exist_ok=True)
-        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        home, project, hermes_bin = _setup_doctor_env(monkeypatch, tmp_path, create_launcher=False)
 
-        project = tmp_path / "project"
-        project.mkdir(exist_ok=True)
-        # Do NOT create any venv entry point
-
-        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
-        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
-        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
         _set_real_user_home(monkeypatch, tmp_path)
-
-        fake_model_tools = types.SimpleNamespace(
-            check_tool_availability=lambda *a, **kw: ([], []),
-            TOOLSET_REQUIREMENTS={},
-        )
-        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
-        try:
-            from hermes_cli import auth as _auth_mod
-            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
-            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
-        except Exception:
-            pass
-        try:
-            import httpx
-            monkeypatch.setattr(httpx, "get", lambda *a, **kw: types.SimpleNamespace(status_code=200))
-        except Exception:
-            pass
 
         out = _run_doctor(fix=False)
         assert "Command Installation" in out


### PR DESCRIPTION
## Summary\n- Use the real OS login home for ~/.local/bin/hermes checks\n- Keep Hermes profile home remapping for user data, not launcher lookup\n- Add regression coverage for profile-scoped Path.home()\n\n## Verification\n- python -m pytest tests/hermes_cli/test_doctor_command_install.py -q