### PR TITLE
fix(tools): collapse duplicate mcp_ prefixes before fuzzy matching

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1677,6 +1677,21 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
                 return s[: -len(suffix)].rstrip("_-")
         return None
 
+    def _collapse_duplicate_mcp_prefixes(s: str) -> str:
+        """Collapse duplicated leading ``mcp_`` prefixes to one prefix.
+
+        Some MCP tool-call repair paths accidentally prepend the namespace
+        twice (e.g. ``mcp_mcp_server_tool``). That shape is far enough from the
+        canonical tool name that the fuzzy matcher can miss, so normalize it
+        before exact/fuzzy matching.
+        """
+        lowered = s.lower()
+        if not lowered.startswith("mcp_"):
+            return lowered
+        while lowered.startswith("mcp_mcp_"):
+            lowered = lowered.replace("mcp_mcp_", "mcp_", 1)
+        return lowered
+
     # Cheap fast-paths first — these cover the common case.
     lowered = tool_name.lower()
     if lowered in agent.valid_tool_names:
@@ -1684,9 +1699,12 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     normalized = _norm(tool_name)
     if normalized in agent.valid_tool_names:
         return normalized
+    collapsed_mcp = _collapse_duplicate_mcp_prefixes(tool_name)
+    if collapsed_mcp in agent.valid_tool_names:
+        return collapsed_mcp
 
     # Build the full candidate set for class-like emissions.
-    cands: set[str] = {tool_name, lowered, normalized, _camel_snake(tool_name)}
+    cands: set[str] = {tool_name, lowered, normalized, _camel_snake(tool_name), collapsed_mcp}
     # Strip trailing tool-suffix up to twice — TodoTool_tool needs it.
     for _ in range(2):
         extra: set[str] = set()

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -25,6 +25,7 @@ VALID = {
     "read_file",
     "write_file",
     "terminal",
+    "mcp_browser_click",
 }
 
 
@@ -94,6 +95,11 @@ class TestClassLikeEmissions:
 
     def test_mixed_separators_and_suffix(self, repair):
         assert repair("write-file_Tool") == "write_file"
+
+    def test_duplicate_mcp_prefix_collapses_before_fuzzy_match(self, repair):
+        # Regression for #37171 — duplicated namespace prefixes should be
+        # normalized to a single leading mcp_ before the fuzzy matcher runs.
+        assert repair("mcp_mcp_browser_click") == "mcp_browser_click"
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## Summary
- Collapse duplicated leading `mcp_` prefixes before fuzzy matching in `AIAgent._repair_tool_call`
- Add regression coverage for duplicated MCP namespace prefixes

## Test
- `scripts/run_tests.sh tests/run_agent/test_repair_tool_call_name.py`

Closes #37171
