### PR TITLE
fix(tui): clear pending image attachments before exit

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2420,6 +2420,23 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     assert len(server._sessions["sid"]["attached_images"]) == 1
 
 
+def test_image_clear_removes_pending_attachments():
+    session = _session()
+    session["attached_images"] = ["/tmp/cat.png", "/tmp/dog.png"]
+    server._sessions["sid"] = session
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.clear",
+            "params": {"session_id": "sid"},
+        }
+    )
+
+    assert resp["result"]["removed"] == 2
+    assert server._sessions["sid"]["attached_images"] == []
+
+
 def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4547,6 +4547,19 @@ def _(rid, params: dict) -> dict:
     )
 
 
+@method("image.clear")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+
+    with session["history_lock"]:
+        removed = len(session.get("attached_images", []))
+        session["attached_images"] = []
+
+    return _ok(rid, {"removed": removed})
+
+
 @method("input.detect_drop")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -1,16 +1,178 @@
-import { describe, expect, it, vi } from 'vitest'
+import { PassThrough } from 'stream'
 
-import { applyVoiceRecordResponse, shouldFallThroughForScroll } from '../app/useInputHandlers.js'
+import { Box, type InputHandler, type Key, renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const baseKey = {
+import type { InputHandlerContext } from '../app/interfaces.js'
+import { resetOverlayState } from '../app/overlayStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import {
+  applyVoiceRecordResponse,
+  clearAttachedImages,
+  shouldFallThroughForScroll,
+  useInputHandlers
+} from '../app/useInputHandlers.js'
+import { isMac } from '../lib/platform.js'
+
+let capturedInput: InputHandler | null = null
+
+vi.mock('@hermes/ink', async importOriginal => {
+  const actual = await importOriginal()
+
+  return {
+    ...actual,
+    useInput: vi.fn((handler: InputHandler) => {
+      capturedInput = handler
+    })
+  }
+})
+
+const baseKey: Key = {
+  alt: false,
+  backspace: false,
+  ctrl: false,
+  delete: false,
   downArrow: false,
+  end: false,
+  escape: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
   pageDown: false,
   pageUp: false,
+  return: false,
+  rightArrow: false,
   shift: false,
+  super: false,
+  tab: false,
   upArrow: false,
   wheelDown: false,
   wheelUp: false
 }
+
+const makeStreams = () => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', () => {})
+
+  return { stderr, stdin, stdout }
+}
+
+const keyWith = (partial: Partial<Key>): Key => ({ ...baseKey, ...partial })
+
+const flushAsync = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function Harness({ ctx }: { ctx: InputHandlerContext }) {
+  useInputHandlers(ctx)
+
+  return React.createElement(Box, null)
+}
+
+const buildContext = () => {
+  const die = vi.fn()
+  const rpc = vi.fn()
+  const sys = vi.fn()
+
+  const ctx: InputHandlerContext = {
+    actions: {
+      answerClarify: vi.fn(),
+      appendMessage: vi.fn(),
+      die,
+      dispatchSubmission: vi.fn(),
+      guardBusySessionSwitch: vi.fn(() => false),
+      newSession: vi.fn(),
+      sys
+    },
+    composer: {
+      actions: {
+        clearIn: vi.fn(),
+        dequeue: vi.fn(),
+        enqueue: vi.fn(),
+        handleTextPaste: vi.fn(),
+        openEditor: vi.fn(async () => {}),
+        pushHistory: vi.fn(),
+        removeQueue: vi.fn(),
+        replaceQueue: vi.fn(),
+        setCompIdx: vi.fn(),
+        setHistoryIdx: vi.fn(),
+        setInput: vi.fn(),
+        setInputBuf: vi.fn(),
+        setPasteSnips: vi.fn(),
+        setQueueEdit: vi.fn(),
+        syncQueue: vi.fn()
+      },
+      refs: {
+        historyDraftRef: { current: '' },
+        historyRef: { current: [] },
+        queueEditRef: { current: null },
+        queueRef: { current: [] },
+        submitRef: { current: vi.fn() }
+      },
+      state: {
+        compIdx: 0,
+        compReplace: 0,
+        completions: [],
+        historyIdx: null,
+        input: '',
+        inputBuf: [],
+        pasteSnips: [],
+        queueEditIdx: null,
+        queuedDisplay: []
+      }
+    },
+    gateway: {
+      gw: {} as never,
+      rpc
+    },
+    terminal: {
+      hasSelection: false,
+      scrollRef: { current: null },
+      scrollWithSelection: vi.fn(),
+      selection: {
+        captureScrolledRows: vi.fn(),
+        clearSelection: vi.fn(),
+        copySelection: vi.fn(),
+        copySelectionNoClear: vi.fn(),
+        getState: vi.fn(),
+        shiftAnchor: vi.fn(),
+        shiftSelection: vi.fn(),
+        version: vi.fn()
+      }
+    },
+    voice: {
+      enabled: false,
+      recordKey: { ch: 'b', mod: 'ctrl', raw: 'ctrl+b' },
+      recording: false,
+      setProcessing: vi.fn(),
+      setRecording: vi.fn(),
+      setVoiceEnabled: vi.fn(),
+      setVoiceTts: vi.fn()
+    },
+    wheelStep: 3
+  }
+
+  return { ctx, die, rpc, sys }
+}
+
+beforeEach(() => {
+  capturedInput = null
+  resetUiState()
+  resetOverlayState()
+})
+
+afterEach(() => {
+  resetUiState()
+  resetOverlayState()
+})
 
 describe('shouldFallThroughForScroll — keep transcript scrolling alive during prompt overlays', () => {
   it('falls through for wheel scrolls', () => {
@@ -73,5 +235,87 @@ describe('applyVoiceRecordResponse', () => {
 
     expect(setRecording).toHaveBeenCalledWith(false)
     expect(setProcessing).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('clearAttachedImages', () => {
+  it('reports when pending images were cleared', async () => {
+    const rpc = vi.fn().mockResolvedValue({ removed: 2 })
+    const sys = vi.fn()
+
+    await expect(clearAttachedImages({ rpc }, 'sid-1', sys)).resolves.toBe(true)
+
+    expect(rpc).toHaveBeenCalledWith('image.clear', { session_id: 'sid-1' })
+    expect(sys).toHaveBeenCalledWith('cleared 2 attached images')
+  })
+
+  it('stays silent when there is nothing to clear', async () => {
+    const rpc = vi.fn().mockResolvedValue({ removed: 0 })
+    const sys = vi.fn()
+
+    await expect(clearAttachedImages({ rpc }, 'sid-1', sys)).resolves.toBe(false)
+
+    expect(sys).not.toHaveBeenCalled()
+  })
+})
+
+describe('useInputHandlers attachment clearing shortcuts', () => {
+  it('uses Ctrl+C to clear pending images before exiting', async () => {
+    const { ctx, die, rpc, sys } = buildContext()
+    rpc.mockResolvedValue({ removed: 1 })
+    patchUiState({ busy: false, sid: 'sid-1', status: 'ready' })
+
+    const streams = makeStreams()
+
+    const instance = renderSync(React.createElement(Harness, { ctx }), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      expect(capturedInput).not.toBeNull()
+      const key = keyWith({ ctrl: true })
+
+      capturedInput!('c', key, { input: 'c', key, keypress: {} })
+      await flushAsync()
+
+      expect(rpc).toHaveBeenCalledWith('image.clear', { session_id: 'sid-1' })
+      expect(sys).toHaveBeenCalledWith('cleared 1 attached image')
+      expect(die).not.toHaveBeenCalled()
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('falls back to exit when Ctrl+D finds no pending images', async () => {
+    const { ctx, die, rpc } = buildContext()
+    rpc.mockResolvedValue({ removed: 0 })
+    patchUiState({ busy: false, sid: 'sid-1', status: 'ready' })
+
+    const streams = makeStreams()
+
+    const instance = renderSync(React.createElement(Harness, { ctx }), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      expect(capturedInput).not.toBeNull()
+      const key = keyWith(isMac ? { meta: true } : { ctrl: true })
+
+      capturedInput!('d', key, { input: 'd', key, keypress: {} })
+      await flushAsync()
+
+      expect(rpc).toHaveBeenCalledWith('image.clear', { session_id: 'sid-1' })
+      expect(die).toHaveBeenCalledTimes(1)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
   })
 })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -6,6 +6,7 @@ import { TYPING_IDLE_MS } from '../config/timing.js'
 import type {
   ApprovalRespondResponse,
   ConfigSetResponse,
+  ImageClearResponse,
   SecretRespondResponse,
   SudoRespondResponse,
   VoiceRecordResponse
@@ -77,6 +78,28 @@ export function applyVoiceRecordResponse(
   } else {
     voice.setProcessing(false)
   }
+}
+
+export async function clearAttachedImages(
+  gateway: Pick<InputHandlerContext['gateway'], 'rpc'>,
+  sessionId: null | string,
+  sys: (text: string) => void
+): Promise<boolean> {
+  if (!sessionId) {
+    return false
+  }
+
+  const count = await gateway
+    .rpc<ImageClearResponse>('image.clear', { session_id: sessionId })
+    .then(result => Number(result?.removed ?? 0))
+
+  if (count <= 0) {
+    return false
+  }
+
+  sys(`cleared ${count} attached image${count === 1 ? '' : 's'}`)
+
+  return true
 }
 
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
@@ -497,11 +520,19 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         return cActions.clearIn()
       }
 
-      return actions.die()
+      return void clearAttachedImages(gateway, live.sid, actions.sys).then(cleared => {
+        if (!cleared) {
+          actions.die()
+        }
+      })
     }
 
     if (isAction(key, ch, 'd')) {
-      return actions.die()
+      return void clearAttachedImages(gateway, live.sid, actions.sys).then(cleared => {
+        if (!cleared) {
+          actions.die()
+        }
+      })
     }
 
     if (isAction(key, ch, 'l')) {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -327,6 +327,10 @@ export interface ImageAttachResponse {
   width?: number
 }
 
+export interface ImageClearResponse {
+  removed?: number
+}
+
 // ── Voice ────────────────────────────────────────────────────────────
 
 export interface VoiceToggleResponse {


### PR DESCRIPTION
Fixes #37184

## Summary
- add a TUI gateway `image.clear` RPC to drop pending attached images before submission
- make the TUI `Ctrl+C` empty-input path clear pending images before exiting, and reuse the same path for the existing exit shortcut
- add gateway and TUI regression coverage for clearing attachments and falling back to exit when none are pending

## Proof
- `uv run --frozen pytest -o addopts='' tests/test_tui_gateway_server.py -k "image_clear or image_attach"`
- `python3 -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`
- `uv run --frozen ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `cd ui-tui && npm run build --prefix packages/hermes-ink`
- `cd ui-tui && npm test -- src/__tests__/useInputHandlers.test.ts`
- `cd ui-tui && ./node_modules/.bin/eslint src/app/useInputHandlers.ts src/gatewayTypes.ts src/__tests__/useInputHandlers.test.ts`  (preexisting warning only in `ui-tui/src/app/useInputHandlers.ts:212`)
- `git diff --check`