### PR TITLE
feat: add target_node proof gate for kanban task completion

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -108,6 +108,15 @@ _IS_WINDOWS = sys.platform == "win32"
 # workloads either finish within 15m, set a longer claim explicitly, or use
 # ``HERMES_KANBAN_CLAIM_TTL_SECONDS`` to raise the default claim window for
 # long single-call MCP workflows.
+# Valid target_node values for proof-node gate (t_728a7e43).
+# NULL or "any" allow completion without proof; others require matching
+# verified_on_node in completion metadata.
+VALID_TARGET_NODES = {"conductor", "cfo-vm", "mac", "any"}
+
+# A running task's claim is valid for 15 minutes; after that the next
+# dispatcher tick reclaims it.  Workers that outlive this window should call
+# ``heartbeat_claim(task_id)`` periodically.  In practice most kanban
+# workloads either finish within 15m or set a longer claim explicitly.
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 
 # If a worker's PID is still alive but its ``last_heartbeat_at`` is
@@ -744,6 +753,11 @@ class Task:
     # set the env var. Lets clients render a per-session board without
     # relying on tenant + time-window heuristics.
     session_id: Optional[str] = None
+    # Proof-node gate for infra/operator cards (t_728a7e43). When set to
+    # a specific node name (conductor, cfo-vm, mac), completion must include
+    # metadata with ``verified_on_node`` matching this value. ``None`` or
+    # ``"any"`` allow completion without proof (default for non-infra cards).
+    target_node: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -818,6 +832,9 @@ class Task:
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
+            ),
+            target_node=(
+                row["target_node"] if "target_node" in keys else None
             ),
         )
 
@@ -981,6 +998,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
     session_id           TEXT
+    -- Proof-node gate for infra/operator cards: when set to a node name
+    -- (conductor, cfo-vm, mac), completion must include metadata with
+    -- verified_on_node matching this value. NULL or 'any' allow completion
+    -- without proof (default for non-infra cards). See t_728a7e43.
+    target_node          TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1650,6 +1672,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+    if "target_node" not in cols:
+        # Proof-node gate for infra/operator cards (t_728a7e43). NULL or
+        # 'any' = no proof required; specific node names (conductor, cfo-vm,
+        # mac) require completion metadata with matching verified_on_node.
+        # Existing rows get NULL, which preserves legacy behavior (complete
+        # without proof).
+        _add_column_if_missing(conn, "tasks", "target_node", "target_node TEXT")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -2014,6 +2043,7 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    target_node: Optional[str] = None,
     board: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
@@ -2039,6 +2069,13 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``target_node`` is an optional proof-node gate for infra/operator
+    cards (t_728a7e43). When set to a specific node name (conductor,
+    cfo-vm, mac), completion requires matching ``verified_on_node`` in
+    the metadata. ``None`` or ``"any"`` allow completion without proof
+    (default for non-infra cards). Prevents false-DONE where proof is
+    collected on the wrong machine.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -2056,6 +2093,16 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    
+    # Validate target_node
+    if target_node is not None:
+        target_node = target_node.strip().lower() if target_node else None
+        if target_node and target_node not in VALID_TARGET_NODES:
+            raise ValueError(
+                f"target_node must be one of {sorted(VALID_TARGET_NODES)}, "
+                f"got {target_node!r}"
+            )
+    
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
@@ -2179,8 +2226,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        target_node
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2202,6 +2250,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        target_node,
                     ),
                 )
                 for pid in parents:
@@ -3541,6 +3590,36 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+
+    # Gate: verify target_node proof BEFORE the main write txn. A rejected
+    # completion still needs an auditable event, so we emit it in a tiny
+    # dedicated txn, then return False. The task remains in its current
+    # state (running/ready/blocked).
+    row = conn.execute(
+        "SELECT target_node FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row:
+        target_node = row["target_node"]
+        # NULL or 'any' allow completion without proof
+        if target_node and target_node != "any":
+            # Specific node name (conductor, cfo-vm, mac) requires matching proof
+            verified_on_node = metadata.get("verified_on_node") if metadata else None
+            if verified_on_node != target_node:
+                # Proof missing or mismatched — emit event and reject
+                with write_txn(conn):
+                    _append_event(
+                        conn, task_id, "completion_blocked_target_node_mismatch",
+                        {
+                            "expected": target_node,
+                            "actual": verified_on_node,
+                            "summary_preview": (
+                                (summary or result or "").strip().splitlines()[0][:200]
+                                if (summary or result)
+                                else None
+                            ),
+                        },
+                    )
+                return False
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a

--- a/tests/hermes_cli/test_target_node_proof_gate.py
+++ b/tests/hermes_cli/test_target_node_proof_gate.py
@@ -1,0 +1,254 @@
+"""Tests for target_node proof gate — t_728a7e43.
+
+Verifies that infra/operator cards with target_node constraints cannot be
+marked DONE unless completion metadata includes proof from the right host.
+"""
+import json
+import socket
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def db():
+    """Fresh in-memory kanban DB for each test."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "test.db"
+        kb.init_db(db_path=db_path)
+        conn = kb.connect(db_path=db_path)
+        yield conn
+        conn.close()
+
+
+def test_target_node_missing_allows_completion(db):
+    """Legacy cards with no target_node set should complete without proof."""
+    tid = kb.create_task(
+        db,
+        title="legacy task",
+        body="no target_node constraint",
+        assignee="builder",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    ok = kb.complete_task(db, tid, summary="done", metadata={})
+    assert ok, "legacy task with no target_node should complete without proof"
+
+
+def test_target_node_any_allows_completion(db):
+    """Cards with target_node=any should complete without proof."""
+    tid = kb.create_task(
+        db,
+        title="any-node task",
+        body="can run anywhere",
+        assignee="builder",
+        target_node="any",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    ok = kb.complete_task(db, tid, summary="done", metadata={})
+    assert ok, "target_node=any should complete without proof"
+
+
+def test_target_node_matching_proof_allows_completion(db):
+    """Completion with matching verified_on_node should succeed."""
+    tid = kb.create_task(
+        db,
+        title="conductor infra task",
+        body="must run on conductor",
+        assignee="operator",
+        target_node="conductor",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    
+    metadata = {
+        "verified_on_node": "conductor",
+        "hostname_proof": socket.gethostname(),
+    }
+    ok = kb.complete_task(db, tid, summary="done on conductor", metadata=metadata)
+    assert ok, "matching target_node=conductor + verified_on_node=conductor should succeed"
+
+
+def test_target_node_mismatched_proof_blocks_completion(db):
+    """Completion with mismatched verified_on_node should fail."""
+    tid = kb.create_task(
+        db,
+        title="conductor infra task",
+        body="must run on conductor",
+        assignee="operator",
+        target_node="conductor",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    
+    # Worker claims they verified on cfo-vm but target was conductor
+    metadata = {
+        "verified_on_node": "cfo-vm",
+        "hostname_proof": "wrong-host",
+    }
+    ok = kb.complete_task(db, tid, summary="done on wrong node", metadata=metadata)
+    assert not ok, "mismatched target_node should reject completion"
+    
+    # Task should still be running, not done
+    row = db.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "running", "task should remain running after rejected completion"
+
+
+def test_target_node_missing_proof_blocks_completion(db):
+    """Completion without verified_on_node when target_node is set should fail."""
+    tid = kb.create_task(
+        db,
+        title="conductor infra task",
+        body="must run on conductor",
+        assignee="operator",
+        target_node="conductor",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    
+    # Metadata has no verified_on_node at all
+    metadata = {"some_other_key": "value"}
+    ok = kb.complete_task(db, tid, summary="done without proof", metadata=metadata)
+    assert not ok, "target_node set but no verified_on_node should reject completion"
+    
+    row = db.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "running"
+
+
+def test_target_node_empty_metadata_blocks_completion(db):
+    """Completion with empty metadata when target_node is set should fail."""
+    tid = kb.create_task(
+        db,
+        title="conductor infra task",
+        body="must run on conductor",
+        assignee="operator",
+        target_node="conductor",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    
+    ok = kb.complete_task(db, tid, summary="done without metadata")
+    assert not ok, "target_node set but metadata=None should reject completion"
+    
+    row = db.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "running"
+
+
+def test_target_node_all_valid_nodes(db):
+    """All acceptable node names (conductor, cfo-vm, mac, any) should work."""
+    for node in ["conductor", "cfo-vm", "mac", "any"]:
+        tid = kb.create_task(
+            db,
+            title=f"task for {node}",
+            body=f"target={node}",
+            assignee="operator",
+            target_node=node,
+        )
+        
+        # target_node=any doesn't require proof
+        if node == "any":
+            kb.claim_task(db, tid, claimer="conductor:99")
+            ok = kb.complete_task(db, tid, summary=f"done on {node}")
+            assert ok, f"target_node={node} should complete without proof"
+        else:
+            kb.claim_task(db, tid, claimer="conductor:99")
+            metadata = {"verified_on_node": node, "hostname_proof": "test"}
+            ok = kb.complete_task(db, tid, summary=f"done on {node}", metadata=metadata)
+            assert ok, f"target_node={node} with matching proof should succeed"
+
+
+def test_target_node_invalid_node_rejected_on_create(db):
+    """Invalid target_node values should be rejected at task creation."""
+    with pytest.raises(ValueError, match="target_node must be one of"):
+        kb.create_task(
+            db,
+            title="invalid node",
+            body="oops",
+            assignee="operator",
+            target_node="invalid-node",
+        )
+
+
+def test_completion_blocked_event_emitted_on_mismatch(db):
+    """A completion_blocked_target_node_mismatch event should be emitted on rejection."""
+    tid = kb.create_task(
+        db,
+        title="conductor infra task",
+        body="must run on conductor",
+        assignee="operator",
+        target_node="conductor",
+    )
+    kb.claim_task(db, tid, claimer="conductor:99")
+    
+    metadata = {"verified_on_node": "cfo-vm"}
+    ok = kb.complete_task(db, tid, summary="wrong node", metadata=metadata)
+    assert not ok
+    
+    # Check that the event was logged
+    events = db.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (tid,)
+    ).fetchall()
+    assert len(events) > 0
+    evt = events[0]
+    assert evt["kind"] == "completion_blocked_target_node_mismatch"
+    payload = json.loads(evt["payload"])
+    assert payload["expected"] == "conductor"
+    assert payload["actual"] == "cfo-vm"
+
+
+def test_target_node_persisted_and_readable(db):
+    """target_node should be persisted and readable via list_tasks."""
+    tid = kb.create_task(
+        db,
+        title="conductor task",
+        body="body",
+        assignee="operator",
+        target_node="conductor",
+    )
+    
+    rows = kb.list_tasks(db)
+    task = next((t for t in rows if t.id == tid), None)
+    assert task is not None
+    assert task.target_node == "conductor"
+
+
+def test_legacy_task_has_null_target_node(db):
+    """Tasks created without target_node should have target_node=NULL."""
+    tid = kb.create_task(
+        db,
+        title="legacy task",
+        body="no target_node",
+        assignee="builder",
+    )
+    
+    row = db.execute("SELECT target_node FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["target_node"] is None
+
+
+def test_target_node_proof_regression_t_e06f0001_class(db):
+    """Regression: t_e06f0001-class false-DONE must be rejected.
+    
+    Context: t_e06f0001 was an infra card that claimed DONE with proof
+    collected on cfo-vm when the artifact was actually on Conductor.
+    This test simulates that scenario and verifies rejection.
+    """
+    tid = kb.create_task(
+        db,
+        title="[conductor-infra] Deploy artifact on conductor",
+        body="Artifact must exist on conductor, not cfo-vm",
+        assignee="operator",
+        target_node="conductor",
+    )
+    kb.claim_task(db, tid, claimer="cfo-vm:99")
+    
+    # Worker on cfo-vm tries to complete with cfo-vm proof
+    metadata = {
+        "verified_on_node": "cfo-vm",
+        "artifact_path": "/opt/artifact",
+        "ls_proof": "-rw-r--r-- 1 ubuntu ubuntu 1234 artifact",
+    }
+    ok = kb.complete_task(db, tid, summary="artifact deployed", metadata=metadata)
+    assert not ok, "t_e06f0001-class false-DONE should be rejected"
+    
+    row = db.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "running", "task should remain running after rejection"


### PR DESCRIPTION
## Summary

Implements `target_node` proof gate to prevent false-DONE scenarios where infra/operator tasks are verified on the wrong machine.

This is a corrective PR for task `t_728a7e43`, which was initially completed but the branch was never pushed to remote. This PR contains the rebased and tested implementation.

## Changes

- **Add `target_node` column** to tasks table with valid values: `conductor`, `cfo-vm`, `mac`, `any`, or `NULL`
- **Add `VALID_TARGET_NODES` constant** with allowlist for node validation
- **Update `create_task()`** to accept and validate `target_node` parameter
- **Add proof gate in `complete_task()`** that checks `metadata.verified_on_node` matches `target_node`
- **Emit `completion_blocked_target_node_mismatch` event** on gate rejection for auditability
- **Update Task dataclass** and `from_row()` to include `target_node` field
- **Add database migration** for existing databases to add the new column
- **Comprehensive test suite**: 12 tests covering all scenarios

## Behavior

- **Backward compatible**: `NULL` or `'any'` target_node bypasses gate (existing tasks continue to work)
- **Specific node validation**: When target_node is set to a specific value (`conductor`, `cfo-vm`, `mac`), completion requires exact `metadata.verified_on_node` match
- **Early validation**: Invalid node names are rejected at task creation time with `ValueError`
- **Auditable rejections**: Rejected completions emit an event but don't modify task state

## Test Coverage

All 12 tests passing in `tests/hermes_cli/test_target_node_proof_gate.py`:
- ✅ Missing target_node allows completion (backward compat)
- ✅ target_node='any' allows completion
- ✅ Matching proof allows completion
- ✅ Mismatched proof blocks completion
- ✅ Missing proof blocks completion
- ✅ Empty metadata blocks completion
- ✅ All valid nodes accepted
- ✅ Invalid nodes rejected at create time
- ✅ Completion blocked event emitted on mismatch
- ✅ target_node persisted and readable
- ✅ Legacy tasks have NULL target_node
- ✅ Regression test for original false-DONE scenario

## Files Changed

- `hermes_cli/kanban_db.py` - Core implementation (83 lines added/modified)
- `tests/hermes_cli/test_target_node_proof_gate.py` - Test suite (254 lines)

## Migration

The migration is automatic on first connection - adds `target_node TEXT` column to tasks table. No data loss, all existing tasks get `NULL` (backward compatible).

## Related

- Original task: `t_728a7e43`
- Corrective task: `t_46c84ec5`
- Commit: `529873cb779ff9be88156f7454d4d7c28b60901b`
