### PR TITLE
fix(delegation): keep child sessions out of parent env

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -980,9 +980,10 @@ def init_agent(
     try:
         from gateway.session_context import set_current_session_id
 
-        set_current_session_id(agent.session_id)
+        set_current_session_id(agent.session_id, update_environ=not bool(parent_session_id))
     except Exception:
-        os.environ["HERMES_SESSION_ID"] = agent.session_id
+        if not parent_session_id:
+            os.environ["HERMES_SESSION_ID"] = agent.session_id
 
     # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
     hermes_home = get_hermes_home()

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -83,7 +83,7 @@ _VAR_MAP = {
 }
 
 
-def set_current_session_id(session_id: str) -> None:
+def set_current_session_id(session_id: str, *, update_environ: bool = True) -> None:
     """Synchronize ``HERMES_SESSION_ID`` across ContextVar and ``os.environ``.
 
     Long-lived single-process entrypoints like the CLI can rotate sessions via
@@ -91,10 +91,17 @@ def set_current_session_id(session_id: str) -> None:
     reconstructing the entire agent. Tools still consult
     ``get_session_env("HERMES_SESSION_ID")`` with an ``os.environ`` fallback,
     so both storage paths must move together when the active session changes.
+
+    ``delegate_task`` children run in worker threads inside the parent process.
+    They need a child-local ContextVar value, but must not mutate the global
+    process environment that later parent tool calls inherit.  Those callers
+    pass ``update_environ=False`` and rely on ``get_session_env`` seeing the
+    thread-local ContextVar before falling back to ``os.environ``.
     """
     import os
 
-    os.environ["HERMES_SESSION_ID"] = session_id
+    if update_environ:
+        os.environ["HERMES_SESSION_ID"] = session_id
     _SESSION_ID.set(session_id)
 
 

--- a/tests/run_agent/test_session_env.py
+++ b/tests/run_agent/test_session_env.py
@@ -1,0 +1,42 @@
+"""Session environment propagation regression tests."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _agent(**kwargs):
+    defaults = {
+        "api_key": "test-key",
+        "base_url": "https://example.test/v1",
+        "model": "test/model",
+        "quiet_mode": True,
+        "skip_context_files": True,
+        "skip_memory": True,
+    }
+    defaults.update(kwargs)
+    return AIAgent(**defaults)
+
+
+@patch("run_agent.OpenAI")
+def test_top_level_agent_publishes_session_id_to_environment(mock_openai, monkeypatch):
+    mock_openai.return_value = MagicMock()
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+    agent = _agent(session_id="parent-session")
+
+    assert getattr(agent, "session_id") == "parent-session"
+    assert os.environ["HERMES_SESSION_ID"] == "parent-session"
+
+
+@patch("run_agent.OpenAI")
+def test_subagent_session_id_does_not_clobber_parent_environment(mock_openai, monkeypatch):
+    mock_openai.return_value = MagicMock()
+    monkeypatch.setenv("HERMES_SESSION_ID", "parent-session")
+
+    child = _agent(session_id="child-session", parent_session_id="parent-session")
+
+    assert getattr(child, "session_id") == "child-session"
+    assert getattr(child, "_parent_session_id") == "parent-session"
+    assert os.environ["HERMES_SESSION_ID"] == "parent-session"


### PR DESCRIPTION
## Summary
- Prevent delegate_task child agents from overwriting the parent process's HERMES_SESSION_ID environment variable.
- Closes #37356.

## Why
- Child agents already have their own session_id for session logging, but mutating os.environ is process-global.
- After a delegate_task call, later parent tools can inherit the child's HERMES_SESSION_ID even though the parent agent's session_id is unchanged.

## Changes
- gateway/session_context.py: add an update_environ switch to set_current_session_id while keeping the ContextVar update.
- agent/agent_init.py: use child-local ContextVar session IDs for agents with parent_session_id without changing process env.
- tests/run_agent/test_session_env.py: cover top-level env publication and subagent env preservation.

## Validation
- python -m pytest tests/run_agent/test_session_env.py -q -o 'addopts='
- python -m pytest tests/gateway/test_session_env.py -q -o 'addopts='
- python -m ruff check gateway/session_context.py agent/agent_init.py tests/run_agent/test_session_env.py
- git diff --check

## Scope
- In scope: avoiding process-global session env clobbering for child agents while preserving ContextVar session identity.
- Out of scope: migrating every existing os.environ reader to get_session_env().