### PR TITLE
[Hermes Agent][hermes-pr35642-split-snowball][1/n] Split dflash canary hardening loop

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -23,11 +23,30 @@ from __future__ import annotations
 
 import logging
 import os
+import faulthandler
+import signal
 import sys
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Optional
 
 from hermes_cli.fallback_config import get_fallback_chain
+
+
+def _install_oneshot_timeout_diagnostics() -> None:
+    """Allow canary supervisors to request a Python thread dump before kill."""
+    if os.getenv("HERMES_ONESHOT_FAULTHANDLER", "1").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return
+    try:
+        faulthandler.enable(file=sys.stderr, all_threads=True)
+        if hasattr(signal, "SIGUSR1"):
+            faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False)
+    except Exception:
+        pass
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -175,6 +194,7 @@ def run_oneshot(
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
     real_stderr = sys.stderr
+    _install_oneshot_timeout_diagnostics()
     devnull = open(os.devnull, "w", encoding="utf-8")
 
     response: Optional[str] = None

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -43,8 +43,9 @@ def _install_oneshot_timeout_diagnostics() -> None:
         return
     try:
         faulthandler.enable(file=sys.stderr, all_threads=True)
-        if hasattr(signal, "SIGUSR1"):
-            faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False)
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        if sigusr1 is not None:
+            faulthandler.register(sigusr1, file=sys.stderr, all_threads=True, chain=False)
     except Exception:
         pass
 

--- a/scripts/dflash_hardening_loop.py
+++ b/scripts/dflash_hardening_loop.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Run the dflash stability canary as a supervised hardening loop.
+
+The base canary is intentionally finite: it proves a build at one point in
+time.  This wrapper is the ownership layer for iterative hardening.  It keeps
+running bounded canary cycles until a failure appears, records local JSONL
+evidence, and can update a MeshBoard repair task so a worker can pick up the
+next root cause without waiting for a human screenshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Sequence
+
+from dflash_stability_canary import (
+    DEFAULT_LOG_DIR,
+    DEFAULT_MODEL,
+    DEFAULT_PROVIDER,
+    DEFAULT_TOOLSETS,
+    iter_cases,
+    record_path,
+    run_case,
+    write_record,
+)
+
+
+TASK_ID_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def slug(value: object) -> str:
+    text = str(value or "unknown").strip().lower().replace("_", "-")
+    text = TASK_ID_RE.sub("-", text)
+    return text.strip("-") or "unknown"
+
+
+def failure_task_id(record: dict, *, prefix: str) -> str:
+    return "-".join(
+        part
+        for part in [
+            slug(prefix),
+            slug(record.get("case")),
+            slug(record.get("failure")),
+        ]
+        if part
+    )
+
+
+def build_meshboard_failure_command(
+    *,
+    meshboard_root: Path,
+    task_id: str,
+    record: dict,
+    log_path: Path,
+    actor: str,
+    parent_task: str,
+) -> list[str]:
+    meshctl = meshboard_root / ".mesh" / "tools" / "meshctl.py"
+    details = (
+        "Automated dflash hardening loop detected a canary failure. "
+        f"case={record.get('case')} failure={record.get('failure')} "
+        f"returncode={record.get('returncode')} elapsed_s={record.get('elapsed_s')}. "
+        "Raw stdout/stderr stay in the local evidence log."
+    )
+    next_step = (
+        "Inspect the evidence log, reproduce the canary failure from the same "
+        "Hermes checkout, fix the root cause, verify with the canary, then "
+        "restart the dflash hardening loop."
+    )
+    cmd = [
+        sys.executable,
+        str(meshctl),
+        "task",
+        "register",
+        task_id,
+        "--update",
+        "--apply",
+        "--state",
+        "open",
+        "--owner",
+        actor,
+        "--priority",
+        "High",
+        "--size",
+        "M",
+        "--risk",
+        "medium",
+        "--requires-human",
+        "false",
+        "--data-policy",
+        "workspace-private",
+        "--title",
+        f"Repair dflash canary failure: {record.get('case')} {record.get('failure')}",
+        "--next",
+        next_step,
+        "--details",
+        details,
+        "--link",
+        str(log_path),
+        "--required-tool",
+        "hermes",
+        "--verification",
+        "Run scripts/dflash_stability_canary.py with the failing case until it passes.",
+    ]
+    if parent_task:
+        cmd.extend(["--parent-task", parent_task])
+    return cmd
+
+
+def register_meshboard_failure(
+    *,
+    meshboard_root: Path,
+    task_id: str,
+    record: dict,
+    log_path: Path,
+    actor: str,
+    parent_task: str,
+) -> dict:
+    cmd = build_meshboard_failure_command(
+        meshboard_root=meshboard_root,
+        task_id=task_id,
+        record=record,
+        log_path=log_path,
+        actor=actor,
+        parent_task=parent_task,
+    )
+    result = subprocess.run(
+        cmd,
+        cwd=str(meshboard_root),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "cmd": [*cmd[:4], "<task-register-args>"],
+        "returncode": result.returncode,
+        "stdout": result.stdout[-2000:],
+        "stderr": result.stderr[-2000:],
+        "task_id": task_id,
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-cycles", type=int, default=0, help="0 means run until failure or interrupt.")
+    parser.add_argument("--cycle-sleep", type=float, default=60.0, help="Seconds between successful cycles.")
+    parser.add_argument("--timeout", type=float, default=180.0, help="Per-case timeout in seconds.")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd(), help="Working directory for hermes -z.")
+    parser.add_argument("--hermes-bin", default="hermes", help="Hermes executable.")
+    parser.add_argument("--provider", default=DEFAULT_PROVIDER, help="Hermes provider override.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Hermes model override.")
+    parser.add_argument("--toolsets", default=DEFAULT_TOOLSETS, help="Comma-separated toolsets for canary turns.")
+    parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR, help="Directory for JSONL evidence logs.")
+    parser.add_argument("--case", action="append", dest="cases", help="Run only this case name; repeatable.")
+    parser.add_argument("--allow-extra-output", action="store_true", help="Allow marker to appear inside extra text.")
+    parser.add_argument("--meshboard-root", type=Path, help="If set, register/update a MeshBoard task on failure.")
+    parser.add_argument("--meshboard-actor", default="dflash-hardening-loop", help="Owner for failure tasks.")
+    parser.add_argument("--meshboard-parent-task", default="", help="Parent MeshBoard task id for failures.")
+    parser.add_argument("--task-prefix", default="hermes-dflash-hardening-loop", help="Failure task id prefix.")
+    parser.add_argument("--continue-after-failure", action="store_true", help="Keep looping after filing a failure.")
+    parser.add_argument("--json", action="store_true", help="Print JSON records to stdout.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    cases = iter_cases(args.cases)
+    strict_marker = not args.allow_extra_output
+    log_path = record_path(args.log_dir)
+    cycle = 0
+
+    while args.max_cycles <= 0 or cycle < args.max_cycles:
+        cycle += 1
+        for case in cases:
+            record = run_case(
+                case,
+                cwd=args.cwd,
+                hermes_bin=args.hermes_bin,
+                model=args.model,
+                provider=args.provider,
+                toolsets=args.toolsets,
+                timeout_s=args.timeout,
+                strict_marker=strict_marker,
+            )
+            record["cycle"] = cycle
+            write_record(log_path, record)
+
+            if args.json:
+                print(json.dumps(record, sort_keys=True), flush=True)
+            else:
+                status = "ok" if record["ok"] else f"fail:{record['failure']}"
+                print(f"cycle={cycle} case={case.name} {status} evidence={log_path}", flush=True)
+
+            if not record["ok"]:
+                if args.meshboard_root:
+                    task_id = failure_task_id(record, prefix=args.task_prefix)
+                    mesh_record = register_meshboard_failure(
+                        meshboard_root=args.meshboard_root,
+                        task_id=task_id,
+                        record=record,
+                        log_path=log_path,
+                        actor=args.meshboard_actor,
+                        parent_task=args.meshboard_parent_task,
+                    )
+                    write_record(log_path, {"cycle": cycle, "meshboard": mesh_record})
+                    if not args.json:
+                        print(
+                            f"registered MeshBoard failure task {task_id} "
+                            f"rc={mesh_record['returncode']}",
+                            flush=True,
+                        )
+                if not args.continue_after_failure:
+                    return 1
+
+        if args.max_cycles > 0 and cycle >= args.max_cycles:
+            break
+        if args.cycle_sleep > 0:
+            time.sleep(args.cycle_sleep)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dflash_hardening_loop.py
+++ b/scripts/dflash_hardening_loop.py
@@ -25,6 +25,7 @@ from dflash_stability_canary import (
     DEFAULT_PROVIDER,
     DEFAULT_TOOLSETS,
     iter_cases,
+    marker_suffix,
     record_path,
     run_case,
     write_record,
@@ -188,6 +189,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 toolsets=args.toolsets,
                 timeout_s=args.timeout,
                 strict_marker=strict_marker,
+                marker_nonce=marker_suffix(log_path.stem, f"c{cycle}", case.name),
             )
             record["cycle"] = cycle
             write_record(log_path, record)

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Run bounded Hermes/dflash stability canaries and write JSONL evidence.
+
+This is intentionally not an endless loop.  It runs a small set of workflow
+prompts through ``hermes -z`` and requires each turn to return an exact success
+marker.  Failures are recorded with enough local evidence to debug the next
+root cause without relying on phone screenshots alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+
+DEFAULT_LOG_DIR = Path.home() / ".hermes" / "logs" / "dflash-stability-canary"
+DEFAULT_PROVIDER = "taro"
+DEFAULT_MODEL = "dflash"
+DEFAULT_TOOLSETS = "terminal,file"
+MAX_OUTPUT_CHARS = 6000
+
+
+@dataclass(frozen=True)
+class CanaryCase:
+    name: str
+    marker: str
+    prompt: str
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_s: float
+    timed_out: bool = False
+
+
+DEFAULT_CASES: tuple[CanaryCase, ...] = (
+    CanaryCase(
+        name="meshboard-onboard",
+        marker="CANARY_ONBOARD_OK",
+        prompt=(
+            "From the current working directory, run "
+            "`python3 .mesh/tools/meshctl.py onboard`. If the command completes "
+            "without a Python traceback, reply exactly CANARY_ONBOARD_OK and "
+            "nothing else. If it fails, do not use the marker; summarize the "
+            "failure briefly."
+        ),
+    ),
+    CanaryCase(
+        name="meshboard-status-read",
+        marker="CANARY_STATUS_OK",
+        prompt=(
+            "From the current working directory, inspect STATUS.md just enough "
+            "to confirm these task ids appear: "
+            "hermes-dflash-phone-cli-sudden-death-root-cause-20260531 and "
+            "hermes-tui-phone-status-bar-readable. Use shell tools if helpful. "
+            "If both appear, reply exactly CANARY_STATUS_OK and nothing else. "
+            "If either is missing, do not use the marker; say which is missing."
+        ),
+    ),
+    CanaryCase(
+        name="short-fragment-detector",
+        marker="CANARY_FRAGMENT_OK",
+        prompt=(
+            "Run a Python check in the current Hermes checkout that imports "
+            "`looks_like_incomplete_final_fragment` from `agent.stall_retry` and "
+            "verifies it returns true for exactly this string: "
+            "`I see a lot of discord-res tasks (digest Discord content) and some`. "
+            "If the check passes, reply exactly CANARY_FRAGMENT_OK and nothing "
+            "else. If it fails, do not use the marker; summarize the failure."
+        ),
+    ),
+)
+
+
+_INCOMPLETE_TAIL_RE = re.compile(
+    r"(?i)(?:^|[\s,;:])("
+    r"and|or|but|then|so|because|with|without|to|for|from|in|on|at|of|by|as|"
+    r"that|which|who|when|where|while|after|before|since|until|if|though|"
+    r"although|some|another"
+    r")\s*[.?!\"')\]]*$"
+)
+
+_ACTION_PROMISE_RE = re.compile(
+    r"(?im)(?:^|\n)\s*(?:let me|now let me|i(?:'ll| will)|i need to)\b.*(?:check|inspect|read|run|look|pick|continue)\b"
+)
+
+_AUTH_RE = re.compile(r"(?i)(?:401|autherror|invalid api key|api key is invalid|unauthorized)")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def truncate(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+
+    half = max(1, max_chars // 2)
+    return f"{text[:half]}\n...[truncated {len(text) - max_chars} chars]...\n{text[-half:]}"
+
+
+def looks_like_incomplete_tail(text: str) -> bool:
+    stripped = text.strip()
+
+    if not stripped:
+        return False
+
+    if _INCOMPLETE_TAIL_RE.search(stripped):
+        return True
+
+    tail = stripped[-240:]
+
+    return bool(_ACTION_PROMISE_RE.search(tail)) and not re.search(r"[.!?]\s*$", tail)
+
+
+def build_command(
+    hermes_bin: str,
+    case: CanaryCase,
+    *,
+    model: str,
+    provider: str,
+    toolsets: str,
+) -> list[str]:
+    cmd = [hermes_bin]
+
+    if provider:
+        cmd.extend(["--provider", provider])
+
+    if model:
+        cmd.extend(["--model", model])
+
+    if toolsets:
+        cmd.extend(["--toolsets", toolsets])
+
+    cmd.extend(["-z", case.prompt])
+
+    return cmd
+
+
+def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> CommandResult:
+    started = time.monotonic()
+
+    try:
+        completed = subprocess.run(
+            list(cmd),
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_s,
+            check=False,
+        )
+        elapsed_s = time.monotonic() - started
+        return CommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            elapsed_s=elapsed_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed_s = time.monotonic() - started
+        stdout = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode(errors="replace")
+        stderr = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode(errors="replace")
+        return CommandResult(returncode=124, stdout=stdout, stderr=stderr, elapsed_s=elapsed_s, timed_out=True)
+
+
+def classify_result(result: CommandResult, marker: str, *, strict_marker: bool = True) -> str | None:
+    combined = f"{result.stdout}\n{result.stderr}".strip()
+    stdout = result.stdout.strip()
+
+    if result.timed_out:
+        return "timeout"
+
+    if result.returncode != 0:
+        return "nonzero-exit"
+
+    if not stdout:
+        return "empty-final"
+
+    if _AUTH_RE.search(combined):
+        return "auth-error"
+
+    if marker:
+        if strict_marker and stdout != marker:
+            return "marker-mismatch"
+        if not strict_marker and marker not in stdout:
+            return "marker-missing"
+
+    if looks_like_incomplete_tail(stdout):
+        return "incomplete-tail"
+
+    return None
+
+
+def record_path(log_dir: Path) -> Path:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return log_dir / f"{stamp}.jsonl"
+
+
+def iter_cases(names: Iterable[str] | None = None) -> list[CanaryCase]:
+    cases = list(DEFAULT_CASES)
+
+    if not names:
+        return cases
+
+    selected: list[CanaryCase] = []
+    available = {case.name: case for case in cases}
+
+    for name in names:
+        if name not in available:
+            raise SystemExit(f"Unknown canary case {name!r}; available: {', '.join(sorted(available))}")
+        selected.append(available[name])
+
+    return selected
+
+
+def run_case(
+    case: CanaryCase,
+    *,
+    cwd: Path,
+    hermes_bin: str,
+    model: str,
+    provider: str,
+    toolsets: str,
+    timeout_s: float,
+    strict_marker: bool,
+    runner: Callable[[Sequence[str], Path, float], CommandResult] | None = None,
+) -> dict:
+    cmd = build_command(hermes_bin, case, model=model, provider=provider, toolsets=toolsets)
+
+    if runner is None:
+        result = run_subprocess(cmd, cwd=cwd, timeout_s=timeout_s)
+    else:
+        result = runner(cmd, cwd, timeout_s)
+
+    failure = classify_result(result, case.marker, strict_marker=strict_marker)
+
+    return {
+        "case": case.name,
+        "cmd": cmd[:-1] + ["<prompt>"],
+        "cwd": str(cwd),
+        "elapsed_s": round(result.elapsed_s, 3),
+        "failure": failure,
+        "marker": case.marker,
+        "ok": failure is None,
+        "returncode": result.returncode,
+        "stderr": truncate(result.stderr),
+        "stdout": truncate(result.stdout),
+        "timed_out": result.timed_out,
+        "ts": utc_now(),
+    }
+
+
+def write_record(path: Path, record: dict) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rounds", type=int, default=1, help="Number of times to run the selected cases.")
+    parser.add_argument("--sleep", type=float, default=10.0, help="Seconds to sleep between rounds.")
+    parser.add_argument("--timeout", type=float, default=180.0, help="Per-case timeout in seconds.")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd(), help="Working directory for hermes -z.")
+    parser.add_argument("--hermes-bin", default=os.environ.get("HERMES_BIN", "hermes"), help="Hermes executable.")
+    parser.add_argument("--provider", default=DEFAULT_PROVIDER, help="Hermes provider override.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Hermes model override.")
+    parser.add_argument("--toolsets", default=DEFAULT_TOOLSETS, help="Comma-separated toolsets for canary turns.")
+    parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR, help="Directory for JSONL evidence logs.")
+    parser.add_argument("--case", action="append", dest="cases", help="Run only this case name; repeatable.")
+    parser.add_argument("--allow-extra-output", action="store_true", help="Allow marker to appear inside extra text.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan without running Hermes.")
+    parser.add_argument("--json", action="store_true", help="Print JSON records to stdout.")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    cases = iter_cases(args.cases)
+
+    if args.rounds < 1:
+        raise SystemExit("--rounds must be >= 1")
+
+    log_path = record_path(args.log_dir)
+    strict_marker = not args.allow_extra_output
+
+    if args.dry_run:
+        plan = {
+            "cases": [case.name for case in cases],
+            "cwd": str(args.cwd),
+            "hermes_bin": args.hermes_bin,
+            "log_path": str(log_path),
+            "model": args.model,
+            "provider": args.provider,
+            "rounds": args.rounds,
+            "toolsets": args.toolsets,
+        }
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+
+    failures = 0
+
+    for round_index in range(args.rounds):
+        for case in cases:
+            record = run_case(
+                case,
+                cwd=args.cwd,
+                hermes_bin=args.hermes_bin,
+                model=args.model,
+                provider=args.provider,
+                toolsets=args.toolsets,
+                timeout_s=args.timeout,
+                strict_marker=strict_marker,
+            )
+            record["round"] = round_index + 1
+            write_record(log_path, record)
+
+            if args.json:
+                print(json.dumps(record, sort_keys=True), flush=True)
+            else:
+                status = "ok" if record["ok"] else f"fail:{record['failure']}"
+                print(f"{record['ts']} round={round_index + 1} case={case.name} {status}", flush=True)
+
+            if not record["ok"]:
+                failures += 1
+                print(f"Evidence: {log_path}", file=sys.stderr)
+                return 1
+
+        if round_index != args.rounds - 1 and args.sleep > 0:
+            time.sleep(args.sleep)
+
+    if not args.json:
+        print(f"All canaries passed. Evidence: {log_path}")
+
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -76,8 +76,9 @@ DEFAULT_CASES: tuple[CanaryCase, ...] = (
         prompt=(
             "Run a Python check from the Hermes checkout at `{source_root}` that imports "
             "`looks_like_incomplete_final_fragment` from `agent.stall_retry` and "
-            "verifies it returns true for exactly this string: "
-            "`I see a lot of discord-res tasks (digest Discord content) and some`. "
+            "verifies `looks_like_incomplete_final_fragment("
+            "\"I see a lot of discord-res tasks (digest Discord content) and some\", "
+            "\"stop\", False, 400)` returns true. "
             "If the check passes, reply exactly CANARY_FRAGMENT_OK and nothing "
             "else. If it fails, do not use the marker; summarize the failure."
         ),

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -152,27 +153,46 @@ def build_command(
 def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> CommandResult:
     started = time.monotonic()
 
+    env = os.environ.copy()
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    env.setdefault("HERMES_ONESHOT_FAULTHANDLER", "1")
+    start_new_session = os.name != "nt"
+    proc = subprocess.Popen(
+        list(cmd),
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=start_new_session,
+    )
+
     try:
-        completed = subprocess.run(
-            list(cmd),
-            cwd=str(cwd),
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=timeout_s,
-            check=False,
-        )
+        stdout, stderr = proc.communicate(timeout=timeout_s)
         elapsed_s = time.monotonic() - started
         return CommandResult(
-            returncode=completed.returncode,
-            stdout=completed.stdout,
-            stderr=completed.stderr,
+            returncode=proc.returncode,
+            stdout=stdout,
+            stderr=stderr,
             elapsed_s=elapsed_s,
         )
-    except subprocess.TimeoutExpired as exc:
+    except subprocess.TimeoutExpired:
+        if start_new_session and hasattr(signal, "SIGUSR1"):
+            try:
+                os.killpg(proc.pid, signal.SIGUSR1)
+                time.sleep(1.0)
+            except Exception:
+                pass
+        try:
+            proc.terminate()
+            stdout, stderr = proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            stdout, stderr = proc.communicate()
         elapsed_s = time.monotonic() - started
-        stdout = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode(errors="replace")
-        stderr = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode(errors="replace")
         return CommandResult(returncode=124, stdout=stdout, stderr=stderr, elapsed_s=elapsed_s, timed_out=True)
 
 

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -204,9 +204,11 @@ def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> Comman
             elapsed_s=elapsed_s,
         )
     except subprocess.TimeoutExpired:
-        if start_new_session and hasattr(signal, "SIGUSR1"):
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        killpg = getattr(os, "killpg", None)
+        if start_new_session and sigusr1 is not None and killpg is not None:
             try:
-                os.killpg(proc.pid, signal.SIGUSR1)
+                killpg(proc.pid, sigusr1)
                 time.sleep(1.0)
             except Exception:
                 pass

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -74,7 +74,7 @@ DEFAULT_CASES: tuple[CanaryCase, ...] = (
         name="short-fragment-detector",
         marker="CANARY_FRAGMENT_OK",
         prompt=(
-            "Run a Python check in the current Hermes checkout that imports "
+            "Run a Python check from the Hermes checkout at `{source_root}` that imports "
             "`looks_like_incomplete_final_fragment` from `agent.stall_retry` and "
             "verifies it returns true for exactly this string: "
             "`I see a lot of discord-res tasks (digest Discord content) and some`. "
@@ -155,16 +155,24 @@ def marker_suffix(*parts: object) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", raw).strip("_")
 
 
-def materialize_case_marker(case: CanaryCase, suffix: str = "") -> CanaryCase:
+def materialize_case_marker(
+    case: CanaryCase,
+    suffix: str = "",
+    *,
+    source_root: Path | None = None,
+) -> CanaryCase:
     suffix = marker_suffix(suffix)
+    prompt = case.prompt
+    if source_root is not None:
+        prompt = prompt.replace("{source_root}", str(source_root))
     if not suffix:
-        return case
+        return CanaryCase(name=case.name, marker=case.marker, prompt=prompt)
 
     marker = f"{case.marker}_{suffix}"
     return CanaryCase(
         name=case.name,
         marker=marker,
-        prompt=case.prompt.replace(case.marker, marker),
+        prompt=prompt.replace(case.marker, marker),
     )
 
 
@@ -276,9 +284,14 @@ def run_case(
     timeout_s: float,
     strict_marker: bool,
     marker_nonce: str = "",
+    source_root: Path | None = None,
     runner: Callable[[Sequence[str], Path, float], CommandResult] | None = None,
 ) -> dict:
-    active_case = materialize_case_marker(case, marker_nonce)
+    active_case = materialize_case_marker(
+        case,
+        marker_nonce,
+        source_root=source_root or Path(__file__).resolve().parents[1],
+    )
     cmd = build_command(hermes_bin, active_case, model=model, provider=provider, toolsets=toolsets)
 
     if runner is None:

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -150,6 +150,24 @@ def build_command(
     return cmd
 
 
+def marker_suffix(*parts: object) -> str:
+    raw = "_".join(str(part) for part in parts if str(part or "").strip())
+    return re.sub(r"[^A-Za-z0-9_]+", "_", raw).strip("_")
+
+
+def materialize_case_marker(case: CanaryCase, suffix: str = "") -> CanaryCase:
+    suffix = marker_suffix(suffix)
+    if not suffix:
+        return case
+
+    marker = f"{case.marker}_{suffix}"
+    return CanaryCase(
+        name=case.name,
+        marker=marker,
+        prompt=case.prompt.replace(case.marker, marker),
+    )
+
+
 def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> CommandResult:
     started = time.monotonic()
 
@@ -257,16 +275,18 @@ def run_case(
     toolsets: str,
     timeout_s: float,
     strict_marker: bool,
+    marker_nonce: str = "",
     runner: Callable[[Sequence[str], Path, float], CommandResult] | None = None,
 ) -> dict:
-    cmd = build_command(hermes_bin, case, model=model, provider=provider, toolsets=toolsets)
+    active_case = materialize_case_marker(case, marker_nonce)
+    cmd = build_command(hermes_bin, active_case, model=model, provider=provider, toolsets=toolsets)
 
     if runner is None:
         result = run_subprocess(cmd, cwd=cwd, timeout_s=timeout_s)
     else:
         result = runner(cmd, cwd, timeout_s)
 
-    failure = classify_result(result, case.marker, strict_marker=strict_marker)
+    failure = classify_result(result, active_case.marker, strict_marker=strict_marker)
 
     return {
         "case": case.name,
@@ -274,7 +294,8 @@ def run_case(
         "cwd": str(cwd),
         "elapsed_s": round(result.elapsed_s, 3),
         "failure": failure,
-        "marker": case.marker,
+        "marker": active_case.marker,
+        "marker_base": case.marker,
         "ok": failure is None,
         "returncode": result.returncode,
         "stderr": truncate(result.stderr),
@@ -317,6 +338,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     log_path = record_path(args.log_dir)
     strict_marker = not args.allow_extra_output
+    run_stamp = log_path.stem
 
     if args.dry_run:
         plan = {
@@ -345,6 +367,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 toolsets=args.toolsets,
                 timeout_s=args.timeout,
                 strict_marker=strict_marker,
+                marker_nonce=marker_suffix(run_stamp, f"r{round_index + 1}", case.name),
             )
             record["round"] = round_index + 1
             write_record(log_path, record)

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -12,6 +12,13 @@ canary = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = canary
 SPEC.loader.exec_module(canary)
 
+LOOP_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "dflash_hardening_loop.py"
+LOOP_SPEC = importlib.util.spec_from_file_location("dflash_hardening_loop", LOOP_MODULE_PATH)
+assert LOOP_SPEC is not None and LOOP_SPEC.loader is not None
+loop = importlib.util.module_from_spec(LOOP_SPEC)
+sys.modules[LOOP_SPEC.name] = loop
+LOOP_SPEC.loader.exec_module(loop)
+
 
 def test_incomplete_tail_classifier_catches_short_connector_fragment():
     assert canary.looks_like_incomplete_tail("I see a lot of discord-res tasks (digest Discord content) and some")
@@ -101,3 +108,39 @@ def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path)
     assert record["failure"] is None
     assert record["cmd"][-1] == "<prompt>"
     assert record["stdout"] == "OK\n"
+
+
+def test_hardening_loop_failure_task_id_is_stable_and_sanitized():
+    record = {"case": "MeshBoard Onboard", "failure": "nonzero_exit"}
+
+    assert (
+        loop.failure_task_id(record, prefix="Hermes DFlash Hardening Loop")
+        == "hermes-dflash-hardening-loop-meshboard-onboard-nonzero-exit"
+    )
+
+
+def test_hardening_loop_meshboard_command_omits_raw_stdout(tmp_path):
+    record = {
+        "case": "meshboard-onboard",
+        "failure": "auth-error",
+        "returncode": 1,
+        "elapsed_s": 12.3,
+        "stdout": "secret-ish raw model text",
+        "stderr": "raw stderr",
+    }
+
+    cmd = loop.build_meshboard_failure_command(
+        meshboard_root=tmp_path,
+        task_id="hermes-dflash-hardening-loop-meshboard-onboard-auth-error",
+        record=record,
+        log_path=tmp_path / "evidence.jsonl",
+        actor="ko-taro.hermes",
+        parent_task="parent-task",
+    )
+    command_text = "\n".join(cmd)
+
+    assert "secret-ish raw model text" not in command_text
+    assert "raw stderr" not in command_text
+    assert "--parent-task" in cmd
+    assert "parent-task" in cmd
+    assert str(tmp_path / "evidence.jsonl") in cmd

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "dflash_stability_canary.py"
+SPEC = importlib.util.spec_from_file_location("dflash_stability_canary", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+canary = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = canary
+SPEC.loader.exec_module(canary)
+
+
+def test_incomplete_tail_classifier_catches_short_connector_fragment():
+    assert canary.looks_like_incomplete_tail("I see a lot of discord-res tasks (digest Discord content) and some")
+    assert canary.looks_like_incomplete_tail("Now let me read the STATUS.md to find a task I can pick up")
+    assert not canary.looks_like_incomplete_tail("CANARY_ONBOARD_OK")
+
+
+def test_classify_result_requires_exact_marker():
+    ok = canary.CommandResult(returncode=0, stdout="CANARY_ONBOARD_OK\n", stderr="", elapsed_s=1.0)
+    noisy = canary.CommandResult(returncode=0, stdout="Done. CANARY_ONBOARD_OK\n", stderr="", elapsed_s=1.0)
+
+    assert canary.classify_result(ok, "CANARY_ONBOARD_OK") is None
+    assert canary.classify_result(noisy, "CANARY_ONBOARD_OK") == "marker-mismatch"
+    assert canary.classify_result(noisy, "CANARY_ONBOARD_OK", strict_marker=False) is None
+
+
+def test_classify_result_flags_auth_empty_timeout_and_nonzero():
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=0, stdout="", stderr="", elapsed_s=1.0),
+            "MARKER",
+        )
+        == "empty-final"
+    )
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=0, stdout="MARKER", stderr="Error code: 401 Invalid API key", elapsed_s=1.0),
+            "MARKER",
+        )
+        == "auth-error"
+    )
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=124, stdout="", stderr="", elapsed_s=180.0, timed_out=True),
+            "MARKER",
+        )
+        == "timeout"
+    )
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=2, stdout="MARKER", stderr="", elapsed_s=1.0),
+            "MARKER",
+        )
+        == "nonzero-exit"
+    )
+
+
+def test_build_command_includes_model_provider_toolsets():
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="reply OK")
+    cmd = canary.build_command("hermes", case, model="dflash", provider="taro", toolsets="terminal,file")
+
+    assert cmd == [
+        "hermes",
+        "--provider",
+        "taro",
+        "--model",
+        "dflash",
+        "--toolsets",
+        "terminal,file",
+        "-z",
+        "reply OK",
+    ]
+
+
+def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path):
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="private prompt")
+
+    def runner(cmd, cwd, timeout_s):
+        assert cmd[-1] == "private prompt"
+        assert cwd == tmp_path
+        assert timeout_s == 5.0
+        return canary.CommandResult(returncode=0, stdout="OK\n", stderr="", elapsed_s=0.25)
+
+    record = canary.run_case(
+        case,
+        cwd=tmp_path,
+        hermes_bin="hermes",
+        model="dflash",
+        provider="taro",
+        toolsets="terminal,file",
+        timeout_s=5.0,
+        strict_marker=True,
+        runner=runner,
+    )
+
+    assert record["ok"] is True
+    assert record["failure"] is None
+    assert record["cmd"][-1] == "<prompt>"
+    assert record["stdout"] == "OK\n"

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -110,6 +110,25 @@ def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path)
     assert record["stdout"] == "OK\n"
 
 
+def test_run_subprocess_timeout_requests_thread_dump(tmp_path):
+    code = (
+        "import faulthandler, signal, sys, time; "
+        "faulthandler.enable(file=sys.stderr, all_threads=True); "
+        "faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False); "
+        "time.sleep(30)"
+    )
+
+    result = canary.run_subprocess(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        timeout_s=0.2,
+    )
+
+    assert result.timed_out is True
+    assert result.returncode == 124
+    assert "Current thread" in result.stderr
+
+
 def test_hardening_loop_failure_task_id_is_stable_and_sanitized():
     record = {"case": "MeshBoard Onboard", "failure": "nonzero_exit"}
 

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -92,6 +92,15 @@ def test_materialize_case_marker_replaces_marker_with_nonce():
     assert materialized.prompt == "reply exactly OK_run_1_case"
 
 
+def test_materialize_case_marker_injects_source_root(tmp_path):
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="cd {source_root}; reply OK")
+
+    materialized = canary.materialize_case_marker(case, "n1", source_root=tmp_path)
+
+    assert str(tmp_path) in materialized.prompt
+    assert materialized.prompt.endswith("reply OK_n1")
+
+
 def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path):
     case = canary.CanaryCase(name="unit", marker="OK", prompt="private prompt")
 

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -83,6 +83,15 @@ def test_build_command_includes_model_provider_toolsets():
     ]
 
 
+def test_materialize_case_marker_replaces_marker_with_nonce():
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="reply exactly OK")
+
+    materialized = canary.materialize_case_marker(case, "run-1 case")
+
+    assert materialized.marker == "OK_run_1_case"
+    assert materialized.prompt == "reply exactly OK_run_1_case"
+
+
 def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path):
     case = canary.CanaryCase(name="unit", marker="OK", prompt="private prompt")
 
@@ -110,11 +119,37 @@ def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path)
     assert record["stdout"] == "OK\n"
 
 
+def test_run_case_uses_nonce_marker(tmp_path):
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="reply OK")
+
+    def runner(cmd, cwd, timeout_s):
+        assert cmd[-1] == "reply OK_cycle_1"
+        return canary.CommandResult(returncode=0, stdout="OK_cycle_1\n", stderr="", elapsed_s=0.25)
+
+    record = canary.run_case(
+        case,
+        cwd=tmp_path,
+        hermes_bin="hermes",
+        model="dflash",
+        provider="taro",
+        toolsets="terminal,file",
+        timeout_s=5.0,
+        strict_marker=True,
+        marker_nonce="cycle-1",
+        runner=runner,
+    )
+
+    assert record["ok"] is True
+    assert record["marker"] == "OK_cycle_1"
+    assert record["marker_base"] == "OK"
+
+
 def test_run_subprocess_timeout_requests_thread_dump(tmp_path):
     code = (
         "import faulthandler, signal, sys, time; "
         "faulthandler.enable(file=sys.stderr, all_threads=True); "
-        "faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False); "
+        "sig=getattr(signal, 'SIGUSR1', None); "
+        "sig is not None and faulthandler.register(sig, file=sys.stderr, all_threads=True, chain=False); "
         "time.sleep(30)"
     )
 


### PR DESCRIPTION
## Summary
- Split the dflash stability canary tooling out of #35642 into its own reviewable PR.
- Add a bounded canary runner that drives representative `hermes -z` dflash workflows and writes JSONL evidence.
- Add a supervised hardening loop that can file sanitized MeshBoard repair tasks when a canary case fails.
- Install opt-in oneshot faulthandler diagnostics so timeout supervisors can request thread dumps before terminating the process.

## Why
#35642 grew into a multi-feature recovery stack. This PR is the measurement/ownership slice only, so it can be reviewed independently from the behavior-changing stall-retry and local-backend failover changes.

## Validation
- `scripts/run_tests.sh tests/scripts/test_dflash_stability_canary.py`
- `python3 scripts/check-windows-footguns.py scripts/dflash_stability_canary.py scripts/dflash_hardening_loop.py hermes_cli/oneshot.py tests/scripts/test_dflash_stability_canary.py`
- `python3 -m py_compile scripts/dflash_stability_canary.py scripts/dflash_hardening_loop.py hermes_cli/oneshot.py tests/scripts/test_dflash_stability_canary.py`
- `git -c core.fsmonitor=false diff --check upstream/main..HEAD`

## Relationship To Existing PRs
Split from #35642. This PR intentionally does not include the stall-retry policy changes, local first-chunk failover, or local backend recovery hook.