### PR TITLE
fix(models): correct MiniMax-M3 context window to 512K (was hardcoded 1M)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -200,12 +200,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,
-    # MiniMax — M3 is 1M context (max output 512K); M2.x series is 204,800.
+    # MiniMax — M3 is 512K context (max output 131,072); M2.x series is 204,800.
+    # Source: models.dev lists 512,000; the live MiniMax API rejects prompts
+    # exceeding ~520K tokens, confirming the documented limit empirically.
     # Keys use substring matching (longest-first), so "minimax-m3" wins over
     # the generic "minimax" catch-all for the M3 slug on every surface
     # (native MiniMax-M3, OpenRouter/Nous minimax/minimax-m3).
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
-    "minimax-m3": 1000000,
+    "minimax-m3": 512000,
     "minimax": 204800,
     # GLM
     "glm": 202752,
@@ -1553,8 +1555,8 @@ def get_model_context_length(
                 _invalidate_cached_context_length(model, base_url)
             # Invalidate stale ≤204,800 cache entries for MiniMax-M3.  Pre-catalog
             # builds resolved M3 via the generic ``minimax`` catch-all (204,800)
-            # and persisted it before the ``minimax-m3`` (1M) entry existed; that
-            # stale value would otherwise stick forever here at step 1.  M3 is 1M,
+            # and persisted it before the ``minimax-m3`` (512K) entry existed; that
+            # stale value would otherwise stick forever here at step 1.  M3 is 512K,
             # so any sub-256K cached value for an M3 slug is a leftover — drop it
             # and fall through to the hardcoded default.
             elif cached <= 204_800 and _model_name_suggests_minimax_m3(model):

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 class TestMinimaxContextLengths:
     """Verify context length entries match official docs.
 
-    M2.x series is 204,800; M3 is 1M (max output 512K).
+    M2.x series is 204,800; M3 is 512K (max output 131,072).
     Source: https://platform.minimax.io/docs/api-reference/text-anthropic-api
     """
 
@@ -21,20 +21,28 @@ class TestMinimaxContextLengths:
             ctx = get_model_context_length(model, "")
             assert ctx == 204_800, f"{model} expected 204800, got {ctx}"
 
-    def test_minimax_m3_resolves_to_1m(self):
+    def test_minimax_m3_hardcoded_catalog_is_512k(self):
+        # Hardcoded fallback for native MiniMax-M3 must be 512,000 — the value
+        # confirmed by models.dev, the TUI status bar, and the live API (which
+        # rejects prompts > ~520K tokens). The previous 1,000,000 was wrong
+        # and could cause Hermes to mis-budget compression / send prompts the
+        # server will reject. See issue #37289.
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+        assert DEFAULT_CONTEXT_LENGTHS["minimax-m3"] == 512_000
+
+    def test_minimax_m3_resolves_above_catch_all(self):
         from agent.model_metadata import get_model_context_length
-        # M3 must beat the generic "minimax" catch-all (204,800) and resolve to
-        # a 1M-class context. The exact value depends on the source: our
-        # hardcoded catalog says 1,000,000; the OpenRouter catalog reports
-        # 1,048,576 (1024²). Either is correct — assert "≥ 1M, not 204,800".
+        # Regardless of which catalog path wins (hardcoded 512K vs an external
+        # registry like OpenRouter that may report 1,048,576), the M3 slug must
+        # beat the generic "minimax" catch-all (204,800).
         for model in ("MiniMax-M3", "minimax/minimax-m3", "minimax-m3"):
             ctx = get_model_context_length(model, "")
-            assert ctx >= 1_000_000, f"{model} expected 1M-class, got {ctx}"
+            assert ctx > 204_800, f"{model} fell back to catch-all, got {ctx}"
 
 
 class TestMinimaxM3StaleCacheGuard:
     """Pre-catalog builds resolved M3 via the generic 'minimax' catch-all
-    (204,800) and persisted it before the 'minimax-m3' (1M) catalog entry
+    (204,800) and persisted it before the 'minimax-m3' (512K) catalog entry
     existed.  The step-1 cache guard must drop that stale value and re-resolve
     to 1M, while leaving correct M2.x entries (204,800) untouched.
     """
@@ -70,11 +78,11 @@ class TestMinimaxM3StaleCacheGuard:
         import agent.model_metadata as mm
         importlib.reload(mm)
         base = "https://api.minimaxi.com/anthropic"
-        mm.save_context_length("MiniMax-M3", base, 1_000_000)
+        mm.save_context_length("MiniMax-M3", base, 512_000)
         ctx = mm.get_model_context_length(
             "MiniMax-M3", base_url=base, api_key="", provider="minimax-cn"
         )
-        assert ctx == 1_000_000
+        assert ctx == 512_000
 
     def test_m2_cache_not_clobbered(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

Fixes #37289. Corrects the hardcoded `MiniMax-M3` context window in `agent/model_metadata.py` from `1_000_000` to `512_000`.

## Why

Three independent sources all agree the real window is 512K — the hardcoded 1M was the outlier:

| Source | Context | Where |
|---|---|---|
| `models.dev` registry | **512,000** | `provider=minimax`, `model=MiniMax-M3`, `limit.context` |
| TUI status bar | **512K** | already reads from models.dev cache |
| Live API empirical cap | **~520K prompt tokens** | API rejects prompts beyond that with `does not support max tokens > 512000` |
| Hardcoded fallback (before this PR) | 1,000,000 | `agent/model_metadata.py:208` |

The previous 1M value caused Hermes to mis-budget compression and could let prompts exceed the server's actual cap — the user in #37289 demonstrated empirically (table of prompt sizes vs. HTTP status) that the input cap sits between 520K and 530K prompt tokens, which is consistent with 512K plus a small tokenisation buffer, not with 1M.

## What changed

* `agent/model_metadata.py` — change `"minimax-m3": 1_000_000` → `512_000`; refresh the surrounding comment (catalog entry + the stale-cache guard inside `get_model_context_length`) to reflect the corrected value.
* `tests/agent/test_minimax_provider.py` — update the docstring + replace the brittle `≥ 1M` assertion with two targeted contracts:
  1. The hardcoded catalog value is exactly `512_000` (pins the fix).
  2. Any resolution path for the M3 slug must beat the generic `minimax` catch-all (204,800) — keeps the test robust whether the value comes from the hardcoded catalog (512K) or an external registry like OpenRouter (which reports 1,048,576).

## Stale-cache guard

The guard at `_load_persisted_context_length` that drops cached entries `≤ 204_800` for M3 slugs is still correct — 512K > 204,800, so the threshold still distinguishes "stale pre-catalog value resolved via the `minimax` catch-all" from "valid M3 value". Only the comment was updated.

## Testing

```
pytest tests/ -k "model_metadata or minimax" -q
# 302 passed, 2 skipped
```

Closes #37289
