### PR TITLE
fix(gateway): ignore unloaded systemd units in forensics

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -362,12 +362,21 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
     # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # that's the common case for hermes.  Only trust timing data from a
+    # manager that reports the unit as loaded; systemctl may otherwise emit
+    # default properties for missing/non-loaded units.
     timeout_us: Optional[int] = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl",
+                    *flag,
+                    "show",
+                    unit_name,
+                    "--property=LoadState",
+                    "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
@@ -375,16 +384,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
         if result.returncode != 0:
             continue
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        values: Dict[str, str] = {}
         for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                # Try numeric microseconds first
-                if value.isdigit():
-                    timeout_us = int(value)
-                else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
+            key, sep, value = line.partition("=")
+            if sep:
+                values[key] = value.strip()
+        if values.get("LoadState", "").lower() != "loaded":
+            continue
+
+        value = values.get("TimeoutStopUSec", "")
+        # Try numeric microseconds first
+        if value.isdigit():
+            timeout_us = int(value)
+        else:
+            timeout_us = _parse_systemd_duration_to_us(value)
         if timeout_us is not None:
             break
 

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -235,6 +237,30 @@ class TestParseSystemdDuration:
 # ---------------------------------------------------------------------------
 
 class TestCheckSystemdTimingAlignment:
+    def _mock_systemd_unit(self, monkeypatch, unit_name="hermes-gateway.service"):
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                return io.StringIO(f"0::/user.slice/app.slice/{unit_name}\n")
+            raise FileNotFoundError(path)
+
+        monkeypatch.setattr(sf, "open", fake_open, raising=False)
+
+    def _mock_systemctl_show(self, monkeypatch, responses):
+        calls = []
+        responses_iter = iter(responses)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            try:
+                response = next(responses_iter)
+            except StopIteration:
+                response = responses[-1]
+            returncode, stdout = response
+            return SimpleNamespace(returncode=returncode, stdout=stdout)
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+        return calls
+
     def test_returns_none_when_not_under_systemd(self, monkeypatch):
         monkeypatch.delenv("INVOCATION_ID", raising=False)
         result = sf.check_systemd_timing_alignment(180.0)
@@ -248,3 +274,76 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_reads_timeout_only_when_unit_is_loaded(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        self._mock_systemd_unit(monkeypatch)
+        calls = self._mock_systemctl_show(
+            monkeypatch,
+            [(0, "LoadState=loaded\nTimeoutStopUSec=210000000\n")],
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result == {
+            "unit": "hermes-gateway.service",
+            "timeout_stop_sec": 210.0,
+            "drain_timeout": 180.0,
+            "expected_min": 210.0,
+            "mismatch": False,
+        }
+        assert "--property=LoadState" in calls[0]
+        assert "--property=TimeoutStopUSec" in calls[0]
+
+    def test_ignores_not_found_user_unit_and_tries_system_manager(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        self._mock_systemd_unit(monkeypatch)
+        calls = self._mock_systemctl_show(
+            monkeypatch,
+            [
+                (0, "LoadState=not-found\nTimeoutStopUSec=1000000\n"),
+                (0, "LoadState=loaded\nTimeoutStopUSec=240000000\n"),
+            ],
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 240.0
+        assert result["mismatch"] is False
+        assert calls[0][:2] == ["systemctl", "--user"]
+        assert calls[1][:2] == ["systemctl", "show"]
+
+    @pytest.mark.parametrize(
+        "load_state",
+        ["not-found", "error", "masked", "bad-setting", "generated"],
+    )
+    def test_returns_none_for_non_loaded_unit_states(self, monkeypatch, load_state):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        self._mock_systemd_unit(monkeypatch)
+        self._mock_systemctl_show(
+            monkeypatch,
+            [
+                (0, f"LoadState={load_state}\nTimeoutStopUSec=1000000\n"),
+                (0, f"LoadState={load_state}\nTimeoutStopUSec=1000000\n"),
+            ],
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is None
+
+    def test_returns_none_when_load_state_is_missing(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        self._mock_systemd_unit(monkeypatch)
+        self._mock_systemctl_show(
+            monkeypatch,
+            [
+                (0, "TimeoutStopUSec=1000000\n"),
+                (0, "TimeoutStopUSec=1000000\n"),
+            ],
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is None


### PR DESCRIPTION
## Summary
- query systemd LoadState together with TimeoutStopUSec before trusting shutdown timing data
- skip missing, non-loaded, or incomplete unit records so nonexistent user units do not produce false mismatch diagnostics
- add regression coverage for loaded, not-found fallback, non-loaded states, and missing LoadState outputs

Fixes #36755.

## Validation
- .venv/bin/python -m pytest tests/gateway/test_shutdown_forensics.py::TestCheckSystemdTimingAlignment -q
- .venv/bin/python -m pytest tests/gateway/test_shutdown_forensics.py -q -k "not test_spawns_subprocess_and_writes_output"

Note: the full test file has one local macOS environment failure in test_spawns_subprocess_and_writes_output because the diagnostic spawn returns None here; the new systemd timing coverage passes.