### PR TITLE
fix: detect and break stuck tool loops when thinking/action mismatch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -408,6 +408,11 @@ def init_agent(
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
 
+    # Tool call history across turns — used to detect stuck tool loops
+    # where the model's thinking block says "stop" but the action keeps
+    # calling the same tool. Each entry is (tool_name, normalized_args).
+    agent._tool_call_history: list[tuple[str, str]] = []
+
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False
     agent._interrupt_message = None  # Optional message that triggered interrupt

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3811,6 +3811,30 @@ def run_conversation(
                     assistant_message.tool_calls
                 )
 
+                # ── Thinking/action inconsistency detection ────────────
+                # Some models (especially DeepSeek V4) reason correctly in
+                # their thinking block that the task is complete and they
+                # should stop, but the action block keeps generating the
+                # same tool call.  Detect this pattern and force-terminate
+                # instead of burning iteration budget on no-op loops.
+                if agent._detect_stuck_tool_loop(assistant_message):
+                    if not agent.quiet_mode:
+                        agent._vprint(
+                            f"{agent.log_prefix}⛔ Detected stuck tool loop — "
+                            f"model keeps calling the same tool while reasoning suggests stop. "
+                            f"Forcing termination.",
+                            force=True,
+                        )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": None,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "partial": True,
+                        "error": "Model stuck in tool loop: repeated identical tool calls while reasoning suggests completion",
+                    }
+
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
                 
                 # If this turn has both content AND tool_calls, capture the content

--- a/run_agent.py
+++ b/run_agent.py
@@ -2866,6 +2866,110 @@ class AIAgent:
                 logger.warning("Removed duplicate tool call: %s", tc.function.name)
         return unique if len(unique) < len(tool_calls) else tool_calls
 
+    def _detect_stuck_tool_loop(self, assistant_message) -> bool:
+        """Detect if the model is stuck in a tool-calling loop.
+
+        Checks whether the model's reasoning/thinking content indicates the
+        task is complete while it keeps calling the same tool.  This is a
+        known issue with DeepSeek V4 and similar models where the reasoning
+        block says "I should stop" but the action decoder generates another
+        tool call.
+
+        Returns True if a stuck loop is detected and the agent should force-
+        terminate the current turn.
+        """
+        if not assistant_message.tool_calls:
+            return False
+
+        # 1. Extract reasoning/thinking content from the assistant message
+        reasoning_text = self._extract_reasoning(assistant_message) or ""
+        thinking_lower = reasoning_text.lower()
+
+        # 2. Check if reasoning suggests the model wants to stop
+        stop_indicators = [
+            "i need to stop",
+            "i should stop",
+            "going to stop",
+            "i will now stop",
+            "i'm done",
+            "i am done",
+            "i'm finished",
+            "task is complete",
+            "task complete",
+            "completed the task",
+            "finished the task",
+            "no more tools",
+            "calling it done",
+            "wrap this up",
+            "final answer now",
+            "stop calling tools",
+            "just give the final answer",
+            "no further actions",
+        ]
+        has_stop_intent = any(indicator in thinking_lower for indicator in stop_indicators)
+
+        # 3. Normalize current tool calls for comparison
+        def _normalize_args(args: str) -> str:
+            """Normalize tool arguments for cross-turn comparison."""
+            try:
+                parsed = json.loads(args)
+                # Remove non-deterministic fields (IDs, timestamps, etc.)
+                for skip_key in ("call_id", "id", "timestamp", "ts"):
+                    if isinstance(parsed, dict):
+                        parsed.pop(skip_key, None)
+                return json.dumps(parsed, sort_keys=True)
+            except (json.JSONDecodeError, TypeError):
+                return args.strip()
+
+        current_calls = [
+            (tc.function.name, _normalize_args(tc.function.arguments or ""))
+            for tc in assistant_message.tool_calls
+        ]
+
+        # 4. Update history (keep last 20 entries)
+        if not hasattr(self, "_tool_call_history"):
+            self._tool_call_history = []
+        self._tool_call_history.extend(current_calls)
+        if len(self._tool_call_history) > 20:
+            self._tool_call_history = self._tool_call_history[-20:]
+
+        # 5. Detect repetition: same tool, same normalized args, at least 3 times
+        if len(current_calls) != 1:
+            # Only detect loops for single-tool turns (multi-tool is complex)
+            return False
+
+        tc_name, tc_args = current_calls[0]
+
+        # Count consecutive occurrences of this exact (name, args) pair
+        consecutive_count = 0
+        for hist_name, hist_args in reversed(self._tool_call_history):
+            if hist_name == tc_name and hist_args == tc_args:
+                consecutive_count += 1
+            else:
+                break
+
+        # 6. Decision logic:
+        #    - At least 3 consecutive identical tool calls AND
+        #    - Reasoning suggests stopping
+        #    OR
+        #    - At least 5 consecutive identical tool calls (regardless of reasoning)
+        if consecutive_count >= 5:
+            logger.warning(
+                "Stuck tool loop detected: %d consecutive '%s' calls with identical args",
+                consecutive_count, tc_name,
+            )
+            return True
+
+        if consecutive_count >= 3 and has_stop_intent:
+            logger.warning(
+                "Thinking/action inconsistency detected: %d consecutive '%s' "
+                "calls while reasoning suggests stopping",
+                consecutive_count, tc_name,
+            )
+            return True
+
+        return False
+
     def _repair_tool_call(self, tool_name: str) -> str | None:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_tool_call``."""
         from agent.agent_runtime_helpers import repair_tool_call


### PR DESCRIPTION
## Fixes #37255

### Problem
When using DeepSeek V4 Pro (and similar reasoning models), the agent enters an infinite tool-calling loop after completing a task. The model's **thinking block** correctly identifies the need to stop, but the **action generation** continues calling the same tool (e.g. `execute_code` with `print('done')`) until the max iterations limit is hit.

### Root Cause
There is a thinking/action inconsistency in some reasoning models: the reasoning decoder correctly determines the task is complete, but the action decoder remains stuck in a verification pattern and keeps producing identical tool calls.

### Solution
This PR adds a cross-turn tool call history tracker and detection logic that:

1. **Tracks the last 20 tool calls** across turns, storing normalized (tool_name, args) pairs
2. **Detects consecutive repetition**: when the same tool is called with the same normalized arguments
3. **Checks reasoning content**: extracts the model's reasoning/thinking block and looks for stop indicators
4. **Force-terminates** when:
   - 5+ consecutive identical tool calls (hard cutoff regardless of reasoning)
   - 3+ consecutive identical tool calls + reasoning suggests stopping (thinking/action mismatch)

### Changes
- `agent/agent_init.py`: Initialize `_tool_call_history` on the agent
- `run_agent.py`: Add `_detect_stuck_tool_loop()` method with repetition detection and reasoning analysis
- `agent/conversation_loop.py`: Integrate detection in the main loop after tool call deduplication