### PR TITLE
feat(api-server): fallback to follow up a session using `conversation`.

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -879,6 +879,33 @@ class APIServerAdapter(BasePlatformAdapter):
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
 
+    def _validate_session_continuation(
+        self, session_id: str
+    ) -> Optional["web.Response"]:
+        """Enforce the authentication boundary for persisted-session access."""
+        if not self._api_key:
+            logger.warning(
+                "Session continuation rejected: no API key configured. "
+                "Set API_SERVER_KEY to enable session continuity."
+            )
+            return web.json_response(
+                _openai_error(
+                    "Session continuation requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+
+        # Session IDs are echoed in response headers, so reject control
+        # characters regardless of whether the ID came from a header or body.
+        if re.search(r'[\r\n\x00]', session_id):
+            return web.json_response(
+                {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        return None
+
     def _parse_session_key_header(
         self, request: "web.Request"
     ) -> tuple[Optional[str], Optional["web.Response"]]:
@@ -1742,25 +1769,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # read arbitrary session history by guessing/enumerating session IDs.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
         if provided_session_id:
-            if not self._api_key:
-                logger.warning(
-                    "Session continuation via X-Hermes-Session-Id rejected: "
-                    "no API key configured.  Set API_SERVER_KEY to enable "
-                    "session continuity."
-                )
-                return web.json_response(
-                    _openai_error(
-                        "Session continuation requires API key authentication. "
-                        "Configure API_SERVER_KEY to enable this feature."
-                    ),
-                    status=403,
-                )
-            # Sanitize: reject control characters that could enable header injection.
-            if re.search(r'[\r\n\x00]', provided_session_id):
-                return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
-                    status=400,
-                )
+            continuation_err = self._validate_session_continuation(provided_session_id)
+            if continuation_err is not None:
+                return continuation_err
             session_id = provided_session_id
             try:
                 db = self._ensure_session_db()
@@ -2835,11 +2846,12 @@ class APIServerAdapter(BasePlatformAdapter):
             if db:
                 session = db.get_session(conversation)
                 if session:
+                    continuation_err = self._validate_session_continuation(conversation)
+                    if continuation_err is not None:
+                        return continuation_err
                     try:
                         conversation_history = db.get_messages_as_conversation(conversation)
                         stored_session_id = conversation
-                        if instructions is None:
-                            instructions = session.get("system_prompt")
                     except Exception as exc:
                         logger.warning("Failed to load session history for fallback %s: %s", conversation, exc)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2829,6 +2829,19 @@ class APIServerAdapter(BasePlatformAdapter):
             # If no instructions provided, carry forward from previous
             if instructions is None:
                 instructions = stored.get("instructions")
+        elif not conversation_history and conversation:
+            # Fallback: if 'conversation' is actually a SessionDB ID, load its history directly.
+            db = self._ensure_session_db()
+            if db:
+                session = db.get_session(conversation)
+                if session:
+                    try:
+                        conversation_history = db.get_messages_as_conversation(conversation)
+                        stored_session_id = conversation
+                        if instructions is None:
+                            instructions = session.get("system_prompt")
+                    except Exception as exc:
+                        logger.warning("Failed to load session history for fallback %s: %s", conversation, exc)
 
         # Append new input messages to history (all but the last become history)
         for msg in input_messages[:-1]:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3057,6 +3057,63 @@ class TestCORS:
 
 class TestConversationParameter:
     @pytest.mark.asyncio
+    async def test_session_db_id_resumes_without_duplicate_instructions(self, auth_adapter):
+        """An unknown conversation may resume a SessionDB session without replaying its prompt."""
+        db_history = [
+            {"role": "user", "content": "stored question"},
+            {"role": "assistant", "content": "stored answer"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {
+            "id": "persisted-session",
+            "system_prompt": "persisted assembled system prompt",
+        }
+        mock_db.get_messages_as_conversation.return_value = db_history
+        auth_adapter._session_db = mock_db
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "continued", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"input": "follow up", "conversation": "persisted-session"},
+                )
+
+        assert resp.status == 200
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["conversation_history"] == db_history
+        assert call_kwargs["session_id"] == "persisted-session"
+        assert call_kwargs["ephemeral_system_prompt"] is None
+        mock_db.get_session.assert_called_once_with("persisted-session")
+        mock_db.get_messages_as_conversation.assert_called_once_with("persisted-session")
+
+    @pytest.mark.asyncio
+    async def test_session_db_id_rejected_without_api_key(self, adapter):
+        """SessionDB continuation through conversation requires API-key authentication."""
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "persisted-session"}
+        adapter._session_db = mock_db
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"input": "follow up", "conversation": "persisted-session"},
+                )
+                data = await resp.json()
+
+        assert resp.status == 403
+        assert "requires API key authentication" in data["error"]["message"]
+        mock_run.assert_not_awaited()
+        mock_db.get_messages_as_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_conversation_creates_new(self, adapter):
         """First request with a conversation name works (new conversation)."""
         app = _create_app(adapter)


### PR DESCRIPTION
## What does this PR do?

Adds a database fallback to the `conversation` parameter in the `/v1/responses` endpoint, allowing clients to seamlessly resume persistent sessions using a known `SessionDB` ID.

### The Problem

Currently, the most reliable way to follow up on a specific session using its Session ID is via the proprietary endpoint:
```http
POST /api/sessions/{session_id}/chat/stream
```

However, frontends built around the industry-standard OpenAI format rely on the `/v1/responses` endpoint. In this endpoint, the `conversation` parameter acts purely as an ephemeral lookup key that checks an in-memory dictionary (`_response_store`). 

This creates significant friction for frontend clients:
1. When a browser tab is refreshed, the frontend loses its ephemeral `conversation` string.
2. If the frontend tries to resume the chat using the real Session ID (obtained via the `X-Hermes-Session-Id` header or the `/api/sessions` list), the `/v1/responses` endpoint fails the ephemeral memory check and spins up a brand new child session, losing the context thread.
3. To prevent this, developers are forced to build and manage their own tracking databases just to maintain persistent mappings between arbitrary `conversation` strings and backend Session IDs.

### The Solution

This PR introduces a graceful fallback mechanism in `_handle_responses`. If the provided `conversation` string is not found in the ephemeral `_response_store`, the endpoint will now check if the string is actually a valid `SessionDB` ID. 
If a match is found in the persistent database, the endpoint automatically loads the historical context and appends the new message to the existing thread. 

Frontends can now reliably and statelessly resume conversations on the standard `/v1/responses` endpoint by simply passing the Session ID, entirely removing the need for complex client-side mapping databases.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `_handle_responses` in gateway/platforms/api_server.py

## How to Test

1. **Start a new conversation and state a fact**
Send a standard request to `/v1/responses` using an ephemeral conversation string. Include `-i` to view the response headers.

```bash
curl -X POST http://localhost/openai-endpoint/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer hermes-api-server-key" \
  -i \
  -d '{
    "input": "My favorite color is blue.",
    "conversation": "test_ephemeral_string"
  }'
```

2. **Extract the Database Session ID**
Look at the HTTP response headers from the command above and copy the actual Database Session ID.
```text
X-Hermes-Session-Id: api_1234567890_abcdefgh
```

3. **Follow up using the Session ID**
Make a second request, but this time pass the Session ID as the `conversation` parameter instead of the ephemeral string. Because this string is NOT in the ephemeral cache (the cache only knows `test_ephemeral_string`), the fallback logic will trigger.

```bash
curl -X POST http://localhost/openai-endpoint/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer hermes-api-server-key" \
  -d '{
    "input": "What is my favorite color?",
    "conversation": "api_1234567890_abcdefgh"
  }'
```

**Expected Result:**
* **Without the PR:** The bot answers "I don't know" (it failed the memory check and started a brand new context-less session).
* **With the PR:** The bot answers "Your favorite color is blue" (it gracefully fell back to the SQLite DB, found the Session ID, loaded the history, and answered correctly).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

