### PR TITLE
fix(codex): extract turn/completed token usage on app-server runtime

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -170,6 +170,12 @@ def run_codex_app_server_turn(
         "error": turn.error,
         "codex_thread_id": turn.thread_id,
         "codex_turn_id": turn.turn_id,
+        # Per-turn token usage from the codex app-server `turn/completed`
+        # event (issue #36801). None when codex did not report it. Surfaced
+        # so the conversation loop can observe context growth on this runtime
+        # path the way the chat-completions path already does — the
+        # prerequisite signal for proactive compaction (left to a follow-up).
+        "codex_usage": getattr(turn, "usage", None),
     }
 
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -79,6 +79,14 @@ class TurnResult:
     # of riding a CPU-spinning or auth-broken process. Mirrors openclaw
     # beta.8's "retire timed-out app-server clients" fix.
     should_retire: bool = False
+    # Token usage for THIS turn, parsed from the terminal `turn/completed`
+    # event's `turn.usage` block when codex reports it. None when codex did
+    # not surface usage (older app-server builds, interrupted/aborted turns).
+    # Other transports (bedrock/chat_completions/anthropic) already expose
+    # per-turn usage; the codex app-server path was the lone blind spot
+    # (issue #36801) — without this the runtime cannot see a session growing
+    # toward the context window until the backend 400s and the session resets.
+    usage: Optional[dict] = None
 
 
 # Markers we accept as terminal even when codex never emits turn/completed.
@@ -574,13 +582,32 @@ class CodexAppServerSession:
 
             if method == "turn/completed":
                 turn_complete = True
-                turn_status = (
-                    (note.get("params") or {}).get("turn") or {}
-                ).get("status")
+                turn_obj = (note.get("params") or {}).get("turn") or {}
+                turn_status = turn_obj.get("status")
+                # Capture per-turn token usage when codex reports it. The
+                # app-server nests it under turn.usage; tolerate both the
+                # {input_tokens,output_tokens,total_tokens} dict shape and a
+                # bare int total. Advisory only — never raises.
+                raw_usage = turn_obj.get("usage")
+                if isinstance(raw_usage, dict):
+                    inp = raw_usage.get("input_tokens")
+                    out = raw_usage.get("output_tokens")
+                    tot = raw_usage.get("total_tokens")
+                    if tot is None and isinstance(inp, int):
+                        tot = inp + (out or 0)
+                    result.usage = {
+                        "input_tokens": inp or 0,
+                        "output_tokens": out or 0,
+                        "total_tokens": tot or 0,
+                    }
+                elif isinstance(raw_usage, int):
+                    result.usage = {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": raw_usage,
+                    }
                 if turn_status and turn_status not in {"completed", "interrupted"}:
-                    err_obj = (
-                        (note.get("params") or {}).get("turn") or {}
-                    ).get("error")
+                    err_obj = turn_obj.get("error")
                     if err_obj:
                         err_msg = _format_responses_error(err_obj, str(turn_status))
                         # If the turn failed for an auth/refresh reason,

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -195,6 +195,9 @@ class TestRunTurn:
                    for m in r.projected_messages)
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
+        # No usage block on the event → usage stays None (no regression for
+        # older app-server builds / omitted usage).
+        assert r.usage is None
 
     def test_rich_content_turn_is_collapsed_to_text_payload(self):
         client = FakeClient()
@@ -1059,3 +1062,63 @@ class TestClassifyOAuthFailure:
             "[stderr] token has expired, run codex login",
         )
         assert hint is not None
+
+
+class TestTurnUsage:
+    """Per-turn token usage extraction off the terminal turn/completed event.
+
+    Without this the codex app-server runtime is blind to a session growing
+    toward the context window until the backend 400s and hard-resets the
+    session (issue #36801, root cause #2). Other transports already surface
+    per-turn usage; these pin the codex app-server path.
+    """
+
+    @staticmethod
+    def _run_turn_with(usage):
+        """Drive one happy-path turn whose turn/completed carries `usage`."""
+        client = FakeClient()
+        turn = {"id": "tu1", "status": "completed", "error": None}
+        if usage is not None:
+            turn["usage"] = usage
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "ok"},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t", turn=turn,
+        )
+        s = make_session(client)
+        return s.run_turn("hi", turn_timeout=2.0)
+
+    def test_turn_completed_dict_usage_is_extracted(self):
+        r = self._run_turn_with(
+            {"input_tokens": 272000, "output_tokens": 1200,
+             "total_tokens": 273200}
+        )
+        assert r.usage == {
+            "input_tokens": 272000,
+            "output_tokens": 1200,
+            "total_tokens": 273200,
+        }
+
+    def test_turn_completed_missing_usage_is_none(self):
+        # Older app-server builds (and aborted turns) omit usage entirely;
+        # the parse must leave usage as None rather than fabricate zeros.
+        r = self._run_turn_with(None)
+        assert r.usage is None
+
+    def test_turn_completed_total_derived_when_absent(self):
+        # codex may report inputs/outputs without a precomputed total; the
+        # parser derives total = input + output so the loop has a usable sum.
+        r = self._run_turn_with({"input_tokens": 100, "output_tokens": 5})
+        assert r.usage["total_tokens"] == 105
+        assert r.usage["input_tokens"] == 100
+        assert r.usage["output_tokens"] == 5
+
+    def test_turn_completed_bare_int_usage(self):
+        # Tolerate a bare-int total shape (some builds send just a number).
+        r = self._run_turn_with(273200)
+        assert r.usage["total_tokens"] == 273200
+        assert r.usage["input_tokens"] == 0
+        assert r.usage["output_tokens"] == 0


### PR DESCRIPTION
## What does this PR do?

The codex app-server runtime (`provider: openai-codex`) extracts NO token usage from `turn/completed` events, so Hermes is blind to a session growing toward the context window until the backend 400s and the session hard-resets to `history=0` (issue #36801, root cause #2). Other transports already surface per-turn usage (`bedrock.py`, `chat_completions.py`, `anthropic.py`); the codex app-server path was the lone gap. This PR parses `turn.usage` off the terminal `turn/completed` event into `TurnResult.usage` and surfaces it as `codex_usage` on the runtime return dict, giving the conversation loop the context-growth signal it needs.

> Sibling code paths that may need the same fix: proactive-threshold compaction and retire-handoff seeding in `agent/conversation_loop.py` (issue #36801 parts 2-4). Intentionally left out of this PR's scope to keep the diff small and the usage-extraction root cause independently reviewable — happy to widen if preferred.

## Related Issue

Fixes #36801

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/codex_app_server_session.py`: add `usage: Optional[dict]` to `TurnResult`; parse `turn.usage` in the existing `turn/completed` handler (tolerant of the `{input_tokens,output_tokens,total_tokens}` dict shape and a bare-int total; derives total when absent; never raises).
- `agent/codex_runtime.py`: surface `codex_usage` on the `run_codex_app_server_turn` return dict.
- `tests/agent/transports/test_codex_app_server_session.py`: add `TestTurnUsage` (4 cases) + a no-usage regression assertion on the existing happy-path turn.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/agent/transports/test_codex_app_server_session.py -v`
2. Regression-verified: stripping the `turn.usage` parse turns the 3 extraction tests red (`TypeError: 'NoneType' object is not subscriptable`); restoring it returns all 61 to green.
3. The no-usage case (`test_turn_completed_missing_usage_is_none`) proves older app-server builds / omitted usage leave `usage` as `None` rather than fabricating zeros.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite (`tests/agent/transports/test_codex_app_server_session.py`, 61 passing) — full `pytest tests/ -q` not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) — pure-Python dict parsing, no platform-specific paths; only macOS exercised
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A