### PR TITLE
fix(hindsight): bound local embedded startup hangs

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -229,6 +229,27 @@ def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
     return future.result(timeout=timeout)
 
 
+def _run_blocking_with_timeout(fn, timeout: float):
+    """Run a blocking callable on a daemon thread with a hard timeout."""
+    result_queue: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+
+    def _worker():
+        try:
+            result_queue.put((True, fn()))
+        except Exception as exc:
+            result_queue.put((False, exc))
+
+    thread = threading.Thread(target=_worker, daemon=True, name="hindsight-blocking-call")
+    thread.start()
+    thread.join(timeout=timeout)
+    if thread.is_alive():
+        raise TimeoutError(f"timed out after {timeout}s")
+    ok, payload = result_queue.get()
+    if ok:
+        return payload
+    raise payload
+
+
 # ---------------------------------------------------------------------------
 # Backward-compatible alias — instances use self._run_sync() instead.
 # ---------------------------------------------------------------------------
@@ -934,6 +955,33 @@ class HindsightMemoryProvider(MemoryProvider):
         """Schedule *coro* on the shared loop using the configured timeout."""
         return _run_sync(coro, timeout=self._timeout)
 
+    def _embedded_timeout_error(self) -> RuntimeError:
+        timeout = self._timeout or _DEFAULT_TIMEOUT
+        return RuntimeError(
+            "Hindsight local memory service did not become ready within "
+            f"{timeout}s. It may be stuck during embedded daemon startup "
+            "(for example, a missing HuggingFace cache while HF_HUB_OFFLINE=1). "
+            "Check ~/.hermes/logs/hindsight-embed.log or disable local_embedded mode."
+        )
+
+    def _run_local_embedded_attempt(self, operation):
+        state: dict[str, Any] = {}
+
+        def _invoke():
+            client = self._get_client()
+            state["client"] = client
+            return self._run_sync(operation(client))
+
+        try:
+            result = _run_blocking_with_timeout(_invoke, timeout=self._timeout or _DEFAULT_TIMEOUT)
+        except TimeoutError as exc:
+            raise self._embedded_timeout_error() from exc
+
+        client = state.get("client")
+        if client is not None:
+            self._client = client
+        return result
+
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
         if self._mode != "local_embedded":
@@ -1018,6 +1066,19 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _run_hindsight_operation(self, operation):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
+        if self._mode == "local_embedded":
+            try:
+                return self._run_local_embedded_attempt(operation)
+            except Exception as exc:
+                if not self._is_retriable_embedded_connection_error(exc):
+                    raise
+                logger.info(
+                    "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
+                    exc,
+                )
+                self._client = None
+                return self._run_local_embedded_attempt(operation)
+
         client = self._get_client()
         try:
             return self._run_sync(operation(client))

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -592,6 +593,43 @@ class TestToolHandlers:
         assert provider._client is second_client
         first_client.arecall.assert_called_once()
         second_client.arecall.assert_called_once()
+
+    def test_local_embedded_recall_times_out_when_client_startup_hangs(self, provider, monkeypatch):
+        provider._mode = "local_embedded"
+        provider._client = None
+        provider._timeout = 0.05
+
+        def _hung_client():
+            threading.Event().wait(0.2)
+            return _make_mock_client()
+
+        monkeypatch.setattr(provider, "_get_client", _hung_client)
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+
+        assert "error" in result
+        assert "did not become ready within 0.05s" in result["error"]
+        assert "HF_HUB_OFFLINE=1" in result["error"]
+
+    def test_local_embedded_recall_surfaces_clear_timeout_error(self, provider, monkeypatch):
+        provider._mode = "local_embedded"
+        provider._timeout = 0.05
+
+        def _timeout(coro):
+            coro.close()
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(provider, "_run_sync", _timeout)
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+
+        assert "error" in result
+        assert "did not become ready within 0.05s" in result["error"]
+        assert "hindsight-embed.log" in result["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- bound local_embedded Hindsight startup / client calls behind a Hermes-side hard timeout
- surface a clear local-memory error when the embedded daemon never becomes ready
- add focused regressions for hung client startup and timeout surfacing

## Testing
- uv run --frozen --extra dev pytest -o addopts= tests/plugins/memory/test_hindsight_provider.py\n- uv run --frozen ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py\n- git diff --check\n- python3 -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py\n\nCloses #36710