### PR TITLE
fix(auxiliary): support named custom providers in auxiliary tasks / 辅助任务支持命名自定义 provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -276,11 +276,11 @@ _PROVIDER_ALIASES = {
 
 def _normalize_aux_provider(provider: Optional[str]) -> str:
     normalized = (provider or "auto").strip().lower()
-    if normalized.startswith("custom:"):
-        suffix = normalized.split(":", 1)[1].strip()
-        if not suffix:
-            return "custom"
-        normalized = suffix
+    # Named custom providers (e.g. "custom:qwen") are preserved intact so
+    # resolve_provider_client can route them through the named-custom-provider
+    # branch which reads custom_providers from config.yaml.  Bare "custom"
+    # (no colon) still falls through to the anonymous-custom path that reads
+    # model.base_url + OPENAI_API_KEY from config/env.
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":
@@ -2285,8 +2285,29 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
 
     custom_base = custom_base.strip().rstrip("/")
     if base_url_host_matches(custom_base, "openrouter.ai"):
-        # requested='custom' falls back to OpenRouter when no custom endpoint is
-        # configured. Treat that as "no custom endpoint" for auxiliary routing.
+        # requested='custom' fell back to OpenRouter because the user has a
+        # named custom provider (e.g. custom:qwen in custom_providers) but no
+        # bare "custom" entry.  Try resolving with requested=None so the
+        # resolver picks up the user's actual main provider from config.
+        try:
+            main_runtime = resolve_runtime_provider(requested=None)
+            if isinstance(main_runtime, dict):
+                mb = main_runtime.get("base_url")
+                mk = main_runtime.get("api_key")
+                if isinstance(mb, str) and mb.strip():
+                    mb = mb.strip().rstrip("/")
+                    if not base_url_host_matches(mb, "openrouter.ai"):
+                        logger.debug(
+                            "Auxiliary client: custom runtime fell back to main "
+                            "provider %s → %s",
+                            main_runtime.get("provider", "unknown"), mb,
+                        )
+                        if not isinstance(mk, str) or not mk.strip():
+                            mk = "no-key-required"
+                        mm = main_runtime.get("api_mode")
+                        return mb, mk.strip(), mm.strip() if isinstance(mm, str) and mm.strip() else None
+        except Exception:
+            pass
         return None, None, None
 
     # Local servers (Ollama, llama.cpp, vLLM, LM Studio) don't require auth.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -394,6 +394,22 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_named_custom_providers_preserved(self):
+        """Named custom providers (custom:xxx) are preserved intact so
+        resolve_provider_client can route them through the named-custom-provider
+        branch. Bare 'custom' (no colon) stays as 'custom' for the anonymous path.
+
+        Regression test: the old strip-to-custom approach (#37182) fixed a bug where
+        'custom:qwen' was normalised to 'qwen' (no auxiliary backend), but it broke
+        named custom providers in auxiliary tasks (vision, goal_judge, etc.) because
+        the strip prevented the named-custom-provider lookup from ever running.
+        """
+        assert _normalize_aux_provider("custom:qwen") == "custom:qwen"
+        assert _normalize_aux_provider("custom:my-vllm") == "custom:my-vllm"
+        assert _normalize_aux_provider("custom:local") == "custom:local"
+        assert _normalize_aux_provider("custom:") == "custom:"
+        assert _normalize_aux_provider("custom") == "custom"
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -58,8 +58,10 @@ class TestNormalizeVisionProvider:
         assert _normalize_vision_provider("deepseek") == "deepseek"
 
     def test_custom_colon_named_provider_preserved(self):
+        """custom:name is preserved intact so the named-custom-provider branch
+        can resolve it through custom_providers.  (Not stripped to bare name.)"""
         from agent.auxiliary_client import _normalize_vision_provider
-        assert _normalize_vision_provider("custom:beans") == "beans"
+        assert _normalize_vision_provider("custom:beans") == "custom:beans"
 
     def test_codex_alias_still_works(self):
         from agent.auxiliary_client import _normalize_vision_provider


### PR DESCRIPTION
## Summary / 概述

辅助任务现在可以正确解析命名自定义 provider（`custom:name`），修复了 vision（图像识别）、goal_judge 等任务在使用自定义 provider 时静默失效的问题。

Auxiliary tasks can now correctly resolve named custom providers (`custom:name`), fixing silent failures in vision, goal_judge, and other tasks when using custom providers.

## Root Cause / 根因

`_normalize_aux_provider()` would strip `custom:qwen` → `custom`, forcing all named custom providers through the anonymous-custom path (reads `model.base_url` + `OPENAI_API_KEY` from env). Users with `custom_providers` in config but no `OPENAI_API_KEY` env var set would get broken auxiliary tasks.

`_normalize_aux_provider()` 会把 `custom:qwen` 强制 strip 成 `custom`，导致所有命名自定义 provider 都走匿名 custom 路径（读环境变量 `OPENAI_API_KEY`）。如果用户没设置这个环境变量，辅助任务就静默失败。

## Changes / 改动

1. **Remove the early return in `_normalize_aux_provider()`** — `custom:name` is now preserved intact so `resolve_provider_client` can route through the named-custom-provider branch, which reads from `custom_providers` in config.yaml.

   移除 `_normalize_aux_provider()` 中 strip `custom:name` 的 early return。`resolve_provider_client` 现在可以正确走 named custom provider 分支，从 `custom_providers` 读取 base_url + api_key。

2. **Add fallback in `_resolve_custom_runtime()`** — when `requested="custom"` falls back to OpenRouter (because no bare `custom` entry exists), try `resolve_runtime_provider(requested=None)` to pick up the user's actual main provider as a safety net.

   在 `_resolve_custom_runtime()` 增加 fallback：当 `custom` 回退到 OpenRouter 时，尝试用 `requested=None` 重新解析用户实际的主 provider 作为兜底。

## Affected Tasks / 影响范围

Any auxiliary task that uses `custom:name` as provider:
- `vision` (image recognition / 图像识别)
- `goal_judge` (automatic goal continuation / 目标自动延续)
- `compression`, `web_extract`, etc.

所有使用 `custom:name` 作为 provider 的辅助任务：
- vision（图像识别）
- goal_judge（目标自动延续）
- compression、web_extract 等

## Testing / 测试

All existing tests pass (32 tests in `test_auxiliary_client.py` + `test_auxiliary_named_custom_providers.py`).

所有已有测试通过（`test_auxiliary_client.py` + `test_auxiliary_named_custom_providers.py` 共 32 个测试）。

Related: #37182