### PR TITLE
feat(sessions): add browse sort option

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -913,6 +913,20 @@ def _has_any_provider_configured() -> bool:
     return False
 
 
+def _session_browse_order_by_last_active(sort: str) -> bool:
+    """Return whether sessions browse should order by last activity.
+
+    ``started`` preserves the historical browse ordering by session start time.
+    ``last-active`` surfaces recently continued/touched conversations first.
+    """
+    normalized = (sort or "started").strip().lower()
+    if normalized == "started":
+        return False
+    if normalized == "last-active":
+        return True
+    raise ValueError(f"Unsupported session browse sort: {sort}")
+
+
 def _session_browse_picker(sessions: list) -> Optional[str]:
     """Interactive curses-based session browser with live search filtering.
 
@@ -13796,6 +13810,12 @@ def main():
     sessions_browse.add_argument(
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"
     )
+    sessions_browse.add_argument(
+        "--sort",
+        choices=("started", "last-active"),
+        default="started",
+        help="Sort sessions by start time or last activity (default: started)",
+    )
 
     def _confirm_prompt(prompt: str) -> bool:
         """Prompt for y/N confirmation, safe against non-TTY environments."""
@@ -14491,8 +14511,19 @@ def main():
             limit = getattr(args, "limit", 500) or 500
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
+            try:
+                order_by_last_active = _session_browse_order_by_last_active(
+                    getattr(args, "sort", "started")
+                )
+            except ValueError as e:
+                print(f"Error: {e}")
+                db.close()
+                return
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
+                order_by_last_active=order_by_last_active,
             )
             db.close()
             if not sessions:

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -6,11 +6,12 @@ Covers:
 - Argument parser registration
 """
 
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
 
-from hermes_cli.main import _session_browse_picker
+from hermes_cli.main import _session_browse_order_by_last_active, _session_browse_picker
 
 
 # ─── Sample session data ──────────────────────────────────────────────────────
@@ -409,11 +410,66 @@ class TestSessionBrowseArgparse:
         args = parser.parse_args(["browse", "--limit", "42"])
         assert args.limit == 42
 
+    def test_browse_sort_maps_started_to_default_order(self):
+        """The browse sort helper should preserve current start-time ordering by default."""
+        assert _session_browse_order_by_last_active("started") is False
+
+    def test_browse_sort_maps_last_active_to_activity_order(self):
+        """--sort last-active should request activity-time ordering from SessionDB."""
+        assert _session_browse_order_by_last_active("last-active") is True
+
+    def test_browse_sort_rejects_unknown_values(self):
+        """Invalid sort values should fail before reaching the database."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Unsupported session browse sort"):
+            _session_browse_order_by_last_active("title")
+
 
 # ─── Integration: cmd_sessions browse action ────────────────────────────────
 
 class TestCmdSessionsBrowse:
     """Integration tests for the 'browse' action in cmd_sessions."""
+
+    @staticmethod
+    def _run_browse_command(monkeypatch, *extra_args):
+        """Run the real parser and command handler with an isolated SessionDB."""
+        import hermes_cli.main as cli_main
+
+        db = MagicMock()
+        db.list_sessions_rich.return_value = []
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+        monkeypatch.setattr(cli_main, "_prepare_agent_startup", lambda _args: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["hermes", "sessions", "browse", *extra_args],
+        )
+
+        cli_main.main()
+        return db
+
+    def test_browse_command_defaults_to_started_order(self, monkeypatch):
+        """The real default command path should preserve started-time ordering."""
+        db = self._run_browse_command(monkeypatch)
+
+        db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool"],
+            limit=500,
+            order_by_last_active=False,
+        )
+
+    def test_browse_command_forwards_last_active_order(self, monkeypatch):
+        """The real command path should forward --sort last-active to SessionDB."""
+        db = self._run_browse_command(monkeypatch, "--sort", "last-active")
+
+        db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool"],
+            limit=500,
+            order_by_last_active=True,
+        )
 
     def test_browse_no_sessions_prints_message(self, capsys):
         """When no sessions exist, _session_browse_picker returns None and prints message."""

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -292,6 +292,27 @@ Help me refactor the auth module please             2h ago        cli    2025030
 What's the weather in Las Vegas?                    3d ago        tele   20250303_101500_f
 ```
 
+### Browse Sessions
+
+Use the interactive browser to search and resume sessions:
+
+```bash
+hermes sessions browse
+
+# Load more sessions into the picker
+hermes sessions browse --limit 1000
+
+# Browse a specific platform/source
+hermes sessions browse --source telegram
+
+# Surface recently active/continued conversations first
+hermes sessions browse --sort last-active
+```
+
+By default, `browse` preserves the historical `started` ordering. Use
+`--sort last-active` when you want compressed or recently continued sessions to
+appear near the top.
+
 ### Export Sessions
 
 `hermes sessions export` is one surface for every export format, selected with `--format`:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
@@ -269,6 +269,26 @@ Help me refactor the auth module please             2h ago        cli    2025030
 What's the weather in Las Vegas?                    3d ago        tele   20250303_101500_f
 ```
 
+### 浏览 Session
+
+使用交互式浏览器搜索并恢复 session：
+
+```bash
+hermes sessions browse
+
+# 在 picker 中加载更多 session
+hermes sessions browse --limit 1000
+
+# 浏览指定平台/source
+hermes sessions browse --source telegram
+
+# 优先显示最近活跃/续接过的对话
+hermes sessions browse --sort last-active
+```
+
+默认情况下，`browse` 保持历史的 `started` 排序。需要把压缩后续接、最近继续过的
+session 顶上来时，可以使用 `--sort last-active`。
+
 ### 导出 Session
 
 `hermes sessions export` 是所有导出格式的统一入口，用 `--format` 选择：


### PR DESCRIPTION
## Summary
- Add `--sort {started,last-active}` to `hermes sessions browse`
- Keep the default sort as `started` for backwards compatibility
- Wire `--sort last-active` to the existing `SessionDB.list_sessions_rich(order_by_last_active=True)` path
- Document the new option in the English and zh-Hans sessions guides

## Why
`sessions browse` currently always uses the default started-time ordering. Users who want the most recently active sessions first need a per-command option that does not require changing global configuration.

## Related PRs
Related to #31851, which proposes a broader global session sort configuration and a `sessions sort` subcommand. This PR is intentionally narrower: it adds a per-invocation flag only for `sessions browse`, preserving the existing default and avoiding global config changes.

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_session_browse.py tests/test_hermes_state.py::TestListSessionsRich::test_order_by_last_active_surfaces_recently_touched_older_session_first tests/test_hermes_state.py::TestListSessionsRich::test_order_by_last_active_uses_compression_tip_activity -q`
- `venv/bin/python -m ruff check hermes_cli/main.py tests/hermes_cli/test_session_browse.py`
- `git diff --check`
- `venv/bin/python -m hermes_cli.main sessions browse --help | grep -E -- '--sort|last-active|started'`
