### PR TITLE
fix(gateway): use launchd service path for in-chat restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,26 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+
+def _running_under_gateway_service_manager() -> bool:
+    """Return True when this gateway process is owned by a service manager.
+
+    systemd exposes ``INVOCATION_ID``.  macOS launchd does not, but LaunchAgents
+    set ``XPC_SERVICE_NAME`` to the job label.  Treat Hermes' launchd labels as
+    service-managed so in-chat restarts use the service restart path instead of
+    a fragile detached shell helper.  This is especially important for launchd
+    plists with ``KeepAlive.SuccessfulExit=false``: a planned restart must exit
+    non-zero so launchd starts the gateway again.
+    """
+    if os.environ.get("INVOCATION_ID"):
+        return True
+    if sys.platform == "darwin":
+        xpc_service_name = os.environ.get("XPC_SERVICE_NAME", "")
+        return xpc_service_name == "ai.hermes.gateway" or xpc_service_name.startswith(
+            "ai.hermes.gateway-"
+        )
+    return False
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -10646,7 +10666,7 @@ class GatewayRunner:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _under_service = _running_under_gateway_service_manager()
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/tests/gateway/test_restart_redelivery_dedup.py
+++ b/tests/gateway/test_restart_redelivery_dedup.py
@@ -153,6 +153,7 @@ async def test_no_marker_file_allows_restart(tmp_path, monkeypatch):
     """Clean gateway start (no prior marker) processes /restart normally."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
@@ -162,6 +163,40 @@ async def test_no_marker_file_allows_restart(tmp_path, monkeypatch):
 
     assert "Restarting gateway" in result
     runner.request_restart.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_restart_uses_service_path_under_launchd(tmp_path, monkeypatch):
+    """macOS LaunchAgent gateways must not rely on detached restart helpers."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    result = await runner._handle_restart_command(_make_restart_event(update_id=100))
+
+    assert "Restarting gateway" in result
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_uses_service_path_under_profile_launchd(tmp_path, monkeypatch):
+    """Profile-scoped launchd labels get the same service-managed restart path."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway-work")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    result = await runner._handle_restart_command(_make_restart_event(update_id=100))
+
+    assert "Restarting gateway" in result
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Detect macOS LaunchAgent-owned gateways via XPC_SERVICE_NAME, not only systemd's INVOCATION_ID
- Route in-chat /restart through the service-managed restart path under launchd
- Add regression coverage for default and profile-scoped launchd labels

## Test plan
- venv/bin/python -m py_compile gateway/run.py
- venv/bin/python -m pytest tests/gateway/test_restart_redelivery_dedup.py -q
- venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_restart_drains_running_gateway_before_kickstart tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_restart_self_requests_graceful_restart_without_kickstart tests/gateway/test_restart_redelivery_dedup.py::test_restart_uses_service_path_under_launchd tests/gateway/test_restart_redelivery_dedup.py::test_restart_uses_service_path_under_profile_launchd -q

## Manual verification
- Recovered local launchd gateway with hermes gateway start
- Verified hermes gateway restart leaves launchd loaded and running with PID