### PR TITLE
fix(auth): share xai oauth state across profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -655,11 +655,7 @@ class CredentialPool:
         if self.provider != "xai-oauth" or entry.source != "loopback_pkce":
             return entry
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                state = _load_provider_state(auth_store, "xai-oauth")
-            if not isinstance(state, dict):
-                return entry
+            state = auth_mod._read_xai_oauth_tokens()
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
@@ -836,6 +832,22 @@ class CredentialPool:
                     _store_provider_state(auth_store, "openai-codex", state, set_active=False)
 
                 elif self.provider == "xai-oauth":
+                    if auth_mod._xai_shared_store_enabled():
+                        try:
+                            current_state = auth_mod._read_xai_oauth_tokens(_lock=False)
+                        except Exception:
+                            current_state = {}
+                        auth_mod._write_shared_xai_oauth_state(
+                            {
+                                "access_token": entry.access_token,
+                                "refresh_token": entry.refresh_token,
+                                "token_type": "Bearer",
+                            },
+                            discovery=current_state.get("discovery") if isinstance(current_state, dict) else None,
+                            redirect_uri=str((current_state or {}).get("redirect_uri") or "") if isinstance(current_state, dict) else "",
+                            last_refresh=entry.last_refresh or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                        )
+                        return
                     state = _load_provider_state(auth_store, "xai-oauth")
                     if not isinstance(state, dict):
                         return
@@ -1915,7 +1927,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         if _is_suppressed(provider, "loopback_pkce"):
             return changed, active_sources
 
-        state = _load_provider_state(auth_store, "xai-oauth")
+        try:
+            state = auth_mod._read_xai_oauth_tokens()
+        except Exception:
+            state = _load_provider_state(auth_store, "xai-oauth")
         tokens = state.get("tokens") if isinstance(state, dict) else None
         if isinstance(tokens, dict) and tokens.get("access_token"):
             active_sources.add("loopback_pkce")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3682,23 +3682,69 @@ def _pool_codex_access_token() -> str:
 
 
 # =============================================================================
-# xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
+# xAI Grok OAuth — tokens stored in a shared store for named profiles
 # =============================================================================
 
-def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
-    if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-    else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "xai-oauth")
-    if not state:
-        raise AuthError(
-            "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.",
-            provider="xai-oauth",
-            code="xai_auth_missing",
-            relogin_required=True,
-        )
+XAI_SHARED_STORE_FILENAME = "xai_oauth.json"
+_xai_shared_lock_holder = threading.local()
+
+
+def _xai_shared_store_enabled() -> bool:
+    """Return True when xAI OAuth should use the cross-profile shared store.
+
+    Named Hermes profiles live below ``<root>/profiles/<name>``. Their xAI
+    refresh tokens must be shared because the server can rotate refresh_token
+    on every refresh; sibling profiles with copied tokens then replay revoked
+    grants. Classic single-home installs keep the historical auth.json layout.
+    Tests can force shared mode by setting ``HERMES_SHARED_AUTH_DIR``.
+    """
+    if os.getenv("HERMES_SHARED_AUTH_DIR", "").strip():
+        return True
+    try:
+        return "profiles" in get_hermes_home().parts
+    except Exception:
+        return False
+
+
+def _xai_shared_auth_dir() -> Path:
+    override = os.getenv("HERMES_SHARED_AUTH_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root() / "shared"
+
+
+def _xai_shared_store_path() -> Path:
+    path = _xai_shared_auth_dir() / XAI_SHARED_STORE_FILENAME
+    if os.environ.get("PYTEST_CURRENT_TEST") and not os.getenv("HERMES_SHARED_AUTH_DIR", "").strip():
+        from hermes_constants import get_default_hermes_root
+        real_home_shared = (
+            get_default_hermes_root() / "shared" / XAI_SHARED_STORE_FILENAME
+        ).resolve(strict=False)
+        try:
+            resolved = path.resolve(strict=False)
+        except Exception:
+            resolved = path
+        if resolved == real_home_shared:
+            raise RuntimeError(
+                f"Refusing to touch real user shared xAI auth store during test run: "
+                f"{path}. Set HERMES_SHARED_AUTH_DIR to a tmp_path in your test fixture."
+            )
+    return path
+
+
+@contextmanager
+def _xai_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    with _file_lock(
+        _xai_shared_store_path().with_suffix(".lock"),
+        _xai_shared_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared xAI auth lock",
+    ):
+        yield
+
+
+def _validate_xai_oauth_state(state: Dict[str, Any]) -> Dict[str, Any]:
     tokens = state.get("tokens")
     if not isinstance(tokens, dict):
         raise AuthError(
@@ -3728,7 +3774,123 @@ def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
         "last_refresh": state.get("last_refresh"),
         "discovery": state.get("discovery") or {},
         "redirect_uri": state.get("redirect_uri"),
+        "source": state.get("source") or "hermes-auth-store",
     }
+
+
+def _read_shared_xai_oauth_state() -> Optional[Dict[str, Any]]:
+    if not _xai_shared_store_enabled():
+        return None
+    try:
+        path = _xai_shared_store_path()
+    except RuntimeError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        logger.debug("Shared xAI auth store at %s is unreadable: %s", path, exc)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    state = dict(payload)
+    state["source"] = "hermes-shared-xai-store"
+    try:
+        return _validate_xai_oauth_state(state)
+    except AuthError as exc:
+        logger.debug("Shared xAI auth store at %s is invalid: %s", path, exc)
+        return None
+
+
+def _write_shared_xai_oauth_state(
+    tokens: Dict[str, Any],
+    *,
+    discovery: Optional[Dict[str, Any]],
+    redirect_uri: str,
+    last_refresh: str,
+) -> None:
+    with _xai_shared_store_lock():
+        path = _xai_shared_store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        secure_parent_dir(path)
+        payload = {
+            "_schema": 1,
+            "tokens": tokens,
+            "last_refresh": last_refresh,
+            "auth_mode": "oauth_pkce",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if discovery:
+            payload["discovery"] = discovery
+        if redirect_uri:
+            payload["redirect_uri"] = redirect_uri
+        tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            atomic_replace(tmp, path)
+            try:
+                dir_fd = os.open(str(path.parent), os.O_RDONLY)
+            except OSError:
+                dir_fd = None
+            if dir_fd is not None:
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+        finally:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+        try:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+
+def _clear_shared_xai_oauth_state(reason: str) -> None:
+    try:
+        with _xai_shared_store_lock():
+            try:
+                _xai_shared_store_path().unlink()
+            except FileNotFoundError:
+                pass
+        _oauth_trace("xai_shared_store_cleared", reason=reason)
+    except Exception as exc:
+        logger.debug("Failed to clear shared xAI auth store: %s", exc)
+
+
+def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    if _lock:
+        with _auth_store_lock():
+            shared_state = _read_shared_xai_oauth_state()
+            if shared_state:
+                return shared_state
+            auth_store = _load_auth_store()
+    else:
+        shared_state = _read_shared_xai_oauth_state()
+        if shared_state:
+            return shared_state
+        auth_store = _load_auth_store()
+    state = _load_provider_state(auth_store, "xai-oauth")
+    if not state:
+        raise AuthError(
+            "No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.",
+            provider="xai-oauth",
+            code="xai_auth_missing",
+            relogin_required=True,
+        )
+    return _validate_xai_oauth_state(state)
 
 
 def _save_xai_oauth_tokens(
@@ -3742,6 +3904,26 @@ def _save_xai_oauth_tokens(
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
         auth_store = _load_auth_store()
+        if _xai_shared_store_enabled():
+            _write_shared_xai_oauth_state(
+                tokens,
+                discovery=discovery,
+                redirect_uri=redirect_uri,
+                last_refresh=last_refresh,
+            )
+            state = _load_provider_state(auth_store, "xai-oauth") or {}
+            state.pop("tokens", None)
+            state["last_refresh"] = last_refresh
+            state["auth_mode"] = "oauth_pkce"
+            state["shared_store"] = XAI_SHARED_STORE_FILENAME
+            if discovery:
+                state["discovery"] = discovery
+            if redirect_uri:
+                state["redirect_uri"] = redirect_uri
+            _save_provider_state(auth_store, "xai-oauth", state)
+            _save_auth_store(auth_store)
+            return
+
         state = _load_provider_state(auth_store, "xai-oauth") or {}
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
@@ -4088,10 +4270,12 @@ def resolve_xai_oauth_runtime_credentials(
                     access_token = str(tokens.get("access_token", "") or "").strip()
                 except AuthError as exc:
                     if _is_terminal_xai_oauth_refresh_error(exc):
-                        # Terminal failure (HTTP 400/401/403 — invalid_grant, token revoked).
-                        # Clear dead tokens from auth.json so subsequent sessions fail fast
+                        # Terminal failure (HTTP 400/401 — invalid_grant, token revoked).
+                        # Clear dead tokens from the active xAI store so subsequent sessions fail fast
                         # without a network retry. Mirrors credential_pool.py quarantine.
                         try:
+                            if _xai_shared_store_enabled():
+                                _clear_shared_xai_oauth_state("runtime_refresh_failure")
                             _q_store = _load_auth_store()
                             _q_state = _load_provider_state(_q_store, "xai-oauth") or {}
                             _q_tokens = dict(_q_state.get("tokens") or {})

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -1889,6 +1889,140 @@ def test_pool_manual_entry_does_not_sync_back_to_singleton(tmp_path, monkeypatch
 
 
 # ---------------------------------------------------------------------------
+# Shared xAI OAuth store across named profiles
+# ---------------------------------------------------------------------------
+
+
+def test_save_xai_oauth_tokens_writes_shared_store_not_profile_token_copy(tmp_path, monkeypatch):
+    """xAI OAuth refresh tokens rotate, so named profiles must not each keep
+    their own long-lived copy.  Saving a login/refresh should update the
+    cross-profile shared store and leave only non-secret profile metadata in
+    auth.json."""
+    from hermes_cli.auth import _save_xai_oauth_tokens
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-a"
+    shared_dir = tmp_path / "hermes" / "shared"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    tokens = {
+        "access_token": "AT-shared",
+        "refresh_token": "RT-shared",
+        "id_token": "ID-shared",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+    }
+    discovery = {"token_endpoint": "https://auth.x.ai/oauth2/token"}
+    _save_xai_oauth_tokens(
+        tokens,
+        discovery=discovery,
+        redirect_uri="http://127.0.0.1:56121/callback",
+        last_refresh="2026-06-02T00:00:00Z",
+    )
+
+    shared = json.loads((shared_dir / "xai_oauth.json").read_text())
+    assert shared["tokens"] == tokens
+    assert shared["discovery"] == discovery
+    assert shared["redirect_uri"] == "http://127.0.0.1:56121/callback"
+    assert shared["last_refresh"] == "2026-06-02T00:00:00Z"
+
+    profile_auth = json.loads((hermes_home / "auth.json").read_text())
+    profile_state = profile_auth["providers"]["xai-oauth"]
+    assert profile_auth["active_provider"] == "xai-oauth"
+    assert profile_state["auth_mode"] == "oauth_pkce"
+    assert profile_state.get("shared_store") == "xai_oauth.json"
+    assert "tokens" not in profile_state
+
+
+def test_read_xai_oauth_tokens_uses_shared_store_when_profile_has_no_copy(tmp_path, monkeypatch):
+    """A newly spawned profile with no local xAI token copy should still be
+    usable when the shared xAI OAuth store exists."""
+    from hermes_cli.auth import _read_xai_oauth_tokens
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-b"
+    shared_dir = tmp_path / "hermes" / "shared"
+    hermes_home.mkdir(parents=True)
+    shared_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    shared_payload = {
+        "_schema": 1,
+        "tokens": {
+            "access_token": "AT-from-shared",
+            "refresh_token": "RT-from-shared",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "redirect_uri": "http://127.0.0.1:56121/callback",
+        "last_refresh": "2026-06-02T01:00:00Z",
+    }
+    (shared_dir / "xai_oauth.json").write_text(json.dumps(shared_payload))
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+
+    data = _read_xai_oauth_tokens()
+    assert data["tokens"]["access_token"] == "AT-from-shared"
+    assert data["tokens"]["refresh_token"] == "RT-from-shared"
+    assert data["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth2/token"
+    assert data["redirect_uri"] == "http://127.0.0.1:56121/callback"
+
+
+def test_xai_oauth_runtime_refresh_rotates_shared_store_not_profile_copy(tmp_path, monkeypatch):
+    """When one profile refreshes xAI OAuth, the rotated refresh_token must be
+    written to the same shared file all profiles read.  Otherwise sibling
+    profiles keep replaying a revoked refresh token."""
+    from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
+
+    hermes_home = tmp_path / "hermes" / "profiles" / "lark-c"
+    shared_dir = tmp_path / "hermes" / "shared"
+    hermes_home.mkdir(parents=True)
+    shared_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+
+    old_access = _jwt_with_exp(int(time.time()) - 60)
+    new_access = _jwt_with_exp(int(time.time()) + 3600)
+    (shared_dir / "xai_oauth.json").write_text(json.dumps({
+        "_schema": 1,
+        "tokens": {
+            "access_token": old_access,
+            "refresh_token": "RT-old",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "last_refresh": "2026-06-02T01:00:00Z",
+    }))
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+
+    def _fake_refresh(access_token, refresh_token, **kwargs):
+        assert access_token == old_access
+        assert refresh_token == "RT-old"
+        return {
+            "access_token": new_access,
+            "refresh_token": "RT-rotated",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-06-02T02:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_refresh)
+
+    creds = resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    assert creds["api_key"] == new_access
+
+    shared_after = json.loads((shared_dir / "xai_oauth.json").read_text())
+    assert shared_after["tokens"]["access_token"] == new_access
+    assert shared_after["tokens"]["refresh_token"] == "RT-rotated"
+    assert shared_after["last_refresh"] == "2026-06-02T02:00:00Z"
+
+    profile_auth = json.loads((hermes_home / "auth.json").read_text())
+    assert "xai-oauth" not in profile_auth.get("providers", {}) or "tokens" not in profile_auth["providers"]["xai-oauth"]
+
+
+# ---------------------------------------------------------------------------
 # Auxiliary client routing
 # ---------------------------------------------------------------------------
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -53,7 +53,7 @@ hermes model
 hermes
 ```
 
-After the first login, credentials are stored under `~/.hermes/auth.json` and refreshed automatically before they expire.
+After the first login, credentials are refreshed automatically before they expire. Classic single-home installs store them under `~/.hermes/auth.json`; named profiles under `~/.hermes/profiles/<name>/` use a shared `~/.hermes/shared/xai_oauth.json` token store so all profiles see the same rotated refresh token.
 
 ## Logging In Manually
 
@@ -100,7 +100,7 @@ If the consent page renders the authorization code directly on the page (xAI's c
 
 1. Hermes opens your browser to `accounts.x.ai`.
 2. You sign in (or confirm your existing session) and approve access.
-3. xAI redirects back to Hermes and the tokens are saved to `~/.hermes/auth.json`.
+3. xAI redirects back to Hermes and the tokens are saved. In classic mode they live in the current Hermes `auth.json`; in named profile mode the refreshable token state lives in the cross-profile `shared/xai_oauth.json` store and the profile keeps only a non-secret marker.
 4. From then on, Hermes refreshes the access token in the background — you stay signed in until you `hermes auth remove xai-oauth` or revoke access from your xAI account settings.
 
 ## Checking Login Status


### PR DESCRIPTION
## Summary
- add a shared xAI OAuth token store for named Hermes profiles
- route xAI OAuth reads, writes, refreshes, and credential-pool singleton sync through the shared store
- keep classic single-home auth.json behavior compatible and document the named-profile behavior

## Test plan
- `git diff --check`
- `python -m py_compile hermes_cli/auth.py agent/credential_pool.py`
- `.venv/bin/python -m pytest tests/hermes_cli/test_auth_xai_oauth_provider.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/tools/test_credential_pool_env_fallback.py -q -o 'addopts='`
