### PR TITLE
fix(bedrock): use Claude native output limits

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -560,7 +560,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
-            max_tokens=agent.max_tokens or 4096,
+            max_tokens=agent.max_tokens,
             region=region,
             guardrail_config=guardrail,
         )

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -41,21 +41,32 @@ class BedrockTransport(ProviderTransport):
         Calls convert_messages and convert_tools internally.
 
         params:
-            max_tokens: int — output token limit (default 4096)
+            max_tokens: int | None — output token limit. When unset, Anthropic
+                Bedrock models use the same native output ceiling as the direct
+                Anthropic transport instead of a small transport-local cap.
             temperature: float | None
             guardrail_config: dict | None — Bedrock guardrails
             region: str — AWS region (default 'us-east-1')
         """
+        from agent.anthropic_adapter import _resolve_anthropic_messages_max_tokens
         from agent.bedrock_adapter import build_converse_kwargs
 
         region = params.get("region", "us-east-1")
         guardrail = params.get("guardrail_config")
+        model_lower = model.lower()
+        if "anthropic." in model_lower or "claude-" in model_lower:
+            max_tokens = _resolve_anthropic_messages_max_tokens(
+                params.get("max_tokens"), model
+            )
+        else:
+            requested_max_tokens = params.get("max_tokens")
+            max_tokens = requested_max_tokens if requested_max_tokens is not None else 4096
 
         kwargs = build_converse_kwargs(
             model=model,
             messages=messages,
             tools=tools,
-            max_tokens=params.get("max_tokens", 4096),
+            max_tokens=max_tokens,
             temperature=params.get("temperature"),
             guardrail_config=guardrail,
         )

--- a/tests/agent/test_bedrock_transport.py
+++ b/tests/agent/test_bedrock_transport.py
@@ -1,0 +1,69 @@
+"""Tests for Bedrock Converse transport request construction."""
+
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import build_api_kwargs
+from agent.transports.bedrock import BedrockTransport
+
+
+_MESSAGES = [{"role": "user", "content": "please write a long report"}]
+
+
+def _max_tokens_for(model: str, **params) -> int:
+    kwargs = BedrockTransport().build_kwargs(
+        model=model,
+        messages=_MESSAGES,
+        **params,
+    )
+    return kwargs["inferenceConfig"]["maxTokens"]
+
+
+def test_bedrock_converse_defaults_sonnet_46_to_native_output_limit():
+    assert _max_tokens_for("global.anthropic.claude-sonnet-4-6") == 64_000
+
+
+def test_bedrock_converse_defaults_opus_48_to_native_output_limit():
+    assert _max_tokens_for("anthropic.claude-opus-4-8") == 128_000
+
+
+def test_bedrock_converse_preserves_explicit_max_tokens():
+    assert _max_tokens_for(
+        "global.anthropic.claude-sonnet-4-6",
+        max_tokens=12_345,
+    ) == 12_345
+
+
+def test_bedrock_converse_keeps_existing_default_for_non_anthropic_models():
+    assert _max_tokens_for("amazon.nova-pro-v1:0") == 4096
+
+
+def test_bedrock_agent_build_api_kwargs_passes_unset_max_tokens_to_transport():
+    agent = SimpleNamespace(
+        api_mode="bedrock_converse",
+        tools=[],
+        model="global.anthropic.claude-sonnet-4-6",
+        max_tokens=None,
+        _bedrock_region="eu-west-1",
+        _bedrock_guardrail_config=None,
+    )
+    agent._get_transport = BedrockTransport
+
+    kwargs = build_api_kwargs(agent, _MESSAGES)
+
+    assert kwargs["inferenceConfig"]["maxTokens"] == 64_000
+
+
+def test_bedrock_agent_build_api_kwargs_keeps_non_anthropic_default_when_unset():
+    agent = SimpleNamespace(
+        api_mode="bedrock_converse",
+        tools=[],
+        model="amazon.nova-pro-v1:0",
+        max_tokens=None,
+        _bedrock_region="us-east-1",
+        _bedrock_guardrail_config=None,
+    )
+    agent._get_transport = BedrockTransport
+
+    kwargs = build_api_kwargs(agent, _MESSAGES)
+
+    assert kwargs["inferenceConfig"]["maxTokens"] == 4096


### PR DESCRIPTION
## Summary
- Let the real `bedrock_converse` agent path pass an unset `max_tokens` through to the Bedrock transport instead of forcing `4096`
- Default Anthropic/Claude Bedrock model IDs to the direct-Anthropic native output ceilings when unset (`64K` for Sonnet 4.6, `128K` for Opus 4.8)
- Preserve explicit `max_tokens` and keep non-Anthropic Bedrock models on the prior `4096` default

Closes #37298

## Test Plan
- RED: `/Users/girthtender/.hermes/hermes-agent/.venv/bin/python -m pytest tests/agent/test_bedrock_transport.py -q` showed the new Bedrock transport and caller-path regressions failing before each fix
- GREEN: `/Users/girthtender/.hermes/hermes-agent/.venv/bin/python -m pytest tests/agent/test_bedrock_transport.py tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/test_ctx_halving_fix.py -q` → `206 passed`
- `git diff --check`

## Review
- Subagent spec/code review: PASS after adding the caller-path and non-Anthropic `None` guard tests
