### PR TITLE
fix(kanban): swap dependency labels

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3604,44 +3604,6 @@
       h("div", { className: "hermes-kanban-deps-row" },
         h("span", { className: "hermes-kanban-deps-label" }, tx(t, "children", "Children:")),
         h("div", { className: "hermes-kanban-deps-chips" },
-          (links.parents || []).length === 0
-            ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
-            : (links.parents || []).map(function (id) {
-                return h("span", { key: id, className: "hermes-kanban-dep-chip" },
-                  id,
-                  h("button", {
-                    type: "button",
-                    className: "hermes-kanban-dep-chip-x",
-                    onClick: function () { props.onRemoveParent(id); },
-                    title: tx(t, "removeDependency", "Remove dependency"),
-                  }, "×"),
-                );
-              }),
-        ),
-      ),
-      h("div", { className: "hermes-kanban-deps-row" },
-        h(Select, Object.assign({
-          value: newParent,
-          className: "h-7 text-xs flex-1",
-        }, selectChangeHandler(setNewParent)),
-          h(SelectOption, { value: "" }, tx(t, "addChild", "— add child —")),
-          candidatesFor(parentExclude).map(function (tk) {
-            return h(SelectOption, { key: tk.id, value: tk.id },
-              `${tk.id} — ${(tk.title || "").slice(0, 50)}`);
-          }),
-        ),
-        h(Button, {
-          onClick: function () {
-            if (!newParent) return;
-            props.onAddParent(newParent).then(function () { setNewParent(""); });
-          },
-          disabled: !newParent,
-          size: "sm",
-        }, "+ child"),
-      ),
-      h("div", { className: "hermes-kanban-deps-row" },
-        h("span", { className: "hermes-kanban-deps-label" }, tx(t, "parents", "Parents:")),
-        h("div", { className: "hermes-kanban-deps-chips" },
           (links.children || []).length === 0
             ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
             : (links.children || []).map(function (id) {
@@ -3662,7 +3624,7 @@
           value: newChild,
           className: "h-7 text-xs flex-1",
         }, selectChangeHandler(setNewChild)),
-          h(SelectOption, { value: "" }, tx(t, "addParent", "— add parent —")),
+          h(SelectOption, { value: "" }, tx(t, "addChild", "— add child —")),
           candidatesFor(childExclude).map(function (tk) {
             return h(SelectOption, { key: tk.id, value: tk.id },
               `${tk.id} — ${(tk.title || "").slice(0, 50)}`);
@@ -3674,6 +3636,44 @@
             props.onAddChild(newChild).then(function () { setNewChild(""); });
           },
           disabled: !newChild,
+          size: "sm",
+        }, "+ child"),
+      ),
+      h("div", { className: "hermes-kanban-deps-row" },
+        h("span", { className: "hermes-kanban-deps-label" }, tx(t, "parents", "Parents:")),
+        h("div", { className: "hermes-kanban-deps-chips" },
+          (links.parents || []).length === 0
+            ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
+            : (links.parents || []).map(function (id) {
+                return h("span", { key: id, className: "hermes-kanban-dep-chip" },
+                  id,
+                  h("button", {
+                    type: "button",
+                    className: "hermes-kanban-dep-chip-x",
+                    onClick: function () { props.onRemoveParent(id); },
+                    title: tx(t, "removeDependency", "Remove dependency"),
+                  }, "×"),
+                );
+              }),
+        ),
+      ),
+      h("div", { className: "hermes-kanban-deps-row" },
+        h(Select, Object.assign({
+          value: newParent,
+          className: "h-7 text-xs flex-1",
+        }, selectChangeHandler(setNewParent)),
+          h(SelectOption, { value: "" }, tx(t, "addParent", "— add parent —")),
+          candidatesFor(parentExclude).map(function (tk) {
+            return h(SelectOption, { key: tk.id, value: tk.id },
+              `${tk.id} — ${(tk.title || "").slice(0, 50)}`);
+          }),
+        ),
+        h(Button, {
+          onClick: function () {
+            if (!newParent) return;
+            props.onAddParent(newParent).then(function () { setNewParent(""); });
+          },
+          disabled: !newParent,
           size: "sm",
         }, "+ parent"),
       ),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3602,7 +3602,7 @@
     return h("div", { className: "hermes-kanban-section" },
       h("div", { className: "hermes-kanban-section-head" }, tx(t, "dependencies", "Dependencies")),
       h("div", { className: "hermes-kanban-deps-row" },
-        h("span", { className: "hermes-kanban-deps-label" }, tx(t, "parents", "Parents:")),
+        h("span", { className: "hermes-kanban-deps-label" }, tx(t, "children", "Children:")),
         h("div", { className: "hermes-kanban-deps-chips" },
           (links.parents || []).length === 0
             ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
@@ -3624,7 +3624,7 @@
           value: newParent,
           className: "h-7 text-xs flex-1",
         }, selectChangeHandler(setNewParent)),
-          h(SelectOption, { value: "" }, tx(t, "addParent", "— add parent —")),
+          h(SelectOption, { value: "" }, tx(t, "addChild", "— add child —")),
           candidatesFor(parentExclude).map(function (tk) {
             return h(SelectOption, { key: tk.id, value: tk.id },
               `${tk.id} — ${(tk.title || "").slice(0, 50)}`);
@@ -3637,10 +3637,10 @@
           },
           disabled: !newParent,
           size: "sm",
-        }, "+ parent"),
+        }, "+ child"),
       ),
       h("div", { className: "hermes-kanban-deps-row" },
-        h("span", { className: "hermes-kanban-deps-label" }, tx(t, "children", "Children:")),
+        h("span", { className: "hermes-kanban-deps-label" }, tx(t, "parents", "Parents:")),
         h("div", { className: "hermes-kanban-deps-chips" },
           (links.children || []).length === 0
             ? h("span", { className: "hermes-kanban-deps-empty" }, tx(t, "none", "none"))
@@ -3662,7 +3662,7 @@
           value: newChild,
           className: "h-7 text-xs flex-1",
         }, selectChangeHandler(setNewChild)),
-          h(SelectOption, { value: "" }, tx(t, "addChild", "— add child —")),
+          h(SelectOption, { value: "" }, tx(t, "addParent", "— add parent —")),
           candidatesFor(childExclude).map(function (tk) {
             return h(SelectOption, { key: tk.id, value: tk.id },
               `${tk.id} — ${(tk.title || "").slice(0, 50)}`);
@@ -3675,7 +3675,7 @@
           },
           disabled: !newChild,
           size: "sm",
-        }, "+ child"),
+        }, "+ parent"),
       ),
     );
   }

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -247,6 +247,29 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     assert 'readSelectedBoard() || "default"' not in js
 
 
+def test_dashboard_dependency_labels_follow_displayed_direction():
+    """The dependency editor labels must match the visible relationship direction."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    dependency_start = js.index("function DependencyEditor(props)")
+    children_label_start = js.index('tx(t, "children", "Children:")', dependency_start)
+    parents_label_start = js.index('tx(t, "parents", "Parents:")', children_label_start)
+    dependency_end = js.index("function StatusActions(props)", parents_label_start)
+    children_section = js[children_label_start:parents_label_start]
+    parents_section = js[parents_label_start:dependency_end]
+
+    assert 'tx(t, "children", "Children:")' in children_section
+    assert 'tx(t, "addChild", "— add child —")' in children_section
+    assert '}, "+ child")' in children_section
+
+    assert 'tx(t, "parents", "Parents:")' in parents_section
+    assert 'tx(t, "addParent", "— add parent —")' in parents_section
+    assert '}, "+ parent")' in parents_section
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -262,12 +262,28 @@ def test_dashboard_dependency_labels_follow_displayed_direction():
     parents_section = js[parents_label_start:dependency_end]
 
     assert 'tx(t, "children", "Children:")' in children_section
+    assert "(links.children || []).length === 0" in children_section
+    assert "(links.children || []).map(function (id)" in children_section
+    assert "props.onRemoveChild(id);" in children_section
     assert 'tx(t, "addChild", "— add child —")' in children_section
+    assert "candidatesFor(childExclude).map(function (tk)" in children_section
+    assert "props.onAddChild(newChild)" in children_section
     assert '}, "+ child")' in children_section
+    assert "links.parents" not in children_section
+    assert "onAddParent" not in children_section
+    assert "onRemoveParent" not in children_section
 
     assert 'tx(t, "parents", "Parents:")' in parents_section
+    assert "(links.parents || []).length === 0" in parents_section
+    assert "(links.parents || []).map(function (id)" in parents_section
+    assert "props.onRemoveParent(id);" in parents_section
     assert 'tx(t, "addParent", "— add parent —")' in parents_section
+    assert "candidatesFor(parentExclude).map(function (tk)" in parents_section
+    assert "props.onAddParent(newParent)" in parents_section
     assert '}, "+ parent")' in parents_section
+    assert "links.children" not in parents_section
+    assert "onAddChild" not in parents_section
+    assert "onRemoveChild" not in parents_section
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- swap the Kanban dashboard dependency editor labels so the displayed parent/child wording matches the requested UI direction
- leave the existing `parent_id` / `child_id` API payload direction unchanged
- add a dashboard bundle regression assertion for the visible dependency labels and add buttons

## Why
The dependency editor displayed the parent/child wording in the reverse direction users expect. This made the `add parent` and `add child` controls read backwards even though the underlying link creation payloads were correct.

Closes #37165.

## Tests
- `uv run --frozen --with pytest --with pytest-timeout --with fastapi --with httpx --with python-multipart pytest tests/plugins/test_kanban_dashboard_plugin.py -q`
- `uv run --frozen --with pytest --with pytest-timeout --with fastapi --with httpx --with python-multipart pytest tests/plugins/test_kanban_dashboard_plugin.py::test_dashboard_dependency_labels_follow_displayed_direction -q`
- `python3 -m py_compile tests/plugins/test_kanban_dashboard_plugin.py`
- `git diff --check -- plugins/kanban/dashboard/dist/index.js tests/plugins/test_kanban_dashboard_plugin.py`
- `uvx --from ruff==0.15.10 ruff check tests/plugins/test_kanban_dashboard_plugin.py`
