### PR TITLE
feat(gateway): add session workspace binding

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -40,6 +40,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import resolve_agent_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -1536,7 +1537,7 @@ def init_agent(
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=str(resolve_agent_cwd()),
     )
     agent._user_turn_count = 0
 

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -6,16 +6,29 @@ gateway/cron startup). The local-CLI backend deliberately leaves it unset and
 relies on the launch dir. Reading it in one place keeps the system prompt, the
 tool surfaces, and context-file discovery agreeing on where the agent lives.
 
-The #29531 per-session extension point is this function: a future PR adds a
-contextvar arm inside `resolve_agent_cwd` and `.set()`s it at the
-`set_session_vars` seam — by design, not a reopening hazard.
+Gateway sessions may set `HERMES_SESSION_CWD` through `set_session_vars`;
+that session-scoped override wins over the process-wide `TERMINAL_CWD`.
 """
 
 import os
 from pathlib import Path
 
 
+def _session_cwd() -> str:
+    try:
+        from gateway.session_context import get_session_context_value
+    except ImportError:
+        return ""
+    return get_session_context_value("HERMES_SESSION_CWD", "").strip()
+
+
 def resolve_agent_cwd() -> Path:
+    session_raw = _session_cwd()
+    if session_raw:
+        session_path = Path(session_raw).expanduser()
+        if session_path.is_dir():
+            return session_path
+
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
@@ -29,5 +42,5 @@ def resolve_context_cwd() -> Path | None:
     # to the launch dir (os.getcwd()) — correct for the local CLI. The gateway
     # avoids slurping its install dir by setting TERMINAL_CWD (see system_prompt.py).
     # No getcwd arm here: that fallback is owned by the caller, not this resolver.
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = _session_cwd() or os.environ.get("TERMINAL_CWD", "").strip()
     return Path(raw).expanduser() if raw else None

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -36,6 +36,7 @@ from agent.tool_dispatch_helpers import (
     _append_subdir_hint_to_multimodal,
     make_tool_result_message,
 )
+from agent.runtime_cwd import resolve_agent_cwd
 from tools.terminal_tool import (
     get_active_env,
 )
@@ -222,7 +223,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
-                        cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        cwd = function_args.get("workdir") or str(resolve_agent_cwd())
                         agent._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )
@@ -674,7 +675,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 cmd = function_args.get("command", "")
                 if _is_destructive_command(cmd):
-                    cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                    cwd = function_args.get("workdir") or str(resolve_agent_cwd())
                     agent._checkpoint_mgr.ensure_checkpoint(
                         cwd, f"before terminal: {cmd[:60]}"
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2323,6 +2323,106 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _global_gateway_cwd(self) -> str:
+        raw = os.environ.get("TERMINAL_CWD", "").strip()
+        if raw:
+            path = Path(raw).expanduser()
+            if path.is_dir():
+                return str(path.resolve())
+        return str(Path.home().resolve())
+
+    def _session_workspace_cwd(self, session_entry: Optional[Any] = None) -> Optional[str]:
+        raw = getattr(session_entry, "workspace_cwd", None)
+        if not raw:
+            return None
+        path = Path(str(raw)).expanduser()
+        if not path.is_dir():
+            return None
+        return str(path.resolve())
+
+    def _effective_workspace_cwd(self, session_entry: Optional[Any] = None) -> str:
+        return self._session_workspace_cwd(session_entry) or self._global_gateway_cwd()
+
+    def _sync_gateway_workspace_state(
+        self,
+        session_key: str,
+        session_entry: Optional[Any],
+        *,
+        previous_session_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return the valid session workspace and keep runtime state in sync.
+
+        If a previously bound directory has disappeared, clear the binding and
+        terminal overrides instead of silently showing the global cwd while
+        tools keep using the stale task override.
+        """
+        if session_entry is None:
+            return None
+
+        current_session_id = getattr(session_entry, "session_id", None)
+        if previous_session_id and previous_session_id != current_session_id:
+            self._register_gateway_workspace_override(previous_session_id, None)
+
+        workspace_cwd = self._session_workspace_cwd(session_entry)
+        raw_workspace = getattr(session_entry, "workspace_cwd", None)
+        if raw_workspace and not workspace_cwd:
+            self.session_store.set_workspace_cwd(session_key, None)
+            session_entry.workspace_cwd = None
+            self._register_gateway_workspace_override(
+                session_key,
+                None,
+                session_id=getattr(session_entry, "session_id", None),
+            )
+            self._evict_cached_agent(session_key)
+            try:
+                from tools.terminal_tool import cleanup_vm
+
+                cleanup_vm(session_key)
+                cleanup_vm(session_entry.session_id)
+            except Exception as exc:
+                logger.debug("workspace: stale workspace cleanup skipped for %s: %s", session_key, exc)
+            logger.warning(
+                "gateway workspace cleared for %s because bound cwd no longer exists: %s",
+                session_key,
+                raw_workspace,
+            )
+            return None
+
+        if workspace_cwd:
+            self._register_gateway_workspace_override(
+                session_key,
+                workspace_cwd,
+                session_id=getattr(session_entry, "session_id", None),
+            )
+            if getattr(session_entry, "session_id", None) and getattr(self.session_store, "_db", None):
+                try:
+                    self.session_store._db.update_session_cwd(session_entry.session_id, workspace_cwd)
+                except Exception as exc:
+                    logger.debug("Session DB workspace cwd sync failed: %s", exc)
+        return workspace_cwd
+
+    def _register_gateway_workspace_override(
+        self,
+        session_key: str,
+        cwd: Optional[str],
+        *,
+        session_id: Optional[str] = None,
+    ) -> None:
+        try:
+            from tools.terminal_tool import (
+                clear_task_env_overrides,
+                register_task_env_overrides,
+            )
+
+            task_ids = [task_id for task_id in (session_key, session_id) if task_id]
+            for task_id in task_ids:
+                if cwd:
+                    register_task_env_overrides(task_id, {"cwd": cwd})
+                else:
+                    clear_task_env_overrides(task_id)
+        except Exception as exc:
+            logger.warning("gateway workspace override registration failed: %s", exc)
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -8045,6 +8145,9 @@ class GatewayRunner:
         if canonical == "sethome":
             return await self._handle_set_home_command(event)
 
+        if canonical == "workspace":
+            return await self._handle_workspace_command(event)
+
         if canonical == "compress":
             return await self._handle_compress_command(event)
 
@@ -8544,7 +8647,12 @@ class GatewayRunner:
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                try:
+                    _msg_entry = self.session_store._entries.get(session_key)
+                except Exception:
+                    _msg_entry = None
+                self._sync_gateway_workspace_state(session_key, _msg_entry)
+                _msg_cwd = self._effective_workspace_cwd(_msg_entry)
                 _msg_runtime = _resolve_runtime_agent_kwargs()
                 _msg_config_ctx = None
                 try:
@@ -8719,6 +8827,8 @@ class GatewayRunner:
             self._set_session_reasoning_override(session_key, None)
             if hasattr(self, "_pending_model_notes"):
                 self._pending_model_notes.pop(session_key, None)
+
+        self._sync_gateway_workspace_state(session_key, session_entry)
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
@@ -9079,8 +9189,14 @@ class GatewayRunner:
                                     # and searchable via session_search.
                                     _hyg_new_sid = _hyg_agent.session_id
                                     if _hyg_new_sid != session_entry.session_id:
+                                        _hyg_old_sid = session_entry.session_id
                                         session_entry.session_id = _hyg_new_sid
                                         self.session_store._save()
+                                        self._sync_gateway_workspace_state(
+                                            session_key,
+                                            session_entry,
+                                            previous_session_id=_hyg_old_sid,
+                                        )
                                         self._sync_telegram_topic_binding(
                                             source, session_entry,
                                             reason="hygiene-compression",
@@ -9348,8 +9464,14 @@ class GatewayRunner:
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
+                old_session_id = session_entry.session_id
                 session_entry.session_id = agent_result["session_id"]
                 self.session_store._save()
+                self._sync_gateway_workspace_state(
+                    session_key,
+                    session_entry,
+                    previous_session_id=old_session_id,
+                )
                 self._sync_telegram_topic_binding(
                     source, session_entry, reason="agent-result-compression",
                 )
@@ -9390,7 +9512,7 @@ class GatewayRunner:
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=self._effective_workspace_cwd(session_entry),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -10241,6 +10363,15 @@ class GatewayRunner:
         lines.extend([
             t("gateway.status.created", timestamp=session_entry.created_at.strftime('%Y-%m-%d %H:%M')),
             t("gateway.status.last_activity", timestamp=session_entry.updated_at.strftime('%Y-%m-%d %H:%M')),
+            t(
+                "gateway.status.workspace",
+                cwd=self._effective_workspace_cwd(session_entry),
+                source=(
+                    t("gateway.workspace.source_session")
+                    if session_entry.workspace_cwd
+                    else t("gateway.workspace.source_global")
+                ),
+            ),
             t("gateway.status.tokens", tokens=f"{db_total_tokens:,}"),
             t("gateway.status.agent_running", state=t("gateway.status.state_yes") if is_running else t("gateway.status.state_no")),
         ])
@@ -11715,6 +11846,73 @@ class GatewayRunner:
 
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)
 
+    async def _handle_workspace_command(self, event: MessageEvent) -> str:
+        """Handle /workspace -- bind this gateway session to a project cwd."""
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+        self._sync_gateway_workspace_state(session_key, session_entry)
+        arg = event.get_command_args().strip()
+        global_cwd = self._global_gateway_cwd()
+
+        if not arg or arg.lower() in {"status", "show"}:
+            current = self._effective_workspace_cwd(session_entry)
+            source_label = (
+                t("gateway.workspace.source_session")
+                if session_entry.workspace_cwd
+                else t("gateway.workspace.source_global")
+            )
+            return t(
+                "gateway.workspace.status",
+                cwd=current,
+                source=source_label,
+                global_cwd=global_cwd,
+            )
+
+        if arg.lower() in {"clear", "reset", "default"}:
+            self.session_store.set_workspace_cwd(session_key, None)
+            self._register_gateway_workspace_override(
+                session_key,
+                None,
+                session_id=session_entry.session_id,
+            )
+            self._evict_cached_agent(session_key)
+            try:
+                from tools.terminal_tool import cleanup_vm
+
+                cleanup_vm(session_key)
+                cleanup_vm(session_entry.session_id)
+            except Exception as exc:
+                logger.debug("workspace: terminal cleanup skipped for %s: %s", session_key, exc)
+            return t("gateway.workspace.cleared", cwd=global_cwd)
+
+        path = Path(os.path.expanduser(arg))
+        if not path.is_absolute():
+            return t("gateway.workspace.relative_rejected")
+        try:
+            resolved = path.resolve()
+        except Exception as exc:
+            return t("gateway.workspace.invalid", path=arg, error=exc)
+        if not resolved.is_dir():
+            return t("gateway.workspace.not_dir", path=str(resolved))
+
+        cwd = str(resolved)
+        self.session_store.set_workspace_cwd(session_key, cwd)
+        self._register_gateway_workspace_override(
+            session_key,
+            cwd,
+            session_id=session_entry.session_id,
+        )
+        self._evict_cached_agent(session_key)
+        try:
+            from tools.terminal_tool import cleanup_vm
+
+            cleanup_vm(session_key)
+            cleanup_vm(session_entry.session_id)
+        except Exception as exc:
+            logger.debug("workspace: terminal cleanup skipped for %s: %s", session_key, exc)
+        return t("gateway.workspace.set", cwd=cwd)
+
     @staticmethod
     def _get_guild_id(event: MessageEvent) -> Optional[int]:
         """Extract Discord guild_id from the raw message object."""
@@ -12270,7 +12468,9 @@ class GatewayRunner:
             max_file_size_mb=cp_cfg.get("max_file_size_mb", 10),
         )
 
-        cwd = os.getenv("TERMINAL_CWD", str(Path.home()))
+        session_entry = self.session_store.get_or_create_session(event.source)
+        self._sync_gateway_workspace_state(session_entry.session_key, session_entry)
+        cwd = self._effective_workspace_cwd(session_entry)
         arg = event.get_command_args().strip()
 
         if not arg:
@@ -15317,6 +15517,13 @@ class GatewayRunner:
         in a ``finally`` block.
         """
         from gateway.session_context import set_session_vars
+        session_entry = None
+        try:
+            session_entry = self.session_store._entries.get(context.session_key)
+        except Exception:
+            session_entry = None
+        self._sync_gateway_workspace_state(context.session_key, session_entry)
+        session_cwd = self._session_workspace_cwd(session_entry) or ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -15325,6 +15532,7 @@ class GatewayRunner:
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_cwd=session_cwd,
             message_id=str(context.source.message_id) if context.source.message_id else "",
         )
 
@@ -18080,8 +18288,14 @@ class GatewayRunner:
                 )
                 entry = self.session_store._entries.get(session_key)
                 if entry:
+                    old_session_id = entry.session_id
                     entry.session_id = agent.session_id
                     self.session_store._save()
+                    self._sync_gateway_workspace_state(
+                        session_key,
+                        entry,
+                        previous_session_id=old_session_id,
+                    )
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -491,6 +491,11 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Optional gateway session-scoped working directory.  When set, this
+    # chat/thread/session uses this project root instead of the process-wide
+    # terminal.cwd / TERMINAL_CWD default.
+    workspace_cwd: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -521,6 +526,7 @@ class SessionEntry:
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
+            "workspace_cwd": self.workspace_cwd,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -569,6 +575,7 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            workspace_cwd=data.get("workspace_cwd") or None,
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -875,6 +882,10 @@ class SessionStore:
         with self._lock:
             self._ensure_loaded_locked()
 
+            previous_workspace_cwd = None
+            if session_key in self._entries:
+                previous_workspace_cwd = self._entries[session_key].workspace_cwd
+
             if session_key in self._entries and not force_new:
                 entry = self._entries[session_key]
 
@@ -926,6 +937,7 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                workspace_cwd=previous_workspace_cwd,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
@@ -937,6 +949,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "cwd": entry.workspace_cwd,
             }
 
         # SQLite operations outside the lock
@@ -969,6 +982,28 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def set_workspace_cwd(self, session_key: str, cwd: Optional[str]) -> Optional[SessionEntry]:
+        """Set or clear the gateway session-scoped workspace directory."""
+        session_id = None
+        workspace_cwd = None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            entry.workspace_cwd = cwd or None
+            entry.updated_at = _now()
+            session_id = entry.session_id
+            workspace_cwd = entry.workspace_cwd
+            self._save()
+
+        if self._db:
+            try:
+                self._db.update_session_cwd(session_id, workspace_cwd or "")
+            except Exception as e:
+                logger.debug("Session DB cwd update failed: %s", e)
+        return entry
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.
@@ -1154,6 +1189,7 @@ class SessionStore:
                 display_name=display_name if display_name is not None else old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                workspace_cwd=old_entry.workspace_cwd,
                 is_fresh_reset=True,
             )
 
@@ -1163,6 +1199,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "cwd": new_entry.workspace_cwd,
             }
 
         if self._db and db_end_session_id:
@@ -1215,6 +1252,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                workspace_cwd=old_entry.workspace_cwd,
             )
 
             self._entries[session_key] = new_entry
@@ -1229,6 +1267,9 @@ class SessionStore:
         if self._db:
             try:
                 self._db.reopen_session(target_session_id)
+                # Gateway workspaces are chat/thread scoped. Resuming an older
+                # transcript into this chat adopts the chat's current workspace.
+                self._db.update_session_cwd(target_session_id, new_entry.workspace_cwd or "")
             except Exception as e:
                 logger.debug("Session DB reopen_session failed: %s", e)
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -56,6 +56,7 @@ _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNS
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
 # ID of the message that triggered the current turn. Used as a reply anchor
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
@@ -76,6 +77,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
+    "HERMES_SESSION_CWD": _SESSION_CWD,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
@@ -106,6 +108,7 @@ def set_session_vars(
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
+    session_cwd: str = "",
     message_id: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
@@ -124,6 +127,7 @@ def set_session_vars(
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
+        _SESSION_CWD.set(session_cwd),
         _SESSION_MESSAGE_ID.set(message_id),
     ]
     return tokens
@@ -148,6 +152,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,
+        _SESSION_CWD,
         _SESSION_MESSAGE_ID,
     ):
         var.set("")
@@ -177,3 +182,19 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def get_session_context_value(name: str, default: str = "") -> str:
+    """Read only the task-local session context value.
+
+    Unlike ``get_session_env()``, this never falls back to ``os.environ``.
+    Use it for values that should not leak across non-gateway entrypoints if a
+    process happens to inherit an old ``HERMES_SESSION_*`` environment variable.
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return default
+    value = var.get()
+    if value is _UNSET:
+        return default
+    return value

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -114,6 +114,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
+    CommandDef("workspace", "Bind this chat to a project directory", "Session",
+               gateway_only=True, aliases=("cwd",), args_hint="[path|clear|status]"),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -974,11 +974,11 @@ class SessionDB:
 
     def update_session_cwd(self, session_id: str, cwd: str) -> None:
         """Persist the session working directory when a frontend knows it."""
-        if not session_id or not cwd:
+        if not session_id:
             return
 
         def _do(conn):
-            conn.execute("UPDATE sessions SET cwd = ? WHERE id = ?", (cwd, session_id))
+            conn.execute("UPDATE sessions SET cwd = ? WHERE id = ?", (cwd or None, session_id))
 
         self._execute_write(_do)
     # ──────────────────────────────────────────────────────────────────────

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -264,12 +264,23 @@ gateway:
     save_failed:           "Failed to save home channel: {error}"
     success:               "✅ Home channel set to **{name}** (ID: {chat_id}).\nCron jobs and cross-platform messages will be delivered here."
 
+  workspace:
+    source_session:         "session override"
+    source_global:          "global default"
+    status:                 "📁 **Workspace:** `{cwd}` ({source})\nGlobal default: `{global_cwd}`\nUse `/workspace /absolute/path` to bind this chat, or `/workspace clear` to return to the global default."
+    set:                    "✅ Workspace set for this session: `{cwd}`\nFuture turns in this chat will use this directory for project context, files, terminal commands, @ references, and rollback. Existing tool environments for this chat were restarted."
+    cleared:                "Workspace override cleared. Using global default: `{cwd}`\nExisting tool environments for this chat were restarted."
+    relative_rejected:      "Use an absolute path, e.g. `/workspace /home/me/project`."
+    invalid:                "Invalid workspace path `{path}`: {error}"
+    not_dir:                "Workspace path is not an existing directory: `{path}`"
+
   status:
     header:                "📊 **Hermes Gateway Status**"
     session_id:            "**Session ID:** `{session_id}`"
     title:                 "**Title:** {title}"
     created:               "**Created:** {timestamp}"
     last_activity:         "**Last Activity:** {timestamp}"
+    workspace:             "**Workspace:** `{cwd}` ({source})"
     tokens:                "**Cumulative API tokens (re-sent each call):** {tokens}"
     agent_running:         "**Agent Running:** {state}"
     state_yes:             "Yes ⚡"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -249,12 +249,23 @@ gateway:
     save_failed:           "无法保存主频道：{error}"
     success:               "✅ 主频道已设置为 **{name}**（ID：{chat_id}）。\n定时任务和跨平台消息将发送到此处。"
 
+  workspace:
+    source_session:         "会话覆盖"
+    source_global:          "全局默认"
+    status:                 "📁 **工作区：** `{cwd}`（{source}）\n全局默认：`{global_cwd}`\n使用 `/workspace /absolute/path` 绑定当前聊天，或使用 `/workspace clear` 回到全局默认。"
+    set:                    "✅ 当前会话工作区已设置为：`{cwd}`\n此聊天后续会使用该目录作为项目上下文、文件、终端命令、@ 引用和回滚的工作目录。当前聊天的既有工具环境已重启。"
+    cleared:                "已清除会话工作区覆盖。正在使用全局默认：`{cwd}`\n当前聊天的既有工具环境已重启。"
+    relative_rejected:      "请使用绝对路径，例如 `/workspace /home/me/project`。"
+    invalid:                "无效的工作区路径 `{path}`：{error}"
+    not_dir:                "工作区路径不是已存在的目录：`{path}`"
+
   status:
     header:                "📊 **Hermes 网关状态**"
     session_id:            "**会话 ID：** `{session_id}`"
     title:                 "**标题：** {title}"
     created:               "**创建时间：** {timestamp}"
     last_activity:         "**最近活动：** {timestamp}"
+    workspace:             "**工作区：** `{cwd}`（{source}）"
     tokens:                "**Token 数：** {tokens}"
     agent_running:         "**代理运行中：** {state}"
     state_yes:             "是 ⚡"

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -14,6 +14,30 @@ def _raise_oserror(*args, **kwargs):
 
 
 class TestResolveAgentCwd:
+    def test_prefers_session_cwd_over_terminal_cwd(self, monkeypatch, tmp_path):
+        session_dir = tmp_path / "session"
+        global_dir = tmp_path / "global"
+        session_dir.mkdir()
+        global_dir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(global_dir))
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(session_cwd=str(session_dir))
+        try:
+            assert resolve_agent_cwd() == session_dir
+        finally:
+            clear_session_vars(tokens)
+
+    def test_ignores_inherited_session_cwd_env(self, monkeypatch, tmp_path):
+        session_dir = tmp_path / "session"
+        global_dir = tmp_path / "global"
+        session_dir.mkdir()
+        global_dir.mkdir()
+        monkeypatch.setenv("HERMES_SESSION_CWD", str(session_dir))
+        monkeypatch.setenv("TERMINAL_CWD", str(global_dir))
+
+        assert resolve_agent_cwd() == global_dir
+
     def test_prefers_terminal_cwd_over_getcwd(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         monkeypatch.chdir(os.path.expanduser("~"))
@@ -51,6 +75,30 @@ class TestResolveAgentCwd:
 
 
 class TestResolveContextCwd:
+    def test_prefers_session_cwd_over_terminal_cwd(self, monkeypatch, tmp_path):
+        session_dir = tmp_path / "session"
+        global_dir = tmp_path / "global"
+        session_dir.mkdir()
+        global_dir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(global_dir))
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(session_cwd=str(session_dir))
+        try:
+            assert resolve_context_cwd() == session_dir
+        finally:
+            clear_session_vars(tokens)
+
+    def test_ignores_inherited_session_cwd_env(self, monkeypatch, tmp_path):
+        session_dir = tmp_path / "session"
+        global_dir = tmp_path / "global"
+        session_dir.mkdir()
+        global_dir.mkdir()
+        monkeypatch.setenv("HERMES_SESSION_CWD", str(session_dir))
+        monkeypatch.setenv("TERMINAL_CWD", str(global_dir))
+
+        assert resolve_context_cwd() == global_dir
+
     def test_returns_dir_when_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert resolve_context_cwd() == tmp_path

--- a/tests/agent/test_tool_executor_workspace_cwd.py
+++ b/tests/agent/test_tool_executor_workspace_cwd.py
@@ -1,0 +1,63 @@
+"""Tests for workspace-aware tool execution bookkeeping."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import agent.tool_executor as tool_executor
+from agent.tool_executor import execute_tool_calls_sequential
+
+
+def test_destructive_terminal_checkpoint_uses_session_cwd(tmp_path, monkeypatch):
+    session_dir = tmp_path / "session"
+    global_dir = tmp_path / "global"
+    session_dir.mkdir()
+    global_dir.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(global_dir))
+
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    tokens = set_session_vars(session_cwd=str(session_dir))
+    try:
+        monkeypatch.setattr(
+            tool_executor,
+            "_ra",
+            lambda: SimpleNamespace(
+                handle_function_call=lambda *_args, **_kwargs: '{"ok": true}',
+                logger=MagicMock(),
+            ),
+        )
+
+        checkpoint_mgr = MagicMock()
+        checkpoint_mgr.enabled = True
+
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent._tool_guardrails.before_call.return_value = SimpleNamespace(allows_execution=True)
+        agent._checkpoint_mgr = checkpoint_mgr
+        agent.quiet_mode = True
+        agent.tool_progress_callback = None
+        agent.tool_start_callback = None
+        agent.tool_delay = 0
+        agent.session_id = "session-1"
+        agent.valid_tool_names = set()
+        agent.enabled_toolsets = None
+        agent.disabled_toolsets = None
+        agent._current_tool = None
+        agent._touch_activity = MagicMock()
+        agent._should_emit_quiet_tool_messages.return_value = False
+
+        tool_call = SimpleNamespace(
+            id="tool-1",
+            function=SimpleNamespace(
+                name="terminal",
+                arguments='{"command": "rm -rf build"}',
+            ),
+        )
+        assistant = SimpleNamespace(tool_calls=[tool_call])
+
+        execute_tool_calls_sequential(agent, assistant, [], "session-1")
+
+        checkpoint_mgr.ensure_checkpoint.assert_called()
+        assert checkpoint_mgr.ensure_checkpoint.call_args.args[0] == str(session_dir)
+    finally:
+        clear_session_vars(tokens)

--- a/tests/gateway/test_workspace_command.py
+++ b/tests/gateway/test_workspace_command.py
@@ -1,0 +1,191 @@
+"""Tests for gateway session-scoped workspace bindings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, SessionStore
+
+
+class _FakeSessionDB:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def create_session(self, **kwargs):
+        self.calls.append(("create", kwargs))
+
+    def end_session(self, session_id, reason):
+        self.calls.append(("end", session_id, reason))
+
+    def reopen_session(self, session_id):
+        self.calls.append(("reopen", session_id))
+
+    def update_session_cwd(self, session_id, cwd):
+        self.calls.append(("update_cwd", session_id, cwd))
+
+
+def _source(chat_id: str = "chat-1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def _event(text: str, source: SessionSource | None = None) -> MessageEvent:
+    return MessageEvent(text=text, source=source or _source(), message_id="m1")
+
+
+def _runner(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    store._db = None
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    runner.config = GatewayConfig()
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._evict_cached_agent = MagicMock()
+    runner._global_gateway_cwd = lambda: str(tmp_path / "global")
+    monkeypatch.setattr("tools.terminal_tool.cleanup_vm", lambda *_a, **_kw: None)
+    calls: list[tuple[str, str | None]] = []
+
+    def _register(session_key, cwd, *, session_id=None):
+        calls.append((session_key, cwd))
+        if session_id:
+            calls.append((session_id, cwd))
+
+    runner._register_gateway_workspace_override = _register
+    runner._workspace_calls = calls
+    runner.adapters = {}
+    runner.hooks = SimpleNamespace(emit=MagicMock())
+    return runner
+
+
+def test_sync_workspace_state_clears_stale_binding(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+    source = _source()
+    project = tmp_path / "project"
+    project.mkdir()
+    entry = runner.session_store.get_or_create_session(source)
+    runner.session_store.set_workspace_cwd(entry.session_key, str(project))
+    project.rmdir()
+
+    result = runner._sync_gateway_workspace_state(entry.session_key, entry)
+
+    assert result is None
+    assert entry.workspace_cwd is None
+    assert (entry.session_key, None) in runner._workspace_calls
+    assert (entry.session_id, None) in runner._workspace_calls
+    runner._evict_cached_agent.assert_called_with(entry.session_key)
+
+
+def test_sync_workspace_state_updates_current_session_id_db_and_override(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+    fake_db = _FakeSessionDB()
+    runner.session_store._db = fake_db
+    source = _source()
+    project = tmp_path / "project"
+    project.mkdir()
+    entry = runner.session_store.get_or_create_session(source)
+    runner.session_store.set_workspace_cwd(entry.session_key, str(project))
+    entry.session_id = "split-session"
+
+    result = runner._sync_gateway_workspace_state(entry.session_key, entry)
+
+    assert result == str(project)
+    assert (entry.session_key, str(project)) in runner._workspace_calls
+    assert ("split-session", str(project)) in runner._workspace_calls
+    assert ("update_cwd", "split-session", str(project)) in fake_db.calls
+
+
+@pytest.mark.asyncio
+async def test_workspace_status_uses_global_default(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+
+    result = await runner._handle_workspace_command(_event("/workspace"))
+
+    assert "global default" in result
+    assert str(tmp_path / "global") in result
+
+
+@pytest.mark.asyncio
+async def test_workspace_set_and_clear_are_session_scoped(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    source = _source()
+
+    set_result = await runner._handle_workspace_command(
+        _event(f"/workspace {project}", source)
+    )
+    entry = runner.session_store.get_or_create_session(source)
+
+    assert "Workspace set" in set_result
+    assert entry.workspace_cwd == str(project)
+    assert (entry.session_key, str(project)) in runner._workspace_calls
+    assert (entry.session_id, str(project)) in runner._workspace_calls
+    runner._evict_cached_agent.assert_called_with(entry.session_key)
+
+    clear_result = await runner._handle_workspace_command(_event("/workspace clear", source))
+    entry = runner.session_store.get_or_create_session(source)
+
+    assert "cleared" in clear_result
+    assert entry.workspace_cwd is None
+    assert (entry.session_key, None) in runner._workspace_calls
+    assert (entry.session_id, None) in runner._workspace_calls
+
+
+@pytest.mark.asyncio
+async def test_workspace_rejects_relative_and_missing_paths(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, monkeypatch)
+
+    relative = await runner._handle_workspace_command(_event("/workspace project"))
+    missing = await runner._handle_workspace_command(
+        _event(f"/workspace {tmp_path / 'missing'}")
+    )
+
+    assert "absolute path" in relative
+    assert "not an existing directory" in missing
+
+
+def test_session_store_persists_workspace_across_reload_and_reset(tmp_path):
+    source = _source()
+    config = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._db = None
+    entry = store.get_or_create_session(source)
+    store.set_workspace_cwd(entry.session_key, "/tmp/project")
+
+    reloaded = SessionStore(sessions_dir=tmp_path, config=config)
+    reloaded._db = None
+    loaded_entry = reloaded.get_or_create_session(source)
+    assert loaded_entry.workspace_cwd == "/tmp/project"
+
+    reset_entry = reloaded.reset_session(loaded_entry.session_key)
+    assert reset_entry is not None
+    assert reset_entry.workspace_cwd == "/tmp/project"
+
+
+def test_session_store_carries_workspace_across_session_switch(tmp_path):
+    source = _source()
+    fake_db = _FakeSessionDB()
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    store._db = fake_db
+
+    entry = store.get_or_create_session(source)
+    store.set_workspace_cwd(entry.session_key, "/tmp/project")
+
+    switched = store.switch_session(entry.session_key, "resumed-session")
+
+    assert switched is not None
+    assert switched.workspace_cwd == "/tmp/project"
+    assert ("reopen", "resumed-session") in fake_db.calls
+    assert ("update_cwd", "resumed-session", "/tmp/project") in fake_db.calls

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -78,6 +78,22 @@ def test_live_tracking_cwd_wins_over_relative_terminal_cwd(_isolated_cwd, monkey
     assert resolved == (workspace / "target.py")
 
 
+def test_task_override_cwd_wins_before_live_env_exists(_isolated_cwd, monkeypatch):
+    """Gateway workspace overrides must route first-turn file tools."""
+    workspace, decoy = _isolated_cwd
+    override = decoy / "gateway-workspace"
+    override.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+    monkeypatch.setattr(
+        "tools.terminal_tool._task_env_overrides",
+        {"gateway-session": {"cwd": str(override)}},
+    )
+
+    resolved = ft._resolve_path_for_task("target.py", task_id="gateway-session")
+
+    assert resolved == (override / "target.py")
+
+
 def test_absolute_terminal_cwd_used_verbatim(_isolated_cwd, monkeypatch):
     """An absolute TERMINAL_CWD is the resolution base (no live tracking)."""
     workspace, decoy = _isolated_cwd
@@ -194,4 +210,3 @@ def test_patch_reports_resolved_absolute_path(_isolated_cwd, monkeypatch):
     assert "WORKSPACE_PATCHED" in (workspace / "target.py").read_text()
     # And the decoy copy is untouched.
     assert (decoy / "target.py").read_text() == "DECOY_ORIGINAL\n"
-

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1678,11 +1678,14 @@ def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
     """
     if mode != "project":
         return staging_dir
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
-    if raw:
-        expanded = os.path.expanduser(raw)
-        if os.path.isdir(expanded):
-            return expanded
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        resolved = str(resolve_agent_cwd())
+        if os.path.isdir(resolved):
+            return resolved
+    except Exception:
+        pass
     here = os.getcwd()
     if os.path.isdir(here):
         return here

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -649,14 +649,21 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     teaching subagents a fake container path while still helping them avoid
     guessing `/workspace/...` for local repo tasks.
     """
-    candidates = [
-        os.getenv("TERMINAL_CWD"),
+    candidates = []
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        candidates.append(str(resolve_agent_cwd()))
+    except Exception:
+        pass
+    candidates.extend([
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
         ),
         getattr(parent_agent, "terminal_cwd", None),
         getattr(parent_agent, "cwd", None),
-    ]
+        os.getenv("TERMINAL_CWD"),
+    ])
     for candidate in candidates:
         if not candidate:
             continue

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -116,14 +116,31 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
     return None
 
 
+def _get_task_override_cwd(task_id: str = "default") -> str | None:
+    """Return a registered per-task cwd before any terminal env exists."""
+    try:
+        from tools.terminal_tool import _resolve_container_task_id, _task_env_overrides
+
+        container_key = _resolve_container_task_id(task_id)
+        for key in (container_key, task_id):
+            override = _task_env_overrides.get(key, {})
+            cwd = override.get("cwd") if isinstance(override, dict) else None
+            if isinstance(cwd, str) and cwd.strip():
+                return cwd
+    except Exception:
+        pass
+    return None
+
+
 def _resolve_base_dir(task_id: str = "default") -> Path:
     """Return the ABSOLUTE base directory for resolving relative paths.
 
     Resolution order:
       1. The task's live terminal cwd (the directory the agent is actually
          working in — e.g. a git worktree). Authoritative when known.
-      2. ``$TERMINAL_CWD`` from config/env.
-      3. The process cwd.
+      2. A registered per-task cwd override, before any terminal env exists.
+      3. ``$TERMINAL_CWD`` from config/env.
+      4. The process cwd.
 
     The returned base is ALWAYS absolute. This is the core invariant that
     prevents the worktree-cwd divergence bug: a relative ``TERMINAL_CWD``
@@ -137,6 +154,8 @@ def _resolve_base_dir(task_id: str = "default") -> Path:
     live = _get_live_tracking_cwd(task_id)
     if live:
         base = Path(live).expanduser()
+    elif override := _get_task_override_cwd(task_id):
+        base = Path(override).expanduser()
     else:
         raw = os.environ.get("TERMINAL_CWD")
         base = Path(raw).expanduser() if raw else Path(os.getcwd())

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -934,9 +934,10 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
 
 
 # Per-task environment overrides registry.
-# Allows environments (e.g., TerminalBench2Env) to specify a custom Docker/Modal
-# image for a specific task_id BEFORE the agent loop starts. When the terminal or
-# file tools create a new sandbox for that task_id, they check this registry first
+# Allows infrastructure code to configure a task's sandbox BEFORE the agent loop
+# starts. RL/benchmark environments use this for custom Docker/Modal images;
+# gateway session workspaces use it for per-chat cwd isolation. When terminal or
+# file tools create a sandbox for that task_id, they check this registry first
 # and fall back to the TERMINAL_MODAL_IMAGE (etc.) env var if no override is set.
 #
 # This is never exposed to the model -- only infrastructure code calls it.
@@ -948,8 +949,8 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     """
     Register environment overrides for a specific task/rollout.
 
-    Called by Atropos environments before the agent loop to configure
-    per-task sandbox settings (e.g., a custom Dockerfile for the Modal image).
+    Called by Atropos environments and gateway session workspace routing before
+    the agent loop to configure per-task sandbox settings.
 
     Supported override keys:
         - modal_image: str -- Path to Dockerfile or Docker Hub image name
@@ -1001,12 +1002,11 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     ``"default"`` here so subagents share the parent's long-lived container
     (one bash, one /workspace, one set of installed packages).
 
-    Exception: RL / benchmark environments (TerminalBench2, HermesSweEnv, ...)
-    call ``register_task_env_overrides(task_id, {...})`` to request a
-    per-task Docker/Modal image. When an override is registered for a
-    task_id, we honour it by returning the task_id unchanged -- those
-    rollouts need their own isolated sandbox, which is the whole point of
-    the override.
+    Exception: infrastructure paths that need task-local runtime state call
+    ``register_task_env_overrides(task_id, {...})``. RL/benchmark rollouts use
+    this for per-task Docker/Modal images; gateway sessions use it for per-chat
+    workspaces. When an override is registered for a task_id, we honour it by
+    returning the task_id unchanged so its sandbox and file tools stay isolated.
     """
     if task_id and task_id in _task_env_overrides:
         return task_id


### PR DESCRIPTION
## What does this PR do?

Adds session-scoped workspace binding for messaging gateway sessions.

Gateway users can now run `/workspace <absolute-path>` or `/cwd <absolute-path>` to bind the current chat/thread to a project directory. Subsequent agent turns in that gateway session resolve runtime cwd, context files, terminal commands, file tools, code execution, delegation hints, checkpoints, and runtime footer/status output against the bound workspace instead of the global `terminal.cwd`.

This keeps the existing default behavior unchanged when no workspace is bound, while making multi-chat and multi-repo gateway usage practical without running one bot process per project.

## Related Issue

 #37277

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `/workspace` and `/cwd` gateway commands for showing, setting, and clearing the current session workspace.
- Persisted workspace cwd on gateway session state and `SessionDB.sessions.cwd`, including resume/session-switch handling.
- Added a session-context cwd resolver so gateway turns can expose their workspace without mutating process-wide environment variables.
- Routed workspace cwd through terminal/file/code/delegate tool resolution, destructive-command checkpoints, subdirectory hints, and runtime footer/status output.
- Added cleanup/sync handling for stale workspace directories and session-id changes after compression.
- Added English and Chinese gateway command messages.
- Added focused tests for workspace commands, runtime cwd resolution, file tool cwd fallback, terminal overrides, footer consistency, and checkpoint cwd handling.

## How to Test

1. Run the focused test suite:

   ```bash
   env UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=/mnt/d/hermes-agent uv run --no-project --offline --with pytest==9.0.2 --with pytest-asyncio==1.3.0 --with pytest-timeout==2.4.0 --with httpx==0.28.1 --with python-dotenv==1.2.2 --with pyyaml==6.0.3 python -m pytest tests/agent/test_tool_executor_workspace_cwd.py tests/tools/test_file_tools_cwd_resolution.py tests/gateway/test_workspace_command.py tests/agent/test_runtime_cwd.py tests/tools/test_terminal_task_cwd.py tests/gateway/test_runtime_footer.py -q --tb=short
   ```

2. In a gateway session, run `/workspace /absolute/path/to/project`.
3. Ask the agent to read a relative file or run `pwd`; it should use the bound workspace.
4. Run `/workspace clear` and confirm the session returns to the global gateway cwd.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu on Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Focused tests passed locally:

```text
67 passed in 27.23s
```
