### PR TITLE
feat(image_gen): support openai base_url override

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -118,6 +118,19 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+def _resolve_base_url() -> Optional[str]:
+    """Return configured OpenAI image base_url, or None when unset."""
+    cfg = _load_openai_config()
+    openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
+    if not isinstance(openai_cfg, dict):
+        return None
+    value = openai_cfg.get("base_url")
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().rstrip("/")
+    return cleaned or None
+
+
 # ---------------------------------------------------------------------------
 # Source-image loading (for image-to-image / edit)
 # ---------------------------------------------------------------------------
@@ -270,7 +283,8 @@ class OpenAIImageGenProvider(ImageGenProvider):
         is_edit = bool(sources)
         modality = "image" if is_edit else "text"
 
-        client = openai.OpenAI()
+        base_url = _resolve_base_url()
+        client = openai.OpenAI(base_url=base_url) if base_url else openai.OpenAI()
 
         if is_edit:
             # images.edit() expects file-like objects. Download/read each

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -119,6 +119,19 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+def _resolve_base_url() -> Optional[str]:
+    """Return configured OpenAI image base_url, or None when unset."""
+    cfg = _load_openai_config()
+    openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
+    if not isinstance(openai_cfg, dict):
+        return None
+    value = openai_cfg.get("base_url")
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().rstrip("/")
+    return cleaned or None
+
+
 # ---------------------------------------------------------------------------
 # Source-image loading (for image-to-image / edit)
 # ---------------------------------------------------------------------------
@@ -272,7 +285,12 @@ class OpenAIImageGenProvider(ImageGenProvider):
         is_edit = bool(sources)
         modality = "image" if is_edit else "text"
 
-        client = openai.OpenAI(api_key=api_key)
+        base_url = _resolve_base_url()
+        client = (
+            openai.OpenAI(api_key=api_key, base_url=base_url)
+            if base_url
+            else openai.OpenAI(api_key=api_key)
+        )
 
         if is_edit:
             # images.edit() expects file-like objects. Download/read each

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -286,11 +286,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         modality = "image" if is_edit else "text"
 
         base_url = _resolve_base_url()
-        client = (
-            openai.OpenAI(api_key=api_key, base_url=base_url)
-            if base_url
-            else openai.OpenAI(api_key=api_key)
-        )
+        client = openai.OpenAI(base_url=base_url) if base_url else openai.OpenAI()
 
         if is_edit:
             # images.edit() expects file-like objects. Download/read each

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -225,6 +225,60 @@ class TestGenerate:
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
+    def test_base_url_unset_keeps_noarg_openai_constructor(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({"image_gen": {"openai": {}}}))
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.args == ()
+        assert fake_openai.OpenAI.call_args.kwargs == {}
+
+    def test_base_url_is_passed_to_openai_client_for_generate(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"base_url": "https://example.test/v1/"}}})
+        )
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://example.test/v1"
+        assert fake_client.images.generate.called
+
+    def test_base_url_is_passed_to_openai_client_for_edit(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"base_url": "https://example.test/v1"}}})
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(bytes.fromhex(_PNG_HEX))
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat", image_url=str(image_path))
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://example.test/v1"
+        assert fake_client.images.edit.called
+
     @pytest.mark.parametrize("tier,expected_quality", [
         ("gpt-image-2-low", "low"),
         ("gpt-image-2-medium", "medium"),

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -171,6 +171,60 @@ class TestGenerate:
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
+    def test_base_url_unset_keeps_noarg_openai_constructor(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({"image_gen": {"openai": {}}}))
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.args == ()
+        assert fake_openai.OpenAI.call_args.kwargs == {}
+
+    def test_base_url_is_passed_to_openai_client_for_generate(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"base_url": "https://example.test/v1/"}}})
+        )
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://example.test/v1"
+        assert fake_client.images.generate.called
+
+    def test_base_url_is_passed_to_openai_client_for_edit(self, provider, monkeypatch, tmp_path):
+        import yaml
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"base_url": "https://example.test/v1"}}})
+        )
+        image_path = tmp_path / "source.png"
+        image_path.write_bytes(bytes.fromhex(_PNG_HEX))
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            result = provider.generate("a cat", image_url=str(image_path))
+
+        assert result["success"] is True
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://example.test/v1"
+        assert fake_client.images.edit.called
+
     @pytest.mark.parametrize("tier,expected_quality", [
         ("gpt-image-2-low", "low"),
         ("gpt-image-2-medium", "medium"),


### PR DESCRIPTION
## Summary
- add explicit `image_gen.openai.base_url` config support for the OpenAI image provider
- pass the configured base URL directly to `openai.OpenAI(base_url=...)`
- keep existing model selection and API behavior unchanged when the config is unset

## Testing
- `./.venv/bin/python -m pytest tests/plugins/image_gen/test_openai_provider.py -q`
