### PR TITLE
Fix Codex Responses max_output_tokens incomplete being routed to truncation error

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1553,7 +1553,15 @@ def run_conversation(
                     else:
                         incomplete_reason = getattr(incomplete_details, "reason", None)
                     if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
-                        finish_reason = "length"
+                        # Codex Responses may finish a step as `incomplete` because
+                        # the hidden output budget was spent on reasoning, while still
+                        # returning replayable reasoning/message items. Do not route
+                        # this through the generic `length` handler: that path was
+                        # built for Chat Completions-style partial text/tool calls and
+                        # returns a user-visible truncation error for Codex. Let the
+                        # normal Codex normalization below mark it `incomplete` and use
+                        # the existing Codex continuation loop.
+                        finish_reason = "incomplete"
                     else:
                         finish_reason = "stop"
                 elif agent.api_mode == "anthropic_messages":
@@ -1661,7 +1669,7 @@ def run_conversation(
                             "The model used all its output tokens on reasoning "
                             "and had none left for the actual response.\n\n"
                             "To fix this:\n"
-                            "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
+                            "→ Lower reasoning effort: `/reasoning low` or `/reasoning minimal`\n"
                             "→ Or switch to a larger/non-reasoning model with `/model`"
                         )
                         agent._cleanup_task_resources(effective_task_id)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -123,6 +123,23 @@ def _codex_incomplete_message_response(text: str):
     )
 
 
+def _codex_max_output_incomplete_reasoning_response():
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_1",
+                encrypted_content="encrypted-reasoning-state",
+                summary=[SimpleNamespace(type="summary_text", text="Still synthesizing.")],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=100, output_tokens=4096, total_tokens=4196),
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        model="gpt-5-codex",
+    )
+
+
 def _codex_commentary_message_response(text: str):
     return SimpleNamespace(
         output=[
@@ -1338,6 +1355,27 @@ def test_run_conversation_codex_continues_after_incomplete_interim_message(monke
         for msg in result["messages"]
     )
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
+
+
+def test_run_conversation_codex_max_output_incomplete_continues(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_max_output_incomplete_reasoning_response(),
+        _codex_message_response("Vendor recommendation complete."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    result = agent.run_conversation("summarize delegated research")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Vendor recommendation complete."
+    assert result.get("error") is None
+    assert any(
+        msg.get("role") == "assistant"
+        and msg.get("finish_reason") == "incomplete"
+        and msg.get("codex_reasoning_items")
+        for msg in result["messages"]
+    )
 
 
 def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(monkeypatch):


### PR DESCRIPTION
When using the openai-codex provider with gpt-5 models, the Responses API can return status=incomplete with incomplete_details.reason=max_output_tokens. This happens when the output budget is exhausted on reasoning (common with high reasoning_effort or after large delegate_task results).

The loop was incorrectly forcing this into finish_reason="length". That path doesn't know about Codex reasoning replay and returns the "Response truncated due to output length limit" error to the user.

This routes those cases into the existing "incomplete" continuation path instead.

Also fixed the outdated `/thinkon` command in the thinking budget exhausted message.

Added a regression test for the exact scenario.

No other files changed.
