### PR TITLE
fix: keep Hindsight memory usable when local reflect LLM fails

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1033,6 +1033,50 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = client
             return self._run_sync(operation(client))
 
+    def _build_recall_kwargs(self, query: str) -> Dict[str, Any]:
+        """Build the shared kwargs for Hindsight recall calls."""
+        recall_kwargs: Dict[str, Any] = {
+            "bank_id": self._bank_id,
+            "query": query,
+            "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        return recall_kwargs
+
+    @staticmethod
+    def _format_recall_results(resp, *, bullet: bool = False) -> str:
+        """Format a Hindsight recall response for context/tool output."""
+        if not getattr(resp, "results", None):
+            return ""
+        if bullet:
+            return "\n".join(
+                f"- {r.text}" for r in resp.results if getattr(r, "text", "")
+            )
+        return "\n".join(
+            f"{i}. {r.text}"
+            for i, r in enumerate(resp.results, 1)
+            if getattr(r, "text", "")
+        )
+
+    def _recall_text(self, query: str, *, bullet: bool = False) -> str:
+        """Run recall and return formatted text, or an empty string when no results."""
+        recall_kwargs = self._build_recall_kwargs(query)
+        logger.debug(
+            "Hindsight recall: bank=%s, query_len=%d, budget=%s",
+            self._bank_id,
+            len(query),
+            self._budget,
+        )
+        resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+        num_results = len(resp.results) if resp.results else 0
+        logger.debug("Hindsight recall: %d results", num_results)
+        return self._format_recall_results(resp, bullet=bullet)
+
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
 
@@ -1334,24 +1378,18 @@ class HindsightMemoryProvider(MemoryProvider):
             try:
                 if self._prefetch_method == "reflect":
                     logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                    resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
-                    text = resp.text or ""
+                    try:
+                        resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                        text = resp.text or ""
+                    except Exception as reflect_exc:
+                        logger.debug(
+                            "Hindsight reflect prefetch failed; falling back to recall: %s",
+                            reflect_exc,
+                            exc_info=True,
+                        )
+                        text = self._recall_text(query, bullet=True)
                 else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._recall_text(query, bullet=True)
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1541,24 +1579,10 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
-                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
-                logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
+                text = self._recall_text(query)
+                if not text:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                return json.dumps({"result": text})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")
@@ -1570,16 +1594,38 @@ class HindsightMemoryProvider(MemoryProvider):
             try:
                 logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(
-                    lambda client: client.areflect(
-                        bank_id=self._bank_id, query=query, budget=self._budget
+                try:
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.areflect(
+                            bank_id=self._bank_id, query=query, budget=self._budget
+                        )
                     )
-                )
-                logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
-                return json.dumps({"result": resp.text or "No relevant memories found."})
+                    logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
+                    return json.dumps({"result": resp.text or "No relevant memories found."})
+                except Exception as reflect_exc:
+                    logger.warning(
+                        "hindsight_reflect failed; falling back to recall: %s",
+                        reflect_exc,
+                        exc_info=True,
+                    )
+                    detail = type(reflect_exc).__name__
+                    text = self._recall_text(query)
+                    if text:
+                        return json.dumps({
+                            "result": (
+                                "Hindsight reflection failed; showing raw recall results instead.\n"
+                                f"Reflect error type: {detail}\n\n{text}"
+                            )
+                        })
+                    return json.dumps({
+                        "result": (
+                            "Hindsight reflection failed and recall found no relevant memories.\n"
+                            f"Reflect error type: {detail}"
+                        )
+                    })
             except Exception as e:
-                logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to reflect: {e}")
+                logger.warning("hindsight_reflect fallback recall failed: %s", e, exc_info=True)
+                return tool_error(f"Failed to reflect or search memory: {e}")
 
         return tool_error(f"Unknown tool: {tool_name}")
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -4,6 +4,7 @@ Long-term memory with knowledge graph, entity resolution, and multi-strategy
 retrieval. Supports cloud (API key) and local modes.
 
 Configurable request timeout via HINDSIGHT_TIMEOUT env var or config.json.
+Configurable reflect timeout via HINDSIGHT_REFLECT_TIMEOUT env var or config.json.
 Configurable embedded daemon idle timeout via HINDSIGHT_IDLE_TIMEOUT env var
 or config.json idle_timeout.
 
@@ -16,6 +17,7 @@ Config via environment variables:
   HINDSIGHT_API_URL                — API endpoint
   HINDSIGHT_MODE                   — cloud or local (default: cloud)
   HINDSIGHT_TIMEOUT                — API request timeout in seconds (default: 120)
+  HINDSIGHT_REFLECT_TIMEOUT        — reflect request timeout in seconds (default: 180)
   HINDSIGHT_IDLE_TIMEOUT           — embedded daemon idle timeout seconds; 0 disables shutdown (default: 300)
   HINDSIGHT_RETAIN_TAGS            — comma-separated tags attached to retained memories
   HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories
@@ -34,6 +36,8 @@ import importlib
 import json
 import logging
 import os
+import time
+from concurrent.futures import TimeoutError as FutureTimeoutError
 import queue
 import threading
 
@@ -51,6 +55,7 @@ _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.4.22"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
+_DEFAULT_REFLECT_TIMEOUT = 180  # seconds — reflect can cold-start a local LLM
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
@@ -324,6 +329,13 @@ def _load_config() -> dict:
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
         "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
         "timeout": _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
+        "reflect_timeout": _parse_int_setting(
+            os.environ.get("HINDSIGHT_REFLECT_TIMEOUT"),
+            max(
+                _parse_int_setting(os.environ.get("HINDSIGHT_TIMEOUT"), _DEFAULT_TIMEOUT),
+                _DEFAULT_REFLECT_TIMEOUT,
+            ),
+        ),
         "idle_timeout": _parse_int_setting(os.environ.get("HINDSIGHT_IDLE_TIMEOUT"), _DEFAULT_IDLE_TIMEOUT),
         "retain_tags": os.environ.get("HINDSIGHT_RETAIN_TAGS", ""),
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
@@ -544,6 +556,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._turn_index = 0
         self._client = None
         self._timeout = _DEFAULT_TIMEOUT
+        self._reflect_timeout = _DEFAULT_REFLECT_TIMEOUT
         self._idle_timeout = _DEFAULT_IDLE_TIMEOUT
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
@@ -781,6 +794,14 @@ class HindsightMemoryProvider(MemoryProvider):
         timeout_val = existing_timeout if existing_timeout is not None else _DEFAULT_TIMEOUT
         provider_config["timeout"] = timeout_val
         env_writes["HINDSIGHT_TIMEOUT"] = str(timeout_val)
+        existing_reflect_timeout = provider_config.get("reflect_timeout")
+        reflect_timeout_val = (
+            existing_reflect_timeout
+            if existing_reflect_timeout is not None
+            else max(_parse_int_setting(timeout_val, _DEFAULT_TIMEOUT), _DEFAULT_REFLECT_TIMEOUT)
+        )
+        provider_config["reflect_timeout"] = reflect_timeout_val
+        env_writes["HINDSIGHT_REFLECT_TIMEOUT"] = str(reflect_timeout_val)
         if mode == "local_embedded":
             existing_idle_timeout = provider_config.get("idle_timeout")
             idle_timeout_val = existing_idle_timeout if existing_idle_timeout is not None else _DEFAULT_IDLE_TIMEOUT
@@ -875,6 +896,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
+            {"key": "reflect_timeout", "description": "Reflect API request timeout in seconds", "default": _DEFAULT_REFLECT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
         ]
 
@@ -930,9 +952,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
-    def _run_sync(self, coro):
+    def _run_sync(self, coro, *, timeout: float | None = None):
         """Schedule *coro* on the shared loop using the configured timeout."""
-        return _run_sync(coro, timeout=self._timeout)
+        return _run_sync(coro, timeout=timeout if timeout is not None else self._timeout)
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1016,11 +1038,11 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception as exc:
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
-    def _run_hindsight_operation(self, operation):
+    def _run_hindsight_operation(self, operation, *, timeout: float | None = None):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), timeout=timeout)
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1031,7 +1053,54 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), timeout=timeout)
+
+    @staticmethod
+    def _extract_operation_id(exc: Exception) -> str:
+        """Best-effort extraction of a Hindsight server operation/request id."""
+        for attr in ("operation_id", "operationId", "request_id", "requestId", "trace_id"):
+            value = getattr(exc, attr, None)
+            if value:
+                return str(value)
+        for arg in getattr(exc, "args", ()):
+            if isinstance(arg, dict):
+                for key in ("operation_id", "operationId", "request_id", "requestId", "trace_id"):
+                    value = arg.get(key)
+                    if value:
+                        return str(value)
+        response = getattr(exc, "response", None)
+        if response is not None:
+            try:
+                data = response.json()
+            except Exception:
+                data = None
+            if isinstance(data, dict):
+                for key in ("operation_id", "operationId", "request_id", "requestId", "trace_id"):
+                    value = data.get(key)
+                    if value:
+                        return str(value)
+        return ""
+
+    def _describe_reflect_error(self, exc: Exception, *, elapsed: float) -> str:
+        """Return an operator-facing reflect failure summary with timing context."""
+        lines = [
+            f"Reflect error type: {type(exc).__name__}",
+            f"Reflect elapsed: {elapsed:.1f}s",
+            f"Reflect timeout: {self._reflect_timeout}s",
+        ]
+        message = str(exc).strip()
+        if message:
+            lines.insert(1, f"Reflect error message: {message}")
+        operation_id = self._extract_operation_id(exc)
+        if operation_id:
+            lines.append(f"Hindsight operation id: {operation_id}")
+        if isinstance(exc, FutureTimeoutError):
+            lines.append(
+                "Reflect timed out on the Hermes client; the Hindsight server "
+                "may still complete the operation. Check Hindsight operations "
+                "or logs for server-side progress."
+            )
+        return "\n".join(lines)
 
     def _build_recall_kwargs(self, query: str) -> Dict[str, Any]:
         """Build the shared kwargs for Hindsight recall calls."""
@@ -1168,6 +1237,12 @@ class HindsightMemoryProvider(MemoryProvider):
         self._timeout = _parse_int_setting(
             self._config.get("timeout") if self._config.get("timeout") is not None else os.environ.get("HINDSIGHT_TIMEOUT"),
             _DEFAULT_TIMEOUT,
+        )
+        self._reflect_timeout = _parse_int_setting(
+            self._config.get("reflect_timeout")
+            if self._config.get("reflect_timeout") is not None
+            else os.environ.get("HINDSIGHT_REFLECT_TIMEOUT"),
+            max(self._timeout, _DEFAULT_REFLECT_TIMEOUT),
         )
         self._idle_timeout = _parse_int_setting(
             self._config.get("idle_timeout") if self._config.get("idle_timeout") is not None else os.environ.get("HINDSIGHT_IDLE_TIMEOUT"),
@@ -1379,12 +1454,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 if self._prefetch_method == "reflect":
                     logger.debug("Prefetch: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
                     try:
-                        resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                        resp = self._run_hindsight_operation(
+                            lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget),
+                            timeout=self._reflect_timeout,
+                        )
                         text = resp.text or ""
                     except Exception as reflect_exc:
                         logger.debug(
                             "Hindsight reflect prefetch failed; falling back to recall: %s",
-                            reflect_exc,
+                            self._describe_reflect_error(reflect_exc, elapsed=0.0),
                             exc_info=True,
                         )
                         text = self._recall_text(query, bullet=True)
@@ -1594,33 +1672,41 @@ class HindsightMemoryProvider(MemoryProvider):
             try:
                 logger.debug("Tool hindsight_reflect: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
+                started = time.monotonic()
                 try:
                     resp = self._run_hindsight_operation(
                         lambda client: client.areflect(
                             bank_id=self._bank_id, query=query, budget=self._budget
-                        )
+                        ),
+                        timeout=self._reflect_timeout,
                     )
-                    logger.debug("Tool hindsight_reflect: response_len=%d", len(resp.text or ""))
+                    elapsed = time.monotonic() - started
+                    logger.debug(
+                        "Tool hindsight_reflect: response_len=%d elapsed=%.1fs",
+                        len(resp.text or ""),
+                        elapsed,
+                    )
                     return json.dumps({"result": resp.text or "No relevant memories found."})
                 except Exception as reflect_exc:
+                    elapsed = time.monotonic() - started
                     logger.warning(
                         "hindsight_reflect failed; falling back to recall: %s",
                         reflect_exc,
                         exc_info=True,
                     )
-                    detail = type(reflect_exc).__name__
+                    detail = self._describe_reflect_error(reflect_exc, elapsed=elapsed)
                     text = self._recall_text(query)
                     if text:
                         return json.dumps({
                             "result": (
                                 "Hindsight reflection failed; showing raw recall results instead.\n"
-                                f"Reflect error type: {detail}\n\n{text}"
+                                f"{detail}\n\n{text}"
                             )
                         })
                     return json.dumps({
                         "result": (
                             "Hindsight reflection failed and recall found no relevant memories.\n"
-                            f"Reflect error type: {detail}"
+                            f"{detail}"
                         )
                     })
             except Exception as e:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -40,6 +40,9 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
         "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_LLM_PROVIDER", "HINDSIGHT_LLM_MODEL", "HINDSIGHT_LLM_BASE_URL",
+        "HINDSIGHT_API_LLM_PROVIDER", "HINDSIGHT_API_LLM_MODEL",
+        "HINDSIGHT_API_LLM_API_KEY", "HINDSIGHT_API_LLM_BASE_URL",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
@@ -544,6 +547,28 @@ class TestToolHandlers:
         ))
         assert result["result"] == "Synthesized answer"
 
+    def test_reflect_falls_back_to_recall_when_synthesis_fails(self, provider):
+        provider._client.areflect.side_effect = RuntimeError("llm unavailable")
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
+        assert "error" not in result
+        assert "Hindsight reflection failed" in result["result"]
+        assert "Reflect error type: RuntimeError" in result["result"]
+        assert "1. Memory 1" in result["result"]
+        assert "2. Memory 2" in result["result"]
+        provider._client.arecall.assert_called_once()
+
+    def test_reflect_fallback_reports_no_results_without_error(self, provider):
+        provider._client.areflect.side_effect = RuntimeError("llm unavailable")
+        provider._client.arecall.return_value = SimpleNamespace(results=[])
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
+        assert "error" not in result
+        assert "recall found no relevant memories" in result["result"]
+        assert "Reflect error type: RuntimeError" in result["result"]
+
     def test_reflect_missing_query(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_reflect", {}
@@ -664,6 +689,17 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    def test_queue_prefetch_reflect_falls_back_to_recall(self, provider_with_config):
+        p = provider_with_config(recall_prefetch_method="reflect")
+        p._client.areflect.side_effect = RuntimeError("llm unavailable")
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        assert p._prefetch_result == "- Memory 1\n- Memory 2"
+        p._client.areflect.assert_called_once()
+        p._client.arecall.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import stat
+from concurrent.futures import TimeoutError as FutureTimeoutError
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -39,7 +40,7 @@ def _clean_env(monkeypatch):
     for key in (
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
         "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
-        "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_REFLECT_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_LLM_PROVIDER", "HINDSIGHT_LLM_MODEL", "HINDSIGHT_LLM_BASE_URL",
         "HINDSIGHT_API_LLM_PROVIDER", "HINDSIGHT_API_LLM_MODEL",
         "HINDSIGHT_API_LLM_API_KEY", "HINDSIGHT_API_LLM_BASE_URL",
@@ -281,6 +282,18 @@ class TestConfig:
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
 
+    def test_env_reflect_timeout_defaults_to_at_least_request_timeout(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_TIMEOUT", "240")
+
+        cfg = _load_config()
+
+        assert cfg["timeout"] == 240
+        assert cfg["reflect_timeout"] == 240
+
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({
             "llm_provider": "openai",
@@ -350,6 +363,7 @@ class TestPostSetup:
         env_text = (hermes_home / ".env").read_text()
         assert "HINDSIGHT_LLM_API_KEY=sk-local-test\n" in env_text
         assert "HINDSIGHT_TIMEOUT=120\n" in env_text
+        assert "HINDSIGHT_REFLECT_TIMEOUT=180\n" in env_text
         assert "HINDSIGHT_IDLE_TIMEOUT=300\n" in env_text
 
         profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
@@ -431,6 +445,7 @@ class TestPostSetup:
             "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT": "0",
             "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE": "1",
             "timeout": 120,
+            "reflect_timeout": 240,
         }
         provider = HindsightMemoryProvider()
         provider.save_config(existing_config, str(hermes_home))
@@ -457,6 +472,7 @@ class TestPostSetup:
         assert saved["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
         assert saved["HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE"] == "1"
         assert saved["timeout"] == 120
+        assert saved["reflect_timeout"] == 240
 
 
 
@@ -555,6 +571,8 @@ class TestToolHandlers:
         assert "error" not in result
         assert "Hindsight reflection failed" in result["result"]
         assert "Reflect error type: RuntimeError" in result["result"]
+        assert "Reflect error message: llm unavailable" in result["result"]
+        assert "Reflect timeout: 180s" in result["result"]
         assert "1. Memory 1" in result["result"]
         assert "2. Memory 2" in result["result"]
         provider._client.arecall.assert_called_once()
@@ -568,6 +586,37 @@ class TestToolHandlers:
         assert "error" not in result
         assert "recall found no relevant memories" in result["result"]
         assert "Reflect error type: RuntimeError" in result["result"]
+
+    def test_reflect_timeout_explains_possible_server_side_progress(self, provider):
+        provider._client.areflect.side_effect = FutureTimeoutError()
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
+        assert "error" not in result
+        assert "Reflect error type: TimeoutError" in result["result"]
+        assert "Reflect timeout: 180s" in result["result"]
+        assert "may still complete the operation" in result["result"]
+
+    def test_reflect_error_reports_operation_id_when_available(self, provider):
+        exc = RuntimeError({"operation_id": "op-123"})
+        provider._client.areflect.side_effect = exc
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
+        assert "Hindsight operation id: op-123" in result["result"]
+
+    def test_reflect_uses_reflect_timeout_config(self, provider_with_config):
+        p = provider_with_config(reflect_timeout=240)
+        calls = []
+        def fake_run(operation, *, timeout=None):
+            calls.append(timeout)
+            return SimpleNamespace(text="ok")
+        p._run_hindsight_operation = fake_run
+        result = json.loads(p.handle_tool_call(
+            "hindsight_reflect", {"query": "summarize"}
+        ))
+        assert result["result"] == "ok"
+        assert calls == [240]
 
     def test_reflect_missing_query(self, provider):
         result = json.loads(provider.handle_tool_call(


### PR DESCRIPTION
## Why
Hindsight has two different paths:

- `hindsight_recall` / default `recall_prefetch_method: recall`: core memory search, which returns raw relevant memories.
- `hindsight_reflect` / `recall_prefetch_method: reflect`: optional LLM-powered synthesis over retrieved memories.

When users enable the reflect-based Hindsight path (for example to have Hindsight synthesize memory context automatically before each turn), that path depends on an additional LLM configuration and can fail independently of memory storage/search. This is especially visible with local or low-resource LLM setups where the Hindsight synthesis model may be unavailable, slow, or unable to complete a reflect request.

Before this change, a reflect failure could make Hindsight look unavailable even though the underlying memory bank and recall path still worked. The fix keeps Hindsight useful by falling back to raw recall results whenever reflect synthesis fails.

## Summary
- Adds a shared Hindsight recall helper used by tool calls and auto-prefetch.
- Falls back to raw `hindsight_recall` results when `hindsight_reflect` synthesis fails, so memory remains usable even when the optional synthesis/LLM path is unavailable.
- Applies the same fallback to auto-prefetch when `recall_prefetch_method: reflect` is enabled.
- Adds a separate `reflect_timeout` / `HINDSIGHT_REFLECT_TIMEOUT` knob (default 180s, at least the general request timeout when only `HINDSIGHT_TIMEOUT` is set) so slow/cold-start synthesis can be configured independently.
- Includes operator-facing reflect diagnostics in fallback output: exception type/message when present, elapsed time, configured timeout, and any available Hindsight operation/request id.
- Calls out client-side reflect timeouts as potentially still running on the Hindsight server, pointing operators to server operations/logs for progress.
- Extends Hindsight tests to cover reflect fallback, prefetch fallback, timeout diagnostics, operation-id extraction, reflect timeout config, and additional Hindsight LLM env isolation.

## Test Plan
- [x] `uv run --extra dev --extra hindsight python -m pytest tests/plugins/memory/test_hindsight_provider.py -q` — 108 passed
- [x] `uv run --extra dev ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- [x] `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` — passed
- [x] `git diff --check` — passed
