### PR TITLE
fix(file_safety): log ignored resolution errors in write-deny guard

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -118,7 +118,12 @@ def is_write_denied(path: str) -> bool:
             real = os.path.realpath(base)
             if real not in hermes_dirs:
                 hermes_dirs.append(real)
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "Ignoring write-deny hermess-dir resolution error for %s: %s",
+                base,
+                exc,
+            )
             continue
 
     for base_real in hermes_dirs:
@@ -126,7 +131,13 @@ def is_write_denied(path: str) -> bool:
             try:
                 if resolved == os.path.realpath(os.path.join(base_real, name)):
                     return True
-            except Exception:
+            except Exception as exc:
+                logger.debug(
+                    "Ignoring write-deny control-file resolution error for %s/%s: %s",
+                    base_real,
+                    name,
+                    exc,
+                )
                 continue
         try:
             mcp_real = os.path.realpath(os.path.join(base_real, mcp_tokens_dir_name))


### PR DESCRIPTION
## Summary

Improve observability in `agent/file_safety.py` by logging path-resolution failures that were previously swallowed inside the write-denylist and control-file guards.

## Problem

`is_write_denied()` has several bare `except Exception:` blocks around `os.path.realpath()` lookups. When one of those lookups failed, the function silently ignored the error and continued. This makes it difficult to diagnose why a path was or was not denied, and can hide filesystem-level problems (missing dirs, permission errors, transient resolution failures).

## Changes

- `agent/file_safety.py`
  - Capture `Exception as exc` instead of bare `except Exception:`
  - Emit `logger.debug(...)` with the failing base path and exception before continuing
  - Preserve existing behavior — no changes to return values or guard logic

## Testing

- Verified with the focused test files:
  - `tests/agent/test_file_safety.py`
  - `tests/agent/test_file_safety_credentials.py`
  - `tests/agent/test_file_safety_cross_profile.py`
- Import and guard behavior unchanged.

## Notes for reviewers

- This is intentionally low-risk: only logging side-effects added
- No new dependencies, no public API change
