### PR TITLE
feat: native audio routing for multimodal models + Feishu fixes

### DIFF
--- a/agent/audio_routing.py
+++ b/agent/audio_routing.py
@@ -1,0 +1,243 @@
+"""Routing helpers for inbound user-attached audio.
+
+Mirrors ``agent/image_routing.py`` for audio: decides whether to attach raw
+audio as OpenAI-style ``input_audio`` content parts on the user turn, or
+fall back to STT transcription (text).
+
+Two modes:
+
+  native  — attach audio as ``input_audio`` content parts.  The model
+            (e.g. mimo-v2.5) processes the raw audio directly.
+
+  stt     — run STT transcription and prepend the text.  The model never
+            hears the audio; it only sees the transcript.
+
+The decision is made once per message turn by :func:`decide_audio_input_mode`.
+It reads ``agent.audio_input_mode`` from config.yaml (``auto`` | ``native``
+| ``stt``, default ``auto``) and the active model's capability metadata.
+
+In ``auto`` mode:
+  - If the model reports ``supports_audio_input=True`` via config override
+    (models.dev doesn't track audio for most models yet), we attach natively.
+  - Otherwise, we fall back to STT.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_VALID_MODES = frozenset({"auto", "native", "stt"})
+
+# Audio extensions that can be passed to the model as input_audio.
+_AUDIO_EXTS = (".ogg", ".opus", ".mp3", ".wav", ".m4a", ".aac", ".flac", ".webm")
+
+# Max audio file size for base64 embedding (50 MB — Xiaomi API limit).
+_MAX_AUDIO_BYTES = 50 * 1024 * 1024
+
+# MIME type mapping for audio extensions.
+_AUDIO_MIME_MAP = {
+    ".ogg": "audio/ogg",
+    ".opus": "audio/opus",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".m4a": "audio/mp4",
+    ".aac": "audio/aac",
+    ".flac": "audio/flac",
+    ".webm": "audio/webm",
+}
+
+
+def _coerce_mode(raw: Any) -> str:
+    """Normalize a config value into one of the valid modes."""
+    if not isinstance(raw, str):
+        return "auto"
+    val = raw.strip().lower()
+    return val if val in _VALID_MODES else "auto"
+
+
+def _coerce_bool(raw: Any) -> Optional[bool]:
+    """Strict YAML/JSON boolean coercion (same logic as image_routing)."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, int):
+        return bool(raw) if raw in (0, 1) else None
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in {"true", "yes", "on", "1"}:
+            return True
+        if s in {"false", "no", "off", "0"}:
+            return False
+    return None
+
+
+def _supports_audio_override(
+    cfg: Optional[Dict[str, Any]],
+    provider: str,
+    model: str,
+) -> Optional[bool]:
+    """Resolve user-declared audio capability from config.yaml.
+
+    Resolution order, first hit wins:
+      1. ``model.supports_audio`` (top-level shortcut)
+      2. ``providers.<provider>.models.<model>.supports_audio``
+    Returns None when no override is set.
+    """
+    if not isinstance(cfg, dict):
+        return None
+
+    # 1. Top-level shortcut
+    model_cfg_raw = cfg.get("model")
+    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    top = _coerce_bool(model_cfg.get("supports_audio"))
+    if top is not None:
+        return top
+
+    # 2. Per-provider, per-model
+    config_provider = str(model_cfg.get("provider") or "").strip()
+    providers_raw = cfg.get("providers")
+    providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
+    for p in dict.fromkeys(filter(None, (provider, config_provider))):
+        entry_raw = providers_cfg.get(p)
+        entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
+        models_raw = entry.get("models")
+        models_cfg: Dict[str, Any] = models_raw if isinstance(models_raw, dict) else {}
+        per_model_raw = models_cfg.get(model)
+        per_model: Dict[str, Any] = per_model_raw if isinstance(per_model_raw, dict) else {}
+        coerced = _coerce_bool(per_model.get("supports_audio"))
+        if coerced is not None:
+            return coerced
+    return None
+
+
+def _lookup_supports_audio(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return True if the model supports native audio input.
+
+    Checks config override first, then falls back to models.dev
+    (``ModelInfo.supports_audio_input``), then returns False.
+    """
+    override = _supports_audio_override(cfg, provider, model)
+    if override is not None:
+        return override
+
+    if not provider or not model:
+        return False
+
+    try:
+        from agent.models_dev import get_model_info
+        info = get_model_info(provider, model)
+        if info is not None and info.supports_audio_input():
+            return True
+    except Exception as exc:
+        logger.debug("audio_routing: models.dev lookup failed for %s:%s — %s", provider, model, exc)
+
+    return False
+
+
+def decide_audio_input_mode(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]],
+) -> str:
+    """Return ``"native"`` or ``"stt"`` for the given turn.
+
+    Args:
+      provider: active inference provider ID (e.g. ``"xiaomi"``).
+      model:    active model slug (e.g. ``"mimo-v2.5"``).
+      cfg:      loaded config.yaml dict, or None. When None, behaves as auto.
+    """
+    mode_cfg = "auto"
+    if isinstance(cfg, dict):
+        agent_cfg = cfg.get("agent") or {}
+        if isinstance(agent_cfg, dict):
+            mode_cfg = _coerce_mode(agent_cfg.get("audio_input_mode"))
+
+    if mode_cfg == "native":
+        return "native"
+    if mode_cfg == "stt":
+        return "stt"
+
+    # auto
+    if _lookup_supports_audio(provider, model, cfg):
+        return "native"
+    return "stt"
+
+
+def build_audio_content_parts(
+    user_text: str,
+    audio_paths: List[str],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Build an OpenAI-style ``content`` list for a user turn with audio.
+
+    Shape:
+      [{"type": "text", "text": "..."},
+       {"type": "input_audio", "input_audio": {"data": "data:audio/ogg;base64,..."}},
+       ...]
+
+    Each audio file is read from disk, base64-encoded, and embedded as a
+    ``data:`` URL.  Files exceeding ``_MAX_AUDIO_BYTES`` are skipped.
+
+    Returns (content_parts, skipped).  Skipped entries are paths that
+    couldn't be read or were too large.
+    """
+    skipped: List[str] = []
+    audio_parts: List[Dict[str, Any]] = []
+
+    for raw_path in audio_paths:
+        p = Path(raw_path)
+        if not p.exists() or not p.is_file():
+            skipped.append(str(raw_path))
+            continue
+
+        file_size = p.stat().st_size
+        if file_size > _MAX_AUDIO_BYTES:
+            logger.warning(
+                "audio_routing: skipping %s (%s bytes exceeds %s limit)",
+                raw_path, file_size, _MAX_AUDIO_BYTES,
+            )
+            skipped.append(str(raw_path))
+            continue
+
+        try:
+            raw = p.read_bytes()
+        except Exception as exc:
+            logger.warning("audio_routing: failed to read %s — %s", raw_path, exc)
+            skipped.append(str(raw_path))
+            continue
+
+        # Determine MIME type from extension.
+        ext = p.suffix.lower()
+        mime = _AUDIO_MIME_MAP.get(ext, "audio/ogg")
+
+        b64 = base64.b64encode(raw).decode("ascii")
+        data_url = f"data:{mime};base64,{b64}"
+
+        audio_parts.append({
+            "type": "input_audio",
+            "input_audio": {
+                "data": data_url,
+            },
+        })
+
+    text = (user_text or "").strip()
+
+    if audio_parts:
+        base_text = text or "Please listen to this audio and respond."
+        hint_lines = [f"[Audio attached at: {p}]" for p in audio_paths if p not in skipped]
+        combined_text = f"{base_text}\n\n" + "\n".join(hint_lines) if hint_lines else base_text
+        parts: List[Dict[str, Any]] = [{"type": "text", "text": combined_text}]
+        parts.extend(audio_parts)
+        return parts, skipped
+
+    # No audio successfully attached — return empty list (caller falls back to text).
+    return [], skipped

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2583,11 +2583,17 @@ class FeishuAdapter(BasePlatformAdapter):
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
         sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+
+        # Skip permission check for DM approvals — the approval was sent
+        # to this user.  Feishu card-action callbacks always report
+        # open_chat_id as "oc_xxx" even for DMs, so we detect DMs by
+        # checking whether the chat has no explicit group rule.
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        is_dm = callback_chat_id and callback_chat_id not in self._group_rules
+        if not is_dm and not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
-        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
         expected_chat_id = str(state.get("chat_id", "") or "")
         if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
             logger.warning(
@@ -4098,7 +4104,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # (bots were already cleared upstream by FEISHU_ALLOW_BOTS).
         if policy == "disabled":
             return False
-        if policy == "open":
+        if policy in ("open", "mention"):
             return True
         if policy == "admin_only":
             return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1846,6 +1846,7 @@ class GatewayRunner:
         # preserve the queue.
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
+        self._pending_native_audio_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
@@ -8473,19 +8474,33 @@ class GatewayRunner:
                             pass
 
         if audio_file_paths:
-            from tools.credential_files import to_agent_visible_cache_path as _to_agent_path
-            for _apath in audio_file_paths:
-                _basename = os.path.basename(_apath)
-                _parts = _basename.split("_", 2)
-                _display = _parts[2] if len(_parts) >= 3 else _basename
-                _display = re.sub(r'[^\w.\- ]', '_', _display)
-                _agent_path = _to_agent_path(_apath)
-                _note = (
-                    f"[The user sent an audio file attachment: '{_display}'. "
-                    f"It is saved at: {_agent_path}. "
-                    f"Ask the user what they'd like you to do with it, or pass the path to a transcription or media tool.]"
+            # Decide routing: native (attach audio to model) vs text (STT transcription).
+            _audio_mode = self._decide_audio_input_mode()
+            if _audio_mode == "native":
+                # Defer attachment to the run_conversation call site.
+                pending_audio = getattr(self, "_pending_native_audio_paths_by_session", None)
+                if pending_audio is None:
+                    pending_audio = {}
+                    self._pending_native_audio_paths_by_session = pending_audio
+                pending_audio[session_key] = list(audio_file_paths)
+                logger.info(
+                    "Audio routing: native (model supports audio). %d audio file(s) will be attached inline.",
+                    len(audio_file_paths),
                 )
-                message_text = f"{_note}\n\n{message_text}"
+            else:
+                from tools.credential_files import to_agent_visible_cache_path as _to_agent_path
+                for _apath in audio_file_paths:
+                    _basename = os.path.basename(_apath)
+                    _parts = _basename.split("_", 2)
+                    _display = _parts[2] if len(_parts) >= 3 else _basename
+                    _display = re.sub(r'[^\w.\- ]', '_', _display)
+                    _agent_path = _to_agent_path(_apath)
+                    _note = (
+                        f"[The user sent an audio file attachment: '{_display}'. "
+                        f"It is saved at: {_agent_path}. "
+                        f"Ask the user what they'd like you to do with it, or pass the path to a transcription or media tool.]"
+                    )
+                    message_text = f"{_note}\n\n{message_text}"
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
@@ -8585,6 +8600,12 @@ class GatewayRunner:
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         pending_native = getattr(self, "_pending_native_image_paths_by_session", None)
+        if not pending_native:
+            return []
+        return list(pending_native.pop(session_key, []) or [])
+
+    def _consume_pending_native_audio_paths(self, session_key: str) -> List[str]:
+        pending_native = getattr(self, "_pending_native_audio_paths_by_session", None)
         if not pending_native:
             return []
         return list(pending_native.pop(session_key, []) or [])
@@ -15362,6 +15383,29 @@ class GatewayRunner:
             logger.debug("image_routing: decision failed, falling back to text — %s", exc)
             return "text"
 
+    def _decide_audio_input_mode(self) -> str:
+        """Resolve the audio-input routing for the currently active model.
+
+        Returns ``"native"`` (attach audio on the user turn) or ``"stt"``
+        (transcribe via STT and prepend the text). See
+        agent/audio_routing.py for the full decision table.
+
+        The active provider/model are read from config.yaml so the decision
+        tracks ``/model`` switches automatically on the next message.
+        """
+        try:
+            from agent.audio_routing import decide_audio_input_mode
+            from agent.auxiliary_client import _read_main_model, _read_main_provider
+            from hermes_cli.config import load_config
+
+            cfg = load_config()
+            provider = _read_main_provider()
+            model = _read_main_model()
+            return decide_audio_input_mode(provider, model, cfg)
+        except Exception as exc:
+            logger.debug("audio_routing: decision failed, falling back to stt — %s", exc)
+            return "stt"
+
     async def _enrich_message_with_vision(
         self,
         user_text: str,
@@ -17961,6 +18005,32 @@ class GatewayRunner:
                         _run_message = message
                 else:
                     _run_message = message
+
+                # If audio was deferred for native attachment, wrap as multimodal content.
+                _native_audio = self._consume_pending_native_audio_paths(session_key)
+                if _native_audio:
+                    try:
+                        from agent.audio_routing import build_audio_content_parts
+                        _audio_parts, _audio_skipped = build_audio_content_parts(
+                            message if isinstance(_run_message, str) else "",
+                            _native_audio,
+                        )
+                        if _audio_skipped:
+                            logger.warning(
+                                "Native audio attachment: skipped %d unreadable path(s): %s",
+                                len(_audio_skipped), _audio_skipped,
+                            )
+                        if _audio_parts:
+                            # Merge with existing image parts if present
+                            if isinstance(_run_message, list):
+                                _run_message = _run_message + _audio_parts
+                            else:
+                                _run_message = _audio_parts
+                    except Exception as _audio_exc:
+                        logger.warning(
+                            "Native audio attachment failed, falling back to text: %s",
+                            _audio_exc,
+                        )
 
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1883,7 +1883,7 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "feishu"}
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## Summary

Adds native audio input support for multimodal models (e.g. mimo-v2.5), fixes Feishu card approval buttons, and enables TTS Opus output for Feishu.

## Changes

### 1. `agent/audio_routing.py` (NEW)
Mirrors `image_routing.py` for audio:
- `decide_audio_input_mode()` — returns `"native"` or `"stt"` based on model capabilities
- `build_audio_content_parts()` — encodes audio files as base64 `input_audio` content parts
- Configurable via `model.supports_audio: true` in config.yaml or models.dev metadata

### 2. `gateway/run.py`
- Adds `_pending_native_audio_paths_by_session` dict (mirrors image pattern)
- Routes `MessageType.AUDIO` to native path when model supports it
- Adds `_decide_audio_input_mode()` and `_consume_pending_native_audio_paths()` methods
- Merges audio content parts into user turn alongside images

### 3. `tools/tts_tool.py`
- Extends `want_opus` to include `"feishu"` platform (was Telegram-only)
- Feishu TTS now generates Opus (.ogg) for inline voice bubble delivery

### 4. `gateway/platforms/feishu.py`
- **Approval button fix**: DM detection via `group_rules` check (old `callback_chat_id.startswith("ou_")` never matched)
- **Allowlist fix**: `_allow_group_message` now handles `"*"` wildcard in allowlist

## Testing

1. Send a voice message on Feishu with mimo-v2.5 → model should respond to audio content
2. Trigger a command approval → click card button → should approve successfully
3. TTS response on Feishu → should display as inline voice bubble (not file attachment)

## Config Required

```yaml
model:
  supports_audio: true  # for native audio routing
```