### PR TITLE
[Hermes Agent][hermes-pr35642-split-snowball][2/n] Split TUI status payload assertion

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2222,7 +2222,15 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     emit.assert_any_call("session.info", "sid", {"model": "x"})
     # Final status.update clears the pinned "compressing" indicator so the
     # status bar can revert to the neutral state when compaction finishes.
-    emit.assert_any_call("status.update", "sid", {"kind": "status", "text": "ready"})
+    status_updates = [
+        call.args[2]
+        for call in emit.call_args_list
+        if call.args[:2] == ("status.update", "sid")
+    ]
+    assert any(
+        update.get("kind") == "status" and update.get("text") == "ready"
+        for update in status_updates
+    )
 
 
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):


### PR DESCRIPTION
## Why
PR #35642 includes a tiny TUI gateway test assertion alongside unrelated dflash retry and local backend changes. Splitting this assertion out keeps the TUI status payload expectation reviewable on its own.

## What changed
- Update `tests/test_tui_gateway_server.py::test_session_compress_uses_compress_helper` to accept any emitted ready status payload instead of requiring an exact single `status.update` call payload.
- Keep the change scoped to the test file; no runtime code changes are included in this slice.

## How to review
Read the one-file diff in `tests/test_tui_gateway_server.py` and confirm the assertion still verifies that compaction clears the pinned status back to ready while tolerating additional fields in the emitted status payload.

## Evidence
- Focused test exercised the changed assertion: `python3 -m pytest tests/test_tui_gateway_server.py::test_session_compress_uses_compress_helper -q` -> 1 passed.
- Compile check covered the edited Python test file: `python3 -m py_compile tests/test_tui_gateway_server.py` -> rc=0.
- Diff hygiene check: `git -c core.fsmonitor=false diff --check upstream/main..HEAD` -> rc=0.

## Verification
- `python3 -m pytest tests/test_tui_gateway_server.py::test_session_compress_uses_compress_helper -q` -> 1 passed.
- `python3 -m py_compile tests/test_tui_gateway_server.py` -> passed.
- `git -c core.fsmonitor=false diff --check upstream/main..HEAD` -> passed.

## Risks / gaps
Low risk: this is test-only and narrows no product behavior. The broader #35642 behavior changes remain out of scope and are tracked by MeshBoard task `hermes-pr35642-split-snowball-20260602` plus sibling split PRs.

## Collaborators

**Participants:**
- **@OmarB97** — operator on `ko-mac`.
- **Codex (GPT-5)** — OpenAI frontier coding lane on `ko-mac`, task `hermes-pr35642-split-snowball-20260602`.

**Process:**
- Continued from the pasted Claude Code analysis of #35642, created a clean worktree from `upstream/main`, cherry-picked the one-file TUI status assertion, and ran focused verification.

**Context:**
- MeshBoard task: `hermes-pr35642-split-snowball-20260602`.
- Split source PR: https://github.com/NousResearch/hermes-agent/pull/35642.

**Timing:**
- Opened during the 2026-06-02 Codex pickup after MeshBoard onboarding and Syncthing doctor.