### PR TITLE
fix(media): add missing extensions to MEDIA delivery whitelist (#37318)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1169,15 +1169,17 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".markdown", ".epub",
     # Spreadsheets / data
-    ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
+    ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml", ".toml",
     # Presentations
     ".pptx", ".ppt", ".odp", ".key",
     # Archives
     ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".apk", ".ipa",
     # Web / rendered output
     ".html", ".htm",
+    # Scripts / code files (plain-text, safe to deliver as documents)
+    ".py", ".js", ".ts", ".sh", ".bash", ".zsh",
 )
 
 # Regex alternation fragment of bare extensions (no leading dot), e.g.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -680,11 +680,9 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {"text_to_speech", "text_to_speech_tool"}
 # pattern so a bare ``MEDIA:`` token in prose (no deliverable extension) is never
 # auto-appended. Kept local to the auto-append path; the producer-tool allowlist
 # below is the primary guard, this is the secondary precision guard.
+from gateway.platforms.base import _MEDIA_EXT_ALTERNATION  # noqa: E402
 _TOOL_MEDIA_RE = re.compile(
-    r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-    r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-    r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-    r'txt|csv|apk|ipa))',
+    r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:' + _MEDIA_EXT_ALTERNATION + r'))',
     re.IGNORECASE,
 )
 
@@ -17764,10 +17762,7 @@ class GatewayRunner:
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
                         _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                            r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                            r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:' + _MEDIA_EXT_ALTERNATION + r'))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):


### PR DESCRIPTION
## Problem

  MEDIA:/path/to/file.md tags silently fail for common file types (.md,
  .json, .yaml, .py, etc.) — the file is never delivered, send_message
  returns misleading {success: true}.

  ## Root Cause

  Two of the three MEDIA regexes in the codebase used a stale
  hardcoded extension list that never grew beyond the original
  image/video/archive set. Only base.py's MEDIA_DELIVERY_EXTS had been
  updated; run.py's _TOOL_MEDIA_RE and its inline clone at L17764
  carried independent, narrower lists.

  ## Changes

  | File | Change |
  |------|--------|
  | `gateway/platforms/base.py` | Added 8 extensions: `.markdown` `.toml` `.py` `.js` `.ts` `.sh` `.bash` `.zsh` |
  | `gateway/run.py` | Replaced 2x hardcoded regex extension lists with `_MEDIA_EXT_ALTERNATION` from base.py |

  All three MEDIA regexes now share one source of truth (60 extensions),
  so new extensions never need syncing across files again.

  ## Platforms affected

  Feishu, Telegram, and any platform using send_document via MEDIA: tags.

  Fixes #37318