### PR TITLE
api_server: support request toolsets and reasoning deltas

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -149,6 +149,35 @@ def _resolve_request_toolset_override(
     return sorted(set(clean)), None
 
 
+def _api_stream_progress_event(
+    event_type: str,
+    *,
+    message_id: str,
+    tool_name: Optional[str] = None,
+    preview: Optional[str] = None,
+    args: Optional[Any] = None,
+) -> Optional[tuple[str, Dict[str, Any]]]:
+    """Map agent progress callbacks to API stream events.
+
+    Reasoning/thinking progress is not a tool call. Keep it on a separate
+    event name so no-tools clients can safely treat ``tool.*`` as real tool
+    activity instead of tripping over an internal thinking update.
+    """
+    if event_type == "reasoning.available":
+        return "reasoning.available", {
+            "message_id": message_id,
+            "delta": preview or "",
+        }
+    if event_type in {"tool.started", "tool.completed", "tool.failed"}:
+        return event_type, {
+            "message_id": message_id,
+            "tool_name": tool_name,
+            "preview": preview,
+            "args": args,
+        }
+    return None
+
+
 def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     """Normalize boolean-like API payload values.
 
@@ -1713,11 +1742,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 _enqueue("assistant.delta", {"message_id": message_id, "delta": delta})
 
         def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
-            if event_type == "reasoning.available":
-                _enqueue("tool.progress", {"message_id": message_id, "tool_name": tool_name or "_thinking", "delta": preview or ""})
-            elif event_type in {"tool.started", "tool.completed", "tool.failed"}:
-                event_name = event_type.replace("tool.", "tool.")
-                _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
+            mapped = _api_stream_progress_event(
+                event_type,
+                message_id=message_id,
+                tool_name=tool_name,
+                preview=preview,
+                args=args,
+            )
+            if mapped is not None:
+                name, payload = mapped
+                _enqueue(name, payload)
 
         async def _run_and_signal() -> None:
             try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -106,6 +106,49 @@ _TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
 _FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
 
 
+def _resolve_request_toolset_override(
+    body: Dict[str, Any],
+    platform_enabled_toolsets: List[str],
+) -> tuple[Optional[List[str]], Optional[str]]:
+    """Resolve a request-local toolset restriction.
+
+    ``None`` means "use the api_server platform default".  A list, including
+    an empty list, is an explicit per-request restriction.  Requests may only
+    disable tools or restrict to a subset of the platform-enabled toolsets;
+    they cannot expand the API-server tool surface.
+    """
+    requested: Optional[Any] = None
+
+    if "enabled_toolsets" in body:
+        requested = body.get("enabled_toolsets")
+    elif "toolsets" in body:
+        requested = body.get("toolsets")
+    elif body.get("tools") == [] or body.get("tool_choice") == "none":
+        requested = []
+
+    if requested is None:
+        return None, None
+
+    if not isinstance(requested, list):
+        return None, "enabled_toolsets/toolsets must be an array of toolset names"
+
+    clean: List[str] = []
+    for idx, item in enumerate(requested):
+        if not isinstance(item, str):
+            return None, f"enabled_toolsets[{idx}] must be a string"
+        name = item.strip()
+        if not name or re.search(r'[\r\n\x00]', name):
+            return None, f"enabled_toolsets[{idx}] is invalid"
+        clean.append(name)
+
+    platform_enabled = set(platform_enabled_toolsets)
+    unknown = sorted(set(clean) - platform_enabled)
+    if unknown:
+        return None, "Requested toolsets are not enabled for api_server: " + ", ".join(unknown)
+
+    return sorted(set(clean)), None
+
+
 def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     """Normalize boolean-like API payload values.
 
@@ -1007,6 +1050,25 @@ class APIServerAdapter(BasePlatformAdapter):
     # Agent creation helper
     # ------------------------------------------------------------------
 
+    def _get_platform_enabled_toolsets(self) -> List[str]:
+        """Return the configured api_server platform toolsets."""
+        from gateway.run import _load_gateway_config
+        from hermes_cli.tools_config import _get_platform_tools
+
+        return sorted(_get_platform_tools(_load_gateway_config(), "api_server"))
+
+    def _request_toolset_override_response(
+        self,
+        body: Dict[str, Any],
+    ) -> tuple[Optional[List[str]], Optional[Any]]:
+        override, error = _resolve_request_toolset_override(
+            body,
+            self._get_platform_enabled_toolsets(),
+        )
+        if error:
+            return None, web.json_response(_openai_error(error, code="invalid_toolsets"), status=400)
+        return override, None
+
     def _create_agent(
         self,
         ephemeral_system_prompt: Optional[str] = None,
@@ -1016,6 +1078,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1033,15 +1096,17 @@ class APIServerAdapter(BasePlatformAdapter):
         — matching the semantics of the native gateway's ``session_key``.
         """
         from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, GatewayRunner
-        from hermes_cli.tools_config import _get_platform_tools
+        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, GatewayRunner
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
-        user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = (
+            enabled_toolsets_override
+            if enabled_toolsets_override is not None
+            else self._get_platform_enabled_toolsets()
+        )
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -1562,6 +1627,9 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        toolset_override, toolset_err = self._request_toolset_override_response(body)
+        if toolset_err is not None:
+            return toolset_err
         history = self._conversation_history_for_session(session_id)
         result, usage = await self._run_agent(
             user_message=user_message,
@@ -1569,6 +1637,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            enabled_toolsets_override=toolset_override,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = result.get("final_response", "") if isinstance(result, dict) else ""
@@ -1606,6 +1675,9 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        toolset_override, toolset_err = self._request_toolset_override_response(body)
+        if toolset_err is not None:
+            return toolset_err
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -1660,6 +1732,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    enabled_toolsets_override=toolset_override,
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -1843,6 +1916,9 @@ class APIServerAdapter(BasePlatformAdapter):
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
         created = int(time.time())
+        toolset_override, toolset_err = self._request_toolset_override_response(body)
+        if toolset_err is not None:
+            return toolset_err
 
         if stream:
             import queue as _q
@@ -1926,6 +2002,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=toolset_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -1945,11 +2022,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=toolset_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "toolsets", "enabled_toolsets", "stream"])
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -2906,6 +2984,9 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id = stored_session_id or str(uuid.uuid4())
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+        toolset_override, toolset_err = self._request_toolset_override_response(body)
+        if toolset_err is not None:
+            return toolset_err
         if stream:
             # Streaming branch — emit OpenAI Responses SSE events as the
             # agent runs so frontends can render text deltas and tool
@@ -2958,6 +3039,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=toolset_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2991,13 +3073,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=toolset_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools", "tool_choice", "toolsets", "enabled_toolsets"],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -3501,6 +3584,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3533,6 +3617,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_start_callback=tool_start_callback,
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
+                    enabled_toolsets_override=enabled_toolsets_override,
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent
@@ -3710,6 +3795,9 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id = body.get("session_id") or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
+        toolset_override, toolset_err = self._request_toolset_override_response(body)
+        if toolset_err is not None:
+            return toolset_err
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         created_at = time.time()
@@ -3750,6 +3838,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
+                    enabled_toolsets_override=toolset_override,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server_request_toolsets.py
+++ b/tests/gateway/test_api_server_request_toolsets.py
@@ -46,6 +46,40 @@ def test_request_can_restrict_to_enabled_subset_only():
     assert error is None
 
 
+def test_api_stream_progress_event_keeps_reasoning_separate_from_tool_events():
+    mapped = api_server._api_stream_progress_event(
+        "reasoning.available",
+        message_id="msg_1",
+        tool_name="_thinking",
+        preview="thinking text",
+    )
+
+    assert mapped == (
+        "reasoning.available",
+        {"message_id": "msg_1", "delta": "thinking text"},
+    )
+
+
+def test_api_stream_progress_event_preserves_real_tool_events():
+    mapped = api_server._api_stream_progress_event(
+        "tool.started",
+        message_id="msg_1",
+        tool_name="terminal",
+        preview="ls",
+        args={"command": "ls"},
+    )
+
+    assert mapped == (
+        "tool.started",
+        {
+            "message_id": "msg_1",
+            "tool_name": "terminal",
+            "preview": "ls",
+            "args": {"command": "ls"},
+        },
+    )
+
+
 def test_request_toolset_override_rejects_expansion_beyond_platform_surface():
     override, error = api_server._resolve_request_toolset_override(
         {"enabled_toolsets": ["web", "terminal"]},

--- a/tests/gateway/test_api_server_request_toolsets.py
+++ b/tests/gateway/test_api_server_request_toolsets.py
@@ -1,0 +1,271 @@
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms import api_server
+
+
+def test_request_toolsets_absent_keeps_platform_default():
+    override, error = api_server._resolve_request_toolset_override(
+        {},
+        platform_enabled_toolsets=["web", "terminal"],
+    )
+
+    assert override is None
+    assert error is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"tools": []},
+        {"tool_choice": "none"},
+        {"enabled_toolsets": []},
+        {"toolsets": []},
+    ],
+)
+def test_request_can_disable_all_tools(body):
+    override, error = api_server._resolve_request_toolset_override(
+        body,
+        platform_enabled_toolsets=["web", "terminal"],
+    )
+
+    assert override == []
+    assert error is None
+
+
+def test_request_can_restrict_to_enabled_subset_only():
+    override, error = api_server._resolve_request_toolset_override(
+        {"enabled_toolsets": ["web"]},
+        platform_enabled_toolsets=["web", "terminal"],
+    )
+
+    assert override == ["web"]
+    assert error is None
+
+
+def test_request_toolset_override_rejects_expansion_beyond_platform_surface():
+    override, error = api_server._resolve_request_toolset_override(
+        {"enabled_toolsets": ["web", "terminal"]},
+        platform_enabled_toolsets=["web"],
+    )
+
+    assert override is None
+    assert error is not None
+    assert "not enabled for api_server" in error
+
+
+def test_request_toolset_override_rejects_invalid_shape():
+    override, error = api_server._resolve_request_toolset_override(
+        {"enabled_toolsets": "web"},
+        platform_enabled_toolsets=["web"],
+    )
+
+    assert override is None
+    assert error is not None
+    assert "must be an array" in error
+
+
+class FakeResponse:
+    def __init__(self, data=None, *, status=200, headers=None):
+        self.data = data
+        self.status = status
+        self.headers = headers or {}
+
+
+class FakeWeb:
+    @staticmethod
+    def json_response(data=None, *, status=200, headers=None):
+        return FakeResponse(data, status=status, headers=headers)
+
+
+class FakeRequest:
+    def __init__(self, body, *, headers=None, match_info=None):
+        self._body = body
+        self.headers = headers or {}
+        self.match_info = match_info or {}
+        self.transport = None
+        self.remote = "127.0.0.1"
+        self.method = "POST"
+        self.path_qs = "/test"
+
+    async def json(self):
+        return self._body
+
+
+def _minimal_adapter(monkeypatch):
+    monkeypatch.setattr(api_server, "web", FakeWeb)
+    adapter = object.__new__(api_server.APIServerAdapter)
+    adapter._api_key = ""
+    adapter._model_name = "test-model"
+    adapter._background_tasks = set()
+    adapter._get_platform_enabled_toolsets = lambda: ["web", "terminal"]
+    adapter._parse_session_key_header = lambda request: (None, None)
+    return adapter
+
+
+def test_chat_completions_handler_passes_empty_tool_override(monkeypatch):
+    async def run_case():
+        captured = {}
+        adapter = _minimal_adapter(monkeypatch)
+
+        async def fake_run_agent(**kwargs):
+            captured.update(kwargs)
+            return {"final_response": "ok", "completed": True, "session_id": "sid"}, {}
+
+        adapter._run_agent = fake_run_agent
+        request = FakeRequest({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "probe"}],
+            "tools": [],
+        })
+
+        response = await adapter._handle_chat_completions(request)
+
+        assert response.status == 200
+        assert captured["enabled_toolsets_override"] == []
+
+    asyncio.run(run_case())
+
+
+def test_responses_handler_passes_empty_tool_override(monkeypatch):
+    async def run_case():
+        captured = {}
+        adapter = _minimal_adapter(monkeypatch)
+
+        async def fake_run_agent(**kwargs):
+            captured.update(kwargs)
+            return {"final_response": "ok", "completed": True, "messages": []}, {}
+
+        adapter._run_agent = fake_run_agent
+        request = FakeRequest({
+            "model": "test-model",
+            "input": "probe",
+            "store": False,
+            "enabled_toolsets": [],
+        })
+
+        response = await adapter._handle_responses(request)
+
+        assert response.status == 200
+        assert captured["enabled_toolsets_override"] == []
+
+    asyncio.run(run_case())
+
+
+def test_session_chat_handler_passes_empty_tool_override(monkeypatch):
+    async def run_case():
+        captured = {}
+        adapter = _minimal_adapter(monkeypatch)
+        adapter._get_existing_session_or_404 = lambda session_id: ({"id": session_id}, None)
+        adapter._conversation_history_for_session = lambda session_id: []
+
+        async def fake_run_agent(**kwargs):
+            captured.update(kwargs)
+            return {"final_response": "ok", "completed": True, "session_id": "sid"}, {}
+
+        adapter._run_agent = fake_run_agent
+        request = FakeRequest(
+            {"message": "probe", "toolsets": []},
+            match_info={"session_id": "sid"},
+        )
+
+        response = await adapter._handle_session_chat(request)
+
+        assert response.status == 200
+        assert captured["enabled_toolsets_override"] == []
+
+    asyncio.run(run_case())
+
+
+def test_runs_handler_passes_empty_tool_override_to_created_agent(monkeypatch):
+    async def run_case():
+        captured = {}
+        adapter = _minimal_adapter(monkeypatch)
+        adapter._response_store = SimpleNamespace(get=lambda response_id: None)
+        adapter._run_streams = {}
+        adapter._run_streams_created = {}
+        adapter._active_run_agents = {}
+        adapter._active_run_tasks = {}
+        adapter._run_statuses = {}
+        adapter._run_approval_sessions = {}
+
+        class FakeAgent:
+            def run_conversation(self, **kwargs):
+                return {"final_response": "ok", "completed": True, "messages": []}
+
+        def fake_create_agent(**kwargs):
+            captured.update(kwargs)
+            return FakeAgent()
+
+        adapter._create_agent = fake_create_agent
+        request = FakeRequest({"input": "probe", "tool_choice": "none"})
+
+        response = await adapter._handle_runs(request)
+        await asyncio.sleep(0.05)
+
+        assert response.status == 202
+        assert captured["enabled_toolsets_override"] == []
+
+    asyncio.run(run_case())
+
+
+def _install_fake_gateway_run(monkeypatch):
+    class FakeGatewayRunner:
+        @staticmethod
+        def _load_reasoning_config():
+            return None
+
+        @staticmethod
+        def _load_fallback_model():
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "gateway.run",
+        SimpleNamespace(
+            _resolve_runtime_agent_kwargs=lambda: {"api_key": "key", "base_url": "http://example.test"},
+            _resolve_gateway_model=lambda: "test-model",
+            GatewayRunner=FakeGatewayRunner,
+        ),
+    )
+
+
+def test_create_agent_uses_request_local_toolset_override(monkeypatch):
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=FakeAIAgent))
+    _install_fake_gateway_run(monkeypatch)
+
+    adapter = object.__new__(api_server.APIServerAdapter)
+    adapter._ensure_session_db = lambda: None
+    adapter._get_platform_enabled_toolsets = lambda: ["web", "terminal"]
+
+    adapter._create_agent(enabled_toolsets_override=[])
+
+    assert captured["enabled_toolsets"] == []
+
+
+def test_create_agent_defaults_to_platform_toolsets_when_no_override(monkeypatch):
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=FakeAIAgent))
+    _install_fake_gateway_run(monkeypatch)
+
+    adapter = object.__new__(api_server.APIServerAdapter)
+    adapter._ensure_session_db = lambda: None
+    adapter._get_platform_enabled_toolsets = lambda: ["web", "terminal"]
+
+    adapter._create_agent()
+
+    assert captured["enabled_toolsets"] == ["web", "terminal"]

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -330,7 +330,8 @@ async def test_session_chat_stream_emits_lifecycle_events_and_keepalive_safe_sha
     assert "event: message.started" in body
     assert "event: assistant.delta" in body
     assert "Hello world" in body
-    assert "event: tool.progress" in body
+    assert "event: reasoning.available" in body
+    assert "event: tool.progress" not in body
     assert "event: assistant.completed" in body
     assert "event: run.completed" in body
     assert "event: done" in body


### PR DESCRIPTION
## Summary
- lets `/v1/chat/completions`, `/v1/responses`, and direct agent API calls restrict enabled toolsets per request with `enabled_toolsets`/`toolsets`
- preserves the configured API-server tool surface as the maximum allowed set, including support for `[]` to run without tools
- emits reasoning stream updates as reasoning deltas instead of tool-call deltas so clients can distinguish thinking from tool execution

## Validation
- `/home/manfred/.local/bin/hermes-python -m pytest tests/gateway/test_api_server_request_toolsets.py -q` → 16 passed
- `/home/manfred/.local/bin/hermes-python -m compileall -q gateway/platforms/api_server.py`
- `git diff --check origin/main...HEAD`
- added-line hygiene scan: no private/local markers; only masked test `api_key` fixture strings matched the generic secret-like pattern
