### PR TITLE
fix(gateway): support Windows paths and more extensions in MEDIA: tag extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2158,8 +2158,9 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        # Supports Unix (/path, ~/path) and Windows (C:/path, D:\path) paths.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|md|html?|json|yaml|yml|xml)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -2223,9 +2224,9 @@ class BasePlatformAdapter(ABC):
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)
-        # (?:~/|/)    anchors to absolute or home-relative paths
+        # (?:~/|/|[A-Za-z]:[/\\]) anchors to absolute, home-relative, or Windows drive paths
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:~/|/|[A-Za-z]:[/\\])(?:[\w.\-]+[/\\])*[\w.\-]+\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -337,10 +337,10 @@ class TestEdgeCases:
         paths, _ = _extract("File at /tmp/my file.png here")
         assert paths == []
 
-    def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
+    def test_windows_path_matched(self):
+        """Windows-style paths should now match."""
         paths, _ = _extract("See C:\\Users\\test\\image.png")
-        assert paths == []
+        assert paths == ["C:\\Users\\test\\image.png"]
 
     def test_relative_path_not_matched(self):
         """Relative paths like ./image.png should not match."""


### PR DESCRIPTION
## Summary

On Windows, `MEDIA:D:/path/to/file.md` in agent responses was never captured by the media extraction regex, causing the gateway to send the raw path string as plain text instead of uploading the file as a native attachment via iLink CDN.

## Root Cause

Two regex patterns in `gateway/platforms/base.py` only matched Unix-style paths (`~/...` or `/...`):

1. `extract_media()` — parses explicit `MEDIA:<path>` tags
2. `extract_local_files()` — detects bare file paths in response text

Additionally, the `extract_media()` extension whitelist was missing common file types like `.md`, `.html`, `.json`, `.yaml`.

## Changes

- Add `[A-Za-z]:[/\]` prefix pattern to match Windows drive paths (e.g. `C:/`, `D:\`)
- Extend `extract_media()` extension whitelist with `md|html?|json|yaml|yml|xml`
- Update `extract_local_files()` path regex to support backslash path separators
- Update test expectation: Windows paths are now correctly matched

## Testing

```
tests/gateway/test_extract_local_files.py — 44 passed
tests/gateway/test_media_extraction.py — 4 passed
```

## Reproduction

1. Agent generates: `MEDIA:D:/ObsidianVault/project/report.md`
2. Before fix: Weixin sends the literal string as text message
3. After fix: Weixin uploads the file via CDN and delivers as document attachment