### PR TITLE
fix(gateway): filter silence narration in agent replies before delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9369,6 +9369,18 @@ class GatewayRunner:
             )
             response = _sanitize_gateway_final_response(source.platform, response)
 
+            # Silence narration filter: skip delivery if agent chose not to respond
+            # (e.g. *silent*, 🔇, ".", "no response"). Reuses the built-in
+            # filter from delivery.py so both cron outputs and agent replies
+            # are covered by the same ruleset.
+            from gateway.delivery import _is_silence_narration
+            if _is_silence_narration(response):
+                logger.info(
+                    "Agent returned silence narration for %s — skipping delivery",
+                    session_key,
+                )
+                return None
+
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:


### PR DESCRIPTION
## What does this PR do?

The gateway already has a `_is_silence_narration()` filter in `delivery.py` that detects when a cron job or agent outputs silence markers (`*silent*`, `🔇`, `"."`, "no response needed", etc.) and skips delivery. However, this filter is only applied to cron job outputs — **not** to live agent replies going through the normal gateway response path.

This means when a gateway-connected agent (e.g. a Feishu/Telegram bot) decides it should stay silent and outputs `*silent*`, the gateway delivers that literal string to the user instead of suppressing it.

This PR reuses the existing `_is_silence_narration()` function in the agent reply delivery path, so silence markers from live agent sessions are handled consistently with cron outputs — the message is logged and delivery is skipped.

## Related Issue

N/A — discovered while running a Feishu group bot that needs to stay silent on off-topic messages.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`:
  - After the agent response is sanitized (`_sanitize_gateway_final_response`), added a call to `_is_silence_narration(response)` imported from `gateway.delivery`.
  - When the response matches a silence pattern, logs `"Agent returned silence narration for {session_key} — skipping delivery"` and returns `None` (no delivery).
  - This is ~12 lines of code, reusing the exact same filter already used for cron outputs, ensuring consistent behavior.

## How to Test

1. Configure a gateway agent with a system prompt that instructs it to output `*silent*` when it should not respond (e.g. for off-topic messages in a group chat).
2. Send an off-topic message to the chat.
3. Before this fix: the literal text `*silent*` (or similar) is delivered to the chat.
4. After this fix: the gateway logs the silence and skips delivery — nothing appears in the chat.

Tested on macOS 15 with Feishu gateway.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (platform-agnostic logic, applies to all gateway platforms)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Gateway log showing silence filter in action:
```
INFO gateway.run: inbound message: platform=feishu msg='今天天气不错'
INFO gateway.run: response ready: response=8 chars
INFO gateway.run: Agent returned silence narration for agent:main:feishu:group:oc_xxx:omt_xxx — skipping delivery
```
