### PR TITLE
feat(agent): opt-in recovery hook for wedged local inference backends

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -975,6 +975,12 @@ def try_recover_primary_transport(
     if agent._fallback_activated:
         return False
 
+    # The local first-chunk watchdog already proved this request was accepted
+    # but produced no SSE data. Rebuilding the same primary client just repeats
+    # the full TTFB wait; route to fallback or fail fast instead.
+    if getattr(api_error, "_hermes_local_first_chunk_timeout", False):
+        return False
+
     # Only for transient transport errors
     error_type = type(api_error).__name__
     if error_type not in _TRANSIENT_TRANSPORT_ERRORS:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -234,6 +234,159 @@ def _check_stale_giveup(agent) -> None:
             "avoid an indefinite stall. Switch models or start a new "
             "session, then retry."
         )
+def _local_provider_stream_stale_timeout(api_payload: Any) -> float | None:
+    """Return an opt-in bounded stale timeout for local streaming calls.
+
+    By default local endpoints keep the historical unbounded behavior (large
+    self-hosted models can legitimately spend a long time pre-filling). Some
+    local backends can instead park a request on an open socket forever; set
+    HERMES_LOCAL_STALE_TIMEOUT (or HERMES_LOCAL_STREAM_STALE_TIMEOUT) to bound
+    them so the normal retry/fallback path gets a chance to run.
+    """
+    raw = os.getenv("HERMES_LOCAL_STALE_TIMEOUT")
+    if raw is None:
+        raw = os.getenv("HERMES_LOCAL_STREAM_STALE_TIMEOUT")
+    if raw is None:
+        return None
+
+    timeout = _env_float(
+        "HERMES_LOCAL_STALE_TIMEOUT",
+        _env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", 75.0),
+    )
+    if timeout <= 0:
+        # Preserve the stale-timeout convention that non-positive env values
+        # explicitly disable the watchdog.
+        return float("inf")
+
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 300.0)
+    if est_tokens > 50_000:
+        return max(timeout, 240.0)
+    if est_tokens > 25_000:
+        return max(timeout, 150.0)
+    if est_tokens > 10_000:
+        return max(timeout, 90.0)
+    return timeout
+
+
+def _local_provider_first_chunk_timeout(api_payload: Any, model: Any) -> float | None:
+    """Return the generic local-provider no-first-chunk cutoff.
+
+    Local backends can legitimately spend longer pre-filling than cloud
+    providers, but they still need a finite TTFB watchdog so a fallback model
+    cannot inherit an infinite wait after the primary already stalled.
+    """
+    timeout = _env_float(
+        "HERMES_LOCAL_FIRST_CHUNK_TIMEOUT",
+        _env_float("HERMES_LOCAL_TTFB_TIMEOUT", 90.0),
+    )
+    if timeout <= 0:
+        return float("inf")
+
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 600.0)
+    if est_tokens > 50_000:
+        return max(timeout, 360.0)
+    if est_tokens > 25_000:
+        return max(timeout, 240.0)
+    if est_tokens > 10_000:
+        return max(timeout, 150.0)
+    return timeout
+
+
+def _local_provider_non_stream_stale_timeout(api_payload: Any, model: Any) -> float:
+    """Return a finite stale timeout for local non-streaming calls.
+
+    Local non-streaming OpenAI-compatible calls are dangerous when left
+    unbounded: the server may accept the request, generate for a very long time,
+    and send no response headers until the entire completion is done. Keep the
+    default finite so fallback can run, while still scaling for large prompt
+    prefill.
+    """
+    timeout = _env_float(
+        "HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT",
+        _env_float("HERMES_LOCAL_RESPONSE_TIMEOUT", 120.0),
+    )
+    if timeout <= 0:
+        return float("inf")
+
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 600.0)
+    if est_tokens > 50_000:
+        return max(timeout, 360.0)
+    if est_tokens > 25_000:
+        return max(timeout, 240.0)
+    if est_tokens > 10_000:
+        return max(timeout, 180.0)
+    return timeout
+
+
+def _mark_local_first_chunk_timeout(
+    error: Exception,
+    *,
+    elapsed: float,
+    threshold: float,
+    model: Any,
+    context_tokens: int,
+) -> Exception:
+    """Preserve the local TTFB watchdog reason across SDK transport wrappers."""
+    meta = {
+        "elapsed": int(elapsed),
+        "threshold": int(threshold),
+        "model": str(model or "unknown"),
+        "context_tokens": int(context_tokens or 0),
+    }
+    try:
+        setattr(error, "_hermes_local_first_chunk_timeout", True)
+        setattr(error, "_hermes_local_first_chunk_meta", meta)
+    except Exception:
+        pass
+    return error
+
+
+def resolve_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Resolve the no-chunk timeout for streaming chat completions."""
+    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    if _cfg_stale is not None:
+        _stream_stale_timeout_base = _cfg_stale
+        _uses_implicit_default = False
+    else:
+        _env_stale = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+        if _env_stale is not None:
+            _stream_stale_timeout_base = _env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+            _uses_implicit_default = False
+        else:
+            _stream_stale_timeout_base = 180.0
+            _uses_implicit_default = True
+
+    _est_tokens = estimate_request_context_tokens(api_kwargs)
+    if (
+        _uses_implicit_default
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
+        _local_stale = _local_provider_stream_stale_timeout(api_kwargs)
+        if _local_stale is not None:
+            logger.debug(
+                "Local provider detected (%s) — stream stale timeout set to %.0fs",
+                agent.base_url,
+                _local_stale,
+            )
+            return _local_stale
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout disabled",
+            agent.base_url,
+        )
+        return float("inf")
+
+    if _est_tokens > 100_000:
+        return max(_stream_stale_timeout_base, 300.0)
+    if _est_tokens > 50_000:
+        return max(_stream_stale_timeout_base, 240.0)
+    return _stream_stale_timeout_base
 
 
 def interruptible_api_call(agent, api_kwargs: dict):
@@ -632,6 +785,22 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Circuit breaker (#58962): count the stale kill.  See the
             # canonical comment block above ``_stale_streak()``.
             _bump_stale_streak(agent)
+            _base_url = getattr(agent, "base_url", "") or ""
+            if _base_url and is_local_endpoint(_base_url):
+                try:
+                    from agent.local_backend_recovery import maybe_recover_local_backend
+
+                    maybe_recover_local_backend(
+                        agent,
+                        reason="local_non_stream_stale_timeout",
+                        model=api_kwargs.get("model") or agent.model,
+                        base_url=_base_url,
+                        context_tokens=_est_ctx,
+                        elapsed=_elapsed,
+                        threshold=_stale_timeout,
+                    )
+                except Exception:
+                    logger.exception("Local backend recovery hook failed")
             agent._touch_activity(
                 f"stale non-streaming call killed after {int(_elapsed)}s"
             )
@@ -1987,7 +2156,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             raise result["error"]
         return result["response"]
 
-    result = {"response": None, "error": None, "partial_tool_names": []}
+    result = {
+        "response": None,
+        "error": None,
+        "partial_tool_names": [],
+        "local_first_chunk_timeout": None,
+    }
 
     # Cross-turn stale-stream circuit breaker (#58962) — see the canonical
     # comment block above ``_stale_streak()``.  Raises past the give-up
@@ -2037,6 +2211,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     first_delta_fired = {"done": False}
     deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
+    # Whether the current attempt has received its first stream chunk/event yet.
+    # The generic local no-first-chunk (TTFB) watchdog in the poll loop reads
+    # this to tell "connected but no first byte" apart from a healthy stream.
+    first_chunk_seen = {"yes": False}
     # Wall-clock timestamp of the last real streaming chunk.  The outer
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
@@ -2135,6 +2313,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
         last_chunk_time["t"] = time.time()
+        first_chunk_seen["yes"] = False
         agent._touch_activity("waiting for provider response (streaming)")
         # Initialize per-attempt stream diagnostics so the retry block can
         # reach for them after the stream dies.  Lives on
@@ -2214,6 +2393,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
+            first_chunk_seen["yes"] = True
             last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
 
@@ -2502,6 +2682,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         # Reset stale-stream timer for this attempt
         last_chunk_time["t"] = time.time()
+        first_chunk_seen["yes"] = False
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -2526,6 +2707,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             except Exception:
                 pass
             for event in stream:
+                first_chunk_seen["yes"] = True
                 # Update stale-stream timer on every event so the
                 # outer poll loop knows data is flowing.  Without
                 # this, the detector kills healthy long-running
@@ -2889,42 +3071,25 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         finally:
             _close_request_client_once("stream_request_complete")
 
-    # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _stream_stale_timeout_base = _cfg_stale
-    else:
-        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts.  Disable the stale detector unless
-    # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
-    else:
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-        else:
-            _stream_stale_timeout = _stream_stale_timeout_base
-        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
-        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
-        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
-        # model threshold during their thinking phase.  The cloud gateway
-        # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
-            _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
+    _stream_stale_timeout = resolve_stream_stale_timeout(agent, api_kwargs)
+    # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
+    # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
+    # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
+    # model threshold during their thinking phase.  The cloud gateway
+    # upstream kills the socket first, surfacing as BrokenPipeError.
+    # Raises the floor only — never overrides explicit user config
+    # (handled by get_provider_stale_timeout above).
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+    if _reasoning_floor is not None:
+        _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
+    _local_first_chunk_timeout = None
+    _local_first_chunk_model = api_kwargs.get("model") or agent.model
+    if agent.base_url and is_local_endpoint(agent.base_url):
+        _local_first_chunk_timeout = _local_provider_first_chunk_timeout(
+            api_kwargs,
+            _local_first_chunk_model,
+        )
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
@@ -2948,6 +3113,81 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._touch_activity(
                 f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
             )
+
+        # Local providers have a distinct no-first-chunk failure mode: the HTTP
+        # request is accepted but the server never emits the first SSE chunk.
+        # Do not inherit the larger long-context stale timeout for this phase;
+        # once any chunk arrives, the normal stale detector below takes over.
+        if _local_first_chunk_timeout is not None and not first_chunk_seen["yes"]:
+            _first_elapsed = time.time() - last_chunk_time["t"]
+            if _first_elapsed > _local_first_chunk_timeout:
+                _est_ctx = estimate_request_context_tokens(api_kwargs)
+                _local_label = f"local {_local_first_chunk_model or 'model'}"
+                logger.warning(
+                    "%s stream produced no first chunk for %.0fs "
+                    "(threshold %.0fs). model=%s context=~%s tokens. "
+                    "Killing connection.",
+                    _local_label.capitalize(),
+                    _first_elapsed,
+                    _local_first_chunk_timeout,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
+                agent._buffer_status(
+                    f"⚠️ No first stream chunk from {_local_label} for "
+                    f"{int(_first_elapsed)}s "
+                    f"(context: ~{_est_ctx:,} tokens). Switching fallback..."
+                )
+                result["local_first_chunk_timeout"] = {
+                    "elapsed": _first_elapsed,
+                    "threshold": _local_first_chunk_timeout,
+                    "model": _local_first_chunk_model,
+                    "context_tokens": _est_ctx,
+                }
+                try:
+                    from agent.local_backend_recovery import maybe_recover_local_backend
+
+                    maybe_recover_local_backend(
+                        agent,
+                        reason="local_first_chunk_timeout",
+                        model=_local_first_chunk_model,
+                        base_url=getattr(agent, "base_url", "") or "",
+                        context_tokens=_est_ctx,
+                        elapsed=_first_elapsed,
+                        threshold=_local_first_chunk_timeout,
+                    )
+                except Exception:
+                    logger.exception("Local backend recovery hook failed")
+                try:
+                    _close_request_client_once("local_first_chunk_kill")
+                except Exception:
+                    pass
+                try:
+                    agent._replace_primary_openai_client(
+                        reason="local_first_chunk_pool_cleanup"
+                    )
+                except Exception:
+                    pass
+                t.join(timeout=_env_float("HERMES_STREAM_ABORT_JOIN_TIMEOUT", 2.0))
+                if result["error"] is None and result["response"] is None:
+                    result["error"] = _mark_local_first_chunk_timeout(
+                        TimeoutError(
+                            f"{_local_label.capitalize()} stream produced no first chunk after "
+                            f"{int(_first_elapsed)}s "
+                            f"(threshold: {int(_local_first_chunk_timeout)}s)"
+                        ),
+                        elapsed=_first_elapsed,
+                        threshold=_local_first_chunk_timeout,
+                        model=_local_first_chunk_model,
+                        context_tokens=_est_ctx,
+                    )
+                    break
+                if result["error"] is not None or result["response"] is not None:
+                    break
+                last_chunk_time["t"] = time.time()
+                agent._touch_activity(
+                    f"{_local_label} first-chunk timeout after {int(_first_elapsed)}s"
+                )
 
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
@@ -3021,6 +3261,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
+        _first_chunk_meta = result.get("local_first_chunk_timeout")
+        if _first_chunk_meta:
+            result["error"] = _mark_local_first_chunk_timeout(
+                result["error"],
+                elapsed=float(_first_chunk_meta.get("elapsed") or 0.0),
+                threshold=float(_first_chunk_meta.get("threshold") or 0.0),
+                model=_first_chunk_meta.get("model"),
+                context_tokens=int(_first_chunk_meta.get("context_tokens") or 0),
+            )
         if deltas_were_sent["yes"]:
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3901,6 +3901,25 @@ def run_conversation(
                     }
 
                 if retry_count >= max_retries:
+                    if classified.reason == FailoverReason.local_first_chunk_timeout:
+                        if agent._has_pending_fallback():
+                            meta = classified.error_context or {}
+                            waited = meta.get("elapsed")
+                            waited_text = (
+                                f" after {int(waited)}s"
+                                if isinstance(waited, (int, float)) and waited > 0
+                                else ""
+                            )
+                            agent._buffer_status(
+                                "⚠️ Local model produced no first chunk"
+                                f"{waited_text} — trying fallback..."
+                            )
+                        if agent._try_activate_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
+                        _retry.primary_recovery_attempted = True
                     # Before falling back, try rebuilding the primary
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -46,6 +46,7 @@ class FailoverReason(enum.Enum):
     # Retrying reproduces the identical handshake failure, so fail fast
     # with actionable guidance instead of burning retries.
     ssl_cert_verification = "ssl_cert_verification"
+    local_first_chunk_timeout = "local_first_chunk_timeout"  # Local stream accepted request but emitted no first chunk — fail over immediately
 
     # Context / payload
     context_overflow = "context_overflow"  # Context too large — compress, not failover
@@ -608,6 +609,18 @@ def classify_api_error(
         return ClassifiedError(**defaults)
 
     # ── 1. Provider-specific patterns (highest priority) ────────────
+
+    # The local-provider TTFB watchdog may force-close the SDK stream, which can
+    # surface as a generic APIConnectionError. Honor the marker from the
+    # watchdog so the retry loop fails over instead of rebuilding and waiting
+    # on the same wedged local path again.
+    if getattr(error, "_hermes_local_first_chunk_timeout", False):
+        return _result(
+            FailoverReason.local_first_chunk_timeout,
+            retryable=False,
+            should_fallback=True,
+            error_context=getattr(error, "_hermes_local_first_chunk_meta", None) or {},
+        )
 
     # Provider content-policy / safety-filter block. The provider has made a
     # deterministic refusal decision about THIS prompt — retrying unchanged

--- a/agent/local_backend_recovery.py
+++ b/agent/local_backend_recovery.py
@@ -1,0 +1,122 @@
+"""Opt-in recovery hook for wedged local inference backends."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import time
+from typing import Any
+
+from agent.model_metadata import is_local_endpoint
+
+logger = logging.getLogger(__name__)
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def maybe_recover_local_backend(
+    agent: Any,
+    *,
+    reason: str,
+    model: Any,
+    base_url: Any,
+    context_tokens: int | None = None,
+    elapsed: float | None = None,
+    threshold: float | None = None,
+) -> bool:
+    """Run a configured recovery command after a local backend timeout.
+
+    Hermes cannot safely know how every self-hosted backend should be repaired:
+    llama.cpp may support slot cancellation, llama-swap may need its child
+    process killed, and production deployments may want a service restart.  The
+    durable contract is therefore an opt-in command hook.  The command receives
+    sanitized metadata through environment variables and is rate-limited per
+    agent process so repeated retries do not flap a shared GPU service.
+    """
+    base_url_s = str(base_url or "").strip()
+    if not is_local_endpoint(base_url_s):
+        return False
+
+    command = str(os.getenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND") or "").strip()
+    if not command:
+        return False
+
+    cooldown = _env_float("HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN", 60.0)
+    now = time.monotonic()
+    last_at = float(getattr(agent, "_local_backend_recovery_last_at", 0.0) or 0.0)
+    if cooldown > 0 and last_at and now - last_at < cooldown:
+        logger.info(
+            "Skipping local backend recovery for %s: cooldown %.0fs still active",
+            reason,
+            cooldown,
+        )
+        return False
+    try:
+        setattr(agent, "_local_backend_recovery_last_at", now)
+    except Exception:
+        pass
+
+    timeout = _env_float("HERMES_LOCAL_BACKEND_RECOVERY_TIMEOUT", 20.0)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HERMES_RECOVERY_REASON": str(reason),
+            "HERMES_RECOVERY_MODEL": str(model or ""),
+            "HERMES_RECOVERY_PROVIDER": str(getattr(agent, "provider", "") or ""),
+            "HERMES_RECOVERY_BASE_URL": base_url_s,
+            "HERMES_RECOVERY_CONTEXT_TOKENS": str(int(context_tokens or 0)),
+            "HERMES_RECOVERY_ELAPSED": str(float(elapsed or 0.0)),
+            "HERMES_RECOVERY_THRESHOLD": str(float(threshold or 0.0)),
+            "HERMES_RECOVERY_SESSION_ID": str(getattr(agent, "session_id", "") or ""),
+        }
+    )
+
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        logger.warning("Invalid local backend recovery command: %s", exc)
+        return False
+    if not argv:
+        return False
+
+    logger.warning(
+        "Running local backend recovery command after %s: model=%s base_url=%s",
+        reason,
+        model or "unknown",
+        base_url_s,
+    )
+    try:
+        completed = subprocess.run(
+            argv,
+            env=env,
+            timeout=timeout if timeout > 0 else None,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Local backend recovery command timed out after %.0fs",
+            timeout,
+        )
+        return False
+    except Exception as exc:
+        logger.warning("Local backend recovery command failed to start: %s", exc)
+        return False
+
+    if completed.returncode != 0:
+        logger.warning(
+            "Local backend recovery command exited rc=%s",
+            completed.returncode,
+        )
+        return False
+
+    logger.info("Local backend recovery command completed successfully")
+    return True

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -9,9 +9,11 @@ which has provider-specific conditionals for max_tokens defaults,
 reasoning configuration, temperature handling, and extra_body assembly.
 """
 
+import os
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from agent.model_metadata import is_local_endpoint
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -112,6 +114,40 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     """
     m = str(model or "").lower()
     return "gemini" in m or "gemma" in m
+
+
+def _local_default_max_tokens(base_url: Any) -> int | None:
+    """Return a finite default output cap for local OpenAI-compatible endpoints.
+
+    Only real HTTP(S) local LLM servers get the default cap. Virtual routing
+    endpoints with a non-HTTP scheme — notably the MoA aggregator placeholder
+    ``moa://local`` — are NOT real local servers: MoA fans each turn out to the
+    reference/aggregator providers' own runtimes, so a cap resolved for the
+    virtual endpoint would leak onto the (often cloud) aggregator call and
+    truncate long syntheses. Those endpoints must keep MoA's no-output-cap
+    contract, while genuine local HTTP endpoints keep the default. See
+    tests/run_agent/test_moa_loop_mode.py::test_moa_does_not_cap_output_tokens.
+    """
+    url = str(base_url or "")
+    if "://" in url:
+        scheme = url.split("://", 1)[0].lower()
+        if scheme not in ("http", "https"):
+            return None
+    if not is_local_endpoint(url):
+        return None
+
+    raw = (
+        os.getenv("HERMES_LOCAL_DEFAULT_MAX_TOKENS")
+        or os.getenv("HERMES_LOCAL_MAX_TOKENS")
+        or "8192"
+    )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = 8192
+    if value <= 0:
+        return None
+    return value
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -362,6 +398,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_kimi = params.get("is_kimi", False)
         is_tokenhub = params.get("is_tokenhub", False)
         reasoning_config = params.get("reasoning_config")
+        local_default = _local_default_max_tokens(params.get("base_url"))
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))
@@ -369,6 +406,11 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.update(max_tokens_fn(max_tokens))
         elif anthropic_max_out is not None:
             api_kwargs["max_tokens"] = anthropic_max_out
+        elif local_default is not None:
+            if max_tokens_fn:
+                api_kwargs.update(max_tokens_fn(local_default))
+            else:
+                api_kwargs["max_tokens"] = local_default
 
         # Kimi: top-level reasoning_effort (unless thinking disabled)
         if is_kimi:
@@ -549,6 +591,7 @@ class ChatCompletionsTransport(ProviderTransport):
         # they front several backends with different completion-token limits
         # (e.g. opencode-go: mimo-v2.5-pro = 131072).
         profile_max = profile.get_max_tokens(model)
+        local_default = _local_default_max_tokens(params.get("base_url"))
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))
@@ -558,6 +601,11 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.update(max_tokens_fn(profile_max))
         elif anthropic_max is not None:
             api_kwargs["max_tokens"] = anthropic_max
+        elif local_default is not None:
+            if max_tokens_fn:
+                api_kwargs.update(max_tokens_fn(local_default))
+            else:
+                api_kwargs["max_tokens"] = local_default
 
         # Provider-specific api_kwargs extras (reasoning_effort, metadata, etc.)
         reasoning_config = params.get("reasoning_config")

--- a/run_agent.py
+++ b/run_agent.py
@@ -1246,9 +1246,9 @@ class AIAgent:
              ``_compute_non_stream_stale_timeout``.
 
         Returns ``(timeout_seconds, uses_implicit_default)`` so the caller can
-        preserve legacy behaviors that only apply when the user has *not*
-        explicitly configured a stale timeout, such as auto-disabling the
-        detector for local endpoints.
+        apply behaviors that only make sense when the user has *not* explicitly
+        configured a stale timeout, such as using local-backend defaults for
+        loopback endpoints.
         """
         cfg = get_provider_stale_timeout(self.provider, self.model)
         if cfg is not None:
@@ -1273,6 +1273,18 @@ class AIAgent:
 
         return 90.0, True
 
+    def _has_explicit_api_call_stale_timeout(self) -> bool:
+        """Whether the user explicitly configured a non-stream stale timeout.
+
+        Explicit config = a provider/model ``stale_timeout_seconds`` value or the
+        ``HERMES_API_CALL_STALE_TIMEOUT`` env var.  The reasoning-model floor is
+        *not* explicit config: it must not suppress the finite local-endpoint
+        bound applied in :meth:`_compute_non_stream_stale_timeout`.
+        """
+        if get_provider_stale_timeout(self.provider, self.model) is not None:
+            return True
+        return os.getenv("HERMES_API_CALL_STALE_TIMEOUT") is not None
+
     def _compute_non_stream_stale_timeout(self, api_payload: Any) -> float:
         """Compute the effective non-stream stale timeout for this request.
 
@@ -1281,11 +1293,28 @@ class AIAgent:
         applies the same way to both shapes via
         :func:`agent.chat_completion_helpers.estimate_request_context_tokens`.
         """
-        stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
-        if uses_implicit_default and base_url and is_local_endpoint(base_url):
-            return float("inf")
+        # Local backends get a finite, context-scaled non-stream bound whenever
+        # the user has not *explicitly* configured a stale timeout.  Gate this on
+        # explicit config alone — NOT on ``uses_implicit_default``, which
+        # _resolved_api_call_stale_timeout_base also clears for the
+        # reasoning-model floor.  A reasoning model served from a local endpoint
+        # still needs the finite local bound so a stalled non-stream call can
+        # fall back, instead of inheriting the cloud reasoning floor.  (Mirrors
+        # the streaming path, whose implicit-default flag is derived from
+        # provider/env config only.)
+        if (
+            base_url
+            and is_local_endpoint(base_url)
+            and not self._has_explicit_api_call_stale_timeout()
+        ):
+            from agent.chat_completion_helpers import _local_provider_non_stream_stale_timeout
+            model = self.model
+            if isinstance(api_payload, dict):
+                model = api_payload.get("model") or model
+            return _local_provider_non_stream_stale_timeout(api_payload, model)
 
+        stale_base, _uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         from agent.chat_completion_helpers import estimate_request_context_tokens
         est_tokens = estimate_request_context_tokens(api_payload)
         if est_tokens > 100_000:

--- a/scripts/recover_local_llama_server.py
+++ b/scripts/recover_local_llama_server.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Recover a wedged local llama.cpp server after Hermes abandons a request.
+
+The script first tries the llama.cpp slots cancel action.  Older builds may
+expose `/slots` monitoring but not the cancel action; for those deployments,
+`--kill-listener` can terminate the process listening on the recovered base
+URL's port.  llama-swap deployments normally respawn the child server on the
+next request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+def _request(url: str, *, api_key: str = "", method: str = "GET", timeout: float = 5.0):
+    req = urllib.request.Request(url, method=method)
+    if api_key:
+        req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+    return json.loads(raw) if raw else None
+
+
+def _load_key(path: str) -> str:
+    if not path:
+        return os.getenv("LLAMA_SERVER_API_KEY", "").strip()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.readline().strip()
+    except OSError:
+        return ""
+
+
+def _management_base_url(base_url: str) -> str:
+    parsed = urllib.parse.urlparse(base_url.rstrip("/"))
+    path = parsed.path.rstrip("/")
+    if path.lower().endswith("/v1"):
+        path = path[:-3]
+    normalized = parsed._replace(path=path, params="", query="", fragment="")
+    return urllib.parse.urlunparse(normalized).rstrip("/")
+
+
+def _active_slot_ids(base_url: str, api_key: str, timeout: float) -> list[int]:
+    data = _request(
+        _management_base_url(base_url) + "/slots",
+        api_key=api_key,
+        timeout=timeout,
+    )
+    if not isinstance(data, list):
+        return []
+    slot_ids: list[int] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if item.get("is_processing"):
+            try:
+                slot_ids.append(int(item.get("id")))
+            except (TypeError, ValueError):
+                pass
+    return slot_ids
+
+
+def _cancel_slots(base_url: str, api_key: str, slot_ids: list[int], timeout: float) -> bool:
+    cancelled = False
+    management_base_url = _management_base_url(base_url)
+    for slot_id in slot_ids:
+        url = f"{management_base_url}/slots/{slot_id}?action=cancel"
+        try:
+            _request(url, api_key=api_key, method="POST", timeout=timeout)
+            cancelled = True
+        except urllib.error.HTTPError as exc:
+            if exc.code == 501:
+                return False
+            raise
+    return cancelled
+
+
+def _listener_pids(port: int) -> list[int]:
+    try:
+        result = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return []
+    pids: list[int] = []
+    for line in result.stdout.splitlines():
+        try:
+            pids.append(int(line.strip()))
+        except ValueError:
+            pass
+    return pids
+
+
+def _kill_pids(pids: list[int], grace: float) -> bool:
+    if not pids:
+        return False
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    deadline = time.monotonic() + max(grace, 0.0)
+    while time.monotonic() < deadline:
+        if not any(_pid_exists(pid) for pid in pids):
+            return True
+        time.sleep(0.2)
+    sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+    for pid in pids:
+        try:
+            os.kill(pid, sigkill)
+        except ProcessLookupError:
+            pass
+    return True
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        import psutil
+
+        return bool(psutil.pid_exists(pid))
+    except Exception:
+        return Path(f"/proc/{pid}").exists()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("HERMES_RECOVERY_BASE_URL", ""),
+        help="llama.cpp base URL; defaults to HERMES_RECOVERY_BASE_URL",
+    )
+    parser.add_argument("--api-key-file", default=os.getenv("LLAMA_SERVER_API_KEY_FILE", ""))
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--kill-listener", action="store_true")
+    parser.add_argument("--kill-grace", type=float, default=5.0)
+    args = parser.parse_args(argv)
+
+    parsed = urllib.parse.urlparse(args.base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        print("invalid or missing local base URL", file=sys.stderr)
+        return 2
+    if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        print("refusing to kill non-loopback listener", file=sys.stderr)
+        return 2
+
+    api_key = _load_key(args.api_key_file)
+    try:
+        active_slots = _active_slot_ids(args.base_url, api_key, args.timeout)
+    except Exception as exc:
+        print(f"slot probe failed: {type(exc).__name__}", file=sys.stderr)
+        active_slots = []
+
+    if active_slots:
+        try:
+            if _cancel_slots(args.base_url, api_key, active_slots, args.timeout):
+                print(f"cancelled active slots: {len(active_slots)}")
+                return 0
+        except Exception as exc:
+            print(f"slot cancel failed: {type(exc).__name__}", file=sys.stderr)
+
+    if not args.kill_listener:
+        print("no slot cancel performed; listener kill disabled")
+        return 1 if active_slots else 0
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    pids = _listener_pids(port)
+    if not pids:
+        print("no listening process found")
+        return 0
+    if _kill_pids(pids, args.kill_grace):
+        print(f"killed listener process count: {len(pids)}")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -56,6 +56,7 @@ class TestFailoverReason:
             "upstream_rate_limit",
             "overloaded", "server_error", "timeout",
             "ssl_cert_verification",
+            "local_first_chunk_timeout",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
@@ -975,6 +976,23 @@ class TestClassifyApiError:
         e = TimeoutError("timed out")
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
+
+    def test_local_first_chunk_timeout_marker_fails_over_without_retry(self):
+        e = ConnectError("Connection error.")
+        e._hermes_local_first_chunk_timeout = True
+        e._hermes_local_first_chunk_meta = {
+            "elapsed": 75,
+            "threshold": 75,
+            "model": "qwen3.6-27b-256k",
+            "context_tokens": 19956,
+        }
+
+        result = classify_api_error(e, provider="local", model="qwen3.6-27b-256k")
+
+        assert result.reason == FailoverReason.local_first_chunk_timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.error_context["elapsed"] == 75
 
     def test_runtime_error_cli_turn_timed_out_classifies_as_timeout(self):
         # RuntimeError from a local claude-cli shim that wraps a subprocess

--- a/tests/agent/test_local_backend_recovery.py
+++ b/tests/agent/test_local_backend_recovery.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.local_backend_recovery import maybe_recover_local_backend
+
+
+def test_recovery_hook_skips_remote_endpoint(monkeypatch):
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND", "echo recover")
+
+    called = {"run": False}
+
+    def fake_run(*_args, **_kwargs):
+        called["run"] = True
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert not maybe_recover_local_backend(
+        SimpleNamespace(provider="openai"),
+        reason="stale",
+        model="gpt-5.4",
+        base_url="https://api.openai.com/v1",
+    )
+    assert called["run"] is False
+
+
+def test_recovery_hook_runs_command_with_sanitized_metadata(monkeypatch):
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND", "recover-local --flag")
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN", "0")
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    agent = SimpleNamespace(provider="local", session_id="s1")
+    assert maybe_recover_local_backend(
+        agent,
+        reason="local_first_chunk_timeout",
+        model="local-q4",
+        base_url="http://127.0.0.1:9090/v1",
+        context_tokens=1234,
+        elapsed=75.5,
+        threshold=75.0,
+    )
+
+    assert captured["argv"] == ["recover-local", "--flag"]
+    env = captured["env"]
+    assert env["HERMES_RECOVERY_REASON"] == "local_first_chunk_timeout"
+    assert env["HERMES_RECOVERY_MODEL"] == "local-q4"
+    assert env["HERMES_RECOVERY_PROVIDER"] == "local"
+    assert env["HERMES_RECOVERY_BASE_URL"] == "http://127.0.0.1:9090/v1"
+    assert env["HERMES_RECOVERY_CONTEXT_TOKENS"] == "1234"
+    assert env["HERMES_RECOVERY_SESSION_ID"] == "s1"
+
+
+def test_recovery_hook_enforces_process_cooldown(monkeypatch):
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND", "recover-local")
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN", "60")
+
+    calls = {"count": 0}
+
+    def fake_run(*_args, **_kwargs):
+        calls["count"] += 1
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    agent = SimpleNamespace(provider="local")
+    assert maybe_recover_local_backend(
+        agent,
+        reason="first",
+        model="local-q4",
+        base_url="http://127.0.0.1:9090/v1",
+    )
+    assert not maybe_recover_local_backend(
+        agent,
+        reason="second",
+        model="local-q4",
+        base_url="http://127.0.0.1:9090/v1",
+    )
+    assert calls["count"] == 1

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -11,6 +11,13 @@ import pytest
 from unittest.mock import patch
 
 from agent.model_metadata import is_local_endpoint
+from agent.chat_completion_helpers import (
+    _local_provider_first_chunk_timeout,
+    _local_provider_non_stream_stale_timeout,
+    _local_provider_stream_stale_timeout,
+    _mark_local_first_chunk_timeout,
+    resolve_stream_stale_timeout,
+)
 
 
 class TestLocalStreamReadTimeout:
@@ -71,6 +78,183 @@ class TestLocalStreamReadTimeout:
             if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 120.0
+
+
+class TestLocalStaleTimeout:
+    """Local backends keep unbounded stale behavior by default, with an opt-in bound."""
+
+    @staticmethod
+    def _payload_for_estimated_tokens(tokens: int) -> dict[str, list[str]]:
+        return {"messages": ["x" * (tokens * 4)]}
+
+    def _make_agent(self, *, model="qwen3.6-27b-256k", base_url="http://127.0.0.1:8080/v1"):
+        from run_agent import AIAgent
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=131072):
+            return AIAgent(
+                api_key="sk-dummy",
+                base_url=base_url,
+                provider="taro",
+                model=model,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                platform="cli",
+            )
+
+    def test_opt_in_local_stream_stale_timeout_bounds_watchdog(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.setenv("HERMES_LOCAL_STALE_TIMEOUT", "75")
+
+        agent = self._make_agent()
+
+        timeout = resolve_stream_stale_timeout(
+            agent,
+            {"model": "qwen3.6-27b-256k", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert timeout == 75.0
+
+    def test_local_stream_stale_timeout_is_opt_in(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LOCAL_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_STREAM_STALE_TIMEOUT", raising=False)
+
+        assert _local_provider_stream_stale_timeout({"messages": []}) is None
+
+    def test_generic_local_first_chunk_timeout_is_finite(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LOCAL_FIRST_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_TTFB_TIMEOUT", raising=False)
+
+        timeout = _local_provider_first_chunk_timeout(
+            self._payload_for_estimated_tokens(6_000),
+            "qwen3.6-27b-256k",
+        )
+
+        assert timeout == 90.0
+
+    def test_generic_local_first_chunk_timeout_scales_for_large_context(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_FIRST_CHUNK_TIMEOUT", "120")
+
+        timeout = _local_provider_first_chunk_timeout(
+            self._payload_for_estimated_tokens(66_000),
+            "qwen3.6-27b-256k",
+        )
+
+        assert timeout == 360.0
+
+    def test_local_first_chunk_timeout_marker_preserves_watchdog_metadata(self):
+        err = RuntimeError("Connection error.")
+
+        marked = _mark_local_first_chunk_timeout(
+            err,
+            elapsed=180.4,
+            threshold=180.0,
+            model="qwen3.6-27b-256k",
+            context_tokens=42000,
+        )
+
+        assert marked is err
+        assert getattr(err, "_hermes_local_first_chunk_timeout") is True
+        assert getattr(err, "_hermes_local_first_chunk_meta") == {
+            "elapsed": 180,
+            "threshold": 180,
+            "model": "qwen3.6-27b-256k",
+            "context_tokens": 42000,
+        }
+
+    def test_generic_local_stream_stale_timeout_still_disables_by_default(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="qwen3.6-27b")
+
+        timeout = resolve_stream_stale_timeout(
+            agent,
+            {"model": "qwen3.6-27b", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert timeout == float("inf")
+
+    def test_local_non_stream_stale_timeout_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        monkeypatch.setenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", "75")
+
+        agent = self._make_agent()
+
+        assert agent._compute_non_stream_stale_timeout({"messages": []}) == 75.0
+
+    def test_generic_local_non_stream_stale_timeout_is_finite(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_RESPONSE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="qwen3.6-27b-256k")
+
+        assert agent._compute_non_stream_stale_timeout({"messages": []}) == 120.0
+
+    def test_generic_local_non_stream_stale_timeout_scales(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", "120")
+
+        timeout = _local_provider_non_stream_stale_timeout(
+            self._payload_for_estimated_tokens(66_000),
+            "qwen3.6-27b-256k",
+        )
+
+        assert timeout == 360.0
+
+    def test_explicit_stream_stale_timeout_wins_over_local_opt_in(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "12")
+        monkeypatch.setenv("HERMES_LOCAL_STALE_TIMEOUT", "75")
+
+        agent = self._make_agent()
+
+        assert resolve_stream_stale_timeout(agent, {"model": "qwen3.6-27b-256k", "messages": []}) == 12.0
+
+    @pytest.mark.parametrize(
+        ("estimated_tokens", "expected_timeout"),
+        [
+            (10_000, 75.0),
+            (10_001, 90.0),
+            (25_000, 90.0),
+            (25_001, 150.0),
+            (50_000, 150.0),
+            (50_001, 240.0),
+            (100_000, 240.0),
+            (100_001, 300.0),
+        ],
+    )
+    def test_opt_in_local_stale_timeout_threshold_boundaries(
+        self,
+        monkeypatch,
+        estimated_tokens,
+        expected_timeout,
+    ):
+        monkeypatch.setenv("HERMES_LOCAL_STALE_TIMEOUT", "75")
+        monkeypatch.delenv("HERMES_LOCAL_STREAM_STALE_TIMEOUT", raising=False)
+
+        timeout = _local_provider_stream_stale_timeout(
+            self._payload_for_estimated_tokens(estimated_tokens),
+        )
+
+        assert timeout == expected_timeout
+
+    def test_non_positive_local_stale_timeout_disables_watchdog(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_STALE_TIMEOUT", "0")
+
+        timeout = _local_provider_stream_stale_timeout(
+            self._payload_for_estimated_tokens(1),
+        )
+
+        assert timeout == float("inf")
 
 
 class TestIsLocalEndpoint:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -606,6 +606,33 @@ class TestChatCompletionsBuildKwargs:
         # Anthropic Messages API which requires the field.
         assert kw["max_tokens"] == 64000
 
+    def test_local_endpoint_gets_finite_default_max_tokens(self, transport, monkeypatch):
+        monkeypatch.delenv("HERMES_LOCAL_DEFAULT_MAX_TOKENS", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_MAX_TOKENS", raising=False)
+
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="qwen3.6-27b-256k",
+            messages=msgs,
+            base_url="http://127.0.0.1:9090/v1",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        assert kw["max_tokens"] == 8192
+
+    def test_local_endpoint_max_tokens_env_override(self, transport, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_DEFAULT_MAX_TOKENS", "4096")
+
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="qwen3.6-27b-256k",
+            messages=msgs,
+            base_url="http://127.0.0.1:9090/v1",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        assert kw["max_tokens"] == 4096
+
     def test_request_overrides_last(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -268,10 +268,12 @@ def test_resolved_api_call_stale_timeout_priority(monkeypatch, tmp_path):
     assert agent2._resolved_api_call_stale_timeout_base() == (90.0, True)
 
 
-def test_default_non_stream_stale_timeout_auto_disables_for_local_endpoints(monkeypatch, tmp_path):
+def test_default_non_stream_stale_timeout_is_finite_for_local_endpoints(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / ".env").write_text("", encoding="utf-8")
     monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_RESPONSE_TIMEOUT", raising=False)
 
     from run_agent import AIAgent
     agent = AIAgent(
@@ -285,7 +287,7 @@ def test_default_non_stream_stale_timeout_auto_disables_for_local_endpoints(monk
         platform="cli",
     )
 
-    assert agent._compute_non_stream_stale_timeout([]) == float("inf")
+    assert agent._compute_non_stream_stale_timeout([]) == 120.0
 
 
 def test_explicit_non_stream_stale_timeout_is_honored_for_local_endpoints(monkeypatch, tmp_path):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7562,6 +7562,18 @@ class TestDeadRetryCode:
             f"but found {occurrences}"
         )
 
+    def test_local_first_chunk_timeout_fallback_precedes_primary_recovery(self):
+        import inspect
+        from agent.conversation_loop import run_conversation as _rc
+        source = inspect.getsource(_rc)
+
+        first_chunk_fallback = source.index(
+            "FailoverReason.local_first_chunk_timeout"
+        )
+        primary_recovery = source.index("agent._try_recover_primary_transport")
+
+        assert first_chunk_fallback < primary_recovery
+
 
 class TestSupportsReasoningExtraBody:
     def _make_agent(self):

--- a/tests/test_recover_local_llama_server.py
+++ b/tests/test_recover_local_llama_server.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import scripts.recover_local_llama_server as recover
+
+
+def test_active_slot_probe_strips_openai_v1_base_url(monkeypatch):
+    captured = {}
+
+    def fake_request(url, *, api_key="", method="GET", timeout=5.0):
+        captured["url"] = url
+        captured["method"] = method
+        return [{"id": 3, "is_processing": True}]
+
+    monkeypatch.setattr(recover, "_request", fake_request)
+
+    slot_ids = recover._active_slot_ids("http://127.0.0.1:9090/v1", "key", 1.0)
+
+    assert slot_ids == [3]
+    assert captured == {
+        "url": "http://127.0.0.1:9090/slots",
+        "method": "GET",
+    }
+
+
+def test_cancel_slots_strips_openai_v1_base_url(monkeypatch):
+    captured = {}
+
+    def fake_request(url, *, api_key="", method="GET", timeout=5.0):
+        captured["url"] = url
+        captured["method"] = method
+        return {}
+
+    monkeypatch.setattr(recover, "_request", fake_request)
+
+    assert recover._cancel_slots("http://127.0.0.1:9090/v1/", "key", [7], 1.0)
+    assert captured == {
+        "url": "http://127.0.0.1:9090/slots/7?action=cancel",
+        "method": "POST",
+    }


### PR DESCRIPTION
## What
When a local backend trips the first-chunk or non-stream stale watchdog (see #37168, which this PR stacks on), Hermes can now invoke an operator-configured recovery command — useful for self-hosted servers that wedge in ways only the operator knows how to repair (slot cancellation, child-process kill, service restart).

## How
- New `agent/local_backend_recovery.py`: `maybe_recover_local_backend()` runs `HERMES_LOCAL_BACKEND_RECOVERY_COMMAND` (opt-in, default off) with sanitized metadata passed via `HERMES_RECOVERY_*` env vars, rate-limited by `HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN` (default 60s) so retries cannot flap a shared GPU service.
- Hook points in the non-stream stale-kill and first-chunk timeout paths; failures in the hook are logged and never affect the turn.
- `scripts/recover_local_llama_server.py`: a reference recovery script for llama-server-style backends.
- New transport default: `HERMES_LOCAL_DEFAULT_MAX_TOKENS` caps local completions (default 8192) so a wedged generation cannot run unbounded.

## Tests
`tests/agent/test_local_backend_recovery.py` (env contract, cooldown, opt-in gating), `tests/test_recover_local_llama_server.py`, transport tests for the max-tokens default. 300 tests pass locally on the stack.

Stacked on #37168 — until that merges, this diff shows the union of both; the recovery-specific changes are `agent/local_backend_recovery.py`, the two hook sites, `scripts/recover_local_llama_server.py`, and their tests. Part 5 of the former #35642 split.