### PR TITLE
fix(send_message): add missing wecom branch in `_parse_target_ref`

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -388,6 +388,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    if platform_name == "wecom":
+        return target_ref.strip(), None, True
     if platform_name == "yuanbao":
         match = _YUANBAO_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## Problem

When `send_message` receives an explicit WeCom target like `wecom:user_123`, `_parse_target_ref()` returns `(None, None, False)` because no `wecom` branch exists. The target falls through to channel-name resolution and ultimately falls back to the home channel — silently delivering to the wrong destination.

## Root cause

The `_parse_target_ref()` function has dedicated branches for all other platforms (telegram, feishu, discord, slack, matrix, weixin, yuanbao, email, phone-based platforms) but `wecom` was missing. Without it, WeCom explicit targets are treated as unresolved channel names.

## Fix

Add a `wecom` branch that returns the raw user ID as-is. WeCom user IDs are arbitrary strings set by the org administrator — no structural validation is possible here. The adapter performs its own validation at send time.

## Testing

- Verified that `wecom:user_123` returns `("user_123", None, True)`
- Existing WeCom adapter tests continue to pass
- Manual: `send_message wecom:actual_user_id \"test message\"` now correctly routes to WeCom instead of falling back to home channel

Fixes: silent misdelivery when using `wecom:<user_id>` target format