### PR TITLE
fix(setup): detect custom provider key_env in provider readiness check (#37296)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -626,7 +626,7 @@ def _has_any_provider_configured() -> bool:
         if isinstance(entries, (list, tuple)):
             for entry in entries:
                 if isinstance(entry, dict):
-                    key_env = str(entry.get("key_env") or "").strip()
+                    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
                     if key_env:
                         provider_env_vars.add(key_env)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -611,6 +611,25 @@ def _has_any_provider_configured() -> bool:
     for pconfig in PROVIDER_REGISTRY.values():
         if pconfig.auth_type == "api_key":
             provider_env_vars.update(pconfig.api_key_env_vars)
+
+    # Include key_env from named custom providers so setup detection
+    # recognizes providers that use non-standard env var names.
+    # Without this, users with custom_providers like
+    #   custom_providers: [{key_env: ARK_API_KEY, ...}]
+    # would be told "no provider configured" even though
+    # resolve_runtime_provider() can find usable credentials. (#37296)
+    for section_name in ("providers", "custom_providers"):
+        section = cfg.get(section_name)
+        if not section:
+            continue
+        entries = list(section.values()) if isinstance(section, dict) else section
+        if isinstance(entries, (list, tuple)):
+            for entry in entries:
+                if isinstance(entry, dict):
+                    key_env = str(entry.get("key_env") or "").strip()
+                    if key_env:
+                        provider_env_vars.add(key_env)
+
     if any(os.getenv(v) for v in provider_env_vars):
         return True
 


### PR DESCRIPTION
 ## Problem

  Windows Desktop onboarding stays stuck on the provider setup screen
  when using named custom providers — even though `resolve_runtime_provider()`
  can successfully find usable credentials.

  Example config that triggers the bug:

  yaml
  model:
    default: ark-code-latest
    model: ark-code-latest
    provider: custom:volcengine-coding

  custom_providers:
  - name: volcengine-coding
    base_url: https://ark.cn-beijing.volces.com/api/coding/v3
    key_env: ARK_API_KEY
    model: ark-code-latest
    api_mode: chat_completions

  .env contains ARK_API_KEY=sk-xxx. CLI hermes status correctly shows
  the provider as configured. But Desktop onboarding stays stuck with
  "No inference provider configured."

  Root Cause

  _has_any_provider_configured() builds a set of recognized env var
  names from hardcoded defaults + built-in PROVIDER_REGISTRY, but never
  includes key_env from providers and custom_providers sections.
  Since ARK_API_KEY is not in the recognized set, both the os.getenv()
  check and the .env file scan miss it — the function returns False.

  resolve_runtime_provider() reads config.yaml directly and resolves
  key_env correctly, so the runtime works. But Desktop onboarding
  gates on _has_any_provider_configured(), which uses a separate
  detection path.

  Fix

  Scan providers and custom_providers sections for key_env /
  api_key_env values and add them to the recognized env var set.
  Both the os.getenv() check and the .env file scan automatically
  benefit because they share the same provider_env_vars set.

  Fixes #37296