### PR TITLE
fix(file_operations): convert MSYS paths to Windows paths on Windows

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -733,6 +733,10 @@ class ShellFileOperations(FileOperations):
         
         This must be done BEFORE shell escaping, since ~ doesn't expand
         inside single quotes.
+        
+        On Windows with MSYS/Git-Bash, we need to handle the case where
+        the shell returns MSYS-style paths (e.g., /c/Users/...) but Python
+        expects Windows-style paths (e.g., C:/Users/...).
         """
         if not path:
             return path
@@ -743,6 +747,9 @@ class ShellFileOperations(FileOperations):
             result = self._exec("echo $HOME")
             if result.exit_code == 0 and result.stdout.strip():
                 home = result.stdout.strip()
+                # Convert MSYS-style path to Windows-style if needed
+                # e.g., /c/Users/xxx -> C:/Users/xxx
+                home = self._msys_to_windows_path(home)
                 if path == '~':
                     return home
                 elif path.startswith('~/'):
@@ -759,8 +766,43 @@ class ShellFileOperations(FileOperations):
                     expand_result = self._exec(f"echo ~{username}")
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
                         user_home = expand_result.stdout.strip()
+                        user_home = self._msys_to_windows_path(user_home)
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
                         return user_home + suffix
+        
+        # Also convert MSYS-style absolute paths (e.g., /d/code/...) to Windows-style
+        path = self._msys_to_windows_path(path)
+        
+        return path
+    
+    def _msys_to_windows_path(self, path: str) -> str:
+        """
+        Convert MSYS/Git-Bash style paths to Windows-style paths.
+        
+        MSYS maps Windows drives as /c/, /d/, etc. Python on Windows
+        expects C:/, D:/, etc. This conversion ensures file operations
+        target the correct physical location.
+        
+        Examples:
+            /c/Users/xxx -> C:/Users/xxx
+            /d/code/xxx  -> D:/code/xxx
+            /tmp/xxx     -> /tmp/xxx (no conversion needed)
+        """
+        if not path:
+            return path
+        
+        # Match MSYS drive pattern: /x/ or /x (where x is a single letter)
+        import re as _re
+        msys_drive_pattern = _re.compile(r'^/([a-zA-Z])(?:/|$)')
+        match = msys_drive_pattern.match(path)
+        if match:
+            drive_letter = match.group(1).upper()
+            # Replace /x/ with X:/
+            rest = path[3:]  # Remove leading /x/
+            if rest:
+                return f"{drive_letter}:/" + rest
+            else:
+                return f"{drive_letter}:/"
         
         return path
     


### PR DESCRIPTION
On Windows with MSYS/Git-Bash, the shell returns paths like /c/Users/... and /d/code/... but Python expects C:/Users/... and D:/code/...

This caused write_file to write files to the wrong location - files appeared to exist when checked via Python but were not visible in Windows Explorer or to terminal commands using Windows paths.

The fix adds a _msys_to_windows_path() method that converts MSYS-style drive paths (/c/, /d/, etc.) to Windows-style paths (C:/, D:/, etc.)

Fixes #37144

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

