### PR TITLE
fix(packaging): verify wheel contents before PyPI publish to catch missing subpackages

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -80,6 +80,75 @@ jobs:
       - name: Build wheel and sdist
         run: uv build --sdist --wheel
 
+      - name: Verify wheel contents
+        # Two-layer check that runs BEFORE the wheel is uploaded to PyPI.
+        # Layer 1 — pyproject.toml config: mirrors the logic in
+        #   tests/test_packaging_metadata.py and catches a misconfigured
+        #   [tool.setuptools.packages.find].include that drops subpackages
+        #   (the root cause of #34346 / #36743).
+        # Layer 2 — built artifact: inspects the .whl ZIP to make sure the
+        #   packages discovered by Layer 1 actually made it into the wheel.
+        #   Catches build-process edge cases that find_packages can't see
+        #   (stale checkout, missing __init__.py, frontend-build ordering).
+        run: |
+          python -c "
+          import sys, glob, tomllib, zipfile
+          from pathlib import Path
+          from setuptools import find_packages
+
+          # ── Layer 1: source config ──────────────────────────────
+          # Read the live pyproject.toml — no hardcoded patterns that
+          # drift out of sync with what the maintainer actually changed.
+          data = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))
+          include = data['tool']['setuptools']['packages']['find']['include']
+
+          # What the real include list selects.
+          selected = set(find_packages(include=include))
+
+          # Every on-disk subpackage (maximal include: every top-level
+          # package + its .* wildcard).
+          top_level = sorted({n for n in include if '.' not in n})
+          expected = set(
+              find_packages(
+                  include=[p for name in top_level for p in (name, f'{name}.*')],
+              )
+          )
+
+          missing_config = sorted(expected - selected)
+          if missing_config:
+              print('ERROR: packages exist on disk but are dropped by pyproject.toml:')
+              for p in missing_config:
+                  print(f'  - {p}')
+              print("Add the matching '<name>.*' entry to [tool.setuptools.packages.find] include.")
+              sys.exit(1)
+
+          print(f'Layer 1 OK — {len(selected)} packages covered by include list, '
+                f'0 missing (maximal would select {len(expected)}).')
+
+          # ── Layer 2: built wheel ────────────────────────────────
+          whl_files = glob.glob('dist/*.whl')
+          if not whl_files:
+              print('ERROR: No .whl found in dist/')
+              sys.exit(1)
+
+          with zipfile.ZipFile(whl_files[0]) as z:
+              wheel_names = set(z.namelist())
+
+          missing_wheel = []
+          for pkg in sorted(expected):
+              init_path = pkg.replace('.', '/') + '/__init__.py'
+              if init_path not in wheel_names:
+                  missing_wheel.append(init_path)
+
+          if missing_wheel:
+              print('ERROR: Built wheel is missing expected packages:')
+              for m in missing_wheel:
+                  print(f'  - {m}')
+              sys.exit(1)
+
+          print(f'Layer 2 OK — all {len(expected)} expected packages present in {whl_files[0]}.')
+          "
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:


### PR DESCRIPTION
## What does this PR do?

The v0.15.2 PyPI wheel shipped without `hermes_cli/dashboard_auth/`. Running `hermes dashboard` crashes immediately with `ModuleNotFoundError`. This same class of bug also dropped `hermes_cli/proxy/` back in v0.15.1.

The underlying `pyproject.toml` fix — adding the `hermes_cli.*` wildcard to `packages.find.include` — landed in #34811 and is already on `main`. But there was no automated check to prevent a misconfigured `pyproject.toml` from producing a broken wheel that reaches PyPI.

This PR adds a pre-publish gate in the release workflow. After `uv build` and before the wheel is uploaded, a new `Verify wheel contents` step checks that every on-disk subpackage actually made it into the `.whl`. If anything is missing, the workflow fails and the wheel never reaches PyPI.

**Two-layer check in `upload_to_pypi.yml`:**

| Layer | What it does | What it catches |
|-------|-------------|-----------------|
| Source config | Reads the live `pyproject.toml` with `tomllib`, runs `find_packages` with the actual include list vs a maximal list (every top-level package + `.*` wildcard). Fails if any on-disk subpackage is dropped. | Misconfigured `packages.find.include` — same root cause as #34346 / #36743 |
| Built artifact | Opens the `.whl` with `zipfile`, checks that the `__init__.py` for every expected package is physically in the archive. | Build-process edge cases: stale checkout, missing `__init__.py`, frontend build ordering |

Either layer fails → workflow exits 1 → wheel never reaches PyPI.

No hardcoded package names or include patterns — everything is read dynamically from `pyproject.toml`, so the check stays in sync with whatever the maintainer changes. The Layer 1 logic mirrors the existing `test_every_on_disk_subpackage_is_covered_by_packages_find()` in `tests/test_packaging_metadata.py`.

## Related Issue

Fixes #36743

Related: #34346, #34811

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/upload_to_pypi.yml` — Added `Verify wheel contents` step in the `build` job, between `uv build` and `Upload distribution artifacts`. Runs a two-layer Python check (source config via `tomllib` + `find_packages`, built artifact via `zipfile`) before the wheel is uploaded to PyPI.

## How to Test

1. Verify the Layer 1 logic locally (no wheel needed):
   ```
   python -c "import tomllib, pathlib, setuptools; data = tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8')); inc = data['tool']['setuptools']['packages']['find']['include']; sel = set(setuptools.find_packages(include=inc)); top = sorted({n for n in inc if '.' not in n}); exp = set(setuptools.find_packages(include=[p for name in top for p in (name, name + '.*')])); miss = sorted(exp - sel); print('OK' if not miss else 'MISSING: ' + str(miss))"
   ```

2. Full build + two-layer verification (optional):
   ```
   uv build --wheel
   # Then run the CI step logic to inspect dist/*.whl with zipfile
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I've considered cross-platform impact — N/A (CI step runs on ubuntu-latest, uses Python stdlib only)
- [x] I've updated tool descriptions/schemas — N/A