### PR TITLE
fix: detect delegate JSON errors with warnings

### DIFF
--- a/tests/tools/test_delegate_error_classification.py
+++ b/tests/tools/test_delegate_error_classification.py
@@ -1,0 +1,17 @@
+import json
+
+from tools.delegate_tool import _looks_like_error_output
+
+
+def test_error_json_with_appended_loop_warning_still_counts_as_error():
+    payload = json.dumps({"error": "child failed"})
+    combined = payload + "\n\n⚠️ Loop warning: child hit the iteration limit"
+
+    assert _looks_like_error_output(combined) is True
+
+
+def test_failed_status_json_with_appended_loop_warning_still_counts_as_error():
+    payload = json.dumps({"status": "failed", "message": "child failed"})
+    combined = payload + "\n\nLoop warning: repeated tool call detected"
+
+    assert _looks_like_error_output(combined) is True

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -290,7 +290,11 @@ def _looks_like_error_output(content: str) -> bool:
     head = content.lstrip()
     if head.startswith("{") or head.startswith("["):
         try:
-            parsed = json.loads(content)
+            # Subagent/tool output can append diagnostic text after a JSON error
+            # blob (for example loop/iteration warnings).  Decode the leading
+            # JSON value instead of requiring the whole preview to be JSON so the
+            # appended diagnostic cannot hide the original failure signal.
+            parsed, _ = json.JSONDecoder().raw_decode(head)
             if isinstance(parsed, dict):
                 if parsed.get("error"):
                     return True


### PR DESCRIPTION
## Summary
- Detect leading JSON error/status payloads even when delegate output appends loop/iteration warning text afterward
- Add regression coverage for `error` and `status: failed` JSON payloads with appended warnings

Closes #37170

## Test Plan
- RED: `python3 -m pytest tests/tools/test_delegate_error_classification.py -q -o 'addopts='` failed with both new cases returning `False`
- GREEN: `python3 -m pytest tests/tools/test_delegate_error_classification.py -q -o 'addopts='` → 2 passed
- `git diff --check`
