### PR TITLE
fix(vision): convert video_url blocks to Anthropic input_video format for MiniMax providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4594,10 +4594,14 @@ def _is_anthropic_compat_endpoint(provider: str, base_url: str) -> bool:
 
 
 def _convert_openai_images_to_anthropic(messages: list) -> list:
-    """Convert OpenAI ``image_url`` content blocks to Anthropic ``image`` blocks.
+    """Convert OpenAI ``image_url`` and ``video_url`` content blocks to Anthropic format.
 
-    Only touches messages that have list-type content with ``image_url`` blocks;
-    plain text messages pass through unchanged.
+    Converts:
+    - ``image_url`` blocks → Anthropic ``image`` blocks
+    - ``video_url`` blocks → Anthropic ``input_video`` blocks
+
+    Only touches messages that have list-type content with ``image_url`` or
+    ``video_url`` blocks; plain text messages pass through unchanged.
     """
     converted = []
     for msg in messages:
@@ -4633,6 +4637,28 @@ def _convert_openai_images_to_anthropic(messages: list) -> list:
                             "url": image_url_val,
                         },
                     })
+                changed = True
+            elif block.get("type") == "video_url":
+                video_url_val = (block.get("video_url") or {}).get("url", "")
+                if video_url_val.startswith("data:"):
+                    # Parse data URI: data:<media_type>;base64,<data>
+                    header, _, b64data = video_url_val.partition(",")
+                    media_type = "video/mp4"
+                    if ":" in header and ";" in header:
+                        media_type = header.split(":", 1)[1].split(";", 1)[0]
+                    new_content.append({
+                        "type": "input_video",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": b64data,
+                        },
+                    })
+                else:
+                    # URL-based video — Anthropic protocol doesn't have a
+                    # native URL-based video block; pass through as-is and
+                    # let the provider handle (or reject) it.
+                    new_content.append(block)
                 changed = True
             else:
                 new_content.append(block)


### PR DESCRIPTION
## Summary

The `video_analyze` tool sends OpenAI-style `video_url` content blocks, which breaks Anthropic-protocol providers (minimax, minimax-cn). These providers expect `input_video` blocks with base64 data instead of data: URLs.

## Problem

When calling `video_analyze` with provider `minimax-cn` and model `MiniMax-M3`, the request is rejected with `unknown content type: video_url` because the wire format doesn't match what the Anthropic Messages API expects.

## Fix

Extends `_convert_openai_images_to_anthropic()` in `agent/auxiliary_client.py` to also handle `video_url` blocks, converting them to Anthropic's `input_video` format when targeting Anthropic-compatible endpoints.

The existing conversion infrastructure already detects Anthropic-compatible endpoints (minimax, minimax-cn, any URL containing `/anthropic`) and converts `image_url` blocks. This fix adds parallel handling for `video_url` blocks.

## Changes

- `agent/auxiliary_client.py`: Extended `_convert_openai_images_to_anthropic()` to convert `video_url` → `input_video` for data URIs, and pass through URL-based videos unchanged.

## Testing

- All 23 existing `TestAnthropicCompatImageConversion` tests pass
- Manual testing confirms:
  - `video_url` data URIs are converted to `input_video` with correct base64 data
  - `video_url` URLs pass through unchanged (Anthropic has no native URL video block)
  - Mixed `image_url` + `video_url` messages are both converted correctly
  - Plain text and image-only messages are unaffected

Fixes #37219