### PR TITLE
feat(config): surface gateway streaming block in DEFAULT_CONFIG

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2037,6 +2037,45 @@ DEFAULT_CONFIG = {
         "trust_recent_files_seconds": 600,
     },
 
+    # Real-time token streaming to messaging platforms (Telegram, Discord,
+    # Slack, etc.). Read at the top level by the gateway; absent this block the
+    # gateway falls back to these same defaults, so adding it here only makes
+    # the feature discoverable in config.yaml — it does not change behavior.
+    #
+    # Disabled by default: streaming costs extra edit/draft API calls per
+    # response. Set ``enabled: true`` and restart the gateway to turn it on.
+    "streaming": {
+        # Master switch. When false, each response is delivered as a single
+        # final message (no progressive updates).
+        "enabled": False,
+        # Transport selection:
+        #   "auto"  — prefer native draft streaming where the platform
+        #             supports it (Telegram DMs via sendMessageDraft,
+        #             Bot API 9.5+) and fall back to edit-based elsewhere.
+        #             Safe global default: platforms without draft support
+        #             (Discord, Slack, Matrix, Telegram groups) transparently
+        #             use the edit path, so "auto" only upgrades chats that
+        #             can render the smoother native preview.
+        #   "draft" — explicitly request native drafts; falls back to edit
+        #             when the platform/chat doesn't support them.
+        #   "edit"  — progressive editMessageText only (legacy behavior).
+        #   "off"   — disable streaming entirely (same as enabled: false).
+        "transport": "auto",
+        # Minimum seconds between progressive edits — tuned for Telegram's
+        # ~1 edit/s flood envelope.
+        "edit_interval": 0.8,
+        # Flush the buffer to the platform once this many characters have
+        # accumulated, so short replies feel near-instant.
+        "buffer_threshold": 24,
+        # Cursor glyph appended to the in-progress message while streaming.
+        "cursor": " \u2589",
+        # When >0, the final edit for a long-running streamed response is
+        # delivered as a fresh message if the preview has been visible at
+        # least this many seconds, so the platform timestamp reflects
+        # completion time. Telegram only; other platforms ignore it.
+        "fresh_final_after_seconds": 60.0,
+    },
+
     # Session storage — controls automatic cleanup of ~/.hermes/state.db.
     # state.db accumulates every session, message, tool call, and FTS5 index
     # entry forever.  Without auto-pruning, a heavy user (gateway + cron)
@@ -3756,7 +3795,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions",
+    "sessions", "streaming",
 }
 
 # Valid fields inside a custom_providers list entry


### PR DESCRIPTION
## Summary
Gateway streaming is now visible in `config.yaml`. The gateway reads top-level `streaming.*` and falls back to `StreamingConfig` defaults when the block is absent — so the feature worked but was undiscoverable: a user with no streaming block sees responses arrive as single messages and has no way to find the toggle short of reading source. (This is exactly the "it didn't stream anything" confusion that surfaced after #37250 landed the transport default.)

Materializes the block in `DEFAULT_CONFIG` with values byte-identical to the dataclass defaults — discoverability only, zero behavior change.

## Changes
- `hermes_cli/config.py`: add a root-level `streaming` block to `DEFAULT_CONFIG` (`enabled`, `transport`, `edit_interval`, `buffer_threshold`, `cursor`, `fresh_final_after_seconds`), each documented inline. Values match `gateway/config.py` `StreamingConfig()` exactly.
- `hermes_cli/config.py`: add `"streaming"` to `_KNOWN_ROOT_KEYS` so the validator accepts the root key.

## Why no version bump
`load_config()` deep-merges `DEFAULT_CONFIG` over the user's YAML, so existing installs pick up the default automatically and new installs get it written. No value migration is needed, so `_config_version` stays at 25.

## Not in scope
Setup wizard is untouched — streaming stays opt-in (off by default), just discoverable. (Per request.)

## Validation
| Check | Result |
|---|---|
| `DEFAULT_CONFIG['streaming']` == `StreamingConfig()` defaults | identical, 0 mismatches |
| `'streaming'` in `_KNOWN_ROOT_KEYS` | yes |
| `_config_version` | unchanged (25) |
| Gateway resolves materialized block | enabled=false, transport=auto |
| Old install (no key) via deep-merge | gets streaming, transport=auto |
| Targeted suite | 164 passed (config, validation, drift, streaming-nested) |

## Infographic

![Streaming config now visible](https://v3b.fal.media/files/b/0a9ca7b2/ffwiYhuv4M2sS_SV5h7Ur_ZZSHAiQs.png)
