### PR TITLE
feat: add bundled WordPress skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 <tr><td><b>Research-ready</b></td><td>Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.</td></tr>
 </table>
 
+Hermes also ships with **bundled domain skills** for real operator workflows, including a new WordPress/WooCommerce cluster for repo triage, WP-CLI operations, migrations, deploys, and store maintenance.
+
+Example prompts:
+- `Inspect this WordPress repo and tell me if it's a plugin, theme, or full site.`
+- `Use WP-CLI to inspect the active plugins and cron state on this WordPress install.`
+- `Help me migrate this WooCommerce site from staging to production with a rollback plan.`
+
 ---
 
 ## Quick Install

--- a/docs/plans/2026-06-02-wordpress-skills-expansion.md
+++ b/docs/plans/2026-06-02-wordpress-skills-expansion.md
@@ -1,0 +1,406 @@
+# WordPress Skills Expansion Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a first-class WordPress skill cluster to Hermes Agent so users can reliably delegate WordPress development, site operations, store operations, and content/admin workflows.
+
+**Architecture:** Hermes currently has no bundled WordPress skills. The fastest path is not a new top-level category, but a prefixed cross-category bundle using existing buckets: `software-development/wordpress-*` for build workflows, `devops/wordpress-*` for operational workflows, and `productivity/wordpress-*` / `productivity/woocommerce-*` for editor/store workflows. We should start with a router + triage pair, then add the highest-demand workflows, then wire the bundle into generated docs/catalog pages via the existing `website/scripts/generate-skill-docs.py` pipeline.
+
+**Tech Stack:** SKILL.md authoring, Markdown references, small deterministic helper scripts, existing bundled-skills docs generator, git, pytest/docs checks where applicable.
+
+---
+
+## Research Summary
+
+### What exists online already
+
+1. **`WordPress/agent-skills`** is the clearest benchmark repository.
+   - Public repo with ~17 WordPress-focused skills.
+   - Covers: router, project triage, block development, block themes, plugin development, REST API, Interactivity API, Abilities API, WP-CLI/ops, performance, PHPStan, Playground, plugin directory guidelines, and WPDS.
+   - Structure is strong: `SKILL.md` + `references/` + optional `scripts/`.
+   - It is already indexed by `VoltAgent/awesome-agent-skills`, which matters for discovery.
+
+2. **WordPress MCP infrastructure is growing faster than reusable skill libraries.**
+   - `WordPress/mcp-adapter` exposes WordPress abilities as MCP tools/resources/prompts.
+   - `msrbuilds/elementor-mcp` exposes a large Elementor tool surface.
+   - `use-novamira/novamira` exposes broad WordPress access through PHP/filesystem operations.
+
+3. **WP-CLI and deployment tooling remain foundational, but are not packaged as agent-friendly skill bundles.**
+   - `wp-cli/wp-cli` remains the core automation surface.
+   - `welaika/wordmove` represents deploy/mirroring workflows that skills could teach well.
+
+### What appears missing or under-served
+
+The public WordPress skill landscape is still thin beyond the official WordPress repo. I did **not** find broad, mature, reusable skill bundles for these high-value areas:
+
+- **WooCommerce operations** — product/catalog, orders, coupons, taxes, shipping, store diagnostics.
+- **WordPress admin/editor workflows** — Site Editor, menus/navigation, reusable patterns, publishing ops.
+- **SEO and content operations** — metadata, schema, redirects, internal links, content refresh workflows.
+- **Migrations and deploys** — local/staging/prod sync, safe search-replace, media/database move checklists.
+- **Security and hardening** — plugin/theme review, capability audits beyond API-specific flows, backup/restore hygiene.
+- **Testing and QA** — plugin/theme smoke tests, Playground-driven checks, visual/content regression.
+- **Popular plugin ecosystems** — ACF, Elementor, Gravity Forms, Contact Form 7, multilingual plugins.
+- **Multisite fleet operations** — network-safe plugin activation, per-site config changes, bulk inspection.
+
+### Practical conclusion
+
+There is already a solid external benchmark for *core WordPress development* skills, but there is still whitespace around:
+- WooCommerce
+- migrations/deploys
+- SEO/content ops
+- admin/editor workflows
+- plugin-ecosystem-specific workflows
+- QA/security playbooks
+
+That makes the best Hermes strategy: **copy the good repo shape, avoid duplicating the official WordPress core coverage 1:1 at first, and win on the missing operator-heavy workflows.**
+
+---
+
+## Target Repo Shape
+
+Do **not** create a new top-level `wordpress/` category yet.
+
+Use these existing categories:
+
+- `skills/software-development/wordpress-*/`
+- `skills/devops/wordpress-*/`
+- `skills/productivity/wordpress-*/`
+- `skills/productivity/woocommerce-*/`
+
+This keeps the bundle aligned with Hermes conventions while making WordPress skills easy to search by prefix.
+
+---
+
+## Proposed Skill Roadmap
+
+### Phase 1 — foundation
+
+1. `skills/software-development/wordpress-project-router/SKILL.md`
+   - Detect whether the repo/site is plugin, theme, block/theme, headless, WooCommerce, or ops-heavy.
+   - Route to the correct follow-on skill.
+
+2. `skills/software-development/wordpress-project-triage/SKILL.md`
+   - Inspect repo structure, WordPress version assumptions, theme/plugin markers, Composer/npm use, build tools, test tools, and WP-CLI presence.
+
+3. `skills/devops/wordpress-wpcli-ops/SKILL.md`
+   - Core operational baseline: plugin/theme management, user ops, cache/transient cleanup, cron checks, search-replace safety, multisite caveats.
+
+### Phase 2 — high-leverage whitespace
+
+4. `skills/devops/wordpress-migrations-and-deploys/SKILL.md`
+   - Safe database/media/code moves across local/staging/prod.
+   - Include search-replace, serialized data caveats, rollback checklist, and verification.
+
+5. `skills/productivity/woocommerce-store-ops/SKILL.md`
+   - Store triage, product/catalog updates, order inspection, coupon/shipping/tax checks, Woo-related troubleshooting.
+
+6. `skills/productivity/wordpress-seo-content-ops/SKILL.md`
+   - Title/meta/schema checks, redirects, internal links, sitemap/robots basics, publishing refresh workflow.
+
+7. `skills/productivity/wordpress-admin-site-editor/SKILL.md`
+   - Site Editor, patterns, templates, template parts, navigation/menu updates, content-safe editing workflow.
+
+### Phase 3 — ecosystem depth
+
+8. `skills/software-development/wordpress-plugin-development/SKILL.md`
+   - Hermes-tailored plugin workflow with modern best practices.
+   - Avoid cloning the official WordPress skill verbatim; focus on Hermes workflow, verification, and common mistakes.
+
+9. `skills/software-development/wordpress-theme-and-block-development/SKILL.md`
+   - Block themes, `theme.json`, patterns, rendering, style variations, and when to choose theme vs plugin vs block.
+
+10. `skills/software-development/wordpress-rest-api-integration/SKILL.md`
+    - Endpoint shape, auth options, schema discipline, permissions, and client/server verification.
+
+### Phase 4 — specialization
+
+11. `skills/software-development/wordpress-acf-workflows/SKILL.md`
+12. `skills/productivity/wordpress-elementor-workflows/SKILL.md`
+13. `skills/productivity/wordpress-forms-workflows/SKILL.md`
+14. `skills/devops/wordpress-security-hardening/SKILL.md`
+15. `skills/devops/wordpress-playground-qa/SKILL.md`
+
+Only do Phase 4 after Phase 2 usage data proves demand.
+
+---
+
+## Implementation Tasks
+
+### Task 1: Create the strategy note in-repo
+
+**Objective:** Preserve the research and expansion direction in a durable repo artifact.
+
+**Files:**
+- Create: `docs/plans/2026-06-02-wordpress-skills-expansion.md`
+
+**Verification:**
+- File exists and includes benchmark repo, gaps, phases, and exact target skill paths.
+
+### Task 2: Scaffold the Phase 1 directories
+
+**Objective:** Create the minimal repo structure for the initial WordPress bundle.
+
+**Files:**
+- Create: `skills/software-development/wordpress-project-router/SKILL.md`
+- Create: `skills/software-development/wordpress-project-triage/SKILL.md`
+- Create: `skills/devops/wordpress-wpcli-ops/SKILL.md`
+
+**Notes:**
+- Follow bundled skill conventions: frontmatter, Overview, When to Use, actionable body, Common Pitfalls, Verification Checklist.
+- Add `references/` and `scripts/` only when they materially help.
+
+### Task 3: Author `wordpress-project-router`
+
+**Objective:** Ensure WordPress requests load the right specialized skill instead of treating every site the same.
+
+**Files:**
+- Modify/create: `skills/software-development/wordpress-project-router/SKILL.md`
+- Optional: `skills/software-development/wordpress-project-router/references/repo-signals.md`
+
+**Must cover:**
+- plugin vs theme vs block theme vs WooCommerce vs headless vs ops-only
+- when to switch to wpcli, deploy, SEO, admin, or store skills
+- quick repo/site signals to inspect first
+
+### Task 4: Author `wordpress-project-triage`
+
+**Objective:** Teach Hermes how to inspect an unfamiliar WordPress repo/site before making changes.
+
+**Files:**
+- Modify/create: `skills/software-development/wordpress-project-triage/SKILL.md`
+- Optional: `skills/software-development/wordpress-project-triage/scripts/detect_wordpress_project.py`
+
+**Must cover:**
+- marker files and directories
+- Composer/npm/build chain detection
+- WordPress version assumptions
+- plugin/theme boundaries
+- test and validation surfaces
+
+### Task 5: Author `wordpress-wpcli-ops`
+
+**Objective:** Ship the first practical operator skill that users can apply immediately.
+
+**Files:**
+- Modify/create: `skills/devops/wordpress-wpcli-ops/SKILL.md`
+- Optional: `skills/devops/wordpress-wpcli-ops/references/common-commands.md`
+- Optional: `skills/devops/wordpress-wpcli-ops/references/multisite-caveats.md`
+
+**Must cover:**
+- safe `wp` command discovery
+- plugin/theme/user/content ops
+- search-replace safety
+- transient/cache cleanup
+- cron inspection
+- multisite caveats
+- verification before/after changes
+
+### Task 6: Scaffold the Phase 2 whitespace skills
+
+**Objective:** Prepare the highest-value missing areas next.
+
+**Files:**
+- Create: `skills/devops/wordpress-migrations-and-deploys/SKILL.md`
+- Create: `skills/productivity/woocommerce-store-ops/SKILL.md`
+- Create: `skills/productivity/wordpress-seo-content-ops/SKILL.md`
+- Create: `skills/productivity/wordpress-admin-site-editor/SKILL.md`
+
+### Task 7: Author `wordpress-migrations-and-deploys`
+
+**Objective:** Cover a major gap not well represented in public WordPress skill repos.
+
+**Files:**
+- Modify/create: `skills/devops/wordpress-migrations-and-deploys/SKILL.md`
+- Optional: `skills/devops/wordpress-migrations-and-deploys/references/rollback-checklist.md`
+
+**Must cover:**
+- code/db/uploads separation
+- staging-to-prod and prod-to-local flows
+- search-replace with serialized data safety
+- backup checkpoints
+- rollback plan
+- post-move verification
+
+### Task 8: Author `woocommerce-store-ops`
+
+**Objective:** Establish Hermes coverage in the biggest obvious whitespace area.
+
+**Files:**
+- Modify/create: `skills/productivity/woocommerce-store-ops/SKILL.md`
+- Optional: `skills/productivity/woocommerce-store-ops/references/store-triage-checklist.md`
+
+**Must cover:**
+- product/catalog updates
+- order inspection
+- coupon/shipping/tax sanity checks
+- extensions/plugin interaction risks
+- what to verify after each change
+
+### Task 9: Author `wordpress-seo-content-ops`
+
+**Objective:** Add non-developer WordPress workflows that broad users will actually ask for.
+
+**Files:**
+- Modify/create: `skills/productivity/wordpress-seo-content-ops/SKILL.md`
+- Optional: `skills/productivity/wordpress-seo-content-ops/references/seo-audit-checklist.md`
+
+**Must cover:**
+- titles/meta/schema basics
+- redirects/canonicals/internal linking
+- sitemap/robots checks
+- content refresh workflow
+- plugin-agnostic guidance first; plugin-specific notes second
+
+### Task 10: Author `wordpress-admin-site-editor`
+
+**Objective:** Cover admin/editor changes that are common, risky, and poorly handled by generic coding agents.
+
+**Files:**
+- Modify/create: `skills/productivity/wordpress-admin-site-editor/SKILL.md`
+- Optional: `skills/productivity/wordpress-admin-site-editor/references/editor-safety-checklist.md`
+
+**Must cover:**
+- Site Editor vs classic admin distinctions
+- patterns/templates/template parts
+- navigation/menu changes
+- safe content-edit workflow
+- verification in browser after edits
+
+### Task 11: Add the Phase 3 dev skills only after the operator baseline is in place
+
+**Objective:** Fill in core code workflows without spending the first release only on overlap with the WordPress benchmark repo.
+
+**Files:**
+- Create: `skills/software-development/wordpress-plugin-development/SKILL.md`
+- Create: `skills/software-development/wordpress-theme-and-block-development/SKILL.md`
+- Create: `skills/software-development/wordpress-rest-api-integration/SKILL.md`
+
+**Priority rule:**
+- If time is limited, ship Phase 2 before these.
+
+### Task 12: Generate docs pages and catalog entries
+
+**Objective:** Make the new skills discoverable in Hermes docs immediately.
+
+**Files:**
+- Generated/updated by script: `website/docs/user-guide/skills/bundled/**`
+- Generated/updated by script: `website/docs/reference/skills-catalog.md`
+
+**Run:**
+```bash
+cd /home/jorgerosal/hermes-agent
+python website/scripts/generate-skill-docs.py
+```
+
+**Expected:**
+- New bundled skill pages appear under the correct category paths.
+- `website/docs/reference/skills-catalog.md` includes the new entries.
+
+### Task 13: Add top-level repo discoverability for the WordPress bundle
+
+**Objective:** Make WordPress support visible in the main repo narrative.
+
+**Files:**
+- Modify: `README.md`
+
+**Suggested additions:**
+- a short bullet in the skills/value section mentioning bundled WordPress skills
+- one concrete example prompt or workflow
+- optionally link to generated docs/catalog page
+
+### Task 14: Validate the bundle end-to-end
+
+**Objective:** Ensure the skills are shippable, not just written.
+
+**Files:**
+- Validate generated docs and skill pages
+- Inspect a few generated pages under `website/docs/user-guide/skills/bundled/`
+
+**Run:**
+```bash
+cd /home/jorgerosal/hermes-agent
+python website/scripts/generate-skill-docs.py
+```
+
+**Manual checks:**
+- frontmatter loads correctly
+- descriptions are concise and trigger-based
+- related skills resolve sensibly
+- no category/path naming mistakes
+- docs pages render under bundled skills
+
+---
+
+## Prioritization Rules
+
+If we only ship **five** WordPress skills in the first PR, ship these:
+
+1. `wordpress-project-router`
+2. `wordpress-project-triage`
+3. `wordpress-wpcli-ops`
+4. `wordpress-migrations-and-deploys`
+5. `woocommerce-store-ops`
+
+Why: this gives Hermes a differentiated operator story instead of only duplicating the official WordPress development bundle.
+
+---
+
+## Suggested Naming Conventions
+
+- Use `wordpress-` prefix for WordPress-specific skills.
+- Use `woocommerce-` prefix only when the skill is store-specific.
+- Keep names action/domain-oriented rather than tool-oriented.
+- Start descriptions with `Use when ...`
+
+Examples:
+- `wordpress-project-router`
+- `wordpress-migrations-and-deploys`
+- `wordpress-seo-content-ops`
+- `woocommerce-store-ops`
+
+---
+
+## Risks and Avoidance
+
+1. **Risk: cloning the official WordPress repo too literally**
+   - Avoidance: use it as a benchmark, but prioritize Hermes-specific workflows and whitespace.
+
+2. **Risk: inventing a new top-level category too early**
+   - Avoidance: stay inside `software-development`, `devops`, and `productivity` for v1.
+
+3. **Risk: writing generic advice with no deterministic verification**
+   - Avoidance: every skill needs concrete checks, commands, and "done means" criteria.
+
+4. **Risk: over-indexing on Gutenberg/core dev and missing operator demand**
+   - Avoidance: ship migrations, WooCommerce, WP-CLI, and SEO/admin skills first.
+
+5. **Risk: docs/catalog drift**
+   - Avoidance: always run `python website/scripts/generate-skill-docs.py` in the same PR.
+
+---
+
+## Success Criteria
+
+- Hermes repo contains at least 5 bundled WordPress-prefixed skills.
+- At least 2 of those skills cover whitespace not strongly served by `WordPress/agent-skills`.
+- Generated docs/catalog pages include all new skills.
+- README makes WordPress support discoverable.
+- The first bundle gives a user enough coverage to handle: repo triage, WP-CLI ops, migration/deploy, and WooCommerce basics.
+
+---
+
+## Recommended First PR Scope
+
+Keep PR 1 tight:
+
+- `wordpress-project-router`
+- `wordpress-project-triage`
+- `wordpress-wpcli-ops`
+- `wordpress-migrations-and-deploys`
+- `woocommerce-store-ops`
+- generated docs/catalog updates
+- small README mention
+
+Leave SEO/admin/editor and plugin/theme/dev skills for PR 2.
+
+This creates a differentiated WordPress bundle quickly without turning the first PR into a huge documentation dump.

--- a/skills/devops/wordpress-migrations-and-deploys/SKILL.md
+++ b/skills/devops/wordpress-migrations-and-deploys/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: wordpress-migrations-and-deploys
+description: Use when moving, deploying, syncing, backing up, or rolling back a WordPress site across local, staging, and production environments.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [wordpress, migration, deploy, backup, rollback]
+    related_skills: [wordpress-project-triage, wordpress-wpcli-ops, webhook-subscriptions, writing-plans, requesting-code-review]
+---
+
+# WordPress Migrations and Deploys
+
+## Overview
+
+Use this skill for WordPress moves and releases that cross environment boundaries: local to staging, staging to production, production to local, host-to-host migrations, rollback planning, and deploy verification.
+
+WordPress moves are rarely just "copy files." A working site depends on the interaction between code, database content, uploads/media, environment configuration, caches, and URL assumptions. The safest workflow separates those layers explicitly.
+
+**Core principle:** treat code, database, uploads, secrets/config, and cache as separate migration surfaces with separate checkpoints.
+
+## When to Use
+
+Use this skill when:
+- moving a site between local, staging, and production
+- changing domains or URLs
+- deploying code that depends on database state or media assets
+- creating backup/restore checkpoints
+- planning rollback before a risky WordPress release
+
+Do not use this skill when:
+- the task is a small runtime admin change better handled by `wordpress-wpcli-ops`
+- the project shape is still unknown; triage first
+- the task is only plugin/theme code editing with no environment move
+
+## The Five Migration Surfaces
+
+Always reason about these separately:
+1. **Code** — themes, plugins, mu-plugins, config, build artifacts
+2. **Database** — posts, options, plugin settings, users, orders, serialized data
+3. **Uploads/media** — `wp-content/uploads/` and any offloaded media assumptions
+4. **Environment/config** — `.env`, `wp-config.php`, salts, domains, credentials, object cache, CDN, mail
+5. **Cache/runtime** — page cache, object cache, transients, opcode cache, CDN cache, cron backlog
+
+## Preflight Checklist
+
+Before moving anything, confirm:
+- source and target environments
+- canonical source of truth for code
+- backup method for database and uploads
+- whether WooCommerce or memberships are involved
+- maintenance window or content-freeze expectations
+- search-replace scope and old/new domains
+- rollback owner and rollback trigger point
+
+## Safe Migration Workflow
+
+### 1. Snapshot the baseline
+Capture:
+- current site URL/home URL
+- active plugins/themes
+- WordPress and PHP versions
+- database dump location
+- uploads backup location
+- deployment commit SHA or release identifier
+
+### 2. Separate what is actually moving
+Common patterns:
+- **staging → prod release:** code only, plus DB migration or option changes
+- **prod → local clone:** code + DB + uploads + URL rewrite
+- **host migration:** everything, plus DNS/CDN/runtime config
+- **theme/plugin deploy:** code only, but still verify dependent options and caches
+
+### 3. Back up before mutation
+Minimum safe stance:
+- a database backup you can restore
+- an uploads backup or sync checkpoint when media matters
+- confidence that the exact deployed code version can be restored
+
+### 4. Use serialized-data-safe replacement
+For domain/path changes, prefer WP-CLI search-replace rather than raw SQL:
+```bash
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables --dry-run
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables
+```
+
+### 5. Rebuild and clear only what is needed
+Potential post-move steps:
+- rebuild theme/plugin assets
+- flush caches
+- clear transients
+- re-save permalinks if routing changed
+- run due cron if queues are stuck
+
+### 6. Verify in layers
+Check all of these before calling the move done:
+- homepage loads
+- admin login works
+- one representative content page works
+- media loads from expected storage
+- forms/cart/checkout/account flows work if applicable
+- background jobs or cron are not obviously stuck
+
+## Common Migration Scenarios
+
+### Production → local
+Typical needs:
+- DB dump/import
+- uploads sync
+- URL rewrite
+- mail/payment safeguards disabled locally
+- search indexing disabled locally if needed
+
+Watch for:
+- hardcoded domains
+- object cache config carried over incorrectly
+- third-party API side effects from copied cron/jobs
+
+### Staging → production
+Typical needs:
+- deploy code from version control
+- run targeted DB changes only if required
+- avoid blindly copying staging DB over production
+- clear deploy-related caches
+
+Watch for:
+- overwriting production orders, users, comments, or form submissions
+- schema changes not matched by code
+- environment constants drifting between staging and production
+
+### Host-to-host migration
+Typical needs:
+- full code sync
+- full DB transfer
+- uploads/media transfer
+- DNS/SSL/CDN alignment
+- PHP extension/version parity
+
+Watch for:
+- file permissions/ownership
+- Nginx/Apache rewrites
+- object cache or Redis/Memcached endpoints
+- offloaded media or CDN origin paths
+
+## Rollback Planning
+
+Define rollback before deployment, not after failure.
+
+Minimum rollback plan:
+- what exact code version to restore
+- where the last known-good DB backup lives
+- whether uploads changed during the release window
+- who decides rollback vs forward-fix
+- what user-visible checks trigger rollback
+
+If a release includes irreversible data mutation, say that explicitly and tighten the checkpoint discipline.
+
+## WooCommerce and Other High-Risk Sites
+
+Extra caution for:
+- live orders/payments
+- subscriptions/memberships
+- booking systems
+- LMS/course progress
+- form submissions
+
+Rules of thumb:
+- do not overwrite a live production DB with stale staging content
+- minimize maintenance windows but prefer explicit freeze rules for risky changes
+- verify order creation, checkout, tax/shipping, and email side effects after release
+
+## Post-Move Verification
+
+Run a representative smoke test set:
+- front page
+- key landing page
+- admin dashboard
+- plugin/theme status
+- media rendering
+- contact form or transactional path
+- WooCommerce cart/checkout for stores
+- cron or scheduled job visibility
+
+## Related Reference
+
+See `references/rollback-checklist.md` for a compact rollback checklist you can copy into a deployment handoff.
+
+## Common Pitfalls
+
+1. **Treating WordPress deploys as code-only when data changed too.**
+   Many failures are option, URL, upload, or cache mismatches.
+
+2. **Using raw SQL for URL rewrites.**
+   Serialized data corruption is a classic self-inflicted outage.
+
+3. **Overwriting production data with staging data.**
+   Especially dangerous on WooCommerce or membership sites.
+
+4. **Skipping uploads/media as a distinct surface.**
+   Broken media is one of the most common post-migration issues.
+
+5. **No rollback plan.**
+   A backup that cannot be found or restored is not a real fallback.
+
+6. **Calling the deploy done after one homepage check.**
+   Always verify at least one real business-critical path.
+
+## Verification Checklist
+
+- [ ] Identified which of code, DB, uploads, config, and cache are changing
+- [ ] Captured or confirmed backups/checkpoints before mutation
+- [ ] Used serialized-data-safe search-replace where URLs/paths changed
+- [ ] Defined rollback inputs and trigger conditions before release
+- [ ] Verified representative frontend, admin, and business-critical paths after the move
+- [ ] Avoided destructive staging-to-production data overwrite for live transactional sites

--- a/skills/devops/wordpress-migrations-and-deploys/references/rollback-checklist.md
+++ b/skills/devops/wordpress-migrations-and-deploys/references/rollback-checklist.md
@@ -1,0 +1,39 @@
+# WordPress Rollback Checklist
+
+Use this checklist before any risky WordPress release or migration.
+
+## Before Deploy
+
+- Record the code version being deployed.
+- Record the current live code version.
+- Confirm where the latest database backup lives.
+- Confirm where uploads/media backup or sync checkpoint lives.
+- Confirm who can trigger rollback.
+- Confirm whether the release mutates data, schema, URLs, or cache behavior.
+
+## Rollback Inputs
+
+Have these ready:
+- last known-good code revision/tag
+- restore command or host control panel path
+- database backup filename and timestamp
+- uploads sync/restore plan if media changed
+- cache flush steps after restore
+
+## Trigger Conditions
+
+Rollback is usually preferred when:
+- admin is inaccessible
+- checkout/orders/payments are broken
+- media or assets fail widely
+- fatal errors persist after a fast, low-risk forward fix attempt
+- a data mutation behaves incorrectly and recovery is time-sensitive
+
+## After Rollback
+
+- Restore code.
+- Restore database if needed.
+- Restore uploads if needed.
+- Flush relevant caches.
+- Verify homepage, admin, one key content path, and one business-critical flow.
+- Document what failed before reattempting deployment.

--- a/skills/devops/wordpress-wpcli-ops/SKILL.md
+++ b/skills/devops/wordpress-wpcli-ops/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: wordpress-wpcli-ops
+description: Use when operating or inspecting a WordPress install with WP-CLI for safe runtime changes, diagnostics, cleanup, and verification.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [wordpress, wp-cli, operations, maintenance, multisite]
+    related_skills: [wordpress-project-triage, wordpress-migrations-and-deploys, woocommerce-store-ops, systematic-debugging, requesting-code-review]
+---
+
+# WordPress WP-CLI Operations
+
+## Overview
+
+Use this skill when the safest control surface is a live or local WordPress install and WP-CLI is available. It covers discovery, inspection, low-risk operational changes, cleanup, and post-change verification.
+
+WP-CLI is often the fastest reliable way to inspect plugins, themes, users, options, cron events, transients, and content relationships without poking the database directly or guessing through the admin UI.
+
+**Core principle:** confirm the target install and environment first, then make the smallest runtime change with a clear before/after verification step.
+
+## When to Use
+
+Use this skill when:
+- the task is primarily runtime inspection or maintenance on a known WordPress install
+- you need to inspect plugins, themes, users, posts, options, cron, cache, or transients
+- you need to run a safe search-replace or URL update
+- the user asks for quick WordPress ops without opening the browser admin first
+
+Do not use this skill when:
+- the project path or target install is still ambiguous
+- the task is a migration, environment move, or rollback-heavy deploy
+- the task is mainly WooCommerce store operations needing store-specific verification
+
+## Safe Discovery First
+
+### 1. Confirm WP-CLI is available
+Typical checks:
+```bash
+wp --info
+wp cli version
+```
+
+### 2. Confirm the correct install path
+Run WP-CLI from the install root, or pass an explicit path:
+```bash
+wp core version
+wp option get siteurl
+wp option get home
+```
+
+If multiple installs may exist, inspect the filesystem first and verify the site URL before changing anything.
+
+### 3. Confirm environment context
+Before state-changing commands, record:
+- hostname / environment name
+- site URL
+- multisite vs single-site
+- active theme
+- active plugins
+
+Useful commands:
+```bash
+wp core is-installed
+wp plugin list
+wp theme list
+wp option get blogname
+```
+
+## High-Value Operations
+
+### Plugin and theme inspection
+```bash
+wp plugin list
+wp plugin status woocommerce
+wp theme list
+wp theme status twentytwentyfour
+```
+
+Use for:
+- active/inactive status
+- version drift
+- update opportunities
+- identifying obvious ownership surfaces
+
+### User and role inspection
+```bash
+wp user list --fields=ID,user_login,user_email,roles
+wp role list
+```
+
+Use for:
+- checking admin access
+- verifying role assignments
+- finding content owners or test accounts
+
+### Option inspection
+```bash
+wp option get siteurl
+wp option get home
+wp option get permalink_structure
+```
+
+Use for:
+- confirming URL assumptions
+- debugging environment mismatches
+- checking basic site configuration
+
+### Content inspection
+```bash
+wp post list --post_type=page --fields=ID,post_title,post_status
+wp post get 123 --field=post_title
+wp term list category --fields=term_id,name,slug
+```
+
+Use for:
+- confirming content presence
+- enumerating pages or custom post types
+- tracing relationships before editing
+
+### Cron inspection
+```bash
+wp cron event list
+wp cron event run --due-now
+```
+
+Use for:
+- identifying stuck tasks
+- checking whether scheduled tasks are overdue
+- validating whether a plugin relies on WP-Cron behavior
+
+### Cache and transient cleanup
+```bash
+wp transient list
+wp transient delete --all
+wp cache flush
+```
+
+Use carefully:
+- clear transients when debugging stale settings or cached remote results
+- flush caches after deploys or major option changes
+- verify front-end effects after cleanup
+
+## Search-Replace Safety
+
+Use `wp search-replace` instead of raw SQL when changing URLs or paths in WordPress data.
+
+Recommended flow:
+1. Confirm source and target values exactly.
+2. Dry-run first.
+3. Prefer precise scope over blanket replacement.
+4. Re-verify URLs and sample pages after the change.
+
+Example:
+```bash
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables --dry-run
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables
+```
+
+Notes:
+- WP-CLI handles serialized data safely; direct SQL often does not.
+- Avoid casual replacement across multiple unrelated installs.
+- On large sites, expect this command to take time and verify backups first.
+
+## Safe Change Workflow
+
+For any state-changing WP-CLI operation:
+1. Inspect current state.
+2. Save or report the baseline.
+3. Make the smallest change.
+4. Re-run the same inspection command.
+5. Verify one browser-visible or admin-visible outcome where possible.
+
+Examples:
+- before/after `wp option get siteurl`
+- before/after `wp plugin status plugin-name`
+- before/after `wp cron event list`
+
+## Multisite Caveats
+
+Before making changes, determine if the install is multisite:
+```bash
+wp site list
+wp network meta list 1
+```
+
+Important caveats:
+- plugin activation can be site-specific or network-wide
+- options may live at the site or network level
+- user membership can vary by site
+- path and domain assumptions differ across sites
+- `--url=<site>` may be required to target the correct site
+
+Examples:
+```bash
+wp --url=https://sub.example.com option get home
+wp --url=https://sub.example.com plugin list
+```
+
+## Commands to Avoid or Treat as High Risk
+
+Be cautious with:
+- direct SQL writes via `wp db query`
+- bulk destructive deletion without a precise filter
+- plugin/theme updates on production without impact awareness
+- blanket cache flushes during incident response unless needed
+- search-replace without a dry run and backup confidence
+
+## Verification Patterns
+
+### After plugin changes
+- re-run `wp plugin list`
+- verify one affected route or admin page
+- check logs if the change was error-driven
+
+### After option changes
+- re-run `wp option get ...`
+- verify the corresponding browser/admin behavior
+
+### After transient/cache cleanup
+- verify the stale behavior is actually gone
+- confirm no plugin immediately recreates the bad state
+
+### After cron actions
+- re-run `wp cron event list`
+- inspect plugin-specific downstream effects if applicable
+
+## Related Reference
+
+See `references/common-commands.md` for a grab-bag of frequently useful WP-CLI commands.
+
+## Common Pitfalls
+
+1. **Running WP-CLI against the wrong install.**
+   Always confirm the path and `siteurl` first.
+
+2. **Using destructive commands without baseline capture.**
+   Before/after inspection is part of the job.
+
+3. **Using raw SQL where WP-CLI has a safe wrapper.**
+   Search-replace is the classic example.
+
+4. **Ignoring multisite context.**
+   A correct command on one site can be wrong at the network level.
+
+5. **Assuming a CLI change is enough verification.**
+   Browser-visible confirmation still matters.
+
+6. **Overusing cache flushes.**
+   Clear only what helps the diagnosis.
+
+## Verification Checklist
+
+- [ ] Confirmed WP-CLI availability and the correct install path
+- [ ] Captured the target site's URL/environment before making changes
+- [ ] Checked for multisite context when relevant
+- [ ] Used dry-run or inspection-first flow for risky commands
+- [ ] Verified the same surface before and after the change
+- [ ] Verified at least one live/admin outcome when possible

--- a/skills/devops/wordpress-wpcli-ops/references/common-commands.md
+++ b/skills/devops/wordpress-wpcli-ops/references/common-commands.md
@@ -1,0 +1,68 @@
+# WP-CLI Common Commands
+
+Use these as a quick reference after you have already confirmed the correct install path and environment.
+
+## Core and Environment
+
+```bash
+wp --info
+wp cli version
+wp core version
+wp core is-installed
+wp option get siteurl
+wp option get home
+```
+
+## Plugins and Themes
+
+```bash
+wp plugin list
+wp plugin status <plugin-slug>
+wp plugin activate <plugin-slug>
+wp plugin deactivate <plugin-slug>
+wp theme list
+wp theme status <theme-slug>
+wp theme activate <theme-slug>
+```
+
+## Users and Roles
+
+```bash
+wp user list --fields=ID,user_login,user_email,roles
+wp user get <id-or-login>
+wp role list
+```
+
+## Content and Taxonomy
+
+```bash
+wp post list --post_type=page --fields=ID,post_title,post_status
+wp post get <post-id>
+wp term list category --fields=term_id,name,slug
+wp menu list
+```
+
+## Maintenance
+
+```bash
+wp cron event list
+wp cron event run --due-now
+wp transient list
+wp transient delete --all
+wp cache flush
+```
+
+## Search/Replace
+
+```bash
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables --dry-run
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables
+```
+
+## Multisite
+
+```bash
+wp site list
+wp --url=https://sub.example.com plugin list
+wp --url=https://sub.example.com option get home
+```

--- a/skills/productivity/woocommerce-store-ops/SKILL.md
+++ b/skills/productivity/woocommerce-store-ops/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: woocommerce-store-ops
+description: Use when operating or validating a WooCommerce store for catalog changes, order inspection, merchandising sanity checks, and extension-aware verification.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [woocommerce, wordpress, ecommerce, catalog, orders]
+    related_skills: [wordpress-project-router, wordpress-project-triage, wordpress-wpcli-ops, wordpress-migrations-and-deploys, requesting-code-review]
+---
+
+# WooCommerce Store Operations
+
+## Overview
+
+Use this skill for the operational side of WooCommerce: product/catalog changes, order inspection, coupon/shipping/tax sanity checks, extension-aware troubleshooting, and post-change validation.
+
+WooCommerce work looks deceptively like ordinary WordPress content work, but store behavior depends on product types, stock rules, taxes, shipping zones, coupons, checkout settings, payment gateways, and extension hooks. Small changes can have revenue impact.
+
+**Core principle:** make small store changes, then verify the exact customer or operator flow affected.
+
+## When to Use
+
+Use this skill when:
+- the user asks about WooCommerce products, variations, orders, coupons, tax, shipping, payments, or fulfillment behavior
+- you need to validate a store after plugin changes or a deployment
+- you need to inspect a store's operational state before editing settings or catalog data
+
+Do not use this skill when:
+- the project is not actually using WooCommerce
+- the task is only generic WordPress runtime maintenance with no store-specific behavior
+- the request is a host migration or deploy plan; use the migration skill first
+
+## Store Triage First
+
+Before changing anything, capture:
+- WooCommerce version
+- active store-critical plugins/extensions
+- payment gateways in use
+- shipping method assumptions
+- tax configuration relevance
+- whether the store is live and transacting now
+
+Useful checks include:
+- active plugin list
+- order status patterns
+- representative product types in the catalog
+- cart and checkout routes
+
+See `references/store-triage-checklist.md` for a concise pre-change checklist.
+
+## High-Value Operational Surfaces
+
+### 1. Product and catalog updates
+Common tasks:
+- title/description updates
+- price or sale-price changes
+- stock/availability changes
+- category/tag cleanup
+- image/media sanity checks
+- variation review for attributes, stock, and pricing consistency
+
+Verification after product changes:
+- product page renders correctly
+- price displays correctly
+- add-to-cart works for the intended product type
+- stock status matches expectation
+- variation selectors behave correctly
+
+### 2. Order inspection
+Common tasks:
+- inspect recent orders and statuses
+- verify payment or fulfillment progression
+- identify stuck processing/on-hold/failed patterns
+- confirm whether a plugin or deploy changed checkout outcomes
+
+Verification after order-related changes:
+- one recent representative order still shows expected metadata/state
+- admin order view loads without errors
+- emails/webhooks are not obviously broken if the change touched those flows
+
+### 3. Coupons, shipping, and tax sanity checks
+Common tasks:
+- confirm a coupon applies when and where expected
+- validate shipping-zone assumptions
+- verify tax display and totals at a high level
+
+Verification after settings changes:
+- test cart subtotal/discount math on a representative product
+- confirm shipping methods appear for the right destination
+- confirm tax-inclusive/exclusive display still matches expectation
+
+### 4. Extension-aware troubleshooting
+Always check for extensions that materially alter behavior:
+- subscriptions
+- bookings
+- bundles/composites
+- multilingual/currency plugins
+- ERP/fulfillment integrations
+- payment gateway add-ons
+- checkout customization plugins
+
+Rule: do not assume core WooCommerce owns the bug until extension interactions are reviewed.
+
+## Safe Change Workflow
+
+1. Inspect the current state first.
+2. Name the exact store surface being changed.
+3. Prefer the smallest reversible change.
+4. Re-check the same operational surface after the change.
+5. Verify one customer-visible flow if the change could affect revenue.
+
+Examples:
+- changing product stock → verify product page + add-to-cart
+- changing shipping settings → verify cart/checkout shipping availability
+- changing coupon rules → verify discount application on a test cart
+
+## Common Risk Areas
+
+### Product types
+Different verification is needed for:
+- simple products
+- variable products
+- grouped/bundled/composite products
+- downloadable/virtual products
+- subscription or booking products
+
+### Payment and checkout
+Be extra careful when the task touches:
+- checkout fields or validation
+- payment gateways
+- taxes and totals
+- shipping calculations
+- stock reservation/reduction timing
+
+### Deploys and plugin updates
+After deploys or plugin changes, verify at minimum:
+- storefront loads
+- one product page loads
+- cart works
+- checkout loads
+- admin orders load
+- no obvious fatal/plugin conflict is present
+
+## Operational Heuristics
+
+- A display problem on product pages may be theme/template override related.
+- A totals or checkout issue may come from taxes, shipping, or gateway extensions.
+- A missing product may be catalog visibility, stock status, schedule, or sync-related.
+- An order-state issue may be payment webhook, fulfillment extension, or custom automation related.
+
+## Reference Workflow
+
+Use the reference checklist when starting on a live store:
+- `references/store-triage-checklist.md`
+
+## Common Pitfalls
+
+1. **Treating WooCommerce as ordinary posts/pages.**
+   Store logic has revenue and fulfillment implications.
+
+2. **Changing settings without testing a customer path.**
+   Admin values can look correct while checkout is broken.
+
+3. **Ignoring extensions.**
+   Many store behaviors are extension-defined, not core-defined.
+
+4. **Testing only one product shape.**
+   Variable, bundled, subscription, or booking products often behave differently.
+
+5. **Applying content-style verification to operational changes.**
+   Store ops need cart/checkout/order verification, not just page rendering.
+
+6. **Overlooking live-transaction risk.**
+   Be explicit when a change could affect active orders or payments.
+
+## Verification Checklist
+
+- [ ] Confirmed WooCommerce is active and identified major store-critical extensions
+- [ ] Identified whether the task affects catalog, orders, shipping, tax, coupons, or checkout
+- [ ] Captured the relevant baseline before changing anything
+- [ ] Verified the same store surface after the change
+- [ ] Verified at least one customer-visible or operator-visible flow tied to the change
+- [ ] Escalated caution appropriately for checkout, payments, or live transactional risk

--- a/skills/productivity/woocommerce-store-ops/references/store-triage-checklist.md
+++ b/skills/productivity/woocommerce-store-ops/references/store-triage-checklist.md
@@ -1,0 +1,43 @@
+# WooCommerce Store Triage Checklist
+
+Use this before changing a live or unfamiliar WooCommerce store.
+
+## Baseline
+
+- Store URL:
+- Environment: local / staging / production
+- WooCommerce version:
+- Active theme:
+- Active store-critical plugins/extensions:
+- Multisite involved? yes / no
+
+## Catalog Surface
+
+- Which product types are affected? simple / variable / grouped / bundled / subscription / booking / other
+- Are stock, price, tax class, or shipping class involved?
+- Are imports/sync jobs involved?
+
+## Order Surface
+
+- Which order statuses are relevant?
+- Are payments, refunds, fulfillment, subscriptions, or webhooks involved?
+- Is there a recent representative order to inspect?
+
+## Customer Flow to Verify
+
+- Product page
+- Add to cart
+- Cart totals
+- Checkout load
+- Payment step
+- Order confirmation/admin order view
+
+## Extension Risk Check
+
+List any plugins that could override the affected behavior:
+- gateway plugins
+- shipping plugins
+- tax/VAT plugins
+- subscription/booking plugins
+- multilingual/currency plugins
+- checkout customization plugins

--- a/skills/software-development/wordpress-project-router/SKILL.md
+++ b/skills/software-development/wordpress-project-router/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: wordpress-project-router
+description: Use when a request might involve WordPress, WooCommerce, a theme, a plugin, or site operations and you need to route to the right specialized skill first.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [wordpress, woocommerce, routing, triage, skills]
+    related_skills: [wordpress-project-triage, wordpress-wpcli-ops, wordpress-migrations-and-deploys, woocommerce-store-ops, systematic-debugging]
+---
+
+# WordPress Project Router
+
+## Overview
+
+Use this skill to decide what kind of WordPress surface you are actually dealing with before you start changing code, content, data, or infrastructure.
+
+WordPress requests are easy to misroute. A user may say "fix my WordPress site" when the real task is one of several very different jobs: plugin development, theme work, WooCommerce catalog operations, WP-CLI maintenance, a staging-to-production migration, or admin/editor cleanup. The right first move is to classify the surface, then load the downstream skill that fits.
+
+**Core principle:** do not treat all WordPress work as generic PHP or generic web debugging. Route first, then act.
+
+## When to Use
+
+Use this skill when:
+- the user mentions WordPress, WooCommerce, wp-content, wp-admin, Gutenberg, block themes, plugins, themes, or WP-CLI
+- the repo or server might be a WordPress install but that is not yet confirmed
+- the task could involve both code and content/admin operations
+- you need to decide whether to inspect files, use WP-CLI, browse the live site, or plan a migration
+
+Do not use this skill when:
+- the project type is already confirmed and a narrower WordPress skill clearly applies
+- the work is generic Linux or generic database administration with no WordPress-specific behavior
+
+## Quick Routing Questions
+
+Ask yourself these in order:
+1. Is this a **WordPress install**, a **theme/plugin repo**, or only a **server hosting WordPress**?
+2. Is the request about **code**, **content/admin**, **store operations**, or **deployment/migration**?
+3. Is there a **live site** to inspect, a **repo** to inspect, or both?
+4. Is the safest control surface **files**, **WP-CLI**, **browser/admin UI**, or a **deployment workflow**?
+
+## Fast Signals to Inspect First
+
+### Filesystem / repo signals
+- `wp-config.php`
+- `wp-content/`
+- `wp-content/plugins/<name>/`
+- `wp-content/themes/<name>/`
+- `style.css` with WordPress theme headers
+- `theme.json`
+- `block.json`
+- `composer.json`
+- `package.json`
+- `mu-plugins/`
+- `docker-compose.yml`, `.ddev/`, `.lando.yml`, `Local/`, `Bedrock/`, `Trellis/`
+
+### Site / runtime signals
+- `/wp-admin/`
+- `/wp-json/`
+- WooCommerce endpoints like `/cart`, `/checkout`, `/my-account`
+- visible block-theme editing or Site Editor usage
+- hosting/deployment references such as WP Engine, Kinsta, Pantheon, Pressable, or shared cPanel workflows
+
+## Routing Map
+
+### 1. Unknown WordPress project or unfamiliar repo
+Load: `wordpress-project-triage`
+
+Use when:
+- you need to confirm whether the repo is a full site, theme, plugin, headless frontend, or only ops tooling
+- you do not yet know the validation surface
+- you need to inspect version assumptions, build chains, and boundaries first
+
+### 2. WP-CLI-driven site operations
+Load: `wordpress-wpcli-ops`
+
+Use when tasks involve:
+- plugin/theme activation or deactivation
+- option, user, post, menu, comment, or cron inspection
+- safe cache/transient cleanup
+- search-replace or URL updates
+- maintenance on a live or staging install
+
+### 3. Migration, deploy, backup, staging, or rollback work
+Load: `wordpress-migrations-and-deploys`
+
+Use when tasks involve:
+- moving a site between local, staging, and production
+- syncing code, database, and uploads
+- URL rewrites
+- deployment risk management
+- backup checkpoints and rollback planning
+
+### 4. WooCommerce store changes or investigations
+Load: `woocommerce-store-ops`
+
+Use when tasks involve:
+- products, variations, stock, orders, coupons, shipping, tax, payment gateways
+- store behavior after plugin changes
+- order triage or catalog sanity checks
+
+### 5. Theme/plugin/block development
+Usually start with: `wordpress-project-triage`, then continue with the repo's normal software-development skills.
+
+Typical cases:
+- plugin bug fixes
+- custom theme or child-theme work
+- block/theme.json/block.json problems
+- REST integration or headless behavior
+
+### 6. Content/editor/admin workflows
+If the task is mainly publishing, menus, patterns, templates, or page-builder/UI work, begin with triage and prefer browser-backed verification over code-first assumptions.
+
+## Common Project Shapes
+
+### Full WordPress site repo
+Signals:
+- root contains `wp-config.php` or Bedrock equivalents
+- includes `wp-content/`, deployment config, maybe database helpers
+
+Bias:
+- start with `wordpress-project-triage`
+- use `wordpress-wpcli-ops` for safe runtime inspection
+- use `wordpress-migrations-and-deploys` for release/move work
+
+### Plugin repo
+Signals:
+- plugin header in a main PHP file
+- `readme.txt`, `composer.json`, PHPUnit or WP test config
+
+Bias:
+- start with `wordpress-project-triage`
+- treat activation/testing boundaries carefully
+- do not assume theme-level control
+
+### Theme or block-theme repo
+Signals:
+- `style.css`, `functions.php`, templates, `theme.json`, `templates/`, `parts/`
+
+Bias:
+- start with `wordpress-project-triage`
+- verify whether this is classic theme, hybrid, or full-site editing theme
+- browser verification matters after code edits
+
+### WooCommerce-heavy project
+Signals:
+- WooCommerce plugin dependency
+- custom checkout/cart/product logic
+- order-management or fulfillment hooks
+
+Bias:
+- route to `woocommerce-store-ops` for operational tasks
+- combine with `wordpress-project-triage` when code ownership is unclear
+
+### Headless WordPress
+Signals:
+- WordPress used for content/backend only
+- frontend repo in Next.js/Nuxt/Gatsby or another stack
+- heavy REST or GraphQL use
+
+Bias:
+- triage both repos or both surfaces
+- do not assume a frontend bug lives inside WordPress
+- verify content, API, and frontend layers separately
+
+### Ops-only server task
+Signals:
+- user asks about backups, disk usage, PHP-FPM, Nginx/Apache, cron, SSL, or deploy failures
+
+Bias:
+- confirm whether the issue is above WordPress or inside it
+- use WordPress-specific skills only after the hosting layer is understood
+
+## Recommended First Move by Situation
+
+- "I have a WordPress repo and I don't know what kind" → `wordpress-project-triage`
+- "Change the site URL / inspect plugins / clear transients" → `wordpress-wpcli-ops`
+- "Move staging to production" → `wordpress-migrations-and-deploys`
+- "Update products / inspect orders" → `woocommerce-store-ops`
+- "Fix this custom plugin/theme bug" → `wordpress-project-triage`, then continue with normal code and test workflows
+
+## Common Pitfalls
+
+1. **Treating WooCommerce as ordinary WordPress content.**
+   Product, order, tax, shipping, and extension interactions need store-specific checks.
+
+2. **Jumping into PHP edits before classifying the repo.**
+   Many WordPress repos are deployment wrappers, Bedrock structures, or theme/plugin-only repos.
+
+3. **Using WP-CLI blindly on the wrong install.**
+   Always confirm the target path, URL, environment, and multisite context first.
+
+4. **Assuming browser-visible bugs are always theme bugs.**
+   They may come from plugin hooks, cache layers, WooCommerce templates, or editor settings.
+
+5. **Using migration steps for small content changes.**
+   If the task is just runtime inspection or a single setting update, prefer WP-CLI or admin verification.
+
+## Verification Checklist
+
+- [ ] Confirmed this is actually WordPress or WooCommerce
+- [ ] Classified the request as code, runtime ops, migration/deploy, or store ops
+- [ ] Identified whether the primary surface is repo, server, site admin, or live frontend
+- [ ] Loaded the narrower downstream skill before making changes
+- [ ] Named the validation surface before acting

--- a/skills/software-development/wordpress-project-triage/SKILL.md
+++ b/skills/software-development/wordpress-project-triage/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: wordpress-project-triage
+description: Use when inspecting an unfamiliar WordPress repo, site, plugin, or theme so you can map boundaries, tooling, risks, and validation surfaces before editing.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [wordpress, triage, repo-inspection, plugins, themes]
+    related_skills: [wordpress-project-router, wordpress-wpcli-ops, wordpress-migrations-and-deploys, systematic-debugging, requesting-code-review]
+---
+
+# WordPress Project Triage
+
+## Overview
+
+Use this skill to inspect an unfamiliar WordPress project before making changes. The goal is to determine what kind of WordPress surface you have, where responsibility boundaries are, which toolchain controls it, and how you can verify changes safely.
+
+WordPress projects vary wildly: full-site repos, Bedrock setups, plugin-only repos, classic themes, block themes, child themes, headless content backends, Dockerized local stacks, and shared-hosting exports. Good triage prevents edits in the wrong layer.
+
+**Core principle:** identify structure, ownership boundaries, runtime assumptions, and validation paths before touching code or data.
+
+## When to Use
+
+Use this skill when:
+- a repo or server might be WordPress but you have not classified it yet
+- the user asks you to "look at this WordPress project" or "figure out how this site is wired"
+- you need to know whether the task belongs to a plugin, theme, infrastructure, content, or store layer
+- you need to discover test/build/deploy surfaces in a WordPress codebase
+
+Do not use this skill when:
+- the exact project shape is already known and a narrower WordPress skill clearly applies
+- the task is only a simple live-site WP-CLI operation and the install/path is already known
+
+## Triage Workflow
+
+### 1. Confirm the WordPress surface
+Inspect for these markers first:
+- `wp-config.php`
+- `wp-content/`
+- `wp-includes/version.php`
+- `wp-content/plugins/`
+- `wp-content/themes/`
+- Bedrock signals such as `config/application.php`, `web/wp`, `.env`, `composer.json` with roots/bedrock packages
+- local dev stack files like `.ddev/`, `.lando.yml`, `docker-compose.yml`, `wp-env.json`
+
+If none appear, do not force a WordPress interpretation.
+
+### 2. Classify the repo shape
+Pick the closest fit:
+- **Full site repo** — contains WordPress app structure or Bedrock layout
+- **Plugin repo** — isolated plugin code, plugin header, plugin tests/build files
+- **Theme repo** — classic or block theme, likely `style.css`, `functions.php`, templates, `theme.json`
+- **Child theme repo** — minimal overrides over a parent theme
+- **Headless split** — WordPress backend plus separate frontend app
+- **Ops wrapper** — deployment scripts, infra config, backup/migration tooling
+
+### 3. Detect boundaries that matter
+Record where each concern lives:
+- theme/presentation logic
+- plugin/business logic
+- WooCommerce/store behavior
+- site configuration and secrets
+- build outputs and generated assets
+- deployment configuration
+- custom mu-plugins or must-use bootstrap code
+
+### 4. Detect build and dependency chains
+Inspect for:
+- `composer.json` / `composer.lock`
+- `package.json` / lockfiles
+- bundlers: Vite, Webpack, Parcel, @wordpress/scripts
+- PHP standards/test tools: PHPUnit, PHPCS, Pest, Rector, PHPStan
+- JS test tools: Vitest, Jest, Playwright, Cypress
+- local stacks: DDEV, Lando, wp-env, Docker Compose
+
+Important: identify **source files vs built assets**. Do not patch a generated bundle if the source tree is present.
+
+### 5. Infer WordPress/runtime assumptions
+Check for:
+- WordPress core version pins or expectations
+- PHP version requirements
+- WooCommerce dependency/version requirements
+- multisite assumptions
+- custom constants, env vars, salts, domain mappings, or content-dir moves
+
+### 6. Identify available validation surfaces
+Prefer the strongest available signals:
+- unit/integration tests
+- lint/type/static-analysis tools
+- local site startup commands
+- WP-CLI commands
+- browser-visible routes or admin flows
+- deployment preview/staging environment
+
+If tests are absent, define a manual verification path before editing.
+
+## File and Directory Signals
+
+### Full site or Bedrock
+Common signals:
+- `wp-config.php`
+- `wp-content/`
+- `web/wp` or `web/app`
+- `config/application.php`
+- `.env.example`
+
+### Plugin repo
+Common signals:
+- main plugin PHP file with `Plugin Name:` header
+- `readme.txt`
+- `uninstall.php`
+- `languages/`, `assets/`, `includes/`, `src/`
+
+### Theme repo
+Common signals:
+- `style.css` with `Theme Name:` header
+- `functions.php`
+- `templates/`, `parts/`, `patterns/`
+- `theme.json`
+- `block-templates/` or block assets
+
+### WooCommerce-heavy customization
+Common signals:
+- checkout/cart hooks
+- product import/export helpers
+- custom order admin code
+- extension-specific folders or package names
+
+## Questions to Answer Before Editing
+
+Write down concise answers to these:
+1. What exact WordPress surface is this?
+2. Which folder or repo owns the requested behavior?
+3. Is WooCommerce involved?
+4. What versions or environment assumptions matter?
+5. What command or browser path will prove the change worked?
+6. What could break if this assumption is wrong?
+
+## Triage Commands and Checks
+
+Typical actions:
+- search for WordPress marker files and headers
+- inspect `composer.json` and `package.json`
+- search for plugin/theme names mentioned by the user
+- read config/bootstrap files before editing behavior files
+- look for CI/test scripts and project README setup notes
+
+When a live install is available, combine repo inspection with safe runtime discovery:
+- `wp core version`
+- `wp plugin list`
+- `wp theme list`
+- `wp option get siteurl`
+
+Use runtime commands only after confirming the correct project path and environment.
+
+## Boundary Heuristics
+
+### If a bug is visual
+Check, in order:
+1. theme/template overrides
+2. block theme templates or patterns
+3. WooCommerce template overrides
+4. plugin CSS/JS injection
+5. cache/minification layers
+
+### If a bug is behavioral
+Check, in order:
+1. plugin hooks/filters/actions
+2. custom mu-plugins
+3. theme `functions.php`
+4. WooCommerce extensions
+5. server/runtime configuration
+
+### If a bug appears only after deploy or migration
+Prefer `wordpress-migrations-and-deploys` and inspect:
+- URL/path assumptions
+- serialized data changes
+- uploads/media sync
+- cache invalidation
+- environment-specific constants
+
+## Hand-off Guidance
+
+After triage, route clearly:
+- runtime maintenance or inspection → `wordpress-wpcli-ops`
+- migration/release/rollback → `wordpress-migrations-and-deploys`
+- store/catalog/order issues → `woocommerce-store-ops`
+- code implementation → continue with normal repo workflows after the WordPress boundaries are mapped
+
+## Common Pitfalls
+
+1. **Editing the wrong layer.**
+   WordPress often splits behavior across plugin, theme, mu-plugin, and admin settings.
+
+2. **Ignoring generated assets.**
+   Many modern themes/plugins compile JS/CSS; patch source, then rebuild if needed.
+
+3. **Assuming the repo contains the full site.**
+   Some repos only ship a plugin or theme and depend on an external WordPress install.
+
+4. **Skipping version assumptions.**
+   A block-theme fix may depend on WordPress core or WooCommerce versions.
+
+5. **Using live WP-CLI before confirming environment.**
+   The same server may host several installs.
+
+6. **Trusting only repo structure.**
+   Runtime state, active plugins, and admin settings can materially change behavior.
+
+## Verification Checklist
+
+- [ ] Confirmed whether this is a full site, plugin, theme, child theme, headless backend, or ops wrapper
+- [ ] Identified the directories or files that actually own the requested behavior
+- [ ] Identified Composer/npm/build/test surfaces, if any
+- [ ] Noted WordPress, PHP, WooCommerce, and multisite assumptions where relevant
+- [ ] Chosen a downstream skill or validation path before editing
+- [ ] Avoided changing generated artifacts when source files are available

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -69,6 +69,8 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`kanban-orchestrator`](/user-guide/skills/bundled/devops/devops-kanban-orchestrator) | Decomposition playbook + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill... | `devops/kanban-orchestrator` |
 | [`kanban-worker`](/user-guide/skills/bundled/devops/devops-kanban-worker) | Pitfalls, examples, and edge cases for Hermes Kanban workers. The lifecycle itself is auto-injected into every worker's system prompt as KANBAN_GUIDANCE (from agent/prompt_builder.py); this skill is what you load when you want deeper det... | `devops/kanban-worker` |
 | [`webhook-subscriptions`](/user-guide/skills/bundled/devops/devops-webhook-subscriptions) | Webhook subscriptions: event-driven agent runs. | `devops/webhook-subscriptions` |
+| [`wordpress-migrations-and-deploys`](/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys) | Use when moving, deploying, syncing, backing up, or rolling back a WordPress site across local, staging, and production environments. | `devops/wordpress-migrations-and-deploys` |
+| [`wordpress-wpcli-ops`](/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops) | Use when operating or inspecting a WordPress install with WP-CLI for safe runtime changes, diagnostics, cleanup, and verification. | `devops/wordpress-wpcli-ops` |
 
 ## dogfood
 
@@ -149,6 +151,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`ocr-and-documents`](/user-guide/skills/bundled/productivity/productivity-ocr-and-documents) | Extract text from PDFs/scans (pymupdf, marker-pdf). | `productivity/ocr-and-documents` |
 | [`powerpoint`](/user-guide/skills/bundled/productivity/productivity-powerpoint) | Create, read, edit .pptx decks, slides, notes, templates. | `productivity/powerpoint` |
 | [`teams-meeting-pipeline`](/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline) | Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions. | `productivity/teams-meeting-pipeline` |
+| [`woocommerce-store-ops`](/user-guide/skills/bundled/productivity/productivity-woocommerce-store-ops) | Use when operating or validating a WooCommerce store for catalog changes, order inspection, merchandising sanity checks, and extension-aware verification. | `productivity/woocommerce-store-ops` |
 
 ## red-teaming
 
@@ -192,6 +195,8 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`subagent-driven-development`](/user-guide/skills/bundled/software-development/software-development-subagent-driven-development) | Execute plans via delegate_task subagents (2-stage review). | `software-development/subagent-driven-development` |
 | [`systematic-debugging`](/user-guide/skills/bundled/software-development/software-development-systematic-debugging) | 4-phase root cause debugging: understand bugs before fixing. | `software-development/systematic-debugging` |
 | [`test-driven-development`](/user-guide/skills/bundled/software-development/software-development-test-driven-development) | TDD: enforce RED-GREEN-REFACTOR, tests before code. | `software-development/test-driven-development` |
+| [`wordpress-project-router`](/user-guide/skills/bundled/software-development/software-development-wordpress-project-router) | Use when a request might involve WordPress, WooCommerce, a theme, a plugin, or site operations and you need to route to the right specialized skill first. | `software-development/wordpress-project-router` |
+| [`wordpress-project-triage`](/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage) | Use when inspecting an unfamiliar WordPress repo, site, plugin, or theme so you can map boundaries, tooling, risks, and validation surfaces before editing. | `software-development/wordpress-project-triage` |
 | [`writing-plans`](/user-guide/skills/bundled/software-development/software-development-writing-plans) | Write implementation plans: bite-sized tasks, paths, code. | `software-development/writing-plans` |
 
 ## yuanbao

--- a/website/docs/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys.md
@@ -1,0 +1,234 @@
+---
+title: "Wordpress Migrations And Deploys"
+sidebar_label: "Wordpress Migrations And Deploys"
+description: "Use when moving, deploying, syncing, backing up, or rolling back a WordPress site across local, staging, and production environments"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Wordpress Migrations And Deploys
+
+Use when moving, deploying, syncing, backing up, or rolling back a WordPress site across local, staging, and production environments.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/devops/wordpress-migrations-and-deploys` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Tags | `wordpress`, `migration`, `deploy`, `backup`, `rollback` |
+| Related skills | [`wordpress-project-triage`](/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage), [`wordpress-wpcli-ops`](/docs/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops), [`webhook-subscriptions`](/docs/user-guide/skills/bundled/devops/devops-webhook-subscriptions), [`writing-plans`](/docs/user-guide/skills/bundled/software-development/software-development-writing-plans), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# WordPress Migrations and Deploys
+
+## Overview
+
+Use this skill for WordPress moves and releases that cross environment boundaries: local to staging, staging to production, production to local, host-to-host migrations, rollback planning, and deploy verification.
+
+WordPress moves are rarely just "copy files." A working site depends on the interaction between code, database content, uploads/media, environment configuration, caches, and URL assumptions. The safest workflow separates those layers explicitly.
+
+**Core principle:** treat code, database, uploads, secrets/config, and cache as separate migration surfaces with separate checkpoints.
+
+## When to Use
+
+Use this skill when:
+- moving a site between local, staging, and production
+- changing domains or URLs
+- deploying code that depends on database state or media assets
+- creating backup/restore checkpoints
+- planning rollback before a risky WordPress release
+
+Do not use this skill when:
+- the task is a small runtime admin change better handled by `wordpress-wpcli-ops`
+- the project shape is still unknown; triage first
+- the task is only plugin/theme code editing with no environment move
+
+## The Five Migration Surfaces
+
+Always reason about these separately:
+1. **Code** — themes, plugins, mu-plugins, config, build artifacts
+2. **Database** — posts, options, plugin settings, users, orders, serialized data
+3. **Uploads/media** — `wp-content/uploads/` and any offloaded media assumptions
+4. **Environment/config** — `.env`, `wp-config.php`, salts, domains, credentials, object cache, CDN, mail
+5. **Cache/runtime** — page cache, object cache, transients, opcode cache, CDN cache, cron backlog
+
+## Preflight Checklist
+
+Before moving anything, confirm:
+- source and target environments
+- canonical source of truth for code
+- backup method for database and uploads
+- whether WooCommerce or memberships are involved
+- maintenance window or content-freeze expectations
+- search-replace scope and old/new domains
+- rollback owner and rollback trigger point
+
+## Safe Migration Workflow
+
+### 1. Snapshot the baseline
+Capture:
+- current site URL/home URL
+- active plugins/themes
+- WordPress and PHP versions
+- database dump location
+- uploads backup location
+- deployment commit SHA or release identifier
+
+### 2. Separate what is actually moving
+Common patterns:
+- **staging → prod release:** code only, plus DB migration or option changes
+- **prod → local clone:** code + DB + uploads + URL rewrite
+- **host migration:** everything, plus DNS/CDN/runtime config
+- **theme/plugin deploy:** code only, but still verify dependent options and caches
+
+### 3. Back up before mutation
+Minimum safe stance:
+- a database backup you can restore
+- an uploads backup or sync checkpoint when media matters
+- confidence that the exact deployed code version can be restored
+
+### 4. Use serialized-data-safe replacement
+For domain/path changes, prefer WP-CLI search-replace rather than raw SQL:
+```bash
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables --dry-run
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables
+```
+
+### 5. Rebuild and clear only what is needed
+Potential post-move steps:
+- rebuild theme/plugin assets
+- flush caches
+- clear transients
+- re-save permalinks if routing changed
+- run due cron if queues are stuck
+
+### 6. Verify in layers
+Check all of these before calling the move done:
+- homepage loads
+- admin login works
+- one representative content page works
+- media loads from expected storage
+- forms/cart/checkout/account flows work if applicable
+- background jobs or cron are not obviously stuck
+
+## Common Migration Scenarios
+
+### Production → local
+Typical needs:
+- DB dump/import
+- uploads sync
+- URL rewrite
+- mail/payment safeguards disabled locally
+- search indexing disabled locally if needed
+
+Watch for:
+- hardcoded domains
+- object cache config carried over incorrectly
+- third-party API side effects from copied cron/jobs
+
+### Staging → production
+Typical needs:
+- deploy code from version control
+- run targeted DB changes only if required
+- avoid blindly copying staging DB over production
+- clear deploy-related caches
+
+Watch for:
+- overwriting production orders, users, comments, or form submissions
+- schema changes not matched by code
+- environment constants drifting between staging and production
+
+### Host-to-host migration
+Typical needs:
+- full code sync
+- full DB transfer
+- uploads/media transfer
+- DNS/SSL/CDN alignment
+- PHP extension/version parity
+
+Watch for:
+- file permissions/ownership
+- Nginx/Apache rewrites
+- object cache or Redis/Memcached endpoints
+- offloaded media or CDN origin paths
+
+## Rollback Planning
+
+Define rollback before deployment, not after failure.
+
+Minimum rollback plan:
+- what exact code version to restore
+- where the last known-good DB backup lives
+- whether uploads changed during the release window
+- who decides rollback vs forward-fix
+- what user-visible checks trigger rollback
+
+If a release includes irreversible data mutation, say that explicitly and tighten the checkpoint discipline.
+
+## WooCommerce and Other High-Risk Sites
+
+Extra caution for:
+- live orders/payments
+- subscriptions/memberships
+- booking systems
+- LMS/course progress
+- form submissions
+
+Rules of thumb:
+- do not overwrite a live production DB with stale staging content
+- minimize maintenance windows but prefer explicit freeze rules for risky changes
+- verify order creation, checkout, tax/shipping, and email side effects after release
+
+## Post-Move Verification
+
+Run a representative smoke test set:
+- front page
+- key landing page
+- admin dashboard
+- plugin/theme status
+- media rendering
+- contact form or transactional path
+- WooCommerce cart/checkout for stores
+- cron or scheduled job visibility
+
+## Related Reference
+
+See `references/rollback-checklist.md` for a compact rollback checklist you can copy into a deployment handoff.
+
+## Common Pitfalls
+
+1. **Treating WordPress deploys as code-only when data changed too.**
+   Many failures are option, URL, upload, or cache mismatches.
+
+2. **Using raw SQL for URL rewrites.**
+   Serialized data corruption is a classic self-inflicted outage.
+
+3. **Overwriting production data with staging data.**
+   Especially dangerous on WooCommerce or membership sites.
+
+4. **Skipping uploads/media as a distinct surface.**
+   Broken media is one of the most common post-migration issues.
+
+5. **No rollback plan.**
+   A backup that cannot be found or restored is not a real fallback.
+
+6. **Calling the deploy done after one homepage check.**
+   Always verify at least one real business-critical path.
+
+## Verification Checklist
+
+- [ ] Identified which of code, DB, uploads, config, and cache are changing
+- [ ] Captured or confirmed backups/checkpoints before mutation
+- [ ] Used serialized-data-safe search-replace where URLs/paths changed
+- [ ] Defined rollback inputs and trigger conditions before release
+- [ ] Verified representative frontend, admin, and business-critical paths after the move
+- [ ] Avoided destructive staging-to-production data overwrite for live transactional sites

--- a/website/docs/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops.md
@@ -1,0 +1,278 @@
+---
+title: "Wordpress Wpcli Ops"
+sidebar_label: "Wordpress Wpcli Ops"
+description: "Use when operating or inspecting a WordPress install with WP-CLI for safe runtime changes, diagnostics, cleanup, and verification"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Wordpress Wpcli Ops
+
+Use when operating or inspecting a WordPress install with WP-CLI for safe runtime changes, diagnostics, cleanup, and verification.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/devops/wordpress-wpcli-ops` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Tags | `wordpress`, `wp-cli`, `operations`, `maintenance`, `multisite` |
+| Related skills | [`wordpress-project-triage`](/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage), [`wordpress-migrations-and-deploys`](/docs/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys), [`woocommerce-store-ops`](/docs/user-guide/skills/bundled/productivity/productivity-woocommerce-store-ops), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# WordPress WP-CLI Operations
+
+## Overview
+
+Use this skill when the safest control surface is a live or local WordPress install and WP-CLI is available. It covers discovery, inspection, low-risk operational changes, cleanup, and post-change verification.
+
+WP-CLI is often the fastest reliable way to inspect plugins, themes, users, options, cron events, transients, and content relationships without poking the database directly or guessing through the admin UI.
+
+**Core principle:** confirm the target install and environment first, then make the smallest runtime change with a clear before/after verification step.
+
+## When to Use
+
+Use this skill when:
+- the task is primarily runtime inspection or maintenance on a known WordPress install
+- you need to inspect plugins, themes, users, posts, options, cron, cache, or transients
+- you need to run a safe search-replace or URL update
+- the user asks for quick WordPress ops without opening the browser admin first
+
+Do not use this skill when:
+- the project path or target install is still ambiguous
+- the task is a migration, environment move, or rollback-heavy deploy
+- the task is mainly WooCommerce store operations needing store-specific verification
+
+## Safe Discovery First
+
+### 1. Confirm WP-CLI is available
+Typical checks:
+```bash
+wp --info
+wp cli version
+```
+
+### 2. Confirm the correct install path
+Run WP-CLI from the install root, or pass an explicit path:
+```bash
+wp core version
+wp option get siteurl
+wp option get home
+```
+
+If multiple installs may exist, inspect the filesystem first and verify the site URL before changing anything.
+
+### 3. Confirm environment context
+Before state-changing commands, record:
+- hostname / environment name
+- site URL
+- multisite vs single-site
+- active theme
+- active plugins
+
+Useful commands:
+```bash
+wp core is-installed
+wp plugin list
+wp theme list
+wp option get blogname
+```
+
+## High-Value Operations
+
+### Plugin and theme inspection
+```bash
+wp plugin list
+wp plugin status woocommerce
+wp theme list
+wp theme status twentytwentyfour
+```
+
+Use for:
+- active/inactive status
+- version drift
+- update opportunities
+- identifying obvious ownership surfaces
+
+### User and role inspection
+```bash
+wp user list --fields=ID,user_login,user_email,roles
+wp role list
+```
+
+Use for:
+- checking admin access
+- verifying role assignments
+- finding content owners or test accounts
+
+### Option inspection
+```bash
+wp option get siteurl
+wp option get home
+wp option get permalink_structure
+```
+
+Use for:
+- confirming URL assumptions
+- debugging environment mismatches
+- checking basic site configuration
+
+### Content inspection
+```bash
+wp post list --post_type=page --fields=ID,post_title,post_status
+wp post get 123 --field=post_title
+wp term list category --fields=term_id,name,slug
+```
+
+Use for:
+- confirming content presence
+- enumerating pages or custom post types
+- tracing relationships before editing
+
+### Cron inspection
+```bash
+wp cron event list
+wp cron event run --due-now
+```
+
+Use for:
+- identifying stuck tasks
+- checking whether scheduled tasks are overdue
+- validating whether a plugin relies on WP-Cron behavior
+
+### Cache and transient cleanup
+```bash
+wp transient list
+wp transient delete --all
+wp cache flush
+```
+
+Use carefully:
+- clear transients when debugging stale settings or cached remote results
+- flush caches after deploys or major option changes
+- verify front-end effects after cleanup
+
+## Search-Replace Safety
+
+Use `wp search-replace` instead of raw SQL when changing URLs or paths in WordPress data.
+
+Recommended flow:
+1. Confirm source and target values exactly.
+2. Dry-run first.
+3. Prefer precise scope over blanket replacement.
+4. Re-verify URLs and sample pages after the change.
+
+Example:
+```bash
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables --dry-run
+wp search-replace 'https://old.example.com' 'https://new.example.com' --all-tables
+```
+
+Notes:
+- WP-CLI handles serialized data safely; direct SQL often does not.
+- Avoid casual replacement across multiple unrelated installs.
+- On large sites, expect this command to take time and verify backups first.
+
+## Safe Change Workflow
+
+For any state-changing WP-CLI operation:
+1. Inspect current state.
+2. Save or report the baseline.
+3. Make the smallest change.
+4. Re-run the same inspection command.
+5. Verify one browser-visible or admin-visible outcome where possible.
+
+Examples:
+- before/after `wp option get siteurl`
+- before/after `wp plugin status plugin-name`
+- before/after `wp cron event list`
+
+## Multisite Caveats
+
+Before making changes, determine if the install is multisite:
+```bash
+wp site list
+wp network meta list 1
+```
+
+Important caveats:
+- plugin activation can be site-specific or network-wide
+- options may live at the site or network level
+- user membership can vary by site
+- path and domain assumptions differ across sites
+- `--url=<site>` may be required to target the correct site
+
+Examples:
+```bash
+wp --url=https://sub.example.com option get home
+wp --url=https://sub.example.com plugin list
+```
+
+## Commands to Avoid or Treat as High Risk
+
+Be cautious with:
+- direct SQL writes via `wp db query`
+- bulk destructive deletion without a precise filter
+- plugin/theme updates on production without impact awareness
+- blanket cache flushes during incident response unless needed
+- search-replace without a dry run and backup confidence
+
+## Verification Patterns
+
+### After plugin changes
+- re-run `wp plugin list`
+- verify one affected route or admin page
+- check logs if the change was error-driven
+
+### After option changes
+- re-run `wp option get ...`
+- verify the corresponding browser/admin behavior
+
+### After transient/cache cleanup
+- verify the stale behavior is actually gone
+- confirm no plugin immediately recreates the bad state
+
+### After cron actions
+- re-run `wp cron event list`
+- inspect plugin-specific downstream effects if applicable
+
+## Related Reference
+
+See `references/common-commands.md` for a grab-bag of frequently useful WP-CLI commands.
+
+## Common Pitfalls
+
+1. **Running WP-CLI against the wrong install.**
+   Always confirm the path and `siteurl` first.
+
+2. **Using destructive commands without baseline capture.**
+   Before/after inspection is part of the job.
+
+3. **Using raw SQL where WP-CLI has a safe wrapper.**
+   Search-replace is the classic example.
+
+4. **Ignoring multisite context.**
+   A correct command on one site can be wrong at the network level.
+
+5. **Assuming a CLI change is enough verification.**
+   Browser-visible confirmation still matters.
+
+6. **Overusing cache flushes.**
+   Clear only what helps the diagnosis.
+
+## Verification Checklist
+
+- [ ] Confirmed WP-CLI availability and the correct install path
+- [ ] Captured the target site's URL/environment before making changes
+- [ ] Checked for multisite context when relevant
+- [ ] Used dry-run or inspection-first flow for risky commands
+- [ ] Verified the same surface before and after the change
+- [ ] Verified at least one live/admin outcome when possible

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-woocommerce-store-ops.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-woocommerce-store-ops.md
@@ -1,0 +1,203 @@
+---
+title: "Woocommerce Store Ops"
+sidebar_label: "Woocommerce Store Ops"
+description: "Use when operating or validating a WooCommerce store for catalog changes, order inspection, merchandising sanity checks, and extension-aware verification"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Woocommerce Store Ops
+
+Use when operating or validating a WooCommerce store for catalog changes, order inspection, merchandising sanity checks, and extension-aware verification.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/productivity/woocommerce-store-ops` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Tags | `woocommerce`, `wordpress`, `ecommerce`, `catalog`, `orders` |
+| Related skills | [`wordpress-project-router`](/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-router), [`wordpress-project-triage`](/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage), [`wordpress-wpcli-ops`](/docs/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops), [`wordpress-migrations-and-deploys`](/docs/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# WooCommerce Store Operations
+
+## Overview
+
+Use this skill for the operational side of WooCommerce: product/catalog changes, order inspection, coupon/shipping/tax sanity checks, extension-aware troubleshooting, and post-change validation.
+
+WooCommerce work looks deceptively like ordinary WordPress content work, but store behavior depends on product types, stock rules, taxes, shipping zones, coupons, checkout settings, payment gateways, and extension hooks. Small changes can have revenue impact.
+
+**Core principle:** make small store changes, then verify the exact customer or operator flow affected.
+
+## When to Use
+
+Use this skill when:
+- the user asks about WooCommerce products, variations, orders, coupons, tax, shipping, payments, or fulfillment behavior
+- you need to validate a store after plugin changes or a deployment
+- you need to inspect a store's operational state before editing settings or catalog data
+
+Do not use this skill when:
+- the project is not actually using WooCommerce
+- the task is only generic WordPress runtime maintenance with no store-specific behavior
+- the request is a host migration or deploy plan; use the migration skill first
+
+## Store Triage First
+
+Before changing anything, capture:
+- WooCommerce version
+- active store-critical plugins/extensions
+- payment gateways in use
+- shipping method assumptions
+- tax configuration relevance
+- whether the store is live and transacting now
+
+Useful checks include:
+- active plugin list
+- order status patterns
+- representative product types in the catalog
+- cart and checkout routes
+
+See `references/store-triage-checklist.md` for a concise pre-change checklist.
+
+## High-Value Operational Surfaces
+
+### 1. Product and catalog updates
+Common tasks:
+- title/description updates
+- price or sale-price changes
+- stock/availability changes
+- category/tag cleanup
+- image/media sanity checks
+- variation review for attributes, stock, and pricing consistency
+
+Verification after product changes:
+- product page renders correctly
+- price displays correctly
+- add-to-cart works for the intended product type
+- stock status matches expectation
+- variation selectors behave correctly
+
+### 2. Order inspection
+Common tasks:
+- inspect recent orders and statuses
+- verify payment or fulfillment progression
+- identify stuck processing/on-hold/failed patterns
+- confirm whether a plugin or deploy changed checkout outcomes
+
+Verification after order-related changes:
+- one recent representative order still shows expected metadata/state
+- admin order view loads without errors
+- emails/webhooks are not obviously broken if the change touched those flows
+
+### 3. Coupons, shipping, and tax sanity checks
+Common tasks:
+- confirm a coupon applies when and where expected
+- validate shipping-zone assumptions
+- verify tax display and totals at a high level
+
+Verification after settings changes:
+- test cart subtotal/discount math on a representative product
+- confirm shipping methods appear for the right destination
+- confirm tax-inclusive/exclusive display still matches expectation
+
+### 4. Extension-aware troubleshooting
+Always check for extensions that materially alter behavior:
+- subscriptions
+- bookings
+- bundles/composites
+- multilingual/currency plugins
+- ERP/fulfillment integrations
+- payment gateway add-ons
+- checkout customization plugins
+
+Rule: do not assume core WooCommerce owns the bug until extension interactions are reviewed.
+
+## Safe Change Workflow
+
+1. Inspect the current state first.
+2. Name the exact store surface being changed.
+3. Prefer the smallest reversible change.
+4. Re-check the same operational surface after the change.
+5. Verify one customer-visible flow if the change could affect revenue.
+
+Examples:
+- changing product stock → verify product page + add-to-cart
+- changing shipping settings → verify cart/checkout shipping availability
+- changing coupon rules → verify discount application on a test cart
+
+## Common Risk Areas
+
+### Product types
+Different verification is needed for:
+- simple products
+- variable products
+- grouped/bundled/composite products
+- downloadable/virtual products
+- subscription or booking products
+
+### Payment and checkout
+Be extra careful when the task touches:
+- checkout fields or validation
+- payment gateways
+- taxes and totals
+- shipping calculations
+- stock reservation/reduction timing
+
+### Deploys and plugin updates
+After deploys or plugin changes, verify at minimum:
+- storefront loads
+- one product page loads
+- cart works
+- checkout loads
+- admin orders load
+- no obvious fatal/plugin conflict is present
+
+## Operational Heuristics
+
+- A display problem on product pages may be theme/template override related.
+- A totals or checkout issue may come from taxes, shipping, or gateway extensions.
+- A missing product may be catalog visibility, stock status, schedule, or sync-related.
+- An order-state issue may be payment webhook, fulfillment extension, or custom automation related.
+
+## Reference Workflow
+
+Use the reference checklist when starting on a live store:
+- `references/store-triage-checklist.md`
+
+## Common Pitfalls
+
+1. **Treating WooCommerce as ordinary posts/pages.**
+   Store logic has revenue and fulfillment implications.
+
+2. **Changing settings without testing a customer path.**
+   Admin values can look correct while checkout is broken.
+
+3. **Ignoring extensions.**
+   Many store behaviors are extension-defined, not core-defined.
+
+4. **Testing only one product shape.**
+   Variable, bundled, subscription, or booking products often behave differently.
+
+5. **Applying content-style verification to operational changes.**
+   Store ops need cart/checkout/order verification, not just page rendering.
+
+6. **Overlooking live-transaction risk.**
+   Be explicit when a change could affect active orders or payments.
+
+## Verification Checklist
+
+- [ ] Confirmed WooCommerce is active and identified major store-critical extensions
+- [ ] Identified whether the task affects catalog, orders, shipping, tax, coupons, or checkout
+- [ ] Captured the relevant baseline before changing anything
+- [ ] Verified the same store surface after the change
+- [ ] Verified at least one customer-visible or operator-visible flow tied to the change
+- [ ] Escalated caution appropriately for checkout, payments, or live transactional risk

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-router.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-router.md
@@ -1,0 +1,224 @@
+---
+title: "Wordpress Project Router"
+sidebar_label: "Wordpress Project Router"
+description: "Use when a request might involve WordPress, WooCommerce, a theme, a plugin, or site operations and you need to route to the right specialized skill first"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Wordpress Project Router
+
+Use when a request might involve WordPress, WooCommerce, a theme, a plugin, or site operations and you need to route to the right specialized skill first.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/software-development/wordpress-project-router` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Tags | `wordpress`, `woocommerce`, `routing`, `triage`, `skills` |
+| Related skills | [`wordpress-project-triage`](/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage), [`wordpress-wpcli-ops`](/docs/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops), [`wordpress-migrations-and-deploys`](/docs/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys), [`woocommerce-store-ops`](/docs/user-guide/skills/bundled/productivity/productivity-woocommerce-store-ops), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# WordPress Project Router
+
+## Overview
+
+Use this skill to decide what kind of WordPress surface you are actually dealing with before you start changing code, content, data, or infrastructure.
+
+WordPress requests are easy to misroute. A user may say "fix my WordPress site" when the real task is one of several very different jobs: plugin development, theme work, WooCommerce catalog operations, WP-CLI maintenance, a staging-to-production migration, or admin/editor cleanup. The right first move is to classify the surface, then load the downstream skill that fits.
+
+**Core principle:** do not treat all WordPress work as generic PHP or generic web debugging. Route first, then act.
+
+## When to Use
+
+Use this skill when:
+- the user mentions WordPress, WooCommerce, wp-content, wp-admin, Gutenberg, block themes, plugins, themes, or WP-CLI
+- the repo or server might be a WordPress install but that is not yet confirmed
+- the task could involve both code and content/admin operations
+- you need to decide whether to inspect files, use WP-CLI, browse the live site, or plan a migration
+
+Do not use this skill when:
+- the project type is already confirmed and a narrower WordPress skill clearly applies
+- the work is generic Linux or generic database administration with no WordPress-specific behavior
+
+## Quick Routing Questions
+
+Ask yourself these in order:
+1. Is this a **WordPress install**, a **theme/plugin repo**, or only a **server hosting WordPress**?
+2. Is the request about **code**, **content/admin**, **store operations**, or **deployment/migration**?
+3. Is there a **live site** to inspect, a **repo** to inspect, or both?
+4. Is the safest control surface **files**, **WP-CLI**, **browser/admin UI**, or a **deployment workflow**?
+
+## Fast Signals to Inspect First
+
+### Filesystem / repo signals
+- `wp-config.php`
+- `wp-content/`
+- `wp-content/plugins/<name>/`
+- `wp-content/themes/<name>/`
+- `style.css` with WordPress theme headers
+- `theme.json`
+- `block.json`
+- `composer.json`
+- `package.json`
+- `mu-plugins/`
+- `docker-compose.yml`, `.ddev/`, `.lando.yml`, `Local/`, `Bedrock/`, `Trellis/`
+
+### Site / runtime signals
+- `/wp-admin/`
+- `/wp-json/`
+- WooCommerce endpoints like `/cart`, `/checkout`, `/my-account`
+- visible block-theme editing or Site Editor usage
+- hosting/deployment references such as WP Engine, Kinsta, Pantheon, Pressable, or shared cPanel workflows
+
+## Routing Map
+
+### 1. Unknown WordPress project or unfamiliar repo
+Load: `wordpress-project-triage`
+
+Use when:
+- you need to confirm whether the repo is a full site, theme, plugin, headless frontend, or only ops tooling
+- you do not yet know the validation surface
+- you need to inspect version assumptions, build chains, and boundaries first
+
+### 2. WP-CLI-driven site operations
+Load: `wordpress-wpcli-ops`
+
+Use when tasks involve:
+- plugin/theme activation or deactivation
+- option, user, post, menu, comment, or cron inspection
+- safe cache/transient cleanup
+- search-replace or URL updates
+- maintenance on a live or staging install
+
+### 3. Migration, deploy, backup, staging, or rollback work
+Load: `wordpress-migrations-and-deploys`
+
+Use when tasks involve:
+- moving a site between local, staging, and production
+- syncing code, database, and uploads
+- URL rewrites
+- deployment risk management
+- backup checkpoints and rollback planning
+
+### 4. WooCommerce store changes or investigations
+Load: `woocommerce-store-ops`
+
+Use when tasks involve:
+- products, variations, stock, orders, coupons, shipping, tax, payment gateways
+- store behavior after plugin changes
+- order triage or catalog sanity checks
+
+### 5. Theme/plugin/block development
+Usually start with: `wordpress-project-triage`, then continue with the repo's normal software-development skills.
+
+Typical cases:
+- plugin bug fixes
+- custom theme or child-theme work
+- block/theme.json/block.json problems
+- REST integration or headless behavior
+
+### 6. Content/editor/admin workflows
+If the task is mainly publishing, menus, patterns, templates, or page-builder/UI work, begin with triage and prefer browser-backed verification over code-first assumptions.
+
+## Common Project Shapes
+
+### Full WordPress site repo
+Signals:
+- root contains `wp-config.php` or Bedrock equivalents
+- includes `wp-content/`, deployment config, maybe database helpers
+
+Bias:
+- start with `wordpress-project-triage`
+- use `wordpress-wpcli-ops` for safe runtime inspection
+- use `wordpress-migrations-and-deploys` for release/move work
+
+### Plugin repo
+Signals:
+- plugin header in a main PHP file
+- `readme.txt`, `composer.json`, PHPUnit or WP test config
+
+Bias:
+- start with `wordpress-project-triage`
+- treat activation/testing boundaries carefully
+- do not assume theme-level control
+
+### Theme or block-theme repo
+Signals:
+- `style.css`, `functions.php`, templates, `theme.json`, `templates/`, `parts/`
+
+Bias:
+- start with `wordpress-project-triage`
+- verify whether this is classic theme, hybrid, or full-site editing theme
+- browser verification matters after code edits
+
+### WooCommerce-heavy project
+Signals:
+- WooCommerce plugin dependency
+- custom checkout/cart/product logic
+- order-management or fulfillment hooks
+
+Bias:
+- route to `woocommerce-store-ops` for operational tasks
+- combine with `wordpress-project-triage` when code ownership is unclear
+
+### Headless WordPress
+Signals:
+- WordPress used for content/backend only
+- frontend repo in Next.js/Nuxt/Gatsby or another stack
+- heavy REST or GraphQL use
+
+Bias:
+- triage both repos or both surfaces
+- do not assume a frontend bug lives inside WordPress
+- verify content, API, and frontend layers separately
+
+### Ops-only server task
+Signals:
+- user asks about backups, disk usage, PHP-FPM, Nginx/Apache, cron, SSL, or deploy failures
+
+Bias:
+- confirm whether the issue is above WordPress or inside it
+- use WordPress-specific skills only after the hosting layer is understood
+
+## Recommended First Move by Situation
+
+- "I have a WordPress repo and I don't know what kind" → `wordpress-project-triage`
+- "Change the site URL / inspect plugins / clear transients" → `wordpress-wpcli-ops`
+- "Move staging to production" → `wordpress-migrations-and-deploys`
+- "Update products / inspect orders" → `woocommerce-store-ops`
+- "Fix this custom plugin/theme bug" → `wordpress-project-triage`, then continue with normal code and test workflows
+
+## Common Pitfalls
+
+1. **Treating WooCommerce as ordinary WordPress content.**
+   Product, order, tax, shipping, and extension interactions need store-specific checks.
+
+2. **Jumping into PHP edits before classifying the repo.**
+   Many WordPress repos are deployment wrappers, Bedrock structures, or theme/plugin-only repos.
+
+3. **Using WP-CLI blindly on the wrong install.**
+   Always confirm the target path, URL, environment, and multisite context first.
+
+4. **Assuming browser-visible bugs are always theme bugs.**
+   They may come from plugin hooks, cache layers, WooCommerce templates, or editor settings.
+
+5. **Using migration steps for small content changes.**
+   If the task is just runtime inspection or a single setting update, prefer WP-CLI or admin verification.
+
+## Verification Checklist
+
+- [ ] Confirmed this is actually WordPress or WooCommerce
+- [ ] Classified the request as code, runtime ops, migration/deploy, or store ops
+- [ ] Identified whether the primary surface is repo, server, site admin, or live frontend
+- [ ] Loaded the narrower downstream skill before making changes
+- [ ] Named the validation surface before acting

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-triage.md
@@ -1,0 +1,236 @@
+---
+title: "Wordpress Project Triage"
+sidebar_label: "Wordpress Project Triage"
+description: "Use when inspecting an unfamiliar WordPress repo, site, plugin, or theme so you can map boundaries, tooling, risks, and validation surfaces before editing"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Wordpress Project Triage
+
+Use when inspecting an unfamiliar WordPress repo, site, plugin, or theme so you can map boundaries, tooling, risks, and validation surfaces before editing.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/software-development/wordpress-project-triage` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Tags | `wordpress`, `triage`, `repo-inspection`, `plugins`, `themes` |
+| Related skills | [`wordpress-project-router`](/docs/user-guide/skills/bundled/software-development/software-development-wordpress-project-router), [`wordpress-wpcli-ops`](/docs/user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops), [`wordpress-migrations-and-deploys`](/docs/user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# WordPress Project Triage
+
+## Overview
+
+Use this skill to inspect an unfamiliar WordPress project before making changes. The goal is to determine what kind of WordPress surface you have, where responsibility boundaries are, which toolchain controls it, and how you can verify changes safely.
+
+WordPress projects vary wildly: full-site repos, Bedrock setups, plugin-only repos, classic themes, block themes, child themes, headless content backends, Dockerized local stacks, and shared-hosting exports. Good triage prevents edits in the wrong layer.
+
+**Core principle:** identify structure, ownership boundaries, runtime assumptions, and validation paths before touching code or data.
+
+## When to Use
+
+Use this skill when:
+- a repo or server might be WordPress but you have not classified it yet
+- the user asks you to "look at this WordPress project" or "figure out how this site is wired"
+- you need to know whether the task belongs to a plugin, theme, infrastructure, content, or store layer
+- you need to discover test/build/deploy surfaces in a WordPress codebase
+
+Do not use this skill when:
+- the exact project shape is already known and a narrower WordPress skill clearly applies
+- the task is only a simple live-site WP-CLI operation and the install/path is already known
+
+## Triage Workflow
+
+### 1. Confirm the WordPress surface
+Inspect for these markers first:
+- `wp-config.php`
+- `wp-content/`
+- `wp-includes/version.php`
+- `wp-content/plugins/`
+- `wp-content/themes/`
+- Bedrock signals such as `config/application.php`, `web/wp`, `.env`, `composer.json` with roots/bedrock packages
+- local dev stack files like `.ddev/`, `.lando.yml`, `docker-compose.yml`, `wp-env.json`
+
+If none appear, do not force a WordPress interpretation.
+
+### 2. Classify the repo shape
+Pick the closest fit:
+- **Full site repo** — contains WordPress app structure or Bedrock layout
+- **Plugin repo** — isolated plugin code, plugin header, plugin tests/build files
+- **Theme repo** — classic or block theme, likely `style.css`, `functions.php`, templates, `theme.json`
+- **Child theme repo** — minimal overrides over a parent theme
+- **Headless split** — WordPress backend plus separate frontend app
+- **Ops wrapper** — deployment scripts, infra config, backup/migration tooling
+
+### 3. Detect boundaries that matter
+Record where each concern lives:
+- theme/presentation logic
+- plugin/business logic
+- WooCommerce/store behavior
+- site configuration and secrets
+- build outputs and generated assets
+- deployment configuration
+- custom mu-plugins or must-use bootstrap code
+
+### 4. Detect build and dependency chains
+Inspect for:
+- `composer.json` / `composer.lock`
+- `package.json` / lockfiles
+- bundlers: Vite, Webpack, Parcel, @wordpress/scripts
+- PHP standards/test tools: PHPUnit, PHPCS, Pest, Rector, PHPStan
+- JS test tools: Vitest, Jest, Playwright, Cypress
+- local stacks: DDEV, Lando, wp-env, Docker Compose
+
+Important: identify **source files vs built assets**. Do not patch a generated bundle if the source tree is present.
+
+### 5. Infer WordPress/runtime assumptions
+Check for:
+- WordPress core version pins or expectations
+- PHP version requirements
+- WooCommerce dependency/version requirements
+- multisite assumptions
+- custom constants, env vars, salts, domain mappings, or content-dir moves
+
+### 6. Identify available validation surfaces
+Prefer the strongest available signals:
+- unit/integration tests
+- lint/type/static-analysis tools
+- local site startup commands
+- WP-CLI commands
+- browser-visible routes or admin flows
+- deployment preview/staging environment
+
+If tests are absent, define a manual verification path before editing.
+
+## File and Directory Signals
+
+### Full site or Bedrock
+Common signals:
+- `wp-config.php`
+- `wp-content/`
+- `web/wp` or `web/app`
+- `config/application.php`
+- `.env.example`
+
+### Plugin repo
+Common signals:
+- main plugin PHP file with `Plugin Name:` header
+- `readme.txt`
+- `uninstall.php`
+- `languages/`, `assets/`, `includes/`, `src/`
+
+### Theme repo
+Common signals:
+- `style.css` with `Theme Name:` header
+- `functions.php`
+- `templates/`, `parts/`, `patterns/`
+- `theme.json`
+- `block-templates/` or block assets
+
+### WooCommerce-heavy customization
+Common signals:
+- checkout/cart hooks
+- product import/export helpers
+- custom order admin code
+- extension-specific folders or package names
+
+## Questions to Answer Before Editing
+
+Write down concise answers to these:
+1. What exact WordPress surface is this?
+2. Which folder or repo owns the requested behavior?
+3. Is WooCommerce involved?
+4. What versions or environment assumptions matter?
+5. What command or browser path will prove the change worked?
+6. What could break if this assumption is wrong?
+
+## Triage Commands and Checks
+
+Typical actions:
+- search for WordPress marker files and headers
+- inspect `composer.json` and `package.json`
+- search for plugin/theme names mentioned by the user
+- read config/bootstrap files before editing behavior files
+- look for CI/test scripts and project README setup notes
+
+When a live install is available, combine repo inspection with safe runtime discovery:
+- `wp core version`
+- `wp plugin list`
+- `wp theme list`
+- `wp option get siteurl`
+
+Use runtime commands only after confirming the correct project path and environment.
+
+## Boundary Heuristics
+
+### If a bug is visual
+Check, in order:
+1. theme/template overrides
+2. block theme templates or patterns
+3. WooCommerce template overrides
+4. plugin CSS/JS injection
+5. cache/minification layers
+
+### If a bug is behavioral
+Check, in order:
+1. plugin hooks/filters/actions
+2. custom mu-plugins
+3. theme `functions.php`
+4. WooCommerce extensions
+5. server/runtime configuration
+
+### If a bug appears only after deploy or migration
+Prefer `wordpress-migrations-and-deploys` and inspect:
+- URL/path assumptions
+- serialized data changes
+- uploads/media sync
+- cache invalidation
+- environment-specific constants
+
+## Hand-off Guidance
+
+After triage, route clearly:
+- runtime maintenance or inspection → `wordpress-wpcli-ops`
+- migration/release/rollback → `wordpress-migrations-and-deploys`
+- store/catalog/order issues → `woocommerce-store-ops`
+- code implementation → continue with normal repo workflows after the WordPress boundaries are mapped
+
+## Common Pitfalls
+
+1. **Editing the wrong layer.**
+   WordPress often splits behavior across plugin, theme, mu-plugin, and admin settings.
+
+2. **Ignoring generated assets.**
+   Many modern themes/plugins compile JS/CSS; patch source, then rebuild if needed.
+
+3. **Assuming the repo contains the full site.**
+   Some repos only ship a plugin or theme and depend on an external WordPress install.
+
+4. **Skipping version assumptions.**
+   A block-theme fix may depend on WordPress core or WooCommerce versions.
+
+5. **Using live WP-CLI before confirming environment.**
+   The same server may host several installs.
+
+6. **Trusting only repo structure.**
+   Runtime state, active plugins, and admin settings can materially change behavior.
+
+## Verification Checklist
+
+- [ ] Confirmed whether this is a full site, plugin, theme, child theme, headless backend, or ops wrapper
+- [ ] Identified the directories or files that actually own the requested behavior
+- [ ] Identified Composer/npm/build/test surfaces, if any
+- [ ] Noted WordPress, PHP, WooCommerce, and multisite assumptions where relevant
+- [ ] Chosen a downstream skill or validation path before editing
+- [ ] Avoided changing generated artifacts when source files are available

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -200,6 +200,8 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/devops/devops-kanban-orchestrator',
                     'user-guide/skills/bundled/devops/devops-kanban-worker',
                     'user-guide/skills/bundled/devops/devops-webhook-subscriptions',
+                    'user-guide/skills/bundled/devops/devops-wordpress-migrations-and-deploys',
+                    'user-guide/skills/bundled/devops/devops-wordpress-wpcli-ops',
                   ],
                 },
                 {
@@ -307,6 +309,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/productivity/productivity-ocr-and-documents',
                     'user-guide/skills/bundled/productivity/productivity-powerpoint',
                     'user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline',
+                    'user-guide/skills/bundled/productivity/productivity-woocommerce-store-ops',
                   ],
                 },
                 {
@@ -365,6 +368,8 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/software-development/software-development-subagent-driven-development',
                     'user-guide/skills/bundled/software-development/software-development-systematic-debugging',
                     'user-guide/skills/bundled/software-development/software-development-test-driven-development',
+                    'user-guide/skills/bundled/software-development/software-development-wordpress-project-router',
+                    'user-guide/skills/bundled/software-development/software-development-wordpress-project-triage',
                     'user-guide/skills/bundled/software-development/software-development-writing-plans',
                   ],
                 },


### PR DESCRIPTION
## Summary
- add a first bundled WordPress skill cluster covering routing, repo triage, WP-CLI ops, migrations/deploys, and WooCommerce store operations
- add supporting reference files and generated bundled skill docs pages
- add a WordPress/WooCommerce mention plus example prompts to the README
- include the dated expansion plan that scoped this first PR

## Test Plan
- [x] `python website/scripts/generate-skill-docs.py`
- [x] `pytest tests/website/test_generate_skill_docs.py -q`
- [x] frontmatter/body validation for the new SKILL.md files via Python

## Notes
- intentionally excluded unrelated working tree changes in `docker-compose.yml` and `.env.save`
