### PR TITLE
feat(kanban): gate notifier watcher on dispatch_in_gateway

### DIFF
--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -1,0 +1,39 @@
+# Multi-gateway deployment
+
+Hermes supports multiple gateway processes running concurrently — one per profile
+(default, writer, admin, coder, researcher). Each gateway opens its own connection
+to platform APIs and delivers messages for its profile's subscribers.
+
+## Single-dispatcher posture
+
+Only one gateway owns the kanban dispatcher. The owning gateway keeps
+`kanban.dispatch_in_gateway: true` (the default); every other gateway sets it
+to `false`.
+
+**Why this matters:** a gateway with `dispatch_in_gateway: true` opens per-board
+SQLite connections for both the dispatcher and the notifier watcher. Multiple
+gateways doing this concurrently multiplies the open file descriptors on each
+`kanban.db` and amplifies WAL `-shm` reader contention. Gating both paths on the
+same flag means exactly one process touches the kanban DBs.
+
+## Configuration
+
+On the dispatch-owning gateway (typically the `default` profile), no change is
+needed. On every other profile gateway, add to `~/.hermes/config.yaml`:
+
+```yaml
+kanban:
+  dispatch_in_gateway: false
+```
+
+Or set the env var: `HERMES_KANBAN_DISPATCH_IN_GATEWAY=false`
+
+## What each gateway does
+
+| Gateway role | dispatch_in_gateway | Opens per-board DBs? | Runs dispatcher + notifier? |
+|---|---|---|---|
+| default (dispatch owner) | true (default) | yes | yes |
+| writer, admin, coder, etc. | false | no | no |
+
+Non-dispatch gateways still deliver messages for their own platform adapters
+(Telegram, Discord, etc.) — they just don't poll kanban boards.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5121,6 +5121,30 @@ class GatewayRunner:
         cross boards, so delivery semantics are unchanged — this is
         purely a fan-out of the single-DB poll.
         """
+        # Gate: only the dispatch-owning gateway opens kanban DBs for notifier polling.
+        # Non-dispatch gateways have no subscriptions to deliver — all kanban state lives
+        # in the dispatch owner's per-board DBs. This prevents N-gateway -shm contention.
+        # TODO: gate per-board when per-board dispatcher_owner tracking lands.
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning("kanban notifier: config loader unavailable; disabled")
+            return
+        env_override = os.environ.get("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "").strip().lower()
+        if env_override in {"0", "false", "no", "off"}:
+            logger.info("kanban notifier: disabled via HERMES_KANBAN_DISPATCH_IN_GATEWAY env")
+            return
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning("kanban notifier: cannot load config (%s); disabled", exc)
+            return
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if not kanban_cfg.get("dispatch_in_gateway", True):
+            logger.info(
+                "kanban notifier: disabled via config kanban.dispatch_in_gateway=false"
+            )
+            return
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb

--- a/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
+++ b/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
@@ -1,0 +1,74 @@
+"""Tests for the dispatch_in_gateway gate on _kanban_notifier_watcher.
+
+- Non-dispatch gateways (dispatch_in_gateway=false) exit before opening any DB.
+- HERMES_KANBAN_DISPATCH_IN_GATEWAY env var disables without loading config.
+- Dispatch-owning gateways (dispatch_in_gateway=true) proceed past the gate.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+def _make_runner(with_adapter=False):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: MagicMock()} if with_adapter else {}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+def _fake_config(dispatch_in_gateway):
+    return {"kanban": {"dispatch_in_gateway": dispatch_in_gateway}}
+
+
+def test_notifier_watcher_skips_when_dispatch_disabled():
+    """dispatch_in_gateway=false returns before opening any board DB."""
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_fake_config(False)):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            asyncio.run(runner._kanban_notifier_watcher())
+    mock_connect.assert_not_called()
+
+
+def test_notifier_watcher_env_override_disables(monkeypatch):
+    """HERMES_KANBAN_DISPATCH_IN_GATEWAY=false skips config load entirely."""
+    runner = _make_runner()
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "false")
+    with patch("hermes_cli.config.load_config") as mock_load_config:
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            asyncio.run(runner._kanban_notifier_watcher())
+    mock_load_config.assert_not_called()
+    mock_connect.assert_not_called()
+
+
+def test_notifier_watcher_runs_when_dispatch_enabled():
+    """dispatch_in_gateway=true proceeds past the gate to the board fan-out."""
+    runner = _make_runner(with_adapter=True)
+    past_gate = []
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        # Stop after the initial delay + first per-interval sleep so the loop
+        # body runs exactly once.
+        if len(sleep_calls) >= 2:
+            runner._running = False
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    import hermes_cli.kanban_db as _kb
+
+    with patch("hermes_cli.config.load_config", return_value=_fake_config(True)):
+        with patch.object(
+            _kb, "list_boards",
+            side_effect=lambda *a, **kw: past_gate.append(True) or [],
+        ):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with patch("asyncio.to_thread", side_effect=fake_to_thread):
+                    asyncio.run(runner._kanban_notifier_watcher())
+
+    assert past_gate, "list_boards should be called when dispatch_in_gateway=true"


### PR DESCRIPTION
## Summary
The `/model` picker no longer silently routes an OpenAI selection to OpenRouter. Users with a configured OpenAI provider (and no OpenRouter key) now stay on `api.openai.com` instead of hitting HTTP 401 "Missing Authentication header."

**Root cause:** `hermes_cli/providers.py` carries a legacy alias `"openai" → "openrouter"`. The picker emitted a standalone `slug="openai"` row (gated on `OPENAI_API_KEY`); selecting it ran `resolve_provider_full("openai")`, which resolved that built-in alias to OpenRouter *before* checking the user's own `providers.openai` config.

## Changes
- `model_switch.list_authenticated_providers`: skip vendor names that are aliases to an aggregator (isolates exactly `openai→openrouter`; `copilot`/`kimi`/etc. are real providers and unaffected). Kills the phantom picker row.
- `providers.resolve_provider_full`: user-config `providers.<name>` now resolves before the built-in alias table, so `providers.openai` (api.openai.com) beats the legacy alias.
- `model_switch` PATH A: user-config providers resolve credentials via their own endpoint instead of the name-based runtime resolver that doesn't know user-config slugs; plus a fail-loud guard for explicit unauthed-aggregator hops.

## Validation
| Reporter config (provider=openai-api, no OpenRouter key) | Before | After |
|---|---|---|
| picker: OpenAI + gpt-4o-mini | `target=openrouter` base=openrouter.ai → 401 | `target=openai` base=api.openai.com ✓ |
| explicit `--provider openai-api` | api.openai.com ✓ | api.openai.com ✓ (unchanged) |

Targeted suites green (model_switch / providers / inventory / runtime / auth — 384 + 224 + 295 passing). Added 3 regression tests; converted 1 test that codified the phantom-row behavior.

## Scope
Independent of #35056 (which doesn't touch the picker) and #24234 (separate encrypted-content 400). Does not change the `OPENAI_API_KEY`-implies-openrouter overlay (issue #6799) — that's a wider resolution-semantics change #35056 rewrites; the reported symptom is fixed without it.

Related issues: #14057 (duplicate OpenAI/openai picker rows), #19858 (model switcher hops to OpenRouter).

## Infographic

![kanban-workspace-inheritance](https://v3b.fal.media/files/b/0a9ca10e/i8j6Mymyfswm-7QE_6Niz_oOKmY8cN.png)

## Infographic

![retro-pop-grid](https://v3b.fal.media/files/b/0a9ca111/vqS9efG5y4ReKQTs9DOD1_7eBKpkwT.png)

## Infographic

![kanban-notifier-gate](https://v3b.fal.media/files/b/0a9ca113/3kZgpaMaYB7RwRfZpQbx0_K7vRDmmK.png)
