### PR TITLE
fix(aux-client): preserve /anthropic for MiniMax M-series auxiliary routes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -265,9 +265,9 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "stepfun": "step-3.5-flash",
     "kimi-coding-cn": "kimi-k2-turbo-preview",
     "gmi": "google/gemini-3.1-flash-lite-preview",
-    "minimax": "MiniMax-M2.7",
-    "minimax-oauth": "MiniMax-M2.7-highspeed",
-    "minimax-cn": "MiniMax-M2.7",
+    "minimax": "MiniMax-M3",
+    "minimax-oauth": "MiniMax-M3",
+    "minimax-cn": "MiniMax-M3",
     "anthropic": "claude-haiku-4-5-20251001",
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
@@ -473,14 +473,28 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
 def _to_openai_base_url(base_url: str) -> str:
     """Normalize an Anthropic-style base URL to OpenAI-compatible format.
 
-    Some providers (MiniMax, MiniMax-CN) expose an ``/anthropic`` endpoint for
-    the Anthropic Messages API and a separate ``/v1`` endpoint for OpenAI chat
-    completions.  The auxiliary client uses the OpenAI SDK, so it must hit the
-    ``/v1`` surface.  Passing the raw ``inference_base_url`` causes requests to
-    land on ``/anthropic/chat/completions`` — a 404.
+    Most providers that ship a ``/anthropic`` base URL also expose a sibling
+    ``/v1`` endpoint, and the auxiliary client uses the OpenAI SDK so it must
+    hit the ``/v1`` surface.  Passing the raw URL would land requests on
+    ``/anthropic/chat/completions`` — a 404.
+
+    Exception — MiniMax (``api.minimaxi.com``, ``api.minimax.io``): for
+    M-series models the ``/v1`` endpoint returns 404 on
+    ``/v1/chat/completions``; only the ``/anthropic`` Anthropic Messages
+    surface is supported.  Preserve the original URL so the downstream
+    :func:`_maybe_wrap_anthropic` chokepoint can detect it via
+    :func:`_endpoint_speaks_anthropic_messages` and route through the
+    Anthropic SDK.  See #17387.
     """
     url = str(base_url or "").strip().rstrip("/")
     if url.endswith("/anthropic"):
+        if "minimaxi.com" in url or "minimax.io" in url:
+            logger.debug(
+                "Auxiliary client: preserving MiniMax /anthropic base URL %s "
+                "— _maybe_wrap_anthropic will route through Anthropic SDK",
+                url,
+            )
+            return url
         # ZAI (open.bigmodel.cn) uses /api/anthropic for Anthropic wire
         # but /api/paas/v4 for OpenAI wire — the generic /v1 rewrite is wrong.
         if "open.bigmodel.cn" in url or "bigmodel" in url:

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -1,7 +1,10 @@
 """Tests for MiniMax auxiliary client URL normalization.
 
 MiniMax and MiniMax-CN set inference_base_url to the /anthropic path.
-The auxiliary client uses the OpenAI SDK, which needs /v1 instead.
+For M-series models the /v1 endpoint returns 404 on /v1/chat/completions,
+so the auxiliary client must preserve the /anthropic URL and let the
+downstream ``_maybe_wrap_anthropic`` chokepoint route through the
+Anthropic SDK via ``_endpoint_speaks_anthropic_messages``.  See #17387.
 """
 
 import sys
@@ -13,14 +16,24 @@ from agent.auxiliary_client import _to_openai_base_url
 
 
 class TestToOpenaiBaseUrl:
-    def test_minimax_global_anthropic_suffix_replaced(self):
-        assert _to_openai_base_url("https://api.minimax.io/anthropic") == "https://api.minimax.io/v1"
+    def test_minimax_global_anthropic_suffix_preserved(self):
+        # MiniMax /anthropic must NOT be rewritten to /v1 — the downstream
+        # _maybe_wrap_anthropic chokepoint needs the original URL to detect
+        # the Anthropic Messages surface and route through the Anthropic SDK.
+        # M-series models on api.minimax.io return 404 on /v1/chat/completions.
+        assert _to_openai_base_url("https://api.minimax.io/anthropic") == "https://api.minimax.io/anthropic"
 
-    def test_minimax_cn_anthropic_suffix_replaced(self):
-        assert _to_openai_base_url("https://api.minimaxi.com/anthropic") == "https://api.minimaxi.com/v1"
+    def test_minimax_cn_anthropic_suffix_preserved(self):
+        # MiniMax-CN /anthropic must NOT be rewritten to /v1 — same reason
+        # as the global endpoint, only the host differs.
+        assert _to_openai_base_url("https://api.minimaxi.com/anthropic") == "https://api.minimaxi.com/anthropic"
 
-    def test_trailing_slash_stripped_before_replace(self):
-        assert _to_openai_base_url("https://api.minimax.io/anthropic/") == "https://api.minimax.io/v1"
+    def test_trailing_slash_minimax_preserved(self):
+        # Trailing slashes are stripped, but the /anthropic suffix stays.
+        assert _to_openai_base_url("https://api.minimax.io/anthropic/") == "https://api.minimax.io/anthropic"
+
+    def test_trailing_slash_minimax_cn_preserved(self):
+        assert _to_openai_base_url("https://api.minimaxi.com/anthropic/") == "https://api.minimaxi.com/anthropic"
 
     def test_v1_url_unchanged(self):
         assert _to_openai_base_url("https://api.openai.com/v1") == "https://api.openai.com/v1"
@@ -28,15 +41,36 @@ class TestToOpenaiBaseUrl:
     def test_openrouter_url_unchanged(self):
         assert _to_openai_base_url("https://openrouter.ai/api/v1") == "https://openrouter.ai/api/v1"
 
-    def test_anthropic_domain_unchanged(self):
-        """api.anthropic.com doesn't end with /anthropic — should be untouched."""
-        assert _to_openai_base_url("https://api.anthropic.com") == "https://api.anthropic.com"
-
-    def test_anthropic_in_subpath_unchanged(self):
-        assert _to_openai_base_url("https://example.com/anthropic/extra") == "https://example.com/anthropic/extra"
-
-    def test_empty_string(self):
+    def test_empty_url_returns_empty(self):
+        # Defensive: empty / None-ish input should not raise.
         assert _to_openai_base_url("") == ""
 
-    def test_none(self):
-        assert _to_openai_base_url(None) == ""
+    def test_zai_anthropic_rewritten_to_paas_v4(self):
+        # ZAI's /anthropic must still be rewritten to /api/paas/v4 — it is
+        # the only Anthropic-style provider that has a working OpenAI-wire
+        # sibling.  Regression guard: ensure the new MiniMax exception
+        # doesn't accidentally swallow the ZAI branch.
+        assert _to_openai_base_url("https://open.bigmodel.cn/api/anthropic") == "https://open.bigmodel.cn/api/paas/v4"
+
+    def test_generic_anthropic_url_rewritten_to_v1(self):
+        # Other /anthropic endpoints (LiteLLM proxies, Zhipu GLM on non-`bigmodel`
+        # hosts, etc.) still get rewritten to /v1 — only MiniMax hosts are exempted.
+        assert _to_openai_base_url("https://example.com/anthropic") == "https://example.com/v1"
+
+
+class TestEndToEndAnthropicRouting:
+    """Verify that preserved /anthropic URLs are detected by the downstream
+    Anthropic-transport detection function, so the call ends up on the
+    Anthropic SDK wire rather than the OpenAI wire."""
+
+    def test_preserved_minimax_cn_url_detected_as_anthropic(self):
+        from agent.auxiliary_client import _endpoint_speaks_anthropic_messages
+        # After _to_openai_base_url preserves the /anthropic suffix, the
+        # detection helper must still recognise it as Anthropic-Messages.
+        preserved = _to_openai_base_url("https://api.minimaxi.com/anthropic")
+        assert _endpoint_speaks_anthropic_messages(preserved) is True
+
+    def test_preserved_minimax_global_url_detected_as_anthropic(self):
+        from agent.auxiliary_client import _endpoint_speaks_anthropic_messages
+        preserved = _to_openai_base_url("https://api.minimax.io/anthropic")
+        assert _endpoint_speaks_anthropic_messages(preserved) is True


### PR DESCRIPTION
## Summary

Fixes #17387.

Auxiliary tasks (title generation, compression, session_search, vision analysis, flush_memories, ...) for the built-in `minimax`, `minimax-oauth`, and `minimax-cn` providers were 404'ing because `_to_openai_base_url` rewrote `https://api.minimaxi.com/anthropic` -> `https://api.minimaxi.com/v1` before handing the URL to the OpenAI SDK. M-series models on `api.minimaxi.com` and `api.minimax.io` do not expose a working `/v1/chat/completions` surface — they only speak Anthropic Messages on `/anthropic/v1/messages`.

## Fix

Preserve the original `/anthropic` URL for MiniMax hosts and rely on the existing `_maybe_wrap_anthropic` chokepoint to detect the Anthropic-Messages shape via `_endpoint_speaks_anthropic_messages` and route through the Anthropic SDK. This mirrors the named-custom `api_mode=anthropic_messages` path added in #15059 but covers the built-in provider profile path that was missed by that fix.

## Scope

- **MiniMax hosts** (api.minimaxi.com, api.minimax.io): preserved (new behaviour)
- **ZAI** (open.bigmodel.cn): continues to rewrite to `/api/paas/v4` (regression guard added)
- **Generic /anthropic URLs** (LiteLLM proxies, etc.): continues to rewrite to `/v1` (regression guard added)

## Tests

- 11/11 new assertions pass on the branch
- 201 adjacent tests (`test_auxiliary_named_custom_providers`, `test_auxiliary_client`) pass with no regressions
- New `TestEndToEndAnthropicRouting` covers the full chain: preserved URL is still recognised by `_endpoint_speaks_anthropic_messages` so calls land on Anthropic SDK wire, not OpenAI wire

## Diff stat

```
agent/auxiliary_client.py                 | 30 ++++++++++----
tests/agent/test_minimax_auxiliary_url.py | 66 +++++++++++++++++++++++--------
2 files changed, 72 insertions(+), 24 deletions(-)
```