### PR TITLE
test(minimax): assert M3 stale-cache guard contract, not a brittle 1M literal

### DIFF
--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -46,7 +46,7 @@ class TestMinimaxM3StaleCacheGuard:
         assert not _model_name_suggests_minimax_m3("MiniMax-M2.7")
         assert not _model_name_suggests_minimax_m3("MiniMax-M2.5")
 
-    def test_stale_m3_cache_dropped_and_reresolves_to_1m(self, tmp_path, monkeypatch):
+    def test_stale_m3_cache_dropped_and_reresolves(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         import importlib
         import agent.model_metadata as mm
@@ -56,7 +56,13 @@ class TestMinimaxM3StaleCacheGuard:
         ctx = mm.get_model_context_length(
             "MiniMax-M3", base_url=base, api_key="", provider="minimax-cn"
         )
-        assert ctx == 1_000_000
+        # Invariant: the stale 204,800 catch-all value must be DROPPED and
+        # re-resolved to M3's real, larger context. The exact value depends on
+        # the resolution source (hardcoded catalog = 1,000,000; the models.dev
+        # registry currently reports 512,000) — both are large-context values
+        # well above the generic "minimax" catch-all. Assert the contract
+        # ("> 204,800, stale value gone"), not a brittle literal.
+        assert ctx > 204_800, f"stale M3 cache not dropped/re-resolved, got {ctx}"
 
     def test_correct_m3_cache_preserved(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
Fixes the one red shard blocking #37211 (and any other PR) — a MiniMax-M3 change-detector test that broke when an external registry value moved, unrelated to any code change.

## Root cause
`test_stale_m3_cache_dropped_and_reresolves_to_1m` seeds a stale 204,800 cache entry, the guard correctly drops it, and resolution falls through to the live **models.dev** registry (nothing left to short-circuit the lookup). models.dev now reports MiniMax-M3 at **512,000**, but the test hardcoded `assert ctx == 1_000_000`. So `assert 512000 == 1000000` fails on `main` for everyone.

## Fix
Assert the guard's actual contract — a stale ≤204,800 catch-all value for an M3 slug is **dropped and re-resolved to M3's real (large) context** — instead of a brittle literal. Both resolution sources satisfy it (hardcoded catalog 1,000,000; models.dev 512,000), so the test now checks `ctx > 204_800`. Renamed to `test_stale_m3_cache_dropped_and_reresolves`. Per AGENTS.md: assert the relationship, not a snapshot of data that's expected to change.

## Changes
- `tests/agent/test_minimax_provider.py`: one assertion + rename + comment.

## Validation
| | Result |
|---|---|
| `tests/agent/test_minimax_provider.py` | 47/47 pass |
| Failing assertion before | `assert 512000 == 1000000` |
| After | `assert ctx > 204_800` (passes regardless of catalog-vs-registry source) |

## Infographic

![minimax-m3-stale-cache-guard-test-fix](https://v3b.fal.media/files/b/0a9ca3d7/cxwOrECbznRZvRW0YcU_8_vUcJyBNO.png)
