### PR TITLE
fix: mark WhatsApp messages as read

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -204,6 +204,13 @@ async function startSocket() {
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
+      if (process.env.HERMES_WHATSAPP_QR_FILE) {
+        try {
+          writeFileSync(process.env.HERMES_WHATSAPP_QR_FILE, qr, { encoding: 'utf8', mode: 0o600 });
+        } catch (err) {
+          console.error('Failed to write QR payload file:', err.message);
+        }
+      }
       console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
       qrcode.generate(qr, { small: true });
       console.log('\nWaiting for scan...\n');
@@ -311,6 +318,15 @@ async function startSocket() {
             }));
           } catch {}
           continue;
+        }
+
+        // Mark accepted inbound messages as read as soon as Hermes sees them.
+        // This triggers WhatsApp read receipts (blue ticks / "seen") for the
+        // sender when read receipts are enabled on the paired account.
+        try {
+          await sock.readMessages([msg.key]);
+        } catch (err) {
+          console.error('[bridge] Failed to mark message read:', err.message);
         }
       }
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -319,15 +319,6 @@ async function startSocket() {
           } catch {}
           continue;
         }
-
-        // Mark accepted inbound messages as read as soon as Hermes sees them.
-        // This triggers WhatsApp read receipts (blue ticks / "seen") for the
-        // sender when read receipts are enabled on the paired account.
-        try {
-          await sock.readMessages([msg.key]);
-        } catch (err) {
-          console.error('[bridge] Failed to mark message read:', err.message);
-        }
       }
 
       const messageContent = getMessageContent(msg);
@@ -455,6 +446,19 @@ async function startSocket() {
         botIds,
         timestamp: msg.messageTimestamp,
       };
+
+      // Mark accepted inbound messages as read only once we know they will
+      // actually be queued for Hermes (i.e. they cleared the empty-body /
+      // unsupported-content gating above). This triggers WhatsApp read
+      // receipts (blue ticks / "seen") for the sender — but not for messages
+      // we skip — when read receipts are enabled on the paired account.
+      if (!msg.key.fromMe) {
+        try {
+          await sock.readMessages([msg.key]);
+        } catch (err) {
+          console.error('[bridge] Failed to mark message read:', err.message);
+        }
+      }
 
       messageQueue.push(event);
       if (messageQueue.length > MAX_QUEUE_SIZE) {

--- a/tests/gateway/test_whatsapp_bridge_read_receipts.py
+++ b/tests/gateway/test_whatsapp_bridge_read_receipts.py
@@ -1,0 +1,22 @@
+"""Tests for WhatsApp bridge read-receipt behavior."""
+
+from pathlib import Path
+
+
+BRIDGE_JS = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge" / "bridge.js"
+
+
+def test_bridge_marks_incoming_messages_read_before_queueing_for_agent():
+    """Accepted incoming WhatsApp messages should be marked read immediately.
+
+    This gives senders WhatsApp read receipts (blue ticks / seen) as soon as
+    the bridge has accepted the message for Hermes, rather than only after the
+    agent sends a reply.
+    """
+    source = BRIDGE_JS.read_text(encoding="utf-8")
+
+    read_call = "await sock.readMessages([msg.key]);"
+    queue_call = "messageQueue.push(event);"
+
+    assert read_call in source
+    assert source.index(read_call) < source.index(queue_call)

--- a/tests/gateway/test_whatsapp_bridge_read_receipts.py
+++ b/tests/gateway/test_whatsapp_bridge_read_receipts.py
@@ -6,17 +6,23 @@ from pathlib import Path
 BRIDGE_JS = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge" / "bridge.js"
 
 
-def test_bridge_marks_incoming_messages_read_before_queueing_for_agent():
-    """Accepted incoming WhatsApp messages should be marked read immediately.
+def test_bridge_marks_messages_read_after_gating_and_before_queueing():
+    """Only messages that will be queued for Hermes should be marked read.
 
-    This gives senders WhatsApp read receipts (blue ticks / seen) as soon as
-    the bridge has accepted the message for Hermes, rather than only after the
-    agent sends a reply.
+    The bridge gives senders WhatsApp read receipts (blue ticks / seen) once it
+    has accepted the message for Hermes. The read-receipt call must run *after*
+    the empty-body / unsupported-content gating (so skipped messages are not
+    marked read) but *before* the message is pushed onto the queue.
     """
     source = BRIDGE_JS.read_text(encoding="utf-8")
 
     read_call = "await sock.readMessages([msg.key]);"
     queue_call = "messageQueue.push(event);"
+    empty_gate = "if (!body && !hasMedia) {"
 
     assert read_call in source
+    assert empty_gate in source
+    # Read receipt must happen after the empty/unsupported-content gating...
+    assert source.index(empty_gate) < source.index(read_call)
+    # ...and before the message is queued for the agent.
     assert source.index(read_call) < source.index(queue_call)


### PR DESCRIPTION
## Summary
- Mark accepted inbound WhatsApp messages as read immediately in the bridge
- Optionally write the WhatsApp QR payload to `HERMES_WHATSAPP_QR_FILE` for external consumers
- Add a regression test covering read-receipt ordering before agent queueing

## Test Plan
- `python -m pytest tests/gateway/test_whatsapp_bridge_read_receipts.py`
