### PR TITLE
fix(kanban): serialize cross-process SQLite writes

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1087,8 +1087,12 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
+_WRITE_LOCKS_GUARD = threading.RLock()
+_WRITE_LOCKS: dict[str, threading.RLock] = {}
+_WRITE_LOCK_DEPTH = threading.local()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
+DEFAULT_WRITE_LOCK_POLL_SECONDS = 0.025
 
 
 def _resolve_busy_timeout_ms() -> int:
@@ -1107,6 +1111,113 @@ def _resolve_busy_timeout_ms() -> int:
         if parsed > 0:
             return parsed
     return DEFAULT_BUSY_TIMEOUT_MS
+
+
+def _resolve_write_lock_timeout_ms() -> int:
+    """Return the bounded timeout for the Kanban sidecar DB write lock."""
+    raw = os.environ.get("HERMES_KANBAN_WRITE_LOCK_TIMEOUT_MS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+    return DEFAULT_BUSY_TIMEOUT_MS
+
+
+def _kanban_db_write_lock_path(path: Path) -> Path:
+    """Return the process-wide write lock sidecar for a Kanban DB path."""
+    return path.with_name(path.name + ".lock")
+
+
+def _connection_db_path(conn: sqlite3.Connection) -> Optional[Path]:
+    """Resolve the main database path for an open SQLite connection, if any."""
+    for row in conn.execute("PRAGMA database_list").fetchall():
+        try:
+            name = row["name"]
+            filename = row["file"]
+        except (TypeError, IndexError):
+            name = row[1]
+            filename = row[2]
+        if name == "main":
+            if filename:
+                return Path(str(filename))
+            return None
+    raise sqlite3.OperationalError("cannot resolve main kanban DB path for write lock")
+
+
+@contextlib.contextmanager
+def _cross_process_write_lock(path: Path):
+    """Serialize Kanban DB writes across processes with a bounded sidecar lock."""
+    resolved_path = path.resolve()
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    key = str(resolved_path)
+    depths = getattr(_WRITE_LOCK_DEPTH, "counts", None)
+    if depths is None:
+        depths = {}
+        _WRITE_LOCK_DEPTH.counts = depths
+    if depths.get(key, 0) > 0:
+        depths[key] += 1
+        try:
+            yield
+        finally:
+            depths[key] -= 1
+            if depths[key] <= 0:
+                depths.pop(key, None)
+        return
+
+    with _WRITE_LOCKS_GUARD:
+        local_lock = _WRITE_LOCKS.setdefault(key, threading.RLock())
+
+    with local_lock:
+        lock_path = _kanban_db_write_lock_path(resolved_path)
+        if _IS_WINDOWS and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_bytes(b" ")
+        handle = lock_path.open("r+b" if _IS_WINDOWS else "a+b")
+        acquired = False
+        deadline = time.monotonic() + (_resolve_write_lock_timeout_ms() / 1000.0)
+        try:
+            while True:
+                try:
+                    if _IS_WINDOWS:
+                        import msvcrt
+
+                        handle.seek(0)
+                        locking = getattr(msvcrt, "locking")
+                        lock_mode = getattr(msvcrt, "LK_NBLCK")
+                        locking(handle.fileno(), lock_mode, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    depths[key] = 1
+                    break
+                except OSError as exc:
+                    if time.monotonic() >= deadline:
+                        raise sqlite3.OperationalError(
+                            f"timed out acquiring kanban DB write lock for {path}"
+                        ) from exc
+                    time.sleep(DEFAULT_WRITE_LOCK_POLL_SECONDS)
+            yield
+        finally:
+            try:
+                depths.pop(key, None)
+                if acquired:
+                    if _IS_WINDOWS:
+                        import msvcrt
+
+                        handle.seek(0)
+                        locking = getattr(msvcrt, "locking")
+                        unlock_mode = getattr(msvcrt, "LK_UNLCK")
+                        locking(handle.fileno(), unlock_mode, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()
 
 
 def _sqlite_connect(path: Path) -> sqlite3.Connection:
@@ -1135,9 +1246,12 @@ def _cross_process_init_lock(path: Path):
     additive migrations single-file/single-writer across the whole host while
     leaving normal post-init DB usage concurrent under SQLite WAL.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = path.with_name(path.name + ".init.lock")
-    handle = lock_path.open("a+b")
+    resolved_path = path.resolve()
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = resolved_path.with_name(resolved_path.name + ".init.lock")
+    if _IS_WINDOWS and (not lock_path.exists() or lock_path.stat().st_size == 0):
+        lock_path.write_bytes(b" ")
+    handle = lock_path.open("r+b" if _IS_WINDOWS else "a+b")
     try:
         if _IS_WINDOWS:
             import msvcrt
@@ -1387,48 +1501,50 @@ def connect(
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
         _validate_sqlite_header(path)
-        # Full integrity probe — catches corruption past the header (malformed
-        # pages, broken internal metadata). Cached per-path after first success
-        # via _INITIALIZED_PATHS so it only runs once per process per path.
-        _guard_existing_db_is_healthy(path)
-        resolved = str(path.resolve())
-        conn = _sqlite_connect(path)
-        try:
-            conn.row_factory = sqlite3.Row
-            with _INIT_LOCK:
-                # WAL activation can take an exclusive lock while SQLite creates the
-                # sidecar files for a fresh database. Keep it in the same process-local
-                # critical section as schema initialization so concurrent gateway
-                # startup threads do not race before _INITIALIZED_PATHS is populated.
-                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
-                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-                # FULL (was NORMAL): fsync before each checkpoint to narrow the
-                # crash window that can leave a b-tree page header torn.
-                conn.execute("PRAGMA synchronous=FULL")
-                conn.execute("PRAGMA wal_autocheckpoint=100")
-                conn.execute("PRAGMA foreign_keys=ON")
-                # Zero freed pages so a later torn write cannot expose stale
-                # cell content; persisted in the DB header for new DBs.
-                conn.execute("PRAGMA secure_delete=ON")
-                # Surface corrupt cells as read errors instead of silent
-                # wrong-data returns.
-                conn.execute("PRAGMA cell_size_check=ON")
-                needs_init = resolved not in _INITIALIZED_PATHS
-                if needs_init:
-                    # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
-                    # migrations. Cached so subsequent connect() calls in the same
-                    # process are cheap. The lock prevents same-process dispatcher
-                    # threads from racing through the additive ALTER TABLE pass with
-                    # stale PRAGMA snapshots during gateway startup.
-                    conn.executescript(SCHEMA_SQL)
-                    _migrate_add_optional_columns(conn)
-                    _INITIALIZED_PATHS.add(resolved)
-        except Exception:
-            conn.close()
-            raise
+        with _cross_process_write_lock(path):
+            # Full integrity probe — catches corruption past the header (malformed
+            # pages, broken internal metadata). Cached per-path after first success
+            # via _INITIALIZED_PATHS so it only runs once per process per path.
+            _guard_existing_db_is_healthy(path)
+            resolved = str(path.resolve())
+            conn = _sqlite_connect(path)
+            try:
+                conn.row_factory = sqlite3.Row
+                with _INIT_LOCK:
+                    # WAL activation can take an exclusive lock while SQLite creates the
+                    # sidecar files for a fresh database. Keep it in the same process-local
+                    # critical section as schema initialization so concurrent gateway
+                    # startup threads do not race before _INITIALIZED_PATHS is populated.
+                    # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
+                    # falls back to DELETE with one WARNING so kanban stays usable there.
+                    # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
+                    from hermes_state import apply_wal_with_fallback
+                    apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                    # FULL (was NORMAL): fsync before each checkpoint to narrow the
+                    # crash window that can leave a b-tree page header torn.
+                    conn.execute("PRAGMA synchronous=FULL")
+                    conn.execute("PRAGMA wal_autocheckpoint=100")
+                    conn.execute("PRAGMA foreign_keys=ON")
+                    # Zero freed pages so a later torn write cannot expose stale
+                    # cell content; persisted in the DB header for new DBs.
+                    conn.execute("PRAGMA secure_delete=ON")
+                    # Surface corrupt cells as read errors instead of silent
+                    # wrong-data returns.
+                    conn.execute("PRAGMA cell_size_check=ON")
+                    needs_init = resolved not in _INITIALIZED_PATHS
+                    if needs_init:
+                        # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
+                        # migrations. Cached so subsequent connect() calls in the same
+                        # process are cheap. The locks prevent cross-process DDL/DML races
+                        # and same-process dispatcher threads from racing through the
+                        # additive ALTER TABLE pass with stale PRAGMA snapshots during
+                        # gateway startup.
+                        conn.executescript(SCHEMA_SQL)
+                        _migrate_add_optional_columns(conn)
+                        _INITIALIZED_PATHS.add(resolved)
+            except Exception:
+                conn.close()
+                raise
     return conn
 
 
@@ -1897,28 +2013,50 @@ def _check_file_length_invariant(conn: sqlite3.Connection) -> None:
             return  # in-memory or unnamed DB; skip
         path = path_str
         page_size = conn.execute("PRAGMA page_size").fetchone()[0]
-        file_size = os.path.getsize(path)
-        with open(path, "rb") as f:
-            f.seek(28)
-            header_bytes = f.read(4)
-        if len(header_bytes) < 4:
-            return  # can't read header; skip
-        header_page_count = int.from_bytes(header_bytes, "big")
-        if header_page_count == 0:
-            return  # new/empty DB; skip
-        actual_pages = file_size // page_size
-        if actual_pages < header_page_count:
-            raise sqlite3.DatabaseError(
-                f"torn-extend detected: page count mismatch on {path}: "
-                f"header claims {header_page_count} pages, "
-                f"file has {actual_pages} pages "
-                f"(missing {header_page_count - actual_pages} pages, "
-                f"file_size={file_size}, page_size={page_size})"
-            )
+        last_mismatch = None
+        for attempt in range(6):
+            file_size = os.path.getsize(path)
+            with open(path, "rb") as f:
+                f.seek(28)
+                header_bytes = f.read(4)
+            if len(header_bytes) < 4:
+                return  # can't read header; skip
+            header_page_count = int.from_bytes(header_bytes, "big")
+            if header_page_count == 0:
+                return  # new/empty DB; skip
+            actual_pages = file_size // page_size
+            if actual_pages >= header_page_count:
+                return
+            last_mismatch = (header_page_count, actual_pages, file_size, page_size)
+            if attempt < 5:
+                time.sleep(0.01)
+        if last_mismatch is None:
+            return
+        header_page_count, actual_pages, file_size, page_size = last_mismatch
+        raise sqlite3.DatabaseError(
+            f"torn-extend detected: page count mismatch on {path}: "
+            f"header claims {header_page_count} pages, "
+            f"file has {actual_pages} pages "
+            f"(missing {header_page_count - actual_pages} pages, "
+            f"file_size={file_size}, page_size={page_size})"
+        )
     except sqlite3.DatabaseError:
         raise
     except Exception:
         pass  # I/O errors during check are non-fatal; let normal ops continue
+
+
+def _write_txn_should_check_file_length(conn: sqlite3.Connection) -> bool:
+    """Return true when the post-commit main-file length invariant is meaningful."""
+    try:
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        journal_mode = str(row[0]).lower() if row and row[0] is not None else ""
+    except sqlite3.DatabaseError:
+        return True
+    # In WAL mode the main database file can lag while valid frames live in the
+    # WAL; comparing the main-file header to the main-file length at that point
+    # can report false torn-extend failures during concurrent writer bursts.
+    return journal_mode != "wal"
 
 
 @contextlib.contextmanager
@@ -1933,23 +2071,31 @@ def write_txn(conn: sqlite3.Connection):
     a SQLite auto-rollback (which leaves no active transaction) does not
     shadow the original exception with a spurious rollback error.
     """
-    conn.execute("BEGIN IMMEDIATE")
-    try:
-        yield conn
-    except Exception:
+    db_path = _connection_db_path(conn)
+    lock_context = (
+        _cross_process_write_lock(db_path)
+        if db_path is not None
+        else contextlib.nullcontext()
+    )
+    with lock_context:
+        conn.execute("BEGIN IMMEDIATE")
         try:
-            conn.execute("ROLLBACK")
-        except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
-            # under EIO, lock contention, or corruption). Nothing to undo;
-            # do not let this secondary failure shadow the real one.
-            pass
-        raise
-    else:
-        conn.execute("COMMIT")
-        # Post-commit file-length check: header page_count must match actual file pages.
-        # A discrepancy means a torn-extend — raise now rather than silently corrupt.
-        _check_file_length_invariant(conn)
+            yield conn
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                # SQLite has already auto-rolled-back the transaction (typical
+                # under EIO, lock contention, or corruption). Nothing to undo;
+                # do not let this secondary failure shadow the real one.
+                pass
+            raise
+        else:
+            conn.execute("COMMIT")
+            # Post-commit file-length check: header page_count must match actual file pages.
+            # A discrepancy means a torn-extend — raise now rather than silently corrupt.
+            if _write_txn_should_check_file_length(conn):
+                _check_file_length_invariant(conn)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import os
 import sqlite3
 import sys
@@ -70,10 +71,14 @@ def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
 def test_cross_process_init_lock_uses_windows_byte_range_lock(tmp_path, monkeypatch):
     """Windows must use a real process lock, not a no-op sidecar open."""
     calls: list[tuple[int, int, int]] = []
+    def fake_locking(fd, mode, nbytes):
+        assert os.fstat(fd).st_size >= 1
+        calls.append((fd, mode, nbytes))
+
     fake_msvcrt = types.SimpleNamespace(
         LK_LOCK=1,
         LK_UNLCK=2,
-        locking=lambda fd, mode, nbytes: calls.append((fd, mode, nbytes)),
+        locking=fake_locking,
     )
     monkeypatch.setattr(kb, "_IS_WINDOWS", True)
     monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
@@ -86,6 +91,125 @@ def test_cross_process_init_lock_uses_windows_byte_range_lock(tmp_path, monkeypa
         (fake_msvcrt.LK_LOCK, 1),
         (fake_msvcrt.LK_UNLCK, 1),
     ]
+
+
+def test_cross_process_write_lock_uses_windows_nonblocking_byte_range_lock(tmp_path, monkeypatch):
+    """Windows write lock should use nonblocking byte-range lock and unlock."""
+    calls: list[tuple[int, int, int]] = []
+    def fake_locking(fd, mode, nbytes):
+        assert os.fstat(fd).st_size >= 1
+        calls.append((fd, mode, nbytes))
+
+    fake_msvcrt = types.SimpleNamespace(
+        LK_NBLCK=3,
+        LK_UNLCK=2,
+        locking=fake_locking,
+    )
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    db_path = tmp_path / "kanban.db"
+    with kb._cross_process_write_lock(db_path):
+        assert calls == [(calls[0][0], fake_msvcrt.LK_NBLCK, 1)]
+
+    assert [call[1:] for call in calls] == [
+        (fake_msvcrt.LK_NBLCK, 1),
+        (fake_msvcrt.LK_UNLCK, 1),
+    ]
+
+
+def test_cross_process_write_lock_timeout_when_sidecar_is_held(tmp_path, monkeypatch):
+    """The DB write lock should time out instead of blocking indefinitely."""
+    if kb._IS_WINDOWS:
+        pytest.skip("Unix flock timeout regression test")
+    import fcntl
+
+    monkeypatch.setenv("HERMES_KANBAN_WRITE_LOCK_TIMEOUT_MS", "25")
+    db_path = tmp_path / "kanban.db"
+    lock_path = db_path.with_name(db_path.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    holder = lock_path.open("a+b")
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+        start = time.monotonic()
+        with pytest.raises(
+            sqlite3.OperationalError,
+            match="timed out acquiring kanban DB write lock",
+        ):
+            with kb._cross_process_write_lock(db_path):
+                pass
+        assert time.monotonic() - start < 1.0
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+
+def test_cross_process_write_lock_canonicalizes_sidecar_for_symlinked_db(tmp_path, monkeypatch):
+    """A DB opened through a symlink should contend on the target DB's lock file."""
+    if kb._IS_WINDOWS:
+        pytest.skip("Unix symlink/flock regression test")
+    import fcntl
+
+    monkeypatch.setenv("HERMES_KANBAN_WRITE_LOCK_TIMEOUT_MS", "25")
+    real_db = tmp_path / "real" / "kanban.db"
+    real_db.parent.mkdir()
+    alias_db = tmp_path / "alias.db"
+    alias_db.symlink_to(real_db)
+    canonical_lock = real_db.with_name(real_db.name + ".lock")
+    holder = canonical_lock.open("a+b")
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+        with pytest.raises(sqlite3.OperationalError, match="timed out acquiring kanban DB write lock"):
+            with kb._cross_process_write_lock(alias_db):
+                pass
+        assert not (tmp_path / "alias.db.lock").exists()
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+
+def test_connect_schema_init_uses_db_write_lock(tmp_path, monkeypatch):
+    """Schema DDL must share the same DB lock as normal write_txn calls."""
+    events: list[str] = []
+    write_lock_active = False
+
+    @contextlib.contextmanager
+    def fake_init_lock(path):
+        events.append(f"init:{Path(path).name}:enter")
+        try:
+            yield
+        finally:
+            events.append(f"init:{Path(path).name}:exit")
+
+    @contextlib.contextmanager
+    def fake_write_lock(path):
+        nonlocal write_lock_active
+        events.append(f"write:{Path(path).name}:enter")
+        write_lock_active = True
+        try:
+            yield
+        finally:
+            write_lock_active = False
+            events.append(f"write:{Path(path).name}:exit")
+
+    def asserting_migrate(conn):
+        assert write_lock_active, "schema migration ran outside the DB write lock"
+
+    monkeypatch.setattr(kb, "_cross_process_init_lock", fake_init_lock)
+    monkeypatch.setattr(kb, "_cross_process_write_lock", fake_write_lock, raising=False)
+    monkeypatch.setattr(kb, "_migrate_add_optional_columns", asserting_migrate)
+
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert events == [
+            "init:kanban.db:enter",
+            "write:kanban.db:enter",
+            "write:kanban.db:exit",
+            "init:kanban.db:exit",
+        ]
+    finally:
+        conn.close()
 
 
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
@@ -3715,6 +3839,56 @@ def test_pragmas_not_accidentally_disabled_by_migrate_path(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_write_txn_uses_write_lock_until_after_commit_check(kanban_home, monkeypatch):
+    """write_txn should hold the DB write lock across BEGIN, COMMIT, and checks."""
+    events: list[str] = []
+
+    @contextlib.contextmanager
+    def fake_write_lock(path):
+        events.append(f"lock:{Path(path).name}:enter")
+        try:
+            yield
+        finally:
+            events.append(f"lock:{Path(path).name}:exit")
+
+    def fake_check(conn):
+        events.append("check")
+
+    class LoggingConnWrapper:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *args, **kwargs):
+            events.append(sql.strip().split()[0].upper())
+            return self._real.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    monkeypatch.setattr(kb, "_cross_process_write_lock", fake_write_lock, raising=False)
+    monkeypatch.setattr(kb, "_write_txn_should_check_file_length", lambda conn: True)
+    monkeypatch.setattr(kb, "_check_file_length_invariant", fake_check)
+
+    with kb.connect() as conn:
+        events.clear()
+        wrapper = LoggingConnWrapper(conn)
+        with kb.write_txn(wrapper) as c:
+            c.execute(
+                "INSERT INTO tasks (id, title, assignee, status, priority, created_at) "
+                "VALUES ('t_lock01', 'locked task', 'tester', 'todo', 0, 1234567890)"
+            )
+
+    assert events == [
+        "PRAGMA",
+        "lock:kanban.db:enter",
+        "BEGIN",
+        "INSERT",
+        "COMMIT",
+        "check",
+        "lock:kanban.db:exit",
+    ]
+
+
 def test_write_txn_preserves_original_exception_when_rollback_fails(kanban_home):
     """When a write inside write_txn raises an OperationalError that SQLite
     has already auto-rolled-back (e.g. ``disk I/O error``,
@@ -3784,11 +3958,12 @@ def test_write_txn_healthy_commit_no_exception(tmp_path):
     conn.close()
 
 
-def test_write_txn_raises_on_truncated_file(tmp_path):
+def test_write_txn_raises_on_truncated_file(tmp_path, monkeypatch):
     """A mocked smaller file size triggers the torn-extend check."""
     from hermes_cli.kanban_db import connect, write_txn
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
+    monkeypatch.setattr(kb, "_write_txn_should_check_file_length", lambda conn: True)
     # Get actual page size so we can fake a smaller file
     page_size = conn.execute("PRAGMA page_size").fetchone()[0]
     original_getsize = os.path.getsize
@@ -3808,12 +3983,13 @@ def test_write_txn_raises_on_truncated_file(tmp_path):
     conn.close()
 
 
-def test_write_txn_post_commit_check_fires_every_call(tmp_path):
+def test_write_txn_post_commit_check_fires_every_call(tmp_path, monkeypatch):
     """The invariant check runs on every write_txn call."""
     from hermes_cli.kanban_db import connect, write_txn
     import hermes_cli.kanban_db as kanban_db_module
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
+    monkeypatch.setattr(kanban_db_module, "_write_txn_should_check_file_length", lambda conn: True)
     call_count = 0
     real_check = kanban_db_module._check_file_length_invariant
 
@@ -3830,6 +4006,27 @@ def test_write_txn_post_commit_check_fires_every_call(tmp_path):
                     f"VALUES ('t_fire{i:02d}', 'task {i}', 'tester', 'todo', 0, 1234567890)"
                 )
     assert call_count == 3
+    conn.close()
+
+
+def test_write_txn_skips_main_file_length_check_in_wal_mode(tmp_path, monkeypatch):
+    """WAL-mode commits should not compare main-file length while WAL frames may lag."""
+    from hermes_cli.kanban_db import connect, write_txn
+    import hermes_cli.kanban_db as kanban_db_module
+
+    db = tmp_path / "test.db"
+    conn = connect(db_path=db)
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+
+    def fail_check(c):
+        raise AssertionError("WAL write_txn should not run main-file length invariant")
+
+    monkeypatch.setattr(kanban_db_module, "_check_file_length_invariant", fail_check)
+    with write_txn(conn) as c:
+        c.execute(
+            "INSERT INTO tasks (id, title, assignee, status, priority, created_at) "
+            "VALUES ('t_walskip', 'wal task', 'tester', 'todo', 0, 1234567890)"
+        )
     conn.close()
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2987,65 +2987,66 @@ class TestPtyWebSocket:
         assert "channel=abc-123" in url
         assert "token=" in url
 
-    def test_pub_forwards_frames_to_broadcast_helper(self, monkeypatch):
-        """Frame written to /api/pub is passed to the channel broadcaster."""
+    def test_pub_broadcasts_to_events_subscribers(self, monkeypatch):
+        """Frame written to /api/pub is rebroadcast verbatim to every
+        /api/events subscriber on the same channel."""
         import time
-        import uuid
         from urllib.parse import urlencode
         from hermes_cli import web_server as ws_mod
 
-        channel = f"broadcast-test-{uuid.uuid4().hex}"
-        payload = '{"type":"tool.start","payload":{"tool_id":"t1"}}'
-        received: list[tuple[str, str]] = []
+        qs = urlencode({"token": self.token, "channel": "broadcast-test"})
+        pub_path = f"/api/pub?{qs}"
+        sub_path = f"/api/events?{qs}"
 
-        async def fake_broadcast(event_channel: str, event_payload: str) -> None:
-            received.append((event_channel, event_payload))
-
-        monkeypatch.setattr(ws_mod, "_broadcast_event", fake_broadcast)
-
-        qs = urlencode({"token": self.token, "channel": channel})
-        with self.client.websocket_connect(f"/api/pub?{qs}") as pub:
-            pub.send_text(payload)
+        with self.client.websocket_connect(sub_path) as sub:
+            # Wait for the subscriber to be registered on the server side.
+            # websocket_connect returns when ws.accept() completes, but the
+            # server adds us to ``_event_channels`` in a follow-up await,
+            # so a publish immediately after connect can race ahead of the
+            # subscriber registration and the message is dropped.
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
-                if received:
+                if ws_mod._event_channels.get("broadcast-test"):
                     break
                 time.sleep(0.01)
+            else:
+                raise AssertionError(
+                    "subscriber did not register on channel within 5s"
+                )
 
-        assert received == [(channel, payload)]
+            with self.client.websocket_connect(pub_path) as pub:
+                pub.send_text('{"type":"tool.start","payload":{"tool_id":"t1"}}')
+                # Yield control so the server-side broadcast handler can
+                # process the frame.  TestClient runs the ASGI app in a
+                # background thread; a small sleep gives that thread time
+                # to call _broadcast_event before we start blocking on
+                # receive_text().  Without this, under heavy CI load the
+                # receive can race the broadcast and hang until
+                # pytest-timeout kills us.
+                import queue, threading
+                recv_q: queue.Queue = queue.Queue()
 
-    def test_broadcast_event_fans_out_to_channel_subscribers(self):
-        """_broadcast_event sends one publisher frame to every channel subscriber."""
-        import asyncio
-        import uuid
-        from hermes_cli import web_server as ws_mod
+                def _recv():
+                    try:
+                        recv_q.put(sub.receive_text())
+                    except Exception as exc:
+                        recv_q.put(exc)
 
-        channel = f"broadcast-test-{uuid.uuid4().hex}"
-        payload = '{"type":"tool.start","payload":{"tool_id":"t1"}}'
+                t = threading.Thread(target=_recv, daemon=True)
+                t.start()
+                try:
+                    received = recv_q.get(timeout=10.0)
+                except queue.Empty:
+                    raise AssertionError(
+                        "broadcast not received within 10s — server likely "
+                        "dropped the frame silently (see _broadcast_event "
+                        "except Exception: pass)"
+                    )
+                if isinstance(received, Exception):
+                    raise received
 
-        class Subscriber:
-            def __init__(self) -> None:
-                self.sent: list[str] = []
-
-            async def send_text(self, text: str) -> None:
-                self.sent.append(text)
-
-        sub_a = Subscriber()
-        sub_b = Subscriber()
-
-        async def exercise() -> None:
-            async with ws_mod._event_lock:
-                ws_mod._event_channels[channel] = {sub_a, sub_b}
-            try:
-                await ws_mod._broadcast_event(channel, payload)
-            finally:
-                async with ws_mod._event_lock:
-                    ws_mod._event_channels.pop(channel, None)
-
-        asyncio.run(exercise())
-
-        assert sub_a.sent == [payload]
-        assert sub_b.sent == [payload]
+        assert "tool.start" in received
+        assert '"tool_id":"t1"' in received
 
     def test_events_rejects_missing_channel(self):
         from starlette.websockets import WebSocketDisconnect

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2987,66 +2987,65 @@ class TestPtyWebSocket:
         assert "channel=abc-123" in url
         assert "token=" in url
 
-    def test_pub_broadcasts_to_events_subscribers(self, monkeypatch):
-        """Frame written to /api/pub is rebroadcast verbatim to every
-        /api/events subscriber on the same channel."""
+    def test_pub_forwards_frames_to_broadcast_helper(self, monkeypatch):
+        """Frame written to /api/pub is passed to the channel broadcaster."""
         import time
+        import uuid
         from urllib.parse import urlencode
         from hermes_cli import web_server as ws_mod
 
-        qs = urlencode({"token": self.token, "channel": "broadcast-test"})
-        pub_path = f"/api/pub?{qs}"
-        sub_path = f"/api/events?{qs}"
+        channel = f"broadcast-test-{uuid.uuid4().hex}"
+        payload = '{"type":"tool.start","payload":{"tool_id":"t1"}}'
+        received: list[tuple[str, str]] = []
 
-        with self.client.websocket_connect(sub_path) as sub:
-            # Wait for the subscriber to be registered on the server side.
-            # websocket_connect returns when ws.accept() completes, but the
-            # server adds us to ``_event_channels`` in a follow-up await,
-            # so a publish immediately after connect can race ahead of the
-            # subscriber registration and the message is dropped.
+        async def fake_broadcast(event_channel: str, event_payload: str) -> None:
+            received.append((event_channel, event_payload))
+
+        monkeypatch.setattr(ws_mod, "_broadcast_event", fake_broadcast)
+
+        qs = urlencode({"token": self.token, "channel": channel})
+        with self.client.websocket_connect(f"/api/pub?{qs}") as pub:
+            pub.send_text(payload)
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
-                if ws_mod._event_channels.get("broadcast-test"):
+                if received:
                     break
                 time.sleep(0.01)
-            else:
-                raise AssertionError(
-                    "subscriber did not register on channel within 5s"
-                )
 
-            with self.client.websocket_connect(pub_path) as pub:
-                pub.send_text('{"type":"tool.start","payload":{"tool_id":"t1"}}')
-                # Yield control so the server-side broadcast handler can
-                # process the frame.  TestClient runs the ASGI app in a
-                # background thread; a small sleep gives that thread time
-                # to call _broadcast_event before we start blocking on
-                # receive_text().  Without this, under heavy CI load the
-                # receive can race the broadcast and hang until
-                # pytest-timeout kills us.
-                import queue, threading
-                recv_q: queue.Queue = queue.Queue()
+        assert received == [(channel, payload)]
 
-                def _recv():
-                    try:
-                        recv_q.put(sub.receive_text())
-                    except Exception as exc:
-                        recv_q.put(exc)
+    def test_broadcast_event_fans_out_to_channel_subscribers(self):
+        """_broadcast_event sends one publisher frame to every channel subscriber."""
+        import asyncio
+        import uuid
+        from hermes_cli import web_server as ws_mod
 
-                t = threading.Thread(target=_recv, daemon=True)
-                t.start()
-                try:
-                    received = recv_q.get(timeout=10.0)
-                except queue.Empty:
-                    raise AssertionError(
-                        "broadcast not received within 10s — server likely "
-                        "dropped the frame silently (see _broadcast_event "
-                        "except Exception: pass)"
-                    )
-                if isinstance(received, Exception):
-                    raise received
+        channel = f"broadcast-test-{uuid.uuid4().hex}"
+        payload = '{"type":"tool.start","payload":{"tool_id":"t1"}}'
 
-        assert "tool.start" in received
-        assert '"tool_id":"t1"' in received
+        class Subscriber:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+
+            async def send_text(self, text: str) -> None:
+                self.sent.append(text)
+
+        sub_a = Subscriber()
+        sub_b = Subscriber()
+
+        async def exercise() -> None:
+            async with ws_mod._event_lock:
+                ws_mod._event_channels[channel] = {sub_a, sub_b}
+            try:
+                await ws_mod._broadcast_event(channel, payload)
+            finally:
+                async with ws_mod._event_lock:
+                    ws_mod._event_channels.pop(channel, None)
+
+        asyncio.run(exercise())
+
+        assert sub_a.sent == [payload]
+        assert sub_b.sent == [payload]
 
     def test_events_rejects_missing_channel(self):
         from starlette.websockets import WebSocketDisconnect


### PR DESCRIPTION
## Summary

- serialize Kanban DB writes across processes with a bounded sidecar write lock
- run first-connect/schema/WAL initialization under the same DB write lock
- avoid WAL-mode false positives from the post-commit main-file length invariant
- add regression coverage for timeout behavior, schema-init locking, write_txn lock scope, symlinked DB lock canonicalization, Windows byte-range lock setup, and WAL invariant gating

## Why

Kanban can have multiple worker processes opening the same board database during dispatcher bursts. SQLite WAL and busy_timeout handle normal lock waiting, but they do not give Hermes a single process-wide critical section around schema initialization and multi-statement write_txn() calls. This leaves DDL/DML and concurrent write bursts vulnerable to corrupt-board outcomes.

This patch adds a bounded DB-scoped sidecar lock that is shared by connect() initialization and write_txn(). It also keeps the existing main-file torn-extend check for non-WAL modes while skipping that check in WAL mode, where valid frames can live in the WAL while the main DB file lags.

## Scope

Changed files:

- hermes_cli/kanban_db.py
- tests/hermes_cli/test_kanban_db.py

Out of scope:

- dispatcher recovery UX
- corrupt-backup cleanup or quarantine policy
- gateway supervision/orphan-process behavior
- notification or messaging adapters
- dashboard/UI changes
- unrelated CI/web-server flake fixes; see #37359

## Related work

Related: #37344, #35770, #35787, #37292, #33482, #33696, #37359

This PR keeps the write-lock fix Kanban-only and includes tests for the lock boundaries and WAL invariant behavior. The unrelated web-server broadcast flake remains split into #37359.

## Fix boundary / coverage

This PR intentionally covers the full Kanban DB write boundary rather than only one call site:

- `connect()` initialization: header/integrity checks, WAL activation, and schema migration run under the DB write lock so first-connect DDL cannot race ordinary writes.
- `write_txn()`: the same DB-scoped lock is held from `BEGIN IMMEDIATE` through `COMMIT` and the post-commit invariant check.
- bounded contention: sidecar lock acquisition times out with a clear SQLite operational error instead of waiting indefinitely.
- path identity: sidecar lock paths are derived from the resolved DB path, with regression coverage for symlinked DB access.
- Windows behavior: both `.init.lock` and `.lock` sidecars are pre-seeded before byte-range locking, with tests covering the non-empty lock-file requirement.
- WAL correctness: the main-file length invariant is skipped in WAL mode, where valid committed frames may still live in the WAL while the main DB file lags.

The related PRs and historical fixes are useful context; this patch keeps the scope limited to the Kanban SQLite lock/invariant boundary and its regression tests.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='`
  - 211 passed
- targeted lock/WAL regression subset
  - 7 passed
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- `git diff --check origin/main...HEAD`
- multi-process smoke: 8 worker processes x 40 create_task calls against one DB
  - quick_check=ok
  - integrity_check=ok
  - tasks=320
  - journal=wal
- independent review: passed after fixing the Windows zero-byte sidecar issue for both .init.lock and .lock
