### PR TITLE
fix(skills): ignore internal asset markdown during skill lookup

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1223,6 +1223,46 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is True
         assert "EXTERNAL BODY" in result["content"]
 
+    def test_legacy_flat_lookup_ignores_internal_skill_assets(self, tmp_path):
+        """A <name>.md file inside another skill's asset tree is not a
+        standalone legacy flat skill and must not collide with a real skill."""
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+
+        _make_skill(local_dir, "notion", category="productivity", body="REAL NOTION")
+        asset_owner = _make_skill(
+            local_dir,
+            "popular-web-designs",
+            category="creative",
+            body="DESIGN SKILL",
+        )
+        templates_dir = asset_owner / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "notion.md").write_text("# Notion template\n")
+
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            raw = skill_view("notion")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "REAL NOTION" in result["content"]
+
+    def test_legacy_flat_lookup_still_loads_top_level_markdown(self, tmp_path):
+        """Legacy flat <name>.md files directly under a skills root still
+        resolve for existing users that keep old-style skills."""
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        (local_dir / "legacy-skill.md").write_text("# Legacy body\n")
+
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            raw = skill_view("legacy-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Legacy body" in result["content"]
+
     def test_two_externals_same_name_also_refuse(self, tmp_path):
         """Collision detection is symmetric — two external dirs with
         same-name skills also trigger the refusal."""

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -935,6 +935,14 @@ def skill_view(
             seen_md.add(key)
             candidates.append((sd, smd))
 
+        def _is_inside_skill_dir(path: Path, root: Path) -> bool:
+            for ancestor in path.parents:
+                if ancestor == root:
+                    return False
+                if (ancestor / "SKILL.md").exists():
+                    return True
+            return False
+
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
@@ -963,6 +971,8 @@ def skill_view(
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
                 if found_md.name != "SKILL.md":
+                    if _is_inside_skill_dir(found_md, search_dir):
+                        continue
                     _record(None, found_md)
 
         if len(candidates) > 1:


### PR DESCRIPTION
## Summary
- fixes #35743
- keeps legacy flat `<name>.md` skill lookup while skipping markdown files inside another skill directory
- adds regression coverage for internal asset files named like real skills and for top-level legacy markdown skills

## Testing
- `uv run --with pytest-timeout pytest tests/tools/test_skills_tool.py -q`
- `uv run ruff check tools/skills_tool.py tests/tools/test_skills_tool.py`
- `python3 -m py_compile tools/skills_tool.py tests/tools/test_skills_tool.py && git diff --check`
- `python3 scripts/check-windows-footguns.py --diff origin/main`

## Notes
- Full repository test suite not run locally.