### PR TITLE
feat(web): add trafilatura as a local web_extract backend

### DIFF
--- a/plugins/web/trafilatura/__init__.py
+++ b/plugins/web/trafilatura/__init__.py
@@ -1,0 +1,5 @@
+from plugins.web.trafilatura.provider import TrafilaturaExtractProvider
+
+
+def register(ctx) -> None:
+    ctx.register_web_search_provider(TrafilaturaExtractProvider())

--- a/plugins/web/trafilatura/plugin.yaml
+++ b/plugins/web/trafilatura/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-trafilatura
+version: 1.0.0
+description: "Trafilatura web content extraction — free, local, no API key needed."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - trafilatura

--- a/plugins/web/trafilatura/provider.py
+++ b/plugins/web/trafilatura/provider.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Trafilatura extract provider — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`.
+Local-only extraction — no API key or external service needed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class TrafilaturaExtractProvider(WebSearchProvider):
+
+    @property
+    def name(self) -> str:
+        return "trafilatura"
+
+    @property
+    def display_name(self) -> str:
+        return "Trafilatura"
+
+    def is_available(self) -> bool:
+        try:
+            import trafilatura  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        import trafilatura
+
+        output_format = kwargs.get("format", "markdown")
+        results: List[Dict[str, Any]] = []
+
+        for url in urls:
+            try:
+                downloaded = trafilatura.fetch_url(url)
+                if not downloaded:
+                    results.append({
+                        "url": url, "title": "", "content": "", "raw_content": "",
+                        "metadata": {},
+                        "error": "Trafilatura: page returned empty content (may be JS-only or paywalled)",
+                    })
+                    continue
+
+                content = trafilatura.extract(
+                    downloaded,
+                    output_format=output_format,
+                    include_comments=False,
+                    include_tables=True,
+                    no_fallback=False,
+                )
+
+                if not content:
+                    results.append({
+                        "url": url, "title": "", "content": "", "raw_content": "",
+                        "metadata": {},
+                        "error": "Trafilatura: could not extract meaningful content",
+                    })
+                    continue
+
+                # Extract metadata
+                metadata: Dict[str, Any] = {}
+                title = ""
+                try:
+                    metadata_raw = trafilatura.extract(
+                        downloaded, output_format="json", include_comments=False,
+                    )
+                    if metadata_raw:
+                        import json
+                        meta_obj = json.loads(metadata_raw)
+                        title = meta_obj.get("title", "")
+                        metadata = {k: v for k, v in meta_obj.items() if k not in ("text", "raw_text")}
+                except Exception:
+                    pass
+
+                results.append({
+                    "url": url, "title": title, "content": content,
+                    "raw_content": content, "metadata": metadata,
+                })
+            except Exception as exc:
+                results.append({
+                    "url": url, "title": "", "content": "", "raw_content": "",
+                    "metadata": {}, "error": f"Trafilatura failed: {exc}",
+                })
+
+        return results

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -130,7 +130,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "trafilatura"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -146,12 +146,22 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("trafilatura", _trafilatura_package_importable()),
     )
     for backend, available in backend_candidates:
         if available:
             return backend
 
     return "firecrawl"  # default (backward compat)
+
+
+def _trafilatura_package_importable() -> bool:
+    """Return True when the ``trafilatura`` Python package can be imported."""
+    try:
+        import trafilatura  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
 
 def _get_search_backend() -> str:
@@ -208,6 +218,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "trafilatura":
+        return _trafilatura_package_importable()
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path
@@ -1155,11 +1167,11 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "trafilatura"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "trafilatura")
     )
 
 


### PR DESCRIPTION
## Summary

Adds [trafilatura](https://github.com/adbar/trafilatura) (local Python package, no API key or credits required) as a supported backend for `web_extract`, matching the existing pattern of local backends like `ddgs` and `brave-free`.

## Problem

Users who want fully local web search + extraction (no external API keys, no paid credits) currently cannot use `web_extract` without Firecrawl. The `web_extract_tool` dispatch already supports per-capability backend selection via `web.extract_backend` in config.yaml — it just had no trafilatura case wired in.

## Changes

### `tools/web_tools.py`
- Add `"trafilatura"` to the recognized backend set in `_get_backend()`
- Add `("trafilatura", _trafilatura_package_importable())` to backend auto-detection candidates in `_get_backend()`
- Add `if backend == "trafilatura": return _trafilatura_package_importable()` to `_is_backend_available()`
- Add `"trafilatura"` to both sets in `check_web_api_key()`
- Add `_trafilatura_package_importable()` helper (identical pattern to `_ddgs_package_importable()`)

### `plugins/web/trafilatura/` (new)
- `__init__.py` — registers `TrafilaturaExtractProvider`
- `plugin.yaml` — plugin metadata
- `provider.py` — full `extract()` implementation using the local `trafilatura` Python package. Returns `List[Dict[str, Any]]` per the calling convention in `web_tools.py`.

## Usage

Users can now add to `~/.hermes/config.yaml`:

```yaml
web:
  extract_backend: trafilatura
```

This enables local, zero-cost web content extraction with no API key or credit requirements. Paired with `search_backend: searxng`, this enables fully local web_search + web_extract.

## Design notes

- Provider returns `List[Dict]` (not `{"results": List}`) — this matches what `web_tools.py` expects: `results = ssrf_blocked + provider_results` performs list concatenation. All existing providers follow this convention.
- Availability check uses `import trafilatura` — same pattern as ddgs's `import ddgs`.
- No changes to any existing provider or tool behavior. Purely additive.

## Testing

- Verified provider returns correct type: `List[Dict[str, Any]]`
- Verified `_get_extract_backend()` returns `"trafilatura"` when `web.extract_backend: trafilatura` is set and the `trafilatura` package is installed
- Verified `web_extract` tool returns extracted content via local trafilatura (tested against multiple URLs)
- Gateway restart required after config change (same as any native tool backend change)
