### PR TITLE
fix(terminal): collapse CWD-only overrides to shared container

### DIFF
--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -105,3 +105,49 @@ def test_get_active_env_honours_rl_override():
         terminal_tool.clear_task_env_overrides("rl-42")
         terminal_tool._active_environments.pop("default", None)
         terminal_tool._active_environments.pop("rl-42", None)
+
+
+def test_cwd_only_override_collapses_to_default():
+    """CWD-only overrides (ACP adapter workspace tracking) must NOT trigger
+    container isolation — they should collapse to the shared 'default'
+    container so all surfaces (TUI, gateway, dashboard) share one sandbox.
+    Regression for #37361."""
+    terminal_tool.register_task_env_overrides(
+        "acp-session-abc", {"cwd": "/home/user/project"}
+    )
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id("acp-session-abc")
+            == "default"
+        )
+    finally:
+        terminal_tool.clear_task_env_overrides("acp-session-abc")
+
+
+def test_cwd_plus_docker_image_keeps_own_id():
+    """When overrides include both cwd AND docker_image, isolation must
+    still be honoured (RL/benchmark pattern with explicit cwd)."""
+    terminal_tool.register_task_env_overrides(
+        "rl-with-cwd", {"docker_image": "myimg:latest", "cwd": "/workspace"}
+    )
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id("rl-with-cwd")
+            == "rl-with-cwd"
+        )
+    finally:
+        terminal_tool.clear_task_env_overrides("rl-with-cwd")
+
+
+def test_env_type_override_keeps_own_id():
+    """env_type is an isolation key — must trigger per-task container."""
+    terminal_tool.register_task_env_overrides(
+        "bench-env", {"env_type": "sandbox", "cwd": "/work"}
+    )
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id("bench-env")
+            == "bench-env"
+        )
+    finally:
+        terminal_tool.clear_task_env_overrides("bench-env")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1006,9 +1006,20 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     task_id, we honour it by returning the task_id unchanged -- those
     rollouts need their own isolated sandbox, which is the whole point of
     the override.
+
+    CWD-only overrides (registered by the ACP adapter for workspace
+    tracking) are *not* isolation signals — they should not cause each
+    session to spin up its own container.  Only overrides containing
+    backend-specific image keys or ``env_type`` trigger isolation.
     """
+    _ISOLATION_KEYS = frozenset({
+        "docker_image", "modal_image", "singularity_image",
+        "daytona_image", "env_type",
+    })
     if task_id and task_id in _task_env_overrides:
-        return task_id
+        overrides = _task_env_overrides[task_id]
+        if set(overrides.keys()) & _ISOLATION_KEYS:
+            return task_id
     return "default"
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes Docker container isolation when `register_task_env_overrides` is called with CWD-only overrides (ACP adapter workspace tracking). Previously, any override registration caused each session to spin up its own container, making it impossible to share auth state across TUI, gateway, and dashboard.

## Related Issue

Fixes #37361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: In `_resolve_container_task_id`, check whether the registered overrides contain any isolation keys (`docker_image`, `modal_image`, `singularity_image`, `daytona_image`, `env_type`). CWD-only overrides now collapse to the shared `"default"` container.
- `tests/tools/test_shared_container_task_id.py`: Added 3 regression tests covering CWD-only collapse, CWD+docker_image isolation, and env_type isolation.

## How to Test

1. Set `terminal.backend: docker` and `terminal.docker_persist_across_processes: true` in config.yaml
2. Start a TUI session and run `touch /root/hello.txt`
3. Open dashboard `/chat` and run `ls /root/` — `hello.txt` should be present (shared container)
4. Run `pytest tests/tools/test_shared_container_task_id.py -v` — all 12 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/terminal_tool.py:_resolve_container_task_id` (callers: 3 — `_resolve_container_task_id` in terminal_tool.py:1378, terminal_tool.py:1783, and `get_active_env`)
- Blast radius: LOW — only affects container key resolution when overrides are registered with CWD-only keys
- Related patterns: `register_task_env_overrides` called from `acp_adapter/session.py` (CWD-only) and `batch_runner.py` (full overrides including docker_image)
