### PR TITLE
fix(hindsight): force CPU embeddings on macOS ARM64 to prevent MPS memory leak

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -36,6 +36,7 @@ import importlib
 import json
 import logging
 import os
+import platform
 import queue
 import sys
 import threading
@@ -543,6 +544,23 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     }
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
+
+    # macOS Apple Silicon: PyTorch MPS pre-allocates 4GB+ IOAccelerator
+    # memory for tiny embedding models, causing system-wide memory exhaustion
+    # on 8GB machines. Force CPU mode unless the user explicitly opts out
+    # via embeddings_local_force_cpu / reranker_local_force_cpu = false.
+    # See issues #7135, #8972 — daemon also hangs on startup with MPS.
+    is_macos_arm = platform.system() == "Darwin" and platform.machine() == "arm64"
+    force_cpu_embeddings = config.get("embeddings_local_force_cpu")
+    force_cpu_reranker = config.get("reranker_local_force_cpu")
+    if force_cpu_embeddings is not None or is_macos_arm:
+        env_values["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = (
+            "false" if force_cpu_embeddings is False else "true"
+        )
+    if force_cpu_reranker is not None or is_macos_arm:
+        env_values["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] = (
+            "false" if force_cpu_reranker is False else "true"
+        )
 
     idle_timeout = (
         config.get("idle_timeout")
@@ -1096,6 +1114,8 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
             {"key": "port_health_grace_timeout", "description": "Seconds to wait for a slow daemon /health before treating it as stale (raise on busy/low-resource hosts; blank uses the 30s default)", "default": "", "when": {"mode": "local_embedded"}},
+            {"key": "embeddings_local_force_cpu", "description": "Force CPU embeddings in the embedded daemon. Default true on macOS Apple Silicon (MPS leaks 4GB+ IOAccelerator memory on 8GB machines, issues #7135/#8972); set false to allow MPS/GPU. Other platforms default to the daemon's own choice.", "default": None, "when": {"mode": "local_embedded"}},
+            {"key": "reranker_local_force_cpu", "description": "Force CPU reranking in the embedded daemon. Default true on macOS Apple Silicon (same MPS memory issue); set false to allow MPS/GPU.", "default": None, "when": {"mode": "local_embedded"}},
         ]
 
     def _get_client(self):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -328,6 +328,61 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
 
+    def test_embedded_profile_env_forces_cpu_on_macos_arm(self, monkeypatch):
+        monkeypatch.setattr("plugins.memory.hindsight.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("plugins.memory.hindsight.platform.machine", lambda: "arm64")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "true"
+        assert env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] == "true"
+
+    def test_embedded_profile_env_cpu_opt_out_respected(self, monkeypatch):
+        # Explicit false opts out of the macOS ARM64 CPU default.
+        monkeypatch.setattr("plugins.memory.hindsight.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("plugins.memory.hindsight.platform.machine", lambda: "arm64")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embeddings_local_force_cpu": False,
+            "reranker_local_force_cpu": False,
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "false"
+        assert env["HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU"] == "false"
+
+    def test_embedded_profile_env_no_cpu_env_on_non_macos(self, monkeypatch):
+        # Non-Apple platforms are left to the daemon's own choice unless
+        # the user explicitly sets a value.
+        monkeypatch.setattr("plugins.memory.hindsight.platform.system", lambda: "Linux")
+        monkeypatch.setattr("plugins.memory.hindsight.platform.machine", lambda: "x86_64")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU" not in env
+        assert "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU" not in env
+
+    def test_embedded_profile_env_explicit_cpu_value_on_any_platform(self, monkeypatch):
+        # Explicit true works on any platform, not just macOS ARM64.
+        monkeypatch.setattr("plugins.memory.hindsight.platform.system", lambda: "Linux")
+        monkeypatch.setattr("plugins.memory.hindsight.platform.machine", lambda: "x86_64")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embeddings_local_force_cpu": True,
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] == "true"
+        assert "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU" not in env
+
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
@@ -399,6 +454,9 @@ class TestPostSetup:
         monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
         saved_configs = []
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
+        # Pin platform so the profile env is deterministic across machines.
+        monkeypatch.setattr("plugins.memory.hindsight.platform.system", lambda: "Linux")
+        monkeypatch.setattr("plugins.memory.hindsight.platform.machine", lambda: "x86_64")
 
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})


### PR DESCRIPTION
## Problem

On macOS Apple Silicon machines (8GB MacBook Air tested), the hindsight embedded daemon consumes 7-8GB of IOAccelerator (GPU) memory immediately on startup. This happens even though the default embedding model is bge-small-en-v1.5 (~130MB on disk).

## Root Cause

PyTorch detects the MPS backend and lets SentenceTransformer auto-select it. The MPS backend pre-allocates 4GB+ of GPU pageable memory for the model, regardless of actual model size. On Apple Silicon with unified memory, this eats directly into system RAM, causing:

- **7.3GB IOAccelerator "Pageable allocation"** (measured via `ioreg -w0 -l`)
- **3.4GB swap** usage (nearly full on 8GB machines)
- System-wide memory pressure, WindowServer starvation, black screen in severe cases

The `embeddings_local_force_cpu` and `reranker_local_force_cpu` config options exist but default to `False`. The generated `~/.hindsight/profiles/hermes.env` file never includes `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true` unless the user manually adds it.

## This Has Bitten Us 3 Times

We first hit this on June 1, set the env vars, fixed it. Then it came back the next day. Turned out the env file gets regenerated from scratch by `_build_embedded_profile_env()` every time the daemon restarts — and the env was being rewritten without FORCE_CPU. We kept patching the env file manually but never committed the source fix. A `git pull` would blow away the uncommitted change and the next daemon restart would regenerate a bad env.

Refs: #7135, #8972

## Fix

In `_build_embedded_profile_env()`, detect macOS ARM64 via `platform.system() + platform.machine()` and default both `HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU` and `HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU` to `true` — unless the user explicitly set them to `false` in their config. This matches how `HINDSIGHT_API_LLM_PROVIDER` and other settings are already handled: reasonable platform-appropriate defaults, overridable by config.

## Before / After

```
# Before (MPS):
$ sudo footprint <pid>
IOAccelerator: 4.1 GB
Total dirty:   5.2 GB
Swap:          3.4 GB

# After (CPU forced):
$ sudo footprint <pid>
Total dirty:   657 MB
Swap:          1.4 GB
```

The footprint tool shows no IOAccelerator entries after the fix. The model (bge-small) runs at its actual memory size (~130MB + Python overhead).

No performance impact in practice — recall latency is still under 10 seconds, and on 8GB machines the system can actually do other work without swap thrashing.