### PR TITLE
fix: preserve config guard before temp-path allowance

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,6 +83,7 @@ AUTHOR_MAP = {
     "211828103+julio-cloudvisor@users.noreply.github.com": "julio-cloudvisor",
     "17778+kweiner@users.noreply.github.com": "kweiner",
     "223516181+faisfamilytravel@users.noreply.github.com": "faisfamilytravel",
+    "rfais370@macbook-pro.tail384032.ts.net": "faisfamilytravel",
     "45189813+baofuen@users.noreply.github.com": "baofuen",
     "interstellar.consulting@gmail.com": "Interstellar-code",
     "33978413+Interstellar-code@users.noreply.github.com": "Interstellar-code",

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,7 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(os.path.realpath("/tmp/out.txt"), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -155,7 +156,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "foo", "bar", False)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -168,7 +169,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -270,15 +270,12 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
+    # this file. Check this before broad temp-path allowances so tests and
+    # profile-scoped config paths remain protected even under macOS /private/var
+    # pytest workspaces.
     hermes_config = _get_hermes_config_resolved()
     if hermes_config and (resolved == hermes_config or normalized == hermes_config):
         return (
@@ -286,6 +283,11 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 


### PR DESCRIPTION
## Summary
- Preserves the Hermes config guard before broad sensitive/temp path checks.
- Keeps security-sensitive `config.yaml` write protection effective even when temp-path allowances are active.
- Updates macOS `/tmp` path expectations in focused file-tool tests to use realpath normalization.
- Adds the missing contributor attribution mapping required by upstream CI for this fork PR.

## Test Plan
- `python -m pytest tests/tools/test_file_tools.py tests/tools/test_file_write_safety.py tests/agent/test_file_safety_sandbox_mirror.py tests/agent/test_file_safety_container_mirror.py -q -o 'addopts='`
- Original run before PR: `87 passed in 5.31s`
- Re-run after attribution mapping: `87 passed in 4.73s`

## Base Defense context
Prepared from an isolated worktree based on current `origin/main`; live XO checkout and runtime were not merged, reset, restarted, or deployed.

Current PR head SHA: `eadf0cedb65fed63943682bbbea21b7f1f013990`
Original fix commit: `961cedae8e8ba79c523ad8ed5c4f48120fb96ae1`
Follow-up CI attribution commit: `eadf0cedb65fed63943682bbbea21b7f1f013990`
