### PR TITLE
fix(agent): use max_completion_tokens for MiniMax

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1199,10 +1199,17 @@ class AIAgent:
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
         'max_completion_tokens'. Azure OpenAI also requires
         'max_completion_tokens' for gpt-5.x models served via the
-        OpenAI-compatible endpoint. OpenRouter, local models, and older
+        OpenAI-compatible endpoint. MiniMax's OpenAI-compatible models
+        also reject the legacy key. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
         """
-        if self._is_direct_openai_url() or self._is_azure_openai_url() or self._is_github_copilot_url():
+        model_lower = (self.model or "").lower()
+        if (
+            self._is_direct_openai_url()
+            or self._is_azure_openai_url()
+            or self._is_github_copilot_url()
+            or model_lower.startswith("minimax")
+        ):
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4578,6 +4578,20 @@ class TestMaxTokensParam:
         result = agent._max_tokens_param(4096)
         assert result == {"max_completion_tokens": 4096}
 
+    def test_returns_max_completion_tokens_for_minimax_models(self, agent):
+        """MiniMax chat-completions models reject the legacy max_tokens key."""
+        agent.base_url = "https://router.example.com/v1"
+        agent.model = "MiniMax-M3"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_completion_tokens": 4096}
+
+    def test_returns_max_completion_tokens_for_minimax_models_case_insensitive(self, agent):
+        """Model-family detection should work even when the configured name is lowercase."""
+        agent.base_url = "https://router.example.com/v1"
+        agent.model = "minimax-m2.7"
+        result = agent._max_tokens_param(4096)
+        assert result == {"max_completion_tokens": 4096}
+
 
 class TestGpt5ApiModeRouting:
     """Verify provider-specific GPT-5 API-mode routing."""


### PR DESCRIPTION
## Summary
- send `max_completion_tokens` for MiniMax chat-completions models even behind custom OpenAI-compatible routers
- keep existing `max_tokens` behavior for other non-OpenAI providers
- add focused `_max_tokens_param` regression coverage for MiniMax model names

## Testing
- python -m pytest -q tests/run_agent/test_run_agent.py -k TestMaxTokensParam
- ruff check run_agent.py tests/run_agent/test_run_agent.py
- git diff --check
- python -m py_compile run_agent.py tests/run_agent/test_run_agent.py

Fixes #37151