### PR TITLE
feat(memory): add graph recall packets

### DIFF
--- a/agent/memory_recall_packet.py
+++ b/agent/memory_recall_packet.py
@@ -1,0 +1,365 @@
+"""Provider-neutral formatting for graph-shaped memory recall packets.
+
+The dataclasses in this module intentionally avoid importing any concrete
+memory provider types. Hindsight, Atlas, session search, or another provider
+can map their native response objects into this small contract and then render
+bounded, provenance-forward text for context injection or tool output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+_METADATA_ALLOWLIST = (
+    "source",
+    "session_id",
+    "platform",
+    "chat_name",
+    "thread_id",
+    "turn_index",
+    "retained_at",
+    "agent_identity",
+)
+
+
+@dataclass
+class EntityObservation:
+    """A short observation attached to a canonical entity."""
+
+    text: str
+    mentioned_at: str | None = None
+
+
+@dataclass
+class RecallEntity:
+    """Canonical entity plus supporting observations."""
+
+    entity_id: str | None = None
+    canonical_name: str = ""
+    observations: list[EntityObservation] = field(default_factory=list)
+
+
+@dataclass
+class RecallObservation:
+    """One top-level memory observation/snippet returned by recall."""
+
+    text: str
+    type: str | None = None
+    entities: list[str] = field(default_factory=list)
+    context: str | None = None
+    occurred_start: str | None = None
+    occurred_end: str | None = None
+    mentioned_at: str | None = None
+    document_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    chunk_id: str | None = None
+    tags: list[str] = field(default_factory=list)
+    source_fact_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RecallEvidenceChunk:
+    """A bounded source chunk handle associated with recall."""
+
+    id: str
+    text: str = ""
+    chunk_index: int | None = None
+    truncated: bool | None = None
+
+
+@dataclass
+class RecallPacket:
+    """Provider-neutral graph recall packet."""
+
+    query: str
+    observations: list[RecallObservation] = field(default_factory=list)
+    entities: list[RecallEntity] = field(default_factory=list)
+    chunks: list[RecallEvidenceChunk] = field(default_factory=list)
+    source_facts: list[Any] = field(default_factory=list)
+    trace: Any | None = None
+
+
+def format_recall_packet(
+    packet: RecallPacket,
+    *,
+    compact: bool = False,
+    max_observations: int = 6,
+    max_entities: int = 8,
+    max_entity_observations: int = 3,
+    max_evidence: int = 6,
+    show_metadata: bool = False,
+) -> str:
+    """Render *packet* as bounded Markdown/text.
+
+    ``compact=True`` is intended for automatic context injection. ``compact=False``
+    keeps more provenance detail for explicit tool calls. Both modes preserve
+    the same trust semantics: this is candidate memory, not verified truth.
+    """
+    max_observations = _positive_or_default(max_observations, 6)
+    max_entities = _positive_or_default(max_entities, 8)
+    max_entity_observations = _positive_or_default(max_entity_observations, 3)
+    max_evidence = _positive_or_default(max_evidence, 6)
+
+    if not (packet.observations or packet.entities or packet.source_facts or packet.chunks):
+        return "No relevant memories found."
+
+    if compact:
+        return _format_compact(
+            packet,
+            max_observations=max_observations,
+            max_entities=max_entities,
+            max_entity_observations=max_entity_observations,
+        )
+
+    return _format_full(
+        packet,
+        max_observations=max_observations,
+        max_entities=max_entities,
+        max_entity_observations=max_entity_observations,
+        max_evidence=max_evidence,
+        show_metadata=show_metadata,
+    )
+
+
+def _format_compact(
+    packet: RecallPacket,
+    *,
+    max_observations: int,
+    max_entities: int,
+    max_entity_observations: int,
+) -> str:
+    lines: list[str] = [
+        "# Memory Recall Packet",
+        "Status: candidate context; verify important claims before acting.",
+        f"Query: {_inline(packet.query)}",
+    ]
+
+    if packet.observations:
+        lines.append("Observations:")
+        shown, omitted = _cap(packet.observations, max_observations)
+        for observation in shown:
+            handles = _compact_observation_handles(observation)
+            suffix = f" [{handles}]" if handles else ""
+            warning = "; warning: missing source handle" if _missing_source_handle(observation) else ""
+            lines.append(f"- {_truncate(_one_line(observation.text), 260)}{suffix}{warning}")
+        if omitted:
+            lines.append(f"- … {omitted} more observation(s) omitted.")
+
+    if packet.entities:
+        lines.append("Entities:")
+        shown_entities, omitted_entities = _cap(packet.entities, max_entities)
+        for entity in shown_entities:
+            name = _one_line(entity.canonical_name or entity.entity_id or "unknown entity")
+            obs_text = ""
+            observations, obs_omitted = _cap(entity.observations, max_entity_observations)
+            if observations:
+                obs_text = ": " + "; ".join(
+                    _truncate(_one_line(obs.text), 140) for obs in observations if obs.text
+                )
+                if obs_omitted:
+                    obs_text += f"; … {obs_omitted} more"
+            lines.append(f"- {name}{obs_text}")
+        if omitted_entities:
+            lines.append(f"- … {omitted_entities} more entit(y/ies) omitted.")
+
+    lines.append("Verification: no authority check performed.")
+    return "\n".join(lines).strip()
+
+
+def _format_full(
+    packet: RecallPacket,
+    *,
+    max_observations: int,
+    max_entities: int,
+    max_entity_observations: int,
+    max_evidence: int,
+    show_metadata: bool,
+) -> str:
+    lines: list[str] = [
+        "## Memory Recall Packet",
+        "",
+        "**Status:** Candidate context from memory retrieval. Verify against source evidence before acting on high-impact facts.",
+        f"**Query:** `{_code(packet.query)}`",
+    ]
+
+    if packet.observations:
+        lines.extend(["", "### Top observations"])
+        shown, omitted = _cap(packet.observations, max_observations)
+        for index, observation in enumerate(shown, 1):
+            lines.append(f"{index}. {_truncate(_one_line(observation.text), 700)}")
+            lines.extend(_observation_detail_lines(observation, show_metadata=show_metadata))
+        if omitted:
+            lines.append(f"- … {omitted} more observation(s) omitted.")
+
+    if packet.entities:
+        lines.extend(["", "### Entities"])
+        shown_entities, omitted_entities = _cap(packet.entities, max_entities)
+        for entity in shown_entities:
+            name = _one_line(entity.canonical_name or "unknown entity")
+            if entity.entity_id:
+                lines.append(f"- **{name}** (`{_code(entity.entity_id)}`)")
+            else:
+                lines.append(f"- **{name}**")
+            observations, obs_omitted = _cap(entity.observations, max_entity_observations)
+            for observation in observations:
+                suffix = f" (`{_code(observation.mentioned_at)}`)" if observation.mentioned_at else ""
+                lines.append(f"  - {_truncate(_one_line(observation.text), 280)}{suffix}")
+            if obs_omitted:
+                lines.append(f"  - … {obs_omitted} more observation(s) omitted.")
+        if omitted_entities:
+            lines.append(f"- … {omitted_entities} more entit(y/ies) omitted.")
+
+    if packet.source_facts or packet.chunks:
+        lines.extend(["", "### Evidence handles"])
+        source_facts, source_omitted = _cap(packet.source_facts, max_evidence)
+        for fact in source_facts:
+            lines.append(f"- source_fact: {_evidence_text(fact)}")
+        if source_omitted:
+            lines.append(f"- … {source_omitted} more source_fact(s) omitted.")
+
+        chunks, chunk_omitted = _cap(packet.chunks, max_evidence)
+        for chunk in chunks:
+            detail_parts = [f"chunk: `{_code(chunk.id)}`"]
+            if chunk.chunk_index is not None:
+                detail_parts.append(f"index: `{chunk.chunk_index}`")
+            if chunk.truncated is not None:
+                detail_parts.append(f"truncated: `{str(chunk.truncated).lower()}`")
+            detail = "; ".join(detail_parts)
+            text = _truncate(_one_line(chunk.text), 240)
+            lines.append(f"- {detail}" + (f" — {text}" if text else ""))
+        if chunk_omitted:
+            lines.append(f"- … {chunk_omitted} more chunk(s) omitted.")
+
+    lines.extend(["", "### Verification notes"])
+    lines.append("- No authority verification performed in this recall packet.")
+    if any(_missing_source_handle(observation) for observation in packet.observations):
+        lines.append("- Missing source handle on one or more observations; treat those as lower-confidence leads.")
+    elif packet.observations:
+        lines.append("- Listed observations include source handles; still verify high-impact claims against authority sources.")
+
+    return "\n".join(lines).strip()
+
+
+def _observation_detail_lines(observation: RecallObservation, *, show_metadata: bool) -> list[str]:
+    lines: list[str] = []
+
+    detail_map: list[tuple[str, Any]] = [
+        ("type", observation.type),
+        ("entities", observation.entities),
+        ("context", observation.context),
+        ("document_id", observation.document_id),
+        ("chunk_id", observation.chunk_id),
+        ("source_fact_ids", observation.source_fact_ids),
+        ("occurred_start", observation.occurred_start),
+        ("occurred_end", observation.occurred_end),
+        ("mentioned_at", observation.mentioned_at),
+        ("tags", observation.tags),
+    ]
+    for key, value in detail_map:
+        rendered = _render_value(value)
+        if rendered:
+            lines.append(f"   - {key}: {rendered}")
+
+    metadata_lines = _metadata_lines(observation.metadata, show_metadata=show_metadata)
+    lines.extend(f"   - {line}" for line in metadata_lines)
+
+    if _missing_source_handle(observation):
+        lines.append("   - warning: Missing source handle.")
+    return lines
+
+
+def _metadata_lines(metadata: dict[str, Any], *, show_metadata: bool) -> list[str]:
+    if not metadata:
+        return []
+
+    lines: list[str] = []
+    unknown_keys: list[str] = []
+    for key in sorted(metadata):
+        value = metadata[key]
+        if key in _METADATA_ALLOWLIST or show_metadata:
+            rendered = _render_value(value)
+            if rendered:
+                lines.append(f"{key}: {rendered}")
+        else:
+            unknown_keys.append(str(key))
+    if unknown_keys and not show_metadata:
+        lines.append("metadata_keys: " + _render_sequence(unknown_keys))
+    return lines
+
+
+def _compact_observation_handles(observation: RecallObservation) -> str:
+    handles: list[str] = []
+    if observation.document_id:
+        handles.append(f"doc: {_one_line(observation.document_id)}")
+    if observation.chunk_id:
+        handles.append(f"chunk: {_one_line(observation.chunk_id)}")
+    if observation.source_fact_ids:
+        handles.append(f"facts: {', '.join(_one_line(x) for x in observation.source_fact_ids[:3])}")
+    if observation.entities:
+        handles.append(f"entities: {', '.join(_one_line(x) for x in observation.entities[:4])}")
+    return "; ".join(handles)
+
+
+def _missing_source_handle(observation: RecallObservation) -> bool:
+    return not (observation.document_id or observation.chunk_id or observation.source_fact_ids)
+
+
+def _evidence_text(value: Any) -> str:
+    if isinstance(value, dict):
+        fact_id = value.get("id") or value.get("fact_id") or value.get("source_fact_id")
+        text = value.get("text") or value.get("content") or value.get("summary") or ""
+        if fact_id:
+            if text:
+                return f"`{_code(fact_id)}` — {_truncate(_one_line(text), 280)}"
+            return f"`{_code(fact_id)}`"
+    return _truncate(_one_line(value), 320)
+
+
+def _render_value(value: Any) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, (list, tuple, set)):
+        return _render_sequence(value)
+    return f"`{_code(value)}`"
+
+
+def _render_sequence(value: Iterable[Any]) -> str:
+    items = [_one_line(item) for item in value if item is not None and str(item).strip()]
+    if not items:
+        return ""
+    return ", ".join(f"`{_code(item)}`" for item in items)
+
+
+def _inline(value: Any) -> str:
+    return _one_line(value)
+
+
+def _code(value: Any) -> str:
+    return _one_line(value).replace("`", "'")
+
+
+def _one_line(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = "".join(ch if (ch >= " " or ch in "\t\n\r") else " " for ch in text)
+    return " ".join(text.split())
+
+
+def _truncate(text: str, limit: int) -> str:
+    if limit <= 0 or len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _cap(items: Sequence[Any], limit: int) -> tuple[list[Any], int]:
+    shown = list(items[:limit])
+    omitted = max(0, len(items) - len(shown))
+    return shown, omitted
+
+
+def _positive_or_default(value: int, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -41,6 +41,14 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
+from agent.memory_recall_packet import (
+    EntityObservation,
+    RecallEntity,
+    RecallEvidenceChunk,
+    RecallObservation,
+    RecallPacket,
+    format_recall_packet,
+)
 from hermes_constants import get_hermes_home
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
@@ -81,6 +89,158 @@ def _parse_int_setting(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
+
+
+def _parse_bool_setting(value: Any, default: bool) -> bool:
+    """Parse a boolean-ish config/env value, falling back on invalid input."""
+    if value is None or value == "":
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    logger.warning("Invalid boolean Hindsight setting %r; using default %s", value, default)
+    return default
+
+
+def _normalise_recall_packet_format(value: Any) -> str:
+    """Return a supported recall packet format name."""
+    text = str(value or "plain").strip().lower()
+    return text if text in {"plain", "graph"} else "plain"
+
+
+def _object_value(obj: Any, *names: str, default: Any = None) -> Any:
+    """Read the first present key/attribute from dicts, Pydantic models, or objects."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        for name in names:
+            if name in obj:
+                return obj[name]
+    for name in names:
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return default
+
+
+def _object_dict(obj: Any) -> dict[str, Any]:
+    """Convert dict/Pydantic/simple objects to a best-effort plain dict."""
+    if obj is None:
+        return {}
+    if isinstance(obj, dict):
+        return dict(obj)
+    if hasattr(obj, "model_dump"):
+        try:
+            data = obj.model_dump(exclude_none=True)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            pass
+    if hasattr(obj, "dict"):
+        try:
+            data = obj.dict(exclude_none=True)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            pass
+    return {
+        key: value
+        for key, value in vars(obj).items()
+        if not key.startswith("_")
+    } if hasattr(obj, "__dict__") else {}
+
+
+def _list_or_empty(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _string_list(value: Any) -> list[str]:
+    return [str(item) for item in _list_or_empty(value) if item is not None and str(item).strip()]
+
+
+def _recall_observation_from_result(result: Any) -> RecallObservation:
+    metadata = _object_value(result, "metadata", default={})
+    if not isinstance(metadata, dict):
+        metadata = _object_dict(metadata)
+    return RecallObservation(
+        text=str(_object_value(result, "text", "content", "summary", default="") or ""),
+        type=_object_value(result, "type", "fact_type", "memory_type"),
+        entities=_string_list(_object_value(result, "entities", "entity_names", default=[])),
+        context=_object_value(result, "context"),
+        occurred_start=_object_value(result, "occurred_start", "valid_at", "start_time"),
+        occurred_end=_object_value(result, "occurred_end", "end_time"),
+        mentioned_at=_object_value(result, "mentioned_at", "timestamp", "created_at"),
+        document_id=_object_value(result, "document_id", "source_document_id", "doc_id"),
+        metadata=metadata,
+        chunk_id=_object_value(result, "chunk_id", "chunkId"),
+        tags=_string_list(_object_value(result, "tags", default=[])),
+        source_fact_ids=_string_list(_object_value(result, "source_fact_ids", "sourceFactIds", "source_facts", default=[])),
+    )
+
+
+def _entity_observation_from_value(value: Any) -> EntityObservation:
+    return EntityObservation(
+        text=str(_object_value(value, "text", "content", "summary", default=value) or ""),
+        mentioned_at=_object_value(value, "mentioned_at", "timestamp", "created_at"),
+    )
+
+
+def _recall_entity_from_value(value: Any) -> RecallEntity:
+    observations = [
+        _entity_observation_from_value(obs)
+        for obs in _list_or_empty(_object_value(value, "observations", "evidence", default=[]))
+    ]
+    return RecallEntity(
+        entity_id=_object_value(value, "entity_id", "id"),
+        canonical_name=str(_object_value(value, "canonical_name", "name", "entity", default="") or ""),
+        observations=observations,
+    )
+
+
+def _recall_chunk_from_value(value: Any) -> RecallEvidenceChunk | None:
+    chunk_id = _object_value(value, "id", "chunk_id", "chunkId")
+    if chunk_id is None:
+        return None
+    return RecallEvidenceChunk(
+        id=str(chunk_id),
+        text=str(_object_value(value, "text", "content", default="") or ""),
+        chunk_index=_object_value(value, "chunk_index", "index"),
+        truncated=_object_value(value, "truncated"),
+    )
+
+
+def _recall_packet_from_response(query: str, resp: Any) -> RecallPacket:
+    chunks: list[RecallEvidenceChunk] = []
+    for chunk in _list_or_empty(_object_value(resp, "chunks", "source_chunks", default=[])):
+        mapped = _recall_chunk_from_value(chunk)
+        if mapped is not None:
+            chunks.append(mapped)
+    return RecallPacket(
+        query=query,
+        observations=[
+            _recall_observation_from_result(result)
+            for result in _list_or_empty(_object_value(resp, "results", default=[]))
+            if _object_value(result, "text", "content", "summary", default="")
+        ],
+        entities=[
+            _recall_entity_from_value(entity)
+            for entity in _list_or_empty(_object_value(resp, "entities", default=[]))
+        ],
+        chunks=chunks,
+        source_facts=_list_or_empty(_object_value(resp, "source_facts", "sourceFacts", default=[])),
+        trace=_object_value(resp, "trace"),
+    )
 
 
 def _check_local_runtime() -> tuple[bool, str | None]:
@@ -269,6 +429,14 @@ RECALL_SCHEMA = {
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "What to search for."},
+            "format": {
+                "type": "string",
+                "enum": ["plain", "graph"],
+                "description": (
+                    "Optional output format. 'plain' preserves the existing numbered-list "
+                    "contract; 'graph' returns a provenance-forward recall packet."
+                ),
+            },
         },
         "required": ["query"],
     },
@@ -874,6 +1042,14 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
+            {"key": "recall_packet_format", "description": "Recall output format for automatic recall and hindsight_recall when no per-call format is provided", "default": "plain", "choices": ["plain", "graph"]},
+            {"key": "recall_graph_entities", "description": "Request entity graph data when recall_packet_format is graph", "default": True},
+            {"key": "recall_graph_source_facts", "description": "Request source-fact handles when recall_packet_format is graph", "default": True},
+            {"key": "recall_graph_chunks", "description": "Request source chunks when recall_packet_format is graph", "default": False},
+            {"key": "recall_graph_trace", "description": "Request provider trace metadata when recall_packet_format is graph", "default": False},
+            {"key": "recall_graph_max_observations", "description": "Maximum observations rendered in graph recall packets", "default": 6},
+            {"key": "recall_graph_max_entities", "description": "Maximum entities rendered in graph recall packets", "default": 8},
+            {"key": "recall_graph_max_evidence", "description": "Maximum evidence handles rendered in graph recall packets", "default": 6},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
         ]
@@ -1210,6 +1386,33 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_packet_format = _normalise_recall_packet_format(
+            self._config.get("recall_packet_format", "plain")
+        )
+        self._recall_graph_entities = _parse_bool_setting(
+            self._config.get("recall_graph_entities"), True
+        )
+        self._recall_graph_source_facts = _parse_bool_setting(
+            self._config.get("recall_graph_source_facts"), True
+        )
+        self._recall_graph_chunks = _parse_bool_setting(
+            self._config.get("recall_graph_chunks"), False
+        )
+        self._recall_graph_trace = _parse_bool_setting(
+            self._config.get("recall_graph_trace"), False
+        )
+        self._recall_graph_max_observations = max(
+            1,
+            _parse_int_setting(self._config.get("recall_graph_max_observations"), 6),
+        )
+        self._recall_graph_max_entities = max(
+            1,
+            _parse_int_setting(self._config.get("recall_graph_max_entities"), 8),
+        )
+        self._recall_graph_max_evidence = max(
+            1,
+            _parse_int_setting(self._config.get("recall_graph_max_evidence"), 6),
+        )
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1298,6 +1501,60 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _effective_recall_packet_format(self, value: Any = None) -> str:
+        """Resolve recall output format from per-call override or provider config."""
+        if value is None or value == "":
+            return self._recall_packet_format
+        return _normalise_recall_packet_format(value)
+
+    def _build_recall_kwargs(self, query: str, *, packet_format: str | None = None) -> Dict[str, Any]:
+        """Build kwargs for Hindsight arecall, adding rich fields only in graph mode."""
+        recall_kwargs: Dict[str, Any] = {
+            "bank_id": self._bank_id,
+            "query": query,
+            "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        if self._effective_recall_packet_format(packet_format) == "graph":
+            recall_kwargs["include_entities"] = self._recall_graph_entities
+            recall_kwargs["include_source_facts"] = self._recall_graph_source_facts
+            recall_kwargs["include_chunks"] = self._recall_graph_chunks
+            recall_kwargs["trace"] = self._recall_graph_trace
+        return recall_kwargs
+
+    def _format_recall_response(
+        self,
+        query: str,
+        resp: Any,
+        *,
+        packet_format: str | None = None,
+        compact: bool = False,
+    ) -> str:
+        """Format a Hindsight recall response using the selected recall contract."""
+        if self._effective_recall_packet_format(packet_format) != "graph":
+            results = _list_or_empty(_object_value(resp, "results", default=[]))
+            if not results:
+                return "No relevant memories found."
+            return "\n".join(
+                f"{i}. {_object_value(result, 'text', 'content', 'summary', default='')}"
+                for i, result in enumerate(results, 1)
+                if _object_value(result, "text", "content", "summary", default="")
+            )
+
+        packet = _recall_packet_from_response(query, resp)
+        return format_recall_packet(
+            packet,
+            compact=compact,
+            max_observations=self._recall_graph_max_observations,
+            max_entities=self._recall_graph_max_entities,
+            max_evidence=self._recall_graph_max_evidence,
+        )
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
@@ -1337,21 +1594,23 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
                     text = resp.text or ""
                 else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
+                    recall_kwargs = self._build_recall_kwargs(
+                        query,
+                        packet_format=self._recall_packet_format,
+                    )
+                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s, format=%s)",
+                                 self._bank_id, len(query), self._budget, self._recall_packet_format)
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._format_recall_response(
+                        query,
+                        resp,
+                        packet_format=self._recall_packet_format,
+                        compact=True,
+                    )
+                    if text == "No relevant memories found.":
+                        text = ""
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1541,24 +1800,21 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
-                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
+                packet_format = self._effective_recall_packet_format(args.get("format"))
+                recall_kwargs = self._build_recall_kwargs(query, packet_format=packet_format)
+                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s, format=%s",
+                             self._bank_id, len(query), self._budget, packet_format)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                 num_results = len(resp.results) if resp.results else 0
                 logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
-                    return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                return json.dumps({
+                    "result": self._format_recall_response(
+                        query,
+                        resp,
+                        packet_format=packet_format,
+                        compact=False,
+                    )
+                })
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")

--- a/tests/agent/test_memory_recall_packet.py
+++ b/tests/agent/test_memory_recall_packet.py
@@ -1,0 +1,151 @@
+"""Tests for provider-neutral graph-shaped memory recall packet formatting."""
+
+from agent.memory_recall_packet import (
+    EntityObservation,
+    RecallEntity,
+    RecallEvidenceChunk,
+    RecallObservation,
+    RecallPacket,
+    format_recall_packet,
+)
+
+
+def test_empty_packet_returns_no_relevant_memories_message():
+    packet = RecallPacket(query="nothing useful")
+
+    assert format_recall_packet(packet) == "No relevant memories found."
+
+
+def test_format_recall_packet_includes_provenance_handles_and_verification_notice():
+    packet = RecallPacket(
+        query="memory architecture",
+        observations=[
+            RecallObservation(
+                text="Atlas is authoritative; Hindsight is candidate recall.",
+                type="world",
+                document_id="session-1-1",
+                source_fact_ids=["fact-1", "fact-2"],
+                entities=["Atlas", "Hindsight"],
+                tags=["hermes", "memory"],
+                mentioned_at="2026-06-01T10:00:00Z",
+                metadata={
+                    "source": "hermes",
+                    "session_id": "session-1",
+                    "turn_index": "3",
+                    "secret_token": "do-not-dump",
+                },
+            )
+        ],
+        entities=[
+            RecallEntity(
+                entity_id="ent-atlas",
+                canonical_name="Atlas",
+                observations=[
+                    EntityObservation(
+                        text="source authority layer",
+                        mentioned_at="2026-06-01T10:00:00Z",
+                    )
+                ],
+            )
+        ],
+        chunks=[
+            RecallEvidenceChunk(
+                id="chunk-1",
+                text="source chunk text",
+                chunk_index=0,
+                truncated=False,
+            )
+        ],
+        source_facts=["fact-1 — Atlas/source files are authority."],
+    )
+
+    text = format_recall_packet(packet, compact=False)
+
+    assert "Memory Recall Packet" in text
+    assert "Candidate context" in text
+    assert "memory architecture" in text
+    assert "Atlas is authoritative" in text
+    assert "type: `world`" in text
+    assert "document_id: `session-1-1`" in text
+    assert "source_fact_ids: `fact-1`, `fact-2`" in text
+    assert "entities: `Atlas`, `Hindsight`" in text
+    assert "tags: `hermes`, `memory`" in text
+    assert "mentioned_at: `2026-06-01T10:00:00Z`" in text
+    assert "source: `hermes`" in text
+    assert "session_id: `session-1`" in text
+    assert "metadata_keys: `secret_token`" in text
+    assert "do-not-dump" not in text
+    assert "ent-atlas" in text
+    assert "source authority layer" in text
+    assert "chunk-1" in text
+    assert "No authority verification performed" in text
+
+
+def test_compact_packet_is_bounded_and_keeps_key_handles():
+    packet = RecallPacket(
+        query="memory graph",
+        observations=[
+            RecallObservation(
+                text="Atlas is authority; Hindsight is candidate recall.",
+                document_id="session-1-1",
+                source_fact_ids=["fact-1"],
+                entities=["Atlas", "Hindsight"],
+            )
+        ],
+        entities=[
+            RecallEntity(
+                entity_id="ent-atlas",
+                canonical_name="Atlas",
+                observations=[EntityObservation(text="authority layer")],
+            )
+        ],
+        chunks=[RecallEvidenceChunk(id="chunk-1", text="verbose source chunk")],
+        source_facts=["fact-1 — Atlas/source files are authority."],
+    )
+
+    text = format_recall_packet(packet, compact=True)
+
+    assert text.startswith("# Memory Recall Packet")
+    assert "Status: candidate context" in text
+    assert "Atlas is authority" in text
+    assert "doc: session-1-1" in text
+    assert "facts: fact-1" in text
+    assert "entities: Atlas, Hindsight" in text
+    assert "authority layer" in text
+    assert "verbose source chunk" not in text
+    assert "Verification: no authority check performed" in text
+
+
+def test_formatter_caps_evidence_lists():
+    packet = RecallPacket(
+        query="evidence caps",
+        observations=[RecallObservation(text="one", document_id="doc-1")],
+        source_facts=["fact-1", "fact-2", "fact-3"],
+        chunks=[
+            RecallEvidenceChunk(id="chunk-1", text="chunk one"),
+            RecallEvidenceChunk(id="chunk-2", text="chunk two"),
+            RecallEvidenceChunk(id="chunk-3", text="chunk three"),
+        ],
+    )
+
+    text = format_recall_packet(packet, compact=False, max_evidence=2)
+
+    assert "fact-1" in text
+    assert "fact-2" in text
+    assert "fact-3" not in text
+    assert "chunk-1" in text
+    assert "chunk-2" in text
+    assert "chunk-3" not in text
+    assert "1 more" in text
+
+
+def test_missing_source_handles_are_flagged_as_lower_confidence():
+    packet = RecallPacket(
+        query="missing handles",
+        observations=[RecallObservation(text="Unsourced lead")],
+    )
+
+    text = format_recall_packet(packet, compact=False)
+
+    assert "Unsourced lead" in text
+    assert "Missing source handle" in text

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -80,7 +80,56 @@ def _make_mock_client():
     return client
 
 
+def _graph_recall_response():
+    """Create a mocked rich Hindsight recall response for graph-mode tests."""
+    return SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                text="Atlas is authority; Hindsight is candidate recall.",
+                type="world",
+                entities=["Atlas", "Hindsight"],
+                context="Hermes memory architecture",
+                occurred_start=None,
+                occurred_end=None,
+                mentioned_at="2026-06-01T10:00:00Z",
+                document_id="session-1-1",
+                metadata={
+                    "source": "hermes",
+                    "session_id": "session-1",
+                    "turn_index": "1",
+                },
+                chunk_id="chunk-1",
+                tags=["hermes", "memory"],
+                source_fact_ids=["fact-1"],
+            )
+        ],
+        entities=[
+            SimpleNamespace(
+                entity_id="ent-atlas",
+                canonical_name="Atlas",
+                observations=[
+                    SimpleNamespace(
+                        text="source-backed authority layer",
+                        mentioned_at="2026-06-01T10:00:00Z",
+                    )
+                ],
+            )
+        ],
+        chunks=[
+            SimpleNamespace(
+                id="chunk-1",
+                text="source chunk text",
+                chunk_index=0,
+                truncated=False,
+            )
+        ],
+        source_facts=["fact-1 — Atlas/source files are authority; Hindsight is a lead."],
+        trace=None,
+    )
+
+
 class _FakeSessionDB:
+
     def __init__(self, messages=None):
         self._messages = list(messages or [])
 
@@ -170,6 +219,12 @@ class TestSchemas:
         assert "query" in RECALL_SCHEMA["parameters"]["properties"]
         assert "query" in RECALL_SCHEMA["parameters"]["required"]
 
+    def test_recall_schema_allows_optional_format(self):
+        props = RECALL_SCHEMA["parameters"]["properties"]
+        assert "format" in props
+        assert props["format"]["enum"] == ["plain", "graph"]
+        assert "format" not in RECALL_SCHEMA["parameters"].get("required", [])
+
     def test_reflect_schema_has_query(self):
         assert REFLECT_SCHEMA["name"] == "hindsight_reflect"
         assert "query" in REFLECT_SCHEMA["parameters"]["properties"]
@@ -206,6 +261,37 @@ class TestConfig:
         assert provider._bank_mission == ""
         assert provider._bank_retain_mission is None
         assert provider._retain_context == "conversation between Hermes Agent and the User"
+        assert provider._recall_packet_format == "plain"
+        assert provider._recall_graph_entities is True
+        assert provider._recall_graph_source_facts is True
+        assert provider._recall_graph_chunks is False
+        assert provider._recall_graph_trace is False
+        assert provider._recall_graph_max_observations == 6
+        assert provider._recall_graph_max_entities == 8
+        assert provider._recall_graph_max_evidence == 6
+
+    def test_recall_packet_format_accepts_graph(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="graph")
+        assert p._recall_packet_format == "graph"
+
+    def test_recall_packet_format_invalid_value_falls_back_to_plain(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="cathedral")
+        assert p._recall_packet_format == "plain"
+
+    def test_recall_graph_caps_accept_config(self, provider_with_config):
+        p = provider_with_config(
+            recall_packet_format="graph",
+            recall_graph_chunks=True,
+            recall_graph_trace=True,
+            recall_graph_max_observations=3,
+            recall_graph_max_entities=4,
+            recall_graph_max_evidence=5,
+        )
+        assert p._recall_graph_chunks is True
+        assert p._recall_graph_trace is True
+        assert p._recall_graph_max_observations == 3
+        assert p._recall_graph_max_entities == 4
+        assert p._recall_graph_max_evidence == 5
 
     def test_recall_types_default_is_observation_only(self, provider):
         """Auto-recall must filter to observation by default."""
@@ -525,6 +611,57 @@ class TestToolHandlers:
         call_kwargs = p._client.arecall.call_args.kwargs
         assert call_kwargs["types"] == ["world", "experience"]
 
+    def test_graph_recall_passes_rich_field_flags(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="graph")
+
+        p.handle_tool_call("hindsight_recall", {"query": "memory graph"})
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["include_entities"] is True
+        assert call_kwargs["include_source_facts"] is True
+        assert call_kwargs["include_chunks"] is False
+        assert call_kwargs["trace"] is False
+
+    def test_graph_recall_formats_packet(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="graph")
+        p._client.arecall.return_value = _graph_recall_response()
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "memory graph"}))
+
+        assert "Memory Recall Packet" in result["result"]
+        assert "Candidate context" in result["result"]
+        assert "Atlas is authority" in result["result"]
+        assert "session-1-1" in result["result"]
+        assert "fact-1" in result["result"]
+        assert "ent-atlas" in result["result"]
+
+    def test_recall_format_override_graph(self, provider):
+        provider._client.arecall.return_value = _graph_recall_response()
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall",
+            {"query": "memory graph", "format": "graph"},
+        ))
+
+        assert provider._recall_packet_format == "plain"
+        assert "Memory Recall Packet" in result["result"]
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert call_kwargs["include_entities"] is True
+        assert call_kwargs["include_source_facts"] is True
+
+    def test_recall_format_override_plain_keeps_flat_output(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="graph")
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall",
+            {"query": "dark mode", "format": "plain"},
+        ))
+
+        assert result["result"] == "1. Memory 1\n2. Memory 2"
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "include_entities" not in call_kwargs
+        assert "include_source_facts" not in call_kwargs
+
     def test_recall_no_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(results=[])
         result = json.loads(provider.handle_tool_call(
@@ -664,6 +801,34 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    def test_graph_prefetch_passes_rich_field_flags(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="graph")
+
+        p.queue_prefetch("memory graph")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["include_entities"] is True
+        assert call_kwargs["include_source_facts"] is True
+        assert call_kwargs["include_chunks"] is False
+        assert call_kwargs["trace"] is False
+
+    def test_graph_prefetch_formats_compact_packet(self, provider_with_config):
+        p = provider_with_config(recall_packet_format="graph")
+        p._client.arecall.return_value = _graph_recall_response()
+
+        p.queue_prefetch("memory graph")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        result = p.prefetch("memory graph")
+        assert "Hindsight Memory" in result
+        assert "candidate" in result.lower()
+        assert "Atlas is authority" in result
+        assert "session-1-1" in result
+        assert "source chunk text" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add provider-neutral memory recall packet dataclasses and a bounded Markdown formatter.
- Add opt-in Hindsight graph recall formatting via `recall_format` / `format: graph` without changing the default plain recall contract.
- Request rich entity/source-fact recall only for graph-mode packet generation and cover the behavior with focused tests.

## Verification
- `uv run --extra dev pytest tests/agent/test_memory_recall_packet.py tests/plugins/memory/test_hindsight_provider.py -q` — 116 passed.
- `uv run --extra dev ruff check agent/memory_recall_packet.py plugins/memory/hindsight/__init__.py tests/agent/test_memory_recall_packet.py tests/plugins/memory/test_hindsight_provider.py` — passed.
- `git diff --check origin/main..HEAD` — passed.
- Outgoing range privacy/secret scan — 0 findings.

## Notes
- Clean PR branch is based on current `origin/main` and contains only the graph recall packet commit.
- Original local worktree had unrelated dirty/local commits; those were intentionally excluded.
- The local commit originally used a documented Claude-review hook skip because the external Claude Code review gate was unavailable; fallback focused verification and an independent reviewer passed before the commit.
