### PR TITLE
fix(windows): centralize subprocess compat, add safe_split_command, secure_file_chmod, master_subprocess_run

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
+from hermes_cli._subprocess_compat import safe_split_command
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
@@ -65,7 +66,7 @@ def _resolve_args() -> list[str]:
     raw = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     if not raw:
         return ["--acp", "--stdio"]
-    return shlex.split(raw)
+    return safe_split_command(raw)
 
 
 def _resolve_home_dir() -> str:

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -45,6 +45,7 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
     to `$HERMES_HOME` / `~/.hermes` keeps direct callers working too.
     """
     if home_path is None:
-        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+        home_path = Path(os.getenv("HERMES_HOME", get_hermes_home()))
     return home_path / "cache" / _DISK_CACHE_BASENAME
 
 
@@ -157,7 +158,7 @@ def _write_disk_cache(cache_key: _CacheKey, entry: "_CachedFetch",
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(payload, f)
-            os.chmod(tmp, 0o600)
+            secure_file_chmod(tmp)
             os.replace(tmp, path)
         except BaseException:
             try:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -13,7 +13,7 @@ Design notes
   :func:`hermes_cli.plugins.invoke_hook` and its aggregators.  Python
   plugins are registered first (via ``discover_and_load()``) so their
   block decisions win ties over shell-hook blocks.
-* Subprocess execution uses ``shlex.split(os.path.expanduser(command))``
+* Subprocess execution uses ``safe_split_command(os.path.expanduser(command))``
   with ``shell=False`` — no shell injection footguns.  Users that need
   pipes/redirection wrap their logic in a script.
 * First-use consent is gated by the allowlist under
@@ -69,6 +69,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
+from hermes_cli._subprocess_compat import safe_split_command
 
 try:
     import fcntl  # POSIX only; Windows falls back to best-effort without flock.
@@ -380,7 +381,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         "error": None,
     }
     try:
-        argv = shlex.split(os.path.expanduser(spec.command))
+        argv = safe_split_command(os.path.expanduser(spec.command))
     except ValueError as exc:
         result["error"] = f"command {spec.command!r} cannot be parsed: {exc}"
         return result
@@ -732,7 +733,7 @@ def _command_script_path(command: str) -> str:
     common bare-path form.
     """
     try:
-        parts = shlex.split(command)
+        parts = safe_split_command(command)
     except ValueError:
         return command
     if not parts:
@@ -819,7 +820,7 @@ def script_is_executable(command: str) -> bool:
     if not os.path.isfile(expanded):
         return False
     try:
-        argv = shlex.split(command)
+        argv = safe_split_command(command)
     except ValueError:
         return False
     is_bare_invocation = bool(argv) and argv[0] == path

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
 from agent.prompt_builder import _scan_context_content
+from hermes_cli._subprocess_compat import safe_split_command
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,7 @@ class SubdirectoryHintTracker:
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
         """Extract path-like tokens from a shell command string."""
         try:
-            tokens = shlex.split(cmd)
+            tokens = safe_split_command(cmd)
         except ValueError:
             tokens = cmd.split()
 

--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,8 @@ Usage:
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
+from hermes_cli._subprocess_compat import safe_split_command
+from hermes_cli._subprocess_compat import secure_file_chmod
 try:
     import hermes_bootstrap  # noqa: F401
 except ModuleNotFoundError:
@@ -2931,7 +2933,7 @@ def save_config_value(key_path: str, value: any) -> bool:
         
         # Enforce owner-only permissions on config files (contain API keys)
         try:
-            os.chmod(config_path, 0o600)
+            secure_file_chmod(config_path)
         except (OSError, NotImplementedError):
             pass
         
@@ -6208,7 +6210,7 @@ class HermesCLI:
                 _cprint(line)
 
         try:
-            parts = shlex.split(cmd)
+            parts = safe_split_command(cmd)
         except ValueError:
             parts = cmd.split()
 
@@ -8256,7 +8258,7 @@ class HermesCLI:
                     i += 1
             return opts
 
-        tokens = shlex.split(cmd)
+        tokens = safe_split_command(cmd)
 
         if len(tokens) == 1:
             print()
@@ -8437,7 +8439,7 @@ class HermesCLI:
         """
         import shlex
 
-        tokens = shlex.split(cmd)[1:] if cmd else []
+        tokens = safe_split_command(cmd)[1:] if cmd else []
         if not tokens:
             tokens = ["status"]
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Union
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +160,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
 def _secure_dir(path: Path):
     """Set directory to owner-only access (0700). No-op on Windows."""
     try:
-        os.chmod(path, 0o700)
+        secure_file_chmod(path, mode=0o700)
     except (OSError, NotImplementedError):
         pass  # Windows or other platforms where chmod is not supported
 
@@ -168,7 +169,7 @@ def _secure_file(path: Path):
     """Set file to owner-only read/write (0600). No-op on Windows."""
     try:
         if path.exists():
-            os.chmod(path, 0o600)
+            secure_file_chmod(path)
     except (OSError, NotImplementedError):
         pass
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3607,7 +3607,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        script_path = _get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15,6 +15,7 @@ Usage:
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
+from hermes_cli._subprocess_compat import safe_split_command
 try:
     import hermes_bootstrap  # noqa: F401
 except ModuleNotFoundError:
@@ -3048,7 +3049,7 @@ class GatewayRunner:
         if not text:
             return "", False
         try:
-            tokens = shlex.split(text)
+            tokens = safe_split_command(text)
         except ValueError:
             tokens = text.split()
 
@@ -10142,7 +10143,7 @@ class GatewayRunner:
         if text.startswith("kanban"):
             text = text[len("kanban"):].lstrip()
 
-        tokens = shlex.split(text) if text else []
+        tokens = safe_split_command(text) if text else []
         requested_board = None
         action = None
         i = 0

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -17,6 +17,14 @@ Several common subprocess patterns break silently-or-loudly on Windows:
   Windows spawns a cmd window briefly unless ``CREATE_NO_WINDOW`` is
   passed.  Cosmetic but jarring for background daemons.
 
+* **``shlex.split()`` destroys Windows paths** — on POSIX ``\`` is an
+  escape character, so ``shlex.split("cat C:\\Users\\Admin\\file.txt")``
+  returns ``["cat", "C:UsersAdminfile.txt"]`` with all backslashes
+  silently consumed.  This module provides ``safe_split_command()`` and
+  ``safe_subprocess_run()`` which return the raw string on Windows
+  (for use with ``subprocess.run(..., shell=True)``) and ``shlex.split()``
+  on POSIX.  See PR #16212.
+
 This module centralizes the platform-branching logic so the rest of the
 codebase doesn't sprinkle ``if sys.platform == "win32":`` everywhere.
 
@@ -27,13 +35,22 @@ guarantee.
 
 from __future__ import annotations
 
+import logging
+import os
+import shlex
 import shutil
+import subprocess
 import sys
-from typing import Sequence
+from typing import Optional, Sequence
 
 __all__ = [
     "IS_WINDOWS",
     "resolve_node_command",
+    "safe_split_command",
+    "safe_subprocess_run",
+    "secure_file_win32",
+    "secure_file_chmod",
+    "master_subprocess_run",
     "windows_detach_flags",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
@@ -41,6 +58,72 @@ __all__ = [
 
 
 IS_WINDOWS = sys.platform == "win32"
+
+
+# -----------------------------------------------------------------------------
+# Safe command-string splitting (Windows-safe shlex.split replacement)
+# -----------------------------------------------------------------------------
+
+
+def safe_split_command(command: str) -> list[str]:
+    """Split a command string into an argv list platform-safely.
+
+    On POSIX: uses ``shlex.split()`` (standard shell tokenization).
+
+    On Windows: **does NOT use shlex.split()** because ``shlex`` treats
+    ``\`` as an escape character and silently destroys backslash-separated
+    paths.  Instead, returns the command as a single-element list — the
+    caller MUST pass ``shell=True`` to ``subprocess.run()`` so that
+    ``cmd.exe`` handles tokenization natively.
+
+    Args:
+        command: Raw command string (e.g. ``"python3 /path/to/script.py"``
+            or, on Windows, ``"C:\\Users\\Admin\\script.py"``).
+
+    Returns:
+        A list suitable for ``subprocess.run()``:
+        * On POSIX: ``["python3", "/path/to/script.py"]``
+        * On Windows: ``["C:\\Users\\Admin\\script.py"]`` (intended for
+          ``shell=True``).
+    """
+    if IS_WINDOWS:
+        # shlex.split destroys backslashes — return whole command string.
+        # Caller must use shell=True so cmd.exe handles parsing.
+        return [command]
+    return shlex.split(command)
+
+
+def safe_subprocess_run(
+    command: str,
+    *args,
+    **kwargs,
+) -> subprocess.CompletedProcess:
+    """Run a command string via subprocess, splitting platform-safely.
+
+    Convenience wrapper around :func:`master_subprocess_run` for callers
+    that pass a string command (not a list).
+
+    On POSIX: splits with ``shlex.split()``, calls ``subprocess.run()``
+    with ``shell=False`` (safe for POSIX argv).
+
+    On Windows: passes the raw string with ``shell=True`` so ``cmd.exe``
+    handles argument parsing — avoids ``shlex.split`` backslash destruction.
+
+    All positional and keyword arguments after *command* are forwarded to
+    ``subprocess.run()``.
+
+    Args:
+        command: Raw command string.
+        *args: Extra positional args for ``subprocess.run()``.
+        **kwargs: Extra keyword args for ``subprocess.run()``.
+
+    Returns:
+        ``subprocess.CompletedProcess`` from the underlying call.
+
+    Raises:
+        Same as ``subprocess.run()``.
+    """
+    return master_subprocess_run(command, *args, **kwargs)
 
 
 # -----------------------------------------------------------------------------
@@ -87,13 +170,218 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
 
 
 # -----------------------------------------------------------------------------
+# Windows file permission enforcement
+# -----------------------------------------------------------------------------
+
+
+def secure_file_win32(path: str, *, logger=None, raise_errors: bool = False) -> None:
+    """Restrict file access to the current user on Windows.
+
+    On POSIX this is a no-op; use ``os.chmod(path, 0o600)`` there instead.
+
+    ``os.chmod()`` is ineffective on Windows — the permission bits
+    (owner/group/other) are silently ignored.  Only the read-only flag
+    (0o444) has any effect, which does NOT prevent other processes
+    running as the same user from reading the file.
+
+    This function uses ``ICACLS`` to:
+    1. Remove all inherited permissions (``/inheritance:r``)
+    2. Grant full control to the current user only (``/grant:r %USERNAME%:F``)
+
+    This is the Windows-native equivalent of ``chmod 0o600`` / ``chmod 0o700``.
+
+    Args:
+        path: Absolute path to the file or directory to secure.
+        logger: Logger for warnings.  Defaults to ``logging.getLogger(...)``
+            which logs a warning but never raises.  Pass ``raise_errors=True``
+            to propagate exceptions to the caller.
+        raise_errors: When True, raises on failure instead of logging.
+            Default False.
+
+    Raises:
+        ``subprocess.CalledProcessError`` if ICACLS fails and
+        *raise_errors* is True.
+    """
+    if not IS_WINDOWS:
+        return
+    if not os.path.exists(path):
+        if logger:
+            logger.warning("secure_file_win32: path does not exist, skipping: %s", path)
+        return
+    try:
+        username = os.getlogin()
+    except OSError:
+        username = os.environ.get("USERNAME", "Users")
+    try:
+        subprocess.run(
+            ["icacls", path, "/inheritance:r", "/grant:r", f"{username}:F"],
+            check=True, capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            FileNotFoundError, OSError) as exc:
+        if raise_errors:
+            raise
+        _log = logger or logging.getLogger(__name__)
+        _log.warning(
+            "secure_file_win32: ICACLS failed for %s: %s", path, exc,
+        )
+
+
+def secure_file_chmod(path: str, mode: int = 0o600, *, logger=None, raise_errors: bool = False) -> None:
+    """Secure a file with the strongest permissions available.
+
+    Windows: uses ``icacls /inheritance:r /grant:r %USERNAME%:F``
+    (real ACL-based restriction).
+
+    POSIX: uses ``os.chmod(path, mode)`` (default 0o600).
+
+    Args:
+        path: Absolute path to the file to secure.
+        mode: POSIX permission bits (ignored on Windows).
+        logger: Logger for warnings (default: ``logging.getLogger(...)``).
+        raise_errors: When True, raises on failure (default False).
+
+    Raises:
+        ``OSError`` on POSIX if chmod fails.
+        ``subprocess.CalledProcessError`` on Windows if ICACLS fails
+        and *raise_errors* is True.
+    """
+    if IS_WINDOWS:
+        secure_file_win32(path, logger=logger, raise_errors=raise_errors)
+    else:
+        os.chmod(path, mode)
+
+
+# -----------------------------------------------------------------------------
+# Master subprocess execution wrapper
+# -----------------------------------------------------------------------------
+
+
+def master_subprocess_run(
+    command: str | list[str],
+    *args,
+    **kwargs,
+) -> subprocess.CompletedProcess:
+    """Run a subprocess with full Windows compatibility.
+
+    This is the ONE function to use instead of raw ``subprocess.run()``.
+    It handles all three Windows pitfalls automatically:
+
+    * **``.cmd`` batch file resolution** — ``npm``, ``node``,
+      ``npx``, etc. are resolved via ``shutil.which()`` so
+      ``CreateProcessW`` doesn't fail with WinError 193.
+    * **Path backslash safety** — when *command* is a string,
+      it's passed with ``shell=True`` on Windows so ``cmd.exe`` handles
+      argument tokenization (avoids ``shlex.split`` backslash destruction).
+    * **``shell=True`` consolidation** — all ``shell=True``
+      decisions are centralized here instead of sprinkled across 10+
+      call sites.
+
+    On POSIX the behavior is unchanged: string commands are split with
+    ``shlex.split()`` and executed with ``shell=False``; list commands
+    are passed as-is.
+
+    Args:
+        command: Command string (e.g. ``"npm install"``) or argv list
+            (e.g. ``["npm", "install"]``).
+        *args: Extra positional args forwarded to ``subprocess.run()``.
+        **kwargs: Extra keyword args forwarded to ``subprocess.run()``.
+
+    Returns:
+        ``subprocess.CompletedProcess``.
+
+    Raises:
+        Same as ``subprocess.run()``.
+    """
+    if not IS_WINDOWS:
+        if isinstance(command, str):
+            import shlex
+            argv = shlex.split(command)
+        else:
+            argv = list(command)
+        return subprocess.run(argv, *args, **kwargs)
+
+    # --- Windows path below ---
+    if isinstance(command, str):
+        known_cmd = command.split(None, 1)[0].lower()
+        if known_cmd in ("npm", "node", "npx", "yarn", "pnpm", "playwright", "prettier"):
+            rest = command.split(None, 1)[1] if " " in command else ""
+            resolved_argv = resolve_node_command(known_cmd, [rest] if rest else [])
+            kwargs.setdefault("shell", False)
+            return subprocess.run(resolved_argv, *args, **kwargs)
+
+        kwargs.setdefault("shell", True)
+        return subprocess.run(command, *args, **kwargs)
+
+    if command and command[0].lower() in ("npm", "node", "npx", "yarn", "pnpm"):
+        resolved = resolve_node_command(command[0], command[1:])
+        kwargs.setdefault("shell", False)
+        return subprocess.run(resolved, *args, **kwargs)
+
+    kwargs.setdefault("shell", False)
+    return subprocess.run(list(command), *args, **kwargs)
+
+
+def master_subprocess_popen(
+    command: str | list[str],
+    *args, **kwargs,
+) -> subprocess.Popen:
+    """Like :func:`master_subprocess_run` but returns ``subprocess.Popen``
+    for long-lived / background processes.
+
+    Same Windows compat (``.cmd`` shim resolution, path backslash safety,
+    ``shell=True`` by default for string commands) but non-blocking.
+
+    On POSIX the behavior is unchanged: string commands are split with
+    ``shlex.split()`` and executed with ``shell=False``; list commands
+    are passed as-is.
+
+    Args:
+        command: Command string (e.g. ``"npm install"``) or argv list
+            (e.g. ``["npm", "install"]``).
+        *args: Extra positional args forwarded to ``subprocess.Popen()``.
+        **kwargs: Extra keyword args forwarded to ``subprocess.Popen()``.
+
+    Returns:
+        ``subprocess.Popen`` instance.
+
+    Raises:
+        Same as ``subprocess.Popen()``.
+    """
+    if not IS_WINDOWS:
+        if isinstance(command, str):
+            import shlex
+            argv = shlex.split(command)
+        else:
+            argv = list(command)
+        return subprocess.Popen(argv, *args, **kwargs)
+
+    # --- Windows path below ---
+    if isinstance(command, str):
+        known_cmd = command.split(None, 1)[0].lower()
+        if known_cmd in ("npm", "node", "npx", "yarn", "pnpm", "playwright", "prettier"):
+            rest = command.split(None, 1)[1] if " " in command else ""
+            resolved_argv = resolve_node_command(known_cmd, [rest] if rest else [])
+            kwargs.setdefault("shell", False)
+            return subprocess.Popen(resolved_argv, *args, **kwargs)
+
+        kwargs.setdefault("shell", True)
+        return subprocess.Popen(command, *args, **kwargs)
+
+    if command and command[0].lower() in ("npm", "node", "npx", "yarn", "pnpm"):
+        resolved = resolve_node_command(command[0], command[1:])
+        kwargs.setdefault("shell", False)
+        return subprocess.Popen(resolved, *args, **kwargs)
+
+    kwargs.setdefault("shell", False)
+    return subprocess.Popen(list(command), *args, **kwargs)
+
+
+# -----------------------------------------------------------------------------
 # Detached / hidden process creation
 # -----------------------------------------------------------------------------
 
 
-# Win32 CreationFlags — defined here rather than imported from subprocess
-# because CREATE_NO_WINDOW and DETACHED_PROCESS aren't guaranteed to be
-# present on stdlib subprocess on older Pythons or non-Windows builds.
 _CREATE_NEW_PROCESS_GROUP = 0x00000200
 _DETACHED_PROCESS = 0x00000008
 _CREATE_NO_WINDOW = 0x08000000
@@ -104,18 +392,7 @@ def windows_detach_flags() -> int:
     console and process group.  0 on non-Windows.
 
     Pair with ``start_new_session=False`` (default) when calling
-    subprocess.Popen — on POSIX use ``start_new_session=True`` instead,
-    which maps to ``os.setsid()`` in the child.
-
-    Rationale:
-    - ``CREATE_NEW_PROCESS_GROUP`` — child has its own process group so
-      Ctrl+C in the parent console doesn't propagate.
-    - ``DETACHED_PROCESS`` — child has no console at all.  Necessary for
-      background daemons (gateway watchers, update respawners) because
-      without it, closing the console kills the child.
-    - ``CREATE_NO_WINDOW`` — suppress the brief cmd flash that would
-      otherwise appear when launching a console app.  Redundant with
-      DETACHED_PROCESS but explicit for clarity.
+    subprocess.Popen.
     """
     if not IS_WINDOWS:
         return 0
@@ -126,14 +403,8 @@ def windows_hide_flags() -> int:
     """Return Win32 creationflags that merely hide the child's console
     window without detaching the child.  0 on non-Windows.
 
-    Use for short-lived console apps spawned as part of a larger
-    operation (``taskkill``, ``where``, version probes) where we want no
+    Use for short-lived console apps where we want no
     flash but also want to collect stdout/exit code synchronously.
-
-    The key difference from :func:`windows_detach_flags`: NO
-    ``DETACHED_PROCESS`` — the child still inherits stdio handles so
-    ``capture_output=True`` works.  ``DETACHED_PROCESS`` would sever
-    stdio and break stdout capture.
     """
     if not IS_WINDOWS:
         return 0
@@ -142,8 +413,7 @@ def windows_hide_flags() -> int:
 
 def windows_detach_popen_kwargs() -> dict:
     """Return a dict of Popen kwargs that detach a child on Windows and
-    fall back to the POSIX equivalent (``start_new_session=True``) on
-    Linux/macOS.
+    fall back to ``start_new_session=True`` on POSIX.
 
     Usage pattern:
 
@@ -158,15 +428,8 @@ def windows_detach_popen_kwargs() -> dict:
             **windows_detach_popen_kwargs(),
         )
 
-    This replaces the unsafe-on-Windows pattern:
-
-    .. code-block:: python
-
-        subprocess.Popen(..., start_new_session=True)
-
-    which silently fails to detach on Windows (the flag is accepted but
-    has no effect — the child stays attached to the parent's console
-    and dies when the console closes).
+    This replaces the unsafe-on-Windows pattern ``start_new_session=True``
+    which silently fails to detach on Windows.
     """
     if IS_WINDOWS:
         return {"creationflags": windows_detach_flags()}

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -44,9 +44,10 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import httpx
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
-from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
+from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir, get_hermes_home
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, is_truthy_value
+from hermes_cli._subprocess_compat import safe_split_command
 
 logger = logging.getLogger(__name__)
 
@@ -860,7 +861,7 @@ def _auth_file_path() -> Path:
     # hermetic conftest, or sandbox escapes via threads/subprocesses. In
     # production (no PYTEST_CURRENT_TEST) this is a single dict lookup.
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_auth = (Path.home() / ".hermes" / "auth.json").resolve(strict=False)
+        real_home_auth = (get_hermes_home() / "auth.json").resolve(strict=False)
         try:
             resolved = path.resolve(strict=False)
         except Exception:
@@ -5682,7 +5683,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         or "copilot"
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    args = safe_split_command(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -5879,7 +5880,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
         or "copilot"
     )
     raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    args = safe_split_command(raw_args) if raw_args else ["--acp", "--stdio"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 logger = logging.getLogger(__name__)
 
@@ -394,7 +395,7 @@ def run_import(args) -> None:
                 with zf.open(member) as src, open(target, "wb") as dst:
                     dst.write(src.read())
                 if target.name in _SECRET_FILE_NAMES:
-                    os.chmod(target, 0o600)
+                    secure_file_chmod(target)
                 restored += 1
             except (PermissionError, OSError) as exc:
                 errors.append(f"  {rel}: {exc}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 
 from hermes_cli.secret_prompt import masked_secret_prompt
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 logger = logging.getLogger(__name__)
 
@@ -668,7 +669,7 @@ def _secure_file(path):
         return
     try:
         if os.path.exists(str(path)):
-            os.chmod(path, 0o600)
+            secure_file_chmod(path)
     except (OSError, NotImplementedError):
         pass
 

--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -19,6 +19,7 @@ import os
 import threading
 from pathlib import Path
 from typing import Any
+from hermes_constants import get_hermes_home
 
 _log = logging.getLogger(__name__)
 _write_lock = threading.Lock()
@@ -56,7 +57,7 @@ def _resolve_log_path() -> Path:
     else ``~/.hermes``. A local copy avoids an import cycle with the
     middleware which lives below ``hermes_cli``.
     """
-    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    home = os.environ.get("HERMES_HOME") or str(get_hermes_home())
     return Path(home) / "logs" / "dashboard-auth.log"
 
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -627,7 +628,7 @@ def run_doctor(args):
                 # creation. touch() obeys umask which is commonly 0o022,
                 # leaving the file world-readable; tighten explicitly.
                 try:
-                    os.chmod(str(env_path), 0o600)
+                    secure_file_chmod(str(env_path))
                 except OSError:
                     pass
                 check_ok(f"Created empty {_DHH}/.env")

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -14,6 +14,7 @@ from utils import atomic_replace
 # only env vars whose values we sanitize on load — we must not silently
 # alter arbitrary user env vars, but credentials are known to require
 # pure ASCII (they become HTTP header values).
+from hermes_constants import get_hermes_home
 _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 
 # Names we've already warned about during this process, so repeated
@@ -224,7 +225,7 @@ def load_hermes_dotenv(
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    home_path = Path(hermes_home or os.getenv("HERMES_HOME", get_hermes_home()))
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2232,7 +2232,7 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
       /opt/custom-hermes               → /opt/custom-hermes  (kept as-is)
     """
     current_hermes = get_hermes_home().resolve()
-    current_default = (Path.home() / ".hermes").resolve()
+    current_default = (get_hermes_home()).resolve()
     target_default = Path(target_home_dir) / ".hermes"
 
     # Default ~/.hermes → remap to target user's default

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -39,6 +39,7 @@ import time
 from pathlib import Path
 
 # Short timeouts: schtasks occasionally wedges and we don't want to hang forever.
+from hermes_cli._subprocess_compat import safe_split_command
 _SCHTASKS_TIMEOUT_S = 15
 _SCHTASKS_NO_OUTPUT_TIMEOUT_S = 30
 # Patterns in schtasks stderr that mean "fall back to the Startup folder".
@@ -147,7 +148,7 @@ def _current_profile_cli_args() -> list[str]:
     from hermes_cli.gateway import _profile_arg
 
     profile_arg = _profile_arg()
-    return shlex.split(profile_arg) if profile_arg else []
+    return safe_split_command(profile_arg) if profile_arg else []
 
 
 def _launch_elevated_gateway_command(command: str, extra_args: list[str] | None = None) -> bool:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -31,6 +31,7 @@ from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_p
 # ---------------------------------------------------------------------------
 # Small formatting helpers
 # ---------------------------------------------------------------------------
+from hermes_cli._subprocess_compat import safe_split_command
 
 _STATUS_ICONS = {
     "todo":     "◻",
@@ -2775,7 +2776,7 @@ def run_slash(rest: str) -> str:
     import io
     import contextlib
 
-    tokens = shlex.split(rest) if rest and rest.strip() else []
+    tokens = safe_split_command(rest) if rest and rest.strip() else []
 
     # Bare ``/kanban`` or ``/kanban help`` / ``--help`` / ``-h`` / ``?``:
     # show the curated short-help block instead of dumping argparse's full

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -88,6 +88,7 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from toolsets import get_toolset_names
+from hermes_constants import get_hermes_home
 
 _log = logging.getLogger(__name__)
 
@@ -6378,7 +6379,7 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
 
     # An unset HERMES_HOME means the worker falls back to the default root
     # home (``~/.hermes``), which ships the bundled skill.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    base = _Path(hermes_home) if hermes_home else (_get_hermes_home())
     skills_root = base / "skills"
     if not skills_root.is_dir():
         return False
@@ -6460,7 +6461,7 @@ def _default_spawn(
     # env, and when the child process starts `hermes -p <name>` the
     # _apply_profile_override() runs *before* hermes_constants is imported.
     # If HERMES_HOME is absent from the child's env, get_hermes_home() falls
-    # back to Path.home() / ".hermes" (the DEFAULT profile root), ignoring the
+    # back to get_hermes_home() (the DEFAULT profile root), ignoring the
     # profile-specific config entirely.  Fixes profile-scoped fallback_providers
     # being invisible to kanban workers.
     from hermes_cli.profiles import resolve_profile_env

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1344,7 +1344,7 @@ def _ensure_tui_node() -> None:
     if not helper.is_file():
         return
 
-    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    hermes_home = os.environ.get("HERMES_HOME") or str(get_hermes_home())
     try:
         # Helper writes logs to stderr; we ask bash to print `command -v node`
         # on stdout once ensure_node succeeds. Subshell PATH edits don't leak

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -19,6 +19,7 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 # ---------------------------------------------------------------------------
 # Curses-based interactive picker (same pattern as hermes tools)
 # ---------------------------------------------------------------------------
+from hermes_cli._subprocess_compat import safe_split_command
 
 def _curses_select(title: str, items: list[tuple[str, str]], default: int = 0) -> int:
     """Interactive single-select with arrow keys.
@@ -130,7 +131,7 @@ def _install_dependencies(provider_name: str) -> None:
         if check_cmd:
             try:
                 subprocess.run(
-                    shlex.split(check_cmd), check=True, capture_output=True, timeout=5
+                    safe_split_command(check_cmd), check=True, capture_output=True, timeout=5
                 )
             except Exception:
                 if install_cmd:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -31,6 +31,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -759,7 +760,7 @@ def create_profile(
                     # explicitly so the clone doesn't inherit weak perms.
                     if filename == ".env":
                         try:
-                            os.chmod(str(dst), 0o600)
+                            secure_file_chmod(str(dst))
                         except OSError:
                             pass
 

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -135,7 +135,7 @@ def slack_manifest_command(args) -> int:
 
                 target = Path(get_hermes_home()) / "slack-manifest.json"
             except Exception:
-                target = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")) / "slack-manifest.json"
+                target = Path(os.environ.get("HERMES_HOME") or str(get_hermes_home())) / "slack-manifest.json"
         else:
             target = Path(write_target).expanduser()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -39,6 +39,7 @@ from hermes_constants import get_config_path, get_hermes_home
 # Sentinel to track whether setup_logging() has already run.  The function
 # is idempotent — calling it twice is safe but the second call is a no-op
 # unless ``force=True``.
+from hermes_cli._subprocess_compat import secure_file_chmod
 _logging_initialized = False
 
 # Thread-local storage for per-conversation session context.
@@ -357,7 +358,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
     def _chmod_if_managed(self):
         if self._managed:
             try:
-                os.chmod(self.baseFilename, 0o660)
+                secure_file_chmod(self.baseFilename, mode=0o660)
             except OSError:
                 pass
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -65,7 +65,7 @@ def _get_sessions_dir() -> Path:
         from hermes_constants import get_hermes_home
         return get_hermes_home() / "sessions"
     except ImportError:
-        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
+        return Path(os.environ.get("HERMES_HOME", get_hermes_home())) / "sessions"
 
 
 def _get_session_db():
@@ -102,7 +102,7 @@ def _load_channel_directory() -> dict:
         directory_file = get_hermes_home() / "channel_directory.json"
     except ImportError:
         directory_file = Path(
-            os.environ.get("HERMES_HOME", Path.home() / ".hermes")
+            os.environ.get("HERMES_HOME", get_hermes_home())
         ) / "channel_directory.json"
 
     if not directory_file.exists():
@@ -365,7 +365,7 @@ class EventBridge:
             from hermes_constants import get_hermes_home
             db_file = get_hermes_home() / "state.db"
         except ImportError:
-            db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
+            db_file = Path(os.environ.get("HERMES_HOME", get_hermes_home())) / "state.db"
 
         try:
             db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
 from . import disk_cleanup as dg
+from hermes_cli._subprocess_compat import safe_split_command
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
     if isinstance(cmd, str) and cmd:
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
         try:
-            for tok in shlex.split(cmd, posix=True):
+            for tok in safe_split_command(cmd, posix=True):
                 if tok.startswith(("/", "~")):
                     paths.add(tok)
         except ValueError:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -35,7 +35,7 @@ except Exception:  # pragma: no cover — plugin may load before constants resol
 
     def get_hermes_home() -> Path:  # type: ignore[no-redef]
         val = (os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val).resolve() if val else (Path.home() / ".hermes").resolve()
+        return Path(val).resolve() if val else (get_hermes_home()).resolve()
 
 
 logger = logging.getLogger(__name__)

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -18,7 +18,7 @@ except ImportError:
     import os as _os
     def get_hermes_home() -> Path:  # type: ignore[misc]
         val = (_os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+        return Path(val) if val else get_hermes_home()
 
 try:
     from fastapi import APIRouter

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -525,7 +525,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             from hermes_constants import get_hermes_home as _get_hermes_home
             _hermes_home = _get_hermes_home()
         except (ModuleNotFoundError, ImportError):
-            _hermes_home = _Path.home() / ".hermes"
+            _hermes_home = _get_hermes_home()
         self._thread_count_store = _ThreadCountStore(
             _hermes_home / "google_chat_thread_counts.json"
         )
@@ -689,7 +689,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
         """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
+        base = os.getenv("HERMES_HOME", str(_get_hermes_home()))
         return _Path(base) / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -70,6 +70,7 @@ from typing import Any, List, Optional, Tuple
 
 # Pin the legacy logger name so operator-side log filters keep matching
 # after the in-tree → plugin migration. See adapter.py for context.
+from hermes_cli._subprocess_compat import secure_file_chmod
 logger = logging.getLogger("gateway.platforms.google_chat_user_oauth")
 
 # Use the project's HERMES_HOME helper so the token follows the user's
@@ -82,7 +83,7 @@ except (ModuleNotFoundError, ImportError):
     # _hermes_home.py shim).
     def get_hermes_home() -> Path:
         val = os.environ.get("HERMES_HOME", "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+        return Path(val) if val else get_hermes_home()
 
     def display_hermes_home() -> str:
         home = get_hermes_home()
@@ -330,7 +331,7 @@ def _write_private_json(path: Path, data: Any) -> None:
     """Atomically write JSON with 0o600 permissions where supported."""
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        os.chmod(path.parent, 0o700)
+        secure_file_chmod(path.parent, mode=0o700)
     except OSError:
         pass
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -42,6 +42,7 @@ import tempfile
 import threading
 import time
 import uuid
+from hermes_cli._subprocess_compat import secure_file_chmod
 
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
@@ -1194,7 +1195,7 @@ def execute_code(
         else:
             server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             server_sock.bind(sock_path)
-            os.chmod(sock_path, 0o600)
+            secure_file_chmod(sock_path)
         server_sock.listen(1)
 
         # Wrapped so the thread inherits the turn's approval context + callbacks

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -119,7 +119,7 @@ def _get_token_dir() -> Path:
         from hermes_constants import get_hermes_home
         base = Path(get_hermes_home())
     except ImportError:
-        base = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+        base = Path(os.environ.get("HERMES_HOME", str(get_hermes_home())))
     return base / "mcp-tokens"
 
 


### PR DESCRIPTION
Adds a comprehensive Windows subprocess compatibility module with:
- safe_split_command: shlex.split replacement that preserves backslashes on Windows
- secure_file_chmod: cross-platform chmod (ICACLS on Windows, os.chmod on POSIX)
- master_subprocess_run/master_subprocess_popen: centralized .cmd shim resolution
- safe_subprocess_run: convenience wrapper for string commands
- windows_detach_popen_kwargs: correct detached-process creation flags

Migrates 31 files from raw shlex.split (backslash destruction on Windows),
os.chmod (ineffective on Windows), and Path.home()/.hermes (breaks profiles)
to the centralized wrapper.
