### PR TITLE
feat(goals): /goal budget <N> — update turn budget on active goal in place

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9337,7 +9337,7 @@ class HermesCLI:
         return mgr
 
     def _handle_goal_command(self, cmd: str) -> None:
-        """Dispatch /goal subcommands: set / status / pause / resume / clear."""
+        """Dispatch /goal subcommands: set / status / pause / resume / clear / budget."""
         parts = (cmd or "").strip().split(None, 1)
         arg = parts[1].strip() if len(parts) > 1 else ""
 
@@ -9380,6 +9380,27 @@ class HermesCLI:
                 _cprint("  ✓ Goal cleared.")
             else:
                 _cprint(f"  {_DIM}No active goal.{_RST}")
+            return
+
+        # /goal budget <N> — bump the turn budget on the active goal
+        if lower.startswith("budget"):
+            sub_parts = arg.split(None, 1)
+            n_str = sub_parts[1].strip() if len(sub_parts) > 1 else ""
+            if not n_str:
+                _cprint(f"  Usage: /goal budget <N>   (e.g. /goal budget 50)")
+                return
+            if not mgr.has_goal():
+                _cprint(f"  {_DIM}No goal set. Set one with /goal <text> first.{_RST}")
+                return
+            try:
+                state = mgr.set_budget(n_str)
+            except ValueError as exc:
+                _cprint(f"  Invalid budget: {exc}")
+                return
+            _cprint(
+                f"  ⊙ Goal budget updated to {state.max_turns} turns "
+                f"({state.turns_used} used so far). Status: {state.status}."
+            )
             return
 
         # Otherwise treat the arg as the goal text.

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -553,6 +553,39 @@ class GoalManager:
         save_goal(self.session_id, self._state)
         return self._state
 
+    def set_budget(self, max_turns: int) -> Optional[GoalState]:
+        """Update the turn budget on the existing goal in place.
+
+        Returns the updated state, or None if no goal is set. Raises
+        ValueError if ``max_turns`` isn't a positive integer.
+
+        Does NOT reset ``turns_used`` — if the new budget is higher than
+        ``turns_used``, the loop has fresh runway; if it's lower or equal,
+        the goal stays paused (or auto-pauses on the next turn boundary
+        via the existing exhausted-budget check).
+        """
+        try:
+            n = int(max_turns)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"max_turns must be an integer, got {max_turns!r}") from exc
+        if n <= 0:
+            raise ValueError(f"max_turns must be positive, got {n}")
+        if not self._state:
+            return None
+        self._state.max_turns = n
+        # If the state was paused purely because the budget was exhausted,
+        # and the new budget gives breathing room, flip it back to active.
+        if (
+            self._state.status == "paused"
+            and self._state.paused_reason
+            and self._state.paused_reason.startswith("turn budget exhausted")
+            and self._state.turns_used < n
+        ):
+            self._state.status = "active"
+            self._state.paused_reason = None
+        save_goal(self.session_id, self._state)
+        return self._state
+
     def clear(self) -> None:
         if self._state is None:
             return

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,6 +252,82 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_set_budget_updates_max_turns_in_place(self, hermes_home):
+        """/goal budget N — bump the budget on an active goal without losing turns_used."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="budget-sid-1", default_max_turns=5)
+        mgr.set("do work")
+        mgr.state.turns_used = 3
+        state = mgr.set_budget(20)
+        assert state is not None
+        assert state.max_turns == 20
+        assert state.turns_used == 3  # NOT reset, unlike resume()
+        assert state.status == "active"
+
+    def test_set_budget_unpauses_when_exhausted_and_new_budget_higher(self, hermes_home):
+        """If the goal auto-paused because the budget was exhausted, raising
+        the ceiling should put it straight back to active so the next user
+        message resumes the loop."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="budget-sid-2", default_max_turns=5)
+        mgr.set("do work")
+        # Simulate the exhausted-budget auto-pause path
+        mgr.state.turns_used = 5
+        mgr.state.status = "paused"
+        mgr.state.paused_reason = "turn budget exhausted (5/5)"
+
+        state = mgr.set_budget(20)
+        assert state.status == "active"
+        assert state.paused_reason is None
+        assert state.max_turns == 20
+        assert state.turns_used == 5  # preserved
+
+    def test_set_budget_preserves_user_pause(self, hermes_home):
+        """A user-initiated pause should stay paused after a budget bump —
+        only budget-exhausted auto-pauses get auto-resumed."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="budget-sid-3", default_max_turns=5)
+        mgr.set("do work")
+        mgr.pause(reason="user-paused")
+
+        state = mgr.set_budget(20)
+        assert state.status == "paused"
+        assert state.paused_reason == "user-paused"
+        assert state.max_turns == 20
+
+    def test_set_budget_rejects_invalid(self, hermes_home):
+        import pytest as _pytest
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="budget-sid-4")
+        mgr.set("g")
+        with _pytest.raises(ValueError):
+            mgr.set_budget(0)
+        with _pytest.raises(ValueError):
+            mgr.set_budget(-3)
+        with _pytest.raises(ValueError):
+            mgr.set_budget("not a number")
+
+    def test_set_budget_returns_none_with_no_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="budget-sid-5")
+        assert mgr.set_budget(50) is None
+
+    def test_set_budget_persists_across_managers(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr1 = GoalManager(session_id="budget-sid-6", default_max_turns=5)
+        mgr1.set("work")
+        mgr1.set_budget(42)
+
+        mgr2 = GoalManager(session_id="budget-sid-6")
+        assert mgr2.state is not None
+        assert mgr2.state.max_turns == 42
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -43,6 +43,7 @@ What you'll see:
 | `/goal` or `/goal status` | Show the current goal, its status, and turns used. |
 | `/goal pause` | Stop the auto-continuation loop without clearing the goal. |
 | `/goal resume` | Resume the loop (resets the turn counter back to zero). |
+| `/goal budget <N>` | Update the turn budget on the active goal in place. Does NOT reset `turns_used` — useful for extending a long-running goal without losing progress. If the goal was auto-paused because the previous budget was exhausted, raising the budget above `turns_used` flips it back to active automatically. |
 | `/goal clear` | Drop the goal entirely. |
 
 Works identically on the CLI and every gateway platform (Telegram, Discord, Slack, Matrix, Signal, WhatsApp, SMS, iMessage, Webhook, API server, and the web dashboard).


### PR DESCRIPTION
## Summary

Adds `/goal budget <N>` — a CLI affordance for bumping the turn budget of an in-flight goal without losing `turns_used` progress.

## Motivation

Today, when an active `/goal` runs out of turn budget, your only in-CLI lever is `/goal resume` — which **resets `turns_used` to 0**. For a long-running goal where the agent has correctly burned 20 turns and just needs more runway (not a do-over), that's the wrong shape.

`hermes config set goals.max_turns N` works but requires a fresh session, which loses the in-flight conversation context entirely.

## Behavior

| Command | Effect |
|---|---|
| `/goal budget 50` | Update the budget on the active goal in place. **Preserves `turns_used`.** |
| `/goal budget 50` (when goal auto-paused via budget exhaustion) | Flips status back to `active` automatically so the next message resumes the loop. |
| `/goal budget 50` (when user explicitly `/goal pause`d) | Updates the ceiling but leaves the pause untouched — the user paused for a reason. |
| `/goal budget 0` / `/goal budget -3` / `/goal budget abc` | `ValueError`, friendly CLI message. |
| `/goal budget 50` (no goal set) | "No goal set" message. |

## Changes

- `hermes_cli/goals.py` — `GoalManager.set_budget(n)` mutator (+33 LOC).
- `cli.py` — wire `/goal budget <N>` into `_handle_goal_command` (+22 LOC).
- `tests/hermes_cli/test_goals.py` — 7 new tests (+76 LOC).
- `website/docs/user-guide/features/goals.md` — table row.

## Test plan

```
$ python -m pytest tests/hermes_cli/test_goals.py tests/cli/test_cli_goal_interrupt.py tests/gateway/test_goal_max_turns_config.py
============================== 64 passed in 1.30s ==============================
```

All 7 new tests pass; the 57 pre-existing goal/CLI/gateway-config tests still pass — no regressions.

## Non-goals

- Doesn't change the default budget or the `goals.max_turns` config knob — those still work as before.
- Doesn't add a `/goal resume --keep-budget` variant; that's a separate ergonomic question.
- Doesn't surface budget changes in the judge prompt — the judge already sees `turns_used/max_turns` at evaluation time.
