### PR TITLE
fix(nix): expose passthru.npmLockfile on desktop derivation

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -106,6 +106,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = { inherit (npm.passthru) npmLockfile; };
+
   meta = with lib; {
     description = "Native Electron desktop shell for Hermes Agent";
     homepage = "https://github.com/NousResearch/hermes-agent";


### PR DESCRIPTION
 ## Problem

  Entering the repo via direnv / `nix develop`, or running
  `nix build .#fix-lockfiles`, fails during evaluation:

  ```
  error: attribute 'npmLockfile' missing
         at nix/lib.nix:129:25:
            129|       entries = map (p: p.passthru.npmLockfile) packages;
  ```

  (On a machine with a stale nix eval-cache this first surfaces as the old
  `Extra/group name 'vercel' ...` failure being replayed; any tree change or a
  cache-less eval reveals the real `npmLockfile` error underneath.)

  ## Root cause

  `nix/desktop.nix` returns a bare `stdenv.mkDerivation` Electron wrapper with
  **no `passthru`**. The `npmLockfile` metadata from `mkNpmPassthru` is only
  merged into the intermediate `renderer` build, not the final package —
  unlike `tui.nix` / `web.nix`, which return `buildNpmPackage (npm // {...})`
  as their final derivation and therefore carry it.

  `packages.nix` passes `hermesDesktop` to `mkFixLockfiles`, which does
  `map (p: p.passthru.npmLockfile) packages` (`lib.nix:129`) with no fallback.
  The devShell's `inputsFrom` is `builtins.attrValues self'.packages` (which
  includes `fix-lockfiles`), so evaluating `.#devShells.default` or
  `.#fix-lockfiles` blows up.

  Introduced by #20059 — the same PR added `hermesDesktop` to the
  `mkFixLockfiles` list. The nix eval-cache masks it wherever a successful
  result is cached, which is why `main` looked fine; clean checkouts / CI on a
  cold cache hit it.

  ## Fix

  Expose the lockfile metadata on the final desktop derivation, matching
  tui/web:

  ```nix
  passthru = { inherit (npm.passthru) npmLockfile; };
  ```

  This also correctly enrolls `apps/desktop`'s lockfile hash into
  `fix-lockfiles` checking — which is what `packages.nix` already intended.

  ## Verification

  - `nix eval .#devShells.aarch64-darwin.default.drvPath` now succeeds, both
    with and without `--option eval-cache false`, where it previously errored.
  - Confirmed `origin/main` still lacks the passthru.

  ## Optional follow-up (not in this PR)

  `lib.nix:129` could use `p.passthru.npmLockfile or null` + filter so a future
  package missing the passthru degrades gracefully instead of taking down the
  whole devShell. Left out to keep this fix minimal — happy to add if preferred.