### PR TITLE
fix(web_server): close log file descriptor when Popen fails

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1060,7 +1060,11 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     else:
         popen_kwargs["start_new_session"] = True
 
-    proc = subprocess.Popen(cmd, **popen_kwargs)
+    try:
+        proc = subprocess.Popen(cmd, **popen_kwargs)
+    except Exception:
+        log_file.close()
+        raise
     # The child inherits its own duplicated fd for stdout/stderr, so the
     # parent's handle can be released immediately — otherwise we leak one
     # fd per spawned action.


### PR DESCRIPTION
## Problem

In `_spawn_action()` (`hermes_cli/web_server.py:1041`), `log_file = open(log_path, "ab", buffering=0)` opens a file descriptor for the action's log. If `subprocess.Popen()` at line 1063 raises (e.g. command not found, permission denied), `log_file.close()` at line 1067 is never reached — it only runs on the success path.

This leaks one file descriptor per failed action spawn. In a long-running web server with repeated failures, this can exhaust the process's fd limit.

## Fix

Wrap the `Popen` call in `try/except` that closes `log_file` before re-raising:

```python
try:
    proc = subprocess.Popen(cmd, **popen_kwargs)
except Exception:
    log_file.close()
    raise
```

## Tests

- `python3 -m py_compile hermes_cli/web_server.py` passes
- The fix is a minimal defensive-coding change with zero behavioral impact on the success path
