### PR TITLE
fix(kanban): decompose children inherit root workspace instead of forcing scratch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4353,13 +4353,21 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant FROM tasks WHERE id = ?", (task_id,)
+            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if root_row is None:
             return None
         if root_row["status"] != "triage":
             return None
         tenant = root_row["tenant"]
+        # Children inherit the root's workspace by default so a fan-out
+        # of a code-gen task lands in the parent's project dir/worktree
+        # rather than throwaway scratch tmp dirs. A child dict can still
+        # override with its own 'workspace_kind' / 'workspace_path'.
+        root_ws_kind = root_row["workspace_kind"] or "scratch"
+        root_ws_path = root_row["workspace_path"]
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -4370,16 +4378,30 @@ def decompose_triage_task(
             title = child["title"].strip()
             body = child.get("body")
             assignee = _canonical_assignee(child.get("assignee"))
+            # Per-child override wins; otherwise inherit the root's
+            # workspace. A child that sets workspace_kind without a path
+            # falls back to the root path only when kinds match (so a
+            # child can't accidentally point a 'dir' at the root's
+            # worktree path or vice versa).
+            child_ws_kind = child.get("workspace_kind") or root_ws_kind
+            if child.get("workspace_path"):
+                child_ws_path = child.get("workspace_path")
+            elif child_ws_kind == root_ws_kind:
+                child_ws_path = root_ws_path
+            else:
+                child_ws_path = None
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    child_ws_kind,
+                    child_ws_path,
                     tenant,
                     now,
                     (author or "decomposer"),

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -166,3 +166,65 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
 
     assert any("Decomposed into" in (c.body or "") for c in comments)
     assert any(ev.kind == "decomposed" for ev in events)
+
+
+def test_decompose_children_inherit_dir_workspace(kanban_home):
+    """Fan-out children inherit the root's dir workspace, not scratch."""
+    proj = "/home/teknium/myproject"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="codegen root", assignee="worker",
+            workspace_kind="dir", workspace_path=proj, triage=True,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn, tid, root_assignee="orchestrator",
+            children=[{"title": "part A"}, {"title": "part B", "parents": [0]}],
+            author="decomposer",
+        )
+    assert child_ids and len(child_ids) == 2
+    with kb.connect() as conn:
+        for cid in child_ids:
+            t = kb.get_task(conn, cid)
+            assert t.workspace_kind == "dir"
+            assert t.workspace_path == proj
+
+
+def test_decompose_children_stay_scratch_when_root_scratch(kanban_home):
+    """No regression: a scratch root still fans out into scratch children."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="scratch root", assignee="worker",
+            workspace_kind="scratch", triage=True,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn, tid, root_assignee="orchestrator",
+            children=[{"title": "s1"}], author="decomposer",
+        )
+    with kb.connect() as conn:
+        t = kb.get_task(conn, child_ids[0])
+    assert t.workspace_kind == "scratch"
+    assert t.workspace_path is None
+
+
+def test_decompose_per_child_workspace_override(kanban_home):
+    """An explicit per-child workspace beats inheritance."""
+    proj = "/home/teknium/myproject"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="root", assignee="worker",
+            workspace_kind="dir", workspace_path=proj, triage=True,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn, tid, root_assignee="orchestrator",
+            children=[
+                {"title": "override", "workspace_kind": "dir",
+                 "workspace_path": "/other/repo"},
+                {"title": "inherit"},
+            ],
+            author="decomposer",
+        )
+    with kb.connect() as conn:
+        over = kb.get_task(conn, child_ids[0])
+        inh = kb.get_task(conn, child_ids[1])
+    assert over.workspace_path == "/other/repo"
+    assert inh.workspace_path == proj


### PR DESCRIPTION
## Summary
The `/model` picker no longer silently routes an OpenAI selection to OpenRouter. Users with a configured OpenAI provider (and no OpenRouter key) now stay on `api.openai.com` instead of hitting HTTP 401 "Missing Authentication header."

**Root cause:** `hermes_cli/providers.py` carries a legacy alias `"openai" → "openrouter"`. The picker emitted a standalone `slug="openai"` row (gated on `OPENAI_API_KEY`); selecting it ran `resolve_provider_full("openai")`, which resolved that built-in alias to OpenRouter *before* checking the user's own `providers.openai` config.

## Changes
- `model_switch.list_authenticated_providers`: skip vendor names that are aliases to an aggregator (isolates exactly `openai→openrouter`; `copilot`/`kimi`/etc. are real providers and unaffected). Kills the phantom picker row.
- `providers.resolve_provider_full`: user-config `providers.<name>` now resolves before the built-in alias table, so `providers.openai` (api.openai.com) beats the legacy alias.
- `model_switch` PATH A: user-config providers resolve credentials via their own endpoint instead of the name-based runtime resolver that doesn't know user-config slugs; plus a fail-loud guard for explicit unauthed-aggregator hops.

## Validation
| Reporter config (provider=openai-api, no OpenRouter key) | Before | After |
|---|---|---|
| picker: OpenAI + gpt-4o-mini | `target=openrouter` base=openrouter.ai → 401 | `target=openai` base=api.openai.com ✓ |
| explicit `--provider openai-api` | api.openai.com ✓ | api.openai.com ✓ (unchanged) |

Targeted suites green (model_switch / providers / inventory / runtime / auth — 384 + 224 + 295 passing). Added 3 regression tests; converted 1 test that codified the phantom-row behavior.

## Scope
Independent of #35056 (which doesn't touch the picker) and #24234 (separate encrypted-content 400). Does not change the `OPENAI_API_KEY`-implies-openrouter overlay (issue #6799) — that's a wider resolution-semantics change #35056 rewrites; the reported symptom is fixed without it.

Related issues: #14057 (duplicate OpenAI/openai picker rows), #19858 (model switcher hops to OpenRouter).

## Infographic

![kanban-workspace-inheritance](https://v3b.fal.media/files/b/0a9ca10e/i8j6Mymyfswm-7QE_6Niz_oOKmY8cN.png)
