### PR TITLE
fix(whatsapp): retry external-bridge probe and skip port-kill on timeout (#33365)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -438,48 +438,80 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
             
-            # Check if bridge is already running and connected
+            # Check if bridge is already running and connected.
+            # Probe up to 3 times so that a brief unresponsive window during a
+            # WhatsApp 515-reconnect cycle doesn't cause us to fall through and
+            # kill an external bridge the user is managing themselves.
+            # _probe_timed_out is True only when every attempt got asyncio.TimeoutError
+            # (meaning something IS on the port but didn't reply fast enough); it stays
+            # False when the connection was outright refused (port truly empty).
             import aiohttp
-            try:
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(
-                        f"http://127.0.0.1:{self._bridge_port}/health",
-                        timeout=aiohttp.ClientTimeout(total=2)
-                    ) as resp:
-                        if resp.status == 200:
-                            data = await resp.json()
-                            bridge_status = data.get("status", "unknown")
-                            if bridge_status == "connected":
-                                # Staleness handshake: only reuse a running
-                                # bridge if it is serving the same bridge.js
-                                # that is on disk right now.  A long-lived
-                                # bridge survives gateway restarts AND
-                                # `hermes update`, so without this check it
-                                # keeps serving pre-update code forever
-                                # (e.g. no inbound media download).  Old
-                                # bridges that don't report scriptHash are
-                                # treated as stale by definition.
-                                running_hash = data.get("scriptHash", "")
-                                disk_hash = _file_content_hash(bridge_path)
-                                if running_hash and disk_hash and running_hash == disk_hash:
-                                    print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
-                                    self._mark_connected()
-                                    self._bridge_process = None  # Not managed by us
-                                    self._http_session = aiohttp.ClientSession()
-                                    self._poll_task = asyncio.create_task(self._poll_messages())
-                                    return True
-                                print(
-                                    f"[{self.name}] Running bridge is stale "
-                                    f"(running={running_hash or 'unversioned'}, disk={disk_hash}), restarting"
-                                )
-                            else:
-                                print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
-            except Exception:
-                pass  # Bridge not running, start a new one
-            
-            # Kill any orphaned bridge from a previous gateway run
+            _probe_timed_out = False
+            for _probe_attempt in range(3):
+                try:
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(
+                            f"http://127.0.0.1:{self._bridge_port}/health",
+                            timeout=aiohttp.ClientTimeout(total=3),
+                        ) as resp:
+                            if resp.status == 200:
+                                data = await resp.json()
+                                bridge_status = data.get("status", "unknown")
+                                if bridge_status == "connected":
+                                    # Staleness handshake: only reuse a running
+                                    # bridge if it is serving the same bridge.js
+                                    # that is on disk right now. A long-lived
+                                    # bridge survives gateway restarts and
+                                    # `hermes update`, so without this check it
+                                    # keeps serving pre-update code forever.
+                                    running_hash = data.get("scriptHash", "")
+                                    disk_hash = _file_content_hash(bridge_path)
+                                    if running_hash and disk_hash and running_hash == disk_hash:
+                                        print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
+                                        self._mark_connected()
+                                        self._bridge_process = None  # Not managed by us
+                                        self._http_session = aiohttp.ClientSession()
+                                        self._poll_task = asyncio.create_task(self._poll_messages())
+                                        return True
+                                    print(
+                                        f"[{self.name}] Running bridge is stale "
+                                        f"(running={running_hash or 'unversioned'}, disk={disk_hash}), restarting"
+                                    )
+                                else:
+                                    print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
+                                    _probe_timed_out = False  # Got a clear answer — safe to kill
+                                    break
+                    _probe_timed_out = False  # Non-200 but a real response — safe to kill
+                    break
+                except asyncio.TimeoutError:
+                    # Port has something listening but it didn't respond in time.
+                    # Don't immediately conclude "bridge not running" — retry.
+                    _probe_timed_out = True
+                    if _probe_attempt < 2:
+                        await asyncio.sleep(1)
+                except Exception:
+                    # ECONNREFUSED or similar: nothing is on the port.
+                    _probe_timed_out = False
+                    break
+
+            # Kill any orphaned bridge from a previous gateway run.
+            # Skip _kill_port_process when all probes timed out — something is
+            # listening on the port (possibly the user's external bridge) and we
+            # couldn't confirm its status.  Killing it blindly would destroy an
+            # externally-managed bridge, then our own managed bridge would fail
+            # to start (port still occupied / session inconsistency), producing
+            # the "Poll error: ECONNREFUSED" crash loop described in #33365.
             _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
+            if not _probe_timed_out:
+                _kill_port_process(self._bridge_port)
+            else:
+                logger.warning(
+                    "[%s] Health-check on port %d timed out on all 3 attempts — "
+                    "skipping port kill to avoid destroying an external bridge. "
+                    "The managed bridge may fail to start if the port is still occupied.",
+                    self.name,
+                    self._bridge_port,
+                )
             await asyncio.sleep(1)
             
             # Start the bridge process in its own process group.

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -701,3 +701,118 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+# ---------------------------------------------------------------------------
+# External bridge detection: timeout retry + port-kill guard  (#33365)
+# ---------------------------------------------------------------------------
+
+class TestExternalBridgeDetectionRetry:
+    """Regression tests for the external-bridge timeout / port-kill race.
+
+    Issue #33365: a 2-second health-check timeout on the external-bridge probe
+    caused connect() to call _kill_port_process() on a bridge that was merely
+    slow (e.g. mid WhatsApp 515-reconnect), destroying the user's externally-
+    managed bridge and replacing it with a managed one that then crashed.
+
+    The fix:
+    * Retry the probe up to 3 times (1 s between attempts).
+    * Skip _kill_port_process when ALL probes timed out (asyncio.TimeoutError)
+      so an external bridge that's briefly unresponsive is not blindly killed.
+    * Still call _kill_port_process when the connection was refused (nothing
+      listening on the port) — that's the safe, stale-process cleanup path.
+    """
+
+    def _bare_adapter(self):
+        adapter = _make_adapter()
+        # Seed attributes that connect() reads before the health-check loop
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._platform_lock_identity = None
+        adapter._shutting_down = False
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_three_timeouts_skips_port_kill(self):
+        """All 3 probes time out → _kill_port_process must NOT be called."""
+        adapter = self._bare_adapter()
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "mkdir", return_value=None), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("builtins.open", return_value=MagicMock()), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill, \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"), \
+             patch("subprocess.Popen", return_value=MagicMock(poll=MagicMock(return_value=None))), \
+             patch("aiohttp.ClientSession", side_effect=asyncio.TimeoutError):
+            await adapter.connect()
+
+        mock_kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connection_refused_still_kills_port(self):
+        """ECONNREFUSED means nothing is on the port → _kill_port_process IS called."""
+        import aiohttp as _aiohttp
+
+        adapter = self._bare_adapter()
+
+        conn_error = _aiohttp.ClientConnectorError(
+            connection_key=MagicMock(), os_error=ConnectionRefusedError()
+        )
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "mkdir", return_value=None), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("builtins.open", return_value=MagicMock()), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill, \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"), \
+             patch("subprocess.Popen", return_value=MagicMock(poll=MagicMock(return_value=None))), \
+             patch("aiohttp.ClientSession", side_effect=conn_error):
+            await adapter.connect()
+
+        mock_kill.assert_called_once_with(adapter._bridge_port)
+
+    @pytest.mark.asyncio
+    async def test_timeout_then_connected_uses_external_bridge(self):
+        """First probe times out, second succeeds with status=connected → external path."""
+        adapter = self._bare_adapter()
+
+        call_count = [0]
+
+        def _session_factory(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise asyncio.TimeoutError
+            # Second call: return a session that yields status=connected
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.json = AsyncMock(
+                return_value={"status": "connected", "scriptHash": "bridge-hash"},
+            )
+            mock_session = MagicMock()
+            mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(return_value=mock_session)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "mkdir", return_value=None), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill, \
+             patch("plugins.platforms.whatsapp.adapter._file_content_hash", return_value="bridge-hash"), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task", return_value=MagicMock()), \
+             patch("aiohttp.ClientSession", side_effect=_session_factory):
+            result = await adapter.connect()
+
+        assert result is True
+        assert adapter._bridge_process is None  # External bridge, not managed
+        mock_kill.assert_not_called()


### PR DESCRIPTION
## What changed and why

Fixes #33365 — WhatsApp gateway crashes on first poll when using an existing external bridge.

**Root cause identified from code analysis:**  
The 2-second `/health` probe in `connect()` can time out even when the external bridge is healthy (e.g. during a brief WhatsApp 515-reconnect cycle). When the probe times out, the code falls through to `_kill_port_process(bridge_port)` — which blindly kills whatever is listening on that port, including the user's externally-managed Baileys bridge. The managed bridge that replaces it then fails immediately (port in TIME_WAIT, or session inconsistency), producing:

```
[Whatsapp] Bridge started on port 3000
[Whatsapp] Poll error: Cannot connect to host 127.0.0.1:3000 [ECONNREFUSED]
[Whatsapp] Disconnecting (external bridge left running)
```

**Changes (`gateway/platforms/whatsapp.py`):**
- Retry the `/health` probe up to **3 times** (1 s apart, 3 s timeout each) before concluding no external bridge is present.
- Track whether *every* failed attempt was `asyncio.TimeoutError`. If so, skip `_kill_port_process` — a timeout means *something* is listening. A plain `ECONNREFUSED` still calls `_kill_port_process` (safe, stale-process cleanup path).
- Emit `logger.warning` when skipping the kill, so operators can diagnose a managed bridge failing to bind an occupied port.

## How to test

1. Start an external Baileys bridge manually: `setsid node scripts/whatsapp-bridge/bridge.js --port 3000 --session ~/.hermes/whatsapp/session --mode personal`
2. Verify `curl 127.0.0.1:3000/health` returns `status: connected`.
3. Start `hermes gateway` — confirm `[Whatsapp] Using existing bridge (status: connected)` appears and the gateway stays up.
4. Simulate a slow bridge by throttling port 3000 for 2 s at gateway startup; confirm the gateway retries and adopts the bridge rather than killing it.
5. Run unit tests: `pytest tests/gateway/test_whatsapp_connect.py -q`

## What platforms tested on

- macOS (Darwin 24.6.0, Python 3.11, unit tests)
- Logic applies equally to Linux (the affected code path is platform-agnostic)

## Per the reporter's clarification on 2026-06-01

The second bot comment (2026-06-01) asked @cpu-16 to confirm whether `[Whatsapp] Using existing bridge` appeared in their logs (to distinguish the 2-second-timeout hypothesis from the external-bridge-poll-failure hypothesis). @cpu-16 has not yet replied. This PR addresses the timeout hypothesis, which is supported by the code path analysis and matches the `Disconnecting (external bridge left running)` message in the crash log.

## Addressing maintainer feedback

No maintainer cross-references in this thread.

<!-- autocontrib:worker-id=issue-followup-384da277 kind=pr-open -->