### PR TITLE
fix(voice): honor PIPEWIRE_REMOTE in WSL audio detection

### DIFF
--- a/tests/tools/test_voice_wsl_pipewire.py
+++ b/tests/tools/test_voice_wsl_pipewire.py
@@ -1,0 +1,58 @@
+"""Regression: WSL voice detection must honor PIPEWIRE_REMOTE, not only PULSE_SERVER.
+
+detect_audio_environment() honors forwarded audio (has_forwarded_audio =
+PULSE_SERVER or PIPEWIRE_REMOTE or a reachable socket) in the SSH and container
+blocks, but the WSL block previously checked only PULSE_SERVER — so a WSL user
+with PipeWire forwarding (PIPEWIRE_REMOTE) was wrongly blocked from voice mode.
+These tests mock /proc/version so they reproduce the WSL path on any host.
+"""
+import builtins
+import io
+from unittest.mock import MagicMock
+
+WSL = "Linux version 5.15.0-microsoft-standard-WSL2 (oe-user@oe-host)"
+
+
+def _force_wsl(monkeypatch, content=WSL):
+    real_open = builtins.open
+    def fake_open(file, *a, **k):
+        if str(file) == "/proc/version":
+            return io.StringIO(content)
+        return real_open(file, *a, **k)
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+def _base(monkeypatch):
+    for v in ("SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION", "PULSE_SERVER"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+    monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
+    sd = MagicMock(); sd.query_devices.return_value = [{"name": "dev"}]
+    monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (sd, MagicMock()))
+
+
+def test_wsl_with_pipewire_remote_allows_voice(monkeypatch):
+    _base(monkeypatch)
+    monkeypatch.setenv("PIPEWIRE_REMOTE", "/run/user/1000/pipewire-0")
+    _force_wsl(monkeypatch)
+    from tools.voice_mode import detect_audio_environment
+    result = detect_audio_environment()
+    assert result["available"] is True, result["warnings"]
+
+
+def test_wsl_with_pulse_server_still_allows_voice(monkeypatch):
+    _base(monkeypatch)
+    monkeypatch.setenv("PULSE_SERVER", "unix:/mnt/wslg/PulseServer")
+    _force_wsl(monkeypatch)
+    from tools.voice_mode import detect_audio_environment
+    assert detect_audio_environment()["available"] is True
+
+
+def test_wsl_without_forwarding_still_blocks(monkeypatch):
+    _base(monkeypatch)
+    _force_wsl(monkeypatch)  # no PULSE_SERVER, no PIPEWIRE_REMOTE
+    from tools.voice_mode import detect_audio_environment
+    res = detect_audio_environment()
+    assert res["available"] is False
+    assert any("WSL" in w for w in res["warnings"])

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -189,19 +189,21 @@ def detect_audio_environment() -> dict:
                 "    PipeWire:    -e PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0"
             )
 
-    # WSL detection — PulseAudio bridge makes audio work in WSL.
-    # Only block if PULSE_SERVER is not configured.
+    # WSL detection — a reachable sound server makes audio work in WSL.
+    # Honor any forwarding (PulseAudio bridge OR a forwarded PipeWire/Pulse
+    # socket), mirroring the SSH and container blocks above. Only block when
+    # no forwarding is configured.
     try:
         with open('/proc/version', 'r', encoding="utf-8") as f:
             if 'microsoft' in f.read().lower():
-                if os.environ.get('PULSE_SERVER'):
-                    notices.append("Running in WSL with PulseAudio bridge")
+                if has_forwarded_audio:
+                    notices.append("Running in WSL with a reachable PulseAudio/PipeWire sound server")
                 else:
                     warnings.append(
-                        "Running in WSL -- audio requires PulseAudio bridge.\n"
-                        "  1. Set PULSE_SERVER=unix:/mnt/wslg/PulseServer\n"
-                        "  2. Create ~/.asoundrc pointing ALSA at PulseAudio\n"
-                        "  3. Verify with: arecord -d 3 /tmp/test.wav && aplay /tmp/test.wav"
+                        "Running in WSL -- audio requires a forwarded sound server.\n"
+                        "  PulseAudio: export PULSE_SERVER=unix:/mnt/wslg/PulseServer\n"
+                        "  PipeWire:   export PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0\n"
+                        "  Then verify: arecord -d 3 /tmp/test.wav && aplay /tmp/test.wav"
                     )
     except (FileNotFoundError, PermissionError, OSError):
         pass


### PR DESCRIPTION
# fix(voice): honor PIPEWIRE_REMOTE in WSL audio detection (was PULSE_SERVER-only)

**Branch:** `fix/voice-wsl-pipewire`
**Commit:** `fix(voice): honor forwarded audio (PIPEWIRE_REMOTE) in WSL detection`

## What

In `detect_audio_environment()` (`tools/voice_mode.py`), the WSL detection block
now honors **any forwarded sound server** (`has_forwarded_audio` = `PULSE_SERVER`
**or** `PIPEWIRE_REMOTE` **or** a reachable Pulse socket), mirroring the SSH and
container blocks. Previously the WSL block checked **only** `PULSE_SERVER`.

## Why

The SSH block (#35622) and the Docker/container block (#21203) already gate on
`has_forwarded_audio`, which includes `PIPEWIRE_REMOTE`. The WSL block was the
odd one out — it only looked at `PULSE_SERVER`. As a result, a **WSL user with
PipeWire forwarding** (`PIPEWIRE_REMOTE` set, no `PULSE_SERVER`) gets a hard-fail
warning and voice mode is blocked, even though audio works.

This surfaced by running the test suite on a real WSL2 machine: the three
`TestDetectAudioEnvironment::test_docker_with_pipewire_remote_*` tests **fail on
WSL** and pass on Linux CI. Root cause: on WSL `/proc/version` contains
`microsoft`, so the WSL block runs; with `PIPEWIRE_REMOTE` (not `PULSE_SERVER`)
it appended a hard-fail warning → `available=False`. On Linux CI the WSL block is
skipped, so the same tests pass — which is why this slipped through.

## Change

- `tools/voice_mode.py`: WSL block uses `has_forwarded_audio` instead of only
  `os.environ.get('PULSE_SERVER')`; notice/warning text updated to mention the
  PipeWire option (consistent with the container block).

## How to test

```bash
# New hermetic regression test (mocks /proc/version → reproduces WSL on any host):
pytest tests/tools/test_voice_wsl_pipewire.py -v
# The three pre-existing WSL tests now pass on WSL too:
pytest tests/tools/test_voice_mode.py::TestDetectAudioEnvironment -v
```

The new `test_wsl_with_pipewire_remote_allows_voice` **fails on current `main`**
(`available` is `False` due to the WSL warning) and passes with this change.
Complementary tests confirm `PULSE_SERVER` still works and that WSL **without**
any forwarding is still correctly blocked.

## Verification done

- New test: 3 pass with fix; the PIPEWIRE one fails on `main` (proven via stash).
- `tests/tools/test_voice_mode.py`: no regression from this change (the WSL
  pipewire cases now pass; any `TestPulseSocketReachable` failures are
  pre-existing environment artifacts — that function is untouched here).
- `ruff --select F,PLW1514` and `scripts/check-windows-footguns.py` on changed
  files: clean.

## Platforms

Fixes WSL2 (Python 3.11). No-op on non-WSL hosts (the block only runs when
`/proc/version` contains `microsoft`); Linux/macOS behavior unchanged.

## Scope

One block change + a regression test. Completes the SSH (#35622) / container
(#21203) audio-forwarding pattern for WSL.
