### PR TITLE
fix: stop waiting after skills hub timeout

### DIFF
--- a/tests/tools/test_skills_hub_timeouts.py
+++ b/tests/tools/test_skills_hub_timeouts.py
@@ -1,0 +1,56 @@
+import time
+
+from tools.skills_hub import SkillMeta, SkillSource, parallel_search_sources
+
+
+class _FastSource(SkillSource):
+    def source_id(self):
+        return "fast"
+
+    def search(self, query, limit=10):
+        return [
+            SkillMeta(
+                name="fast-skill",
+                description="fast",
+                source="fast",
+                identifier="fast/skill",
+                trust_level="community",
+            )
+        ]
+
+    def fetch(self, identifier):
+        return None
+
+    def inspect(self, identifier):
+        return None
+
+
+class _StuckSource(SkillSource):
+    def source_id(self):
+        return "stuck"
+
+    def search(self, query, limit=10):
+        time.sleep(1.5)
+        return []
+
+    def fetch(self, identifier):
+        return None
+
+    def inspect(self, identifier):
+        return None
+
+
+def test_parallel_search_returns_promptly_after_timeout_with_partial_results():
+    start = time.monotonic()
+
+    results, counts, timed_out = parallel_search_sources(
+        [_FastSource(), _StuckSource()],
+        query="demo",
+        overall_timeout=0.05,
+    )
+
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.5
+    assert [result.name for result in results] == ["fast-skill"]
+    assert counts == {"fast": 1}
+    assert timed_out == ["stuck"]

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3692,8 +3692,9 @@ def parallel_search_sources(
     if not active:
         return all_results, source_counts, timed_out_ids
 
-    with ThreadPoolExecutor(max_workers=min(len(active), 8)) as pool:
-        futures = {}
+    pool = ThreadPoolExecutor(max_workers=min(len(active), 8))
+    futures = {}
+    try:
         for src in active:
             lim = per_source_limits.get(src.source_id(), 50)
             fut = pool.submit(_search_one_source, src, query, lim)
@@ -3718,6 +3719,12 @@ def parallel_search_sources(
                     "Skills browse timed out waiting for: %s",
                     ", ".join(timed_out_ids),
                 )
+    finally:
+        # Do not let a stalled optional registry keep the CLI inside the
+        # executor context after the overall timeout.  Running calls cannot be
+        # killed by ThreadPoolExecutor, but we can stop waiting here and cancel
+        # any not-yet-started work so completed sources remain usable.
+        pool.shutdown(wait=False, cancel_futures=True)
 
     return all_results, source_counts, timed_out_ids
 


### PR DESCRIPTION
## Summary
- Stop waiting on `ThreadPoolExecutor` workers after the skills hub overall search timeout is reached
- Preserve completed source results and report timed-out source IDs while cancelling not-yet-started work
- Add regression coverage proving partial search results return promptly after timeout

Closes #37008

## Test Plan
- RED: `python3 -m pytest tests/tools/test_skills_hub_timeouts.py -q -o 'addopts='` failed because `parallel_search_sources` waited ~1.5s for a stuck source despite a 0.05s timeout
- GREEN: `python3 -m pytest tests/tools/test_skills_hub_timeouts.py tests/hermes_cli/test_skills_hub.py -q -o 'addopts='` → 28 passed
- `git diff --check`
