### PR TITLE
fix(agent): tolerate broken model_dump on provider metadata

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -920,7 +920,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             elif hasattr(d, "__dict__"):
                 preserved.append(d.__dict__)
             elif hasattr(d, "model_dump"):
-                preserved.append(d.model_dump())
+                try:
+                    preserved.append(d.model_dump())
+                except Exception:
+                    pass
         if preserved:
             msg["reasoning_details"] = preserved
 
@@ -993,7 +996,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             extra = getattr(tool_call, "extra_content", None)
             if extra is not None:
                 if hasattr(extra, "model_dump"):
-                    extra = extra.model_dump()
+                    try:
+                        extra = extra.model_dump()
+                    except Exception:
+                        pass
                 tc_dict["extra_content"] = extra
             tool_calls.append(tc_dict)
         msg["tool_calls"] = tool_calls
@@ -1873,7 +1879,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         extra = (tc_delta.model_extra or {}).get("extra_content")
                     if extra is not None:
                         if hasattr(extra, "model_dump"):
-                            extra = extra.model_dump()
+                            try:
+                                extra = extra.model_dump()
+                            except Exception:
+                                pass
                         entry["extra_content"] = extra
                     # Fire once per tool when the full name is available
                     name = entry["function"]["name"]

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -13,6 +13,11 @@ def transport():
     return get_transport("chat_completions")
 
 
+class _BrokenModelDumpDict(dict):
+    def model_dump(self):
+        raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+
 class TestChatCompletionsBasic:
 
     def test_api_mode(self, transport):
@@ -747,6 +752,28 @@ class TestChatCompletionsNormalize:
             usage=None,
         )
         nr = transport.normalize_response(r)
+        assert nr.tool_calls[0].provider_data == {
+            "extra_content": {"google": {"thought_signature": "SIG_ABC123"}}
+        }
+
+    def test_tool_call_extra_content_broken_model_dump_falls_back(self, transport):
+        tc = SimpleNamespace(
+            id="call_gem",
+            function=SimpleNamespace(name="terminal", arguments='{"command": "ls"}'),
+            extra_content=_BrokenModelDumpDict(
+                {"google": {"thought_signature": "SIG_ABC123"}}
+            ),
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tc], reasoning_content=None),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
         assert nr.tool_calls[0].provider_data == {
             "extra_content": {"google": {"thought_signature": "SIG_ABC123"}}
         }

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -225,6 +225,18 @@ def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
     )
 
 
+class _BrokenModelDumpDict(dict):
+    def model_dump(self):
+        raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+
+class _BrokenModelDumpObject:
+    __slots__ = ()
+
+    def model_dump(self):
+        raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+
 def _mock_response(
     content="Hello",
     finish_reason="stop",
@@ -1873,6 +1885,16 @@ class TestBuildAssistantMessage:
         assert "reasoning_details" in result
         assert result["reasoning_details"][0]["text"] == "step1"
 
+    def test_broken_reasoning_detail_model_dump_is_ignored(self, agent):
+        msg = _mock_assistant_msg(
+            content="ans", reasoning_details=[_BrokenModelDumpObject()]
+        )
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert "reasoning_details" not in result
+
+
     def test_empty_content(self, agent):
         msg = _mock_assistant_msg(content=None)
         result = agent._build_assistant_message(msg, "stop")
@@ -1943,6 +1965,21 @@ class TestBuildAssistantMessage:
         tc.extra_content = {"google": {"thought_signature": "abc123"}}
         msg = _mock_assistant_msg(content="", tool_calls=[tc])
         result = agent._build_assistant_message(msg, "tool_calls")
+        assert result["tool_calls"][0]["extra_content"] == {
+            "google": {"thought_signature": "abc123"}
+        }
+
+    def test_tool_call_extra_content_broken_model_dump_falls_back(self, agent):
+        tc = _mock_tool_call(
+            name="get_weather", arguments='{"city":"NYC"}', call_id="c2"
+        )
+        tc.extra_content = _BrokenModelDumpDict(
+            {"google": {"thought_signature": "abc123"}}
+        )
+        msg = _mock_assistant_msg(content="", tool_calls=[tc])
+
+        result = agent._build_assistant_message(msg, "tool_calls")
+
         assert result["tool_calls"][0]["extra_content"] == {
             "google": {"thought_signature": "abc123"}
         }
@@ -5246,10 +5283,22 @@ def _make_chunk(content=None, tool_calls=None, finish_reason=None, model="test/m
     return SimpleNamespace(model=model, choices=[choice])
 
 
-def _make_tc_delta(index=0, tc_id=None, name=None, arguments=None):
+def _make_tc_delta(
+    index=0,
+    tc_id=None,
+    name=None,
+    arguments=None,
+    extra_content=None,
+    model_extra=None,
+):
     """Build a SimpleNamespace mimicking a streaming tool_call delta."""
     func = SimpleNamespace(name=name, arguments=arguments)
-    return SimpleNamespace(index=index, id=tc_id, function=func)
+    delta = SimpleNamespace(index=index, id=tc_id, function=func)
+    if extra_content is not None:
+        delta.extra_content = extra_content
+    if model_extra is not None:
+        delta.model_extra = model_extra
+    return delta
 
 
 class TestStreamingApiCall:
@@ -5294,6 +5343,32 @@ class TestStreamingApiCall:
         assert tc[0].function.name == "web_search"
         assert tc[0].function.arguments == '{"q":"test"}'
         assert tc[0].id == "call_1"
+
+    def test_tool_call_extra_content_broken_model_dump_falls_back(self, agent):
+        chunks = [
+            _make_chunk(
+                tool_calls=[
+                    _make_tc_delta(
+                        0,
+                        "call_1",
+                        "web_search",
+                        "{}",
+                        extra_content=_BrokenModelDumpDict(
+                            {"google": {"thought_signature": "sig-123"}}
+                        ),
+                    )
+                ]
+            ),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert tc[0].extra_content == {
+            "google": {"thought_signature": "sig-123"}
+        }
 
     def test_multiple_tool_calls(self, agent):
         chunks = [


### PR DESCRIPTION
## What does this PR do?

Prevents provider-specific tool-call and reasoning metadata from crashing the agent when an object advertises `model_dump()` but calling it raises. This matches the existing fail-open behavior in the chat-completions transport and keeps MiniMax streaming tool-call deltas from terminating the conversation loop.

## Related Issue

Fixes #19968

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`: Wrap `model_dump()` calls for reasoning details, persisted tool-call `extra_content`, and streamed tool-call `extra_content` so malformed provider metadata falls back instead of crashing.
- `tests/run_agent/test_run_agent.py`: Add regressions for broken `model_dump()` in assistant message reasoning details, persisted tool-call metadata, and streaming tool-call deltas.
- `tests/agent/transports/test_chat_completions.py`: Add a transport-level regression proving the existing non-streaming fallback preserves metadata when `model_dump()` raises.

## How to Test

1. `HERMES_HOME=/private/tmp/hermes-agent-test-home-$USER $VIRTUAL_ENV/bin/python -m pytest tests/run_agent/test_run_agent.py tests/agent/transports/test_chat_completions.py -q -x --timeout=60` — 431 passed.
2. `ruff check .` — passed, with an existing warning about `run_agent.py:68` `# noqa` syntax.
3. `python scripts/check-windows-footguns.py agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py tests/agent/transports/test_chat_completions.py` — passed.
4. `git diff --check` — passed.
5. `HERMES_HOME=/private/tmp/hermes-agent-test-home-$USER TMPDIR=/private/tmp $VIRTUAL_ENV/bin/python -m pytest tests/ -q -x --timeout=60` — attempted; stopped on unrelated `tests/agent/lsp/test_client_e2e.py::test_client_lifecycle_clean` live-system-guard failure while terminating an LSP subprocess outside the test process subtree.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on darwin-arm64 (local)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

No UI changes. Relevant command output is summarized in `## How to Test`.

<!-- autocontrib:worker-id=issue-new-f1f88718 kind=pr-open -->