### PR TITLE
fix(bedrock): use per-model native output limit instead of hardcoded 4096 max_tokens (#37298)

### DIFF
--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -41,12 +41,13 @@ class BedrockTransport(ProviderTransport):
         Calls convert_messages and convert_tools internally.
 
         params:
-            max_tokens: int — output token limit (default 4096)
+            max_tokens: int — output token limit (defaults to model native limit)
             temperature: float | None
             guardrail_config: dict | None — Bedrock guardrails
             region: str — AWS region (default 'us-east-1')
         """
         from agent.bedrock_adapter import build_converse_kwargs
+        from agent.anthropic_adapter import _get_anthropic_max_output
 
         region = params.get("region", "us-east-1")
         guardrail = params.get("guardrail_config")
@@ -55,7 +56,7 @@ class BedrockTransport(ProviderTransport):
             model=model,
             messages=messages,
             tools=tools,
-            max_tokens=params.get("max_tokens", 4096),
+            max_tokens=params.get("max_tokens") or _get_anthropic_max_output(model),
             temperature=params.get("temperature"),
             guardrail_config=guardrail,
         )


### PR DESCRIPTION
 ## Problem

  The Bedrock Converse transport defaults `max_tokens` to 4096 when
  `model.max_tokens` is unset in config. This silently truncates long
  generations — Claude Sonnet 4.6 supports 64K, Opus 4.8 supports 128K.

  When truncation hits mid-tool-call, the agent surfaces a misleading
  "Response truncated due to output length limit" error.

  ## Root Cause

  v0.5.0 added `_ANTHROPIC_OUTPUT_LIMITS` — a per-model native output
  table used by the direct Anthropic API path — but the Bedrock Converse
  transport was never updated to use it, keeping its original hardcoded
  4096 fallback.

  ## Fix

  Replace the hardcoded 4096 with a call to the existing
  `_get_anthropic_max_output()` lookup (table-driven, same as the
  direct Anthropic path).

  | Scenario | Before | After |
  |----------|--------|-------|
  | No config set, Sonnet 4.6 | 4096 | 64000 |
  | No config set, Opus 4.8 | 4096 | 128000 |
  | `model.max_tokens: 8192` | 8192 | 8192 (unchanged) |

  Fixes #37298