### PR TITLE
fix(tui): re-emit session.info after MCP discovery to fix stale branding

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -213,6 +213,13 @@ def main():
         try:
             from tools.mcp_tool import discover_mcp_tools
             discover_mcp_tools()
+            # Re-emit session.info after MCP discovery so TUI branding
+            # shows accurate status instead of stale 'failed' (issue #37159).
+            try:
+                from tui_gateway.server import _refresh_mcp_status_for_all_sessions
+                _refresh_mcp_status_for_all_sessions()
+            except Exception:
+                pass
         except Exception:
             pass
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -116,6 +116,21 @@ except Exception:
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
 
 _sessions: dict[str, dict] = {}
+
+
+def _refresh_mcp_status_for_all_sessions() -> None:
+   """Re-emit session.info for all active sessions after MCP discovery.
+
+   Called after discover_mcp_tools() completes so the TUI branding shows
+   accurate MCP server status instead of stale "failed" (issue #37159).
+   """
+   for sid, sess in list(_sessions.items()):
+       agent = sess.get("agent")
+       if agent is not None:
+           try:
+               _emit("session.info", sid, _session_info(agent))
+           except Exception:
+               pass
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}


### PR DESCRIPTION
## Problem

TUI branding shows all MCP servers as failed on startup — `session.info` emitted before `discover_mcp_tools()` completes. Status never self-corrects without `/reload-mcp` (issue #37159).

## Fix

1. Add `_refresh_mcp_status_for_all_sessions()` helper in `server.py`
2. Call it after `discover_mcp_tools()` in `entry.py`

This PR is a clean rewrite of #37249 — only TUI-related changes, no unrelated commits.

Fixes #37159