### PR TITLE
fix(tui): make shift+cmd+z trigger redo

### DIFF
--- a/ui-tui/src/__tests__/textInputEditHistory.test.ts
+++ b/ui-tui/src/__tests__/textInputEditHistory.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { editHistoryActionForKey } from '../components/textInput.js'
+
+const key = (overrides: Record<string, unknown> = {}) =>
+  ({ shift: false, ...overrides }) as any
+
+describe('editHistoryActionForKey', () => {
+  it('maps action+z to undo', () => {
+    expect(editHistoryActionForKey('z', key(), true)).toBe('undo')
+  })
+
+  it('maps action+shift+z to redo before the broader action+z undo case', () => {
+    expect(editHistoryActionForKey('z', key({ shift: true }), true)).toBe('redo')
+  })
+
+  it('also maps action+y to redo', () => {
+    expect(editHistoryActionForKey('y', key(), true)).toBe('redo')
+  })
+
+  it('ignores z/y when the action modifier is absent', () => {
+    expect(editHistoryActionForKey('z', key({ shift: true }), false)).toBeNull()
+    expect(editHistoryActionForKey('y', key(), false)).toBeNull()
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -123,6 +123,30 @@ export function applyPrintableInsert(
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
 
+export type EditHistoryAction = 'redo' | 'undo'
+
+export function editHistoryActionForKey(
+  input: string,
+  key: Pick<Key, 'shift'>,
+  actionMod: boolean
+): EditHistoryAction | null {
+  if (!actionMod) {
+    return null
+  }
+
+  const ch = input.toLowerCase()
+
+  if (ch === 'y' || (key.shift && ch === 'z')) {
+    return 'redo'
+  }
+
+  if (ch === 'z') {
+    return 'undo'
+  }
+
+  return null
+}
+
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
   if (env.WT_SESSION) {
     return true
@@ -997,12 +1021,14 @@ export function TextInput({
         flushKeyBurst()
       }
 
-      if (mod && inp === 'z') {
-        return swap(undo, redo)
+      const editHistoryAction = editHistoryActionForKey(inp, k, mod)
+
+      if (editHistoryAction === 'redo') {
+        return swap(redo, undo)
       }
 
-      if ((mod && inp === 'y') || (mod && k.shift && inp === 'z')) {
-        return swap(redo, undo)
+      if (editHistoryAction === 'undo') {
+        return swap(undo, redo)
       }
 
       if (isMac && mod && inp === 'a') {


### PR DESCRIPTION
## Summary
- Route edit-history shortcuts through a helper.
- Ensure action+shift+z resolves to redo before the broader action+z undo case.
- Add regression coverage for undo/redo key mapping.

## Test
- `npm test -- textInputEditHistory.test.ts`
- `npm test -- textInputEditHistory.test.ts textInputPassThrough.test.ts textInputBurstInput.test.ts textInputFastEcho.test.ts`
- `npm run build`

## Notes
No issue filed; this is a small bugfix discovered while testing iTerm2 CSI-u mappings.

A full `npm test` run was also attempted locally, but currently has unrelated failures in `virtualHeights.test.ts` and a `cursorDriftRegression.test.ts` timeout.
