### PR TITLE
fix(auxiliary): pass reasoning_config and extra_body through to auxiliary Anthropic calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -997,7 +997,7 @@ class _AnthropicCompletionsAdapter:
             messages=messages,
             tools=tools,
             max_tokens=max_tokens,
-            reasoning_config=None,
+            reasoning_config=kwargs.get("reasoning_config"),
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
         )
@@ -1008,6 +1008,19 @@ class _AnthropicCompletionsAdapter:
             from agent.anthropic_adapter import _forbids_sampling_params
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
+
+        # Pass through any caller-supplied extra_body so providers behind
+        # Anthropic-compatible gateways can receive their per-vendor request
+        # fields (e.g. thinking control, metadata, service_tier). The dict
+        # form is the documented Anthropic SDK passthrough for non-standard
+        # request body keys; merge on top of whatever build_anthropic_kwargs
+        # already produced to preserve call-time settings.
+        caller_extra_body = kwargs.get("extra_body")
+        if caller_extra_body and isinstance(caller_extra_body, dict):
+            existing = anthropic_kwargs.get("extra_body") or {}
+            if not isinstance(existing, dict):
+                existing = {}
+            anthropic_kwargs["extra_body"] = {**existing, **caller_extra_body}
 
         response = self._client.messages.create(**anthropic_kwargs)
         _transport = get_transport("anthropic_messages")


### PR DESCRIPTION
## Summary

`_AnthropicCompletionsAdapter.create()` in `agent/auxiliary_client.py` silently discards caller-supplied `reasoning_config` and `extra_body` for every auxiliary task routed through the Anthropic-Messages protocol (anthropic, minimax, kimi-coding, z.ai, any custom `/anthropic`-suffixed endpoint). The main agent path (`agent/transports/anthropic.py`) already handles these correctly; this PR aligns the auxiliary adapter with the same pattern.

## Two bugs, one root cause

**Bug A — `reasoning_config` hardcoded to `None` (L1000)**

```python
anthropic_kwargs = build_anthropic_kwargs(
    ...
    reasoning_config=None,   # always None, regardless of caller
    ...
)
```

The main agent path already does this right:
```python
return build_anthropic_kwargs(..., reasoning_config=params.get("reasoning_config"), ...)
```

**Bug B — `extra_body` dropped between caller and SDK (L1012)**

`create(**kwargs)` accepts the caller's OpenAI-style kwargs but only forwards a hand-picked subset to `self._client.messages.create(**anthropic_kwargs)`. `extra_body` (and any other caller-supplied field) never reaches the wire. The codex/responses transport in the same file already merges `extra_body`; the Anthropic branch is the gap.

## Fix

```diff
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -997,7 +997,7 @@ class _AnthropicCompletionsAdapter:
             messages=messages,
             tools=tools,
             max_tokens=max_tokens,
-            reasoning_config=None,
+            reasoning_config=kwargs.get("reasoning_config"),
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
         )
@@ -1009,6 +1009,19 @@ class _AnthropicCompletionsAdapter:
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature

+        # Merge caller-supplied extra_body so providers behind
+        # Anthropic-compatible gateways can receive per-vendor request
+        # fields (e.g. thinking control, metadata, service_tier). Dict
+        # form is the documented Anthropic SDK passthrough for
+        # non-standard request body keys.
+        caller_extra_body = kwargs.get("extra_body")
+        if caller_extra_body and isinstance(caller_extra_body, dict):
+            existing = anthropic_kwargs.get("extra_body") or {}
+            if not isinstance(existing, dict):
+                existing = {}
+            anthropic_kwargs["extra_body"] = {**existing, **caller_extra_body}
+
         response = self._client.messages.create(**anthropic_kwargs)
```

## Behavior

* Backward-compatible. Callers that don't pass `reasoning_config` or `extra_body` see no change.
* Unlocks caller `extra_body` for the auxiliary path. Callers can now pass `extra_body={"thinking": {"type": "disabled"}}` (or any vendor field) via the standard OpenAI-style kwarg and have it reach the Anthropic SDK.
* `reasoning_config` kwarg now flows into `build_anthropic_kwargs` like the main agent does, instead of being silently replaced with `None`.

## Tests

Add a unit test under `tests/agent/` mocking `self._client.messages.create()` and asserting:

1. `reasoning_config={"enabled": True, "effort": "medium"}` from the caller → `build_anthropic_kwargs` is invoked with that value.
2. `extra_body={"thinking": {"type": "disabled"}}` from the caller → kwargs to `messages.create()` include the merged dict under `extra_body`.
3. Neither passed → kwargs to `messages.create()` are byte-identical to today (no regression).

## Related issues

Same family of issue, different surfaces — flagging for reviewers:

* #35566 — auxiliary `extra_body` ignored from config.yaml
* #7209 — extra_body passthrough for CLI/gateway main agent
* #16533 — Z.AI/GLM `reasoning_content` never returned (root cause: extra_body shape)
* #32813 — per-auxiliary reasoning effort configuration (becomes solvable once this lands)
* #29248 — `/reasoning max` rejected by frontend
