### PR TITLE
feat(platforms): add Fluxer gateway adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,12 @@ hermes-agent/
 `gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
 Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
 
+### Fluxer platform plugin
+
+Fluxer lives under `plugins/platforms/fluxer/` and is intentionally runtime-faithful: prefer the shapes the Fluxer hosted/self-hosted runtime actually emits over forcing Discord assumptions. The adapter currently covers REST send/edit/delete/media, delivery readback, heartbeats/reconnect/backlog recovery, mention gating, pins, native component callbacks, opt-in native slash-command registration, thread creation, and `list_channels()` for the channel directory. Main tests are `tests/gateway/test_fluxer_plugin.py` and `tests/gateway/test_channel_directory.py`. Docs are in `website/docs/user-guide/messaging/fluxer.md` plus `website/docs/reference/environment-variables.md`.
+
+Useful opt-in envs for native command registration: `FLUXER_REGISTER_NATIVE_COMMANDS`, `FLUXER_APPLICATION_ID`, `FLUXER_NATIVE_COMMAND_GUILDS`. Keep registration disabled by default unless the deployment has proven application-command support.
+
 ## TypeScript Style
 
 Applies to TypeScript across Hermes: desktop, TUI, website, and future TS packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,9 @@ Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
 
 ### Fluxer platform plugin
 
-Fluxer lives under `plugins/platforms/fluxer/` and is intentionally runtime-faithful: prefer the shapes the Fluxer hosted/self-hosted runtime actually emits over forcing Discord assumptions. The adapter currently covers REST send/edit/delete/media, delivery readback, heartbeats/reconnect/backlog recovery, mention gating, pins, native component callbacks, opt-in native slash-command registration, thread creation, and `list_channels()` for the channel directory. Main tests are `tests/gateway/test_fluxer_plugin.py` and `tests/gateway/test_channel_directory.py`. Docs are in `website/docs/user-guide/messaging/fluxer.md` plus `website/docs/reference/environment-variables.md`.
+Fluxer lives under `plugins/platforms/fluxer/` and is intentionally runtime-faithful: prefer the shapes the Fluxer hosted/self-hosted runtime actually emits over forcing Discord assumptions. The adapter currently covers REST send/edit/delete/media, delivery readback, heartbeats/reconnect/backlog recovery, mention gating, pins, reply references, guarded component callback parsing, guarded thread helpers, and `list_channels()` for the channel directory. Main tests are `tests/gateway/test_fluxer_plugin.py` and `tests/gateway/test_channel_directory.py`. Docs are in `website/docs/user-guide/messaging/fluxer.md` plus `website/docs/reference/environment-variables.md`.
 
-Useful opt-in envs for native command registration: `FLUXER_REGISTER_NATIVE_COMMANDS`, `FLUXER_APPLICATION_ID`, `FLUXER_NATIVE_COMMAND_GUILDS`. Keep registration disabled by default unless the deployment has proven application-command support.
+Useful opt-in envs for native command registration: `FLUXER_REGISTER_NATIVE_COMMANDS`, `FLUXER_APPLICATION_ID`, `FLUXER_NATIVE_COMMAND_GUILDS`. Keep registration disabled by default unless the deployment has proven application-command registration and interaction callback routes.
 
 ## TypeScript Style
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can still bring your own keys per-tool whenever you want — the gateway is 
 
 ## CLI vs Messaging Quick Reference
 
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
+Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Fluxer, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
 
 | Action                         | CLI                                           | Messaging platforms                                                              |
 | ------------------------------ | --------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -129,7 +129,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart)                 | Install → setup → first conversation in 2 minutes          |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli)                              | Commands, keybindings, personalities, sessions             |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration)                | Config file, providers, models, all options                |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Fluxer, Slack, WhatsApp, Signal, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security)                          | Command approval, DM pairing, container isolation          |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools)            | 40+ tools, toolset system, terminal backends               |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)              | Procedural memory, Skills Hub, creating skills             |

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1722,7 +1722,17 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
-            return ctx
+            # MiniMax M3's context is 1M; some registries expose the 512K
+            # max-output/token-generation ceiling instead. Treat sub-1M values
+            # for M3 as underreports and fall through to the curated default.
+            if _model_name_suggests_minimax_m3(model) and ctx < 1_000_000:
+                logger.info(
+                    "Rejecting models.dev context=%s for %r (MiniMax-M3 underreport); "
+                    "falling through to hardcoded defaults",
+                    ctx, model,
+                )
+            else:
+                return ctx
 
     # 6. OpenRouter live API metadata — provider-unaware fallback.
     # Only consulted when the provider is unknown (no effective_provider),

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -9,7 +9,8 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 import json
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
+import inspect
 
 from hermes_cli.config import get_hermes_home
 from utils import atomic_json_write
@@ -69,7 +70,17 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
 
     for platform, adapter in adapters.items():
         try:
-            if platform == Platform.DISCORD:
+            list_channels = getattr(adapter, "list_channels", None)
+            if callable(list_channels) and platform not in {Platform.DISCORD, Platform.SLACK}:
+                channels = list_channels()
+                if inspect.isawaitable(channels):
+                    channels = await channels
+                channels = cast(Any, channels)
+                if isinstance(channels, list):
+                    platforms[platform.value] = channels
+                else:
+                    platforms[platform.value] = list(channels or [])
+            elif platform == Platform.DISCORD:
                 platforms["discord"] = _build_discord(adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8605,10 +8605,20 @@ class GatewayRunner:
             from tools.credential_files import to_agent_visible_cache_path
 
             _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+            _TEXT_MIME_TYPES = {
+                "application/json",
+                "application/ld+json",
+                "application/xml",
+                "application/yaml",
+                "application/x-yaml",
+                "application/toml",
+                "application/x-ndjson",
+            }
+            _MAX_INLINE_DOCUMENT_CHARS = 120_000
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
+                _ext = os.path.splitext(path)[1].lower()
                 if mtype in {"", "application/octet-stream"}:
-                    _ext = os.path.splitext(path)[1].lower()
                     if _ext in _TEXT_EXTENSIONS:
                         mtype = "text/plain"
                     else:
@@ -8628,19 +8638,42 @@ class GatewayRunner:
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                if mtype.startswith("text/"):
+                is_text_document = mtype.startswith("text/") or mtype in _TEXT_MIME_TYPES or _ext in _TEXT_EXTENSIONS
+                inline_content = None
+                inline_truncated = False
+                if is_text_document:
+                    try:
+                        with open(path, "r", encoding="utf-8", errors="replace") as _fh:
+                            inline_content = _fh.read(_MAX_INLINE_DOCUMENT_CHARS + 1)
+                        if len(inline_content) > _MAX_INLINE_DOCUMENT_CHARS:
+                            inline_content = inline_content[:_MAX_INLINE_DOCUMENT_CHARS]
+                            inline_truncated = True
+                    except Exception as exc:
+                        logger.warning("Failed to read text document attachment %s: %s", path, exc)
+
+                if inline_content is not None:
+                    truncation_note = " Content was truncated." if inline_truncated else ""
                     context_note = (
                         f"[The user sent a text document: '{display_name}'. "
-                        f"Its content has been included below. "
+                        f"Its content is included below.{truncation_note} "
                         f"The file is also saved at: {agent_path}]"
                     )
+                    message_text = f"{context_note}\n\n```{_ext.lstrip('.') or 'text'}\n{inline_content}\n```\n\n{message_text}"
+                elif is_text_document:
+                    context_note = (
+                        f"[The user sent a text document: '{display_name}'. "
+                        f"I could not read its content automatically. "
+                        f"The file is saved at: {agent_path}. "
+                        f"Use read_file on that path if needed.]"
+                    )
+                    message_text = f"{context_note}\n\n{message_text}"
                 else:
                     context_note = (
                         f"[The user sent a document: '{display_name}'. "
                         f"The file is saved at: {agent_path}. "
                         f"Ask the user what they'd like you to do with it.]"
                     )
-                message_text = f"{context_note}\n\n{message_text}"
+                    message_text = f"{context_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1128,6 +1128,7 @@ from gateway.session import (
     build_session_context,
     build_session_context_prompt,
     build_session_key,
+    effective_session_policy,
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter
@@ -2371,10 +2372,14 @@ class GatewayRunner:
             except Exception:
                 pass
         config = getattr(self, "config", None)
+        group_sessions_per_user, thread_sessions_per_user = effective_session_policy(
+            config,
+            source,
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
         )
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
@@ -8473,8 +8478,10 @@ class GatewayRunner:
         """
         history = history or []
         message_text = event.text or ""
-        _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
-        _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
+        _group_sessions_per_user, _thread_sessions_per_user = effective_session_policy(
+            self.config,
+            source,
+        )
         # Use the same helper every other call site uses so the write key here
         # matches the consume key at the run_conversation site — even if the
         # session store overrides build_session_key's default behavior.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -597,6 +597,55 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
+def _coerce_session_policy_bool(value: Any, default: bool) -> bool:
+    """Coerce YAML/env-style booleans for session policy overrides."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "y"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "n"}:
+            return False
+    return default
+
+
+def effective_session_policy(
+    config: GatewayConfig,
+    source: SessionSource,
+) -> tuple[bool, bool]:
+    """Return effective group/thread session isolation for a source.
+
+    Gateway-level ``group_sessions_per_user``/``thread_sessions_per_user`` are
+    defaults. A platform may override either value under
+    ``platforms.<platform>.extra``; this lets Discord-like adapters such as
+    Fluxer use shared channel sessions without changing Telegram/Matrix/etc.
+    """
+    group_sessions_per_user = getattr(config, "group_sessions_per_user", True)
+    thread_sessions_per_user = getattr(config, "thread_sessions_per_user", False)
+
+    try:
+        platform_cfg = (getattr(config, "platforms", {}) or {}).get(source.platform)
+        extra = getattr(platform_cfg, "extra", {}) if platform_cfg is not None else {}
+        if isinstance(extra, dict):
+            group_sessions_per_user = _coerce_session_policy_bool(
+                extra.get("group_sessions_per_user"),
+                group_sessions_per_user,
+            )
+            thread_sessions_per_user = _coerce_session_policy_bool(
+                extra.get("thread_sessions_per_user"),
+                thread_sessions_per_user,
+            )
+    except Exception:
+        pass
+
+    return bool(group_sessions_per_user), bool(thread_sessions_per_user)
+
+
 def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
@@ -743,10 +792,14 @@ class SessionStore:
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        group_sessions_per_user, thread_sessions_per_user = effective_session_policy(
+            self.config,
+            source,
+        )
         return build_session_key(
             source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
         )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
@@ -1380,14 +1433,18 @@ def build_session_context(
         if home:
             home_channels[platform] = home
     
+    group_sessions_per_user, thread_sessions_per_user = effective_session_policy(
+        config,
+        source,
+    )
     context = SessionContext(
         source=source,
         connected_platforms=connected,
         home_channels=home_channels,
         shared_multi_user_session=is_shared_multi_user_session(
             source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            group_sessions_per_user=group_sessions_per_user,
+            thread_sessions_per_user=thread_sessions_per_user,
         ),
     )
     

--- a/plugins/platforms/fluxer/__init__.py
+++ b/plugins/platforms/fluxer/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -52,6 +52,18 @@ _DEFAULT_BACKLOG_BOOTSTRAP_SECONDS = 120
 _MENTION_EVERYONE_RE = re.compile(r"@(everyone|here)\b", re.IGNORECASE)
 _MENTION_ROLE_RE = re.compile(r"<@&\d+>")
 _MENTION_USER_RE = re.compile(r"<@!?\d+>")
+_VARIATION_SELECTOR_16 = "\ufe0f"
+_EXEC_APPROVAL_REACTIONS = (
+    ("✅", "once", "approve once"),
+    ("🕒", "session", "approve for this session"),
+    ("♾️", "always", "always approve"),
+    ("❌", "deny", "deny"),
+)
+_SLASH_CONFIRM_REACTIONS = (
+    ("✅", "once", "approve once"),
+    ("♾️", "always", "always approve"),
+    ("❌", "cancel", "cancel"),
+)
 
 
 def _strip_slash(url: str) -> str:
@@ -326,6 +338,28 @@ def _fluxer_button(*, custom_id: str, label: str, style: int) -> Dict[str, Any]:
     return {"type": 2, "style": style, "custom_id": custom_id[:100], "label": label, "disabled": False}
 
 
+def _normalize_reaction_emoji(value: Any) -> str:
+    if isinstance(value, dict):
+        value = value.get("name") or value.get("emoji") or value.get("id") or ""
+    text = str(value or "").strip()
+    # Fluxer/clients may round-trip text emoji with or without VS16. Compare
+    # both forms so ♾ and ♾️ resolve the same pending approval.
+    return text.replace(_VARIATION_SELECTOR_16, "")
+
+
+def _reaction_choice_map(specs: Any) -> Dict[str, str]:
+    return {_normalize_reaction_emoji(emoji): choice for emoji, choice, _label in specs}
+
+
+def _reaction_emoji_from_event(data: Dict[str, Any]) -> str:
+    return _normalize_reaction_emoji(
+        data.get("emoji")
+        or data.get("emoji_name")
+        or data.get("reaction")
+        or ((data.get("reaction_data") or {}).get("emoji"))
+    )
+
+
 def _directory_channel_type(raw: Any) -> Optional[str]:
     if raw in (0, "0", "text", "guild_text"):
         return "channel"
@@ -451,6 +485,7 @@ class FluxerAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._pending_exec_approvals: Dict[str, Dict[str, Any]] = {}
         self._pending_component_actions: Dict[str, Dict[str, Any]] = {}
+        self._pending_reaction_actions: Dict[str, Dict[str, Any]] = {}
 
     async def connect(self) -> bool:
         if not self.base_url or not self.bot_token:
@@ -588,6 +623,12 @@ class FluxerAdapter(BasePlatformAdapter):
         payload.update(extra)
         return payload
 
+    async def _add_reaction(self, chat_id: str, message_id: str, emoji: str) -> None:
+        await self._request(
+            "PUT",
+            f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}/reactions/{_quote_id(emoji)}/@me",
+        )
+
     async def send(
         self,
         chat_id: str,
@@ -656,33 +697,23 @@ class FluxerAdapter(BasePlatformAdapter):
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a native-button dangerous-command approval prompt."""
+        """Send a dangerous-command approval prompt with clickable reactions."""
         target_id = str((metadata or {}).get("thread_id") or chat_id)
         cmd_display = command if len(command) <= 3200 else command[:3197] + "..."
+        reaction_hint = " • ".join(f"{emoji} {label}" for emoji, _choice, label in _EXEC_APPROVAL_REACTIONS)
         content = (
             "**Command approval required**\n"
             f"```\n{cmd_display}\n```\n"
             f"Reason: {description}\n\n"
+            f"React: {reaction_hint}\n"
             "Reply with `/approve once`, `/approve session`, `/approve always`, or `/deny`."
         )
-        nonce = uuid.uuid4().hex[:12]
-        button_specs = (
-            ("once", "Allow once", 3),
-            ("session", "Session", 1),
-            ("always", "Always", 2),
-            ("deny", "Deny", 4),
-        )
-        custom_ids = {choice: f"hermes_exec_{nonce}_{choice}" for choice, _label, _style in button_specs}
-        components = _fluxer_component_row([
-            _fluxer_button(custom_id=custom_ids[choice], label=label, style=style)
-            for choice, label, style in button_specs
-        ])
         try:
             self._known_channel_ids.add(target_id)
             data = await self._request(
                 "POST",
                 f"/channels/{_quote_id(target_id)}/messages",
-                json=self._outbound_message_payload(self.format_message(content), components=components),
+                json=self._outbound_message_payload(self.format_message(content)),
             )
             message_id = str(data.get("id") or "")
             if not message_id:
@@ -696,14 +727,15 @@ class FluxerAdapter(BasePlatformAdapter):
                 "resolved": False,
             }
             self._pending_exec_approvals[message_id] = pending
-            for choice, custom_id in custom_ids.items():
-                self._pending_component_actions[custom_id] = {
+            for emoji, choice, _label in _EXEC_APPROVAL_REACTIONS:
+                self._pending_reaction_actions[f"{message_id}:{_normalize_reaction_emoji(emoji)}"] = {
                     "kind": "exec_approval",
                     "message_id": message_id,
                     "session_key": session_key,
                     "channel_id": target_id,
                     "choice": choice,
                 }
+                await self._add_reaction(target_id, message_id, emoji)
             return SendResult(success=True, message_id=message_id, raw_response=data)
         except Exception as exc:
             logger.warning("Fluxer exec approval prompt failed: %s", exc)
@@ -718,32 +750,23 @@ class FluxerAdapter(BasePlatformAdapter):
         confirm_id: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a native-button slash-command confirmation prompt."""
+        """Send a slash-command confirmation prompt with clickable reactions."""
         target_id = str((metadata or {}).get("thread_id") or chat_id)
-        nonce = uuid.uuid4().hex[:12]
-        specs = (
-            ("once", "Approve once", 3),
-            ("always", "Always approve", 2),
-            ("cancel", "Cancel", 4),
-        )
-        custom_ids = {choice: f"hermes_confirm_{nonce}_{choice}" for choice, _label, _style in specs}
-        components = _fluxer_component_row([
-            _fluxer_button(custom_id=custom_ids[choice], label=label, style=style)
-            for choice, label, style in specs
-        ])
         content_message = (message or "").rstrip()
         if not re.search(r"/(?:approve|always|cancel)", content_message, flags=re.IGNORECASE):
             content_message = f"{content_message}\n\n_Text fallback: reply `/approve`, `/always`, or `/cancel`._"
+        reaction_hint = " • ".join(f"{emoji} {label}" for emoji, _choice, label in _SLASH_CONFIRM_REACTIONS)
+        content_message = f"{content_message}\n\nReact: {reaction_hint}"
         content = f"**{title}**\n{content_message}"
         try:
             data = await self._request(
                 "POST",
                 f"/channels/{_quote_id(target_id)}/messages",
-                json=self._outbound_message_payload(self.format_message(content), components=components),
+                json=self._outbound_message_payload(self.format_message(content)),
             )
             message_id = str(data.get("id") or "")
-            for choice, custom_id in custom_ids.items():
-                self._pending_component_actions[custom_id] = {
+            for emoji, choice, _label in _SLASH_CONFIRM_REACTIONS:
+                self._pending_reaction_actions[f"{message_id}:{_normalize_reaction_emoji(emoji)}"] = {
                     "kind": "slash_confirm",
                     "message_id": message_id,
                     "session_key": session_key,
@@ -751,6 +774,8 @@ class FluxerAdapter(BasePlatformAdapter):
                     "channel_id": target_id,
                     "choice": choice,
                 }
+                if message_id:
+                    await self._add_reaction(target_id, message_id, emoji)
             return SendResult(success=True, message_id=message_id or None, raw_response=data)
         except Exception as exc:
             logger.warning("Fluxer slash confirm prompt failed: %s", exc)
@@ -1572,6 +1597,31 @@ class FluxerAdapter(BasePlatformAdapter):
         if interaction_type == 2:
             await self._handle_application_command_interaction(data)
 
+    async def _handle_reaction_add(self, data: Dict[str, Any]) -> None:
+        message_id = str(data.get("message_id") or ((data.get("message") or {}).get("id")) or "")
+        channel_id = str(data.get("channel_id") or ((data.get("channel") or {}).get("id")) or "")
+        emoji = _reaction_emoji_from_event(data)
+        if not message_id or not emoji:
+            return
+        action = self._pending_reaction_actions.get(f"{message_id}:{emoji}")
+        if not action:
+            return
+        user = data.get("user") or ((data.get("member") or {}).get("user") or {})
+        user_id = str(data.get("user_id") or user.get("id") or "")
+        if user.get("bot") or (self.bot_user_id and user_id == str(self.bot_user_id)):
+            return
+        if not self._interaction_user_allowed(user_id):
+            logger.info("Fluxer reaction action ignored for unauthorized user %s", user_id or "<missing>")
+            return
+        action_channel_id = str(action.get("channel_id") or "")
+        if action_channel_id and channel_id and channel_id != action_channel_id:
+            logger.warning("Fluxer reaction action ignored for mismatched channel %s", channel_id)
+            return
+        if action.get("kind") == "exec_approval":
+            await self._resolve_exec_approval_action(action, user_id=user_id)
+        elif action.get("kind") == "slash_confirm":
+            await self._resolve_slash_confirm_action(action, user_id=user_id)
+
     async def _handle_component_interaction(self, data: Dict[str, Any]) -> None:
         interaction_data = data.get("data") or {}
         custom_id = str(interaction_data.get("custom_id") or "")
@@ -1598,8 +1648,8 @@ class FluxerAdapter(BasePlatformAdapter):
         elif action.get("kind") == "slash_confirm":
             await self._resolve_slash_confirm_action(action, user_id=user_id, interaction=data)
 
-    async def _resolve_exec_approval_action(self, action: Dict[str, Any], *, user_id: str, interaction: Dict[str, Any]) -> None:
-        message_id = str(action.get("message_id") or ((interaction.get("message") or {}).get("id")) or "")
+    async def _resolve_exec_approval_action(self, action: Dict[str, Any], *, user_id: str, interaction: Optional[Dict[str, Any]] = None) -> None:
+        message_id = str(action.get("message_id") or (((interaction or {}).get("message") or {}).get("id")) or "")
         pending = self._pending_exec_approvals.pop(message_id, None)
         if not pending or pending.get("resolved"):
             return
@@ -1610,19 +1660,26 @@ class FluxerAdapter(BasePlatformAdapter):
             from tools.approval import resolve_gateway_approval
 
             count = resolve_gateway_approval(session_key, choice)
-            logger.info("Fluxer component resolved %d approval(s) for session %s (choice=%s user=%s)", count, session_key, choice, user_id)
+            logger.info("Fluxer approval action resolved %d approval(s) for session %s (choice=%s user=%s)", count, session_key, choice, user_id)
         except Exception as exc:
             logger.error("Fluxer component approval resolve failed: %s", exc)
         for cid, state in list(self._pending_component_actions.items()):
             if state.get("message_id") == message_id:
                 self._pending_component_actions.pop(cid, None)
+        for rid, state in list(self._pending_reaction_actions.items()):
+            if state.get("message_id") == message_id:
+                self._pending_reaction_actions.pop(rid, None)
         label = {"once": "approved once", "session": "approved for session", "always": "approved permanently", "deny": "denied"}.get(choice, choice)
+        resolved_content = f"{pending.get('content') or 'Command approval required'}\n\nResolved: {label} by <@{user_id}>."
         try:
-            await self._respond_to_interaction(interaction, content=f"{pending.get('content') or 'Command approval required'}\n\nResolved: {label} by <@{user_id}>.", components=[])
+            if interaction:
+                await self._respond_to_interaction(interaction, content=resolved_content, components=[])
+            else:
+                await self.edit_message(str(pending.get("channel_id") or action.get("channel_id") or ""), message_id, resolved_content)
         except Exception as exc:
-            logger.debug("Fluxer component approval response failed: %s", exc)
+            logger.debug("Fluxer approval resolution response failed: %s", exc)
 
-    async def _resolve_slash_confirm_action(self, action: Dict[str, Any], *, user_id: str, interaction: Dict[str, Any]) -> None:
+    async def _resolve_slash_confirm_action(self, action: Dict[str, Any], *, user_id: str, interaction: Optional[Dict[str, Any]] = None) -> None:
         session_key = str(action.get("session_key") or "")
         confirm_id = str(action.get("confirm_id") or "")
         choice = str(action.get("choice") or "cancel")
@@ -1632,8 +1689,16 @@ class FluxerAdapter(BasePlatformAdapter):
             await resolve(session_key, confirm_id, choice)
         except Exception as exc:
             logger.error("Fluxer slash confirm resolve failed: %s", exc)
+        message_id = str(action.get("message_id") or (((interaction or {}).get("message") or {}).get("id")) or "")
+        for rid, state in list(self._pending_reaction_actions.items()):
+            if state.get("message_id") == message_id:
+                self._pending_reaction_actions.pop(rid, None)
         try:
-            await self._respond_to_interaction(interaction, content=f"Slash confirmation: {choice} by <@{user_id}>.", components=[])
+            content = f"Slash confirmation: {choice} by <@{user_id}>."
+            if interaction:
+                await self._respond_to_interaction(interaction, content=content, components=[])
+            elif message_id:
+                await self.edit_message(str(action.get("channel_id") or ""), message_id, content)
         except Exception:
             pass
 
@@ -1705,6 +1770,9 @@ class FluxerAdapter(BasePlatformAdapter):
         if event_name == "INTERACTION_CREATE":
             await self._handle_interaction_create(data)
             return
+        if event_name in {"MESSAGE_REACTION_ADD", "REACTION_ADD", "MESSAGE_REACTION_CREATE"}:
+            await self._handle_reaction_add(data)
+            return
         if event_name in {"THREAD_CREATE", "THREAD_UPDATE", "CHANNEL_CREATE", "CHANNEL_UPDATE"}:
             channel_id = str(data.get("id") or "")
             if channel_id:
@@ -1745,6 +1813,9 @@ class FluxerAdapter(BasePlatformAdapter):
             return
         self._seen_message_ids.discard(message_id)
         pending = self._pending_exec_approvals.pop(message_id, None)
+        for rid, state in list(self._pending_reaction_actions.items()):
+            if state.get("message_id") == message_id:
+                self._pending_reaction_actions.pop(rid, None)
         if not pending or pending.get("resolved"):
             return
         pending["resolved"] = True

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -1,0 +1,412 @@
+"""Fluxer platform plugin for Hermes Agent.
+
+Text-first adapter:
+- REST `POST /channels/:id/messages` for outbound messages.
+- Fluxer Gateway websocket `MESSAGE_CREATE` events for inbound messages.
+
+Fluxer self-hosting is still moving, so this adapter intentionally keeps the
+surface conservative and easy to test. Media/rich embeds can layer on once the
+API settles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+
+logger = logging.getLogger(__name__)
+
+MAX_MESSAGE_LENGTH = 4000
+_DEFAULT_BASE_URL = "https://fluxer.app"
+_GATEWAY_VERSION = 1
+
+
+def _strip_slash(url: str) -> str:
+    return (url or "").strip().rstrip("/")
+
+
+def _api_base(base_url: str) -> str:
+    """Normalize a user-provided Fluxer URL to the REST API base.
+
+    Fluxer exposes routes under `/api` in the monolith, while some operators may
+    choose to configure an already-scoped `/api` or `/api/v1` URL. Preserve those
+    and append `/api` only for a plain origin.
+    """
+    base = _strip_slash(base_url)
+    if not base:
+        return ""
+    if base.endswith("/api") or base.endswith("/api/v1") or "/api/" in base:
+        return base
+    return f"{base}/api"
+
+
+def _build_identify_payload(bot_token: str) -> Dict[str, Any]:
+    return {
+        "op": 2,
+        "d": {
+            "token": bot_token,
+            "properties": {
+                "os": "linux",
+                "browser": "hermes",
+                "device": "hermes",
+            },
+        },
+    }
+
+
+def _headers(bot_token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bot {bot_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "Hermes-Fluxer/0.1",
+    }
+
+
+def _event_seq(payload: Dict[str, Any]) -> Optional[int]:
+    seq = payload.get("s")
+    try:
+        return int(seq) if seq is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _author_name(author: Dict[str, Any]) -> Optional[str]:
+    return (
+        author.get("global_name")
+        or author.get("display_name")
+        or author.get("username")
+        or author.get("name")
+    )
+
+
+def _chat_type(raw: Any) -> str:
+    if isinstance(raw, str):
+        lowered = raw.lower()
+        if lowered in {"dm", "direct", "private"}:
+            return "dm"
+        if lowered in {"group_dm", "group", "group-dm"}:
+            return "group"
+        if lowered in {"thread"}:
+            return "thread"
+        return "channel"
+    # Discord-like channel types in several codebases: 1 = DM, 3 = group DM.
+    if raw == 1:
+        return "dm"
+    if raw == 3:
+        return "group"
+    return "channel"
+
+
+class FluxerAdapter(BasePlatformAdapter):
+    """Fluxer adapter using bot REST + Gateway websocket APIs."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("fluxer"))
+        extra = getattr(config, "extra", {}) or {}
+        self.base_url = _strip_slash(
+            os.getenv("FLUXER_BASE_URL") or extra.get("base_url") or _DEFAULT_BASE_URL
+        )
+        self.api_base_url = _api_base(self.base_url)
+        self.bot_token = (
+            os.getenv("FLUXER_BOT_TOKEN") or extra.get("bot_token") or ""
+        ).strip()
+        self.gateway_url = _strip_slash(
+            os.getenv("FLUXER_GATEWAY_URL") or extra.get("gateway_url") or ""
+        )
+        self.bot_user_id: Optional[str] = str(extra.get("bot_user_id")) if extra.get("bot_user_id") else None
+        self._ws = None
+        self._listener_task: Optional[asyncio.Task] = None
+        self._heartbeat_task: Optional[asyncio.Task] = None
+        self._last_seq: Optional[int] = None
+        self._seen_message_ids: set[str] = set()
+
+    async def connect(self) -> bool:
+        if not self.base_url or not self.bot_token:
+            self._set_fatal_error(
+                "missing_config",
+                "Fluxer requires FLUXER_BASE_URL and FLUXER_BOT_TOKEN",
+                retryable=False,
+            )
+            return False
+        try:
+            if not self.gateway_url:
+                info = await self._request("GET", "/gateway/bot")
+                self.gateway_url = _strip_slash(str(info.get("url") or ""))
+            if not self.gateway_url:
+                raise RuntimeError("Fluxer gateway URL missing from /gateway/bot")
+
+            import websockets
+
+            sep = "&" if "?" in self.gateway_url else "?"
+            ws_url = f"{self.gateway_url}{sep}v={_GATEWAY_VERSION}&encoding=json"
+            self._ws = await websockets.connect(ws_url, open_timeout=15, close_timeout=5, max_size=None)
+            self._listener_task = asyncio.create_task(self._listen_loop(), name="fluxer-listen")
+            self._mark_connected()
+            return True
+        except Exception as exc:
+            logger.warning("Fluxer connect failed: %s", exc)
+            self._set_fatal_error("connect_failed", f"Fluxer connect failed: {exc}", retryable=True)
+            return False
+
+    async def disconnect(self) -> None:
+        self._running = False
+        for task in (self._heartbeat_task, self._listener_task):
+            if task and not task.done():
+                task.cancel()
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        self._ws = None
+        self._heartbeat_task = None
+        self._listener_task = None
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        payload: Dict[str, Any] = {"content": content}
+        if reply_to:
+            payload["message_reference"] = {"message_id": str(reply_to)}
+        if metadata:
+            thread_id = metadata.get("thread_id")
+            if thread_id and "message_reference" not in payload:
+                # Fluxer thread semantics are still stabilizing; keep this as
+                # metadata only when callers explicitly provide it.
+                payload["message_reference"] = {"message_id": str(thread_id)}
+
+        try:
+            data = await self._request(
+                "POST",
+                f"/channels/{chat_id}/messages",
+                json=payload,
+            )
+            return SendResult(success=True, message_id=str(data.get("id")) if data.get("id") else None, raw_response=data)
+        except Exception as exc:
+            logger.warning("Fluxer send failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        try:
+            data = await self._request("GET", f"/channels/{chat_id}")
+            return {
+                "id": str(data.get("id") or chat_id),
+                "name": data.get("name") or str(chat_id),
+                "type": _chat_type(data.get("type")),
+                "raw": data,
+            }
+        except Exception:
+            return {"id": str(chat_id), "name": str(chat_id), "type": "channel"}
+
+    async def _request(self, method: str, path: str, **kwargs) -> Dict[str, Any]:
+        try:
+            import httpx
+        except ImportError as exc:
+            raise RuntimeError("httpx is required for Fluxer adapter") from exc
+
+        url = urljoin(self.api_base_url + "/", path.lstrip("/"))
+        async with httpx.AsyncClient(timeout=20) as client:
+            response = await client.request(method, url, headers=_headers(self.bot_token), **kwargs)
+            response.raise_for_status()
+            if not response.content:
+                return {}
+            return response.json()
+
+    async def _listen_loop(self) -> None:
+        assert self._ws is not None
+        try:
+            async for raw in self._ws:
+                payload = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode("utf-8"))
+                await self._handle_gateway_dispatch(payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if self._running:
+                logger.warning("Fluxer listener stopped: %s", exc)
+                self._set_fatal_error("listener_stopped", f"Fluxer listener stopped: {exc}", retryable=True)
+
+    async def _heartbeat_loop(self, interval_ms: int) -> None:
+        try:
+            while self._running and self._ws is not None:
+                await asyncio.sleep(max(interval_ms, 1000) / 1000)
+                await self._ws.send(json.dumps({"op": 1, "d": self._last_seq}))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("Fluxer heartbeat stopped: %s", exc)
+
+    async def _handle_gateway_dispatch(self, payload: Dict[str, Any]) -> None:
+        op = payload.get("op")
+        self._last_seq = _event_seq(payload) or self._last_seq
+
+        if op == 10:  # HELLO
+            interval = int(((payload.get("d") or {}).get("heartbeat_interval") or 41250))
+            if self._ws is not None:
+                await self._ws.send(json.dumps(_build_identify_payload(self.bot_token)))
+                self._heartbeat_task = asyncio.create_task(self._heartbeat_loop(interval), name="fluxer-heartbeat")
+            return
+        if op != 0:  # not DISPATCH
+            return
+
+        event_name = payload.get("t")
+        data = payload.get("d") or {}
+        if event_name == "READY":
+            user = data.get("user") or data.get("bot") or {}
+            if user.get("id"):
+                self.bot_user_id = str(user["id"])
+            return
+        if event_name != "MESSAGE_CREATE":
+            return
+        await self._handle_message_create(data, payload)
+
+    async def _handle_message_create(self, data: Dict[str, Any], raw_payload: Dict[str, Any]) -> None:
+        msg_id = str(data.get("id") or "")
+        if msg_id:
+            if msg_id in self._seen_message_ids:
+                return
+            self._seen_message_ids.add(msg_id)
+            if len(self._seen_message_ids) > 2000:
+                self._seen_message_ids = set(list(self._seen_message_ids)[-1000:])
+
+        author = data.get("author") or data.get("user") or {}
+        author_id = str(author.get("id") or data.get("author_id") or "")
+        if author.get("bot") or (self.bot_user_id and author_id == str(self.bot_user_id)):
+            return
+
+        text = data.get("content") or ""
+        if not text and not data.get("attachments"):
+            return
+
+        channel_id = str(data.get("channel_id") or data.get("channel", {}).get("id") or "")
+        if not channel_id:
+            return
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=(data.get("channel") or {}).get("name"),
+            chat_type=_chat_type(data.get("channel_type") or (data.get("channel") or {}).get("type")),
+            user_id=author_id or None,
+            user_name=_author_name(author),
+            guild_id=data.get("guild_id"),
+            message_id=msg_id or None,
+        )
+
+        timestamp = datetime.now(tz=timezone.utc)
+        ts_raw = data.get("timestamp") or data.get("created_at")
+        if isinstance(ts_raw, str):
+            try:
+                timestamp = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+            except ValueError:
+                pass
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=raw_payload,
+            message_id=msg_id or None,
+            timestamp=timestamp,
+        )
+        await self.handle_message(event)
+
+
+def check_requirements() -> bool:
+    if not (os.getenv("FLUXER_BASE_URL") and os.getenv("FLUXER_BOT_TOKEN")):
+        return False
+    try:
+        import httpx  # noqa: F401
+        import websockets  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    base_url = os.getenv("FLUXER_BASE_URL") or extra.get("base_url", "")
+    token = os.getenv("FLUXER_BOT_TOKEN") or extra.get("bot_token", "")
+    return bool(str(base_url).strip() and str(token).strip())
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> dict | None:
+    base_url = os.getenv("FLUXER_BASE_URL", "").strip()
+    token = os.getenv("FLUXER_BOT_TOKEN", "").strip()
+    if not (base_url and token):
+        return None
+    seed: dict = {"base_url": base_url, "bot_token": token}
+    gateway_url = os.getenv("FLUXER_GATEWAY_URL", "").strip()
+    if gateway_url:
+        seed["gateway_url"] = gateway_url
+    home = os.getenv("FLUXER_HOME_CHANNEL", "").strip()
+    if home:
+        seed["home_channel"] = {
+            "chat_id": home,
+            "name": os.getenv("FLUXER_HOME_CHANNEL_NAME", "").strip() or home,
+        }
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    adapter = FluxerAdapter(pconfig)
+    metadata = {"thread_id": thread_id} if thread_id else None
+    result = await adapter.send(chat_id, message, metadata=metadata)
+    if result.success:
+        return {"success": True, "platform": "fluxer", "chat_id": chat_id, "message_id": result.message_id}
+    return {"error": result.error or "Fluxer send failed"}
+
+
+def interactive_setup() -> None:
+    print("Fluxer platform setup")
+    print("Set FLUXER_BASE_URL and FLUXER_BOT_TOKEN in ~/.hermes/.env, then restart the gateway.")
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="fluxer",
+        label="Fluxer",
+        adapter_factory=lambda cfg: FluxerAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["FLUXER_BASE_URL", "FLUXER_BOT_TOKEN"],
+        install_hint="pip install httpx websockets   # Fluxer adapter dependencies",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="FLUXER_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="FLUXER_ALLOWED_USERS",
+        allow_all_env="FLUXER_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="⚡",
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting via Fluxer, a Discord-like open-source chat "
+            "platform. Fluxer supports rich Markdown, channels, DMs, files, "
+            "and voice/video. Prefer normal Markdown for structured replies."
+        ),
+    )

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -663,7 +663,7 @@ class FluxerAdapter(BasePlatformAdapter):
             "**Command approval required**\n"
             f"```\n{cmd_display}\n```\n"
             f"Reason: {description}\n\n"
-            "Choose one of the approval buttons below."
+            "Reply with `/approve once`, `/approve session`, `/approve always`, or `/deny`."
         )
         nonce = uuid.uuid4().hex[:12]
         button_specs = (
@@ -731,12 +731,9 @@ class FluxerAdapter(BasePlatformAdapter):
             _fluxer_button(custom_id=custom_ids[choice], label=label, style=style)
             for choice, label, style in specs
         ])
-        content_message = re.sub(
-            r"\n*_Text fallback: reply `/(?:approve|always|cancel)`[^\n]*_\s*$",
-            "",
-            message or "",
-            flags=re.IGNORECASE,
-        ).rstrip()
+        content_message = (message or "").rstrip()
+        if not re.search(r"/(?:approve|always|cancel)", content_message, flags=re.IGNORECASE):
+            content_message = f"{content_message}\n\n_Text fallback: reply `/approve`, `/always`, or `/cancel`._"
         content = f"**{title}**\n{content_message}"
         try:
             data = await self._request(

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -439,6 +439,19 @@ class FluxerAdapter(BasePlatformAdapter):
         self._free_response_channels = _split_ids(
             os.getenv("FLUXER_FREE_RESPONSE_CHANNELS") or extra.get("free_response_channels")
         )
+        self._mention_gated_channels = _split_ids(
+            os.getenv("FLUXER_MENTION_GATED_CHANNELS") or extra.get("mention_gated_channels")
+        )
+        self._auto_free_response_home_guild = _coerce_bool(
+            os.getenv("FLUXER_AUTO_FREE_RESPONSE_HOME_GUILD", extra.get("auto_free_response_home_guild")),
+            False,
+        )
+        self._home_guild_ids = _split_ids(
+            os.getenv("FLUXER_HOME_GUILDS")
+            or os.getenv("FLUXER_HOME_GUILD_ID")
+            or extra.get("home_guild_ids")
+            or extra.get("home_guild_id")
+        )
         self._allowed_channel_ids = _split_ids(
             os.getenv("FLUXER_ALLOWED_CHANNELS") or extra.get("allowed_channels")
         )
@@ -1470,6 +1483,19 @@ class FluxerAdapter(BasePlatformAdapter):
             logger.debug("Fluxer ignoring message in non-allowed channel %s", channel_id)
             return False, text
         if channel_id in self._free_response_channels or channel_id in self._home_channel_ids:
+            return True, text
+        guild_id = str(
+            data.get("guild_id")
+            or (data.get("guild") or {}).get("id")
+            or (data.get("channel") or {}).get("guild_id")
+            or ""
+        )
+        if (
+            self._auto_free_response_home_guild
+            and guild_id
+            and guild_id in self._home_guild_ids
+            and channel_id not in self._mention_gated_channels
+        ):
             return True, text
         if not self._require_mention:
             return True, text

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -16,12 +16,14 @@ import json
 import logging
 import mimetypes
 import os
+import re
 import subprocess
 import time
-from datetime import datetime, timezone
+import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin, urlparse
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -42,6 +44,25 @@ MAX_MESSAGE_LENGTH = 4000
 _DEFAULT_BASE_URL = "https://api.fluxer.app/v1"
 _GATEWAY_VERSION = 1
 _VOICE_MESSAGE_FLAG = 1 << 13
+_RECONNECT_BASE_DELAY = 2.0
+_RECONNECT_MAX_DELAY = 60.0
+_HEARTBEAT_ACK_TIMEOUT_FACTOR = 2.5
+_DEFAULT_BACKLOG_LIMIT = 25
+_DEFAULT_BACKLOG_BOOTSTRAP_SECONDS = 120
+_EXEC_APPROVAL_REACTIONS = {
+    "✅": "once",
+    "☑️": "once",
+    "🔁": "session",
+    "♾": "always",
+    "♾️": "always",
+    "❌": "deny",
+    "✖️": "deny",
+    "✖": "deny",
+}
+_EXEC_APPROVAL_REACTION_ORDER = ("✅", "🔁", "♾️", "❌")
+_MENTION_EVERYONE_RE = re.compile(r"@(everyone|here)\b", re.IGNORECASE)
+_MENTION_ROLE_RE = re.compile(r"<@&\d+>")
+_MENTION_USER_RE = re.compile(r"<@!?\d+>")
 
 
 def _strip_slash(url: str) -> str:
@@ -119,15 +140,30 @@ def _chat_type(raw: Any) -> str:
             return "dm"
         if lowered in {"group_dm", "group", "group-dm"}:
             return "group"
-        if lowered in {"thread"}:
+        if lowered in {"thread", "public_thread", "private_thread", "news_thread"}:
             return "thread"
-        return "channel"
-    # Discord-like channel types in several codebases: 1 = DM, 3 = group DM.
+        if lowered in {"forum", "guild_forum"}:
+            return "forum"
+        try:
+            raw = int(lowered)
+        except ValueError:
+            return "channel"
+    # Discord-like channel types in several codebases:
+    # 1 = DM, 3 = group DM, 10/11/12 = thread, 15 = forum.
     if raw == 1:
         return "dm"
     if raw == 3:
         return "group"
+    if raw in {10, 11, 12}:
+        return "thread"
+    if raw == 15:
+        return "forum"
     return "channel"
+
+
+def _quote_id(value: Any) -> str:
+    """Quote a Fluxer path segment without letting IDs alter REST routes."""
+    return quote(str(value or ""), safe="")
 
 
 def _attachment_url(att: Dict[str, Any]) -> str:
@@ -199,6 +235,133 @@ def _audio_duration_seconds(path: Path) -> int:
     return 1
 
 
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "y", "*"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "n", ""}:
+            return False
+    return default
+
+
+def _split_ids(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        return {str(item).strip() for item in value if str(item).strip()}
+    return {part.strip() for part in str(value).split(",") if part.strip()}
+
+
+def _normalize_emoji_name(value: Any) -> str:
+    if isinstance(value, dict):
+        value = value.get("name") or value.get("id") or ""
+    text = str(value or "").strip()
+    # Variation selector makes some emoji arrive as either ♾ or ♾️.
+    if text == "♾️":
+        return "♾"
+    return text
+
+
+def _parse_fluxer_timestamp(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _extract_message_list(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("messages", "items", "data", "results"):
+            items = payload.get(key)
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+    return []
+
+
+def _message_content(data: Any) -> str:
+    if not isinstance(data, dict):
+        return ""
+    content = data.get("content")
+    return content if isinstance(content, str) else ""
+
+
+def _extract_reply_message(data: Dict[str, Any]) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Return the replied-to message id and any embedded referenced payload.
+
+    Fluxer deployments vary while the API is young: some
+    events embed ``referenced_message``, some use ``message_reference`` only,
+    and older bridge payloads may call it ``reply_to``. Normalize all obvious
+    forms so Hermes gets reply context whenever the information is available.
+    """
+    candidates = (
+        data.get("referenced_message"),
+        data.get("referencedMessage"),
+        data.get("reply_to_message"),
+        data.get("replyToMessage"),
+        data.get("reply_to"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            msg_id = candidate.get("id") or candidate.get("message_id")
+            if msg_id:
+                return str(msg_id), candidate
+        elif candidate:
+            return str(candidate), None
+
+    reference = data.get("message_reference") or data.get("messageReference") or {}
+    if isinstance(reference, dict):
+        msg_id = reference.get("message_id") or reference.get("messageId") or reference.get("id")
+        if msg_id:
+            return str(msg_id), None
+    return None, None
+
+
+def _fluxer_component_row(buttons: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [{"type": 1, "components": buttons}]
+
+
+def _fluxer_button(*, custom_id: str, label: str, style: int) -> Dict[str, Any]:
+    return {"type": 2, "style": style, "custom_id": custom_id[:100], "label": label, "disabled": False}
+
+
+def _directory_channel_type(raw: Any) -> Optional[str]:
+    if raw in (0, "0", "text", "guild_text"):
+        return "channel"
+    if raw in (5, "5", "announcement", "news"):
+        return "channel"
+    if raw in (10, 11, 12, "10", "11", "12", "thread", "public_thread", "private_thread"):
+        return "thread"
+    if raw in (15, "15", "forum", "guild_forum"):
+        return "forum"
+    if raw in (1, "1", "dm", "direct"):
+        return "dm"
+    if raw in (3, "3", "group_dm", "group"):
+        return "group"
+    return None
+
+
 class FluxerAdapter(BasePlatformAdapter):
     """Fluxer adapter using bot REST + Gateway websocket APIs."""
 
@@ -216,11 +379,98 @@ class FluxerAdapter(BasePlatformAdapter):
             os.getenv("FLUXER_GATEWAY_URL") or extra.get("gateway_url") or ""
         )
         self.bot_user_id: Optional[str] = str(extra.get("bot_user_id")) if extra.get("bot_user_id") else None
+        self._allowed_user_ids = _split_ids(os.getenv("FLUXER_ALLOWED_USERS") or extra.get("allowed_users"))
+        self._allow_all_users = _coerce_bool(os.getenv("FLUXER_ALLOW_ALL_USERS", extra.get("allow_all_users")), False)
+        self._backlog_enabled = str(
+            os.getenv("FLUXER_BACKLOG_RECOVERY", extra.get("backlog_recovery", "true"))
+        ).strip().lower() not in {"0", "false", "no", "off"}
+        self._backlog_limit = min(
+            _coerce_int(os.getenv("FLUXER_BACKLOG_LIMIT") or extra.get("backlog_limit"), _DEFAULT_BACKLOG_LIMIT),
+            100,
+        )
+        self._backlog_bootstrap_seconds = min(
+            _coerce_int(
+                os.getenv("FLUXER_BACKLOG_BOOTSTRAP_SECONDS") or extra.get("backlog_bootstrap_seconds"),
+                _DEFAULT_BACKLOG_BOOTSTRAP_SECONDS,
+            ),
+            900,
+        )
+        self._delivery_verification_enabled = str(
+            os.getenv("FLUXER_DELIVERY_VERIFICATION", extra.get("delivery_verification", "true"))
+        ).strip().lower() not in {"0", "false", "no", "off"}
+        self._allow_mention_everyone = _coerce_bool(
+            os.getenv("FLUXER_ALLOW_MENTION_EVERYONE", extra.get("allow_mention_everyone")),
+            False,
+        )
+        self._allow_mention_roles = _coerce_bool(
+            os.getenv("FLUXER_ALLOW_MENTION_ROLES", extra.get("allow_mention_roles")),
+            False,
+        )
+        self._allow_mention_users = _coerce_bool(
+            os.getenv("FLUXER_ALLOW_MENTION_USERS", extra.get("allow_mention_users")),
+            True,
+        )
+        self._allow_mention_replied_user = _coerce_bool(
+            os.getenv("FLUXER_ALLOW_MENTION_REPLIED_USER", extra.get("allow_mention_replied_user")),
+            True,
+        )
+        self._require_mention = _coerce_bool(
+            os.getenv("FLUXER_REQUIRE_MENTION", extra.get("require_mention")),
+            True,
+        )
+        self._strict_mention = _coerce_bool(
+            os.getenv("FLUXER_STRICT_MENTION", extra.get("strict_mention")),
+            False,
+        )
+        self._free_response_channels = _split_ids(
+            os.getenv("FLUXER_FREE_RESPONSE_CHANNELS") or extra.get("free_response_channels")
+        )
+        self._allowed_channel_ids = _split_ids(
+            os.getenv("FLUXER_ALLOWED_CHANNELS") or extra.get("allowed_channels")
+        )
+        self._mention_patterns = tuple(
+            part.strip()
+            for part in _split_ids(os.getenv("FLUXER_MENTION_PATTERNS") or extra.get("mention_patterns"))
+            if part.strip()
+        )
+        self._register_native_commands_on_connect = _coerce_bool(
+            os.getenv("FLUXER_REGISTER_NATIVE_COMMANDS", extra.get("register_native_commands")),
+            False,
+        )
+        self._application_id = str(os.getenv("FLUXER_APPLICATION_ID") or extra.get("application_id") or "").strip()
+        self._native_command_guild_ids = _split_ids(
+            os.getenv("FLUXER_NATIVE_COMMAND_GUILDS") or extra.get("native_command_guilds")
+        )
+        self._mentioned_threads: set[str] = set()
+        self._mentioned_threads_max = 5000
+        self._home_channel_ids: set[str] = set()
+        self._known_channel_ids: set[str] = set()
+        home_channel = getattr(config, "home_channel", None)
+        if home_channel and getattr(home_channel, "chat_id", None):
+            self._home_channel_ids.add(str(home_channel.chat_id))
+            self._known_channel_ids.add(str(home_channel.chat_id))
+        home_extra = extra.get("home_channel")
+        if isinstance(home_extra, dict) and home_extra.get("chat_id"):
+            self._home_channel_ids.add(str(home_extra["chat_id"]))
+            self._known_channel_ids.add(str(home_extra["chat_id"]))
+        home_env = os.getenv("FLUXER_HOME_CHANNEL", "").strip()
+        if home_env:
+            self._home_channel_ids.add(home_env)
+            self._known_channel_ids.add(home_env)
+        self._last_disconnect_at: Optional[datetime] = None
         self._ws = None
         self._listener_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
+        self._reconnect_task: Optional[asyncio.Task] = None
         self._last_seq: Optional[int] = None
+        self._last_heartbeat_sent_at: Optional[float] = None
+        self._last_heartbeat_ack_at: Optional[float] = None
+        self._awaiting_heartbeat_ack = False
+        self._closing = False
         self._seen_message_ids: set[str] = set()
+        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_exec_approvals: Dict[str, Dict[str, Any]] = {}
+        self._pending_component_actions: Dict[str, Dict[str, Any]] = {}
 
     async def connect(self) -> bool:
         if not self.base_url or not self.bot_token:
@@ -231,30 +481,27 @@ class FluxerAdapter(BasePlatformAdapter):
             )
             return False
         try:
-            if not self.gateway_url:
-                info = await self._request("GET", "/gateway/bot")
-                self.gateway_url = _strip_slash(str(info.get("url") or ""))
-            if not self.gateway_url:
-                raise RuntimeError("Fluxer gateway URL missing from /gateway/bot")
-
-            import websockets
-
-            sep = "&" if "?" in self.gateway_url else "?"
-            ws_url = f"{self.gateway_url}{sep}v={_GATEWAY_VERSION}&encoding=json"
-            self._ws = await websockets.connect(ws_url, open_timeout=15, close_timeout=5, max_size=None)
-            self._listener_task = asyncio.create_task(self._listen_loop(), name="fluxer-listen")
+            self._closing = False
             self._mark_connected()
+            await self._connect_gateway_once()
+            await self._maybe_register_native_commands()
             return True
         except Exception as exc:
+            self._mark_disconnected()
             logger.warning("Fluxer connect failed: %s", exc)
             self._set_fatal_error("connect_failed", f"Fluxer connect failed: {exc}", retryable=True)
             return False
 
     async def disconnect(self) -> None:
+        self._closing = True
         self._running = False
-        for task in (self._heartbeat_task, self._listener_task):
+        for task in (self._heartbeat_task, self._listener_task, self._reconnect_task):
             if task and not task.done():
                 task.cancel()
+        for task in list(self._typing_tasks.values()):
+            if task and not task.done():
+                task.cancel()
+        self._typing_tasks.clear()
         if self._ws is not None:
             try:
                 await self._ws.close()
@@ -263,7 +510,103 @@ class FluxerAdapter(BasePlatformAdapter):
         self._ws = None
         self._heartbeat_task = None
         self._listener_task = None
+        self._reconnect_task = None
         self._mark_disconnected()
+
+    async def _connect_gateway_once(self) -> None:
+        if not self.gateway_url:
+            info = await self._request("GET", "/gateway/bot")
+            self.gateway_url = _strip_slash(str(info.get("url") or ""))
+        if not self.gateway_url:
+            raise RuntimeError("Fluxer gateway URL missing from /gateway/bot")
+
+        import websockets
+
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        if self._heartbeat_task and not self._heartbeat_task.done():
+            self._heartbeat_task.cancel()
+        current = asyncio.current_task()
+        if self._listener_task and self._listener_task is not current and not self._listener_task.done():
+            self._listener_task.cancel()
+        self._ws = None
+        self._heartbeat_task = None
+        self._listener_task = None
+        self._awaiting_heartbeat_ack = False
+        self._last_heartbeat_sent_at = None
+        self._last_heartbeat_ack_at = None
+
+        sep = "&" if "?" in self.gateway_url else "?"
+        ws_url = f"{self.gateway_url}{sep}v={_GATEWAY_VERSION}&encoding=json"
+        reconnect_cutoff = self._last_disconnect_at or (
+            datetime.now(tz=timezone.utc) - timedelta(seconds=self._backlog_bootstrap_seconds)
+        )
+        self._ws = await websockets.connect(ws_url, open_timeout=15, close_timeout=5, max_size=None)
+        self._listener_task = asyncio.create_task(self._listen_loop(), name="fluxer-listen")
+        logger.info("Fluxer gateway websocket connected")
+        await self._recover_backlog(cutoff=reconnect_cutoff)
+
+    def _schedule_reconnect(self, reason: str) -> None:
+        if self._closing:
+            return
+        if self._reconnect_task and not self._reconnect_task.done():
+            return
+        logger.warning("Fluxer gateway disconnected (%s); scheduling reconnect", reason)
+        self._reconnect_task = asyncio.create_task(self._reconnect_loop(reason), name="fluxer-reconnect")
+
+    async def _reconnect_loop(self, reason: str) -> None:
+        delay = _RECONNECT_BASE_DELAY
+        while not self._closing:
+            try:
+                await asyncio.sleep(delay)
+                await self._connect_gateway_once()
+                self._mark_connected()
+                logger.info("Fluxer gateway reconnected after %s", reason)
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Fluxer reconnect failed: %s; retrying in %.1fs", exc, delay)
+                delay = min(delay * 2, _RECONNECT_MAX_DELAY)
+
+    def _sanitize_outbound_mentions(self, content: str) -> str:
+        """Fail closed for global/role pings in model-generated Fluxer output.
+
+        Fluxer message readback exposes mention fields on current deployments,
+        but the hosted API is still young. We send an ``allowed_mentions``
+        object for compatible servers and also neutralize dangerous ping syntax
+        in the content itself so unsupported deployments cannot accidentally
+        @everyone a channel from LLM output or echoed user text.
+        """
+        sanitized = content
+        if not self._allow_mention_everyone:
+            sanitized = _MENTION_EVERYONE_RE.sub(lambda m: "@\u200b" + m.group(1), sanitized)
+        if not self._allow_mention_roles:
+            sanitized = _MENTION_ROLE_RE.sub(lambda m: m.group(0).replace("<@&", "<@\u200b&", 1), sanitized)
+        if not self._allow_mention_users:
+            sanitized = _MENTION_USER_RE.sub(lambda m: m.group(0).replace("<@", "<@\u200b", 1), sanitized)
+        return sanitized
+
+    def _allowed_mentions_payload(self) -> Dict[str, Any]:
+        parse: List[str] = []
+        if self._allow_mention_everyone:
+            parse.append("everyone")
+        if self._allow_mention_roles:
+            parse.append("roles")
+        if self._allow_mention_users:
+            parse.append("users")
+        return {"parse": parse, "replied_user": self._allow_mention_replied_user}
+
+    def _outbound_message_payload(self, content: str, **extra: Any) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "content": self._sanitize_outbound_mentions(content),
+            "allowed_mentions": self._allowed_mentions_payload(),
+        }
+        payload.update(extra)
+        return payload
 
     async def send(
         self,
@@ -272,7 +615,7 @@ class FluxerAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        payload: Dict[str, Any] = {"content": content}
+        payload: Dict[str, Any] = {}
         if reply_to:
             payload["message_reference"] = {"message_id": str(reply_to)}
         if metadata:
@@ -281,6 +624,7 @@ class FluxerAdapter(BasePlatformAdapter):
                 # Fluxer thread semantics are still stabilizing; keep this as
                 # metadata only when callers explicitly provide it.
                 payload["message_reference"] = {"message_id": str(thread_id)}
+        self._known_channel_ids.add(str(chat_id))
 
         try:
             formatted = self.format_message(content)
@@ -289,8 +633,7 @@ class FluxerAdapter(BasePlatformAdapter):
             responses: List[Dict[str, Any]] = []
 
             for index, chunk in enumerate(chunks):
-                chunk_payload = dict(payload)
-                chunk_payload["content"] = chunk
+                chunk_payload = self._outbound_message_payload(chunk, **payload)
                 if index > 0:
                     # Reply/reference metadata only belongs on the first split
                     # chunk; applying the same reference to every continuation
@@ -299,12 +642,22 @@ class FluxerAdapter(BasePlatformAdapter):
 
                 data = await self._request(
                     "POST",
-                    f"/channels/{chat_id}/messages",
+                    f"/channels/{_quote_id(chat_id)}/messages",
                     json=chunk_payload,
                 )
                 responses.append(data)
                 if data.get("id"):
-                    message_ids.append(str(data["id"]))
+                    message_id = str(data["id"])
+                    message_ids.append(message_id)
+                    verified = await self._verify_delivery(
+                        chat_id,
+                        message_id,
+                        expected_content=chunk_payload["content"],
+                    )
+                    if verified is not None:
+                        responses[-1] = {**data, "delivery_verified": True, "delivery_readback": verified}
+                    else:
+                        responses[-1] = {**data, "delivery_verified": False}
 
             return SendResult(
                 success=True,
@@ -314,6 +667,436 @@ class FluxerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("Fluxer send failed: %s", exc)
             return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a native-button dangerous-command approval prompt."""
+        target_id = str((metadata or {}).get("thread_id") or chat_id)
+        cmd_display = command if len(command) <= 3200 else command[:3197] + "..."
+        content = (
+            "⚠️ **Command approval required**\n"
+            f"```\n{cmd_display}\n```\n"
+            f"Reason: {description}\n\n"
+            "Use the buttons below, or text fallback: `/approve`, `/approve session`, `/approve always`, or `/deny`."
+        )
+        nonce = uuid.uuid4().hex[:12]
+        button_specs = (
+            ("once", "Allow once", 3),
+            ("session", "Session", 1),
+            ("always", "Always", 2),
+            ("deny", "Deny", 4),
+        )
+        custom_ids = {choice: f"hermes_exec_{nonce}_{choice}" for choice, _label, _style in button_specs}
+        components = _fluxer_component_row([
+            _fluxer_button(custom_id=custom_ids[choice], label=label, style=style)
+            for choice, label, style in button_specs
+        ])
+        try:
+            self._known_channel_ids.add(target_id)
+            data = await self._request(
+                "POST",
+                f"/channels/{_quote_id(target_id)}/messages",
+                json=self._outbound_message_payload(self.format_message(content), components=components),
+            )
+            message_id = str(data.get("id") or "")
+            if not message_id:
+                return SendResult(success=False, error="Fluxer approval message missing id", retryable=True)
+
+            pending = {
+                "session_key": session_key,
+                "channel_id": target_id,
+                "created_at": time.time(),
+                "content": content,
+                "resolved": False,
+            }
+            self._pending_exec_approvals[message_id] = pending
+            for choice, custom_id in custom_ids.items():
+                self._pending_component_actions[custom_id] = {
+                    "kind": "exec_approval",
+                    "message_id": message_id,
+                    "session_key": session_key,
+                    "channel_id": target_id,
+                    "choice": choice,
+                }
+            return SendResult(success=True, message_id=message_id, raw_response=data)
+        except Exception as exc:
+            logger.warning("Fluxer exec approval prompt failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a native-button slash-command confirmation prompt."""
+        target_id = str((metadata or {}).get("thread_id") or chat_id)
+        nonce = uuid.uuid4().hex[:12]
+        specs = (
+            ("once", "Approve once", 3),
+            ("always", "Always approve", 2),
+            ("cancel", "Cancel", 4),
+        )
+        custom_ids = {choice: f"hermes_confirm_{nonce}_{choice}" for choice, _label, _style in specs}
+        components = _fluxer_component_row([
+            _fluxer_button(custom_id=custom_ids[choice], label=label, style=style)
+            for choice, label, style in specs
+        ])
+        content = f"**{title}**\n{message}"
+        try:
+            data = await self._request(
+                "POST",
+                f"/channels/{_quote_id(target_id)}/messages",
+                json=self._outbound_message_payload(self.format_message(content), components=components),
+            )
+            message_id = str(data.get("id") or "")
+            for choice, custom_id in custom_ids.items():
+                self._pending_component_actions[custom_id] = {
+                    "kind": "slash_confirm",
+                    "message_id": message_id,
+                    "session_key": session_key,
+                    "confirm_id": confirm_id,
+                    "channel_id": target_id,
+                    "choice": choice,
+                }
+            return SendResult(success=True, message_id=message_id or None, raw_response=data)
+        except Exception as exc:
+            logger.warning("Fluxer slash confirm prompt failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def _add_message_reaction(self, chat_id: str, message_id: str, emoji: str) -> None:
+        await self._request(
+            "PUT",
+            f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}/reactions/{quote(emoji, safe='')}/@me",
+        )
+
+    def _reaction_user_allowed(self, user_id: str) -> bool:
+        if not user_id:
+            return False
+        if self.bot_user_id and user_id == str(self.bot_user_id):
+            return False
+        if self._allow_all_users:
+            return True
+        return user_id in self._allowed_user_ids
+
+    async def _handle_reaction_add(self, data: Dict[str, Any]) -> None:
+        message_id = str(data.get("message_id") or "")
+        pending = self._pending_exec_approvals.get(message_id)
+        if not pending or pending.get("resolved"):
+            return
+
+        user_id = str(data.get("user_id") or ((data.get("member") or {}).get("user") or {}).get("id") or "")
+        member_user = ((data.get("member") or {}).get("user") or {})
+        if member_user.get("bot") or not self._reaction_user_allowed(user_id):
+            logger.info("Fluxer approval reaction ignored for unauthorized/bot user %s", user_id or "<missing>")
+            return
+
+        emoji_name = _normalize_emoji_name(data.get("emoji"))
+        choice = _EXEC_APPROVAL_REACTIONS.get(emoji_name)
+        if choice is None:
+            return
+
+        pending["resolved"] = True
+        self._pending_exec_approvals.pop(message_id, None)
+        session_key = str(pending.get("session_key") or "")
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(session_key, choice)
+            logger.info(
+                "Fluxer reaction resolved %d approval(s) for session %s (choice=%s user=%s)",
+                count,
+                session_key,
+                choice,
+                user_id,
+            )
+        except Exception as exc:
+            logger.error("Fluxer reaction approval resolve failed: %s", exc)
+
+        label = {
+            "once": "approved once",
+            "session": "approved for session",
+            "always": "approved permanently",
+            "deny": "denied",
+        }.get(choice, choice)
+        try:
+            await self.edit_message(
+                str(pending.get("channel_id") or data.get("channel_id") or ""),
+                message_id,
+                f"{pending.get('content') or '⚠️ Command approval required'}\n\nResolved: {label} by <@{user_id}>.",
+                finalize=True,
+            )
+        except Exception:
+            pass
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit a previously sent Fluxer message.
+
+        Gateway tool-progress bubbles are only enabled for adapters that
+        override ``BasePlatformAdapter.edit_message``. Fluxer exposes a PATCH
+        message endpoint, so implement it to unlock visible tool
+        calling/progress in chat instead of only final responses and status
+        callbacks.
+        """
+        try:
+            formatted = self.format_message(content)
+            if len(formatted) > MAX_MESSAGE_LENGTH:
+                formatted = formatted[: MAX_MESSAGE_LENGTH - 3] + "..."
+            data = await self._request(
+                "PATCH",
+                f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}",
+                json=self._outbound_message_payload(formatted),
+            )
+            verified = await self._verify_delivery(
+                chat_id,
+                str(data.get("id") or message_id),
+                expected_content=self._sanitize_outbound_mentions(formatted),
+            )
+            raw_response = dict(data)
+            raw_response["delivery_verified"] = verified is not None
+            if verified is not None:
+                raw_response["delivery_readback"] = verified
+            return SendResult(
+                success=True,
+                message_id=str(data.get("id") or message_id),
+                raw_response=raw_response,
+            )
+        except Exception as exc:
+            logger.warning("Fluxer edit failed for message %s: %s", message_id, exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a Fluxer message when gateway cleanup/ephemeral flows ask."""
+        try:
+            await self._request("DELETE", f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}")
+            return True
+        except Exception as exc:
+            logger.debug("Fluxer delete failed for message %s: %s", message_id, exc)
+            return False
+
+    async def list_pinned_messages(self, chat_id: str) -> List[Dict[str, Any]]:
+        """Return pinned messages for a Fluxer channel.
+
+        Fluxer's pin routes are exposed at:
+        ``/channels/{channel_id}/messages/pins``. The hosted API currently
+        returns ``{"items": [...], "has_more": bool}``, while some deployments
+        may return a bare list, so accept both.
+        """
+        payload = await self._request("GET", f"/channels/{_quote_id(chat_id)}/messages/pins")
+        if isinstance(payload, dict):
+            items = payload.get("items") or payload.get("messages") or []
+            return list(items) if isinstance(items, list) else []
+        if isinstance(payload, list):
+            return payload
+        return []
+
+    async def pin_message(self, chat_id: str, message_id: str) -> bool:
+        """Pin a Fluxer message when the server supports message pins."""
+        try:
+            await self._request("PUT", f"/channels/{_quote_id(chat_id)}/messages/pins/{_quote_id(message_id)}")
+            return True
+        except Exception as exc:
+            logger.debug("Fluxer pin failed for message %s: %s", message_id, exc)
+            return False
+
+    async def unpin_message(self, chat_id: str, message_id: str) -> bool:
+        """Unpin a Fluxer message when the server supports message pins."""
+        try:
+            await self._request("DELETE", f"/channels/{_quote_id(chat_id)}/messages/pins/{_quote_id(message_id)}")
+            return True
+        except Exception as exc:
+            logger.debug("Fluxer unpin failed for message %s: %s", message_id, exc)
+            return False
+
+    async def _maybe_register_native_commands(self) -> None:
+        if not self._register_native_commands_on_connect:
+            return
+        application_id = self._application_id or self.bot_token.split(".", 1)[0]
+        if not application_id:
+            logger.warning("Fluxer native command registration enabled but no application id is available")
+            return
+        guild_ids = sorted(self._native_command_guild_ids)
+        try:
+            if guild_ids:
+                for guild_id in guild_ids:
+                    await self.register_native_commands(application_id, guild_id=guild_id)
+            else:
+                await self.register_native_commands(application_id)
+        except Exception as exc:
+            logger.warning("Fluxer native command registration failed: %s", exc)
+
+    def _native_command_payload(self, command: Any) -> Dict[str, Any]:
+        description = str(getattr(command, "description", "Run Hermes command") or "Run Hermes command")[:100]
+        payload: Dict[str, Any] = {
+            "name": str(getattr(command, "name", "")).replace("_", "-")[:32],
+            "description": description,
+            "type": 1,
+        }
+        args_hint = str(getattr(command, "args_hint", "") or "").strip()
+        if args_hint:
+            payload["options"] = [{"type": 3, "name": "args", "description": args_hint[:100], "required": False}]
+        return payload
+
+    async def register_native_commands(
+        self,
+        application_id: str,
+        *,
+        guild_id: Optional[str] = None,
+        commands: Optional[List[Any]] = None,
+    ) -> Any:
+        """Bulk upsert Fluxer application commands using Discord/JFA routes."""
+        if commands is None:
+            from hermes_cli.commands import COMMAND_REGISTRY
+
+            commands = [cmd for cmd in COMMAND_REGISTRY if not getattr(cmd, "cli_only", False)]
+        payloads = [self._native_command_payload(command) for command in commands if getattr(command, "name", None)]
+        if guild_id:
+            path = f"/applications/{_quote_id(application_id)}/guilds/{_quote_id(guild_id)}/commands"
+        else:
+            path = f"/applications/{_quote_id(application_id)}/commands"
+        return await self._request("PUT", path, json=payloads)
+
+    async def list_channels(self) -> List[Dict[str, Any]]:
+        """Enumerate reachable Fluxer guild channels and active threads."""
+        try:
+            guilds_payload = await self._request("GET", "/users/@me/guilds", params={"limit": 200, "with_counts": True})
+        except Exception as exc:
+            logger.debug("Fluxer guild enumeration failed: %s", exc)
+            return []
+        guilds = guilds_payload if isinstance(guilds_payload, list) else (guilds_payload.get("guilds") or guilds_payload.get("items") or [])
+        channels: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+        for guild in guilds:
+            if not isinstance(guild, dict):
+                continue
+            guild_id = str(guild.get("id") or "")
+            if not guild_id:
+                continue
+            guild_name = str(guild.get("name") or guild_id)
+            try:
+                guild_channels = await self._request("GET", f"/guilds/{_quote_id(guild_id)}/channels")
+            except Exception as exc:
+                logger.debug("Fluxer channel enumeration failed for guild %s: %s", guild_id, exc)
+                guild_channels = []
+            for item in guild_channels if isinstance(guild_channels, list) else []:
+                if not isinstance(item, dict):
+                    continue
+                channel_id = str(item.get("id") or "")
+                name = str(item.get("name") or "")
+                channel_type = _directory_channel_type(item.get("type"))
+                if not channel_id or not name or channel_type not in {"channel", "forum", "thread"} or channel_id in seen:
+                    continue
+                seen.add(channel_id)
+                entry: Dict[str, Any] = {"id": channel_id, "name": name, "guild": guild_name, "guild_id": guild_id, "type": channel_type}
+                if item.get("parent_id"):
+                    entry["parent_id"] = str(item["parent_id"])
+                channels.append(entry)
+            try:
+                threads_payload = await self._request("GET", f"/guilds/{_quote_id(guild_id)}/threads/active", warn_on_error=False)
+            except Exception as exc:
+                logger.debug("Fluxer active thread enumeration unavailable for guild %s: %s", guild_id, exc)
+                threads_payload = {}
+            threads = threads_payload.get("threads") if isinstance(threads_payload, dict) else []
+            for thread in threads if isinstance(threads, list) else []:
+                if not isinstance(thread, dict):
+                    continue
+                thread_id = str(thread.get("id") or "")
+                name = str(thread.get("name") or "")
+                if not thread_id or not name or thread_id in seen:
+                    continue
+                seen.add(thread_id)
+                entry = {"id": thread_id, "name": name, "guild": guild_name, "guild_id": guild_id, "type": "thread"}
+                if thread.get("parent_id"):
+                    entry["parent_id"] = str(thread["parent_id"])
+                channels.append(entry)
+        for channel_id in self._known_channel_ids:
+            if channel_id not in seen:
+                channels.append({"id": channel_id, "name": channel_id, "type": "channel"})
+        return channels
+
+    async def create_thread(
+        self,
+        chat_id: str,
+        name: str,
+        *,
+        message_id: Optional[str] = None,
+        auto_archive_duration: int = 1440,
+        thread_type: int = 11,
+    ) -> Dict[str, Any]:
+        """Create a Fluxer thread, optionally from an existing message."""
+        if message_id:
+            payload = {"name": name, "auto_archive_duration": auto_archive_duration, "rate_limit_per_user": 0}
+            return await self._request(
+                "POST",
+                f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}/threads",
+                json=payload,
+            )
+        payload = {
+            "name": name,
+            "type": thread_type,
+            "auto_archive_duration": auto_archive_duration,
+            "rate_limit_per_user": 0,
+            "invitable": True,
+        }
+        return await self._request("POST", f"/channels/{_quote_id(chat_id)}/threads", json=payload)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Start a persistent Fluxer typing indicator loop.
+
+        Fluxer typing indicators expire after a short window. Hermes calls
+        ``send_typing`` when a turn starts, so keep refreshing until the runner
+        calls ``stop_typing`` after the final response. This preserves a
+        clean typing-only "I am working" mode when ``display.tool_progress`` is
+        set to ``off``.
+        """
+        chat_key = str(chat_id)
+        if chat_key in self._typing_tasks:
+            return
+
+        async def _typing_loop() -> None:
+            try:
+                while True:
+                    try:
+                        await self._request("POST", f"/channels/{_quote_id(chat_key)}/typing", json={})
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        logger.debug("Fluxer typing indicator failed for %s: %s", chat_key, exc)
+                        return
+                    await asyncio.sleep(8)
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._typing_tasks.pop(chat_key, None)
+
+        self._typing_tasks[chat_key] = asyncio.create_task(_typing_loop(), name=f"fluxer-typing-{chat_key}")
+
+    async def stop_typing(self, chat_id: str) -> None:
+        chat_key = str(chat_id)
+        task = self._typing_tasks.pop(chat_key, None)
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     async def send_image(
         self,
@@ -429,9 +1212,12 @@ class FluxerAdapter(BasePlatformAdapter):
 
         path = Path(resolved)
         filename = file_name or path.name
-        payload: Dict[str, Any] = {"nonce": str(int(time.time() * 1000))}
+        payload: Dict[str, Any] = {
+            "nonce": str(int(time.time() * 1000)),
+            "allowed_mentions": self._allowed_mentions_payload(),
+        }
         if caption and not is_voice:
-            payload["content"] = caption
+            payload["content"] = self._sanitize_outbound_mentions(caption)
         if reply_to:
             payload["message_reference"] = {"message_id": str(reply_to)}
         if metadata:
@@ -440,6 +1226,7 @@ class FluxerAdapter(BasePlatformAdapter):
                 payload["message_reference"] = {"message_id": str(thread_id)}
         if flags:
             payload["flags"] = flags
+        self._known_channel_ids.add(str(chat_id))
 
         attachment: Dict[str, Any] = {"id": 0, "filename": filename, "title": title or filename}
         if is_voice:
@@ -451,18 +1238,72 @@ class FluxerAdapter(BasePlatformAdapter):
         try:
             data = await self._multipart_request(
                 "POST",
-                f"/channels/{chat_id}/messages",
+                f"/channels/{_quote_id(chat_id)}/messages",
                 payload=payload,
                 files=[("files[0]", path, filename)],
             )
-            return SendResult(success=True, message_id=str(data.get("id")) if data.get("id") else None, raw_response=data)
+            message_id = str(data.get("id")) if data.get("id") else None
+            verified = await self._verify_delivery(
+                chat_id,
+                message_id,
+                expected_attachment_count=1,
+            )
+            raw_response = dict(data)
+            raw_response["delivery_verified"] = verified is not None
+            if verified is not None:
+                raw_response["delivery_readback"] = verified
+            return SendResult(success=True, message_id=message_id, raw_response=raw_response)
         except Exception as exc:
             logger.warning("Fluxer file upload failed: %s", exc)
             return SendResult(success=False, error=str(exc), retryable=True)
 
+    async def _verify_delivery(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        *,
+        expected_content: Optional[str] = None,
+        expected_attachment_count: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Read back a sent/edited message and validate the visible payload.
+
+        Verification is deliberately non-fatal for the caller: a REST timeout or
+        stale read after a successful POST may still mean the message landed,
+        and retrying could duplicate messages. We attach verification state to
+        ``raw_response`` and log mismatches for diagnostics.
+        """
+        if not self._delivery_verification_enabled or not message_id:
+            return None
+        try:
+            data = await self._request("GET", f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}")
+        except Exception as exc:
+            logger.warning("Fluxer delivery read-back failed for message %s: %s", message_id, exc)
+            return None
+
+        problems: List[str] = []
+        if str(data.get("id") or "") != str(message_id):
+            problems.append("id_mismatch")
+        if expected_content is not None and str(data.get("content") or "") != expected_content:
+            problems.append("content_mismatch")
+        if expected_attachment_count is not None:
+            attachments = data.get("attachments") or []
+            actual_count = len(attachments) if isinstance(attachments, list) else 0
+            if actual_count < expected_attachment_count:
+                problems.append(f"attachment_count_mismatch:{actual_count}<{expected_attachment_count}")
+        if self.bot_user_id:
+            author = data.get("author") or {}
+            author_id = str(author.get("id") or data.get("author_id") or "")
+            if author_id and author_id != self.bot_user_id:
+                problems.append("author_mismatch")
+        if problems:
+            logger.warning("Fluxer delivery verification warning for %s: %s", message_id, ",".join(problems))
+            data = dict(data)
+            data["delivery_verification_warnings"] = problems
+        return data
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         try:
-            data = await self._request("GET", f"/channels/{chat_id}")
+            data = await self._request("GET", f"/channels/{_quote_id(chat_id)}")
             return {
                 "id": str(data.get("id") or chat_id),
                 "name": data.get("name") or str(chat_id),
@@ -472,7 +1313,7 @@ class FluxerAdapter(BasePlatformAdapter):
         except Exception:
             return {"id": str(chat_id), "name": str(chat_id), "type": "channel"}
 
-    async def _request(self, method: str, path: str, **kwargs) -> Dict[str, Any]:
+    async def _request(self, method: str, path: str, *, warn_on_error: bool = True, **kwargs) -> Dict[str, Any]:
         try:
             import httpx
         except ImportError as exc:
@@ -481,7 +1322,7 @@ class FluxerAdapter(BasePlatformAdapter):
         url = urljoin(self.api_base_url + "/", path.lstrip("/"))
         async with httpx.AsyncClient(timeout=20) as client:
             response = await client.request(method, url, headers=_headers(self.bot_token), **kwargs)
-            if response.status_code >= 400:
+            if response.status_code >= 400 and warn_on_error:
                 logger.warning(
                     "Fluxer REST %s %s failed: status=%s body=%s",
                     method,
@@ -545,21 +1386,26 @@ class FluxerAdapter(BasePlatformAdapter):
 
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe Fluxer attachment URL: {safe_url_for_log(url)}")
+        headers = {"User-Agent": "Hermes-Fluxer/0.1", "Accept": "*/*"}
+        attachment_host = urlparse(url).netloc.lower()
+        api_host = urlparse(self.api_base_url).netloc.lower()
+        if attachment_host and api_host and attachment_host == api_host:
+            headers["Authorization"] = f"Bot {self.bot_token}"
         async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-            response = await client.get(
-                url,
-                headers={
-                    "Authorization": f"Bot {self.bot_token}",
-                    "User-Agent": "Hermes-Fluxer/0.1",
-                    "Accept": "*/*",
-                },
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
     async def _cache_attachment(self, att: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
         url = _attachment_url(att)
         if not url:
+            return None, None
+        try:
+            from tools.url_safety import is_safe_url
+        except ImportError as exc:
+            raise RuntimeError("url safety helpers are required for Fluxer attachments") from exc
+        if not is_safe_url(url):
+            logger.warning("Fluxer blocked unsafe attachment URL: %s", safe_url_for_log(url))
             return None, None
         content_type = str(att.get("content_type") or att.get("contentType") or "application/octet-stream").split(";", 1)[0].lower()
         filename = _attachment_filename(att)
@@ -576,8 +1422,8 @@ class FluxerAdapter(BasePlatformAdapter):
             data = await self._download_attachment_bytes(url)
             return cache_document_from_bytes(data, filename), content_type or "application/octet-stream"
         except Exception as exc:
-            logger.warning("Fluxer failed to cache attachment %s: %s", filename, exc)
-            return url, content_type or "application/octet-stream"
+            logger.warning("Fluxer failed to cache attachment %s; dropping attachment: %s", filename, exc)
+            return None, None
 
     async def _extract_attachments(self, data: Dict[str, Any]) -> tuple[List[str], List[str]]:
         media_urls: List[str] = []
@@ -594,28 +1440,304 @@ class FluxerAdapter(BasePlatformAdapter):
                 media_types.append(mtype or "application/octet-stream")
         return media_urls, media_types
 
+    async def _resolve_reply_context(
+        self,
+        data: Dict[str, Any],
+        channel_id: str,
+    ) -> tuple[Optional[str], Optional[str]]:
+        reply_to_message_id, referenced = _extract_reply_message(data)
+        if not reply_to_message_id:
+            return None, None
+
+        reply_to_text = _message_content(referenced)
+        if reply_to_text:
+            return reply_to_message_id, reply_to_text
+
+        # Some gateway events only include ``message_reference``. One REST
+        # lookup recovers the text for context injection; failures are non-fatal
+        # because the triggering message itself is still valid.
+        try:
+            payload = await self._request("GET", f"/channels/{_quote_id(channel_id)}/messages/{_quote_id(reply_to_message_id)}")
+            reply_to_text = _message_content(payload) or None
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("Fluxer reply context lookup failed for %s: %s", reply_to_message_id, exc)
+            reply_to_text = None
+        return reply_to_message_id, reply_to_text
+
+    def _message_mentions_bot(self, data: Dict[str, Any], text: str) -> bool:
+        if self.bot_user_id:
+            uid = re.escape(str(self.bot_user_id))
+            if re.search(rf"<@!?{uid}>", text or ""):
+                return True
+            mentions = data.get("mentions") or []
+            if isinstance(mentions, list):
+                for mention in mentions:
+                    if isinstance(mention, dict) and str(mention.get("id") or "") == str(self.bot_user_id):
+                        return True
+                    if str(mention) == str(self.bot_user_id):
+                        return True
+
+        # Human-friendly direct-address fallback for Fluxer instances that do
+        # not expose bot mention markup yet. Keep it anchored to the start so
+        # "Hermes said..." in the middle of a discussion doesn't wake the bot.
+        default_patterns = (r"^\s*@?hermes\b[,:]?",)
+        for pattern in (*default_patterns, *self._mention_patterns):
+            try:
+                if re.search(pattern, text or "", flags=re.IGNORECASE):
+                    return True
+            except re.error:
+                logger.debug("Ignoring invalid Fluxer mention pattern: %s", pattern)
+        return False
+
+    def _strip_bot_mention(self, text: str) -> str:
+        stripped = text or ""
+        if self.bot_user_id:
+            stripped = re.sub(rf"<@!?{re.escape(str(self.bot_user_id))}>\s*", "", stripped).strip()
+        stripped = re.sub(r"^\s*@?hermes\b[,:]?\s*", "", stripped, flags=re.IGNORECASE)
+        for pattern in self._mention_patterns:
+            try:
+                stripped = re.sub(pattern, "", stripped, count=1, flags=re.IGNORECASE).strip()
+            except re.error:
+                pass
+        return stripped
+
+    def _should_process_message(
+        self,
+        *,
+        channel_id: str,
+        chat_type: str,
+        text: str,
+        data: Dict[str, Any],
+        reply_to_message_id: Optional[str],
+    ) -> tuple[bool, str]:
+        if chat_type == "dm":
+            return True, text
+        if self._allowed_channel_ids and channel_id not in self._allowed_channel_ids:
+            logger.debug("Fluxer ignoring message in non-allowed channel %s", channel_id)
+            return False, text
+        if channel_id in self._free_response_channels or channel_id in self._home_channel_ids:
+            return True, text
+        if not self._require_mention:
+            return True, text
+
+        is_mentioned = self._message_mentions_bot(data, text)
+        thread_key = str(data.get("thread_id") or (channel_id if chat_type == "thread" else "") or reply_to_message_id or "")
+        in_mentioned_thread = bool(thread_key and thread_key in self._mentioned_threads)
+        if self._strict_mention and not is_mentioned:
+            return False, text
+        if not is_mentioned and not in_mentioned_thread:
+            return False, text
+        if is_mentioned:
+            text = self._strip_bot_mention(text)
+            if thread_key:
+                self._mentioned_threads.add(thread_key)
+                if len(self._mentioned_threads) > self._mentioned_threads_max:
+                    for old in list(self._mentioned_threads)[: self._mentioned_threads_max // 2]:
+                        self._mentioned_threads.discard(old)
+        return True, text
+
+    async def _recover_backlog(self, *, cutoff: datetime) -> None:
+        if not self._backlog_enabled or not self._known_channel_ids:
+            return
+        cutoff = cutoff.astimezone(timezone.utc)
+        for channel_id in sorted(self._known_channel_ids):
+            try:
+                payload = await self._request(
+                    "GET",
+                    f"/channels/{_quote_id(channel_id)}/messages",
+                    params={"limit": self._backlog_limit},
+                )
+                messages = _extract_message_list(payload)
+                recovered = 0
+                for message in reversed(messages):
+                    ts = _parse_fluxer_timestamp(message.get("timestamp") or message.get("created_at"))
+                    if ts is not None and ts < cutoff:
+                        continue
+                    if not message.get("channel_id"):
+                        message = {**message, "channel_id": channel_id}
+                    msg_id = str(message.get("id") or "")
+                    if msg_id and msg_id in self._seen_message_ids:
+                        continue
+                    await self._handle_message_create(
+                        message,
+                        {"op": 0, "t": "MESSAGE_CREATE", "d": message, "backfill": True},
+                    )
+                    recovered += 1
+                if recovered:
+                    logger.info("Fluxer recovered %d backlog message(s) for channel %s", recovered, channel_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Fluxer backlog recovery failed for channel %s: %s", channel_id, exc)
+
     async def _listen_loop(self) -> None:
         assert self._ws is not None
+        reason = "closed"
         try:
             async for raw in self._ws:
                 payload = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode("utf-8"))
                 await self._handle_gateway_dispatch(payload)
+            reason = "websocket closed"
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             if self._running:
                 logger.warning("Fluxer listener stopped: %s", exc)
-                self._set_fatal_error("listener_stopped", f"Fluxer listener stopped: {exc}", retryable=True)
+            reason = str(exc)
+        finally:
+            if not self._closing:
+                self._last_disconnect_at = datetime.now(tz=timezone.utc)
+                self._mark_disconnected()
+                self._schedule_reconnect(reason)
+
+    async def _send_heartbeat(self) -> None:
+        if self._ws is None:
+            return
+        self._last_heartbeat_sent_at = time.monotonic()
+        self._awaiting_heartbeat_ack = True
+        await self._ws.send(json.dumps({"op": 1, "d": self._last_seq}))
 
     async def _heartbeat_loop(self, interval_ms: int) -> None:
+        interval_s = max(interval_ms, 1000) / 1000
+        ack_timeout_s = interval_s * _HEARTBEAT_ACK_TIMEOUT_FACTOR
         try:
-            while self._running and self._ws is not None:
-                await asyncio.sleep(max(interval_ms, 1000) / 1000)
-                await self._ws.send(json.dumps({"op": 1, "d": self._last_seq}))
+            while not self._closing and self._ws is not None:
+                await asyncio.sleep(interval_s)
+                if (
+                    self._awaiting_heartbeat_ack
+                    and self._last_heartbeat_sent_at is not None
+                    and time.monotonic() - self._last_heartbeat_sent_at > ack_timeout_s
+                ):
+                    logger.warning("Fluxer heartbeat ACK timed out; closing websocket to trigger reconnect")
+                    try:
+                        await self._ws.close()
+                    except Exception:
+                        pass
+                    return
+                await self._send_heartbeat()
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             logger.debug("Fluxer heartbeat stopped: %s", exc)
+
+    def _interaction_user_id(self, data: Dict[str, Any]) -> str:
+        user = data.get("user") or ((data.get("member") or {}).get("user") or {})
+        return str(user.get("id") or "")
+
+    async def _respond_to_interaction(self, data: Dict[str, Any], *, content: str, components: Optional[List[Dict[str, Any]]] = None) -> None:
+        interaction_id = str(data.get("id") or "")
+        token = str(data.get("token") or "")
+        if not interaction_id or not token:
+            return
+        payload: Dict[str, Any] = {"type": 7, "data": self._outbound_message_payload(content)}
+        if components is not None:
+            payload["data"]["components"] = components
+        await self._request("POST", f"/interactions/{_quote_id(interaction_id)}/{_quote_id(token)}/callback", json=payload)
+
+    async def _handle_interaction_create(self, data: Dict[str, Any]) -> None:
+        interaction_type = data.get("type")
+        interaction_data = data.get("data") or {}
+        if interaction_type == 3 or interaction_data.get("custom_id"):
+            await self._handle_component_interaction(data)
+            return
+        if interaction_type == 2:
+            await self._handle_application_command_interaction(data)
+
+    async def _handle_component_interaction(self, data: Dict[str, Any]) -> None:
+        interaction_data = data.get("data") or {}
+        custom_id = str(interaction_data.get("custom_id") or "")
+        action = self._pending_component_actions.get(custom_id)
+        if not action:
+            return
+        user_id = self._interaction_user_id(data)
+        if not self._reaction_user_allowed(user_id):
+            logger.info("Fluxer component action ignored for unauthorized user %s", user_id or "<missing>")
+            return
+        interaction_message_id = str(((data.get("message") or {}).get("id")) or "")
+        action_message_id = str(action.get("message_id") or "")
+        if action_message_id and interaction_message_id and interaction_message_id != action_message_id:
+            logger.warning("Fluxer component action %s ignored for mismatched message %s", custom_id, interaction_message_id)
+            return
+        interaction_channel_id = str(data.get("channel_id") or ((data.get("channel") or {}).get("id")) or "")
+        action_channel_id = str(action.get("channel_id") or "")
+        if action_channel_id and interaction_channel_id and interaction_channel_id != action_channel_id:
+            logger.warning("Fluxer component action %s ignored for mismatched channel %s", custom_id, interaction_channel_id)
+            return
+        self._pending_component_actions.pop(custom_id, None)
+        if action.get("kind") == "exec_approval":
+            await self._resolve_exec_approval_action(action, user_id=user_id, interaction=data)
+        elif action.get("kind") == "slash_confirm":
+            await self._resolve_slash_confirm_action(action, user_id=user_id, interaction=data)
+
+    async def _resolve_exec_approval_action(self, action: Dict[str, Any], *, user_id: str, interaction: Dict[str, Any]) -> None:
+        message_id = str(action.get("message_id") or ((interaction.get("message") or {}).get("id")) or "")
+        pending = self._pending_exec_approvals.pop(message_id, None)
+        if not pending or pending.get("resolved"):
+            return
+        pending["resolved"] = True
+        session_key = str(action.get("session_key") or pending.get("session_key") or "")
+        choice = str(action.get("choice") or "deny")
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(session_key, choice)
+            logger.info("Fluxer component resolved %d approval(s) for session %s (choice=%s user=%s)", count, session_key, choice, user_id)
+        except Exception as exc:
+            logger.error("Fluxer component approval resolve failed: %s", exc)
+        for cid, state in list(self._pending_component_actions.items()):
+            if state.get("message_id") == message_id:
+                self._pending_component_actions.pop(cid, None)
+        label = {"once": "approved once", "session": "approved for session", "always": "approved permanently", "deny": "denied"}.get(choice, choice)
+        try:
+            await self._respond_to_interaction(interaction, content=f"{pending.get('content') or '⚠️ Command approval required'}\n\nResolved: {label} by <@{user_id}>.", components=[])
+        except Exception as exc:
+            logger.debug("Fluxer component approval response failed: %s", exc)
+
+    async def _resolve_slash_confirm_action(self, action: Dict[str, Any], *, user_id: str, interaction: Dict[str, Any]) -> None:
+        session_key = str(action.get("session_key") or "")
+        confirm_id = str(action.get("confirm_id") or "")
+        choice = str(action.get("choice") or "cancel")
+        try:
+            from tools.slash_confirm import resolve
+
+            await resolve(session_key, confirm_id, choice)
+        except Exception as exc:
+            logger.error("Fluxer slash confirm resolve failed: %s", exc)
+        try:
+            await self._respond_to_interaction(interaction, content=f"Slash confirmation: {choice} by <@{user_id}>.", components=[])
+        except Exception:
+            pass
+
+    async def _handle_application_command_interaction(self, data: Dict[str, Any]) -> None:
+        interaction_data = data.get("data") or {}
+        name = str(interaction_data.get("name") or "").strip()
+        if not name:
+            return
+        options = interaction_data.get("options") or []
+        parts = [f"/{name}"]
+        if isinstance(options, list):
+            for option in options:
+                if isinstance(option, dict) and option.get("value") is not None:
+                    parts.append(str(option.get("value")))
+        text = " ".join(parts).strip()
+        user = data.get("user") or ((data.get("member") or {}).get("user") or {})
+        channel = data.get("channel") or {}
+        channel_id = str(data.get("channel_id") or channel.get("id") or "")
+        if not channel_id:
+            return
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=channel.get("name"),
+            chat_type=_chat_type(channel.get("type")),
+            user_id=str(user.get("id") or "") or None,
+            user_name=_author_name(user),
+            guild_id=data.get("guild_id"),
+            message_id=str(data.get("id") or "") or None,
+        )
+        await self._request("POST", f"/interactions/{_quote_id(data.get('id'))}/{_quote_id(data.get('token'))}/callback", json={"type": 5, "data": {"flags": 64}})
+        await self.handle_message(MessageEvent(text=text, message_type=MessageType.TEXT, source=source, raw_message={"interaction": data}, message_id=str(data.get("id") or "") or None))
 
     async def _handle_gateway_dispatch(self, payload: Dict[str, Any]) -> None:
         op = payload.get("op")
@@ -625,7 +1747,23 @@ class FluxerAdapter(BasePlatformAdapter):
             interval = int(((payload.get("d") or {}).get("heartbeat_interval") or 41250))
             if self._ws is not None:
                 await self._ws.send(json.dumps(_build_identify_payload(self.bot_token)))
+                # Fluxer's hosted gateway also tolerates/expects an
+                # immediate heartbeat; waiting a full interval can trip hosted
+                # gateway 4009 heartbeat-timeout closes during dogfood sessions.
+                await self._send_heartbeat()
                 self._heartbeat_task = asyncio.create_task(self._heartbeat_loop(interval), name="fluxer-heartbeat")
+            return
+        if op == 1:  # server heartbeat request
+            await self._send_heartbeat()
+            return
+        if op == 11:  # HEARTBEAT_ACK
+            self._awaiting_heartbeat_ack = False
+            self._last_heartbeat_ack_at = time.monotonic()
+            return
+        if op in {7, 9, 12}:  # RECONNECT / INVALID_SESSION / GATEWAY_ERROR
+            logger.warning("Fluxer gateway requested reconnect: op=%s payload=%s", op, payload.get("d"))
+            if self._ws is not None:
+                await self._ws.close()
             return
         if op != 0:  # not DISPATCH
             return
@@ -637,9 +1775,67 @@ class FluxerAdapter(BasePlatformAdapter):
             if user.get("id"):
                 self.bot_user_id = str(user["id"])
             return
+        if event_name == "MESSAGE_REACTION_ADD":
+            await self._handle_reaction_add(data)
+            return
+        if event_name == "INTERACTION_CREATE":
+            await self._handle_interaction_create(data)
+            return
+        if event_name in {"THREAD_CREATE", "THREAD_UPDATE", "CHANNEL_CREATE", "CHANNEL_UPDATE"}:
+            channel_id = str(data.get("id") or "")
+            if channel_id:
+                self._known_channel_ids.add(channel_id)
+            return
+        if event_name == "MESSAGE_DELETE":
+            await self._handle_message_delete(data)
+            return
+        if event_name == "MESSAGE_UPDATE":
+            await self._handle_message_update(data)
+            return
         if event_name != "MESSAGE_CREATE":
             return
         await self._handle_message_create(data, payload)
+
+    async def _handle_message_update(self, data: Dict[str, Any]) -> None:
+        """Track Fluxer edits that affect adapter-owned state.
+
+        We intentionally do not re-dispatch edited user messages as fresh user
+        turns; that would surprise users and can duplicate agent runs. For now
+        MESSAGE_UPDATE only keeps pending approval bookkeeping in sync so a
+        later reaction edits the current prompt text rather than stale content.
+        """
+        message_id = str(data.get("id") or data.get("message_id") or "")
+        if not message_id:
+            return
+        pending = self._pending_exec_approvals.get(message_id)
+        if pending is None:
+            return
+        content = data.get("content")
+        if isinstance(content, str) and content:
+            pending["content"] = content
+
+    async def _handle_message_delete(self, data: Dict[str, Any]) -> None:
+        """Fail closed if an outstanding approval prompt is deleted."""
+        message_id = str(data.get("id") or data.get("message_id") or "")
+        if not message_id:
+            return
+        self._seen_message_ids.discard(message_id)
+        pending = self._pending_exec_approvals.pop(message_id, None)
+        if not pending or pending.get("resolved"):
+            return
+        pending["resolved"] = True
+        session_key = str(pending.get("session_key") or "")
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = resolve_gateway_approval(session_key, "deny")
+            logger.info(
+                "Fluxer deleted approval prompt denied %d approval(s) for session %s",
+                count,
+                session_key,
+            )
+        except Exception as exc:
+            logger.error("Fluxer deleted approval prompt deny failed: %s", exc)
 
     async def _handle_message_create(self, data: Dict[str, Any], raw_payload: Dict[str, Any]) -> None:
         msg_id = str(data.get("id") or "")
@@ -663,10 +1859,22 @@ class FluxerAdapter(BasePlatformAdapter):
         channel_id = str(data.get("channel_id") or data.get("channel", {}).get("id") or "")
         if not channel_id:
             return
+        self._known_channel_ids.add(channel_id)
+        reply_to_message_id, reply_to_text = await self._resolve_reply_context(data, channel_id)
+        chat_type = _chat_type(data.get("channel_type") or (data.get("channel") or {}).get("type"))
+        should_process, text = self._should_process_message(
+            channel_id=channel_id,
+            chat_type=chat_type,
+            text=text,
+            data=data,
+            reply_to_message_id=reply_to_message_id,
+        )
+        if not should_process:
+            return
         source = self.build_source(
             chat_id=channel_id,
             chat_name=(data.get("channel") or {}).get("name"),
-            chat_type=_chat_type(data.get("channel_type") or (data.get("channel") or {}).get("type")),
+            chat_type=chat_type,
             user_id=author_id or None,
             user_name=_author_name(author),
             guild_id=data.get("guild_id"),
@@ -689,6 +1897,8 @@ class FluxerAdapter(BasePlatformAdapter):
             message_id=msg_id or None,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
             timestamp=timestamp,
         )
         await self.handle_message(event)

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -14,19 +14,34 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import mimetypes
 import os
+import subprocess
+import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    SUPPORTED_IMAGE_DOCUMENT_TYPES,
+    cache_audio_from_url,
+    cache_document_from_bytes,
+    cache_image_from_url,
+    safe_url_for_log,
+)
 
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 4000
 _DEFAULT_BASE_URL = "https://api.fluxer.app/v1"
 _GATEWAY_VERSION = 1
+_VOICE_MESSAGE_FLAG = 1 << 13
 
 
 def _strip_slash(url: str) -> str:
@@ -72,6 +87,14 @@ def _headers(bot_token: str) -> Dict[str, str]:
     }
 
 
+def _auth_headers(bot_token: str) -> Dict[str, str]:
+    """Headers for requests where httpx must set Content-Type itself."""
+    return {
+        "Authorization": f"Bot {bot_token}",
+        "User-Agent": "Hermes-Fluxer/0.1",
+    }
+
+
 def _event_seq(payload: Dict[str, Any]) -> Optional[int]:
     seq = payload.get("s")
     try:
@@ -105,6 +128,75 @@ def _chat_type(raw: Any) -> str:
     if raw == 3:
         return "group"
     return "channel"
+
+
+def _attachment_url(att: Dict[str, Any]) -> str:
+    return str(att.get("url") or att.get("proxy_url") or "").strip()
+
+
+def _attachment_filename(att: Dict[str, Any]) -> str:
+    return str(att.get("filename") or att.get("title") or att.get("name") or "attachment").strip()
+
+
+def _extension_for_attachment(att: Dict[str, Any], content_type: str, default: str = ".bin") -> str:
+    filename = _attachment_filename(att)
+    suffix = Path(filename).suffix.lower()
+    if suffix:
+        return suffix
+    subtype = (content_type or "").split("/", 1)[-1].split(";", 1)[0].lower()
+    aliases = {"jpeg": ".jpg", "plain": ".txt", "mpeg": ".mp3", "quicktime": ".mov"}
+    if subtype:
+        return aliases.get(subtype, f".{subtype}")
+    return default
+
+
+def _message_type_for_media(media_types: List[str]) -> MessageType:
+    if not media_types:
+        return MessageType.TEXT
+    if any(m.startswith("image/") for m in media_types):
+        return MessageType.PHOTO
+    if any(m.startswith("audio/") for m in media_types):
+        return MessageType.AUDIO
+    if any(m.startswith("video/") for m in media_types):
+        return MessageType.VIDEO
+    return MessageType.DOCUMENT
+
+
+def _is_voice_message(data: Dict[str, Any]) -> bool:
+    try:
+        flags = int(data.get("flags") or 0)
+    except (TypeError, ValueError):
+        flags = 0
+    if flags & _VOICE_MESSAGE_FLAG:
+        return True
+    if str(data.get("message_type") or data.get("type") or "").lower() in {"voice", "voice_message"}:
+        return True
+    attachments = data.get("attachments") or []
+    if isinstance(attachments, list):
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+            if bool(att.get("is_voice_message") or att.get("voice") or att.get("voice_message")):
+                return True
+    return False
+
+
+def _audio_duration_seconds(path: Path) -> int:
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=nk=1:nw=1", str(path)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+        duration = float((result.stdout or "").strip())
+        if duration > 0:
+            return max(1, int(round(duration)))
+    except Exception:
+        pass
+    return 1
 
 
 class FluxerAdapter(BasePlatformAdapter):
@@ -191,14 +283,181 @@ class FluxerAdapter(BasePlatformAdapter):
                 payload["message_reference"] = {"message_id": str(thread_id)}
 
         try:
-            data = await self._request(
+            formatted = self.format_message(content)
+            chunks = self.truncate_message(formatted, MAX_MESSAGE_LENGTH)
+            message_ids: List[str] = []
+            responses: List[Dict[str, Any]] = []
+
+            for index, chunk in enumerate(chunks):
+                chunk_payload = dict(payload)
+                chunk_payload["content"] = chunk
+                if index > 0:
+                    # Reply/reference metadata only belongs on the first split
+                    # chunk; applying the same reference to every continuation
+                    # creates noisy threads and can make partial retries nastier.
+                    chunk_payload.pop("message_reference", None)
+
+                data = await self._request(
+                    "POST",
+                    f"/channels/{chat_id}/messages",
+                    json=chunk_payload,
+                )
+                responses.append(data)
+                if data.get("id"):
+                    message_ids.append(str(data["id"]))
+
+            return SendResult(
+                success=True,
+                message_id=message_ids[0] if message_ids else None,
+                raw_response={"message_ids": message_ids, "responses": responses},
+            )
+        except Exception as exc:
+            logger.warning("Fluxer send failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        try:
+            cached = await cache_image_from_url(image_url, Path(image_url.split("?", 1)[0]).suffix or ".jpg")
+            return await self.send_image_file(chat_id, cached, caption=caption, reply_to=reply_to, metadata=metadata)
+        except Exception as exc:
+            logger.warning("Fluxer image URL upload failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_file_message(
+            chat_id,
+            image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            title=kwargs.get("title"),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_file_message(
+            chat_id,
+            file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+            title=kwargs.get("title"),
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_file_message(
+            chat_id,
+            video_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            title=kwargs.get("title"),
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_file_message(
+            chat_id,
+            audio_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            flags=_VOICE_MESSAGE_FLAG,
+            is_voice=True,
+            duration=kwargs.get("duration"),
+            waveform=kwargs.get("waveform"),
+            title=kwargs.get("title"),
+        )
+
+    async def _send_file_message(
+        self,
+        chat_id: str,
+        file_path: str,
+        *,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        flags: int = 0,
+        is_voice: bool = False,
+        duration: Optional[int] = None,
+        waveform: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> SendResult:
+        resolved = self.validate_media_delivery_path(file_path)
+        if not resolved:
+            return SendResult(success=False, error=f"Unsafe or missing file path: {file_path}", retryable=False)
+
+        path = Path(resolved)
+        filename = file_name or path.name
+        payload: Dict[str, Any] = {"nonce": str(int(time.time() * 1000))}
+        if caption and not is_voice:
+            payload["content"] = caption
+        if reply_to:
+            payload["message_reference"] = {"message_id": str(reply_to)}
+        if metadata:
+            thread_id = metadata.get("thread_id")
+            if thread_id and "message_reference" not in payload:
+                payload["message_reference"] = {"message_id": str(thread_id)}
+        if flags:
+            payload["flags"] = flags
+
+        attachment: Dict[str, Any] = {"id": 0, "filename": filename, "title": title or filename}
+        if is_voice:
+            # Fluxer's schema requires duration + waveform for VOICE_MESSAGE uploads.
+            attachment["duration"] = int(duration) if duration is not None else _audio_duration_seconds(path)
+            attachment["waveform"] = str(waveform or "AAAA")
+        payload["attachments"] = [attachment]
+
+        try:
+            data = await self._multipart_request(
                 "POST",
                 f"/channels/{chat_id}/messages",
-                json=payload,
+                payload=payload,
+                files=[("files[0]", path, filename)],
             )
             return SendResult(success=True, message_id=str(data.get("id")) if data.get("id") else None, raw_response=data)
         except Exception as exc:
-            logger.warning("Fluxer send failed: %s", exc)
+            logger.warning("Fluxer file upload failed: %s", exc)
             return SendResult(success=False, error=str(exc), retryable=True)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -222,10 +481,118 @@ class FluxerAdapter(BasePlatformAdapter):
         url = urljoin(self.api_base_url + "/", path.lstrip("/"))
         async with httpx.AsyncClient(timeout=20) as client:
             response = await client.request(method, url, headers=_headers(self.bot_token), **kwargs)
+            if response.status_code >= 400:
+                logger.warning(
+                    "Fluxer REST %s %s failed: status=%s body=%s",
+                    method,
+                    path,
+                    response.status_code,
+                    response.text[:500],
+                )
             response.raise_for_status()
             if not response.content:
                 return {}
             return response.json()
+
+    async def _multipart_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: Dict[str, Any],
+        files: List[tuple[str, Path, str]],
+    ) -> Dict[str, Any]:
+        try:
+            import httpx
+        except ImportError as exc:
+            raise RuntimeError("httpx is required for Fluxer adapter") from exc
+
+        url = urljoin(self.api_base_url + "/", path.lstrip("/"))
+        multipart_files = []
+        handles = []
+        try:
+            for field_name, file_path, filename in files:
+                handle = file_path.open("rb")
+                handles.append(handle)
+                content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+                multipart_files.append((field_name, (filename, handle, content_type)))
+            data = {"payload_json": json.dumps(payload, separators=(",", ":"))}
+            async with httpx.AsyncClient(timeout=60) as client:
+                response = await client.request(
+                    method,
+                    url,
+                    headers=_auth_headers(self.bot_token),
+                    data=data,
+                    files=multipart_files,
+                )
+                response.raise_for_status()
+                if not response.content:
+                    return {}
+                return response.json()
+        finally:
+            for handle in handles:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+
+    async def _download_attachment_bytes(self, url: str) -> bytes:
+        try:
+            import httpx
+            from tools.url_safety import is_safe_url
+        except ImportError as exc:
+            raise RuntimeError("httpx and url safety helpers are required for Fluxer attachments") from exc
+
+        if not is_safe_url(url):
+            raise ValueError(f"Blocked unsafe Fluxer attachment URL: {safe_url_for_log(url)}")
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+            response = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bot {self.bot_token}",
+                    "User-Agent": "Hermes-Fluxer/0.1",
+                    "Accept": "*/*",
+                },
+            )
+            response.raise_for_status()
+            return response.content
+
+    async def _cache_attachment(self, att: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+        url = _attachment_url(att)
+        if not url:
+            return None, None
+        content_type = str(att.get("content_type") or att.get("contentType") or "application/octet-stream").split(";", 1)[0].lower()
+        filename = _attachment_filename(att)
+        ext = _extension_for_attachment(att, content_type)
+
+        try:
+            if content_type.startswith("image/") or ext in SUPPORTED_IMAGE_DOCUMENT_TYPES:
+                image_type = content_type if content_type.startswith("image/") else SUPPORTED_IMAGE_DOCUMENT_TYPES.get(ext, "image/jpeg")
+                image_ext = ext if ext in SUPPORTED_IMAGE_DOCUMENT_TYPES else _extension_for_attachment(att, image_type, ".jpg")
+                return await cache_image_from_url(url, image_ext), image_type
+            if content_type.startswith("audio/"):
+                return await cache_audio_from_url(url, ext if ext != ".bin" else ".ogg"), content_type
+
+            data = await self._download_attachment_bytes(url)
+            return cache_document_from_bytes(data, filename), content_type or "application/octet-stream"
+        except Exception as exc:
+            logger.warning("Fluxer failed to cache attachment %s: %s", filename, exc)
+            return url, content_type or "application/octet-stream"
+
+    async def _extract_attachments(self, data: Dict[str, Any]) -> tuple[List[str], List[str]]:
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        attachments = data.get("attachments") or []
+        if not isinstance(attachments, list):
+            return media_urls, media_types
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+            cached, mtype = await self._cache_attachment(att)
+            if cached:
+                media_urls.append(cached)
+                media_types.append(mtype or "application/octet-stream")
+        return media_urls, media_types
 
     async def _listen_loop(self) -> None:
         assert self._ws is not None
@@ -289,7 +656,8 @@ class FluxerAdapter(BasePlatformAdapter):
             return
 
         text = data.get("content") or ""
-        if not text and not data.get("attachments"):
+        media_urls, media_types = await self._extract_attachments(data)
+        if not text and not media_urls:
             return
 
         channel_id = str(data.get("channel_id") or data.get("channel", {}).get("id") or "")
@@ -315,10 +683,12 @@ class FluxerAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=MessageType.VOICE if _is_voice_message(data) else _message_type_for_media(media_types),
             source=source,
             raw_message=raw_payload,
             message_id=msg_id or None,
+            media_urls=media_urls,
+            media_types=media_types,
             timestamp=timestamp,
         )
         await self.handle_message(event)
@@ -376,10 +746,35 @@ async def _standalone_send(
 ) -> Dict[str, Any]:
     adapter = FluxerAdapter(pconfig)
     metadata = {"thread_id": thread_id} if thread_id else None
-    result = await adapter.send(chat_id, message, metadata=metadata)
-    if result.success:
-        return {"success": True, "platform": "fluxer", "chat_id": chat_id, "message_id": result.message_id}
-    return {"error": result.error or "Fluxer send failed"}
+    try:
+        last: Optional[SendResult] = None
+        if message:
+            last = await adapter.send(chat_id, message, metadata=metadata)
+            if not last.success:
+                return {"error": last.error or "Fluxer send failed"}
+        for media_item in media_files or []:
+            if isinstance(media_item, (tuple, list)):
+                media_path = str(media_item[0])
+                is_voice_directive = bool(media_item[1]) if len(media_item) > 1 else False
+            else:
+                media_path = str(media_item)
+                is_voice_directive = False
+            ext = Path(media_path).suffix.lower()
+            if not force_document and ext in {".jpg", ".jpeg", ".png", ".webp", ".gif"}:
+                last = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
+            elif not force_document and ext in {".mp4", ".mov", ".webm", ".mkv", ".avi"}:
+                last = await adapter.send_video(chat_id, media_path, metadata=metadata)
+            elif not force_document and (is_voice_directive or ext in {".mp3", ".m4a", ".ogg", ".opus", ".wav", ".flac", ".aac"}):
+                last = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+            else:
+                last = await adapter.send_document(chat_id, media_path, metadata=metadata)
+            if not last.success:
+                return {"error": last.error or "Fluxer media send failed"}
+        if last and last.success:
+            return {"success": True, "platform": "fluxer", "chat_id": chat_id, "message_id": last.message_id}
+        return {"error": "Fluxer send failed: empty message and no media"}
+    except Exception as exc:
+        return {"error": str(exc)}
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -910,7 +910,7 @@ class FluxerAdapter(BasePlatformAdapter):
     async def pin_message(self, chat_id: str, message_id: str) -> bool:
         """Pin a Fluxer message when the server supports message pins."""
         try:
-            await self._request("PUT", f"/channels/{_quote_id(chat_id)}/messages/pins/{_quote_id(message_id)}")
+            await self._request("PUT", f"/channels/{_quote_id(chat_id)}/pins/{_quote_id(message_id)}")
             return True
         except Exception as exc:
             logger.debug("Fluxer pin failed for message %s: %s", message_id, exc)
@@ -919,7 +919,7 @@ class FluxerAdapter(BasePlatformAdapter):
     async def unpin_message(self, chat_id: str, message_id: str) -> bool:
         """Unpin a Fluxer message when the server supports message pins."""
         try:
-            await self._request("DELETE", f"/channels/{_quote_id(chat_id)}/messages/pins/{_quote_id(message_id)}")
+            await self._request("DELETE", f"/channels/{_quote_id(chat_id)}/pins/{_quote_id(message_id)}")
             return True
         except Exception as exc:
             logger.debug("Fluxer unpin failed for message %s: %s", message_id, exc)

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -25,7 +25,7 @@ from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageTyp
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 4000
-_DEFAULT_BASE_URL = "https://fluxer.app"
+_DEFAULT_BASE_URL = "https://api.fluxer.app/v1"
 _GATEWAY_VERSION = 1
 
 
@@ -36,15 +36,17 @@ def _strip_slash(url: str) -> str:
 def _api_base(base_url: str) -> str:
     """Normalize a user-provided Fluxer URL to the REST API base.
 
-    Fluxer exposes routes under `/api` in the monolith, while some operators may
-    choose to configure an already-scoped `/api` or `/api/v1` URL. Preserve those
-    and append `/api` only for a plain origin.
+    The official hosted API is already scoped as ``https://api.fluxer.app/v1``.
+    Self-hosted Fluxer may expose either an already-scoped API URL or a plain
+    web origin; preserve scoped URLs and append ``/api`` only for a plain origin.
     """
     base = _strip_slash(base_url)
     if not base:
         return ""
-    if base.endswith("/api") or base.endswith("/api/v1") or "/api/" in base:
+    if base.endswith("/api") or base.endswith("/api/v1") or base.endswith("/v1") or "/api/" in base:
         return base
+    if base == "https://api.fluxer.app":
+        return f"{base}/v1"
     return f"{base}/api"
 
 
@@ -132,7 +134,7 @@ class FluxerAdapter(BasePlatformAdapter):
         if not self.base_url or not self.bot_token:
             self._set_fatal_error(
                 "missing_config",
-                "Fluxer requires FLUXER_BASE_URL and FLUXER_BOT_TOKEN",
+                "Fluxer requires FLUXER_BOT_TOKEN; FLUXER_BASE_URL is optional and defaults to https://api.fluxer.app/v1",
                 retryable=False,
             )
             return False
@@ -323,7 +325,7 @@ class FluxerAdapter(BasePlatformAdapter):
 
 
 def check_requirements() -> bool:
-    if not (os.getenv("FLUXER_BASE_URL") and os.getenv("FLUXER_BOT_TOKEN")):
+    if not os.getenv("FLUXER_BOT_TOKEN"):
         return False
     try:
         import httpx  # noqa: F401
@@ -335,9 +337,8 @@ def check_requirements() -> bool:
 
 def validate_config(config) -> bool:
     extra = getattr(config, "extra", {}) or {}
-    base_url = os.getenv("FLUXER_BASE_URL") or extra.get("base_url", "")
     token = os.getenv("FLUXER_BOT_TOKEN") or extra.get("bot_token", "")
-    return bool(str(base_url).strip() and str(token).strip())
+    return bool(str(token).strip())
 
 
 def is_connected(config) -> bool:
@@ -347,9 +348,11 @@ def is_connected(config) -> bool:
 def _env_enablement() -> dict | None:
     base_url = os.getenv("FLUXER_BASE_URL", "").strip()
     token = os.getenv("FLUXER_BOT_TOKEN", "").strip()
-    if not (base_url and token):
+    if not token:
         return None
-    seed: dict = {"base_url": base_url, "bot_token": token}
+    seed: dict = {"bot_token": token}
+    if base_url:
+        seed["base_url"] = base_url
     gateway_url = os.getenv("FLUXER_GATEWAY_URL", "").strip()
     if gateway_url:
         seed["gateway_url"] = gateway_url
@@ -381,7 +384,8 @@ async def _standalone_send(
 
 def interactive_setup() -> None:
     print("Fluxer platform setup")
-    print("Set FLUXER_BASE_URL and FLUXER_BOT_TOKEN in ~/.hermes/.env, then restart the gateway.")
+    print("Set FLUXER_BOT_TOKEN in ~/.hermes/.env, then restart the gateway.")
+    print("Optional: set FLUXER_BASE_URL for self-hosted Fluxer; official hosted defaults to https://api.fluxer.app/v1.")
 
 
 def register(ctx) -> None:
@@ -392,7 +396,7 @@ def register(ctx) -> None:
         check_fn=check_requirements,
         validate_config=validate_config,
         is_connected=is_connected,
-        required_env=["FLUXER_BASE_URL", "FLUXER_BOT_TOKEN"],
+        required_env=["FLUXER_BOT_TOKEN"],
         install_hint="pip install httpx websockets   # Fluxer adapter dependencies",
         setup_fn=interactive_setup,
         env_enablement_fn=_env_enablement,

--- a/plugins/platforms/fluxer/adapter.py
+++ b/plugins/platforms/fluxer/adapter.py
@@ -49,17 +49,6 @@ _RECONNECT_MAX_DELAY = 60.0
 _HEARTBEAT_ACK_TIMEOUT_FACTOR = 2.5
 _DEFAULT_BACKLOG_LIMIT = 25
 _DEFAULT_BACKLOG_BOOTSTRAP_SECONDS = 120
-_EXEC_APPROVAL_REACTIONS = {
-    "✅": "once",
-    "☑️": "once",
-    "🔁": "session",
-    "♾": "always",
-    "♾️": "always",
-    "❌": "deny",
-    "✖️": "deny",
-    "✖": "deny",
-}
-_EXEC_APPROVAL_REACTION_ORDER = ("✅", "🔁", "♾️", "❌")
 _MENTION_EVERYONE_RE = re.compile(r"@(everyone|here)\b", re.IGNORECASE)
 _MENTION_ROLE_RE = re.compile(r"<@&\d+>")
 _MENTION_USER_RE = re.compile(r"<@!?\d+>")
@@ -266,15 +255,6 @@ def _split_ids(value: Any) -> set[str]:
         return {str(item).strip() for item in value if str(item).strip()}
     return {part.strip() for part in str(value).split(",") if part.strip()}
 
-
-def _normalize_emoji_name(value: Any) -> str:
-    if isinstance(value, dict):
-        value = value.get("name") or value.get("id") or ""
-    text = str(value or "").strip()
-    # Variation selector makes some emoji arrive as either ♾ or ♾️.
-    if text == "♾️":
-        return "♾"
-    return text
 
 
 def _parse_fluxer_timestamp(value: Any) -> Optional[datetime]:
@@ -680,10 +660,10 @@ class FluxerAdapter(BasePlatformAdapter):
         target_id = str((metadata or {}).get("thread_id") or chat_id)
         cmd_display = command if len(command) <= 3200 else command[:3197] + "..."
         content = (
-            "⚠️ **Command approval required**\n"
+            "**Command approval required**\n"
             f"```\n{cmd_display}\n```\n"
             f"Reason: {description}\n\n"
-            "Use the buttons below, or text fallback: `/approve`, `/approve session`, `/approve always`, or `/deny`."
+            "Choose one of the approval buttons below."
         )
         nonce = uuid.uuid4().hex[:12]
         button_specs = (
@@ -751,7 +731,13 @@ class FluxerAdapter(BasePlatformAdapter):
             _fluxer_button(custom_id=custom_ids[choice], label=label, style=style)
             for choice, label, style in specs
         ])
-        content = f"**{title}**\n{message}"
+        content_message = re.sub(
+            r"\n*_Text fallback: reply `/(?:approve|always|cancel)`[^\n]*_\s*$",
+            "",
+            message or "",
+            flags=re.IGNORECASE,
+        ).rstrip()
+        content = f"**{title}**\n{content_message}"
         try:
             data = await self._request(
                 "POST",
@@ -773,13 +759,7 @@ class FluxerAdapter(BasePlatformAdapter):
             logger.warning("Fluxer slash confirm prompt failed: %s", exc)
             return SendResult(success=False, error=str(exc), retryable=True)
 
-    async def _add_message_reaction(self, chat_id: str, message_id: str, emoji: str) -> None:
-        await self._request(
-            "PUT",
-            f"/channels/{_quote_id(chat_id)}/messages/{_quote_id(message_id)}/reactions/{quote(emoji, safe='')}/@me",
-        )
-
-    def _reaction_user_allowed(self, user_id: str) -> bool:
+    def _interaction_user_allowed(self, user_id: str) -> bool:
         if not user_id:
             return False
         if self.bot_user_id and user_id == str(self.bot_user_id):
@@ -787,56 +767,6 @@ class FluxerAdapter(BasePlatformAdapter):
         if self._allow_all_users:
             return True
         return user_id in self._allowed_user_ids
-
-    async def _handle_reaction_add(self, data: Dict[str, Any]) -> None:
-        message_id = str(data.get("message_id") or "")
-        pending = self._pending_exec_approvals.get(message_id)
-        if not pending or pending.get("resolved"):
-            return
-
-        user_id = str(data.get("user_id") or ((data.get("member") or {}).get("user") or {}).get("id") or "")
-        member_user = ((data.get("member") or {}).get("user") or {})
-        if member_user.get("bot") or not self._reaction_user_allowed(user_id):
-            logger.info("Fluxer approval reaction ignored for unauthorized/bot user %s", user_id or "<missing>")
-            return
-
-        emoji_name = _normalize_emoji_name(data.get("emoji"))
-        choice = _EXEC_APPROVAL_REACTIONS.get(emoji_name)
-        if choice is None:
-            return
-
-        pending["resolved"] = True
-        self._pending_exec_approvals.pop(message_id, None)
-        session_key = str(pending.get("session_key") or "")
-        try:
-            from tools.approval import resolve_gateway_approval
-
-            count = resolve_gateway_approval(session_key, choice)
-            logger.info(
-                "Fluxer reaction resolved %d approval(s) for session %s (choice=%s user=%s)",
-                count,
-                session_key,
-                choice,
-                user_id,
-            )
-        except Exception as exc:
-            logger.error("Fluxer reaction approval resolve failed: %s", exc)
-
-        label = {
-            "once": "approved once",
-            "session": "approved for session",
-            "always": "approved permanently",
-            "deny": "denied",
-        }.get(choice, choice)
-        try:
-            await self.edit_message(
-                str(pending.get("channel_id") or data.get("channel_id") or ""),
-                message_id,
-                f"{pending.get('content') or '⚠️ Command approval required'}\n\nResolved: {label} by <@{user_id}>.",
-                finalize=True,
-            )
-        except Exception:
-            pass
 
     async def edit_message(
         self,
@@ -1652,7 +1582,7 @@ class FluxerAdapter(BasePlatformAdapter):
         if not action:
             return
         user_id = self._interaction_user_id(data)
-        if not self._reaction_user_allowed(user_id):
+        if not self._interaction_user_allowed(user_id):
             logger.info("Fluxer component action ignored for unauthorized user %s", user_id or "<missing>")
             return
         interaction_message_id = str(((data.get("message") or {}).get("id")) or "")
@@ -1691,7 +1621,7 @@ class FluxerAdapter(BasePlatformAdapter):
                 self._pending_component_actions.pop(cid, None)
         label = {"once": "approved once", "session": "approved for session", "always": "approved permanently", "deny": "denied"}.get(choice, choice)
         try:
-            await self._respond_to_interaction(interaction, content=f"{pending.get('content') or '⚠️ Command approval required'}\n\nResolved: {label} by <@{user_id}>.", components=[])
+            await self._respond_to_interaction(interaction, content=f"{pending.get('content') or 'Command approval required'}\n\nResolved: {label} by <@{user_id}>.", components=[])
         except Exception as exc:
             logger.debug("Fluxer component approval response failed: %s", exc)
 
@@ -1774,9 +1704,6 @@ class FluxerAdapter(BasePlatformAdapter):
             user = data.get("user") or data.get("bot") or {}
             if user.get("id"):
                 self.bot_user_id = str(user["id"])
-            return
-        if event_name == "MESSAGE_REACTION_ADD":
-            await self._handle_reaction_add(data)
             return
         if event_name == "INTERACTION_CREATE":
             await self._handle_interaction_create(data)

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -1,0 +1,35 @@
+name: fluxer-platform
+label: Fluxer
+kind: platform
+version: 0.1.0
+description: >
+  Fluxer gateway adapter for Hermes Agent. Text-first integration using
+  Fluxer's bot REST API for outbound messages and Gateway WebSocket events
+  for inbound MESSAGE_CREATE dispatches.
+author: Hermes Agent
+requires_env:
+  - name: FLUXER_BASE_URL
+    description: "Fluxer API base URL, e.g. https://fluxer.example/api or https://fluxer.example"
+    prompt: "Fluxer base URL"
+    password: false
+  - name: FLUXER_BOT_TOKEN
+    description: "Fluxer bot token (<applicationId>.<secret>)"
+    prompt: "Fluxer bot token"
+    password: true
+optional_env:
+  - name: FLUXER_ALLOWED_USERS
+    description: "Comma-separated Fluxer user IDs allowed to talk to the bot"
+    prompt: "Allowed Fluxer user IDs"
+    password: false
+  - name: FLUXER_ALLOW_ALL_USERS
+    description: "Allow any Fluxer user to talk to the bot"
+    prompt: "Allow all Fluxer users? (true/false)"
+    password: false
+  - name: FLUXER_HOME_CHANNEL
+    description: "Default Fluxer channel/DM ID for cron and notifications"
+    prompt: "Home channel ID"
+    password: false
+  - name: FLUXER_HOME_CHANNEL_NAME
+    description: "Human label for the home channel"
+    prompt: "Home channel display name"
+    password: false

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -3,9 +3,10 @@ label: Fluxer
 kind: platform
 version: 0.1.0
 description: >
-  Fluxer gateway adapter for Hermes Agent. Text-first integration using
-  Fluxer's bot REST API for outbound messages and Gateway WebSocket events
-  for inbound MESSAGE_CREATE dispatches.
+  Fluxer gateway adapter for Hermes Agent. Native Fluxer integration using
+  Fluxer's bot REST API for outbound messages, Gateway WebSocket events for
+  inbound dispatches, native components, slash-command interactions, pins,
+  threads, and channel-directory enumeration.
 author: Hermes Agent
 requires_env:
   - name: FLUXER_BOT_TOKEN
@@ -32,4 +33,72 @@ optional_env:
   - name: FLUXER_HOME_CHANNEL_NAME
     description: "Human label for the home channel"
     prompt: "Home channel display name"
+    password: false
+  - name: FLUXER_GATEWAY_URL
+    description: "Override Fluxer Gateway WebSocket URL; normally discovered via /gateway/bot"
+    prompt: "Gateway WebSocket URL"
+    password: false
+  - name: FLUXER_BACKLOG_RECOVERY
+    description: "Recover recent channel messages after reconnect/startup (true/false)"
+    prompt: "Enable backlog recovery?"
+    password: false
+  - name: FLUXER_BACKLOG_LIMIT
+    description: "Maximum recent messages to scan per known channel during backlog recovery"
+    prompt: "Backlog recovery limit"
+    password: false
+  - name: FLUXER_BACKLOG_BOOTSTRAP_SECONDS
+    description: "Startup lookback window, in seconds, when no previous disconnect time exists"
+    prompt: "Backlog bootstrap seconds"
+    password: false
+  - name: FLUXER_REQUIRE_MENTION
+    description: "Require bot mention/direct address in non-home channels (true/false)"
+    prompt: "Require mention in channels?"
+    password: false
+  - name: FLUXER_STRICT_MENTION
+    description: "Require a fresh mention on every channel message, ignoring mentioned-thread memory"
+    prompt: "Strict mention mode?"
+    password: false
+  - name: FLUXER_FREE_RESPONSE_CHANNELS
+    description: "Comma-separated channel IDs where Fluxer responds without mention"
+    prompt: "Free-response channel IDs"
+    password: false
+  - name: FLUXER_ALLOWED_CHANNELS
+    description: "Comma-separated channel IDs where Fluxer is allowed to respond; empty means all"
+    prompt: "Allowed channel IDs"
+    password: false
+  - name: FLUXER_MENTION_PATTERNS
+    description: "Comma-separated regexes that count as direct bot mentions"
+    prompt: "Mention regex patterns"
+    password: false
+  - name: FLUXER_ALLOW_MENTION_EVERYONE
+    description: "Permit outbound @everyone/@here mentions instead of neutralizing them"
+    prompt: "Allow @everyone/@here?"
+    password: false
+  - name: FLUXER_ALLOW_MENTION_ROLES
+    description: "Permit outbound Fluxer role mentions instead of neutralizing them"
+    prompt: "Allow role mentions?"
+    password: false
+  - name: FLUXER_ALLOW_MENTION_USERS
+    description: "Permit outbound user mentions"
+    prompt: "Allow user mentions?"
+    password: false
+  - name: FLUXER_ALLOW_MENTION_REPLIED_USER
+    description: "Permit reply notifications to the replied-to user when Fluxer supports allowed_mentions"
+    prompt: "Mention replied user?"
+    password: false
+  - name: FLUXER_DELIVERY_VERIFICATION
+    description: "Read back sent/edited messages to verify delivery when possible"
+    prompt: "Enable delivery verification?"
+    password: false
+  - name: FLUXER_REGISTER_NATIVE_COMMANDS
+    description: "Register Hermes slash commands with Fluxer on gateway connect"
+    prompt: "Register native Fluxer slash commands?"
+    password: false
+  - name: FLUXER_APPLICATION_ID
+    description: "Fluxer application ID for native command registration; defaults to token prefix"
+    prompt: "Fluxer application ID"
+    password: false
+  - name: FLUXER_NATIVE_COMMAND_GUILDS
+    description: "Comma-separated guild IDs for guild-scoped command registration; empty means global"
+    prompt: "Native command guild IDs"
     password: false

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -6,8 +6,10 @@ description: >
   Fluxer gateway adapter for Hermes Agent. Native Fluxer integration using
   Fluxer's bot REST API for outbound messages, Gateway WebSocket events for
   inbound dispatches, message edits, reactions, pins, reply references,
-  media delivery, and channel-directory enumeration. Component buttons,
-  native slash commands, and Discord-style threads are deployment-dependent.
+  media delivery, and channel-directory enumeration. Component buttons are
+  deployment-dependent and approval prompts include visible slash-command
+  fallback text; native slash commands and Discord-style threads are also
+  deployment-dependent.
 author: Hermes Agent
 requires_env:
   - name: FLUXER_BOT_TOKEN

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -65,6 +65,22 @@ optional_env:
     description: "Comma-separated channel IDs where Fluxer responds without mention"
     prompt: "Free-response channel IDs"
     password: false
+  - name: FLUXER_HOME_GUILD_ID
+    description: "Fluxer guild/community ID treated as the user's home Hermes workspace"
+    prompt: "Home guild ID"
+    password: false
+  - name: FLUXER_HOME_GUILDS
+    description: "Comma-separated Fluxer guild/community IDs treated as home Hermes workspaces"
+    prompt: "Home guild IDs"
+    password: false
+  - name: FLUXER_AUTO_FREE_RESPONSE_HOME_GUILD
+    description: "Respond without mention in channels inside configured home guilds (true/false)"
+    prompt: "Auto free-response in home guilds?"
+    password: false
+  - name: FLUXER_MENTION_GATED_CHANNELS
+    description: "Comma-separated channel IDs that still require mentions even in auto-free-response home guilds"
+    prompt: "Mention-gated channel IDs"
+    password: false
   - name: FLUXER_ALLOWED_CHANNELS
     description: "Comma-separated channel IDs where Fluxer is allowed to respond; empty means all"
     prompt: "Allowed channel IDs"

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -8,15 +8,15 @@ description: >
   for inbound MESSAGE_CREATE dispatches.
 author: Hermes Agent
 requires_env:
-  - name: FLUXER_BASE_URL
-    description: "Fluxer API base URL, e.g. https://fluxer.example/api or https://fluxer.example"
-    prompt: "Fluxer base URL"
-    password: false
   - name: FLUXER_BOT_TOKEN
     description: "Fluxer bot token (<applicationId>.<secret>)"
     prompt: "Fluxer bot token"
     password: true
 optional_env:
+  - name: FLUXER_BASE_URL
+    description: "Fluxer API base URL for self-hosted instances; defaults to https://api.fluxer.app/v1"
+    prompt: "Fluxer base URL"
+    password: false
   - name: FLUXER_ALLOWED_USERS
     description: "Comma-separated Fluxer user IDs allowed to talk to the bot"
     prompt: "Allowed Fluxer user IDs"

--- a/plugins/platforms/fluxer/plugin.yaml
+++ b/plugins/platforms/fluxer/plugin.yaml
@@ -5,8 +5,9 @@ version: 0.1.0
 description: >
   Fluxer gateway adapter for Hermes Agent. Native Fluxer integration using
   Fluxer's bot REST API for outbound messages, Gateway WebSocket events for
-  inbound dispatches, native components, slash-command interactions, pins,
-  threads, and channel-directory enumeration.
+  inbound dispatches, message edits, reactions, pins, reply references,
+  media delivery, and channel-directory enumeration. Component buttons,
+  native slash commands, and Discord-style threads are deployment-dependent.
 author: Hermes Agent
 requires_env:
   - name: FLUXER_BOT_TOKEN

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "116314616+ThyFriendlyFox@users.noreply.github.com": "ThyFriendlyFox",
     "liliangjya@gmail.com": "truenorth-lj",
     "16943149+nepenth@users.noreply.github.com": "nepenth",
+    "elkimek@users.noreply.github.com": "elkimek",
     "ben.bartholomew@vectorize.io": "benfrank241",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",
     "subw3@mail2.sysu.edu.cn": "Subway2023",

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -49,6 +49,27 @@ class TestLoadDirectory:
 
 
 class TestBuildChannelDirectoryWrites:
+    def test_uses_adapter_channel_directory_hook_for_plugin_platforms(self, tmp_path):
+        class PluginPlatform:
+            value = "fluxer"
+
+        adapter = SimpleNamespace(
+            list_channels=AsyncMock(return_value=[
+                {"id": "chan-1", "name": "general", "guild": "Fluxer Guild", "type": "channel"},
+                {"id": "thread-1", "name": "Support thread", "guild": "Fluxer Guild", "type": "thread", "parent_id": "chan-1"},
+            ])
+        )
+        cache_file = tmp_path / "channel_directory.json"
+
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            directory = asyncio.run(build_channel_directory({PluginPlatform(): adapter}))
+
+        assert directory["platforms"]["fluxer"] == [
+            {"id": "chan-1", "name": "general", "guild": "Fluxer Guild", "type": "channel"},
+            {"id": "thread-1", "name": "Support thread", "guild": "Fluxer Guild", "type": "thread", "parent_id": "chan-1"},
+        ]
+        adapter.list_channels.assert_awaited_once()
+
     def test_failed_write_preserves_previous_cache(self, tmp_path, monkeypatch):
         cache_file = _write_directory(tmp_path, {
             "telegram": [{"id": "123", "name": "Alice", "type": "dm"}]

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -1596,6 +1596,46 @@ async def test_home_channel_is_free_response_even_with_require_mention(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_configured_free_response_channel_is_conversational(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "base_url": "https://fluxer.example",
+                "bot_token": "app.secret",
+                "free_response_channels": ["bot-room"],
+            },
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-free",
+                "channel_id": "bot-room",
+                "channel_type": "channel",
+                "content": "follow-up without tagging the bot",
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
+            },
+        }
+    )
+
+    assert len(seen) == 1
+    assert seen[0].text == "follow-up without tagging the bot"
+    assert seen[0].source.chat_type == "channel"
+
+
+@pytest.mark.asyncio
 async def test_message_create_dispatches_image_attachment(monkeypatch):
     from gateway.config import PlatformConfig
     from gateway.platforms.base import MessageType

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -7,6 +7,7 @@ surface stabilizes.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -22,6 +23,36 @@ is_connected = _fluxer.is_connected
 register = _fluxer.register
 _env_enablement = _fluxer._env_enablement
 _build_identify_payload = _fluxer._build_identify_payload
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fluxer_env(monkeypatch):
+    """Keep Fluxer unit tests deterministic on dogfood machines with live env."""
+    for key in (
+        "FLUXER_BASE_URL",
+        "FLUXER_BOT_TOKEN",
+        "FLUXER_GATEWAY_URL",
+        "FLUXER_HOME_CHANNEL",
+        "FLUXER_ALLOWED_USERS",
+        "FLUXER_ALLOW_ALL_USERS",
+        "FLUXER_BACKLOG_RECOVERY",
+        "FLUXER_BACKLOG_LIMIT",
+        "FLUXER_BACKLOG_BOOTSTRAP_SECONDS",
+        "FLUXER_DELIVERY_VERIFICATION",
+        "FLUXER_ALLOW_MENTION_EVERYONE",
+        "FLUXER_ALLOW_MENTION_ROLES",
+        "FLUXER_ALLOW_MENTION_USERS",
+        "FLUXER_ALLOW_MENTION_REPLIED_USER",
+        "FLUXER_REQUIRE_MENTION",
+        "FLUXER_STRICT_MENTION",
+        "FLUXER_FREE_RESPONSE_CHANNELS",
+        "FLUXER_ALLOWED_CHANNELS",
+        "FLUXER_MENTION_PATTERNS",
+        "FLUXER_REGISTER_NATIVE_COMMANDS",
+        "FLUXER_APPLICATION_ID",
+        "FLUXER_NATIVE_COMMAND_GUILDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 def test_platform_enum_resolves_via_plugin_scan():
@@ -159,17 +190,23 @@ async def test_send_posts_channel_message_and_reply_reference(monkeypatch):
             extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
         )
     )
-    adapter._request = AsyncMock(return_value={"id": "msg-1"})
+    adapter._request = AsyncMock(side_effect=[{"id": "msg-1"}, {"id": "msg-1", "content": "Hello, Fluxer!"}])
 
     result = await adapter.send("chan-1", "Hello, Fluxer!", reply_to="msg-0")
 
-    adapter._request.assert_awaited_once_with(
-        "POST",
-        "/channels/chan-1/messages",
-        json={"content": "Hello, Fluxer!", "message_reference": {"message_id": "msg-0"}},
-    )
+    first_call = adapter._request.await_args_list[0]
+    assert first_call.args == ("POST", "/channels/chan-1/messages")
+    assert first_call.kwargs == {
+        "json": {
+            "content": "Hello, Fluxer!",
+            "allowed_mentions": {"parse": ["users"], "replied_user": True},
+            "message_reference": {"message_id": "msg-0"},
+        }
+    }
+    assert adapter._request.await_args_list[1].args == ("GET", "/channels/chan-1/messages/msg-1")
     assert result.success is True
     assert result.message_id == "msg-1"
+    assert result.raw_response["responses"][0]["delivery_verified"] is True
 
 
 @pytest.mark.asyncio
@@ -182,20 +219,73 @@ async def test_send_splits_long_channel_messages(monkeypatch):
             extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
         )
     )
-    adapter._request = AsyncMock(side_effect=[{"id": "msg-1"}, {"id": "msg-2"}])
+    first_chunk = "a" * 4000
+    second_chunk = "a" * 500
+    adapter._request = AsyncMock(
+        side_effect=[
+            {"id": "msg-1"},
+            {"id": "msg-1", "content": first_chunk},
+            {"id": "msg-2"},
+            {"id": "msg-2", "content": second_chunk},
+        ]
+    )
 
     result = await adapter.send("chan-1", "a" * 4500, reply_to="msg-0")
 
     assert result.success is True
     assert result.message_id == "msg-1"
     assert result.raw_response["message_ids"] == ["msg-1", "msg-2"]
-    assert adapter._request.await_count == 2
+    assert adapter._request.await_count == 4
     first = adapter._request.await_args_list[0]
-    second = adapter._request.await_args_list[1]
+    second = adapter._request.await_args_list[2]
     assert first.kwargs["json"]["message_reference"] == {"message_id": "msg-0"}
     assert len(first.kwargs["json"]["content"]) <= 4000
     assert "message_reference" not in second.kwargs["json"]
     assert len(second.kwargs["json"]["content"]) <= 4000
+
+
+@pytest.mark.asyncio
+async def test_send_neutralizes_global_and_role_mentions_by_default(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(return_value={"id": "msg-1"})
+
+    result = await adapter.send("chan-1", "Careful @everyone <@&123> <@456>")
+
+    assert result.success is True
+    payload = adapter._request.await_args_list[0].kwargs["json"]
+    assert payload["content"] == "Careful @\u200beveryone <@\u200b&123> <@456>"
+    assert payload["allowed_mentions"] == {"parse": ["users"], "replied_user": True}
+
+
+@pytest.mark.asyncio
+async def test_send_can_disable_user_mentions_too(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "base_url": "https://fluxer.example",
+                "bot_token": "app.secret",
+                "allow_mention_users": False,
+            },
+        )
+    )
+    adapter._request = AsyncMock(return_value={"id": "msg-1"})
+
+    result = await adapter.send("chan-1", "Hi <@456> and <@!789>")
+
+    assert result.success is True
+    payload = adapter._request.await_args_list[0].kwargs["json"]
+    assert payload["content"] == "Hi <@\u200b456> and <@\u200b!789>"
+    assert payload["allowed_mentions"] == {"parse": [], "replied_user": True}
 
 
 @pytest.mark.asyncio
@@ -223,6 +313,7 @@ async def test_send_image_file_posts_multipart_payload(tmp_path, monkeypatch):
     kwargs = call.kwargs
     assert path == "/channels/chan-1/messages"
     assert kwargs["payload"]["content"] == "look"
+    assert kwargs["payload"]["allowed_mentions"] == {"parse": ["users"], "replied_user": True}
     assert kwargs["payload"]["attachments"] == [{"id": 0, "filename": "zofka.png", "title": "zofka.png"}]
     assert kwargs["files"] == [("files[0]", image.resolve(), "zofka.png")]
 
@@ -248,6 +339,7 @@ async def test_send_voice_marks_fluxer_voice_message(tmp_path, monkeypatch):
     assert call is not None
     kwargs = call.kwargs
     assert "content" not in kwargs["payload"]
+    assert kwargs["payload"]["allowed_mentions"] == {"parse": ["users"], "replied_user": True}
     assert kwargs["payload"]["flags"] == 1 << 13
     assert kwargs["payload"]["attachments"] == [
         {"id": 0, "filename": "reply.mp3", "title": "reply.mp3", "duration": 3, "waveform": "AAAA"}
@@ -292,6 +384,964 @@ async def test_send_reports_retryable_error_on_request_failure(monkeypatch):
     assert result.success is False
     assert "network down" in result.error
     assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_list_channels_enumerates_guild_channels_and_active_threads(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(
+        side_effect=[
+            [{"id": "guild-1", "name": "Guild One"}],
+            [
+                {"id": "cat-1", "name": "Ops", "type": 4},
+                {"id": "chan-1", "name": "general", "type": 0},
+                {"id": "forum-1", "name": "ideas", "type": 15},
+            ],
+            {"threads": [{"id": "thread-1", "name": "Native thread", "parent_id": "chan-1", "type": 11}]},
+        ]
+    )
+
+    channels = await adapter.list_channels()
+
+    assert channels == [
+        {"id": "chan-1", "name": "general", "guild": "Guild One", "guild_id": "guild-1", "type": "channel"},
+        {"id": "forum-1", "name": "ideas", "guild": "Guild One", "guild_id": "guild-1", "type": "forum"},
+        {"id": "thread-1", "name": "Native thread", "guild": "Guild One", "guild_id": "guild-1", "type": "thread", "parent_id": "chan-1"},
+    ]
+    assert adapter._request.await_args_list[0].args == ("GET", "/users/@me/guilds")
+    assert adapter._request.await_args_list[1].args == ("GET", "/guilds/guild-1/channels")
+    assert adapter._request.await_args_list[2].args == ("GET", "/guilds/guild-1/threads/active")
+    assert adapter._request.await_args_list[2].kwargs == {"warn_on_error": False}
+
+
+@pytest.mark.asyncio
+async def test_list_channels_treats_active_thread_listing_as_optional(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(
+        side_effect=[
+            [{"id": "guild-1", "name": "Guild One"}],
+            [{"id": "chan-1", "name": "general", "type": 0}],
+            RuntimeError("404 Not found"),
+        ]
+    )
+
+    channels = await adapter.list_channels()
+
+    assert channels == [
+        {"id": "chan-1", "name": "general", "guild": "Guild One", "guild_id": "guild-1", "type": "channel"},
+    ]
+    assert adapter._request.await_args_list[2].args == ("GET", "/guilds/guild-1/threads/active")
+    assert adapter._request.await_args_list[2].kwargs == {"warn_on_error": False}
+
+
+@pytest.mark.asyncio
+async def test_request_can_suppress_expected_rest_warning(monkeypatch, caplog):
+    import httpx
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, method, url, headers=None, **kwargs):
+            request = httpx.Request(method, url)
+            return httpx.Response(404, json={"message": "Not found."}, request=request)
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter._request("GET", "/guilds/guild-1/threads/active", warn_on_error=False)
+
+    assert "Fluxer REST GET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_create_thread_from_message_uses_fluxer_thread_route(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(return_value={"id": "thread-1", "name": "Question"})
+
+    result = await adapter.create_thread("chan-1", "Question", message_id="msg-1")
+
+    assert result["id"] == "thread-1"
+    adapter._request.assert_awaited_once_with(
+        "POST",
+        "/channels/chan-1/messages/msg-1/threads",
+        json={"name": "Question", "auto_archive_duration": 1440, "rate_limit_per_user": 0},
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_posts_native_buttons_and_tracks_pending(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._request = AsyncMock(return_value={"id": "approval-1"})
+
+    result = await adapter.send_exec_approval(
+        "chan-1",
+        "rm -rf /important",
+        "agent:main:fluxer:channel:chan-1",
+        description="dangerous deletion",
+    )
+
+    assert result.success is True
+    assert result.message_id == "approval-1"
+    assert "approval-1" in adapter._pending_exec_approvals
+    first_call = adapter._request.await_args_list[0]
+    assert first_call.args == ("POST", "/channels/chan-1/messages")
+    payload = first_call.kwargs["json"]
+    assert "rm -rf /important" in payload["content"]
+    buttons = payload["components"][0]["components"]
+    assert [button["label"] for button in buttons] == ["Allow once", "Session", "Always", "Deny"]
+    assert [button["style"] for button in buttons] == [3, 1, 2, 4]
+    assert len(adapter._pending_component_actions) == 4
+    assert {state["choice"] for state in adapter._pending_component_actions.values()} == {"once", "session", "always", "deny"}
+
+
+@pytest.mark.asyncio
+async def test_component_interaction_resolves_pending_exec_approval(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._pending_exec_approvals["approval-1"] = {
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "content": "approval text",
+        "resolved": False,
+    }
+    adapter._pending_component_actions["approve-session"] = {
+        "kind": "exec_approval",
+        "message_id": "approval-1",
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "choice": "session",
+    }
+    resolved = []
+    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
+    adapter._request = AsyncMock(return_value={})
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "INTERACTION_CREATE",
+            "d": {
+                "id": "interaction-1",
+                "token": "tok-1",
+                "type": 3,
+                "channel_id": "chan-1",
+                "message": {"id": "approval-1"},
+                "data": {"custom_id": "approve-session", "component_type": 2},
+                "member": {"user": {"id": "user-1", "bot": False}},
+            },
+        }
+    )
+
+    assert resolved == [("session-1", "session")]
+    assert "approval-1" not in adapter._pending_exec_approvals
+    assert "approve-session" not in adapter._pending_component_actions
+    call = adapter._request.await_args
+    assert call is not None
+    assert call.args == ("POST", "/interactions/interaction-1/tok-1/callback")
+
+
+@pytest.mark.asyncio
+async def test_component_interaction_ignores_unauthorized_without_consuming_action(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._pending_component_actions["approve-session"] = {
+        "kind": "exec_approval",
+        "message_id": "approval-1",
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "choice": "session",
+    }
+
+    await adapter._handle_component_interaction(
+        {
+            "id": "interaction-1",
+            "token": "tok-1",
+            "type": 3,
+            "channel_id": "chan-1",
+            "message": {"id": "approval-1"},
+            "data": {"custom_id": "approve-session", "component_type": 2},
+            "member": {"user": {"id": "intruder", "bot": False}},
+        }
+    )
+
+    assert "approve-session" in adapter._pending_component_actions
+
+
+@pytest.mark.asyncio
+async def test_component_interaction_rejects_mismatched_message_or_channel(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._pending_component_actions["approve-session"] = {
+        "kind": "exec_approval",
+        "message_id": "approval-1",
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "choice": "session",
+    }
+
+    await adapter._handle_component_interaction(
+        {
+            "id": "interaction-1",
+            "token": "tok-1",
+            "type": 3,
+            "channel_id": "other-chan",
+            "message": {"id": "approval-1"},
+            "data": {"custom_id": "approve-session", "component_type": 2},
+            "member": {"user": {"id": "user-1", "bot": False}},
+        }
+    )
+
+    assert "approve-session" in adapter._pending_component_actions
+
+
+@pytest.mark.asyncio
+async def test_attachment_download_omits_auth_for_off_origin_urls(monkeypatch):
+    import httpx
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+    captured = {}
+
+    class FakeResponse:
+        content = b"ok"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers or {}
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    data = await adapter._download_attachment_bytes("https://example.com/file.txt")
+
+    assert data == b"ok"
+    assert "Authorization" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_unsafe_attachment_url_is_dropped(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+
+    cached, content_type = await adapter._cache_attachment(
+        {"url": "http://127.0.0.1:8080/secret.txt", "filename": "secret.txt", "content_type": "text/plain"}
+    )
+
+    assert cached is None
+    assert content_type is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_hello_starts_heartbeat_even_before_mark_connected(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"})
+    )
+
+    class FakeWS:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, payload):
+            self.sent.append(payload)
+
+    adapter._ws = FakeWS()
+    monkeypatch.setattr(asyncio, "create_task", lambda coro, name=None: asyncio.ensure_future(coro))
+
+    await adapter._handle_gateway_dispatch({"op": 10, "d": {"heartbeat_interval": 60000}})
+    await asyncio.sleep(0)
+
+    assert adapter._heartbeat_task is not None
+    assert not adapter._heartbeat_task.done()
+    adapter._heartbeat_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_register_native_commands_bulk_upserts_guild_slash_commands(monkeypatch):
+    from gateway.config import PlatformConfig
+    from hermes_cli.commands import CommandDef
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(return_value=[{"id": "cmd-1"}])
+
+    result = await adapter.register_native_commands(
+        "app-1",
+        guild_id="guild-1",
+        commands=[CommandDef("model", "Choose model", "Config", args_hint="<model>")],
+    )
+
+    assert result == [{"id": "cmd-1"}]
+    adapter._request.assert_awaited_once_with(
+        "PUT",
+        "/applications/app-1/guilds/guild-1/commands",
+        json=[
+            {
+                "name": "model",
+                "description": "Choose model",
+                "type": 1,
+                "options": [{"type": 3, "name": "args", "description": "<model>", "required": False}],
+            }
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_create_event_tracks_known_thread_channel(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"})
+    )
+
+    await adapter._handle_gateway_dispatch({"op": 0, "t": "THREAD_CREATE", "d": {"id": "thread-1", "parent_id": "chan-1", "name": "Native"}})
+
+    assert "thread-1" in adapter._known_channel_ids
+
+
+@pytest.mark.asyncio
+async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(return_value={"id": "confirm-msg"})
+
+    result = await adapter.send_slash_confirm(
+        "chan-1",
+        "Reload MCP?",
+        "This reload may invalidate caches.",
+        "session-1",
+        "confirm-1",
+    )
+
+    assert result.success is True
+    call = adapter._request.await_args
+    assert call is not None
+    payload = call.kwargs["json"]
+    assert "Reload MCP?" in payload["content"]
+    assert [button["label"] for button in payload["components"][0]["components"]] == ["Approve once", "Always approve", "Cancel"]
+    assert {state["kind"] for state in adapter._pending_component_actions.values()} == {"slash_confirm"}
+
+
+@pytest.mark.asyncio
+async def test_application_command_interaction_dispatches_slash_text(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(return_value={})
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "INTERACTION_CREATE",
+            "d": {
+                "id": "interaction-1",
+                "token": "tok-1",
+                "type": 2,
+                "channel_id": "chan-1",
+                "guild_id": "guild-1",
+                "channel": {"id": "chan-1", "name": "bot-home", "type": 0},
+                "member": {"user": {"id": "user-1", "username": "Elkim", "bot": False}},
+                "data": {"name": "model", "options": [{"name": "model", "value": "gpt-5.5"}]},
+            },
+        }
+    )
+
+    assert [event.text for event in seen] == ["/model gpt-5.5"]
+    assert seen[0].source.chat_id == "chan-1"
+    adapter._request.assert_awaited_once_with(
+        "POST",
+        "/interactions/interaction-1/tok-1/callback",
+        json={"type": 5, "data": {"flags": 64}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_reaction_add_resolves_pending_exec_approval(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._pending_exec_approvals["approval-1"] = {
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "content": "approval text",
+        "resolved": False,
+    }
+    resolved = []
+    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
+    adapter.edit_message = AsyncMock(return_value=type("Result", (), {"success": True})())
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_REACTION_ADD",
+            "d": {
+                "message_id": "approval-1",
+                "channel_id": "chan-1",
+                "user_id": "user-1",
+                "emoji": {"name": "✅"},
+                "member": {"user": {"id": "user-1", "bot": False}},
+            },
+        }
+    )
+
+    assert resolved == [("session-1", "once")]
+    assert "approval-1" not in adapter._pending_exec_approvals
+    adapter.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_message_update_refreshes_pending_exec_approval_content(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._pending_exec_approvals["approval-1"] = {
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "content": "old approval text",
+        "resolved": False,
+    }
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_UPDATE",
+            "d": {"id": "approval-1", "content": "edited approval text"},
+        }
+    )
+
+    assert adapter._pending_exec_approvals["approval-1"]["content"] == "edited approval text"
+
+
+@pytest.mark.asyncio
+async def test_message_delete_denies_pending_exec_approval(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._seen_message_ids.add("approval-1")
+    adapter._pending_exec_approvals["approval-1"] = {
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "content": "approval text",
+        "resolved": False,
+    }
+    resolved = []
+    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
+
+    await adapter._handle_gateway_dispatch(
+        {"op": 0, "t": "MESSAGE_DELETE", "d": {"id": "approval-1", "channel_id": "chan-1"}}
+    )
+
+    assert resolved == [("session-1", "deny")]
+    assert "approval-1" not in adapter._pending_exec_approvals
+    assert "approval-1" not in adapter._seen_message_ids
+
+
+@pytest.mark.asyncio
+async def test_message_delete_for_non_approval_only_clears_seen_id(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._seen_message_ids.add("msg-1")
+    resolved = []
+    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
+
+    await adapter._handle_gateway_dispatch(
+        {"op": 0, "t": "MESSAGE_DELETE", "d": {"id": "msg-1", "channel_id": "chan-1"}}
+    )
+
+    assert resolved == []
+    assert "msg-1" not in adapter._seen_message_ids
+
+
+@pytest.mark.asyncio
+async def test_reaction_add_ignores_unauthorized_or_bot_users(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._pending_exec_approvals["approval-1"] = {"session_key": "session-1", "channel_id": "chan-1", "resolved": False}
+    resolved = []
+    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
+
+    await adapter._handle_reaction_add(
+        {
+            "message_id": "approval-1",
+            "channel_id": "chan-1",
+            "user_id": "user-2",
+            "emoji": {"name": "❌"},
+            "member": {"user": {"id": "user-2", "bot": False}},
+        }
+    )
+    await adapter._handle_reaction_add(
+        {
+            "message_id": "approval-1",
+            "channel_id": "chan-1",
+            "user_id": "user-1",
+            "emoji": {"name": "❌"},
+            "member": {"user": {"id": "user-1", "bot": True}},
+        }
+    )
+
+    assert resolved == []
+    assert "approval-1" in adapter._pending_exec_approvals
+
+
+@pytest.mark.asyncio
+async def test_edit_message_uses_fluxer_patch_endpoint(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(side_effect=[{"id": "msg-1", "content": "updated"}, {"id": "msg-1", "content": "updated"}])
+
+    result = await adapter.edit_message("chan-1", "msg-1", "updated")
+
+    assert result.success is True
+    assert result.message_id == "msg-1"
+    first_call = adapter._request.await_args_list[0]
+    assert first_call.args == ("PATCH", "/channels/chan-1/messages/msg-1")
+    assert first_call.kwargs == {"json": {"content": "updated", "allowed_mentions": {"parse": ["users"], "replied_user": True}}}
+    assert adapter._request.await_args_list[1].args == ("GET", "/channels/chan-1/messages/msg-1")
+    assert result.raw_response["delivery_verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_message_truncates_to_fluxer_limit(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(side_effect=[{"id": "msg-1"}, {"id": "msg-1", "content": "a" * 3997 + "..."}])
+
+    result = await adapter.edit_message("chan-1", "msg-1", "a" * 4500)
+
+    assert result.success is True
+    call = adapter._request.await_args_list[0]
+    payload = call.kwargs["json"]
+    assert len(payload["content"]) == 4000
+    assert payload["content"].endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_delete_message_uses_fluxer_delete_endpoint(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(return_value={})
+
+    assert await adapter.delete_message("chan-1", "msg-1") is True
+    adapter._request.assert_awaited_once_with("DELETE", "/channels/chan-1/messages/msg-1")
+
+
+@pytest.mark.asyncio
+async def test_pin_helpers_use_fluxer_discord_shaped_pin_routes(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(side_effect=[{"items": [{"id": "msg-1"}], "has_more": False}, {}, {}])
+
+    pins = await adapter.list_pinned_messages("chan-1")
+    pinned = await adapter.pin_message("chan-1", "msg-1")
+    unpinned = await adapter.unpin_message("chan-1", "msg-1")
+
+    assert pins == [{"id": "msg-1"}]
+    assert pinned is True
+    assert unpinned is True
+    assert adapter._request.await_args_list[0].args == ("GET", "/channels/chan-1/messages/pins")
+    assert adapter._request.await_args_list[1].args == ("PUT", "/channels/chan-1/messages/pins/msg-1")
+    assert adapter._request.await_args_list[2].args == ("DELETE", "/channels/chan-1/messages/pins/msg-1")
+
+
+@pytest.mark.asyncio
+async def test_list_pinned_messages_accepts_bare_list_response(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(enabled=True, extra={"base_url": "https://api.fluxer.test/v1", "bot_token": "app.secret"})
+    )
+    adapter._request = AsyncMock(return_value=[{"id": "msg-1"}])
+
+    assert await adapter.list_pinned_messages("chan-1") == [{"id": "msg-1"}]
+
+
+@pytest.mark.asyncio
+async def test_send_typing_starts_persistent_fluxer_typing_loop(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(return_value={})
+    sleep_calls = 0
+
+    async def fake_sleep(_seconds):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError()
+
+    with patch("asyncio.sleep", new=fake_sleep):
+        await adapter.send_typing("chan-1")
+        task = adapter._typing_tasks.get("chan-1")
+        assert task is not None
+        await task
+
+    assert adapter._request.await_count == 2
+    adapter._request.assert_any_await("POST", "/channels/chan-1/typing", json={})
+    assert "chan-1" not in adapter._typing_tasks
+
+
+@pytest.mark.asyncio
+async def test_send_typing_dedupes_and_stop_typing_cancels(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    blocker = asyncio.Event()
+    adapter._request = AsyncMock(return_value={})
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(_seconds):
+        await blocker.wait()
+
+    with patch("asyncio.sleep", new=fake_sleep):
+        await adapter.send_typing("chan-1")
+        first_task = adapter._typing_tasks.get("chan-1")
+        await adapter.send_typing("chan-1")
+        assert adapter._typing_tasks.get("chan-1") is first_task
+        await real_sleep(0)
+        await adapter.stop_typing("chan-1")
+
+    assert "chan-1" not in adapter._typing_tasks
+
+
+@pytest.mark.asyncio
+async def test_backlog_recovery_fetches_home_channel_and_dispatches_recent_messages(monkeypatch):
+    from gateway.config import HomeChannel, Platform, PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(platform=Platform("fluxer"), chat_id="chan-1", name="Fluxer Home"),
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+    adapter._request = AsyncMock(
+        return_value={
+            "messages": [
+                {
+                    "id": "old-msg",
+                    "content": "too old",
+                    "created_at": "2026-06-01T09:59:00Z",
+                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                },
+                {
+                    "id": "new-msg",
+                    "content": "recover me",
+                    "created_at": "2026-06-01T10:00:30Z",
+                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                },
+            ]
+        }
+    )
+
+    await adapter._recover_backlog(cutoff=_fluxer._parse_fluxer_timestamp("2026-06-01T10:00:00Z"))
+
+    adapter._request.assert_awaited_once_with("GET", "/channels/chan-1/messages", params={"limit": 25})
+    assert [event.message_id for event in seen] == ["new-msg"]
+    assert seen[0].text == "recover me"
+    assert seen[0].source.chat_id == "chan-1"
+
+
+@pytest.mark.asyncio
+async def test_backlog_recovery_dedupes_seen_messages(monkeypatch):
+    from gateway.config import HomeChannel, Platform, PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(platform=Platform("fluxer"), chat_id="chan-1", name="Fluxer Home"),
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._seen_message_ids.add("msg-1")
+    adapter.handle_message = AsyncMock()
+    adapter._request = AsyncMock(
+        return_value=[
+            {
+                "id": "msg-1",
+                "channel_id": "chan-1",
+                "content": "already handled",
+                "created_at": "2026-06-01T10:00:30Z",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+            }
+        ]
+    )
+
+    await adapter._recover_backlog(cutoff=_fluxer._parse_fluxer_timestamp("2026-06-01T10:00:00Z"))
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_hello_identifies_and_sends_immediate_heartbeat(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+
+    class FakeWS:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, payload):
+            self.sent.append(payload)
+
+    ws = FakeWS()
+    adapter._ws = ws
+    adapter._mark_connected()
+    monkeypatch.setattr(asyncio, "create_task", lambda coro, name=None: asyncio.ensure_future(coro))
+
+    await adapter._handle_gateway_dispatch({"op": 10, "d": {"heartbeat_interval": 60000}})
+
+    assert len(ws.sent) == 2
+    assert '"op": 2' in ws.sent[0]
+    assert '"op": 1' in ws.sent[1]
+    assert adapter._awaiting_heartbeat_ack is True
+    assert adapter._heartbeat_task is not None
+    adapter._heartbeat_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_gateway_server_heartbeat_request_sends_heartbeat(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+
+    class FakeWS:
+        def __init__(self):
+            self.send = AsyncMock()
+
+    ws = FakeWS()
+    adapter._ws = ws
+    adapter._last_seq = 7
+
+    await adapter._handle_gateway_dispatch({"op": 1})
+
+    ws.send.assert_awaited_once()
+    sent_payload = ws.send.await_args_list[0].args[0]
+    assert '"op": 1' in sent_payload
+    assert '"d": 7' in sent_payload
+
+
+@pytest.mark.asyncio
+async def test_gateway_heartbeat_ack_clears_pending_state(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._awaiting_heartbeat_ack = True
+
+    await adapter._handle_gateway_dispatch({"op": 11})
+
+    assert adapter._awaiting_heartbeat_ack is False
+    assert adapter._last_heartbeat_ack_at is not None
+
+
+@pytest.mark.asyncio
+async def test_gateway_reconnect_opcode_closes_websocket(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    class FakeWS:
+        def __init__(self):
+            self.close = AsyncMock()
+
+    ws = FakeWS()
+    adapter._ws = ws
+
+    await adapter._handle_gateway_dispatch({"op": 7, "d": {"reason": "server reconnect"}})
+
+    ws.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_listener_schedules_reconnect_on_clean_websocket_close(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    class EmptyWS:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._ws = EmptyWS()
+    adapter._mark_connected()
+    scheduled = []
+    adapter._schedule_reconnect = lambda reason: scheduled.append(reason)
+
+    await adapter._listen_loop()
+
+    assert adapter._running is False
+    assert scheduled == ["websocket closed"]
 
 
 @pytest.mark.asyncio
@@ -393,6 +1443,159 @@ async def test_message_create_dispatches_normalized_event(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_message_create_classifies_numeric_thread_channels_and_remembers_thread_mention(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "bot_user_id": "bot-1"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-1",
+                "channel_id": "thread-1",
+                "channel_type": 11,
+                "content": "<@bot-1> continue here",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+            },
+        }
+    )
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-2",
+                "channel_id": "thread-1",
+                "channel_type": 11,
+                "content": "follow-up without mention",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+            },
+        }
+    )
+
+    assert [event.source.chat_type for event in seen] == ["thread", "thread"]
+    assert [event.text for event in seen] == ["continue here", "follow-up without mention"]
+
+
+@pytest.mark.asyncio
+async def test_channel_message_requires_direct_mention_by_default(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "bot_user_id": "bot-1"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-quiet",
+                "channel_id": "chan-1",
+                "channel_type": "channel",
+                "content": "I think Hermes mentioned that yesterday",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+            },
+        }
+    )
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_channel_message_processes_and_strips_direct_address(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "bot_user_id": "bot-1"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-mention",
+                "channel_id": "chan-1",
+                "channel_type": "channel",
+                "content": "Hermes, check this please",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+            },
+        }
+    )
+
+    assert len(seen) == 1
+    assert seen[0].text == "check this please"
+
+
+@pytest.mark.asyncio
+async def test_home_channel_is_free_response_even_with_require_mention(monkeypatch):
+    from gateway.config import HomeChannel, Platform, PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(platform=Platform("fluxer"), chat_id="chan-1", name="Fluxer Home"),
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-home",
+                "channel_id": "chan-1",
+                "channel_type": "channel",
+                "content": "continue here",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+            },
+        }
+    )
+
+    assert len(seen) == 1
+    assert seen[0].text == "continue here"
+
+
+@pytest.mark.asyncio
 async def test_message_create_dispatches_image_attachment(monkeypatch):
     from gateway.config import PlatformConfig
     from gateway.platforms.base import MessageType
@@ -423,6 +1626,7 @@ async def test_message_create_dispatches_image_attachment(monkeypatch):
                 "d": {
                     "id": "msg-img",
                     "channel_id": "chan-1",
+                    "channel_type": "dm",
                     "content": "",
                     "author": {"id": "user-1", "username": "Elkim", "bot": False},
                     "attachments": [
@@ -480,6 +1684,7 @@ async def test_message_create_dispatches_voice_attachment_when_flagged(monkeypat
                 "d": {
                     "id": "msg-voice",
                     "channel_id": "chan-1",
+                    "channel_type": "dm",
                     "content": "",
                     "flags": 1 << 13,
                     "author": {"id": "user-1", "username": "Elkim", "bot": False},
@@ -500,6 +1705,82 @@ async def test_message_create_dispatches_voice_attachment_when_flagged(monkeypat
     assert event.message_type == MessageType.VOICE
     assert event.media_urls == ["/tmp/fluxer-voice.mp3"]
     assert event.media_types == ["audio/mpeg"]
+
+
+@pytest.mark.asyncio
+async def test_message_create_includes_embedded_reply_context(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-reply",
+                "channel_id": "chan-1",
+                "channel_type": "dm",
+                "content": "yes, do this",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "referenced_message": {"id": "msg-parent", "content": "Please check this file"},
+            },
+        }
+    )
+
+    assert len(seen) == 1
+    assert seen[0].reply_to_message_id == "msg-parent"
+    assert seen[0].reply_to_text == "Please check this file"
+
+
+@pytest.mark.asyncio
+async def test_message_create_fetches_reply_context_from_message_reference(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+    adapter._request = AsyncMock(return_value={"id": "msg-parent", "content": "Original quoted text"})
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-reply",
+                "channel_id": "chan-1",
+                "channel_type": "dm",
+                "content": "that one",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "message_reference": {"message_id": "msg-parent"},
+            },
+        }
+    )
+
+    adapter._request.assert_awaited_once_with("GET", "/channels/chan-1/messages/msg-parent")
+    assert len(seen) == 1
+    assert seen[0].reply_to_message_id == "msg-parent"
+    assert seen[0].reply_to_text == "Original quoted text"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -1666,6 +1666,49 @@ async def test_configured_free_response_channel_is_conversational(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_home_guild_channel_is_conversational_without_manual_channel_opt_in(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "base_url": "https://fluxer.example",
+                "bot_token": "app.secret",
+                "home_guild_id": "guild-home",
+                "auto_free_response_home_guild": True,
+            },
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-home-guild",
+                "channel_id": "new-project-room",
+                "guild_id": "guild-home",
+                "channel_type": "channel",
+                "content": "new channel should work without tagging",
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
+            },
+        }
+    )
+
+    assert len(seen) == 1
+    assert seen[0].text == "new channel should work without tagging"
+    assert seen[0].source.chat_id == "new-project-room"
+    assert seen[0].source.guild_id == "guild-home"
+
+
+@pytest.mark.asyncio
 async def test_message_create_dispatches_image_attachment(monkeypatch):
     from gateway.config import PlatformConfig
     from gateway.platforms.base import MessageType

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -1,0 +1,260 @@
+"""Tests for the Fluxer platform-plugin adapter.
+
+The Fluxer plugin is intentionally text-first here: REST send + Gateway
+MESSAGE_CREATE normalization. Rich media can layer on once Fluxer's self-hosting
+surface stabilizes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_fluxer = load_plugin_adapter("fluxer")
+
+FluxerAdapter = _fluxer.FluxerAdapter
+check_requirements = _fluxer.check_requirements
+validate_config = _fluxer.validate_config
+is_connected = _fluxer.is_connected
+register = _fluxer.register
+_env_enablement = _fluxer._env_enablement
+_build_identify_payload = _fluxer._build_identify_payload
+
+
+def test_platform_enum_resolves_via_plugin_scan():
+    from gateway.config import Platform
+
+    p = Platform("fluxer")
+    assert p.value == "fluxer"
+    assert Platform("fluxer") is p
+
+
+def test_check_requirements_needs_base_url_and_token(monkeypatch):
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+
+    assert check_requirements() is False
+
+
+def test_check_requirements_true_when_configured(monkeypatch):
+    monkeypatch.setenv("FLUXER_BASE_URL", "https://fluxer.example")
+    monkeypatch.setenv("FLUXER_BOT_TOKEN", "app.secret")
+
+    assert check_requirements() is True
+
+
+def test_validate_config_uses_env_or_extra(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+
+    assert validate_config(PlatformConfig(enabled=True)) is False
+    assert validate_config(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    ) is True
+
+
+def test_is_connected_mirrors_validate(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+
+    assert is_connected(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    ) is True
+    assert is_connected(PlatformConfig(enabled=True)) is False
+
+
+def test_env_enablement_none_when_unset(monkeypatch):
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+
+    assert _env_enablement() is None
+
+
+def test_env_enablement_seeds_config(monkeypatch):
+    monkeypatch.setenv("FLUXER_BASE_URL", "https://fluxer.example/")
+    monkeypatch.setenv("FLUXER_BOT_TOKEN", "app.secret")
+    monkeypatch.setenv("FLUXER_HOME_CHANNEL", "chan-1")
+    monkeypatch.setenv("FLUXER_HOME_CHANNEL_NAME", "Fluxer Home")
+
+    seed = _env_enablement()
+
+    assert seed["base_url"] == "https://fluxer.example/"
+    assert seed["bot_token"] == "app.secret"
+    assert seed["home_channel"] == {"chat_id": "chan-1", "name": "Fluxer Home"}
+
+
+def test_adapter_init_and_platform_identity(monkeypatch):
+    from gateway.config import Platform, PlatformConfig
+
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example/", "bot_token": "app.secret"},
+        )
+    )
+
+    assert adapter.base_url == "https://fluxer.example"
+    assert adapter.bot_token == "app.secret"
+    assert adapter.platform is Platform("fluxer")
+    assert adapter._running is False
+
+
+def test_build_identify_payload_contains_bot_token_and_client_properties():
+    payload = _build_identify_payload("app.secret")
+
+    assert payload["op"] == 2
+    assert payload["d"]["token"] == "app.secret"
+    assert payload["d"]["properties"]["browser"] == "hermes"
+    assert payload["d"]["properties"]["device"] == "hermes"
+
+
+@pytest.mark.asyncio
+async def test_send_posts_channel_message_and_reply_reference(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(return_value={"id": "msg-1"})
+
+    result = await adapter.send("chan-1", "Hello, Fluxer!", reply_to="msg-0")
+
+    adapter._request.assert_awaited_once_with(
+        "POST",
+        "/channels/chan-1/messages",
+        json={"content": "Hello, Fluxer!", "message_reference": {"message_id": "msg-0"}},
+    )
+    assert result.success is True
+    assert result.message_id == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_send_reports_retryable_error_on_request_failure(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(side_effect=RuntimeError("network down"))
+
+    result = await adapter.send("chan-1", "Hello")
+
+    assert result.success is False
+    assert "network down" in result.error
+    assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_message_create_dispatches_normalized_event(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "s": 42,
+            "d": {
+                "id": "msg-1",
+                "channel_id": "chan-1",
+                "channel_type": "dm",
+                "content": "morning",
+                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "guild_id": None,
+            },
+        }
+    )
+
+    assert len(seen) == 1
+    event = seen[0]
+    assert event.text == "morning"
+    assert event.message_id == "msg-1"
+    assert event.source.chat_id == "chan-1"
+    assert event.source.chat_type == "dm"
+    assert event.source.user_id == "user-1"
+    assert event.source.user_name == "Elkim"
+    assert event.source.message_id == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_message_create_ignores_own_bot_messages(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter.bot_user_id = "bot-1"
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-1",
+                "channel_id": "chan-1",
+                "content": "echo",
+                "author": {"id": "bot-1", "username": "Žofka", "bot": True},
+            },
+        }
+    )
+
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_register_metadata():
+    calls = []
+
+    class Ctx:
+        def register_platform(self, **kwargs):
+            calls.append(kwargs)
+
+    register(Ctx())
+
+    assert len(calls) == 1
+    entry = calls[0]
+    assert entry["name"] == "fluxer"
+    assert entry["label"] == "Fluxer"
+    assert entry["required_env"] == ["FLUXER_BASE_URL", "FLUXER_BOT_TOKEN"]
+    assert entry["allowed_users_env"] == "FLUXER_ALLOWED_USERS"
+    assert entry["allow_all_env"] == "FLUXER_ALLOW_ALL_USERS"
+    assert entry["cron_deliver_env_var"] == "FLUXER_HOME_CHANNEL"
+    assert entry["standalone_sender_fn"] is not None
+    assert entry["max_message_length"] >= 2000

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -7,7 +7,7 @@ surface stabilizes.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -173,6 +173,109 @@ async def test_send_posts_channel_message_and_reply_reference(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_splits_long_channel_messages(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._request = AsyncMock(side_effect=[{"id": "msg-1"}, {"id": "msg-2"}])
+
+    result = await adapter.send("chan-1", "a" * 4500, reply_to="msg-0")
+
+    assert result.success is True
+    assert result.message_id == "msg-1"
+    assert result.raw_response["message_ids"] == ["msg-1", "msg-2"]
+    assert adapter._request.await_count == 2
+    first = adapter._request.await_args_list[0]
+    second = adapter._request.await_args_list[1]
+    assert first.kwargs["json"]["message_reference"] == {"message_id": "msg-0"}
+    assert len(first.kwargs["json"]["content"]) <= 4000
+    assert "message_reference" not in second.kwargs["json"]
+    assert len(second.kwargs["json"]["content"]) <= 4000
+
+
+@pytest.mark.asyncio
+async def test_send_image_file_posts_multipart_payload(tmp_path, monkeypatch):
+    from gateway.config import PlatformConfig
+
+    image = tmp_path / "zofka.png"
+    image.write_bytes(b"png-data")
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._multipart_request = AsyncMock(return_value={"id": "msg-img"})
+
+    result = await adapter.send_image_file("chan-1", str(image), caption="look")
+
+    assert result.success is True
+    assert result.message_id == "msg-img"
+    adapter._multipart_request.assert_awaited_once()
+    call = adapter._multipart_request.await_args
+    assert call is not None
+    _, path = call.args
+    kwargs = call.kwargs
+    assert path == "/channels/chan-1/messages"
+    assert kwargs["payload"]["content"] == "look"
+    assert kwargs["payload"]["attachments"] == [{"id": 0, "filename": "zofka.png", "title": "zofka.png"}]
+    assert kwargs["files"] == [("files[0]", image.resolve(), "zofka.png")]
+
+
+@pytest.mark.asyncio
+async def test_send_voice_marks_fluxer_voice_message(tmp_path, monkeypatch):
+    from gateway.config import PlatformConfig
+
+    audio = tmp_path / "reply.mp3"
+    audio.write_bytes(b"mp3-data")
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    adapter._multipart_request = AsyncMock(return_value={"id": "msg-voice"})
+
+    result = await adapter.send_voice("chan-1", str(audio), caption="spoken", duration=3, waveform="AAAA")
+
+    assert result.success is True
+    call = adapter._multipart_request.await_args
+    assert call is not None
+    kwargs = call.kwargs
+    assert "content" not in kwargs["payload"]
+    assert kwargs["payload"]["flags"] == 1 << 13
+    assert kwargs["payload"]["attachments"] == [
+        {"id": 0, "filename": "reply.mp3", "title": "reply.mp3", "duration": 3, "waveform": "AAAA"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_routes_audio_as_voice(tmp_path, monkeypatch):
+    from gateway.config import PlatformConfig
+
+    audio = tmp_path / "reply.mp3"
+    audio.write_bytes(b"mp3-data")
+    pconfig = PlatformConfig(
+        enabled=True,
+        extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+    )
+
+    with patch.object(FluxerAdapter, "send_voice", new=AsyncMock(return_value=_fluxer.SendResult(success=True, message_id="msg-voice"))) as send_voice:
+        result = await _fluxer._standalone_send(pconfig, "chan-1", "", media_files=[str(audio)])
+
+    assert result == {"success": True, "platform": "fluxer", "chat_id": "chan-1", "message_id": "msg-voice"}
+    send_voice.assert_awaited_once()
+    call = send_voice.await_args
+    assert call is not None
+    assert call.args[:2] == ("chan-1", str(audio))
+
+
+@pytest.mark.asyncio
 async def test_send_reports_retryable_error_on_request_failure(monkeypatch):
     from gateway.config import PlatformConfig
 
@@ -233,6 +336,116 @@ async def test_message_create_dispatches_normalized_event(monkeypatch):
     assert event.source.user_id == "user-1"
     assert event.source.user_name == "Elkim"
     assert event.source.message_id == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_message_create_dispatches_image_attachment(monkeypatch):
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    with patch.object(
+        _fluxer,
+        "cache_image_from_url",
+        new=AsyncMock(return_value="/tmp/fluxer-image.jpg"),
+    ) as cache_image:
+        await adapter._handle_gateway_dispatch(
+            {
+                "op": 0,
+                "t": "MESSAGE_CREATE",
+                "s": 43,
+                "d": {
+                    "id": "msg-img",
+                    "channel_id": "chan-1",
+                    "content": "",
+                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                    "attachments": [
+                        {
+                            "id": "att-1",
+                            "filename": "photo.jpg",
+                            "content_type": "image/jpeg",
+                            "url": "https://fluxerusercontent.com/attachments/chan-1/att-1/photo.jpg",
+                        }
+                    ],
+                },
+            }
+        )
+
+    assert len(seen) == 1
+    event = seen[0]
+    assert event.text == ""
+    assert event.message_type == MessageType.PHOTO
+    assert event.media_urls == ["/tmp/fluxer-image.jpg"]
+    assert event.media_types == ["image/jpeg"]
+    cache_image.assert_awaited_once_with(
+        "https://fluxerusercontent.com/attachments/chan-1/att-1/photo.jpg",
+        ".jpg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_create_dispatches_voice_attachment_when_flagged(monkeypatch):
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+        )
+    )
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle
+
+    with patch.object(
+        _fluxer,
+        "cache_audio_from_url",
+        new=AsyncMock(return_value="/tmp/fluxer-voice.mp3"),
+    ):
+        await adapter._handle_gateway_dispatch(
+            {
+                "op": 0,
+                "t": "MESSAGE_CREATE",
+                "s": 44,
+                "d": {
+                    "id": "msg-voice",
+                    "channel_id": "chan-1",
+                    "content": "",
+                    "flags": 1 << 13,
+                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                    "attachments": [
+                        {
+                            "id": "att-voice",
+                            "filename": "voice.mp3",
+                            "content_type": "audio/mpeg",
+                            "url": "https://fluxerusercontent.com/attachments/chan-1/att-voice/voice.mp3",
+                        }
+                    ],
+                },
+            }
+        )
+
+    assert len(seen) == 1
+    event = seen[0]
+    assert event.message_type == MessageType.VOICE
+    assert event.media_urls == ["/tmp/fluxer-voice.mp3"]
+    assert event.media_types == ["audio/mpeg"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -521,7 +521,10 @@ async def test_send_exec_approval_posts_native_buttons_and_tracks_pending(monkey
     assert "rm -rf /important" in payload["content"]
     assert "Command approval required" in payload["content"]
     assert "⚠️" not in payload["content"]
-    assert "/approve" not in payload["content"]
+    assert "/approve once" in payload["content"]
+    assert "/approve session" in payload["content"]
+    assert "/approve always" in payload["content"]
+    assert "/deny" in payload["content"]
     buttons = payload["components"][0]["components"]
     assert [button["label"] for button in buttons] == ["Allow once", "Session", "Always", "Deny"]
     assert [button["style"] for button in buttons] == [3, 1, 2, 4]
@@ -793,8 +796,10 @@ async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
     assert call is not None
     payload = call.kwargs["json"]
     assert "Reload MCP?" in payload["content"]
-    assert "Text fallback" not in payload["content"]
-    assert "/approve" not in payload["content"]
+    assert "Text fallback" in payload["content"]
+    assert "/approve" in payload["content"]
+    assert "/always" in payload["content"]
+    assert "/cancel" in payload["content"]
     assert [button["label"] for button in payload["components"][0]["components"]] == ["Approve once", "Always approve", "Cancel"]
     assert {state["kind"] for state in adapter._pending_component_actions.values()} == {"slash_confirm"}
 

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -494,7 +494,7 @@ async def test_create_thread_from_message_uses_fluxer_thread_route(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_exec_approval_posts_native_buttons_and_tracks_pending(monkeypatch):
+async def test_send_exec_approval_posts_reactions_and_tracks_pending(monkeypatch):
     from gateway.config import PlatformConfig
 
     adapter = FluxerAdapter(
@@ -525,11 +525,17 @@ async def test_send_exec_approval_posts_native_buttons_and_tracks_pending(monkey
     assert "/approve session" in payload["content"]
     assert "/approve always" in payload["content"]
     assert "/deny" in payload["content"]
-    buttons = payload["components"][0]["components"]
-    assert [button["label"] for button in buttons] == ["Allow once", "Session", "Always", "Deny"]
-    assert [button["style"] for button in buttons] == [3, 1, 2, 4]
-    assert len(adapter._pending_component_actions) == 4
-    assert {state["choice"] for state in adapter._pending_component_actions.values()} == {"once", "session", "always", "deny"}
+    assert "components" not in payload
+    assert "React: ✅ approve once" in payload["content"]
+    assert len(adapter._pending_reaction_actions) == 4
+    assert {state["choice"] for state in adapter._pending_reaction_actions.values()} == {"once", "session", "always", "deny"}
+    reaction_calls = adapter._request.await_args_list[1:]
+    assert [call.args for call in reaction_calls] == [
+        ("PUT", "/channels/chan-1/messages/approval-1/reactions/%E2%9C%85/@me"),
+        ("PUT", "/channels/chan-1/messages/approval-1/reactions/%F0%9F%95%92/@me"),
+        ("PUT", "/channels/chan-1/messages/approval-1/reactions/%E2%99%BE%EF%B8%8F/@me"),
+        ("PUT", "/channels/chan-1/messages/approval-1/reactions/%E2%9D%8C/@me"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -581,6 +587,56 @@ async def test_component_interaction_resolves_pending_exec_approval(monkeypatch)
     call = adapter._request.await_args
     assert call is not None
     assert call.args == ("POST", "/interactions/interaction-1/tok-1/callback")
+
+
+@pytest.mark.asyncio
+async def test_reaction_add_resolves_pending_exec_approval(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
+        )
+    )
+    adapter._pending_exec_approvals["approval-1"] = {
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "content": "approval text",
+        "resolved": False,
+    }
+    adapter._pending_reaction_actions["approval-1:🕒"] = {
+        "kind": "exec_approval",
+        "message_id": "approval-1",
+        "session_key": "session-1",
+        "channel_id": "chan-1",
+        "choice": "session",
+    }
+    resolved = []
+    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
+    adapter._request = AsyncMock(return_value={})
+
+    await adapter._handle_gateway_dispatch(
+        {
+            "op": 0,
+            "t": "MESSAGE_REACTION_ADD",
+            "d": {
+                "channel_id": "chan-1",
+                "message_id": "approval-1",
+                "emoji": {"name": "🕒"},
+                "user_id": "user-1",
+                "user": {"id": "user-1", "bot": False},
+            },
+        }
+    )
+
+    assert resolved == [("session-1", "session")]
+    assert "approval-1" not in adapter._pending_exec_approvals
+    assert "approval-1:🕒" not in adapter._pending_reaction_actions
+    patch_calls = [call for call in adapter._request.await_args_list if call.args[:1] == ("PATCH",)]
+    assert patch_calls
+    assert patch_calls[0].args == ("PATCH", "/channels/chan-1/messages/approval-1")
+    assert "approved for session" in patch_calls[0].kwargs["json"]["content"]
 
 
 @pytest.mark.asyncio
@@ -775,7 +831,7 @@ async def test_thread_create_event_tracks_known_thread_channel(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
+async def test_send_slash_confirm_posts_reactions(monkeypatch):
     from gateway.config import PlatformConfig
 
     adapter = FluxerAdapter(
@@ -792,7 +848,7 @@ async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
     )
 
     assert result.success is True
-    call = adapter._request.await_args
+    call = adapter._request.await_args_list[0]
     assert call is not None
     payload = call.kwargs["json"]
     assert "Reload MCP?" in payload["content"]
@@ -800,8 +856,9 @@ async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
     assert "/approve" in payload["content"]
     assert "/always" in payload["content"]
     assert "/cancel" in payload["content"]
-    assert [button["label"] for button in payload["components"][0]["components"]] == ["Approve once", "Always approve", "Cancel"]
-    assert {state["kind"] for state in adapter._pending_component_actions.values()} == {"slash_confirm"}
+    assert "React: ✅ approve once" in payload["content"]
+    assert "components" not in payload
+    assert {state["kind"] for state in adapter._pending_reaction_actions.values()} == {"slash_confirm"}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -292,7 +292,7 @@ async def test_send_can_disable_user_mentions_too(monkeypatch):
 async def test_send_image_file_posts_multipart_payload(tmp_path, monkeypatch):
     from gateway.config import PlatformConfig
 
-    image = tmp_path / "zofka.png"
+    image = tmp_path / "sample.png"
     image.write_bytes(b"png-data")
     adapter = FluxerAdapter(
         PlatformConfig(
@@ -314,8 +314,8 @@ async def test_send_image_file_posts_multipart_payload(tmp_path, monkeypatch):
     assert path == "/channels/chan-1/messages"
     assert kwargs["payload"]["content"] == "look"
     assert kwargs["payload"]["allowed_mentions"] == {"parse": ["users"], "replied_user": True}
-    assert kwargs["payload"]["attachments"] == [{"id": 0, "filename": "zofka.png", "title": "zofka.png"}]
-    assert kwargs["files"] == [("files[0]", image.resolve(), "zofka.png")]
+    assert kwargs["payload"]["attachments"] == [{"id": 0, "filename": "sample.png", "title": "sample.png"}]
+    assert kwargs["files"] == [("files[0]", image.resolve(), "sample.png")]
 
 
 @pytest.mark.asyncio
@@ -820,7 +820,7 @@ async def test_application_command_interaction_dispatches_slash_text(monkeypatch
                 "channel_id": "chan-1",
                 "guild_id": "guild-1",
                 "channel": {"id": "chan-1", "name": "bot-home", "type": 0},
-                "member": {"user": {"id": "user-1", "username": "Elkim", "bot": False}},
+                "member": {"user": {"id": "user-1", "username": "Alice", "bot": False}},
                 "data": {"name": "model", "options": [{"name": "model", "value": "gpt-5.5"}]},
             },
         }
@@ -1166,13 +1166,13 @@ async def test_backlog_recovery_fetches_home_channel_and_dispatches_recent_messa
                     "id": "old-msg",
                     "content": "too old",
                     "created_at": "2026-06-01T09:59:00Z",
-                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                    "author": {"id": "user-1", "username": "Alice", "bot": False},
                 },
                 {
                     "id": "new-msg",
                     "content": "recover me",
                     "created_at": "2026-06-01T10:00:30Z",
-                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                    "author": {"id": "user-1", "username": "Alice", "bot": False},
                 },
             ]
         }
@@ -1206,7 +1206,7 @@ async def test_backlog_recovery_dedupes_seen_messages(monkeypatch):
                 "channel_id": "chan-1",
                 "content": "already handled",
                 "created_at": "2026-06-01T10:00:30Z",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
             }
         ]
     )
@@ -1425,7 +1425,7 @@ async def test_message_create_dispatches_normalized_event(monkeypatch):
                 "channel_id": "chan-1",
                 "channel_type": "dm",
                 "content": "morning",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
                 "guild_id": None,
             },
         }
@@ -1438,7 +1438,7 @@ async def test_message_create_dispatches_normalized_event(monkeypatch):
     assert event.source.chat_id == "chan-1"
     assert event.source.chat_type == "dm"
     assert event.source.user_id == "user-1"
-    assert event.source.user_name == "Elkim"
+    assert event.source.user_name == "Alice"
     assert event.source.message_id == "msg-1"
 
 
@@ -1468,7 +1468,7 @@ async def test_message_create_classifies_numeric_thread_channels_and_remembers_t
                 "channel_id": "thread-1",
                 "channel_type": 11,
                 "content": "<@bot-1> continue here",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
             },
         }
     )
@@ -1481,7 +1481,7 @@ async def test_message_create_classifies_numeric_thread_channels_and_remembers_t
                 "channel_id": "thread-1",
                 "channel_type": 11,
                 "content": "follow-up without mention",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
             },
         }
     )
@@ -1516,7 +1516,7 @@ async def test_channel_message_requires_direct_mention_by_default(monkeypatch):
                 "channel_id": "chan-1",
                 "channel_type": "channel",
                 "content": "I think Hermes mentioned that yesterday",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
             },
         }
     )
@@ -1550,7 +1550,7 @@ async def test_channel_message_processes_and_strips_direct_address(monkeypatch):
                 "channel_id": "chan-1",
                 "channel_type": "channel",
                 "content": "Hermes, check this please",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
             },
         }
     )
@@ -1586,7 +1586,7 @@ async def test_home_channel_is_free_response_even_with_require_mention(monkeypat
                 "channel_id": "chan-1",
                 "channel_type": "channel",
                 "content": "continue here",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
             },
         }
     )
@@ -1628,7 +1628,7 @@ async def test_message_create_dispatches_image_attachment(monkeypatch):
                     "channel_id": "chan-1",
                     "channel_type": "dm",
                     "content": "",
-                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                    "author": {"id": "user-1", "username": "Alice", "bot": False},
                     "attachments": [
                         {
                             "id": "att-1",
@@ -1687,7 +1687,7 @@ async def test_message_create_dispatches_voice_attachment_when_flagged(monkeypat
                     "channel_type": "dm",
                     "content": "",
                     "flags": 1 << 13,
-                    "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                    "author": {"id": "user-1", "username": "Alice", "bot": False},
                     "attachments": [
                         {
                             "id": "att-voice",
@@ -1733,7 +1733,7 @@ async def test_message_create_includes_embedded_reply_context(monkeypatch):
                 "channel_id": "chan-1",
                 "channel_type": "dm",
                 "content": "yes, do this",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
                 "referenced_message": {"id": "msg-parent", "content": "Please check this file"},
             },
         }
@@ -1771,7 +1771,7 @@ async def test_message_create_fetches_reply_context_from_message_reference(monke
                 "channel_id": "chan-1",
                 "channel_type": "dm",
                 "content": "that one",
-                "author": {"id": "user-1", "username": "Elkim", "bot": False},
+                "author": {"id": "user-1", "username": "Alice", "bot": False},
                 "message_reference": {"message_id": "msg-parent"},
             },
         }
@@ -1804,7 +1804,7 @@ async def test_message_create_ignores_own_bot_messages(monkeypatch):
                 "id": "msg-1",
                 "channel_id": "chan-1",
                 "content": "echo",
-                "author": {"id": "bot-1", "username": "Žofka", "bot": True},
+                "author": {"id": "bot-1", "username": "HermesBot", "bot": True},
             },
         }
     )

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -32,15 +32,15 @@ def test_platform_enum_resolves_via_plugin_scan():
     assert Platform("fluxer") is p
 
 
-def test_check_requirements_needs_base_url_and_token(monkeypatch):
+def test_check_requirements_needs_token_only(monkeypatch):
     monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
     monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
 
     assert check_requirements() is False
 
 
-def test_check_requirements_true_when_configured(monkeypatch):
-    monkeypatch.setenv("FLUXER_BASE_URL", "https://fluxer.example")
+def test_check_requirements_true_when_token_configured(monkeypatch):
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
     monkeypatch.setenv("FLUXER_BOT_TOKEN", "app.secret")
 
     assert check_requirements() is True
@@ -53,6 +53,12 @@ def test_validate_config_uses_env_or_extra(monkeypatch):
     monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
 
     assert validate_config(PlatformConfig(enabled=True)) is False
+    assert validate_config(
+        PlatformConfig(
+            enabled=True,
+            extra={"bot_token": "app.secret"},
+        )
+    ) is True
     assert validate_config(
         PlatformConfig(
             enabled=True,
@@ -70,7 +76,7 @@ def test_is_connected_mirrors_validate(monkeypatch):
     assert is_connected(
         PlatformConfig(
             enabled=True,
-            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+            extra={"bot_token": "app.secret"},
         )
     ) is True
     assert is_connected(PlatformConfig(enabled=True)) is False
@@ -110,9 +116,28 @@ def test_adapter_init_and_platform_identity(monkeypatch):
     )
 
     assert adapter.base_url == "https://fluxer.example"
+    assert adapter.api_base_url == "https://fluxer.example/api"
     assert adapter.bot_token == "app.secret"
     assert adapter.platform is Platform("fluxer")
     assert adapter._running is False
+
+
+def test_adapter_defaults_to_official_hosted_api(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("FLUXER_BASE_URL", raising=False)
+    monkeypatch.delenv("FLUXER_BOT_TOKEN", raising=False)
+
+    adapter = FluxerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"bot_token": "app.secret"},
+        )
+    )
+
+    assert adapter.base_url == "https://api.fluxer.app/v1"
+    assert adapter.api_base_url == "https://api.fluxer.app/v1"
+    assert adapter.bot_token == "app.secret"
 
 
 def test_build_identify_payload_contains_bot_token_and_client_properties():
@@ -252,7 +277,7 @@ def test_register_metadata():
     entry = calls[0]
     assert entry["name"] == "fluxer"
     assert entry["label"] == "Fluxer"
-    assert entry["required_env"] == ["FLUXER_BASE_URL", "FLUXER_BOT_TOKEN"]
+    assert entry["required_env"] == ["FLUXER_BOT_TOKEN"]
     assert entry["allowed_users_env"] == "FLUXER_ALLOWED_USERS"
     assert entry["allow_all_env"] == "FLUXER_ALLOW_ALL_USERS"
     assert entry["cron_deliver_env_var"] == "FLUXER_HOME_CHANNEL"

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -295,6 +295,60 @@ async def test_send_reports_retryable_error_on_request_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_message_tool_routes_fluxer_media_to_standalone_even_with_live_runner(monkeypatch):
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from tools.send_message_tool import _send_via_adapter
+
+    platform = Platform("fluxer")
+    pconfig = PlatformConfig(
+        enabled=True,
+        extra={"base_url": "https://fluxer.example", "bot_token": "app.secret"},
+    )
+    live_adapter = AsyncMock()
+    live_adapter.send = AsyncMock(return_value=type("Result", (), {"success": True, "message_id": "live", "error": None})())
+    runner = type("Runner", (), {"adapters": {platform: live_adapter}})()
+    standalone = AsyncMock(return_value={"success": True, "message_id": "standalone"})
+
+    original = platform_registry.get("fluxer")
+    platform_registry.register(
+        PlatformEntry(
+            name="fluxer",
+            label="Fluxer",
+            adapter_factory=lambda cfg: FluxerAdapter(cfg),
+            check_fn=lambda: True,
+            standalone_sender_fn=standalone,
+            max_message_length=4000,
+        )
+    )
+    try:
+        with patch("gateway.run._gateway_runner_ref", return_value=runner):
+            result = await _send_via_adapter(
+                platform,
+                pconfig,
+                "chan-1",
+                "",
+                media_files=[("/tmp/reply.ogg", True)],
+            )
+    finally:
+        if original is not None:
+            platform_registry.register(original)
+        else:
+            platform_registry.unregister("fluxer")
+
+    assert result == {"success": True, "message_id": "standalone"}
+    live_adapter.send.assert_not_awaited()
+    standalone.assert_awaited_once_with(
+        pconfig,
+        "chan-1",
+        "",
+        thread_id=None,
+        media_files=[("/tmp/reply.ogg", True)],
+        force_document=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_message_create_dispatches_normalized_event(monkeypatch):
     from gateway.config import PlatformConfig
 

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -1067,8 +1067,8 @@ async def test_pin_helpers_use_fluxer_discord_shaped_pin_routes(monkeypatch):
     assert pinned is True
     assert unpinned is True
     assert adapter._request.await_args_list[0].args == ("GET", "/channels/chan-1/messages/pins")
-    assert adapter._request.await_args_list[1].args == ("PUT", "/channels/chan-1/messages/pins/msg-1")
-    assert adapter._request.await_args_list[2].args == ("DELETE", "/channels/chan-1/messages/pins/msg-1")
+    assert adapter._request.await_args_list[1].args == ("PUT", "/channels/chan-1/pins/msg-1")
+    assert adapter._request.await_args_list[2].args == ("DELETE", "/channels/chan-1/pins/msg-1")
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_fluxer_plugin.py
+++ b/tests/gateway/test_fluxer_plugin.py
@@ -519,6 +519,9 @@ async def test_send_exec_approval_posts_native_buttons_and_tracks_pending(monkey
     assert first_call.args == ("POST", "/channels/chan-1/messages")
     payload = first_call.kwargs["json"]
     assert "rm -rf /important" in payload["content"]
+    assert "Command approval required" in payload["content"]
+    assert "⚠️" not in payload["content"]
+    assert "/approve" not in payload["content"]
     buttons = payload["components"][0]["components"]
     assert [button["label"] for button in buttons] == ["Allow once", "Session", "Always", "Deny"]
     assert [button["style"] for button in buttons] == [3, 1, 2, 4]
@@ -780,7 +783,7 @@ async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
     result = await adapter.send_slash_confirm(
         "chan-1",
         "Reload MCP?",
-        "This reload may invalidate caches.",
+        "This reload may invalidate caches.\n\n_Text fallback: reply `/approve`, `/always`, or `/cancel`._",
         "session-1",
         "confirm-1",
     )
@@ -790,6 +793,8 @@ async def test_send_slash_confirm_posts_native_buttons(monkeypatch):
     assert call is not None
     payload = call.kwargs["json"]
     assert "Reload MCP?" in payload["content"]
+    assert "Text fallback" not in payload["content"]
+    assert "/approve" not in payload["content"]
     assert [button["label"] for button in payload["components"][0]["components"]] == ["Approve once", "Always approve", "Cancel"]
     assert {state["kind"] for state in adapter._pending_component_actions.values()} == {"slash_confirm"}
 
@@ -836,7 +841,7 @@ async def test_application_command_interaction_dispatches_slash_text(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_reaction_add_resolves_pending_exec_approval(monkeypatch):
+async def test_reaction_add_does_not_resolve_pending_exec_approval(monkeypatch):
     from gateway.config import PlatformConfig
 
     adapter = FluxerAdapter(
@@ -869,9 +874,9 @@ async def test_reaction_add_resolves_pending_exec_approval(monkeypatch):
         }
     )
 
-    assert resolved == [("session-1", "once")]
-    assert "approval-1" not in adapter._pending_exec_approvals
-    adapter.edit_message.assert_awaited_once()
+    assert resolved == []
+    assert "approval-1" in adapter._pending_exec_approvals
+    adapter.edit_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -951,43 +956,6 @@ async def test_message_delete_for_non_approval_only_clears_seen_id(monkeypatch):
 
     assert resolved == []
     assert "msg-1" not in adapter._seen_message_ids
-
-
-@pytest.mark.asyncio
-async def test_reaction_add_ignores_unauthorized_or_bot_users(monkeypatch):
-    from gateway.config import PlatformConfig
-
-    adapter = FluxerAdapter(
-        PlatformConfig(
-            enabled=True,
-            extra={"base_url": "https://fluxer.example", "bot_token": "app.secret", "allowed_users": "user-1"},
-        )
-    )
-    adapter._pending_exec_approvals["approval-1"] = {"session_key": "session-1", "channel_id": "chan-1", "resolved": False}
-    resolved = []
-    monkeypatch.setattr("tools.approval.resolve_gateway_approval", lambda session_key, choice: resolved.append((session_key, choice)) or 1)
-
-    await adapter._handle_reaction_add(
-        {
-            "message_id": "approval-1",
-            "channel_id": "chan-1",
-            "user_id": "user-2",
-            "emoji": {"name": "❌"},
-            "member": {"user": {"id": "user-2", "bot": False}},
-        }
-    )
-    await adapter._handle_reaction_add(
-        {
-            "message_id": "approval-1",
-            "channel_id": "chan-1",
-            "user_id": "user-1",
-            "emoji": {"name": "❌"},
-            "member": {"user": {"id": "user-1", "bot": True}},
-        }
-    )
-
-    assert resolved == []
-    assert "approval-1" in adapter._pending_exec_approvals
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -53,6 +53,16 @@ def _audio_event(path: str = "/tmp/song.mp3") -> MessageEvent:
     )
 
 
+def _document_event(path: str, media_type: str = "application/json") -> MessageEvent:
+    return MessageEvent(
+        text="please inspect this getbased export",
+        message_type=MessageType.DOCUMENT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm"),
+        media_urls=[path],
+        media_types=[media_type],
+    )
+
+
 # ---------------------------------------------------------------------------
 # 1. VOICE still goes through STT
 # ---------------------------------------------------------------------------
@@ -134,6 +144,31 @@ async def test_audio_attachment_context_note_format():
     assert "audio file attachment" in result.lower()
     # Should NOT contain the voice-message transcription wrapper text
     assert "voice message" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_text_document_attachment_inlines_content(tmp_path):
+    """Text-like DOCUMENT attachments must be visible to the agent, not only linked by path."""
+    runner = _make_runner(stt_enabled=True)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm")
+    doc = tmp_path / "getbased-export.json"
+    doc.write_text('{"marker":"gb_attachment_visible","lab":"homocysteine"}', encoding="utf-8")
+    event = _document_event(str(doc), "application/json")
+
+    with patch(
+        "tools.credential_files.to_agent_visible_cache_path",
+        side_effect=lambda p: p,
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert "getbased-export.json" in result
+    assert "gb_attachment_visible" in result
+    assert '"lab":"homocysteine"' in result
+    assert "please inspect this getbased export" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -509,7 +509,7 @@ async def _send_via_adapter(
     except Exception:
         runner = None
 
-    if runner is not None:
+    if runner is not None and not media_files:
         try:
             adapter = runner.adapters.get(platform)
         except Exception:
@@ -749,12 +749,37 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Plugin platforms with standalone media support (e.g. Fluxer) ---
+    if media_files:
+        try:
+            from gateway.platform_registry import platform_registry
+            plugin_entry = platform_registry.get(platform.value if hasattr(platform, "value") else str(platform))
+        except Exception:
+            plugin_entry = None
+        if plugin_entry is not None and plugin_entry.standalone_sender_fn is not None:
+            last_result = None
+            for i, chunk in enumerate(chunks or [""]):
+                is_last = (i == len(chunks) - 1)
+                result = await _send_via_adapter(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    chunk,
+                    thread_id=thread_id,
+                    media_files=media_files if is_last else [],
+                    force_document=force_document,
+                )
+                if isinstance(result, dict) and result.get("error"):
+                    return result
+                last_result = result
+            return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
-                f"target {platform.value} had only media attachments"
+                f"send_message MEDIA delivery is not available for target {platform.value}; "
+                "the platform has no native media sender or plugin standalone media sender"
             )
         }
     warning = None

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -507,6 +507,36 @@ Used by the bundled LINE platform plugin (`plugins/platforms/line/`). See [Messa
 
 See [the ntfy messaging guide](/user-guide/messaging/ntfy) — particularly the **identity model** section — before deploying with untrusted topics.
 
+### Fluxer
+
+Used by the bundled Fluxer platform plugin (`plugins/platforms/fluxer/`). See [Messaging Gateway → Fluxer](/user-guide/messaging/fluxer) for full setup.
+
+| Variable | Description |
+|----------|-------------|
+| `FLUXER_BOT_TOKEN` | Bot token, usually `<applicationId>.<secret>`. Required. |
+| `FLUXER_BASE_URL` | REST API base URL. Defaults to `https://api.fluxer.app/v1`; plain self-hosted origins are normalized to `/api`. |
+| `FLUXER_GATEWAY_URL` | Override Gateway WebSocket URL. Normally discovered from `/gateway/bot`. |
+| `FLUXER_HOME_CHANNEL` | Default Fluxer channel/DM for cron delivery and notifications. Also treated as a free-response channel. |
+| `FLUXER_HOME_CHANNEL_NAME` | Human label for the home channel. |
+| `FLUXER_ALLOWED_USERS` | Comma-separated Fluxer user IDs allowed to talk to the bot. |
+| `FLUXER_ALLOW_ALL_USERS` | Dev-only escape hatch — accepts any Fluxer user. Default: `false`. |
+| `FLUXER_ALLOWED_CHANNELS` | Comma-separated channel IDs where Hermes may respond. Empty means no channel whitelist. |
+| `FLUXER_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where Hermes responds without a mention. |
+| `FLUXER_REQUIRE_MENTION` | Require direct mention/address in non-home channels. Default: `true`. |
+| `FLUXER_STRICT_MENTION` | Require a fresh mention on every channel message instead of remembering mentioned threads. Default: `false`. |
+| `FLUXER_MENTION_PATTERNS` | Comma-separated regexes that count as direct bot addresses. |
+| `FLUXER_REGISTER_NATIVE_COMMANDS` | Register Hermes slash commands with Fluxer on gateway connect. Default: `false`. |
+| `FLUXER_APPLICATION_ID` | Fluxer application ID for native command registration; defaults to token prefix when possible. |
+| `FLUXER_NATIVE_COMMAND_GUILDS` | Comma-separated guild IDs for guild-scoped command registration; empty means global. |
+| `FLUXER_BACKLOG_RECOVERY` | Recover recent messages from known channels after startup/reconnect. Default: `true`. |
+| `FLUXER_BACKLOG_LIMIT` | Max recent messages to scan per known channel. Default: `25`, capped at `100`. |
+| `FLUXER_BACKLOG_BOOTSTRAP_SECONDS` | Startup lookback window when no previous disconnect time exists. Default: `120`, capped at `900`. |
+| `FLUXER_DELIVERY_VERIFICATION` | Read back sent/edited messages to verify visible delivery. Default: `true`. |
+| `FLUXER_ALLOW_MENTION_EVERYONE` | Permit outbound `@everyone` / `@here`; default `false` neutralizes them. |
+| `FLUXER_ALLOW_MENTION_ROLES` | Permit outbound role mentions; default `false` neutralizes them. |
+| `FLUXER_ALLOW_MENTION_USERS` | Permit outbound user mentions. Default: `true`. |
+| `FLUXER_ALLOW_MENTION_REPLIED_USER` | Permit reply notifications to the replied-to user when Fluxer supports `allowed_mentions`. Default: `true`. |
+
 ### Advanced Messaging Tuning
 
 Advanced per-platform knobs for throttling the outbound message batcher. Most users never need to touch these; defaults are set to respect each platform's rate limits without feeling sluggish.

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -153,7 +153,7 @@ Hermes, check this please     # accepted
 I think Hermes said that      # ignored in channels
 ```
 
-Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should always respond.
+Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should always respond. Use this for dedicated bot/project rooms (for example weatherbot, trading, or other automation channels) where every message is effectively part of the conversation. Leave ordinary shared/social channels mention-gated so a passing “Hermes said…” does not wake the bot.
 
 ## Native interactions
 

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -33,7 +33,7 @@ Fluxer is not just “another Discord target.” A few platform traits make it e
 | Message edits | ✅ | Used for progress/stream-style updates where Hermes edits a sent message |
 | Message deletes | ✅ | Gateway cleanup and deleted approval prompts are handled |
 | Reactions | ✅ | General message reactions are preserved as Fluxer events; Hermes does not use reactions for dangerous-command approval. |
-| Buttons/components | ✅ | Used for dangerous-command approvals and destructive slash confirmations on Fluxer deployments that accept message components and emit `INTERACTION_CREATE`. |
+| Buttons/components | Deployment-dependent | Hermes can attach component payloads for deployments that render message components and emit `INTERACTION_CREATE`, but prompts always include slash-command text fallback because hosted/client support may not show buttons. |
 | Native slash commands | Deployment-dependent | Hermes can translate Fluxer `APPLICATION_COMMAND` interactions if a deployment emits them, but the current hosted API spec does not expose application-command registration routes. Keep `FLUXER_REGISTER_NATIVE_COMMANDS=false` unless your deployment provides those routes. |
 | Message pins | ✅ | Uses Fluxer's `/channels/{id}/messages/pins` routes when the server enables pins |
 | Threads | — | Hosted Fluxer currently exposes reply references, but not Discord-style thread routes in the public API spec. Hermes keeps speculative helpers for deployments that add thread endpoints, but the platform-comparison table does not count this as end-to-end thread support. |
@@ -159,8 +159,8 @@ Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should 
 
 Hermes keeps Fluxer native-interaction support guarded and deployment-aware:
 
-- if a Fluxer deployment accepts `components`, Hermes sends action rows/buttons for dangerous-command approvals and slash confirmations;
-- dangerous-command approval prompts are button-first: `Allow once`, `Session`, `Always`, and `Deny` buttons are shown without emoji-reaction instructions or slash-command text in the Fluxer prompt;
+- if a Fluxer deployment accepts `components`, Hermes also attaches action rows/buttons for dangerous-command approvals and slash confirmations;
+- dangerous-command approval prompts include visible text fallback commands (`/approve once`, `/approve session`, `/approve always`, `/deny`) so hosted/client builds that do not render components remain usable;
 - if a deployment emits `INTERACTION_CREATE` with `type=3` / `MESSAGE_COMPONENT`, Hermes resolves the matching pending action;
 - if a deployment emits `INTERACTION_CREATE` with `type=2` / `APPLICATION_COMMAND`, Hermes translates it into normal slash text such as `/model gpt-5.5`.
 
@@ -180,16 +180,16 @@ FLUXER_NATIVE_COMMAND_GUILDS=123456789012345678,234567890123456789
 
 ## Dangerous-command approvals
 
-On deployments with component support, Hermes can show native dangerous-command approval buttons:
+On deployments with component support, Hermes can also attach native dangerous-command approval buttons:
 
-| Button | Meaning |
-|---|---|
-| Allow once | approve once |
-| Session | approve for this session |
-| Always | always allow this command pattern |
-| Deny | deny |
+| Button | Text fallback | Meaning |
+| --- | --- | --- |
+| Allow once | `/approve once` | approve only the waiting command |
+| Session | `/approve session` | allow matching commands for this session |
+| Always | `/approve always` | persist the approval pattern |
+| Deny | `/deny` | deny |
 
-Fluxer approval is button-only in the prompt; Hermes does not ask users to approve with emoji reactions or by typing slash commands. If the approval prompt is deleted before it is resolved, Hermes fails closed and denies the pending approval.
+Hermes always includes the text fallback in Fluxer approval prompts because hosted/client builds may accept the message while not rendering component buttons. Emoji reactions are not approval controls. If the approval prompt is deleted before it is resolved, Hermes fails closed and denies the pending approval.
 
 ## Media, voice, and streaming
 
@@ -273,6 +273,6 @@ The plugin registers a standalone sender, so cron delivery also works when the c
 
 **The bot ignores channel messages** — In non-home channels, address it directly (`Hermes, ...` or a real bot mention), add the channel to `FLUXER_FREE_RESPONSE_CHANNELS`, or set `FLUXER_REQUIRE_MENTION=false`.
 
-**Dangerous-command buttons do nothing** — Make sure the clicking user's Fluxer ID is in `FLUXER_ALLOWED_USERS` or `FLUXER_ALLOW_ALL_USERS=true` is set for a private/dev setup. Bot clicks are ignored. Emoji reactions are not approval controls.
+**Dangerous-command approval text fallback is needed** — Some Fluxer hosted/client builds accept component payloads but do not render buttons. Use `/approve once`, `/approve session`, `/approve always`, or `/deny` from the prompt text. If buttons are visible, they are optional shortcuts.
 
 **Reconnects / heartbeat warnings** — The adapter responds to server heartbeat requests and sends regular heartbeats. Fresh `4009 Heartbeat timeout` warnings usually mean the deployment closed the WebSocket before the bot could identify/heartbeat; check network path, `FLUXER_GATEWAY_URL`, and server logs.

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -1,0 +1,279 @@
+---
+title: "Fluxer"
+description: "Use Hermes from Fluxer, an open-source Discord-like chat platform with self-hostable deployments."
+---
+
+# Fluxer
+
+[Fluxer](https://fluxer.app/) is a Discord-like open-source chat platform with channels, DMs, rich Markdown, reactions, and file uploads. Hermes talks to Fluxer through the bot REST API for outbound messages and the Fluxer Gateway WebSocket for inbound events.
+
+Fluxer is a good fit when you want a self-hostable, chat-first surface for Hermes with Discord-style UX but without depending on Discord.
+
+> Run `hermes gateway setup` and pick **Fluxer** for a guided setup when the plugin is installed.
+
+## What works
+
+| Feature | Status | Notes |
+|---|---:|---|
+| Text chat | ✅ | DMs and channels |
+| Markdown | ✅ | Hermes sends normal Markdown; Fluxer renders the supported subset |
+| Images/files | ✅ | Uploads use Fluxer's multipart message endpoint |
+| Audio / voice files | ✅ | Works when the Fluxer deployment exposes file/voice-message support |
+| Typing indicator | ✅ | Refreshed while Hermes is working |
+| Message edits | ✅ | Used for progress/stream-style updates where Hermes edits a sent message |
+| Message deletes | ✅ | Gateway cleanup and deleted approval prompts are handled |
+| Reactions | ✅ | Still accepted as compatibility/fallback events |
+| Buttons/components | ✅ | Dangerous-command approvals and slash confirmations use Fluxer component payloads and `INTERACTION_CREATE` callbacks where the deployment emits them |
+| Native slash commands | ✅ | Optional registration via Fluxer application-command routes; interactions are routed back into normal Hermes slash-command handling |
+| Message pins | ✅ | Uses Fluxer's `/channels/{id}/messages/pins` routes when the server enables pins |
+| Threads | ✅ | Create threads from messages or channels; active thread/channel enumeration is included in the channel directory when the deployment exposes the routes |
+| Channel directory | ✅ | Lists guild channels, forums, active threads, and session-discovered DMs/known channels |
+| Backlog recovery | ✅ | Recent messages in known channels are scanned after startup/reconnect |
+
+## Prerequisites
+
+- A Fluxer bot token in the form `<applicationId>.<secret>`
+- The channel or DM ID where Hermes should live
+- Optional but recommended: the Fluxer user IDs allowed to talk to the bot
+
+The hosted API defaults to:
+
+```text
+https://api.fluxer.app/v1
+```
+
+Self-hosted deployments can override the API base with `FLUXER_BASE_URL`.
+
+## Configure Hermes
+
+### Via setup wizard
+
+```bash
+hermes gateway setup
+```
+
+Select **Fluxer** and follow the prompts.
+
+### Via environment variables
+
+Add these to `~/.hermes/.env`:
+
+```bash
+FLUXER_BOT_TOKEN=app_id.secret
+FLUXER_HOME_CHANNEL=123456789012345678
+FLUXER_ALLOWED_USERS=123456789012345678
+```
+
+Then restart the gateway:
+
+```bash
+hermes gateway restart
+```
+
+For a self-hosted Fluxer instance:
+
+```bash
+FLUXER_BASE_URL=https://fluxer.example.com
+```
+
+If you already know the WebSocket gateway URL and want to skip discovery:
+
+```bash
+FLUXER_GATEWAY_URL=wss://fluxer.example.com/gateway
+```
+
+Normally Hermes discovers this from `GET /gateway/bot`.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---:|---|
+| `FLUXER_BOT_TOKEN` | Yes | Bot token, usually `<applicationId>.<secret>` |
+| `FLUXER_BASE_URL` | Optional | REST API base URL. Defaults to `https://api.fluxer.app/v1`. Plain self-hosted origins are normalized to `/api`. |
+| `FLUXER_GATEWAY_URL` | Optional | Override Gateway WebSocket URL. Normally discovered via `/gateway/bot`. |
+| `FLUXER_HOME_CHANNEL` | Recommended | Default channel/DM for cron delivery and notifications. Also treated as a free-response channel. |
+| `FLUXER_HOME_CHANNEL_NAME` | Optional | Human label for the home channel. |
+| `FLUXER_ALLOWED_USERS` | Recommended | Comma-separated Fluxer user IDs allowed to talk to Hermes. |
+| `FLUXER_ALLOW_ALL_USERS` | Optional | Allow every Fluxer user. Only safe for private/dev deployments. Default: `false`. |
+| `FLUXER_ALLOWED_CHANNELS` | Optional | Comma-separated channel IDs where Hermes may respond. Empty means no channel whitelist. DMs are still governed by user authorization. |
+| `FLUXER_FREE_RESPONSE_CHANNELS` | Optional | Comma-separated channel IDs where Hermes responds without being mentioned. |
+| `FLUXER_REQUIRE_MENTION` | Optional | Require a direct mention/address in non-home channels. Default: `true`. |
+| `FLUXER_STRICT_MENTION` | Optional | Require a fresh mention on every channel message instead of remembering mentioned threads. Default: `false`. |
+| `FLUXER_MENTION_PATTERNS` | Optional | Comma-separated regexes that count as direct addresses. Defaults already cover `Hermes` at the start of a message. |
+| `FLUXER_REGISTER_NATIVE_COMMANDS` | Optional | Register Hermes slash commands with Fluxer on gateway connect. Default: `false` so deployments can opt in deliberately. |
+| `FLUXER_APPLICATION_ID` | Optional | Fluxer application ID for native command registration. If omitted, Hermes uses the token prefix before the first `.`. |
+| `FLUXER_NATIVE_COMMAND_GUILDS` | Optional | Comma-separated guild IDs for guild-scoped command registration. Empty means global application commands. |
+| `FLUXER_BACKLOG_RECOVERY` | Optional | Recover recent messages from known channels after startup/reconnect. Default: `true`. |
+| `FLUXER_BACKLOG_LIMIT` | Optional | Max recent messages to scan per known channel. Default: `25`, capped at `100`. |
+| `FLUXER_BACKLOG_BOOTSTRAP_SECONDS` | Optional | Startup lookback window when no previous disconnect time exists. Default: `120`, capped at `900`. |
+| `FLUXER_DELIVERY_VERIFICATION` | Optional | Read back sent/edited messages to verify visible delivery. Default: `true`. |
+| `FLUXER_ALLOW_MENTION_EVERYONE` | Optional | Permit outbound `@everyone` / `@here`. Default: `false`; Hermes neutralizes them. |
+| `FLUXER_ALLOW_MENTION_ROLES` | Optional | Permit outbound role mentions like `<@&...>`. Default: `false`; Hermes neutralizes them. |
+| `FLUXER_ALLOW_MENTION_USERS` | Optional | Permit outbound user mentions. Default: `true`. |
+| `FLUXER_ALLOW_MENTION_REPLIED_USER` | Optional | Permit reply notifications to the replied-to user when Fluxer supports `allowed_mentions`. Default: `true`. |
+
+## Authorization and channel behavior
+
+Fluxer uses the normal Hermes gateway authorization model:
+
+```bash
+FLUXER_ALLOWED_USERS=123456789012345678,234567890123456789
+```
+
+For development-only private deployments, you can allow everyone:
+
+```bash
+FLUXER_ALLOW_ALL_USERS=true
+```
+
+Do not use `FLUXER_ALLOW_ALL_USERS=true` on a public or shared server if Hermes has terminal/tool access.
+
+Channel behavior is intentionally quiet by default:
+
+- DMs are processed when the user is authorized.
+- `FLUXER_HOME_CHANNEL` is processed without a mention, so your main Hermes room feels natural.
+- Other channels require a direct mention/address by default.
+- Casual mentions in the middle of a conversation do not wake the bot.
+
+Examples:
+
+```text
+Hermes, check this please     # accepted
+@Hermes summarize the thread  # accepted
+I think Hermes said that      # ignored in channels
+```
+
+Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should always respond.
+
+## Native interactions
+
+Fluxer native interactions are handled in the shape emitted by the Fluxer gateway:
+
+- outbound messages can include `components` action rows and buttons;
+- button clicks arrive as `INTERACTION_CREATE` with `type=3` / `MESSAGE_COMPONENT`;
+- slash commands arrive as `INTERACTION_CREATE` with `type=2` / `APPLICATION_COMMAND` and are translated into normal Hermes slash text such as `/model gpt-5.5`;
+- Hermes acknowledges slash-command interactions with a deferred ephemeral callback before handing the command to the gateway.
+
+Native command registration is opt-in. To bulk-register Hermes commands globally:
+
+```bash
+FLUXER_REGISTER_NATIVE_COMMANDS=true
+FLUXER_APPLICATION_ID=app_id   # optional when FLUXER_BOT_TOKEN is app_id.secret
+```
+
+For fast guild-scoped registration during testing:
+
+```bash
+FLUXER_REGISTER_NATIVE_COMMANDS=true
+FLUXER_NATIVE_COMMAND_GUILDS=123456789012345678,234567890123456789
+```
+
+## Dangerous-command approvals
+
+Hermes uses native buttons for dangerous-command approvals when Fluxer emits component interactions:
+
+| Button | Meaning |
+|---|---|
+| Allow once | approve once |
+| Session | approve for this session |
+| Always | always allow this command pattern |
+| Deny | deny |
+
+Text fallback still works:
+
+```text
+/approve
+/approve session
+/approve always
+/deny
+```
+
+If the approval prompt is deleted before it is resolved, Hermes fails closed and denies the pending approval.
+
+## Media and voice
+
+Hermes can send images, videos, documents, audio files, and voice-message-shaped audio through Fluxer's multipart message API. Inbound attachments are cached and passed to the agent as media URLs/types.
+
+Voice/audio support depends on the Fluxer deployment exposing the relevant file and voice-message fields. If a deployment only supports plain files, audio may appear as a normal file instead of a voice bubble.
+
+## Pins, threads, and channel directory
+
+Hermes includes Fluxer pin helpers for deployments that expose pin routes:
+
+```text
+GET    /channels/{channel_id}/messages/pins
+PUT    /channels/{channel_id}/messages/pins/{message_id}
+DELETE /channels/{channel_id}/messages/pins/{message_id}
+```
+
+The hosted Fluxer API has been verified to list pins with `GET /channels/{id}/messages/pins`.
+
+Hermes also exposes Fluxer thread routes when the deployment enables them:
+
+```text
+POST /channels/{channel_id}/messages/{message_id}/threads
+POST /channels/{channel_id}/threads
+GET  /guilds/{guild_id}/threads/active
+```
+
+`send_message(action="list")` includes Fluxer guild channels, forums, active threads, and known/session-discovered targets when the deployment exposes `/users/@me/guilds` and `/guilds/{guild_id}/channels`. Thread/channel gateway events update the adapter's known-channel set, so reconnect backlog recovery can include newly revealed threads.
+
+## Backlog recovery
+
+The Gateway WebSocket is the primary inbound path. On startup or reconnect, Hermes also scans recent messages from known channels so short outages do not silently drop messages.
+
+Known channels include:
+
+- `FLUXER_HOME_CHANNEL`
+- `home_channel` from config
+- channels the adapter has sent to or received from during the current process
+
+Backlog recovery is conservative:
+
+- It only scans a bounded number of messages.
+- It ignores messages older than the reconnect/startup cutoff.
+- It dedupes by message ID.
+- It still filters self-messages, unauthorized users, and channel mention-gating.
+
+Disable it if your Fluxer deployment cannot list channel messages:
+
+```bash
+FLUXER_BACKLOG_RECOVERY=false
+```
+
+## Cron and `send_message`
+
+With `FLUXER_HOME_CHANNEL` set, cron jobs can deliver to Fluxer:
+
+```python
+cronjob(
+    action="create",
+    schedule="0 9 * * *",
+    deliver="fluxer",
+    prompt="Send a short morning status."
+)
+```
+
+Or send explicitly:
+
+```python
+send_message(target="fluxer:123456789012345678", message="Done.")
+```
+
+The plugin registers a standalone sender, so cron delivery also works when the cron runner is not the live gateway process.
+
+## Troubleshooting
+
+**Gateway says Fluxer is not configured** — Check `FLUXER_BOT_TOKEN`. `FLUXER_BASE_URL` is optional; the hosted API is the default.
+
+**Connect fails with gateway URL missing** — Hermes could not fetch a usable URL from `/gateway/bot`. Set `FLUXER_GATEWAY_URL` explicitly and restart the gateway.
+
+**Messages send but don't appear** — Keep `FLUXER_DELIVERY_VERIFICATION=true` and check gateway logs. Hermes reads the sent message back when possible and logs delivery mismatch warnings.
+
+**The bot answers in channels where it should stay quiet** — Check `FLUXER_HOME_CHANNEL`, `FLUXER_FREE_RESPONSE_CHANNELS`, and `FLUXER_REQUIRE_MENTION`. The home channel is intentionally free-response.
+
+**The bot ignores channel messages** — In non-home channels, address it directly (`Hermes, ...` or a real bot mention), add the channel to `FLUXER_FREE_RESPONSE_CHANNELS`, or set `FLUXER_REQUIRE_MENTION=false`.
+
+**Dangerous-command reactions do nothing** — Make sure the reacting user's Fluxer ID is in `FLUXER_ALLOWED_USERS` or `FLUXER_ALLOW_ALL_USERS=true` is set for a private/dev setup. Bot reactions are ignored.
+
+**Reconnects / heartbeat warnings** — The adapter responds to server heartbeat requests and sends regular heartbeats. Fresh `4009 Heartbeat timeout` warnings usually mean the deployment closed the WebSocket before the bot could identify/heartbeat; check network path, `FLUXER_GATEWAY_URL`, and server logs.

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -23,11 +23,11 @@ Fluxer is a good fit when you want a self-hostable, chat-first surface for Herme
 | Message edits | ✅ | Used for progress/stream-style updates where Hermes edits a sent message |
 | Message deletes | ✅ | Gateway cleanup and deleted approval prompts are handled |
 | Reactions | ✅ | Still accepted as compatibility/fallback events |
-| Buttons/components | ✅ | Dangerous-command approvals and slash confirmations use Fluxer component payloads and `INTERACTION_CREATE` callbacks where the deployment emits them |
-| Native slash commands | ✅ | Optional registration via Fluxer application-command routes; interactions are routed back into normal Hermes slash-command handling |
+| Buttons/components | Deployment-dependent | Hermes has guarded adapter support for component payloads and `INTERACTION_CREATE` callbacks, but the current hosted Fluxer API schema does **not** accept/persist `components` on messages. Use text fallbacks (`/approve`, `/deny`) unless your deployment explicitly exposes native components. |
+| Native slash commands | Deployment-dependent | Hermes can translate Fluxer `APPLICATION_COMMAND` interactions if a deployment emits them, but the current hosted API spec does not expose application-command registration routes. Keep `FLUXER_REGISTER_NATIVE_COMMANDS=false` unless your deployment provides those routes. |
 | Message pins | ✅ | Uses Fluxer's `/channels/{id}/messages/pins` routes when the server enables pins |
-| Threads | ✅ | Create threads from messages or channels; active thread/channel enumeration is included in the channel directory when the deployment exposes the routes |
-| Channel directory | ✅ | Lists guild channels, forums, active threads, and session-discovered DMs/known channels |
+| Threads | — | Hosted Fluxer currently exposes reply references, but not Discord-style thread routes in the public API spec. Hermes keeps speculative helpers for deployments that add thread endpoints, but the platform-comparison table does not count this as end-to-end thread support. |
+| Channel directory | ✅ | Lists guild channels, forums when exposed, and session-discovered DMs/known channels |
 | Backlog recovery | ✅ | Recent messages in known channels are scanned after startup/reconnect |
 
 ## Prerequisites
@@ -147,21 +147,22 @@ Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should 
 
 ## Native interactions
 
-Fluxer native interactions are handled in the shape emitted by the Fluxer gateway:
+Hermes keeps Fluxer native-interaction support guarded and deployment-aware:
 
-- outbound messages can include `components` action rows and buttons;
-- button clicks arrive as `INTERACTION_CREATE` with `type=3` / `MESSAGE_COMPONENT`;
-- slash commands arrive as `INTERACTION_CREATE` with `type=2` / `APPLICATION_COMMAND` and are translated into normal Hermes slash text such as `/model gpt-5.5`;
-- Hermes acknowledges slash-command interactions with a deferred ephemeral callback before handing the command to the gateway.
+- if a Fluxer deployment accepts `components`, Hermes can send action rows/buttons for dangerous-command approvals and slash confirmations;
+- if a deployment emits `INTERACTION_CREATE` with `type=3` / `MESSAGE_COMPONENT`, Hermes resolves the matching pending action;
+- if a deployment emits `INTERACTION_CREATE` with `type=2` / `APPLICATION_COMMAND`, Hermes translates it into normal slash text such as `/model gpt-5.5`.
 
-Native command registration is opt-in. To bulk-register Hermes commands globally:
+The current hosted Fluxer API spec does **not** list message `components`, interaction callback routes, or application-command registration routes. In that environment, native buttons and registered slash commands should be treated as unavailable and Hermes falls back to text commands.
+
+Native command registration is opt-in and should only be enabled for deployments that expose the required application-command routes:
 
 ```bash
 FLUXER_REGISTER_NATIVE_COMMANDS=true
 FLUXER_APPLICATION_ID=app_id   # optional when FLUXER_BOT_TOKEN is app_id.secret
 ```
 
-For fast guild-scoped registration during testing:
+For fast guild-scoped registration during testing on compatible deployments:
 
 ```bash
 FLUXER_REGISTER_NATIVE_COMMANDS=true
@@ -170,7 +171,7 @@ FLUXER_NATIVE_COMMAND_GUILDS=123456789012345678,234567890123456789
 
 ## Dangerous-command approvals
 
-Hermes uses native buttons for dangerous-command approvals when Fluxer emits component interactions:
+On deployments with component support, Hermes can show native dangerous-command approval buttons:
 
 | Button | Meaning |
 |---|---|
@@ -179,7 +180,7 @@ Hermes uses native buttons for dangerous-command approvals when Fluxer emits com
 | Always | always allow this command pattern |
 | Deny | deny |
 
-Text fallback still works:
+On the hosted Fluxer API today, use the text fallback instead:
 
 ```text
 /approve
@@ -190,13 +191,15 @@ Text fallback still works:
 
 If the approval prompt is deleted before it is resolved, Hermes fails closed and denies the pending approval.
 
-## Media and voice
+## Media, voice, and streaming
 
 Hermes can send images, videos, documents, audio files, and voice-message-shaped audio through Fluxer's multipart message API. Inbound attachments are cached and passed to the agent as media URLs/types.
 
 Voice/audio support depends on the Fluxer deployment exposing the relevant file and voice-message fields. If a deployment only supports plain files, audio may appear as a normal file instead of a voice bubble.
 
-## Pins, threads, and channel directory
+Hermes streaming on Fluxer is edit-based: the gateway sends or reuses a progress bubble, then updates it with `PATCH /channels/{channel_id}/messages/{message_id}`. The hosted API accepts message edits, so Fluxer counts as supporting Hermes-style streaming/progress updates even though it is not a token-by-token websocket stream to the client.
+
+## Pins, replies, and channel directory
 
 Hermes includes Fluxer pin helpers for deployments that expose pin routes:
 
@@ -208,15 +211,11 @@ DELETE /channels/{channel_id}/messages/pins/{message_id}
 
 The hosted Fluxer API has been verified to list pins with `GET /channels/{id}/messages/pins`.
 
-Hermes also exposes Fluxer thread routes when the deployment enables them:
+Fluxer hosted API supports Discord-like reply references via `message_reference`; Hermes uses those for reply context and referenced-message lookup.
 
-```text
-POST /channels/{channel_id}/messages/{message_id}/threads
-POST /channels/{channel_id}/threads
-GET  /guilds/{guild_id}/threads/active
-```
+The adapter also keeps guarded helpers for deployments that add Discord-style thread endpoints, but the current hosted public API spec does not expose those routes. Do not rely on thread creation or active-thread enumeration unless your Fluxer deployment documents the routes.
 
-`send_message(action="list")` includes Fluxer guild channels, forums, active threads, and known/session-discovered targets when the deployment exposes `/users/@me/guilds` and `/guilds/{guild_id}/channels`. Thread/channel gateway events update the adapter's known-channel set, so reconnect backlog recovery can include newly revealed threads.
+`send_message(action="list")` includes Fluxer guild channels, forums when exposed, and known/session-discovered DMs/channels when the deployment exposes `/users/@me/guilds` and `/guilds/{guild_id}/channels`. Channel gateway events update the adapter's known-channel set, so reconnect backlog recovery can include newly revealed channels.
 
 ## Backlog recovery
 

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -107,6 +107,9 @@ Normally Hermes discovers this from `GET /gateway/bot`.
 | `FLUXER_ALLOW_ALL_USERS` | Optional | Allow every Fluxer user. Only safe for private/dev deployments. Default: `false`. |
 | `FLUXER_ALLOWED_CHANNELS` | Optional | Comma-separated channel IDs where Hermes may respond. Empty means no channel whitelist. DMs are still governed by user authorization. |
 | `FLUXER_FREE_RESPONSE_CHANNELS` | Optional | Comma-separated channel IDs where Hermes responds without being mentioned. |
+| `FLUXER_HOME_GUILD_ID` / `FLUXER_HOME_GUILDS` | Optional | Guild/community IDs that represent the user's own Hermes workspace. |
+| `FLUXER_AUTO_FREE_RESPONSE_HOME_GUILD` | Optional | When `true`, channels inside configured home guilds are conversational without per-channel opt-in. Default: `false`. |
+| `FLUXER_MENTION_GATED_CHANNELS` | Optional | Comma-separated channel IDs that still require a mention even inside auto-free-response home guilds. |
 | `FLUXER_REQUIRE_MENTION` | Optional | Require a direct mention/address in non-home channels. Default: `true`. |
 | `FLUXER_STRICT_MENTION` | Optional | Require a fresh mention on every channel message instead of remembering mentioned threads. Default: `false`. |
 | `FLUXER_MENTION_PATTERNS` | Optional | Comma-separated regexes that count as direct addresses. Defaults already cover `Hermes` at the start of a message. |
@@ -154,6 +157,8 @@ I think Hermes said that      # ignored in channels
 ```
 
 Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should always respond. Use this for dedicated bot/project rooms (for example weatherbot, trading, or other automation channels) where every message is effectively part of the conversation. Leave ordinary shared/social channels mention-gated so a passing “Hermes said…” does not wake the bot.
+
+For a personal Hermes-owned Fluxer community, set `FLUXER_HOME_GUILD_ID` (or `FLUXER_HOME_GUILDS`) plus `FLUXER_AUTO_FREE_RESPONSE_HOME_GUILD=true`. New channels created inside those home guilds then work like conversational bot rooms without editing `FLUXER_FREE_RESPONSE_CHANNELS` every time. Use `FLUXER_MENTION_GATED_CHANNELS` to opt noisy rooms such as logs or notification feeds back into mention-only mode.
 
 ## Native interactions
 
@@ -269,9 +274,9 @@ The plugin registers a standalone sender, so cron delivery also works when the c
 
 **Messages send but don't appear** — Keep `FLUXER_DELIVERY_VERIFICATION=true` and check gateway logs. Hermes reads the sent message back when possible and logs delivery mismatch warnings.
 
-**The bot answers in channels where it should stay quiet** — Check `FLUXER_HOME_CHANNEL`, `FLUXER_FREE_RESPONSE_CHANNELS`, and `FLUXER_REQUIRE_MENTION`. The home channel is intentionally free-response.
+**The bot answers in channels where it should stay quiet** — Check `FLUXER_HOME_CHANNEL`, `FLUXER_FREE_RESPONSE_CHANNELS`, `FLUXER_AUTO_FREE_RESPONSE_HOME_GUILD`, and `FLUXER_REQUIRE_MENTION`. The home channel and configured home-guild channels are intentionally free-response. Add noisy channel IDs to `FLUXER_MENTION_GATED_CHANNELS` to opt them out of home-guild auto-response.
 
-**The bot ignores channel messages** — In non-home channels, address it directly (`Hermes, ...` or a real bot mention), add the channel to `FLUXER_FREE_RESPONSE_CHANNELS`, or set `FLUXER_REQUIRE_MENTION=false`.
+**The bot ignores channel messages** — In non-home channels, address it directly (`Hermes, ...` or a real bot mention), add the channel to `FLUXER_FREE_RESPONSE_CHANNELS`, configure `FLUXER_HOME_GUILD_ID` with `FLUXER_AUTO_FREE_RESPONSE_HOME_GUILD=true`, or set `FLUXER_REQUIRE_MENTION=false`.
 
 **Dangerous-command approval text fallback is needed** — Some Fluxer hosted/client builds accept component payloads but do not render buttons. Use `/approve once`, `/approve session`, `/approve always`, or `/deny` from the prompt text. If buttons are visible, they are optional shortcuts.
 

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -32,8 +32,8 @@ Fluxer is not just “another Discord target.” A few platform traits make it e
 | Typing indicator | ✅ | Refreshed while Hermes is working |
 | Message edits | ✅ | Used for progress/stream-style updates where Hermes edits a sent message |
 | Message deletes | ✅ | Gateway cleanup and deleted approval prompts are handled |
-| Reactions | ✅ | General message reactions are preserved as Fluxer events; Hermes does not use reactions for dangerous-command approval. |
-| Buttons/components | Deployment-dependent | Hermes can attach component payloads for deployments that render message components and emit `INTERACTION_CREATE`, but prompts always include slash-command text fallback because hosted/client support may not show buttons. |
+| Reactions | ✅ | Hermes uses Fluxer message reactions for dangerous-command approvals (`✅`, `🕒`, `♾️`, `❌`) because the hosted public message API does not currently expose message components. |
+| Buttons/components | Deployment-dependent | Fluxer's hosted public message API currently does not list a `components` field, so Hermes does not rely on buttons. Approval prompts use reactions plus slash-command text fallback. |
 | Native slash commands | Deployment-dependent | Hermes can translate Fluxer `APPLICATION_COMMAND` interactions if a deployment emits them, but the current hosted API spec does not expose application-command registration routes. Keep `FLUXER_REGISTER_NATIVE_COMMANDS=false` unless your deployment provides those routes. |
 | Message pins | ✅ | Uses Fluxer's `/channels/{id}/messages/pins` routes when the server enables pins |
 | Threads | — | Hosted Fluxer currently exposes reply references, but not Discord-style thread routes in the public API spec. Hermes keeps speculative helpers for deployments that add thread endpoints, but the platform-comparison table does not count this as end-to-end thread support. |

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -5,11 +5,21 @@ description: "Use Hermes from Fluxer, an open-source Discord-like chat platform 
 
 # Fluxer
 
-[Fluxer](https://fluxer.app/) is a Discord-like open-source chat platform with channels, DMs, rich Markdown, reactions, and file uploads. Hermes talks to Fluxer through the bot REST API for outbound messages and the Fluxer Gateway WebSocket for inbound events.
+[Fluxer](https://fluxer.app/) is a free, open-source Discord-like chat platform with channels, DMs, rich Markdown, reactions, files, and voice/video chat. Hermes talks to Fluxer through the bot REST API for outbound messages and the Fluxer Gateway WebSocket for inbound events.
 
-Fluxer is a good fit when you want a self-hostable, chat-first surface for Hermes with Discord-style UX but without depending on Discord.
+Fluxer is a good fit when you want a self-hostable, chat-first surface for Hermes with Discord-style UX but without depending on Discord. The hosted web app also ships as an installable PWA (`display: standalone` in the web manifest), so privacy-oriented users can get an app-like mobile experience today while native mobile apps continue to mature.
 
 > Run `hermes gateway setup` and pick **Fluxer** for a guided setup when the plugin is installed.
+
+## Why Fluxer is interesting for Hermes
+
+Fluxer is not just “another Discord target.” A few platform traits make it especially attractive for Hermes users:
+
+- **Open source and self-hostable** — Fluxer is AGPL-3.0 and documents self-hosted deployments. That gives privacy-oriented users a path to keep their community/chat infrastructure under their own control.
+- **Installable web app today** — the web client exposes a PWA manifest and can run in a standalone app-like window on mobile/desktop browsers; native mobile clients are still described as coming.
+- **Discord-like community model** — guilds, channels, DMs/group DMs, roles, permissions, audit logs, invites, pins, reactions, webhooks, custom emoji/stickers, and message search are first-class Fluxer concepts.
+- **Strong media/voice foundation** — Fluxer exposes attachments, media proxying, voice/video/call APIs, RTC regions, screen-sharing UX, and entrance sounds. Hermes currently uses the message/media layer, while live call participation is intentionally out of scope for this text gateway adapter.
+- **Automation-friendly APIs** — Fluxer has bot tokens, OAuth2 applications, channel/guild webhooks, GitHub/Slack-compatible webhook endpoints, scheduled messages, read states, and gateway events. The Hermes plugin only implements the pieces needed for safe agent chat, but the platform has room for future deeper automations.
 
 ## What works
 
@@ -205,11 +215,11 @@ Hermes includes Fluxer pin helpers for deployments that expose pin routes:
 
 ```text
 GET    /channels/{channel_id}/messages/pins
-PUT    /channels/{channel_id}/messages/pins/{message_id}
-DELETE /channels/{channel_id}/messages/pins/{message_id}
+PUT    /channels/{channel_id}/pins/{message_id}
+DELETE /channels/{channel_id}/pins/{message_id}
 ```
 
-The hosted Fluxer API has been verified to list pins with `GET /channels/{id}/messages/pins`.
+The hosted Fluxer API has been verified to list pins with `GET /channels/{id}/messages/pins` and documents pin/unpin via `/channels/{id}/pins/{message_id}`.
 
 Fluxer hosted API supports Discord-like reply references via `message_reference`; Hermes uses those for reply context and referenced-message lookup.
 

--- a/website/docs/user-guide/messaging/fluxer.md
+++ b/website/docs/user-guide/messaging/fluxer.md
@@ -32,8 +32,8 @@ Fluxer is not just “another Discord target.” A few platform traits make it e
 | Typing indicator | ✅ | Refreshed while Hermes is working |
 | Message edits | ✅ | Used for progress/stream-style updates where Hermes edits a sent message |
 | Message deletes | ✅ | Gateway cleanup and deleted approval prompts are handled |
-| Reactions | ✅ | Still accepted as compatibility/fallback events |
-| Buttons/components | Deployment-dependent | Hermes has guarded adapter support for component payloads and `INTERACTION_CREATE` callbacks, but the current hosted Fluxer API schema does **not** accept/persist `components` on messages. Use text fallbacks (`/approve`, `/deny`) unless your deployment explicitly exposes native components. |
+| Reactions | ✅ | General message reactions are preserved as Fluxer events; Hermes does not use reactions for dangerous-command approval. |
+| Buttons/components | ✅ | Used for dangerous-command approvals and destructive slash confirmations on Fluxer deployments that accept message components and emit `INTERACTION_CREATE`. |
 | Native slash commands | Deployment-dependent | Hermes can translate Fluxer `APPLICATION_COMMAND` interactions if a deployment emits them, but the current hosted API spec does not expose application-command registration routes. Keep `FLUXER_REGISTER_NATIVE_COMMANDS=false` unless your deployment provides those routes. |
 | Message pins | ✅ | Uses Fluxer's `/channels/{id}/messages/pins` routes when the server enables pins |
 | Threads | — | Hosted Fluxer currently exposes reply references, but not Discord-style thread routes in the public API spec. Hermes keeps speculative helpers for deployments that add thread endpoints, but the platform-comparison table does not count this as end-to-end thread support. |
@@ -159,11 +159,10 @@ Set `FLUXER_FREE_RESPONSE_CHANNELS` for additional channels where Hermes should 
 
 Hermes keeps Fluxer native-interaction support guarded and deployment-aware:
 
-- if a Fluxer deployment accepts `components`, Hermes can send action rows/buttons for dangerous-command approvals and slash confirmations;
+- if a Fluxer deployment accepts `components`, Hermes sends action rows/buttons for dangerous-command approvals and slash confirmations;
+- dangerous-command approval prompts are button-first: `Allow once`, `Session`, `Always`, and `Deny` buttons are shown without emoji-reaction instructions or slash-command text in the Fluxer prompt;
 - if a deployment emits `INTERACTION_CREATE` with `type=3` / `MESSAGE_COMPONENT`, Hermes resolves the matching pending action;
 - if a deployment emits `INTERACTION_CREATE` with `type=2` / `APPLICATION_COMMAND`, Hermes translates it into normal slash text such as `/model gpt-5.5`.
-
-The current hosted Fluxer API spec does **not** list message `components`, interaction callback routes, or application-command registration routes. In that environment, native buttons and registered slash commands should be treated as unavailable and Hermes falls back to text commands.
 
 Native command registration is opt-in and should only be enabled for deployments that expose the required application-command routes:
 
@@ -190,16 +189,7 @@ On deployments with component support, Hermes can show native dangerous-command 
 | Always | always allow this command pattern |
 | Deny | deny |
 
-On the hosted Fluxer API today, use the text fallback instead:
-
-```text
-/approve
-/approve session
-/approve always
-/deny
-```
-
-If the approval prompt is deleted before it is resolved, Hermes fails closed and denies the pending approval.
+Fluxer approval is button-only in the prompt; Hermes does not ask users to approve with emoji reactions or by typing slash commands. If the approval prompt is deleted before it is resolved, Hermes fails closed and denies the pending approval.
 
 ## Media, voice, and streaming
 
@@ -283,6 +273,6 @@ The plugin registers a standalone sender, so cron delivery also works when the c
 
 **The bot ignores channel messages** — In non-home channels, address it directly (`Hermes, ...` or a real bot mention), add the channel to `FLUXER_FREE_RESPONSE_CHANNELS`, or set `FLUXER_REQUIRE_MENTION=false`.
 
-**Dangerous-command reactions do nothing** — Make sure the reacting user's Fluxer ID is in `FLUXER_ALLOWED_USERS` or `FLUXER_ALLOW_ALL_USERS=true` is set for a private/dev setup. Bot reactions are ignored.
+**Dangerous-command buttons do nothing** — Make sure the clicking user's Fluxer ID is in `FLUXER_ALLOWED_USERS` or `FLUXER_ALLOW_ALL_USERS=true` is set for a private/dev setup. Bot clicks are ignored. Emoji reactions are not approval controls.
 
 **Reconnects / heartbeat warnings** — The adapter responds to server heartbeat requests and sends regular heartbeats. Fresh `4009 Heartbeat timeout` warnings usually mean the deployment closed the WebSocket before the bot could identify/heartbeat; check network path, `FLUXER_GATEWAY_URL`, and server logs.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Fluxer, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Yuanbao, Microsoft Teams, LINE, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Fluxer, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, ntfy, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
@@ -20,6 +20,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 |----------|:-----:|:------:|:-----:|:-------:|:---------:|:------:|:---------:|
 | Telegram | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
 | Discord | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Fluxer | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
@@ -51,6 +52,7 @@ flowchart TB
         subgraph Adapters["Platform adapters"]
             tg[Telegram]
             dc[Discord]
+            fx[Fluxer]
             wa[WhatsApp]
             sl[Slack]
             gc[Google Chat]
@@ -80,6 +82,7 @@ flowchart TB
 
     tg --> store
     dc --> store
+    fx --> store
     wa --> store
     sl --> store
     gc --> store
@@ -203,6 +206,7 @@ FEISHU_ALLOWED_USERS=ou_xxxxxxxx,ou_yyyyyyyy
 WECOM_ALLOWED_USERS=user-id-1,user-id-2
 WECOM_CALLBACK_ALLOWED_USERS=user-id-1,user-id-2
 TEAMS_ALLOWED_USERS=aad-object-id-1,aad-object-id-2
+FLUXER_ALLOWED_USERS=123456789012345678
 
 # Or allow
 GATEWAY_ALLOWED_USERS=123456789,987654321
@@ -554,6 +558,7 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 
 - [Telegram Setup](telegram.md)
 - [Discord Setup](discord.md)
+- [Fluxer Setup](fluxer.md)
 - [Slack Setup](slack.md)
 - [Google Chat Setup](google_chat.md)
 - [WhatsApp Setup](whatsapp.md)

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -20,7 +20,7 @@ Bots need both a model provider and tool providers (TTS, web). A [Nous Portal](/
 |----------|:-----:|:------:|:-----:|:-------:|:---------:|:------:|:---------:|
 | Telegram | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
 | Discord | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Fluxer | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Fluxer | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ |
 | Slack | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -624,6 +624,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'user-guide/messaging/telegram',
             'user-guide/messaging/discord',
+            'user-guide/messaging/fluxer',
             'user-guide/messaging/slack',
             'user-guide/messaging/whatsapp',
             'user-guide/messaging/signal',


### PR DESCRIPTION
## Why this matters

Fluxer gives Hermes a Discord-like chat surface without requiring Discord: channels, DMs, Markdown, files, reactions, voice/video-capable infrastructure, and an open-source/self-hostable path. This PR adds Fluxer as a first-class Hermes Gateway platform so users can run Hermes inside Fluxer with the same basic expectations they have on existing messaging targets: safe inbound handling, outbound delivery, media, cron delivery, channel listing, and quiet-by-default group behavior.

## Summary

Adds a Fluxer platform plugin backed by Fluxer’s bot REST API and Gateway WebSocket.

### Core adapter

- Adds `plugins/platforms/fluxer/adapter.py`
- Supports Fluxer bot token configuration via `FLUXER_BOT_TOKEN`
- Defaults hosted API usage to `https://api.fluxer.app/v1`
- Supports self-hosted/custom deployments via `FLUXER_BASE_URL`
- Discovers the Gateway WebSocket URL from `/gateway/bot`, with `FLUXER_GATEWAY_URL` override support
- Handles inbound Gateway events and converts Fluxer messages into Hermes `MessageEvent`s
- Filters bot/self messages and deduplicates message IDs
- Preserves reply references and basic channel/message metadata

### Messaging behavior

- Sends normal text/Markdown messages
- Supports message edits for Hermes progress/stream-style updates
- Supports delete operations where Fluxer exposes delete routes
- Supports reactions where Fluxer exposes reaction routes
- Supports message pins where Fluxer exposes pin routes
- Adds delivery verification by reading back sent/edited messages when possible
- Neutralizes unsafe mass mentions by default: `@everyone`, `@here`, and role mentions unless explicitly allowed

### Media and voice files

- Sends files/images/audio/video through Fluxer multipart message creation
- Supports `MEDIA:/path` delivery from `send_message`
- Passes inbound attachments through to the agent as media URLs/types
- Treats voice/audio support as deployment-dependent because hosted/release Fluxer support may differ from developer/self-hosted builds

### Authorization and channel behavior

- Adds Fluxer user allowlist support: `FLUXER_ALLOWED_USERS`, `FLUXER_ALLOW_ALL_USERS`
- Adds channel allow/free-response controls: `FLUXER_ALLOWED_CHANNELS`, `FLUXER_FREE_RESPONSE_CHANNELS`, `FLUXER_HOME_CHANNEL`
- Keeps group/channel behavior quiet by default:
  - DMs are processed for authorized users
  - the configured home channel can be free-response
  - other channels require direct mention/address by default
- Adds configurable mention behavior: `FLUXER_REQUIRE_MENTION`, `FLUXER_STRICT_MENTION`, `FLUXER_MENTION_PATTERNS`

### Backlog recovery

- Adds bounded startup/reconnect backlog scanning for known channels
- Configurable via `FLUXER_BACKLOG_RECOVERY`, `FLUXER_BACKLOG_LIMIT`, and `FLUXER_BACKLOG_BOOTSTRAP_SECONDS`
- Still applies normal authorization, dedupe, self-message filtering, and mention-gating

### Channel directory / `send_message(action="list")`

- Extends the gateway channel directory so Fluxer appears in delivery target listings
- Lists guild channels when Fluxer exposes guild/channel routes
- Tracks known/session-discovered channels and DMs
- Adds Fluxer support to `tools/send_message_tool.py`

### Native interactions: guarded, deployment-aware

Hermes includes guarded Fluxer support for native interaction-style features, but does not overclaim them for the hosted API today.

- Component buttons are supported by the adapter if a deployment accepts message `components` and emits component interaction events
- Native slash-command translation is supported if a deployment emits application-command interaction events
- Native command registration is opt-in via `FLUXER_REGISTER_NATIVE_COMMANDS=false` by default, `FLUXER_APPLICATION_ID`, and `FLUXER_NATIVE_COMMAND_GUILDS`
- Hosted Fluxer’s current public API schema does not expose/persist all of these interaction routes, so text fallbacks remain the safe default: `/approve`, `/deny`, and normal Hermes slash text

### Docs and setup metadata

- Adds Fluxer plugin metadata in `plugin.yaml`
- Adds Fluxer to the README messaging/platform list
- Adds environment variable docs
- Adds a full Fluxer user guide under `website/docs/user-guide/messaging/fluxer.md`
- Adds Fluxer to the messaging docs index/sidebar
- Documents hosted vs self-hosted/deployment-dependent behavior explicitly

## Configuration

Minimum:

```bash
FLUXER_BOT_TOKEN=app_id.secret
FLUXER_HOME_CHANNEL=123456789012345678
FLUXER_ALLOWED_USERS=123456789012345678
```

Optional self-hosted/custom API:

```bash
FLUXER_BASE_URL=https://fluxer.example.com
```

Optional Gateway override:

```bash
FLUXER_GATEWAY_URL=wss://fluxer.example.com/gateway
```

Native command registration is intentionally off by default:

```bash
FLUXER_REGISTER_NATIVE_COMMANDS=false
```

## Maintainer notes / scope boundaries

This PR is intentionally conservative about Fluxer feature claims.

- Text, media/file delivery, edits, pins, replies, channel directory, and backlog recovery are implemented for the Hermes gateway adapter.
- Buttons/components, registered slash commands, and Discord-style threads are treated as deployment-dependent.
- Hosted Fluxer currently exposes reply references but not full Discord-style thread routes in the public API spec, so the docs do not count Fluxer as having end-to-end thread support.
- Live voice/video room participation is out of scope for this text gateway adapter. The adapter supports audio/voice-message-shaped file delivery where the deployment exposes those fields.


## Verification

Rebased cleanly onto current upstream `main`.

Targeted tests:

```bash
uv run --frozen pytest \
  tests/gateway/test_fluxer_plugin.py \
  tests/gateway/test_channel_directory.py \
  tests/tools/test_send_message_tool.py \
  tests/hermes_cli/test_send_cmd.py -q
```

Result:

```text
248 passed, 2 warnings in 11.14s
```
