### PR TITLE
feat(web): harden SearXNG provider fallbacks

### DIFF
--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -15,20 +15,108 @@ Config keys this provider responds to::
       search_backend: "searxng"     # explicit per-capability
       backend: "searxng"            # shared fallback
 
-Env var::
+Env vars::
 
     SEARXNG_URL=http://localhost:8080
+    SEARXNG_GENERAL_ENGINES=bing,mojeek,presearch
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict
+from html.parser import HTMLParser
+from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
+
+_NEWS_HINTS = (
+    "news",
+    "headlines",
+    "breaking",
+    "latest",
+    "today",
+    "recent",
+    "current",
+    "updates",
+)
+_DEFAULT_GENERAL_ENGINES = "bing,mojeek,presearch"
+
+
+class _SearXNGHTMLParser(HTMLParser):
+    """Small dependency-free parser for SearXNG HTML result pages."""
+
+    def __init__(self, limit: int):
+        super().__init__()
+        self.limit = limit
+        self.results: List[Dict[str, Any]] = []
+        self._in_article = False
+        self._in_title_link = False
+        self._in_content = False
+        self._current: Dict[str, str] = {}
+        self._title_chunks: List[str] = []
+        self._content_chunks: List[str] = []
+
+    @staticmethod
+    def _classes(attrs: list[tuple[str, str | None]]) -> set[str]:
+        for key, value in attrs:
+            if key == "class" and value:
+                return set(value.split())
+        return set()
+
+    @staticmethod
+    def _attr(attrs: list[tuple[str, str | None]], name: str) -> str:
+        for key, value in attrs:
+            if key == name and value:
+                return value
+        return ""
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if len(self.results) >= self.limit:
+            return
+        classes = self._classes(attrs)
+        if tag == "article" and "result" in classes:
+            self._in_article = True
+            self._current = {}
+            self._title_chunks = []
+            self._content_chunks = []
+            return
+        if not self._in_article:
+            return
+        if tag == "a" and not self._current.get("url"):
+            href = self._attr(attrs, "href")
+            if href:
+                self._current["url"] = href
+                self._in_title_link = True
+        elif tag == "p" and "content" in classes:
+            self._in_content = True
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title_link:
+            self._title_chunks.append(data)
+        elif self._in_content:
+            self._content_chunks.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._in_title_link:
+            self._in_title_link = False
+        elif tag == "p" and self._in_content:
+            self._in_content = False
+        elif tag == "article" and self._in_article:
+            self._in_article = False
+            title = " ".join("".join(self._title_chunks).split())
+            url = self._current.get("url", "")
+            if title and url:
+                self.results.append(
+                    {
+                        "title": title,
+                        "url": url,
+                        "content": " ".join("".join(self._content_chunks).split()),
+                        "score": 0,
+                    }
+                )
 
 
 class SearXNGWebSearchProvider(WebSearchProvider):
@@ -52,77 +140,168 @@ class SearXNGWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
-        """Execute a search against the configured SearXNG instance."""
-        import httpx
+    def _base_url(self) -> str:
+        return os.getenv("SEARXNG_URL", "").strip().rstrip("/")
 
-        base_url = os.getenv("SEARXNG_URL", "").strip().rstrip("/")
-        if not base_url:
-            return {"success": False, "error": "SEARXNG_URL is not set"}
+    def _general_engines(self) -> str:
+        """Return comma-separated engines for general queries.
 
+        Many self-hosted SearXNG instances have default general engines that are
+        CAPTCHA/rate-limit prone. A known-good default improves fresh installs,
+        while ``SEARXNG_GENERAL_ENGINES=`` lets operators opt out.
+        """
+        return os.getenv("SEARXNG_GENERAL_ENGINES", _DEFAULT_GENERAL_ENGINES).strip()
+
+    def _looks_like_news_query(self, query: str) -> bool:
+        q = query.lower()
+        return any(hint in q for hint in _NEWS_HINTS)
+
+    def _json_params(self, query: str, *, category: str = "general", language: str = "en", engines: str = "") -> Dict[str, Any]:
         params: Dict[str, Any] = {
             "q": query,
             "format": "json",
             "pageno": 1,
         }
+        if category:
+            params["categories"] = category
+        if language:
+            params["language"] = language
+        if engines and category == "general":
+            params["engines"] = engines
+        return params
 
-        try:
-            resp = httpx.get(
-                f"{base_url}/search",
-                params=params,
-                timeout=15,
-                headers={"Accept": "application/json"},
-            )
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            logger.warning("SearXNG HTTP error: %s", exc)
-            return {
-                "success": False,
-                "error": f"SearXNG returned HTTP {exc.response.status_code}",
-            }
-        except httpx.RequestError as exc:
-            logger.warning("SearXNG request error: %s", exc)
-            return {
-                "success": False,
-                "error": f"Could not reach SearXNG at {base_url}: {exc}",
-            }
+    def _request_json(self, base_url: str, params: Dict[str, Any]) -> tuple[list[dict], dict]:
+        import httpx
 
-        try:
-            data = resp.json()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("SearXNG response parse error: %s", exc)
-            return {
-                "success": False,
-                "error": "Could not parse SearXNG response as JSON",
-            }
-
+        resp = httpx.get(
+            f"{base_url}/search",
+            params=params,
+            timeout=15,
+            headers={"Accept": "application/json"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
         raw_results = data.get("results", [])
+        if not isinstance(raw_results, list):
+            raw_results = []
+        return raw_results, data
 
-        # SearXNG may return a score field; sort descending and cap to limit.
-        sorted_results = sorted(
-            raw_results,
-            key=lambda r: float(r.get("score", 0)),
-            reverse=True,
-        )[:limit]
+    def _request_html(self, base_url: str, query: str, limit: int) -> list[dict]:
+        import httpx
 
-        web_results = [
+        resp = httpx.get(
+            f"{base_url}/search",
+            params={"q": query},
+            timeout=15,
+            headers={"Accept": "text/html"},
+        )
+        resp.raise_for_status()
+        parser = _SearXNGHTMLParser(limit=limit)
+        parser.feed(resp.text)
+        return parser.results
+
+    def _normalize_results(self, raw_results: list[dict], limit: int) -> list[dict]:
+        def _score(result: dict) -> float:
+            try:
+                return float(result.get("score", 0))
+            except (TypeError, ValueError):
+                return 0.0
+
+        valid_results = [r for r in raw_results if r.get("url")]
+        sorted_results = sorted(valid_results, key=_score, reverse=True)[:limit]
+        return [
             {
                 "title": str(r.get("title", "")),
                 "url": str(r.get("url", "")),
-                "description": str(r.get("content", "")),
+                "description": str(r.get("content", "") or r.get("snippet", "")),
                 "position": i + 1,
             }
             for i, r in enumerate(sorted_results)
         ]
 
-        logger.info(
-            "SearXNG search '%s': %d results (from %d raw, limit %d)",
-            query,
-            len(web_results),
-            len(raw_results),
-            limit,
-        )
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a search against the configured SearXNG instance.
 
+        The provider tries the JSON API first, then retries common self-hosted
+        SearXNG failure modes before falling back to parsing the HTML result
+        page. The returned shape stays compatible with other Hermes web
+        providers: ``{"success": True, "data": {"web": [...]}}``.
+        """
+        import httpx
+
+        base_url = self._base_url()
+        if not base_url:
+            return {"success": False, "error": "SEARXNG_URL is not set"}
+
+        general_engines = self._general_engines()
+        attempts: list[tuple[str, Dict[str, Any]]] = []
+        if self._looks_like_news_query(query):
+            attempts.append(("news", self._json_params(query, category="news", language="en")))
+            attempts.append(("news-fallback-general", self._json_params(query, category="general", language="en", engines=general_engines)))
+        else:
+            attempts.append(("general", self._json_params(query, category="general", language="en", engines=general_engines)))
+
+        attempts.append(("without-language", self._json_params(query, category="general", language="", engines=general_engines)))
+        if general_engines:
+            attempts.append(("default-engines", self._json_params(query, category="general", language="en", engines="")))
+
+        last_error = ""
+        last_data: dict = {}
+        raw_results: list[dict] = []
+        for label, params in attempts:
+            try:
+                raw_results, last_data = self._request_json(base_url, params)
+                if any(r.get("url") for r in raw_results):
+                    logger.info("SearXNG %s search returned %d raw results for %r", label, len(raw_results), query)
+                    break
+                if raw_results:
+                    logger.info(
+                        "SearXNG %s search returned %d URL-less raw results for %r; continuing fallbacks",
+                        label,
+                        len(raw_results),
+                        query,
+                    )
+                unresponsive = last_data.get("unresponsive_engines") if isinstance(last_data, dict) else None
+                if unresponsive:
+                    logger.info("SearXNG %s search had unresponsive engines for %r: %s", label, query, unresponsive)
+            except httpx.HTTPStatusError as exc:
+                logger.warning("SearXNG HTTP error during %s attempt: %s", label, exc)
+                last_error = f"SearXNG returned HTTP {exc.response.status_code}"
+                continue
+            except httpx.RequestError as exc:
+                logger.warning("SearXNG request error during %s attempt: %s", label, exc)
+                last_error = f"Could not reach SearXNG at {base_url}: {exc}"
+                break
+            except Exception as exc:  # noqa: BLE001 - JSON parse and malformed response fallback to HTML
+                logger.warning("SearXNG JSON attempt %s failed: %s", label, exc)
+                last_error = "Could not parse SearXNG response as JSON"
+                break
+
+        has_usable_raw_results = any(r.get("url") for r in raw_results)
+        should_try_html = not has_usable_raw_results and (
+            not last_error or last_error.startswith("Could not parse SearXNG response")
+        )
+        if should_try_html:
+            logger.info("SearXNG JSON attempts produced no usable results for %r; trying HTML fallback", query)
+            try:
+                raw_results = self._request_html(base_url, query, limit)
+                if raw_results:
+                    last_error = ""
+            except httpx.HTTPStatusError as exc:
+                logger.warning("SearXNG HTML fallback HTTP error: %s", exc)
+                last_error = f"SearXNG returned HTTP {exc.response.status_code}"
+            except httpx.RequestError as exc:
+                logger.warning("SearXNG HTML fallback request error: %s", exc)
+                last_error = f"Could not reach SearXNG at {base_url}: {exc}"
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("SearXNG HTML fallback parse error: %s", exc)
+                last_error = "Could not parse SearXNG response as JSON or HTML"
+
+        if last_error and not raw_results:
+            return {"success": False, "error": last_error}
+
+        web_results = self._normalize_results(raw_results, limit)
+        logger.info("SearXNG search '%s': %d results (from %d raw, limit %d)", query, len(web_results), len(raw_results), limit)
         return {"success": True, "data": {"web": web_results}}
 
     def get_setup_schema(self) -> Dict[str, Any]:
@@ -135,6 +314,11 @@ class SearXNGWebSearchProvider(WebSearchProvider):
                     "key": "SEARXNG_URL",
                     "prompt": "SearXNG instance URL (e.g. http://localhost:8080)",
                     "url": "https://searx.space/",
+                },
+                {
+                    "key": "SEARXNG_GENERAL_ENGINES",
+                    "prompt": "Optional comma-separated general engines (default: bing,mojeek,presearch; blank disables pinning)",
+                    "url": "https://docs.searxng.org/user/search-syntax.html",
                 },
             ],
         }

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -138,6 +138,25 @@ class TestSearXNGSearchProviderSearch:
         assert result["success"] is True
         assert result["data"]["web"] == []
 
+    def test_url_less_high_score_result_does_not_consume_limit(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+        data = {
+            "results": [
+                {"title": "No URL", "content": "ignored", "score": 100},
+                {"title": "Valid one", "url": "https://one.example.com", "content": "", "score": 0.9},
+                {"title": "Valid two", "url": "https://two.example.com", "content": "", "score": 0.8},
+            ]
+        }
+        mock_resp = self._make_mock_response(data)
+
+        with patch("httpx.get", return_value=mock_resp):
+            result = SearXNGWebSearchProvider().search("query", limit=2)
+
+        assert result["success"] is True
+        titles = [item["title"] for item in result["data"]["web"]]
+        assert titles == ["Valid one", "Valid two"]
+
     def test_missing_score_falls_back_to_zero(self, monkeypatch):
         """Results without a score field should sort to the bottom."""
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
@@ -327,3 +346,271 @@ class TestSearXNGOnlyExtractCrawlErrors:
         result = json.loads(result_str)
         assert result["success"] is False
         assert "search-only" in result["error"].lower() or "SearXNG" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# SearXNG hardening: fallback attempts and HTML fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSearXNGSearchProviderFallbacks:
+    def _make_mock_response(self, json_data, status_code=200, text=""):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.text = text
+        mock_resp.json.return_value = json_data
+        mock_resp.raise_for_status = MagicMock()
+        return mock_resp
+
+    def test_general_search_uses_default_engine_pinning(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [{"title": "Pinned", "url": "https://example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            return mock_resp
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("normal query", limit=5)
+
+        assert result["success"] is True
+        assert calls[0]["categories"] == "general"
+        assert calls[0]["language"] == "en"
+        assert calls[0]["engines"] == "bing,mojeek,presearch"
+
+    def test_custom_general_engines_env_is_respected(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        monkeypatch.setenv("SEARXNG_GENERAL_ENGINES", "brave,duckduckgo")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        mock_resp = self._make_mock_response({
+            "results": [{"title": "Custom", "url": "https://example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            return mock_resp
+
+        with patch("httpx.get", side_effect=capture_get):
+            SearXNGWebSearchProvider().search("normal query", limit=5)
+
+        assert calls[0]["engines"] == "brave,duckduckgo"
+
+    def test_news_query_retries_general_when_news_category_http_errors(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        error_resp = MagicMock()
+        error_resp.status_code = 400
+        news_error = httpx.HTTPStatusError("bad category", request=MagicMock(), response=error_resp)
+        general_hit = self._make_mock_response({
+            "results": [{"title": "General after news error", "url": "https://news.example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            if len(calls) == 1:
+                raise news_error
+            return general_hit
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("latest ai news", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "General after news error"
+        assert calls[0]["categories"] == "news"
+        assert calls[1]["categories"] == "general"
+
+    def test_news_query_retries_general_engines_when_news_empty(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        empty_news = self._make_mock_response({"results": []})
+        general_hit = self._make_mock_response({
+            "results": [{"title": "Fallback", "url": "https://news.example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            return empty_news if len(calls) == 1 else general_hit
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("latest ai news", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Fallback"
+        assert calls[0]["categories"] == "news"
+        assert calls[1]["categories"] == "general"
+        assert calls[1]["engines"] == "bing,mojeek,presearch"
+
+    def test_pinned_general_engine_http_error_retries_without_language(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        error_resp = MagicMock()
+        error_resp.status_code = 400
+        engine_error = httpx.HTTPStatusError("bad engines", request=MagicMock(), response=error_resp)
+        no_language_hit = self._make_mock_response({
+            "results": [{"title": "Recovered", "url": "https://example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            if len(calls) == 1:
+                raise engine_error
+            return no_language_hit
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("normal query", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Recovered"
+        assert calls[0]["engines"] == "bing,mojeek,presearch"
+        assert "language" not in calls[1]
+
+    def test_language_pinned_empty_retries_without_language(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        empty = self._make_mock_response({"results": []})
+        no_language_hit = self._make_mock_response({
+            "results": [{"title": "No lang", "url": "https://example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            return no_language_hit if len(calls) == 2 else empty
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("normal query", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "No lang"
+        assert "language" in calls[0]
+        assert "language" not in calls[1]
+
+    def test_pinned_engines_empty_retries_default_engines(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        empty = self._make_mock_response({"results": []})
+        default_engine_hit = self._make_mock_response({
+            "results": [{"title": "Default engines", "url": "https://example.com", "content": "ok", "score": 1}]
+        })
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs["params"])
+            return default_engine_hit if len(calls) == 3 else empty
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("normal query", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Default engines"
+        assert "engines" in calls[0]
+        assert "engines" in calls[1]
+        assert "engines" not in calls[2]
+
+    def test_html_fallback_when_json_parse_fails(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        bad_json_resp = self._make_mock_response({})
+        bad_json_resp.json.side_effect = ValueError("not json")
+        html = """
+        <html><body>
+          <article class="result">
+            <h3><a href="https://html-parse.example.com">HTML After Bad JSON</a></h3>
+            <p class="content">Recovered from HTML</p>
+          </article>
+        </body></html>
+        """
+        html_resp = self._make_mock_response({}, text=html)
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs)
+            return html_resp if kwargs.get("headers", {}).get("Accept") == "text/html" else bad_json_resp
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("parse fallback", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "HTML After Bad JSON"
+        assert calls[-1]["headers"]["Accept"] == "text/html"
+
+    def test_url_less_json_results_continue_to_html_fallback(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        url_less_json = self._make_mock_response({
+            "results": [{"title": "No URL", "content": "not usable", "score": 10}]
+        })
+        html = """
+        <html><body>
+          <article class="result">
+            <h3><a href="https://usable.example.com">Usable Fallback</a></h3>
+            <p class="content">usable html snippet</p>
+          </article>
+        </body></html>
+        """
+        html_resp = self._make_mock_response({}, text=html)
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs)
+            return html_resp if kwargs.get("headers", {}).get("Accept") == "text/html" else url_less_json
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("url less", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Usable Fallback"
+        assert calls[-1]["headers"]["Accept"] == "text/html"
+
+    def test_html_fallback_when_json_attempts_return_empty(self, monkeypatch):
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        empty = self._make_mock_response({"results": []})
+        html = """
+        <html><body>
+          <article class="result">
+            <h3><a href="https://html.example.com">HTML Result</a></h3>
+            <p class="content">HTML snippet</p>
+          </article>
+        </body></html>
+        """
+        html_resp = self._make_mock_response({}, text=html)
+        calls = []
+
+        def capture_get(url, **kwargs):
+            calls.append(kwargs)
+            return html_resp if kwargs.get("headers", {}).get("Accept") == "text/html" else empty
+
+        with patch("httpx.get", side_effect=capture_get):
+            result = SearXNGWebSearchProvider().search("nothing", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"] == [
+            {
+                "title": "HTML Result",
+                "url": "https://html.example.com",
+                "description": "HTML snippet",
+                "position": 1,
+            }
+        ]
+        assert calls[-1]["headers"]["Accept"] == "text/html"


### PR DESCRIPTION
## Summary
- Add resilient SearXNG search retries for self-hosted instances.
- Pin known-good general engines by default, configurable with `SEARXNG_GENERAL_ENGINES`.
- Detect news/fresh queries and try SearXNG news category first.
- Retry empty or rejected searches through safer fallback variants.
- Add dependency-free HTML fallback when JSON results are empty/malformed.
- Prevent URL-less raw results from consuming the result limit or suppressing fallbacks.

## Validation
- `python -m pytest tests/tools/test_web_providers_searxng.py -q -o 'addopts='`
- `python -m pytest tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_brave_free.py -q -o 'addopts='`
- `python -m py_compile plugins/web/searxng/provider.py tests/tools/test_web_providers_searxng.py`
- `git diff --check`
- Live smoke against local SearXNG at `127.0.0.1:8080`
- Independent reviewer passed