### PR TITLE
fix: route TUI skill bundle commands

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2608,6 +2608,43 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     assert "failed" in resp["error"]["message"]
 
 
+def test_command_dispatch_routes_skill_bundle_without_slash_worker(monkeypatch):
+    server._sessions["sid"] = _session()
+    try:
+        monkeypatch.setattr("agent.skill_commands.scan_skill_commands", lambda: {})
+        monkeypatch.setattr(
+            "agent.skill_bundles.resolve_bundle_command_key",
+            lambda command: "/review-pack" if command == "review-pack" else None,
+        )
+        monkeypatch.setattr(
+            "agent.skill_bundles.build_bundle_invocation_message",
+            lambda key, arg, task_id=None: (
+                f"bundle={key}; arg={arg}; task={task_id}",
+                ["codebase-inspection"],
+                [],
+            ),
+        )
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {
+                    "arg": "check this",
+                    "name": "review-pack",
+                    "session_id": "sid",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["result"]["type"] == "skill_bundle"
+    assert resp["result"]["message"] == "bundle=/review-pack; arg=check this; task=session-key"
+    assert resp["result"]["name"] == "review-pack"
+    assert resp["result"]["skills"] == ["codebase-inspection"]
+
+
 def test_plugins_list_surfaces_loader_error(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", side_effect=Exception("boom")):
         resp = server.handle_request(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5819,6 +5819,32 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
 
+    try:
+        from agent.skill_bundles import (
+            resolve_bundle_command_key,
+            build_bundle_invocation_message,
+        )
+
+        bundle_key = resolve_bundle_command_key(name)
+        if bundle_key:
+            built = build_bundle_invocation_message(
+                bundle_key, arg, task_id=session.get("session_key", "") if session else ""
+            )
+            if built:
+                msg, loaded_skills, missing_skills = built
+                return _ok(
+                    rid,
+                    {
+                        "type": "skill_bundle",
+                        "message": msg,
+                        "name": bundle_key.lstrip("/"),
+                        "skills": loaded_skills,
+                        "missing_skills": missing_skills,
+                    },
+                )
+    except Exception:
+        pass
+
     # ── Commands that queue messages onto _pending_input in the CLI ───
     # In the TUI the slash worker subprocess has no reader for that queue,
     # so we handle them here and return a structured payload.


### PR DESCRIPTION
## Summary
- Route TUI `command.dispatch` requests for skill bundle slash commands through `agent.skill_bundles`
- Return the same bundle invocation message shape to the TUI instead of falling through to unknown/pending command handling
- Add gateway regression coverage for bundle dispatch without starting a slash worker

Closes #37254

## Test Plan
- RED: `python3 -m pytest tests/test_tui_gateway_server.py::test_command_dispatch_routes_skill_bundle_without_slash_worker -q -o 'addopts='` failed with no `result` for the bundle command
- GREEN: `python3 -m pytest tests/test_tui_gateway_server.py::test_command_dispatch_routes_skill_bundle_without_slash_worker tests/test_tui_gateway_server.py::test_command_dispatch_exec_nonzero_surfaces_error -q -o 'addopts='` → 2 passed
- `git diff --check`
