### PR TITLE
[verified] feat(browser): add AgentCookie profile support

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -945,6 +945,14 @@ DEFAULT_CONFIG = {
         "engine": "auto",
         "auto_local_for_private_urls": True,  # When a cloud provider is set, auto-spawn local Chromium for LAN/localhost URLs instead of sending them to the cloud
         "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
+        # AgentCookie profile reuse for local agent-browser Chromium sessions.
+        # When enabled, Hermes passes --profile <profile_dir> and exports
+        # AGENTCOOKIE_PLAIN_COOKIES to the spawned browser process.
+        "agentcookie": {
+            "enabled": False,
+            "profile_dir": "~/.agentcookie/chrome-profile",
+            "plain_cookies_db": "~/.agentcookie/cookies-plain.db",
+        },
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.
         # Active only when a CDP-capable backend is attached (Browserbase or
         # local Chrome via /browser connect). See

--- a/tests/tools/test_browser_agentcookie.py
+++ b/tests/tools/test_browser_agentcookie.py
@@ -1,0 +1,283 @@
+"""Tests for AgentCookie integration in browser_tool.py."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_AGENTCOOKIE_ENV_VARS = (
+    "HERMES_AGENTCOOKIE_ENABLED",
+    "AGENTCOOKIE_ENABLED",
+    "HERMES_AGENTCOOKIE_PROFILE_DIR",
+    "AGENTCOOKIE_PROFILE_DIR",
+    "HERMES_AGENTCOOKIE_PLAIN_COOKIES",
+    "AGENTCOOKIE_PLAIN_COOKIES",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agentcookie_cache(monkeypatch):
+    import tools.browser_tool as bt
+
+    for name in _AGENTCOOKIE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    if hasattr(bt, "_cached_agentcookie_config"):
+        bt._cached_agentcookie_config = None
+    if hasattr(bt, "_agentcookie_config_resolved"):
+        bt._agentcookie_config_resolved = False
+    yield
+    if hasattr(bt, "_cached_agentcookie_config"):
+        bt._cached_agentcookie_config = None
+    if hasattr(bt, "_agentcookie_config_resolved"):
+        bt._agentcookie_config_resolved = False
+
+
+def test_agentcookie_config_defaults_disabled():
+    import tools.browser_tool as bt
+
+    with patch("hermes_cli.config.read_raw_config", return_value={}):
+        cfg = bt._get_agentcookie_config()
+
+    assert cfg["enabled"] is False
+    assert cfg["profile_dir"] == os.path.expanduser("~/.agentcookie/chrome-profile")
+    assert cfg["plain_cookies_db"] == os.path.expanduser("~/.agentcookie/cookies-plain.db")
+
+
+def test_agentcookie_config_reads_browser_agentcookie_block(tmp_path):
+    import tools.browser_tool as bt
+
+    profile = tmp_path / "agc-profile"
+    sidecar = tmp_path / "cookies-plain.db"
+    raw_cfg = {
+        "browser": {
+            "agentcookie": {
+                "enabled": True,
+                "profile_dir": str(profile),
+                "plain_cookies_db": str(sidecar),
+            }
+        }
+    }
+
+    with patch("hermes_cli.config.read_raw_config", return_value=raw_cfg):
+        cfg = bt._get_agentcookie_config()
+
+    assert cfg == {
+        "enabled": True,
+        "profile_dir": str(profile),
+        "plain_cookies_db": str(sidecar),
+    }
+
+
+def test_agentcookie_env_overrides_config(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+
+    profile = tmp_path / "env-profile"
+    sidecar = tmp_path / "env-cookies.db"
+    monkeypatch.setenv("HERMES_AGENTCOOKIE_ENABLED", "1")
+    monkeypatch.setenv("HERMES_AGENTCOOKIE_PROFILE_DIR", str(profile))
+    monkeypatch.setenv("AGENTCOOKIE_PLAIN_COOKIES", str(sidecar))
+
+    with patch("hermes_cli.config.read_raw_config", return_value={"browser": {"agentcookie": {"enabled": False}}}):
+        cfg = bt._get_agentcookie_config()
+
+    assert cfg == {
+        "enabled": True,
+        "profile_dir": str(profile),
+        "plain_cookies_db": str(sidecar),
+    }
+
+
+def test_local_browser_command_uses_agentcookie_profile_and_sidecar_env(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+
+    profile = tmp_path / "chrome-profile"
+    sidecar = tmp_path / "cookies-plain.db"
+    captured = {}
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, cmd, stdout, stderr, stdin=None, env=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = env or {}
+            os.write(stdout, json.dumps({"success": True, "data": {"ok": True}}).encode())
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/usr/local/bin/agent-browser")
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: True)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(bt, "_get_session_info", lambda task_id: {"session_name": "h_agentcookie"})
+    monkeypatch.setattr(
+        bt,
+        "_get_agentcookie_config",
+        lambda: {"enabled": True, "profile_dir": str(profile), "plain_cookies_db": str(sidecar)},
+    )
+    monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
+
+    with patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)):
+        result = bt._run_browser_command("task", "snapshot", [])
+
+    assert result["success"] is True
+    cmd = captured["cmd"]
+    assert cmd[:4] == ["/usr/local/bin/agent-browser", "--profile", str(profile), "--session"]
+    assert "h_agentcookie" in cmd
+    assert captured["env"]["AGENTCOOKIE_PLAIN_COOKIES"] == str(sidecar)
+
+
+def test_agentcookie_profile_not_added_for_cdp_sessions(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+
+    captured = {}
+    monkeypatch.setenv("AGENTCOOKIE_PLAIN_COOKIES", str(tmp_path / "inherited-cookies.db"))
+    monkeypatch.setenv("HERMES_AGENTCOOKIE_PROFILE_DIR", str(tmp_path / "inherited-profile"))
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, cmd, stdout, stderr, stdin=None, env=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = env or {}
+            os.write(stdout, json.dumps({"success": True, "data": {"ok": True}}).encode())
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/usr/local/bin/agent-browser")
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(
+        bt,
+        "_get_session_info",
+        lambda task_id: {"session_name": "cdp_agentcookie", "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x"},
+    )
+    monkeypatch.setattr(
+        bt,
+        "_get_agentcookie_config",
+        lambda: {"enabled": True, "profile_dir": str(tmp_path / "profile"), "plain_cookies_db": str(tmp_path / "cookies.db")},
+    )
+    monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
+
+    with patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)):
+        result = bt._run_browser_command("task", "snapshot", [])
+
+    assert result["success"] is True
+    assert "--profile" not in captured["cmd"]
+    assert captured["cmd"][1:3] == ["--cdp", "ws://127.0.0.1:9222/devtools/browser/x"]
+    assert "AGENTCOOKIE_PLAIN_COOKIES" not in captured["env"]
+    assert "HERMES_AGENTCOOKIE_PROFILE_DIR" not in captured["env"]
+
+
+def test_agentcookie_not_added_for_lightpanda_sessions(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+
+    captured = {}
+    monkeypatch.setenv("AGENTCOOKIE_PLAIN_COOKIES", str(tmp_path / "inherited-cookies.db"))
+    monkeypatch.setenv("HERMES_AGENTCOOKIE_PROFILE_DIR", str(tmp_path / "inherited-profile"))
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, cmd, stdout, stderr, stdin=None, env=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = env or {}
+            os.write(
+                stdout,
+                json.dumps({"success": True, "data": {"snapshot": "lightpanda content long enough", "refs": []}}).encode(),
+            )
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/usr/local/bin/agent-browser")
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: True)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "lightpanda")
+    monkeypatch.setattr(bt, "_get_session_info", lambda task_id: {"session_name": "lp_agentcookie"})
+    monkeypatch.setattr(
+        bt,
+        "_get_agentcookie_config",
+        lambda: {"enabled": True, "profile_dir": str(tmp_path / "profile"), "plain_cookies_db": str(tmp_path / "cookies.db")},
+    )
+    monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
+
+    with patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)):
+        result = bt._run_browser_command("task", "snapshot", [])
+
+    assert result["success"] is True
+    assert "--profile" not in captured["cmd"]
+    engine_pairs = [captured["cmd"][i : i + 2] for i in range(len(captured["cmd"]) - 1)]
+    assert ["--engine", "lightpanda"] in engine_pairs
+    assert "AGENTCOOKIE_PLAIN_COOKIES" not in captured["env"]
+    assert "HERMES_AGENTCOOKIE_PROFILE_DIR" not in captured["env"]
+
+
+def test_chrome_fallback_uses_agentcookie_profile_and_sidecar_env(tmp_path, monkeypatch):
+    import tools.browser_tool as bt
+
+    profile = tmp_path / "fallback-profile"
+    sidecar = tmp_path / "fallback-cookies.db"
+    captured = {"cmds": [], "envs": []}
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, cmd, stdout, stderr, stdin=None, env=None, **kwargs):
+            captured["cmds"].append(cmd)
+            captured["envs"].append(env or {})
+            command = cmd[-2] if cmd[-1] == "https://example.test/page" else cmd[-1]
+            payload = {"success": True, "data": {"command": command}}
+            os.write(stdout, json.dumps(payload).encode())
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        bt,
+        "_run_browser_command",
+        lambda *args, **kwargs: {"success": True, "data": {"result": "https://example.test/page"}},
+    )
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/usr/local/bin/agent-browser")
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(
+        bt,
+        "_get_agentcookie_config",
+        lambda: {"enabled": True, "profile_dir": str(profile), "plain_cookies_db": str(sidecar)},
+    )
+    monkeypatch.setattr(bt.subprocess, "Popen", FakePopen)
+
+    with patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)):
+        result = bt._run_chrome_fallback_command("task", "snapshot", [], 10)
+
+    assert result["success"] is True
+    assert [cmd[-1] for cmd in captured["cmds"]] == ["https://example.test/page", "snapshot", "close"]
+    for cmd in captured["cmds"]:
+        assert cmd[:4] == ["/usr/local/bin/agent-browser", "--profile", str(profile), "--engine"]
+        assert "chrome" in cmd
+    for env in captured["envs"]:
+        assert env["AGENTCOOKIE_PLAIN_COOKIES"] == str(sidecar)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -435,6 +435,15 @@ _cached_allow_private_urls: Optional[bool] = None
 _cached_agent_browser: Optional[str] = None
 _agent_browser_resolved = False
 
+# AgentCookie support. AgentCookie exposes a Chrome profile directory plus an
+# optional plaintext cookie sidecar DB. Hermes passes the profile to
+# agent-browser's persistent-profile flag for local Chromium sessions and makes
+# the sidecar path available to the spawned browser process via env.
+_DEFAULT_AGENTCOOKIE_PROFILE_DIR = "~/.agentcookie/chrome-profile"
+_DEFAULT_AGENTCOOKIE_PLAIN_COOKIES = "~/.agentcookie/cookies-plain.db"
+_cached_agentcookie_config: Optional[Dict[str, Any]] = None
+_agentcookie_config_resolved = False
+
 # Lightpanda engine support — cached like _get_cloud_provider().
 # agent-browser v0.25.3+ supports ``--engine lightpanda`` natively.
 _cached_browser_engine: Optional[str] = None
@@ -681,6 +690,154 @@ def _get_browser_engine() -> str:
     return _cached_browser_engine
 
 
+def _expand_agentcookie_path(value: Any, default: str) -> str:
+    """Normalize AgentCookie path-like config values."""
+    text = str(value or default).strip() or default
+    return os.path.expandvars(os.path.expanduser(text))
+
+
+def _get_agentcookie_config() -> Dict[str, Any]:
+    """Return AgentCookie integration settings.
+
+    Config path:
+
+    ``browser.agentcookie.enabled``
+        Enables the integration. Disabled by default so browser auth behavior
+        does not change for existing installs.
+
+    ``browser.agentcookie.profile_dir``
+        Persistent Chrome profile directory passed to agent-browser via
+        ``--profile`` for local Chromium sessions.
+
+    ``browser.agentcookie.plain_cookies_db``
+        Plain-cookie sidecar DB path exported as ``AGENTCOOKIE_PLAIN_COOKIES``
+        for the spawned agent-browser/Chrome process.
+
+    Env overrides:
+    ``HERMES_AGENTCOOKIE_ENABLED``/``AGENTCOOKIE_ENABLED``,
+    ``HERMES_AGENTCOOKIE_PROFILE_DIR``/``AGENTCOOKIE_PROFILE_DIR``, and
+    ``HERMES_AGENTCOOKIE_PLAIN_COOKIES``/``AGENTCOOKIE_PLAIN_COOKIES``.
+    """
+    global _cached_agentcookie_config, _agentcookie_config_resolved
+    if _agentcookie_config_resolved and _cached_agentcookie_config is not None:
+        return dict(_cached_agentcookie_config)
+
+    enabled = False
+    profile_dir: Any = _DEFAULT_AGENTCOOKIE_PROFILE_DIR
+    plain_cookies_db: Any = _DEFAULT_AGENTCOOKIE_PLAIN_COOKIES
+
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        agentcookie_cfg = {}
+        if isinstance(browser_cfg, dict):
+            agentcookie_cfg = browser_cfg.get("agentcookie", {})
+
+        if isinstance(agentcookie_cfg, dict):
+            if "enabled" in agentcookie_cfg:
+                enabled = is_truthy_value(agentcookie_cfg.get("enabled"))
+            profile_dir = agentcookie_cfg.get("profile_dir", profile_dir)
+            plain_cookies_db = agentcookie_cfg.get(
+                "plain_cookies_db",
+                agentcookie_cfg.get("plain_cookies", plain_cookies_db),
+            )
+        elif agentcookie_cfg:
+            enabled = is_truthy_value(agentcookie_cfg)
+    except Exception as e:
+        logger.debug("Could not read browser.agentcookie from config: %s", e)
+
+    enabled_env = (
+        os.environ.get("HERMES_AGENTCOOKIE_ENABLED")
+        or os.environ.get("AGENTCOOKIE_ENABLED")
+    )
+    if enabled_env is not None and str(enabled_env).strip() != "":
+        enabled = is_truthy_value(enabled_env)
+
+    profile_env = (
+        os.environ.get("HERMES_AGENTCOOKIE_PROFILE_DIR")
+        or os.environ.get("AGENTCOOKIE_PROFILE_DIR")
+    )
+    if profile_env:
+        profile_dir = profile_env
+
+    plain_env = (
+        os.environ.get("HERMES_AGENTCOOKIE_PLAIN_COOKIES")
+        or os.environ.get("AGENTCOOKIE_PLAIN_COOKIES")
+    )
+    if plain_env:
+        plain_cookies_db = plain_env
+
+    _cached_agentcookie_config = {
+        "enabled": enabled,
+        "profile_dir": _expand_agentcookie_path(
+            profile_dir,
+            _DEFAULT_AGENTCOOKIE_PROFILE_DIR,
+        ),
+        "plain_cookies_db": _expand_agentcookie_path(
+            plain_cookies_db,
+            _DEFAULT_AGENTCOOKIE_PLAIN_COOKIES,
+        ),
+    }
+    _agentcookie_config_resolved = True
+    return dict(_cached_agentcookie_config)
+
+
+def _agentcookie_applies_to_backend(session_info: Dict[str, Any], engine: str) -> bool:
+    """Return True for local Chrome/Chromium launches that can use AgentCookie."""
+    if session_info.get("cdp_url"):
+        # CDP/cloud sessions are already attached to an existing browser; do
+        # not pass local profile or plaintext-cookie sidecar state into them.
+        return False
+    if _is_camofox_mode():
+        # Camofox manages its own browser profile/session isolation.
+        return False
+    return (engine or "auto").strip().lower() != "lightpanda"
+
+
+def _apply_agentcookie_env(
+    browser_env: Dict[str, str],
+    session_info: Dict[str, Any],
+    engine: str,
+) -> None:
+    """Inject AgentCookie sidecar env for local Chrome/Chromium subprocesses."""
+    # Start from a clean child env. The parent may use these vars to configure
+    # Hermes, but agent-browser should only see cookie sidecar state when this
+    # specific backend is allowed to use it.
+    for name in (
+        "HERMES_AGENTCOOKIE_ENABLED",
+        "AGENTCOOKIE_ENABLED",
+        "HERMES_AGENTCOOKIE_PROFILE_DIR",
+        "AGENTCOOKIE_PROFILE_DIR",
+        "HERMES_AGENTCOOKIE_PLAIN_COOKIES",
+        "AGENTCOOKIE_PLAIN_COOKIES",
+    ):
+        browser_env.pop(name, None)
+
+    if not _agentcookie_applies_to_backend(session_info, engine):
+        return
+    cfg = _get_agentcookie_config()
+    if not cfg.get("enabled"):
+        return
+    plain_cookies_db = str(cfg.get("plain_cookies_db") or "").strip()
+    if plain_cookies_db:
+        browser_env["AGENTCOOKIE_PLAIN_COOKIES"] = plain_cookies_db
+
+
+def _agentcookie_backend_args(session_info: Dict[str, Any], engine: str) -> List[str]:
+    """Return args needed for AgentCookie local Chrome profile reuse."""
+    if not _agentcookie_applies_to_backend(session_info, engine):
+        return []
+    cfg = _get_agentcookie_config()
+    if not cfg.get("enabled"):
+        return []
+    profile_dir = str(cfg.get("profile_dir") or "").strip()
+    if not profile_dir:
+        return []
+    return ["--profile", profile_dir]
+
+
 def _should_inject_engine(engine: str) -> bool:
     """Return True when the engine flag should be added to agent-browser commands.
 
@@ -853,12 +1010,18 @@ def _run_chrome_fallback_command(
         cmd_prefix = [_npx_bin, "agent-browser"]
     else:
         cmd_prefix = [browser_cmd]
-    base_args = cmd_prefix + ["--engine", "chrome", "--session", tmp_session, "--json"]
+    tmp_session_info = {"session_name": tmp_session}
+    base_args = (
+        cmd_prefix
+        + _agentcookie_backend_args(tmp_session_info, "chrome")
+        + ["--engine", "chrome", "--session", tmp_session, "--json"]
+    )
 
     task_socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{tmp_session}")
     os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
     browser_env = {**os.environ, "AGENT_BROWSER_SOCKET_DIR": task_socket_dir}
     browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
+    _apply_agentcookie_env(browser_env, tmp_session_info, "chrome")
 
     if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
         browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
@@ -1941,6 +2104,16 @@ def _run_browser_command(
         logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
 
+    # Resolve the requested engine before backend args so AgentCookie can stay
+    # scoped to local Chrome/Chromium launches only.
+    configured_engine = _get_browser_engine()
+    engine = _engine_override or configured_engine
+    agentcookie_engine = engine
+    if _engine_override == "auto" and configured_engine == "lightpanda":
+        # Internal probes of an existing Lightpanda daemon pass no --engine flag;
+        # do not mistake that for a new Chrome launch.
+        agentcookie_engine = configured_engine
+
     # Build the command with the appropriate backend flag.
     # Cloud mode: --cdp <websocket_url> connects to Browserbase.
     # Local mode: --session <name> launches a local headless Chromium.
@@ -1951,14 +2124,17 @@ def _run_browser_command(
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
     else:
-        # Local mode — launch a headless Chromium instance
-        backend_args = ["--session", session_info["session_name"]]
+        # Local mode — launch a browser instance. AgentCookie is only forwarded
+        # when that local backend is Chrome/Chromium, not Lightpanda/Camofox.
+        backend_args = _agentcookie_backend_args(session_info, agentcookie_engine) + [
+            "--session",
+            session_info["session_name"],
+        ]
 
     # Lightpanda engine injection (local mode only, agent-browser v0.25.3+).
     # Use the resolved session backend rather than global cloud-provider state:
     # hybrid private-URL routing can create a local sidecar while a cloud
     # provider remains configured for public URLs.
-    engine = _engine_override or _get_browser_engine()
     if engine != "auto" and not _is_camofox_mode() and not session_info.get("cdp_url"):
         backend_args += ["--engine", engine]
 
@@ -1997,6 +2173,7 @@ def _run_browser_command(
         # used during CLI discovery.
         browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
         browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
+        _apply_agentcookie_env(browser_env, session_info, agentcookie_engine)
 
         # Tell the agent-browser daemon to self-terminate after being idle
         # for our configured inactivity timeout.  This is the daemon-side
@@ -3521,6 +3698,7 @@ def cleanup_all_browsers() -> None:
     global _cached_command_timeout, _command_timeout_resolved
     global _cached_chromium_installed
     global _cached_browser_engine, _browser_engine_resolved
+    global _cached_agentcookie_config, _agentcookie_config_resolved
     _cached_agent_browser = None
     _agent_browser_resolved = False
     _discover_homebrew_node_dirs.cache_clear()
@@ -3529,6 +3707,8 @@ def cleanup_all_browsers() -> None:
     _cached_chromium_installed = None
     _cached_browser_engine = None
     _browser_engine_resolved = False
+    _cached_agentcookie_config = None
+    _agentcookie_config_resolved = False
 
 # ============================================================================
 # Requirements Check

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -383,6 +383,29 @@ See the MCP guide for the practical setup:
 
 If you do **not** set any cloud credentials and don't use `/browser connect`, Hermes can still use the browser tools through a local Chromium install driven by `agent-browser`.
 
+#### AgentCookie profile reuse
+
+If you use [AgentCookie](https://agentcookie.dev/) to maintain a reusable Chrome login profile, enable Hermes' local `agent-browser` integration:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  agentcookie:
+    enabled: true
+    profile_dir: ~/.agentcookie/chrome-profile
+    plain_cookies_db: ~/.agentcookie/cookies-plain.db
+```
+
+When enabled, Hermes passes `--profile <profile_dir>` to local `agent-browser` Chrome/Chromium sessions and exports `AGENTCOOKIE_PLAIN_COOKIES=<plain_cookies_db>` to the spawned local Chrome process. This only changes local Chrome-backed agent-browser sessions; Lightpanda, Camofox, cloud, and CDP sessions attach to different browser backends and do not receive AgentCookie profile or sidecar settings.
+
+Equivalent environment overrides:
+
+```bash
+HERMES_AGENTCOOKIE_ENABLED=true
+HERMES_AGENTCOOKIE_PROFILE_DIR=~/.agentcookie/chrome-profile
+HERMES_AGENTCOOKIE_PLAIN_COOKIES=~/.agentcookie/cookies-plain.db
+```
+
 ### Optional Environment Variables
 
 ```bash


### PR DESCRIPTION
## Summary
- add disabled-by-default `browser.agentcookie` config for AgentCookie Chrome profile reuse
- pass `--profile` and `AGENTCOOKIE_PLAIN_COOKIES` only to local Chrome/Chromium agent-browser sessions
- keep AgentCookie out of CDP/cloud, Camofox, and Lightpanda sessions; Chrome fallback may use it because it launches explicit local Chrome
- document config/env overrides and add regression coverage

## Verification
- `python -m pytest tests/tools/test_browser_agentcookie.py tests/tools/test_browser_homebrew_paths.py tests/tools/test_browser_cloud_fallback.py -q -o 'addopts='` -> 37 passed
- `python -m py_compile tools/browser_tool.py tests/tools/test_browser_agentcookie.py hermes_cli/config.py`
- `git diff --cached --check`
- static diff scan for hardcoded secrets, shell injection, eval/exec, pickle, SQL-format injection -> no findings
- independent reviewer subagent approved staged diff

## Boundaries
- Does not enable AgentCookie at runtime by default
- Does not create/import authenticated browser profiles
- Does not touch `~/.hermes/config.yaml` or `~/.agentcookie`