### PR TITLE
fix(memory): keep Honcho turn-one recall non-blocking

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -575,51 +575,35 @@ class HonchoMemoryProvider(MemoryProvider):
         parts = []
 
         # ----- Layer 1: Base context (representation + card) -----
-        # On first call, fetch synchronously so turn 1 isn't empty.
-        # After that, serve from cache and refresh in background on cadence.
-        with self._base_context_lock:
-            if self._base_context_cache is None:
-                # First call — synchronous fetch
-                try:
-                    ctx = self._manager.get_prefetch_context(self._session_key)
-                    self._base_context_cache = self._format_first_turn_context(ctx) if ctx else ""
-                    self._last_context_turn = self._turn_count
-                except Exception as e:
-                    logger.debug("Honcho base context fetch failed: %s", e)
-                    self._base_context_cache = ""
-            base_context = self._base_context_cache
-
-        # Check if background context prefetch has a fresher result
+        # Consume only background-prefetched context here. A cold-cache turn
+        # returns empty rather than paying a synchronous Honcho round-trip on
+        # the gateway message path.
+        fresh_ctx = {}
         if self._manager:
             fresh_ctx = self._manager.pop_context_result(self._session_key)
+
+        with self._base_context_lock:
             if fresh_ctx:
-                formatted = self._format_first_turn_context(fresh_ctx)
-                if formatted:
-                    with self._base_context_lock:
-                        self._base_context_cache = formatted
-                    base_context = formatted
+                self._base_context_cache = self._format_first_turn_context(fresh_ctx)
+            elif self._base_context_cache is None:
+                self._base_context_cache = ""
+            base_context = self._base_context_cache
 
         if base_context:
             parts.append(base_context)
 
         # ----- Layer 2: Dialectic supplement -----
         # On the very first turn, no queue_prefetch() has run yet so the
-        # dialectic result is empty.  Run with a bounded timeout so a slow
-        # Honcho connection doesn't block the first response indefinitely.
-        # On timeout we let the thread keep running and write its result into
-        # _prefetch_result under the lock, so the next turn picks it up.
-        #
-        # Skip if the session-start prewarm already filled _prefetch_result —
-        # firing another .chat() would be duplicate work.
+        # dialectic result may still be empty. If the session-start prewarm
+        # has not landed yet, fire the dialectic in background and surface it
+        # on a later turn instead of synchronously waiting on the gateway
+        # message-processing path.
         with self._prefetch_lock:
             _prewarm_landed = bool(self._prefetch_result)
         if _prewarm_landed and self._last_dialectic_turn == -999:
             self._last_dialectic_turn = self._turn_count
 
-        if self._last_dialectic_turn == -999 and query:
-            _first_turn_timeout = (
-                self._config.timeout if self._config and self._config.timeout else 8.0
-            )
+        if self._last_dialectic_turn == -999 and query and not self._thread_is_live():
             _fired_at = self._turn_count
 
             def _run_first_turn() -> None:
@@ -645,16 +629,6 @@ class HonchoMemoryProvider(MemoryProvider):
                 target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
             )
             self._prefetch_thread.start()
-            self._prefetch_thread.join(timeout=_first_turn_timeout)
-            if self._prefetch_thread.is_alive():
-                logger.debug(
-                    "Honcho first-turn dialectic still running after %.1fs — "
-                    "will surface on next turn",
-                    _first_turn_timeout,
-                )
-
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             dialectic_result = self._prefetch_result
             fired_at = self._prefetch_result_fired_at

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1344,24 +1344,60 @@ class TestSessionStartDialecticPrewarm:
         # The sync first-turn path must NOT have fired another .chat()
         assert p._manager.dialectic_query.call_count == 0
 
-    def test_turn1_falls_back_to_sync_when_prewarm_missing(self):
-        """If the prewarm produced nothing (empty graph, API blip), turn 1
-        still fires its own sync dialectic."""
-        p = self._make_provider(dialectic_result="")  # prewarm returns empty
+    def test_turn1_stays_nonblocking_when_prewarm_missing(self):
+        """If the prewarm produced nothing, turn 1 should stay non-blocking
+        and let the recovery dialectic finish in background."""
+        import threading as _threading
+        import time as _time
+
+        p = self._make_provider(cfg_extra={"timeout": 0.05}, dialectic_result="")
         if p._prefetch_thread:
             p._prefetch_thread.join(timeout=3.0)
         with p._prefetch_lock:
             assert p._prefetch_result == ""  # prewarm landed nothing
-        # Switch dialectic_query to return something on the sync first-turn call
-        p._manager.dialectic_query.return_value = "sync recovery"
         p._manager.dialectic_query.reset_mock()
+        started = _threading.Event()
+        release = _threading.Event()
+
+        def _late_recovery(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=10.0)
+            return "async recovery"
+
+        p._manager.dialectic_query.side_effect = _late_recovery
         p._session_key = "test-prewarm"
         p._base_context_cache = ""
         p._turn_count = 1
 
+        started_at = _time.perf_counter()
         result = p.prefetch("hello world")
-        assert "sync recovery" in result
+        elapsed = _time.perf_counter() - started_at
+
+        assert result == ""
+        assert elapsed < 0.5, "turn 1 must not wait on a slow Honcho dialectic"
+        assert started.wait(timeout=1.0), "background dialectic should still fire"
         assert p._manager.dialectic_query.call_count == 1
+        assert p._prefetch_thread and p._prefetch_thread.is_alive()
+        release.set()
+        p._prefetch_thread.join(timeout=2.0)
+
+    def test_turn1_does_not_fetch_base_context_synchronously(self):
+        """A cold cache with no ready background context should return empty
+        instead of calling get_prefetch_context() inline."""
+        p = self._make_provider(dialectic_result="prewarm synthesis")
+        _settle_prewarm(p)
+        p._manager.get_prefetch_context.reset_mock()
+        p._manager.pop_context_result.return_value = {}
+        p._session_key = "test-prewarm"
+        p._base_context_cache = None
+        p._turn_count = 1
+        p._last_dialectic_turn = 0
+
+        result = p.prefetch("hello world")
+
+        assert result == ""
+        assert p._manager.get_prefetch_context.call_count == 0
+        assert p._base_context_cache == ""
 
 
 class TestDialecticLiveness:


### PR DESCRIPTION
Fixes #36858

## Summary
- stop Honcho first-turn memory injection from synchronously fetching cold base context
- let missing first-turn dialectic recovery continue in the background instead of waiting on the gateway message path
- add regressions that cover prewarm consumption, non-blocking recovery, and cold-cache context behavior

## Proof
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-35070-version-consistency-doctor/.venv/bin/python -m pytest -q tests/honcho_plugin/test_session.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-35070-version-consistency-doctor/.venv/bin/python -m pytest -q tests/test_honcho_session_context.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-35070-version-consistency-doctor/.venv/bin/python -m ruff check plugins/memory/honcho/__init__.py tests/honcho_plugin/test_session.py`
- `git diff --check`

## Attribution
- Local proof is green for `24dd1bdaf69496040215cbc0f1c3b48c5ce0cb05`.
- Recent company PRs do not show a stable shared-red baseline for this surface, so no preexisting CI failure is being claimed here.