### PR TITLE
feat(deepseek): R1 tool-call scavenge from reasoning_content

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3575,6 +3575,36 @@ def run_conversation(
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
             
+            # ── DeepSeek R1 tool-call scavenge ────────────────────────
+            # R1 reasoning models sometimes write well-formed tool call JSON
+            # inside reasoning_content but forget to emit them as actual
+            # tool_calls.  Scan reasoning text for these lost calls before
+            # deciding there are no tool calls.  Opt-in via config key
+            # ``agent.deepseek_scavenge`` (default: false).
+            try:
+                if (not assistant_message.tool_calls
+                    and getattr(assistant_message, 'reasoning_content', None)
+                ):
+                    from agent.deepseek_scavenge import (
+                        scavenge_tool_calls_from_reasoning,
+                        deepseek_scavenge_enabled,
+                    )
+                    if deepseek_scavenge_enabled(agent):
+                        _scavenged, _msg = scavenge_tool_calls_from_reasoning(
+                            assistant_message.reasoning_content,
+                            agent.valid_tool_names,
+                        )
+                        if _scavenged is not None:
+                            assistant_message.tool_calls = _scavenged
+                            logger.info("DeepSeek R1 scavenge: %s", _msg)
+                            if not agent.quiet_mode:
+                                agent._vprint(
+                                    f"{agent.log_prefix}🔍 {_msg}"
+                                )
+            except Exception:
+                # Scavenge is best-effort — failures must not abort the turn.
+                logger.debug("DeepSeek scavenge failed", exc_info=True)
+            
             # Check for tool calls
             if assistant_message.tool_calls:
                 if not agent.quiet_mode:

--- a/agent/deepseek_scavenge.py
+++ b/agent/deepseek_scavenge.py
@@ -1,0 +1,160 @@
+"""DeepSeek R1 scavenge: extract tool calls leaked into reasoning_content.
+
+DeepSeek R1 thinking models occasionally generate well-formed tool call JSON
+inside their `reasoning_content` but fail to emit them as actual `tool_calls`
+in the response. This module provides a recovery function that scans
+reasoning text for these lost tool calls.
+
+Based on Reasonix (esengine/DeepSeek-Reasonix) scavenge pass.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_arguments(raw: str) -> dict:
+    """Try to parse a JSON arguments block, with brace-balancing fallback."""
+    raw = raw.strip()
+    if not raw:
+        return {}
+    # Simple case — valid JSON
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    # Fallback: count braces and balance. Walk through the string
+    # counting braces; when depth returns to 0 we've found the end.
+    if raw[0] == "{":
+        depth = 0
+        end = len(raw)
+        for i, ch in enumerate(raw):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        if end:
+            try:
+                return json.loads(raw[:end])
+            except json.JSONDecodeError:
+                pass
+    return {}
+
+
+def scavenge_tool_calls_from_reasoning(
+    reasoning: str,
+    valid_tool_names: set,
+) -> tuple[Optional[List[Any]], str]:
+    """Scan reasoning_content for tool calls that R1 forgot to emit."""
+    if not reasoning or not valid_tool_names:
+        return None, "skipped: empty reasoning or no tool names"
+
+    # Scan for tool-call patterns: {"name": "tool", "arguments": {...}}
+    # with brace-balanced argument extraction.
+    candidates: list[tuple[str, dict]] = []
+    pattern = re.compile(r'\{\s*"name"\s*:\s*"(\w+)"\s*,\s*"arguments"\s*:\s*', re.DOTALL)
+    for match in pattern.finditer(reasoning):
+        name = match.group(1)
+        if name not in valid_tool_names:
+            continue
+        # Find brace-balanced arguments block starting at match end
+        start = match.end()
+        args_str = _extract_balanced_braces(reasoning, start)
+        if args_str is None:
+            continue
+        args = _parse_arguments(args_str)
+        if not isinstance(args, dict):
+            continue
+        candidates.append((name, args))
+
+    if not candidates:
+        return None, "skipped: no valid tool calls found in reasoning"
+
+    # Deduplicate by (name, sorted-json-args)
+    seen: set[str] = set()
+    unique: list[tuple[str, dict]] = []
+    for name, args in candidates:
+        key = f"{name}\x00{json.dumps(args, sort_keys=True)}"
+        if key not in seen:
+            seen.add(key)
+            unique.append((name, args))
+
+    # Build ToolCall-like objects (simple namespace with .function)
+    class _FauxFunction:
+        def __init__(self, name: str, arguments: str):
+            self.name = name
+            self.arguments = arguments
+
+    class _FauxToolCall:
+        def __init__(self, id: str, name: str, arguments: dict):
+            self.id = id
+            self.function = _FauxFunction(name, json.dumps(arguments))
+
+    tool_calls = [
+        _FauxToolCall(f"scavenged_{i:03d}", name, args)
+        for i, (name, args) in enumerate(unique)
+    ]
+
+    names = ", ".join(f"{n}({len(json.dumps(a))}b)" for n, a in unique)
+    msg = f"scavenged {len(unique)} tool(s) from reasoning: {names}"
+    return tool_calls, msg
+
+
+def _extract_balanced_braces(text: str, start: int) -> Optional[str]:
+    """Extract a brace-balanced JSON object starting at position *start*.
+
+    Returns the substring (including the opening `{`) or None.
+    """
+    if start >= len(text) or text[start] != "{":
+        return None
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None
+
+
+def deepseek_scavenge_enabled(agent) -> bool:
+    """Check whether R1 tool-call scavenge should run for this agent.
+
+    Only active for DeepSeek providers when the ``agent.deepseek_scavenge``
+    config key is true.
+    """
+    provider = getattr(agent, "provider", "").lower()
+    if provider not in ("deepseek",):
+        return False
+    # Check instance-level override first (test/mock path)
+    if hasattr(agent, "deepseek_scavenge"):
+        return bool(agent.deepseek_scavenge)
+    # Fall back to config file
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return bool(cfg.get("agent", {}).get("deepseek_scavenge", False))
+    except Exception:
+        return False

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -716,6 +716,12 @@ DEFAULT_CONFIG = {
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
         "disabled_toolsets": [],
+        # DeepSeek R1 tool-call scavenge (experimental): when the R1 thinking
+        # model writes well-formed tool call JSON inside its reasoning_content
+        # but forgets to emit them as actual tool_calls, automatically extract
+        # and execute them.  Based on the Reasonix scavenge pass.
+        # Default: false (opt-in; safe for all providers).
+        "deepseek_scavenge": False,
     },
     
     "terminal": {

--- a/tests/agent/test_deepseek_scavenge.py
+++ b/tests/agent/test_deepseek_scavenge.py
@@ -1,0 +1,76 @@
+"""Tests for DeepSeek R1 tool-call scavenge."""
+import pytest
+from agent.deepseek_scavenge import (
+    scavenge_tool_calls_from_reasoning,
+    _parse_arguments,
+)
+
+VALID_TOOLS = {"read_file", "web_search", "terminal", "write_file"}
+
+
+class TestParseArguments:
+    def test_valid_json(self):
+        assert _parse_arguments('{"path": "/tmp/x"}') == {"path": "/tmp/x"}
+
+    def test_truncated_with_brace_balancing(self):
+        # Bare truncated JSON without brace balancing yields empty dict;
+        # this function is meant for already-balanced args from _extract_balanced_braces.
+        result = _parse_arguments('{"path": "/tmp/x", "offset": 1')
+        # Graceful degradation: return empty dict on unparseable input
+        assert isinstance(result, dict)
+
+    def test_empty(self):
+        assert _parse_arguments("") == {}
+        assert _parse_arguments("not json") == {}
+
+    def test_nested(self):
+        result = _parse_arguments('{"a": {"b": 1}, "c": [1, 2, 3]}')
+        assert result == {"a": {"b": 1}, "c": [1, 2, 3]}
+
+
+class TestScavenge:
+    def test_no_reasoning(self):
+        calls, msg = scavenge_tool_calls_from_reasoning("", VALID_TOOLS)
+        assert calls is None
+        assert "empty reasoning" in msg
+
+    def test_no_valid_tool_names(self):
+        calls, msg = scavenge_tool_calls_from_reasoning(
+            '{"name": "read_file", "arguments": {"path": "/x"}}', set()
+        )
+        assert calls is None
+        assert "no tool names" in msg
+
+    def test_single_valid_tool_call(self):
+        reasoning = 'Let me read the file...\n{"name": "read_file", "arguments": {"path": "/tmp/x"}}'
+        calls, msg = scavenge_tool_calls_from_reasoning(reasoning, VALID_TOOLS)
+        assert calls is not None
+        assert len(calls) == 1
+        assert calls[0].function.name == "read_file"
+        assert '{"path": "/tmp/x"}' in calls[0].function.arguments
+
+    def test_unknown_tool_ignored(self):
+        reasoning = '{"name": "delete_everything", "arguments": {}}'
+        calls, msg = scavenge_tool_calls_from_reasoning(reasoning, VALID_TOOLS)
+        assert calls is None
+        assert "no valid tool calls" in msg
+
+    def test_duplicates_removed(self):
+        reasoning = (
+            '{"name": "read_file", "arguments": {"path": "/a"}}\n'
+            '{"name": "read_file", "arguments": {"path": "/a"}}'
+        )
+        calls, msg = scavenge_tool_calls_from_reasoning(reasoning, VALID_TOOLS)
+        assert calls is not None
+        assert len(calls) == 1
+
+    def test_multiple_valid_tools(self):
+        reasoning = (
+            '{"name": "read_file", "arguments": {"path": "/a"}}\n'
+            '{"name": "web_search", "arguments": {"query": "test"}}'
+        )
+        calls, msg = scavenge_tool_calls_from_reasoning(reasoning, VALID_TOOLS)
+        assert calls is not None
+        assert len(calls) == 2
+        names = {c.function.name for c in calls}
+        assert names == {"read_file", "web_search"}


### PR DESCRIPTION
## Summary

DeepSeek R1 thinking models occasionally generate well-formed tool call JSON inside their `reasoning_content` but **forget to emit them** as actual `tool_calls` in the response.

This PR adds an **opt-in scavenge pass** that recovers these lost tool calls.

## How It Works

1. After the assistant message is received, before deciding there are no tool calls, scan `reasoning_content` for `{"name":"...", "arguments":{...}}` patterns
2. Use brace-balanced parsing to correctly extract nested argument objects
3. Validate recovered tool names against the session"s `valid_tool_names` set
4. Deduplicate identical calls
5. Promote scavenged calls to `assistant_message.tool_calls` — the existing tool-call pipeline processes them as if natively emitted

## Config

```yaml
agent:
  deepseek_scavenge: false  # default: off, opt-in, safe for all providers
```

Only activates when provider is DeepSeek AND `agent.deepseek_scavenge` is explicitly true.

## Files Changed

| File | Change |
|------|--------|
| `agent/deepseek_scavenge.py` | **New** — scavenge logic + config gate (160 lines) |
| `agent/conversation_loop.py` | +30 lines — hook into tool-call processing |
| `hermes_cli/config.py` | +6 lines — config default |
| `tests/agent/test_deepseek_scavenge.py` | **New** — 10 unit tests, all passing |

## Safety

- **Off by default** — no behavioral change for existing setups
- **Provider-gated** — only activates for DeepSeek
- **Best-effort** — wrapped in try/except, failures silently fall through
- **Tool-name validation** — only recovers calls to tools the session actually has
- **Dedup** — prevents duplicate execution

## Based On

[Reasonix](https://github.com/esengine/DeepSeek-Reasonix) scavenge pass (MIT, Go).

---

**Status: Draft** — seeking architecture feedback before merging.