### PR TITLE
fix(mcp): raise headless discovery timeout and add HERMES_MCP_DISCOVERY_WAIT override

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -790,7 +790,7 @@ def get_tool_definitions(*args, **kwargs):
     from hermes_cli.mcp_startup import wait_for_mcp_discovery
     from model_tools import get_tool_definitions as _get_tool_definitions
 
-    wait_for_mcp_discovery()
+    wait_for_mcp_discovery(timeout=5.0)
     return _get_tool_definitions(*args, **kwargs)
 
 
@@ -4934,7 +4934,7 @@ class HermesCLI:
 
         from hermes_cli.mcp_startup import wait_for_mcp_discovery
 
-        wait_for_mcp_discovery()
+        wait_for_mcp_discovery(timeout=5.0)
 
         # Initialize SQLite session store for CLI sessions (if not already done in __init__)
         if self._session_db is None:

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -52,8 +52,39 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
 
 
 def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly wait for background MCP discovery before the first tool snapshot."""
+    """Briefly wait for background MCP discovery before the first tool snapshot.
+
+    The effective timeout is resolved in this order:
+    1. ``HERMES_MCP_DISCOVERY_WAIT`` environment variable (float, seconds).
+    2. ``mcp.discovery_wait`` key in config.yaml.
+    3. The ``timeout`` argument passed by the caller.
+
+    Headless one-shot callers (``hermes -z``) should pass a higher default
+    (5.0 s) so container- and stdio-backed servers with a real process
+    cold-start have enough time to connect before the tool snapshot is taken.
+    """
+    import os
+
+    effective = timeout
+    # 1. env var override
+    raw_env = os.getenv("HERMES_MCP_DISCOVERY_WAIT", "").strip()
+    if raw_env:
+        try:
+            effective = float(raw_env)
+        except ValueError:
+            pass
+    else:
+        # 2. config.yaml override
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            val = cfg.get("mcp", {}).get("discovery_wait")
+            if val is not None:
+                effective = float(val)
+        except Exception:
+            pass
+
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return
-    thread.join(timeout=timeout)
+    thread.join(timeout=effective)

--- a/tests/hermes_cli/test_mcp_discovery_timeout.py
+++ b/tests/hermes_cli/test_mcp_discovery_timeout.py
@@ -77,19 +77,37 @@ class TestEnvVarOverride:
 class TestHeadlessDefault:
 
     def test_headless_caller_passes_5s(self, monkeypatch):
-        """cli.py headless path must pass timeout=5.0 to wait_for_mcp_discovery."""
+        """cli.py get_tool_definitions headless path must call wait_for_mcp_discovery(timeout=5.0)
+        while a discovery thread is in-flight, proving the real caller is exercised."""
         _reset()
         monkeypatch.delenv("HERMES_MCP_DISCOVERY_WAIT", raising=False)
+
+        # Put an in-flight discovery thread in place so wait_for_mcp_discovery
+        # actually blocks and the timeout value is meaningful.
+        mcp_startup._mcp_discovery_thread = _make_slow_thread(0.05)
+        mcp_startup._mcp_discovery_started = True
+
         received = []
 
         def _fake_wait(timeout=0.75):
             received.append(timeout)
 
+        # Patch on the module that cli.py imports from at call time.
         monkeypatch.setattr(mcp_startup, "wait_for_mcp_discovery", _fake_wait)
 
-        # Simulate what cli.py headless path does
-        mcp_startup.wait_for_mcp_discovery(timeout=5.0)
+        # Also patch model_tools so get_tool_definitions doesn't need the full stack.
+        import types
+        fake_model_tools = types.ModuleType("model_tools")
+        fake_model_tools.get_tool_definitions = lambda *a, **kw: []
+        monkeypatch.setitem(__import__("sys").modules, "model_tools", fake_model_tools)
+
+        import cli
+        # Reload so cli.py picks up the patched sys.modules entry.
+        import importlib
+        importlib.reload(cli)
+
+        cli.get_tool_definitions()
 
         assert received == [5.0], (
-            f"Headless path should pass timeout=5.0, got {received}"
+            f"cli.get_tool_definitions() headless path should pass timeout=5.0, got {received}"
         )

--- a/tests/hermes_cli/test_mcp_discovery_timeout.py
+++ b/tests/hermes_cli/test_mcp_discovery_timeout.py
@@ -1,0 +1,95 @@
+"""Regression tests for wait_for_mcp_discovery timeout override — fixes #37013.
+
+Before the fix, hermes -z used the hardcoded 0.75 s default which is too short
+for container/stdio-backed MCP servers with a real process cold-start (~1-2 s).
+The fix adds HERMES_MCP_DISCOVERY_WAIT env var and mcp.discovery_wait config key,
+and raises the headless caller default to 5.0 s.
+"""
+
+import threading
+import time
+
+import pytest
+
+import hermes_cli.mcp_startup as mcp_startup
+
+
+def _reset():
+    mcp_startup._mcp_discovery_thread = None
+    mcp_startup._mcp_discovery_started = False
+
+
+def _make_slow_thread(delay: float):
+    """Return a started thread that sleeps for delay seconds."""
+    def _work():
+        time.sleep(delay)
+    t = threading.Thread(target=_work, daemon=True)
+    t.start()
+    return t
+
+
+class TestEnvVarOverride:
+
+    def test_env_var_extends_timeout(self, monkeypatch):
+        """HERMES_MCP_DISCOVERY_WAIT must override the caller's default."""
+        _reset()
+        monkeypatch.setenv("HERMES_MCP_DISCOVERY_WAIT", "3.0")
+        # fast thread finishes well within 3 s
+        mcp_startup._mcp_discovery_thread = _make_slow_thread(0.05)
+        t0 = time.monotonic()
+        mcp_startup.wait_for_mcp_discovery(timeout=0.75)
+        elapsed = time.monotonic() - t0
+        # thread finished; we should NOT have waited the full 3 s
+        assert elapsed < 2.0
+
+    def test_env_var_zero_skips_wait(self, monkeypatch):
+        """HERMES_MCP_DISCOVERY_WAIT=0 must return immediately."""
+        _reset()
+        monkeypatch.setenv("HERMES_MCP_DISCOVERY_WAIT", "0")
+        mcp_startup._mcp_discovery_thread = _make_slow_thread(5.0)
+        t0 = time.monotonic()
+        mcp_startup.wait_for_mcp_discovery(timeout=0.75)
+        elapsed = time.monotonic() - t0
+        assert elapsed < 0.5
+
+    def test_invalid_env_var_falls_back_to_caller_default(self, monkeypatch):
+        """Non-float HERMES_MCP_DISCOVERY_WAIT must be ignored silently."""
+        _reset()
+        monkeypatch.setenv("HERMES_MCP_DISCOVERY_WAIT", "notanumber")
+        mcp_startup._mcp_discovery_thread = _make_slow_thread(5.0)
+        t0 = time.monotonic()
+        mcp_startup.wait_for_mcp_discovery(timeout=0.1)
+        elapsed = time.monotonic() - t0
+        # should use 0.1 s fallback, not hang
+        assert elapsed < 1.0
+
+    def test_no_env_var_uses_caller_default(self, monkeypatch):
+        """Without env var, caller's timeout argument must be respected."""
+        _reset()
+        monkeypatch.delenv("HERMES_MCP_DISCOVERY_WAIT", raising=False)
+        mcp_startup._mcp_discovery_thread = _make_slow_thread(5.0)
+        t0 = time.monotonic()
+        mcp_startup.wait_for_mcp_discovery(timeout=0.1)
+        elapsed = time.monotonic() - t0
+        assert elapsed < 1.0
+
+
+class TestHeadlessDefault:
+
+    def test_headless_caller_passes_5s(self, monkeypatch):
+        """cli.py headless path must pass timeout=5.0 to wait_for_mcp_discovery."""
+        _reset()
+        monkeypatch.delenv("HERMES_MCP_DISCOVERY_WAIT", raising=False)
+        received = []
+
+        def _fake_wait(timeout=0.75):
+            received.append(timeout)
+
+        monkeypatch.setattr(mcp_startup, "wait_for_mcp_discovery", _fake_wait)
+
+        # Simulate what cli.py headless path does
+        mcp_startup.wait_for_mcp_discovery(timeout=5.0)
+
+        assert received == [5.0], (
+            f"Headless path should pass timeout=5.0, got {received}"
+        )

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -195,19 +195,39 @@ def _log_exit(reason: str) -> None:
 def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
     """Briefly block until background MCP discovery finishes, up to ``timeout``.
 
-    MCP discovery runs in a daemon thread spawned at startup (see main()) so a
-    slow/dead server can't freeze ``gateway.ready``.  But the agent snapshots
-    its tool list ONCE at build time and never re-reads it, so a reachable-but-
-    slow server that finishes connecting *after* the first prompt would be
-    invisible for the whole session.  Joining with a short bounded timeout
-    before the first agent build lets already-spawning fast servers land
-    without re-introducing the startup hang: a dead server simply isn't waited
-    on beyond ``timeout``.  No-op when no discovery thread was started.
+    The effective timeout is resolved in this order:
+    1. ``HERMES_MCP_DISCOVERY_WAIT`` environment variable (float, seconds).
+    2. ``mcp.discovery_wait`` key in config.yaml.
+    3. The ``timeout`` argument passed by the caller.
+
+    Headless one-shot callers (``hermes -z``) should pass a higher default
+    (5.0 s) so container- and stdio-backed servers with a real process
+    cold-start have enough time to connect before the tool snapshot is taken.
+    No-op when no discovery thread was started.
     """
+    import os
+
+    effective = timeout
+    raw_env = os.getenv("HERMES_MCP_DISCOVERY_WAIT", "").strip()
+    if raw_env:
+        try:
+            effective = float(raw_env)
+        except ValueError:
+            pass
+    else:
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            val = cfg.get("mcp", {}).get("discovery_wait")
+            if val is not None:
+                effective = float(val)
+        except Exception:
+            pass
+
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return
-    thread.join(timeout=timeout)
+    thread.join(timeout=effective)
 
 
 def main():


### PR DESCRIPTION
## Description

### Problem
When running in `hermes -z` (headless/oneshot) mode, Model Context Protocol (MCP) servers that take longer than 0.75 seconds to connect are silently dropped. Container- and stdio-backed servers requiring a real process cold-start (typically 1–2 seconds) consistently miss this narrow initialization window. Because the toolset is frozen at session startup and never refreshed, the agent operates throughout the entire session as if these tools do not exist.

### Root Cause
The `wait_for_mcp_discovery()` function utilized a hardcoded 0.75-second default timeout, offering no mechanism for overrides via environment variables or configuration files. Furthermore, the headless execution path in `cli.py` invoked this function without arguments, leaving deployments without any escape hatch to handle slower server spin-ups.

### Solution
* **`hermes_cli/mcp_startup.py`**: Refactored `wait_for_mcp_discovery()` to resolve the effective timeout dynamically using the following order of precedence:
  1. `HERMES_MCP_DISCOVERY_WAIT` environment variable (float, in seconds)
  2. `mcp.discovery_wait` key defined in `config.yaml`
  3. The explicit `timeout` argument provided by the caller
* **`tui_gateway/entry.py`**: Applied the identical resolution logic to the duplicate implementation found here.
* **`cli.py`**: Updated both headless call sites to pass `timeout=5.0` as the new, safer default (which remains fully overridable via env/config).

---

## Technical Changes
* Eliminated hardcoded timeout values in the MCP discovery phase.
* Introduced flexible configuration options for operators managing slow-starting MCP servers.

---

## Testing Handled
Added 5 new regression tests in `tests/hermes_cli/test_mcp_discovery_timeout.py` to validate the fallback hierarchy and behaviors:
* **Environment Variable Override:** Verifies that setting the env var properly extends the timeout.
* **Immediate Skip:** Confirms that setting the env var to `0` skips the wait duration immediately.
* **Fallback on Invalid Input:** Ensures an invalid env var value safely falls back to the caller's default.
* **Default Behavior:** Validates that the caller's default is respected when no env var is present.
* **Headless Default:** Confirms the headless caller correctly passes the new 5.0-second default.

**Test Results:** All 13 tests passed successfully (8 existing + 5 new).

---

## Impact
* Container and stdio-backed MCP servers with ~1–2 second startup times are now reliably included in the headless toolset.
* **Operational Flexibility:** Operators requiring longer initialization windows can now easily set `HERMES_MCP_DISCOVERY_WAIT=10` or append `mcp: {discovery_wait: 10}` to `config.yaml` without modifying the codebase.

Fixes #37013