### PR TITLE
Honor disabled title generation config

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,6 +9,8 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
+from hermes_cli.config import load_config_readonly
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +26,17 @@ _TITLE_PROMPT = (
     "following exchange. The title should capture the main topic or intent. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
+
+
+def _auto_title_enabled() -> bool:
+    """Return whether automatic session title generation is enabled."""
+    try:
+        config = load_config_readonly()
+        title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
+        return is_truthy_value(title_config.get("enabled"), default=True)
+    except Exception:
+        logger.debug("Failed to read title_generation.enabled", exc_info=True)
+        return True
 
 
 def generate_title(
@@ -44,6 +57,10 @@ def generate_title(
     ``AIAgent._emit_auxiliary_failure`` so the user sees a warning instead
     of silently accumulating untitled sessions.
     """
+    if not _auto_title_enabled():
+        logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
+        return None
+
     # Truncate long messages to keep the request small
     user_snippet = user_message[:500] if user_message else ""
     assistant_snippet = assistant_response[:500] if assistant_response else ""
@@ -147,6 +164,10 @@ def maybe_auto_title(
     - No title is already set
     """
     if not session_db or not session_id or not user_message or not assistant_response:
+        return
+
+    if not _auto_title_enabled():
+        logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
 
     # Count user messages in history to detect first exchange.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1205,6 +1205,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
         "title_generation": {
+            "enabled": True,
             "provider": "auto",
             "model": "",
             "base_url": "",

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -111,6 +111,18 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_skips_when_title_generation_disabled(self):
+        """auxiliary.title_generation.enabled=false disables automatic titles."""
+        config = {"auxiliary": {"title_generation": {"enabled": False}}}
+
+        with (
+            patch("agent.title_generator.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm") as mock_call_llm,
+        ):
+            assert generate_title("question", "answer") is None
+
+        mock_call_llm.assert_not_called()
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""
@@ -203,6 +215,23 @@ class TestMaybeAutoTitle:
                 main_runtime=None,
                 title_callback=None,
             )
+
+    def test_skips_when_title_generation_disabled(self):
+        """Disabled title generation should not even start the background worker."""
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        config = {"auxiliary": {"title_generation": {"enabled": False}}}
+
+        with (
+            patch("agent.title_generator.load_config_readonly", return_value=config),
+            patch("agent.title_generator.auto_title_session") as mock_auto,
+        ):
+            maybe_auto_title(db, "sess-1", "hello", "hi there", history)
+
+        mock_auto.assert_not_called()
 
     def test_forwards_failure_callback_to_worker(self):
         """maybe_auto_title must forward failure_callback into the thread."""

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -36,6 +36,7 @@ def test_title_generation_present_in_default_config():
     """
     assert "title_generation" in DEFAULT_CONFIG["auxiliary"]
     tg = DEFAULT_CONFIG["auxiliary"]["title_generation"]
+    assert tg["enabled"] is True
     assert tg["provider"] == "auto"
     assert tg["model"] == ""
     assert tg["timeout"] > 0

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -829,6 +829,10 @@ $ hermes model
 
 Select a task, pick a provider (OAuth flows open a browser; API-key providers prompt), pick a model. The change persists to `auxiliary.<task>.*` in `config.yaml`. Same machinery as the main-model picker — no extra syntax to learn.
 
+If you do not want Hermes to auto-generate titles after the first exchange, set
+`auxiliary.title_generation.enabled: false`. Manual titles still work through
+`/title` and `hermes sessions rename`.
+
 ### Video Tutorial
 
 <div style={{position: 'relative', width: '100%', aspectRatio: '16 / 9', marginBottom: '1.5rem'}}>
@@ -890,6 +894,15 @@ auxiliary:
 
   # Dangerous command approval classifier
   approval:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 30                # seconds
+
+  # Automatic session title generation after the first exchange
+  title_generation:
+    enabled: true              # set false to disable auto-title generation
     provider: "auto"
     model: ""
     base_url: ""


### PR DESCRIPTION
## Summary
- add `auxiliary.title_generation.enabled` to the default config
- skip automatic title generation when that flag is false
- document the disable knob alongside the auxiliary model config

## Why
The docs already recommend setting `auxiliary.title_generation.enabled: false` for sensitive sessions, but the auto-title pipeline did not read that flag. This makes the documented config actually disable background title generation while preserving manual `/title` and `hermes sessions rename`.

## Tests
- `python -m pytest tests/agent/test_title_generator.py tests/hermes_cli/test_aux_config.py`
- `python -m py_compile agent/title_generator.py hermes_cli/config.py`