### PR TITLE
fix: normalize local tool JSON fallbacks

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,7 +10,10 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
-from typing import Any, Dict
+import json
+import re
+import uuid
+from typing import Any, Dict, cast
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
@@ -19,7 +22,72 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
-def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
+def _extract_tool_list_payload(content: object) -> tuple[str | None, list[ToolCall] | None]:
+    """Parse non-standard local-model JSON content with tool-like lists.
+
+    Some local models emit a plain assistant JSON object instead of OpenAI
+    ``tool_calls``.  Treat that as a compatibility fallback only when the
+    content is valid JSON and has entries shaped like either
+    ``tools_used: [{"name": ..., "arguments": {...}}]`` or
+    ``commands: [{"name": ..., ...args...}]``.
+    """
+    if not isinstance(content, str) or (
+        "tools_used" not in content and "commands" not in content
+    ):
+        return None, None
+
+    raw = content.strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.IGNORECASE)
+        raw = re.sub(r"\s*```$", "", raw)
+
+    try:
+        payload_obj, _ = json.JSONDecoder().raw_decode(raw)
+    except Exception:
+        return None, None
+    if not isinstance(payload_obj, dict):
+        return None, None
+    payload = cast(dict[str, object], payload_obj)
+
+    entries: list[object] = []
+    for key in ("commands", "tools_used"):
+        entries_obj = payload.get(key)
+        if isinstance(entries_obj, list):
+            entries.extend(entries_obj)
+    if not entries:
+        return None, None
+
+    tool_calls: list[ToolCall] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            return None, None
+        entry_map = cast(dict[str, object], entry)
+        name = entry_map.get("name")
+        args_obj = entry_map.get("arguments")
+        if isinstance(args_obj, dict):
+            args = args_obj
+        else:
+            args = {k: v for k, v in entry_map.items() if k != "name"}
+        if not isinstance(name, str) or not name.strip() or not isinstance(args, dict):
+            return None, None
+        tool_calls.append(
+            ToolCall(
+                id=f"call_{uuid.uuid4().hex[:24]}",
+                name=name.strip(),
+                arguments=json.dumps(args, ensure_ascii=False),
+            )
+        )
+
+    # Do not display the raw JSON block to the user once it has been consumed
+    # as tool calls; the tool result will become the visible next step.
+    return "", tool_calls
+
+
+
+def _build_gemini_thinking_config(
+    model: str,
+    reasoning_config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
     """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig."""
     if reasoning_config is None or not isinstance(reasoning_config, dict):
         return None
@@ -75,7 +143,9 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     return thinking_config
 
 
-def _snake_case_gemini_thinking_config(config: dict | None) -> dict | None:
+def _snake_case_gemini_thinking_config(
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
     """Convert Gemini thinking config keys to the OpenAI-compat field names."""
     if not isinstance(config, dict) or not config:
         return None
@@ -583,6 +653,13 @@ class ChatCompletionsTransport(ProviderTransport):
                     )
                 )
 
+        content = msg.content
+        if not tool_calls:
+            parsed_content, parsed_tool_calls = _extract_tool_list_payload(content)
+            if parsed_tool_calls:
+                content = parsed_content
+                tool_calls = parsed_tool_calls
+
         usage = None
         if hasattr(response, "usage") and response.usage:
             u = response.usage
@@ -611,7 +688,7 @@ class ChatCompletionsTransport(ProviderTransport):
             provider_data["reasoning_details"] = rd
 
         return NormalizedResponse(
-            content=msg.content,
+            content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1,5 +1,7 @@
 """Tests for the ChatCompletionsTransport."""
 
+import json
+
 import pytest
 from types import SimpleNamespace
 
@@ -728,6 +730,129 @@ class TestChatCompletionsNormalize:
         assert len(nr.tool_calls) == 1
         assert nr.tool_calls[0].name == "terminal"
         assert nr.tool_calls[0].id == "call_123"
+
+    def test_tools_used_json_content_becomes_tool_calls(self, transport):
+        content = json.dumps({
+            "analysis": "The tool rejected the command.",
+            "plan": "Try a shell command.",
+            "tools_used": [{
+                "name": "execute_code",
+                "arguments": {
+                    "command": "python3 -c 'print(123)'",
+                    "timeout": 400,
+                },
+            }],
+        })
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None, reasoning_content=None),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == ""
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "execute_code"
+        args = json.loads(nr.tool_calls[0].arguments)
+        assert args == {
+            "command": "python3 -c 'print(123)'",
+            "timeout": 400,
+        }
+
+    def test_commands_json_content_becomes_tool_calls(self, transport):
+        content = json.dumps({
+            "analysis": "I found the reference files.",
+            "plan": "Read the files.",
+            "commands": [
+                {
+                    "name": "read_file",
+                    "path": "/workspace/project/scripts/diversify_v2.py",
+                },
+                {
+                    "name": "read_file",
+                    "path": "/workspace/project/references/diversify_hermes.py",
+                    "offset": 10,
+                    "limit": 20,
+                },
+            ],
+        })
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None, reasoning_content=None),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == ""
+        assert len(nr.tool_calls) == 2
+        assert [tc.name for tc in nr.tool_calls] == ["read_file", "read_file"]
+        assert json.loads(nr.tool_calls[0].arguments) == {
+            "path": "/workspace/project/scripts/diversify_v2.py",
+        }
+        assert json.loads(nr.tool_calls[1].arguments) == {
+            "path": "/workspace/project/references/diversify_hermes.py",
+            "offset": 10,
+            "limit": 20,
+        }
+
+    def test_mixed_commands_and_tools_used_json_content_becomes_tool_calls(self, transport):
+        content = json.dumps({
+            "analysis": "Search and replace the model identifier.",
+            "commands": [
+                {
+                    "name": "execute_code",
+                    "command": "grep -r old-model /workspace/project --include='*.py'\n",
+                    "timeout": 10,
+                },
+                {
+                    "name": "execute_code",
+                    "command": "grep -r new-model /workspace/project --include='*.py'\n",
+                    "timeout": 10,
+                },
+            ],
+            "tools_used": [
+                {
+                    "name": "execute_code",
+                    "command": "cd /workspace/project && sed -i 's/old-model/new-model/g' .\n",
+                    "timeout": 5,
+                },
+            ],
+        })
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None, reasoning_content=None),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == ""
+        assert len(nr.tool_calls) == 3
+        assert [tc.name for tc in nr.tool_calls] == [
+            "execute_code",
+            "execute_code",
+            "execute_code",
+        ]
+        assert json.loads(nr.tool_calls[0].arguments) == {
+            "command": "grep -r old-model /workspace/project --include='*.py'\n",
+            "timeout": 10,
+        }
+        assert json.loads(nr.tool_calls[1].arguments) == {
+            "command": "grep -r new-model /workspace/project --include='*.py'\n",
+            "timeout": 10,
+        }
+        assert json.loads(nr.tool_calls[2].arguments) == {
+            "command": "cd /workspace/project && sed -i 's/old-model/new-model/g' .\n",
+            "timeout": 5,
+        }
 
     def test_tool_call_extra_content_preserved(self, transport):
         """Gemini 3 thinking models attach extra_content with thought_signature

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -43,6 +43,7 @@ from tools.code_execution_tool import (
     build_execute_code_schema,
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
+    _execute_code_arg,
     _execute_remote,
 )
 
@@ -71,6 +72,26 @@ class TestSandboxRequirements(unittest.TestCase):
     def test_available_on_posix(self):
         if sys.platform != "win32":
             self.assertTrue(check_sandbox_requirements())
+
+
+class TestExecuteCodeArgumentCompatibility(unittest.TestCase):
+    def test_command_argument_is_wrapped_as_python_subprocess_code(self):
+        code = _execute_code_arg({
+            "command": "python3 -c 'print(123)'",
+            "timeout": 7,
+        })
+
+        self.assertIn("subprocess.run", code)
+        self.assertIn("python3 -c", code)
+        self.assertIn("timeout=7", code)
+
+    def test_code_argument_takes_precedence_over_command(self):
+        code = _execute_code_arg({
+            "code": "print('ok')",
+            "command": "python3 -c 'print(123)'",
+        })
+
+        self.assertEqual(code, "print('ok')")
 
     def test_schema_is_valid(self):
         self.assertEqual(EXECUTE_CODE_SCHEMA["name"], "execute_code")

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1814,6 +1814,39 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
 EXECUTE_CODE_SCHEMA = build_execute_code_schema()
 
 
+def _execute_code_arg(args: dict[str, object]) -> str:
+    code = args.get("code", "")
+    if isinstance(code, str) and code.strip():
+        return code
+
+    command = args.get("command", "")
+    if not isinstance(command, str) or not command.strip():
+        return code if isinstance(code, str) else ""
+
+    timeout_obj = args.get("timeout", 400)
+    try:
+        timeout = int(timeout_obj) if isinstance(timeout_obj, (int, float, str)) else 400
+    except ValueError:
+        timeout = 400
+
+    return (
+        "import subprocess\n"
+        f"command = {command!r}\n"
+        "result = subprocess.run(\n"
+        "    command,\n"
+        "    shell=True,\n"
+        "    text=True,\n"
+        "    capture_output=True,\n"
+        f"    timeout={timeout!r},\n"
+        ")\n"
+        "if result.stdout:\n"
+        "    print(result.stdout, end='')\n"
+        "if result.stderr:\n"
+        "    print(result.stderr, end='')\n"
+        "print(f'\\n[exit_code={result.returncode}]')\n"
+    )
+
+
 # --- Registry ---
 from tools.registry import registry, tool_error
 
@@ -1822,7 +1855,7 @@ registry.register(
     toolset="code_execution",
     schema=EXECUTE_CODE_SCHEMA,
     handler=lambda args, **kw: execute_code(
-        code=args.get("code", ""),
+        code=_execute_code_arg(args),
         task_id=kw.get("task_id"),
         enabled_tools=kw.get("enabled_tools")),
     check_fn=check_sandbox_requirements,


### PR DESCRIPTION
## Summary
- normalize local-model assistant JSON with commands/tools_used into OpenAI-style tool calls
- support direct argument fields as well as nested arguments objects
- allow execute_code(command=...) compatibility by wrapping shell commands into Python subprocess code while preserving code= precedence

## Tests
- scripts/run_tests.sh tests/agent/transports/test_chat_completions.py tests/tools/test_code_execution.py
- 141 passed, 0 failed
- scripts/check-windows-footguns.py agent/transports/chat_completions.py tools/code_execution_tool.py tests/agent/transports/test_chat_completions.py tests/tools/test_code_execution.py
- No Windows footguns found