### PR TITLE
fix(minimax): ignore M3 models.dev context underreport

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1722,7 +1722,18 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
-            return ctx
+            # models.dev currently reports MiniMax-M3's max output window
+            # (512K) as context. The provider docs and static fallback define
+            # M3 as 1M context, so reject the underreport and fall through to
+            # DEFAULT_CONTEXT_LENGTHS.
+            if ctx < 1_000_000 and _model_name_suggests_minimax_m3(model):
+                logger.info(
+                    "Rejecting models.dev context=%s for %r "
+                    "(MiniMax-M3 underreport); falling through to hardcoded defaults",
+                    ctx, model,
+                )
+            else:
+                return ctx
 
     # 6. OpenRouter live API metadata — provider-unaware fallback.
     # Only consulted when the provider is unknown (no effective_provider),


### PR DESCRIPTION
## Summary
- reject models.dev's 512K underreport for MiniMax-M3
- fall through to the hardcoded 1M MiniMax-M3 context default after stale cache invalidation

## Test Plan
- python -m pytest tests/agent/test_minimax_provider.py::TestMinimaxM3StaleCacheGuard::test_stale_m3_cache_dropped_and_reresolves_to_1m -q
- python -m pytest tests/agent/test_minimax_provider.py -q
- python -m pytest tests/agent/test_model_metadata.py tests/agent/test_models_dev.py tests/agent/test_minimax_provider.py -q
- python -m ruff check agent/model_metadata.py tests/agent/test_minimax_provider.py
- python -m ty check agent/model_metadata.py