### PR TITLE
fix(vision): add opencode-go to media tool-result whitelist

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -56,6 +56,12 @@ class TestSupportsMediaInToolResults:
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False
 
+    def test_opencode_go_yes(self):
+        assert _supports_media_in_tool_results("opencode-go", "minimax-m3") is True
+
+    def test_opencode_go_glm_yes(self):
+        assert _supports_media_in_tool_results("opencode-go", "glm-5.1") is True
+
     def test_empty_provider_no(self):
         assert _supports_media_in_tool_results("", "anything") is False
         assert _supports_media_in_tool_results(None, "anything") is False  # type: ignore[arg-type]

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -468,6 +468,9 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
       * Anthropic Messages API (``anthropic`` provider, plus aggregators that
         proxy Claude — ``openrouter``, ``nous``, ``vertex``, ``bedrock``):
         ``tool_result`` blocks accept ``image`` content blocks.
+      * OpenCode Go (``opencode-go``): routes MiniMax models via
+        ``anthropic_messages`` api_mode; GLM/Kimi via ``chat_completions``.
+        Both wire shapes support image content inside tool-result messages.
       * OpenAI Chat Completions: tool messages accept array content with
         ``image_url`` parts.
       * OpenAI Responses (``openai-codex``): ``function_call_output.output``
@@ -495,8 +498,9 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in _AGGREGATORS:
         return True
 
-    # Native Anthropic
-    if p in {"anthropic", "claude", "anthropic-direct"}:
+    # Native Anthropic (and OpenCode Go which routes MiniMax via
+    # anthropic_messages api_mode — supports multimodal tool results)
+    if p in {"anthropic", "claude", "anthropic-direct", "opencode-go"}:
         return True
 
     # OpenAI Chat Completions and Responses


### PR DESCRIPTION
## Summary

Adds `"opencode-go"` to the `_supports_media_in_tool_results()` whitelist so OpenCode Go users with vision-capable models (e.g. minimax-m3) benefit from the native vision fast path instead of falling through to auxiliary vision text.

## Root Cause

In `tools/vision_tools.py`, function `_supports_media_in_tool_results()` has a hardcoded set of providers that support image content inside tool-result messages. `opencode-go` was missing from the whitelist.

OpenCode Go routes models via two API modes:
- **MiniMax models** → `anthropic_messages` api_mode (supports multimodal tool results)
- **GLM / Kimi models** → `chat_completions` api_mode (also supports multimodal tool results — OpenAI-compatible `image_url` content in tool messages)

Both wire shapes accept image content inside tool-result messages, so `opencode-go` should be allowlisted.

## Impact

Without this fix, `_handle_vision_analyze()` and `computer_use` capture routing skip the native fast path and route through auxiliary vision, which:
1. Adds an unnecessary extra LLM call
2. Loses pixel fidelity (main model sees text description, not actual pixels)
3. Increases latency and cost

## Empirical Verification

Tested directly against the OpenCode Go endpoint with a tool-result message containing `image_url` content:

```python
# tool role message with image_url content → HTTP 200, model correctly processed the image
{"role": "tool", "tool_call_id": "call_test123",
 "content": [
   {"type": "text", "text": "Screenshot captured:"},
   {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
 ]}
```

Response: `HTTP 200` with MiniMax-M3 correctly describing the image content.

## Tests

2 new test cases added to `test_vision_native_fast_path.py`:
- `test_opencode_go_yes` — `_supports_media_in_tool_results("opencode-go", "minimax-m3")` → `True`
- `test_opencode_go_glm_yes` — `_supports_media_in_tool_results("opencode-go", "glm-5.1")` → `True`

All 22 existing tests pass + 2 new = 24 passed, 1 skipped.

## Related

- PR #25932 adds MiniMax native providers (`minimax`, `minimax-cn`, `minimax-oauth`) to the same whitelist. This PR is complementary — it covers the `opencode-go` aggregation layer that routes to MiniMax via `anthropic_messages` api_mode.
