### PR TITLE
Fix delegate router toolset scoping

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1549,6 +1549,14 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
+        # Optional escape hatch for lean parent/router sessions.  When set to a
+        # non-empty list of toolset names, delegate_task may grant an
+        # explicitly requested child toolset if it is present either on the
+        # parent OR in this allowlist.  This lets the parent expose only the
+        # small delegation/router surface while still spawning narrow subagents
+        # such as ["terminal", "file"] or ["web"] on demand.  Empty list keeps
+        # the historical strict parent-intersection behavior.
+        "allowed_child_toolsets": [],
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         "child_timeout_seconds": 600,  # wall-clock timeout for each child agent (floor 30s,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -72,6 +72,7 @@ CONFIGURABLE_TOOLSETS = [
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
+    ("router",          "🧭 Lean Router",               "skills, planning, recall, clarify, cron/messaging, delegation"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -1,14 +1,15 @@
 """Tests for delegate_tool toolset scoping.
 
-Verifies that subagents cannot gain tools that the parent does not have.
-The LLM controls the `toolsets` parameter — without intersection with the
-parent's enabled_toolsets, it can escalate privileges by requesting
-arbitrary toolsets.
+By default, subagents cannot gain tools that the parent does not have.  The
+LLM controls the `toolsets` parameter, so requested toolsets are intersected
+with the parent's enabled toolsets.  Operators may opt into a narrow
+``delegation.allowed_child_toolsets`` allowlist so lean router parents can
+spawn explicit subtools without exposing those schemas globally.
 """
-
+from unittest.mock import patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import _scope_requested_toolsets, _strip_blocked_tools
 
 
 class TestToolsetIntersection:
@@ -18,10 +19,10 @@ class TestToolsetIntersection:
         """LLM requests toolsets parent doesn't have — extras are dropped."""
         parent = SimpleNamespace(enabled_toolsets=["terminal", "file"])
 
-        # Simulate the intersection logic from _build_child_agent
         parent_toolsets = set(parent.enabled_toolsets)
         requested = ["terminal", "file", "web", "browser", "rl"]
-        scoped = [t for t in requested if t in parent_toolsets]
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            scoped = _scope_requested_toolsets(requested, parent_toolsets)
 
         assert sorted(scoped) == ["file", "terminal"]
         assert "web" not in scoped
@@ -34,7 +35,8 @@ class TestToolsetIntersection:
 
         parent_toolsets = set(parent.enabled_toolsets)
         requested = ["terminal", "web"]
-        scoped = [t for t in requested if t in parent_toolsets]
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            scoped = _scope_requested_toolsets(requested, parent_toolsets)
 
         assert sorted(scoped) == ["terminal", "web"]
 
@@ -48,11 +50,26 @@ class TestToolsetIntersection:
 
     def test_strip_blocked_removes_delegation(self):
         """Blocked toolsets (delegation, clarify, etc.) are always removed."""
-        child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory"])
+        child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory", "messaging"])
         assert "delegation" not in child
         assert "clarify" not in child
         assert "memory" not in child
+        assert "messaging" not in child
         assert "terminal" in child
+
+    def test_strip_blocked_expands_router_without_blocked_includes(self):
+        """Router inheritance must not leak delegation/memory/messaging to leaves."""
+        child = _strip_blocked_tools(["router"])
+
+        assert "router" not in child
+        assert "delegation" not in child
+        assert "clarify" not in child
+        assert "memory" not in child
+        assert "messaging" not in child
+        assert "skills" in child
+        assert "todo" in child
+        assert "session_search" in child
+        assert "cronjob" in child
 
     def test_empty_intersection_yields_empty_toolsets(self):
         """If parent has no overlap with requested, child gets nothing extra."""
@@ -60,6 +77,23 @@ class TestToolsetIntersection:
 
         parent_toolsets = set(parent.enabled_toolsets)
         requested = ["web", "browser"]
-        scoped = [t for t in requested if t in parent_toolsets]
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            scoped = _scope_requested_toolsets(requested, parent_toolsets)
 
         assert scoped == []
+
+    def test_allowed_child_toolsets_let_router_parent_grant_subtools(self):
+        """Opt-in allowlist permits explicit child subtools absent from parent."""
+        parent = SimpleNamespace(enabled_toolsets=["router"])
+        parent_toolsets = set(parent.enabled_toolsets)
+        requested = ["terminal", "file", "web", "browser", "rl"]
+
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allowed_child_toolsets": ["terminal", "file", "web"]},
+        ):
+            scoped = _scope_requested_toolsets(requested, parent_toolsets)
+
+        assert sorted(scoped) == ["file", "terminal", "web"]
+        assert "browser" not in scoped
+        assert "rl" not in scoped

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -479,11 +479,11 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
     the names of any individual toolsets whose tools are a *subset* of the
     parent's available tools.  The original parent toolset names are preserved.
     """
+    from toolsets import resolve_toolset
+
     parent_tool_names: set = set()
     for ts_name in parent_toolsets:
-        ts_def = TOOLSETS.get(ts_name)
-        if ts_def:
-            parent_tool_names.update(ts_def.get("tools", []))
+        parent_tool_names.update(resolve_toolset(ts_name))
 
     if not parent_tool_names:
         return set(parent_toolsets)
@@ -496,6 +496,38 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
         if ts_tools and set(ts_tools).issubset(parent_tool_names):
             expanded.add(ts_name)
     return expanded
+
+
+def _get_allowed_child_toolset_scope() -> Optional[set[str]]:
+    """Return operator-configured child-only toolsets, expanded to leaves.
+
+    By default delegate_task is strictly non-escalating: children can only use
+    toolsets already present on the parent. Lean router sessions intentionally
+    keep the parent small (often just ``router`` + ``delegation``) and need an
+    explicit, audited allowlist for subtools they may grant to children.
+
+    Config key: ``delegation.allowed_child_toolsets``. Empty/missing preserves
+    the historical strict parent-intersection behavior.
+    """
+    raw = _load_config().get("allowed_child_toolsets")
+    if not isinstance(raw, list) or not raw:
+        return None
+    configured = {str(name).strip() for name in raw if str(name).strip()}
+    if not configured:
+        return None
+    return configured | _expand_parent_toolsets(configured)
+
+
+def _scope_requested_toolsets(
+    requested_toolsets: List[str], parent_toolsets: set[str]
+) -> List[str]:
+    """Limit requested child toolsets to parent scope plus optional allowlist."""
+    expanded_parent = _expand_parent_toolsets(parent_toolsets)
+    allowed = set(expanded_parent)
+    configured_scope = _get_allowed_child_toolset_scope()
+    if configured_scope:
+        allowed.update(configured_scope)
+    return [t for t in requested_toolsets if t in allowed]
 
 
 def _preserve_parent_mcp_toolsets(
@@ -670,14 +702,53 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
-    """Remove toolsets that contain only blocked tools."""
+    """Remove blocked toolsets, including blocked members of composites.
+
+    Composite toolsets such as ``router`` can include blocked child toolsets
+    (for example ``delegation`` or ``messaging``). Passing the composite name
+    through unchanged would re-enable those blocked tools for leaf children, so
+    composites are expanded to their safe included toolsets when needed.
+    """
     blocked_toolset_names = {
         "delegation",
         "clarify",
         "memory",
         "code_execution",
+        "messaging",
     }
-    return [t for t in toolsets if t not in blocked_toolset_names]
+
+    def _sanitize(name: str, seen: Optional[set[str]] = None) -> List[str]:
+        if name in blocked_toolset_names:
+            return []
+        if seen is None:
+            seen = set()
+        if name in seen:
+            return []
+        seen.add(name)
+
+        ts_def = TOOLSETS.get(name)
+        includes = list((ts_def or {}).get("includes", []) or [])
+        if not includes:
+            return [name]
+
+        safe_includes: List[str] = []
+        for included in includes:
+            safe_includes.extend(_sanitize(included, seen.copy()))
+
+        # Keep composites with their own direct tools (e.g. debugging), but do
+        # not keep include-only composites (e.g. router) because that would also
+        # keep their blocked includes active.
+        direct_tools = list((ts_def or {}).get("tools", []) or [])
+        if direct_tools:
+            return [name, *safe_includes]
+        return safe_includes
+
+    stripped: List[str] = []
+    for toolset_name in toolsets:
+        for safe_name in _sanitize(toolset_name):
+            if safe_name not in stripped:
+                stripped.append(safe_name)
+    return stripped
 
 
 def _build_child_progress_callback(
@@ -943,11 +1014,12 @@ def _build_child_agent(
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
     if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks.
-        # Expand composite toolsets (e.g. hermes-cli) so that individual
-        # toolset names (e.g. web, terminal) are recognised during intersection.
-        expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+        # Intersect with parent by default so subagents cannot gain tools the
+        # parent lacks. If delegation.allowed_child_toolsets is configured,
+        # also allow explicitly requested child toolsets from that allowlist;
+        # this is the intentional "lean router parent -> narrow subtool child"
+        # architecture and is opt-in for operators.
+        child_toolsets = _scope_requested_toolsets(toolsets, parent_toolsets)
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -2580,6 +2652,9 @@ def _build_top_level_description() -> str:
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
+        "- Toolsets are parent-scoped by default. If delegation.allowed_child_toolsets "
+        "is configured, a lean router parent may grant explicitly requested child "
+        "toolsets from that allowlist without exposing those schemas in the parent.\n"
         "- Results are always returned as an array, one entry per task."
     )
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -246,6 +246,20 @@ TOOLSETS = {
         "includes": []
     },
 
+    "router": {
+        "description": (
+            "Lean parent-agent router: planning, memory/session recall, skills, "
+            "clarification, messaging/cron, and delegation. Use this when the "
+            "parent should stay context-light and hand detailed file/web/terminal "
+            "work to explicitly scoped subagents."
+        ),
+        "tools": [],
+        "includes": [
+            "skills", "todo", "memory", "session_search", "clarify",
+            "delegation", "cronjob", "messaging",
+        ],
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 


### PR DESCRIPTION
## Summary
- add a lean router toolset and configurable child toolset allowlist for delegation
- scope delegated child toolsets through parent scope plus the explicit allowlist
- expand router inheritance safely so blocked delegation/memory/messaging tools do not leak to leaf subagents

## Tests
- uvx --with PyYAML --with requests pytest tests/tools/test_delegate_toolset_scope.py -o 'addopts='