### PR TITLE
docs(readme): sync zh-CN install notes

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 **由 [Nous Research](https://nousresearch.com) 构建的自进化 AI 代理。** 它是唯一内置学习闭环的智能代理——从经验中创建技能，在使用中改进技能，主动持久化知识，搜索过往对话，并在跨会话中逐步构建对你的深度理解。可以在 $5 的 VPS 上运行，也可以在 GPU 集群上运行，或者使用几乎零成本的 Serverless 基础设施。它不绑定你的笔记本——你可以在 Telegram 上与它对话，而它在云端 VM 上工作。
 
-支持任意模型——[Nous Portal](https://portal.nousresearch.com)、[OpenRouter](https://openrouter.ai)（200+ 模型）、[NVIDIA NIM](https://build.nvidia.com)（Nemotron）、[小米 MiMo](https://platform.xiaomimimo.com)、[z.ai/GLM](https://z.ai)、[Kimi/Moonshot](https://platform.moonshot.ai)、[MiniMax](https://www.minimax.io)、[Hugging Face](https://huggingface.co)、OpenAI，或自定义端点。使用 `hermes model` 即可切换——无需改代码，无锁定。
+支持任意模型——[Nous Portal](https://portal.nousresearch.com)、[OpenRouter](https://openrouter.ai)（200+ 模型）、[NovitaAI](https://novita.ai)（面向模型 API、Agent Sandbox 和 GPU Cloud 的 AI 原生云）、[NVIDIA NIM](https://build.nvidia.com)（Nemotron）、[小米 MiMo](https://platform.xiaomimimo.com)、[z.ai/GLM](https://z.ai)、[Kimi/Moonshot](https://platform.moonshot.ai)、[MiniMax](https://www.minimax.io)、[Hugging Face](https://huggingface.co)、OpenAI，或自定义端点。使用 `hermes model` 即可切换——无需改代码，无锁定。
 
 <table>
 <tr><td><b>真正的终端界面</b></td><td>完整的 TUI，支持多行编辑、斜杠命令自动补全、对话历史、中断重定向和流式工具输出。</td></tr>
@@ -30,15 +30,29 @@
 
 ## 快速安装
 
+### Linux、macOS、WSL2、Termux
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
-支持 Linux、macOS、WSL2 和 Android (Termux)。安装程序会自动处理平台特定的配置。
+### Windows（原生，PowerShell）
+
+> **提示：** 原生 Windows 无需 WSL 即可运行 Hermes：CLI、gateway、TUI 和工具都可原生工作。如果你更喜欢 WSL2，也可以在 WSL2 中使用上面的 Linux/macOS 一行命令。发现问题请 [提交 issue](https://github.com/NousResearch/hermes-agent/issues)。
+
+在 PowerShell 中运行：
+
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+```
+
+安装器会处理 uv、Python 3.11、Node.js、ripgrep、ffmpeg 和 **便携版 Git Bash**（MinGit，解压到 `%LOCALAPPDATA%\hermes\git`，无需管理员权限，不影响系统 Git）。Hermes 会使用这个内置 Git Bash 运行 shell 命令。
+
+如果你已经安装了 Git，安装器会检测并优先使用它。否则只需下载约 45MB 的 MinGit；它不会触碰或干扰系统 Git。
 
 > **Android / Termux：** 已测试的手动安装路径请参考 [Termux 指南](https://hermes-agent.nousresearch.com/docs/getting-started/termux)。在 Termux 上，Hermes 会安装精选的 `.[termux]` 扩展，因为完整的 `.[all]` 扩展会拉取 Android 不兼容的语音依赖。
 >
-> **Windows：** 原生 Windows 不受支持。请安装 [WSL2](https://learn.microsoft.com/zh-cn/windows/wsl/install) 并运行上述命令。
+> **Windows：** 原生 Windows 已完全支持，PowerShell 一行命令会安装所需内容。如果你更喜欢 WSL2，也可以在 WSL2 中运行 Linux 命令。原生 Windows 安装在 `%LOCALAPPDATA%\hermes`，WSL2 则与 Linux 一样安装在 `~/.hermes`。目前唯一仍需要 WSL2 的 Hermes 功能是浏览器版 dashboard 的聊天窗格（它依赖 POSIX PTY；经典 CLI 和 gateway 都可原生运行）。
 
 安装后：
 
@@ -176,10 +190,10 @@ cd hermes-agent
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv venv --python 3.11
-source venv/bin/activate
+uv venv .venv --python 3.11
+source .venv/bin/activate
 uv pip install -e ".[all,dev]"
-python -m pytest tests/ -q
+scripts/run_tests.sh
 ```
 
 ---


### PR DESCRIPTION
Updates the zh-CN README to match the English install notes, including native Windows PowerShell installation support and the current contributor setup commands.

Tested:
- git diff --check