### PR TITLE
fix(security): denylist ~/.hermes/mcp-tokens/ for media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1134,12 +1134,18 @@ def _media_delivery_denied_paths() -> List[Path]:
         # Bitwarden Secrets Manager plaintext disk cache.
         os.path.join("cache", "bws_cache.json"),
     )
-    # Directory trees whose every child is credential material. (MCP OAuth
-    # tokens under mcp-tokens/ are handled by the sibling targeted PR #37222;
-    # session/kanban SQLite stores by #41071 — kept out of this diff to avoid
-    # overlap.)
+    # Directory trees whose every child is credential material.
+    #
+    # mcp-tokens/ holds live MCP OAuth access tokens (<server>.json) and
+    # dynamically-registered client credentials (<server>.client.json); see
+    # tools/mcp_oauth.py. Same credential class as auth.json/credentials/.
+    # The write side already denies it (file_tools _check_sensitive_path);
+    # this pairs the media-delivery (exfil) side so a prompt-injection MEDIA
+    # tag can't deliver a live bearer token as a native attachment.
+    # (session/kanban SQLite stores are handled by #41071 — kept out here.)
     _ROOT_CREDENTIAL_DIRS = (
         "pairing",
+        "mcp-tokens",
     )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
         for rel in _ROOT_CREDENTIAL_FILES:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -928,6 +928,38 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(env_file)) is None
 
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "mcp-tokens/github.json",
+            "mcp-tokens/github.client.json",
+            "mcp-tokens/github.meta.json",
+        ],
+    )
+    def test_denylist_blocks_mcp_oauth_tokens(self, tmp_path, monkeypatch, rel):
+        """Live MCP OAuth tokens/client creds under ~/.hermes/mcp-tokens/ must
+        never deliver as native media — same exfil class as auth.json/.env.
+        Sibling to the pairing/ directory denylist entry.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        (hermes_dir / "mcp-tokens").mkdir(parents=True)
+        secret = hermes_dir / rel
+        secret.write_text('{"access_token": "live-bearer-abc123"}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_HOME",
+            hermes_dir,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._HERMES_ROOT",
+            hermes_dir,
+        )
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
+
     def test_denylist_blocks_hermes_config_in_active_profile(self, tmp_path, monkeypatch):
         """The active profile config stays blocked in default mode."""
         self._patch_roots(monkeypatch)


### PR DESCRIPTION
## This is a sibling follow-up to commit 4ec0adebe (#35634 family)

- #35634 / commit `4ec0adebe` covered: media-delivery denylist now blocks `~/.hermes/config.yaml` (joining the existing `.env`, `auth.json`, `credentials/`).
- That family did NOT touch: `~/.hermes/mcp-tokens/` — the directory holding live MCP OAuth **access tokens** (`<server>.json`) and dynamically-registered OAuth **client credentials** (`<server>.client.json`), layout per `tools/mcp_oauth.py`.
- This PR adds the same per-Hermes-root denylist entry for `mcp-tokens/`, pairing the media-delivery (exfil) side with the write-side deny that already exists (`file_tools._check_sensitive_path`, covered by `test_hermes_control_files_oauth_and_mcp_tokens_denied`).

## What does this PR do?

`_media_delivery_denied_paths()` in `gateway/platforms/base.py` is the defense-in-depth gate that stops a prompt-injection `MEDIA:` tag from delivering host secrets as a native gateway attachment. It denies `.env`, `auth.json`, `credentials/`, and `config.yaml` under both `_HERMES_HOME` and `_HERMES_ROOT` — but not `mcp-tokens/`. A payload emitting `MEDIA:~/.hermes/mcp-tokens/github.json` would, in default (non-strict) mode, pass the denylist and exfiltrate a live OAuth bearer token to the same untrusted channel. This PR closes that gap. `mcp-tokens` is a directory and `_path_under_denied_prefix` already does containment matching (via `_path_is_within`), so the whole subtree (`.json`/`.client.json`/`.meta.json`) is denied, mirroring `credentials/`.

## Related Issue

Fixes #
<!-- sibling-widening; no single linked issue. Related context: #36767 documents that mcp-tokens/ holds live OAuth client/credential material. -->

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/base.py`: in `_media_delivery_denied_paths()`, append `hermes_root / "mcp-tokens"` to the per-Hermes-root denylist (covers both active profile and shared root).
- `tests/gateway/test_platform_base.py`: add a parametrized test asserting `validate_media_delivery_path` returns `None` for `mcp-tokens/<server>.json`, `.client.json`, and `.meta.json`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_platform_base.py -v`
2. New `test_denylist_blocks_mcp_oauth_tokens` cases fail before the prod change, pass after.
3. Manual: `validate_media_delivery_path("~/.hermes/mcp-tokens/github.json")` returns `None`; a fresh file in a cache dir still returns its resolved path (existing tests cover this).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring/comment in the denylist) — or N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact considered (home-relative paths resolved at check time) — or N/A
- [x] Tool descriptions/schemas — N/A