### PR TITLE
fix: de-dupe WSL interop paths in gateway units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2188,11 +2188,18 @@ def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:
             candidates.append(entry)
 
     result: list[str] = []
-    seen = set(path_entries)
+
+    def _dedupe_key(entry: str) -> str:
+        return entry.rstrip("/") if entry.startswith("/mnt/") else entry
+
+    seen = {_dedupe_key(entry) for entry in path_entries}
     for entry in candidates:
-        if entry and entry not in seen:
-            seen.add(entry)
-            result.append(entry)
+        if not entry:
+            continue
+        key = _dedupe_key(entry)
+        if key not in seen:
+            seen.add(key)
+            result.append(key)
     return result
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -38,6 +38,19 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    def test_wsl_interop_paths_dedupe_trailing_slash_variants(self, monkeypatch):
+        powershell_dir = "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0"
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
+        monkeypatch.setenv("PATH", f"/usr/bin{os.pathsep}{powershell_dir}")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda executable: None)
+        monkeypatch.setattr(gateway_cli.Path, "exists", lambda self: str(self).startswith("/mnt/c/WINDOWS"))
+
+        paths = gateway_cli._build_wsl_interop_paths([])
+
+        assert powershell_dir in paths
+        assert f"{powershell_dir}/" not in paths
+        assert paths.count(powershell_dir) == 1
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- De-duplicate WSL interop PATH entries while generating gateway systemd units
- Treat `/mnt/...` entries with and without trailing slashes as the same source path during PATH construction
- Prevent false-positive "Installed gateway service definition is outdated" warnings caused by duplicate equivalent Windows PATH entries on WSL

## Test Plan
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_wsl_interop_paths_dedupe_trailing_slash_variants -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh -q -o 'addopts='`
