### PR TITLE
fix(deps): honor quoted false lazy-install opt-out (#36648)

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -135,6 +135,33 @@ class TestSecurityGating:
         )
         assert ld._allow_lazy_installs() is True
 
+    @pytest.mark.parametrize("value", ["false", "False", " 0 ", "no", "off"])
+    def test_quoted_falsey_config_disables(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is False
+
+    @pytest.mark.parametrize("value", [False, 0, None])
+    def test_falsey_scalar_config_disables(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is False
+
+    @pytest.mark.parametrize("value", [True, "true", "1", "yes", "on"])
+    def test_truthy_config_allows(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is True
+
     def test_config_failure_fails_open(self, monkeypatch):
         # If config can't be read at all, we ALLOW installs rather than
         # blocking the user out of their own backends.

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -144,6 +144,15 @@ class TestSecurityGating:
         )
         assert ld._allow_lazy_installs() is False
 
+    def test_quoted_falsey_real_config_disables(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            'security:\n  allow_lazy_installs: "false"\n',
+            encoding="utf-8",
+        )
+        assert ld._allow_lazy_installs() is False
+
     @pytest.mark.parametrize("value", [False, 0, None])
     def test_falsey_scalar_config_disables(self, monkeypatch, value):
         monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -114,6 +114,42 @@ class TestSecurityGating:
             ld.ensure("test.feat", prompt=False)
 
 
+    @pytest.mark.parametrize("value", ["false", "False", " 0 ", "no", "off"])
+    def test_quoted_falsey_config_disables(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is False
+
+    def test_quoted_falsey_real_config_disables(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            'security:\n  allow_lazy_installs: "false"\n',
+            encoding="utf-8",
+        )
+        assert ld._allow_lazy_installs() is False
+
+    @pytest.mark.parametrize("value", [False, 0, None])
+    def test_falsey_scalar_config_disables(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is False
+
+    @pytest.mark.parametrize("value", [True, "true", "1", "yes", "on"])
+    def test_truthy_config_allows(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is True
+
     def test_config_failure_fails_open(self, monkeypatch):
         # If config can't be read at all, we ALLOW installs rather than
         # blocking the user out of their own backends.

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -80,6 +80,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -445,7 +446,9 @@ def _allow_lazy_installs() -> bool:
         cfg = None
     if cfg is not None:
         sec = cfg.get("security") or {}
-        if not bool(sec.get("allow_lazy_installs", True)):
+        if "allow_lazy_installs" in sec and not is_truthy_value(
+            sec.get("allow_lazy_installs")
+        ):
             return False
 
     # (2) Sealed-venv env var: blocks ONLY when there is no safe durable

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -318,7 +319,7 @@ def _allow_lazy_installs() -> bool:
     with contextlib.suppress(Exception):
         from hermes_cli.config import load_config
         cfg = load_config()
-    if cfg is not None and not bool((cfg.get("security") or {}).get("allow_lazy_installs", True)):
+    if cfg is not None and not is_truthy_value((cfg.get("security") or {}).get("allow_lazy_installs", True)):
         return False
     if os.environ.get("HERMES_DISABLE_LAZY_INSTALLS") == "1":
         return _lazy_install_target() is not None


### PR DESCRIPTION
Quoted values such as `"false"`, `"0"`, `"no"`, and `"off"` currently permit lazy installs because the config gate uses Python string truthiness. Parse the configured value with the existing shared boolean helper.

Keep the default enabled when the setting is missing, explicit null disabled, and unreadable config behavior unchanged. Preserve current sealed-venv behavior: `HERMES_DISABLE_LAZY_INSTALLS=1` permits a configured durable target, while a config opt-out blocks both installation modes.

The regression tests cover quoted and scalar values plus the real YAML config loader. The original implementation and its review-requested loader test are now one commit; reviewer attribution is retained.

Validation on current main `485aaf69b7f0930a5f6631752172d90a4a5575c6`:
- Before: six quoted-value/config-loader cases failed; eight scalar/truthy cases passed.
- After: `scripts/run_tests.sh tests/tools/test_lazy_deps.py tests/test_utils_truthy_values.py -q`: 87 passed, one Windows-only test skipped on Linux.
- Ruff and diff checks passed. Ruff reported an existing invalid `noqa` directive outside this diff.

Not checked: full suite, native Windows locally, CodeRabbit (skipped for author-side maintenance without P0/P1 priority).

Fixes #36648

Agent disclosure: original work by GPT-5.5 and GPT-5.6-sol with xhigh reasoning in Codex. Maintenance by GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
