### PR TITLE
fix(web): patch xterm WebGL glyph atlas mipmaps

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "patch:xterm-webgl": "node scripts/patch-xterm-webgl.mjs",
+    "postinstall": "node scripts/patch-xterm-webgl.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/scripts/patch-xterm-webgl.mjs
+++ b/web/scripts/patch-xterm-webgl.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+const packagePath = join(root, 'node_modules', '@xterm', 'addon-webgl', 'package.json');
+
+if (!existsSync(packagePath)) {
+  console.warn('[patch-xterm-webgl] @xterm/addon-webgl is not installed; skipping');
+  process.exit(0);
+}
+
+const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+if (pkg.version !== '0.19.0') {
+  console.warn(`[patch-xterm-webgl] Expected @xterm/addon-webgl 0.19.0, found ${pkg.version}; skipping`);
+  process.exit(0);
+}
+
+const bundledFiles = [
+  join(root, 'node_modules', '@xterm', 'addon-webgl', 'lib', 'addon-webgl.mjs'),
+  join(root, 'node_modules', '@xterm', 'addon-webgl', 'lib', 'addon-webgl.js'),
+];
+
+const bundlePattern = /([A-Za-z_$][\w$]*)\.texImage2D\(\1\.TEXTURE_2D,0,\1\.RGBA,\1\.RGBA,\1\.UNSIGNED_BYTE,([^)]*?\.canvas)\),\1\.generateMipmap\(\1\.TEXTURE_2D\),/g;
+
+for (const file of bundledFiles) {
+  if (!existsSync(file)) {
+    throw new Error(`[patch-xterm-webgl] Expected bundle file missing: ${file}`);
+  }
+
+  let source = readFileSync(file, 'utf8');
+  if (!source.includes('generateMipmap')) {
+    console.log(`[patch-xterm-webgl] ${file} already patched`);
+    continue;
+  }
+
+  const patched = source.replace(
+    bundlePattern,
+    (_match, gl, canvasExpr) =>
+      `${gl}.texImage2D(${gl}.TEXTURE_2D,0,${gl}.RGBA,${gl}.RGBA,${gl}.UNSIGNED_BYTE,${canvasExpr}),` +
+      `${gl}.texParameteri(${gl}.TEXTURE_2D,${gl}.TEXTURE_MIN_FILTER,${gl}.LINEAR),` +
+      `${gl}.texParameteri(${gl}.TEXTURE_2D,${gl}.TEXTURE_MAG_FILTER,${gl}.LINEAR),`,
+  );
+
+  if (patched === source || patched.includes('generateMipmap')) {
+    throw new Error(`[patch-xterm-webgl] Failed to remove generateMipmap from ${file}`);
+  }
+
+  writeFileSync(file, patched);
+  console.log(`[patch-xterm-webgl] patched ${file}`);
+}
+
+const sourceFile = join(root, 'node_modules', '@xterm', 'addon-webgl', 'src', 'GlyphRenderer.ts');
+if (existsSync(sourceFile)) {
+  const source = readFileSync(sourceFile, 'utf8');
+  const patched = source.replace(
+    '    gl.generateMipmap(gl.TEXTURE_2D);',
+    '    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);\n    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);',
+  );
+  if (patched !== source) {
+    writeFileSync(sourceFile, patched);
+    console.log(`[patch-xterm-webgl] patched ${sourceFile}`);
+  }
+}
+
+console.log('[patch-xterm-webgl] xterm WebGL glyph atlas mipmaps disabled');


### PR DESCRIPTION
## Summary

Fixes #37203.

Hermes dashboard Chat uses xterm's WebGL renderer on wide layouts. On Linux + Wayland GPU stacks, the WebGL glyph atlas upload path can corrupt dense terminal text into black cell blocks. This is the same failure i encountered and fixed in orca:

- https://github.com/stablyai/orca/issues/1579
- https://github.com/stablyai/orca/pull/1743

This PR preserves WebGL rendering, but patches `@xterm/addon-webgl@0.19.0` after install so the glyph atlas upload path stops calling `gl.generateMipmap(gl.TEXTURE_2D)` and uses explicit non-mipmapped filters instead:

```js
gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
```

## Changes

- Add `web/scripts/patch-xterm-webgl.mjs`.
- Add `patch:xterm-webgl` and `postinstall` scripts to `web/package.json`.
- Patch both bundled addon outputs:
  - `lib/addon-webgl.mjs`
  - `lib/addon-webgl.js`
- Patch `src/GlyphRenderer.ts` when present for local source inspection consistency.
- Skip patching if the installed addon version is not `0.19.0`, rather than applying a brittle regex to an unknown bundle shape.

## Verification

Ran from `web/`:

```bash
npm ci
npm run build
```

Confirmed fresh install applies the patch:

```text
node_modules/@xterm/addon-webgl/lib/addon-webgl.mjs generateMipmap= False TEXTURE_MIN_FILTER= True TEXTURE_MAG_FILTER= True
node_modules/@xterm/addon-webgl/lib/addon-webgl.js  generateMipmap= False TEXTURE_MIN_FILTER= True TEXTURE_MAG_FILTER= True
node_modules/@xterm/addon-webgl/src/GlyphRenderer.ts generateMipmap= False TEXTURE_MIN_FILTER= True TEXTURE_MAG_FILTER= True
```

Confirmed production dashboard bundle preserves WebGL but removes mipmap generation:

```text
index-DZ3LSrrI.js
generateMipmap= False
TEXTURE_MIN_FILTER= True
TEXTURE_MAG_FILTER= True
webgl refs= True
```

Also ran the dashboard WebSocket regression tests related to current local dashboard work:

```bash
python -m pytest \
  tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_allows_public_url_origin_with_loopback_tunnel_host \
  tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_rejects_public_origin_without_public_url \
  -q -o 'addopts='
```

Result:

```text
2 passed
```

## Known baseline issue

`npm run lint` currently fails on existing dashboard lint debt in files unrelated to this PR (`App.tsx`, `LanguageSwitcher.tsx`, `OAuthProvidersCard.tsx`, etc.). This PR does not touch those files. The build passes.

## Security review

No new network calls, shell execution, credentials, or user input handling. The postinstall script only rewrites a local installed dependency under `web/node_modules/@xterm/addon-webgl` during package installation.
