### PR TITLE
fix(tts): honor wav/flac output in OpenAI TTS provider instead of forcing mp3

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -997,9 +997,17 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
-    # Determine response format from extension
+    # Determine response format from extension. Mirror the Mistral provider so a
+    # configured wav/flac output_format is honored instead of always forcing mp3.
+    # wav/flac are valid OpenAI audio.speech response_format values, and some
+    # OpenAI-compatible backends only implement native WAV (e.g. Chatterbox-TTS-Server),
+    # where forcing mp3 yields a hard "500: Failed to encode audio".
     if output_path.endswith(".ogg"):
         response_format = "opus"
+    elif output_path.endswith(".wav"):
+        response_format = "wav"
+    elif output_path.endswith(".flac"):
+        response_format = "flac"
     else:
         response_format = "mp3"
 


### PR DESCRIPTION
## Problem

`tools/tts_tool.py::_generate_openai_tts` derives the OpenAI `response_format` solely from a `.ogg` check, mapping every other extension — including `.wav` and `.flac` — to `mp3`:

```python
if output_path.endswith(".ogg"):
    response_format = "opus"
else:
    response_format = "mp3"
```

This ignores the user's configured `output_format`, which Hermes already validates against `COMMAND_TTS_OUTPUT_FORMATS = {mp3, wav, ogg, flac}` and uses to set the output file's extension (`_get_command_tts_output_format`).

Impact:

1. Configured `wav`/`flac` output is re-encoded to mp3 (or written as mp3 bytes under a `.wav` name) even when the backend produces the requested format natively.
2. On OpenAI-compatible backends without server-side mp3 encoding — e.g. [`devnen/Chatterbox-TTS-Server`](https://github.com/devnen/Chatterbox-TTS-Server), which returns native 24 kHz WAV — the forced mp3 request fails with `500: Failed to encode audio`, breaking TTS entirely when `wav` would have succeeded.

The sibling **Mistral** provider in the same file already maps `.ogg/.wav/.flac/else` correctly; the OpenAI provider is simply inconsistent with it.

## Fix

Mirror the Mistral provider and map `.wav -> wav` / `.flac -> flac`. Both are documented values for OpenAI's `audio.speech` `response_format` (`mp3, opus, aac, flac, wav, pcm`), so this stays within the API contract and adds no new config surface — the resolved `output_format` already controls the extension.

## Testing

- `output_format: wav` against an OpenAI-compatible backend returning native WAV (Chatterbox-TTS-Server): now succeeds with a valid WAV instead of `500: Failed to encode audio`.
- `.ogg` (opus) and default `.mp3` paths unchanged.
