### PR TITLE
fix(qqbot): wrap _reconnect in try/except at all call sites to prevent backoff counter bypass (#37125)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -581,11 +581,21 @@ class QQAdapter(BasePlatformAdapter):
                         self._mark_disconnected()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
-                    if await self._reconnect(backoff_idx):
-                        backoff_idx = 0
-                        quick_disconnect_count = 0
-                    else:
+                    try:
+                        if await self._reconnect(backoff_idx):
+                            backoff_idx = 0
+                            quick_disconnect_count = 0
+                        else:
+                            backoff_idx += 1
+                    except Exception:
                         backoff_idx += 1
+                        if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                            logger.error(
+                                "[%s] Max reconnect attempts reached (rate limit reconnect failed)",
+                                self._log_tag,
+                            )
+                            self._mark_disconnected()
+                            return
                     continue
 
                 # Token invalid → clear cached token so _ensure_token() refreshes
@@ -626,13 +636,26 @@ class QQAdapter(BasePlatformAdapter):
                     self._session_id = None
                     self._last_seq = None
 
-                if await self._reconnect(backoff_idx):
-                    backoff_idx = 0
-                    quick_disconnect_count = 0
-                else:
+                try:
+                    if await self._reconnect(backoff_idx):
+                        backoff_idx = 0
+                        quick_disconnect_count = 0
+                    else:
+                        backoff_idx += 1
+                        if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                            logger.error(
+                                "[%s] Max reconnect attempts reached (QQCloseError)",
+                                self._log_tag,
+                            )
+                            self._mark_disconnected()
+                            return
+                except Exception:
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        logger.error(
+                            "[%s] Max reconnect attempts reached (QQCloseError reconnect failed)",
+                            self._log_tag,
+                        )
                         self._mark_disconnected()
                         return
 
@@ -648,11 +671,21 @@ class QQAdapter(BasePlatformAdapter):
                     self._mark_disconnected()
                     return
 
-                if await self._reconnect(backoff_idx):
-                    backoff_idx = 0
-                    quick_disconnect_count = 0
-                else:
+                try:
+                    if await self._reconnect(backoff_idx):
+                        backoff_idx = 0
+                        quick_disconnect_count = 0
+                    else:
+                        backoff_idx += 1
+                except Exception:
                     backoff_idx += 1
+                    if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        logger.error(
+                            "[%s] Max reconnect attempts reached (reconnect failed)",
+                            self._log_tag,
+                        )
+                        self._mark_disconnected()
+                        return
 
     async def _reconnect(self, backoff_idx: int) -> bool:
         """Attempt to reconnect the WebSocket. Returns True on success."""

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2196,3 +2196,90 @@ class TestCloseCodeClassification:
         assert 4014 in fatal_codes
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
+
+
+# ---------------------------------------------------------------------------
+# _listen_loop: reconnect exception backoff (regression tests for #37125)
+# ---------------------------------------------------------------------------
+
+class TestReconnectExceptionBackoff:
+    """Verify _reconnect exceptions increment backoff and eventually stop."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_reconnect_exception_increments_backoff(self):
+        """When _reconnect raises, backoff_idx is incremented (not skipped)."""
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+
+        from gateway.platforms.qqbot.adapter import QQCloseError
+
+        # Make _read_events raise a non-fatal close code (4006 = session invalid)
+        # then stop the loop by setting _running = False
+        call_count = [0]
+
+        async def raise_close_then_stop():
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                adapter._running = False
+            raise QQCloseError(4006, "session invalid")
+
+        adapter._read_events = raise_close_then_stop
+        # _reconnect raises an unexpected exception
+        adapter._reconnect = mock.AsyncMock(side_effect=RuntimeError("DNS failure"))
+
+        adapter._mark_disconnected = mock.MagicMock()
+        adapter._mark_transport_disconnected = mock.MagicMock()
+        adapter._fail_pending = mock.MagicMock()
+        adapter._set_fatal_error = mock.MagicMock()
+        adapter._fatal_error_message = None
+
+        try:
+            await asyncio.wait_for(adapter._listen_loop(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+
+        # _reconnect should have been called (the exception was handled, backoff incremented)
+        assert adapter._reconnect.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_reconnect_exception_hits_max_stops(self):
+        """When _reconnect keeps failing, MAX_RECONNECT_ATTEMPTS stops the loop."""
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+
+        from gateway.platforms.qqbot.adapter import QQCloseError, MAX_RECONNECT_ATTEMPTS
+
+        # Make _read_events raise a non-fatal close code
+        call_count = [0]
+
+        async def raise_close():
+            call_count[0] += 1
+            raise QQCloseError(4006, "session invalid")
+
+        adapter._read_events = raise_close
+        adapter._reconnect = mock.AsyncMock(side_effect=RuntimeError("persistent DNS failure"))
+        adapter._mark_disconnected = mock.MagicMock()
+        adapter._mark_transport_disconnected = mock.MagicMock()
+        adapter._fail_pending = mock.MagicMock()
+        adapter._set_fatal_error = mock.MagicMock()
+        adapter._fatal_error_message = None
+
+        # Disable quick-disconnect guard so MAX_RECONNECT_ATTEMPTS is reached
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.MAX_QUICK_DISCONNECT_COUNT", 999
+        ):
+            try:
+                await asyncio.wait_for(adapter._listen_loop(), timeout=3.0)
+            except asyncio.TimeoutError:
+                pass
+
+        # Should have called _mark_disconnected at least once (stopped due to max attempts)
+        assert adapter._mark_disconnected.call_count >= 1
+        # _reconnect should have been called at least MAX_RECONNECT_ATTEMPTS times
+        assert adapter._reconnect.call_count >= MAX_RECONNECT_ATTEMPTS


### PR DESCRIPTION
## What does this PR do?

Wraps all three `_reconnect()` call sites in the QQ bot `_listen_loop` with try/except Exception to prevent the backoff counter from being bypassed when `_reconnect()` raises an unexpected exception.

## Related Issue

Fixes #37125

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `tests/gateway/test_qqbot.py` — 161 passed, 0 failed
- [x] Fail-without-fix verified: reverting production changes causes both new tests to crash
- [x] New tests: `TestReconnectExceptionBackoff::test_reconnect_exception_increments_backoff`, `test_reconnect_exception_hits_max_stops`

## Root Cause

When `_reconnect()` raises an unexpected exception (e.g., DNS failure, `CancelledError` from `asyncio.sleep`), the exception propagates uncaught at all three call sites because none were wrapped in try/except. `backoff_idx` is never incremented → immediate retry loop with no backoff.

## Fix

Each `_reconnect()` call site now:
1. Wraps the call in try/except Exception
2. Increments `backoff_idx` on failure
3. Checks `MAX_RECONNECT_ATTEMPTS` — logs and calls `_mark_disconnected()` + returns when exhausted

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] No new dependencies added
- [x] No AI attribution in commits