### PR TITLE
fix: harden Windows update and backup paths

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -32,13 +32,15 @@ logger = logging.getLogger(__name__)
 
 # Directory names to skip entirely (matched against each path component)
 _EXCLUDED_DIRS = {
-    "hermes-agent",     # the codebase repo — re-clone instead
-    "__pycache__",      # bytecode caches — regenerated on import
-    ".git",             # nested git dirs (profiles shouldn't have these, but safety)
-    "node_modules",     # js deps if website/ somehow leaks in
-    "backups",          # prior auto-backups — don't nest backups exponentially
-    "checkpoints",      # session-local trajectory caches — regenerated per-session,
-                        # session-hash-keyed so they don't port to another machine anyway
+    "hermes-agent",             # the codebase repo — re-clone instead
+    "__pycache__",              # bytecode caches — regenerated on import
+    ".git",                     # nested git dirs (profiles shouldn't have these, but safety)
+    "node_modules",             # js deps if website/ somehow leaks in
+    "backups",                  # prior auto-backups — don't nest backups exponentially
+    "checkpoints",              # session-local trajectory caches — regenerated per-session,
+                                # session-hash-keyed so they don't port to another machine anyway
+    "browser-cdp-profile",      # live Chrome profile: SQLite DBs can block sqlite3.backup() on Windows
+    "browser-cdp-test-profile", # same for test/runtime CDP profile
 }
 
 # File-name suffixes to skip

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -41,6 +41,7 @@ from pathlib import Path
 # Short timeouts: schtasks occasionally wedges and we don't want to hang forever.
 _SCHTASKS_TIMEOUT_S = 15
 _SCHTASKS_NO_OUTPUT_TIMEOUT_S = 30
+_SCHTASKS_ENCODINGS = ("mbcs", "utf-8", "cp1252")
 # Patterns in schtasks stderr that mean "fall back to the Startup folder".
 _FALLBACK_PATTERNS = re.compile(
     r"(access is denied|acceso denegado|přístup byl odepřen|schtasks timed out|schtasks produced no output)",
@@ -97,6 +98,20 @@ def _quote_schtasks_arg(value: str) -> str:
 # schtasks.exe wrapper
 # ---------------------------------------------------------------------------
 
+def _decode_schtasks_output(data: bytes | str | None) -> str:
+    """Decode localized schtasks.exe output without crashing on Windows."""
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return data
+    for enc in _SCHTASKS_ENCODINGS:
+        try:
+            return data.decode(enc)
+        except (LookupError, UnicodeDecodeError):
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
 def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
     """Run ``schtasks.exe`` with a hard timeout. Return (code, stdout, stderr).
 
@@ -108,17 +123,24 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
     if schtasks is None:
         return (1, "", "schtasks.exe not found on PATH")
     try:
+        env = os.environ.copy()
+        env.setdefault("MSYS2_ARG_CONV_EXCL", "*")
         proc = subprocess.run(
             [schtasks, *args],
             capture_output=True,
-            text=True,
+            text=False,
             timeout=_SCHTASKS_TIMEOUT_S,
+            env=env,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the
             # same pattern and the windows-subprocess-sigint-storm.md ref.
             creationflags=0x08000000,  # CREATE_NO_WINDOW
         )
-        return (proc.returncode, proc.stdout or "", proc.stderr or "")
+        return (
+            proc.returncode,
+            _decode_schtasks_output(proc.stdout),
+            _decode_schtasks_output(proc.stderr),
+        )
     except subprocess.TimeoutExpired:
         return (124, "", f"schtasks timed out after {_SCHTASKS_TIMEOUT_S}s")
     except OSError as e:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7263,6 +7263,39 @@ def _format_time_ago(iso_ts: str) -> str:
         return "recently"
 
 
+def _windows_subprocess_creationflags() -> int:
+    """Return subprocess creation flags that avoid console popups on Windows."""
+    if sys.platform != "win32":
+        return 0
+    return getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+
+
+def _decode_windows_subprocess_output(data: bytes | str | None) -> str:
+    """Decode localized Windows subprocess output without crashing."""
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return data
+    encodings = ("mbcs", "utf-8", "cp1252") if sys.platform == "win32" else ("utf-8",)
+    for enc in encodings:
+        try:
+            return data.decode(enc)
+        except (LookupError, UnicodeDecodeError):
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+def _windows_taskkill_pid_not_found(message: str) -> bool:
+    """Return True when taskkill says the process already exited."""
+    lower = message.lower()
+    return (
+        "not found" in lower
+        or "not running" in lower
+        or "no running instance" in lower
+        or "没有找到进程" in message
+    )
+
+
 def _kill_stale_dashboard_processes(
     reason: str = "the running backend no longer matches the updated frontend",
 ) -> None:
@@ -7297,16 +7330,26 @@ def _kill_stale_dashboard_processes(
     if sys.platform == "win32":
         for pid in pids:
             try:
+                env = os.environ.copy()
+                env.setdefault("MSYS2_ARG_CONV_EXCL", "*")
                 result = subprocess.run(
                     ["taskkill", "/PID", str(pid), "/F"],
                     capture_output=True,
-                    text=True,
+                    text=False,
                     timeout=10,
+                    env=env,
+                    creationflags=_windows_subprocess_creationflags(),
                 )
+                output = (
+                    _decode_windows_subprocess_output(result.stderr)
+                    or _decode_windows_subprocess_output(result.stdout)
+                ).strip()
                 if result.returncode == 0:
                     killed.append(pid)
+                elif _windows_taskkill_pid_not_found(output):
+                    killed.append(pid)
                 else:
-                    failed.append((pid, (result.stderr or result.stdout or "").strip()))
+                    failed.append((pid, output))
             except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
                 failed.append((pid, str(e)))
     else:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -110,6 +110,13 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_browser_cdp_runtime_profiles(self):
+        """Live Chrome/CDP profiles contain locked SQLite DBs on Windows."""
+        from hermes_cli.backup import _should_exclude
+
+        assert _should_exclude(Path("browser-cdp-profile/Default/Cookies"))
+        assert _should_exclude(Path("browser-cdp-test-profile/first_party_sets.db"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -29,6 +29,35 @@ def test_schtasks_fallback_does_not_hide_unknown_errors():
     assert gateway_windows._should_fall_back(1, "ERROR: The system cannot find the file specified.") is False
 
 
+def test_exec_schtasks_decodes_localized_bytes_without_text_mode_crash(monkeypatch):
+    """Chinese Windows schtasks output may not be UTF-8."""
+
+    class Result:
+        returncode = 1
+        stdout = "成功".encode("gbk")
+        stderr = "错误: 没有找到任务".encode("gbk")
+
+    def fake_run(cmd, **kwargs):
+        assert kwargs["text"] is False
+        assert kwargs["env"]["MSYS2_ARG_CONV_EXCL"] == "*"
+        assert kwargs["creationflags"] == 0x08000000
+        return Result()
+
+    monkeypatch.setattr(gateway_windows.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_windows.shutil, "which", lambda name: r"C:\Windows\System32\schtasks.exe")
+    monkeypatch.setattr(gateway_windows.subprocess, "run", fake_run)
+
+    code, stdout, stderr = gateway_windows._exec_schtasks(["/Query"])
+
+    assert code == 1
+    assert stdout == "成功"
+    assert "没有找到任务" in stderr
+
+
+def test_decode_schtasks_output_replaces_undecodable_bytes():
+    assert "�" in gateway_windows._decode_schtasks_output(b"\x81")
+
+
 def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, tmp_path):
     """Avoid uv's venv pythonw launcher because it respawns console python.exe."""
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -314,10 +314,30 @@ class TestKillStaleDashboardWindows:
         assert len(taskkill_calls) == 2
         assert ["taskkill", "/PID", "12345", "/F"] in [c.args[0] for c in taskkill_calls]
         assert ["taskkill", "/PID", "12346", "/F"] in [c.args[0] for c in taskkill_calls]
+        for call in taskkill_calls:
+            assert call.kwargs["text"] is False
+            assert call.kwargs["env"]["MSYS2_ARG_CONV_EXCL"] == "*"
+            assert call.kwargs["creationflags"] != 0
 
         out = capsys.readouterr().out
         assert "✓ stopped PID 12345" in out
         assert "✓ stopped PID 12346" in out
+
+    def test_taskkill_missing_pid_counts_as_stopped(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        def fake_run(args, *a, **kw):
+            return MagicMock(returncode=128, stdout=b"",
+                             stderr="错误: 没有找到进程 \"40360\"。".encode("gbk"))
+
+        with patch("hermes_cli.main._find_stale_dashboard_pids",
+                   return_value=[40360]), \
+             patch("subprocess.run", side_effect=fake_run):
+            _kill_stale_dashboard_processes()
+
+        out = capsys.readouterr().out
+        assert "✓ stopped PID 40360" in out
+        assert "failed to stop" not in out
 
     def test_taskkill_failure_is_reported(self, monkeypatch, capsys):
         monkeypatch.setattr(sys, "platform", "win32")


### PR DESCRIPTION
## Summary
- exclude live browser CDP profiles from `hermes backup` so Windows backups don't hang on locked SQLite databases
- make Windows dashboard cleanup use bytes-mode `taskkill` with localized-output decoding
- treat `taskkill` "process not found" races as success instead of reporting a false failure
- pass `MSYS2_ARG_CONV_EXCL=*` and `CREATE_NO_WINDOW` for the Windows `taskkill` path

## Problem classification
- Evidence level: confirmed local Windows reproduction.
- Public search: no existing issue/PR found for the exact CDP backup hang, localized `taskkill` race, or conhost popup path.
- Classification: upstream design gap exposed by Windows-native usage, not an operator mistake.

## Test plan
- `python -m pytest -o addopts='' tests/hermes_cli/test_backup.py::TestShouldExclude::test_excludes_browser_cdp_runtime_profiles tests/hermes_cli/test_update_stale_dashboard.py::TestKillStaleDashboardWindows::test_taskkill_invoked_for_each_pid tests/hermes_cli/test_update_stale_dashboard.py::TestKillStaleDashboardWindows::test_taskkill_missing_pid_counts_as_stopped tests/hermes_cli/test_update_stale_dashboard.py::TestKillStaleDashboardWindows::test_taskkill_failure_is_reported -q`
- Result: `4 passed in 0.99s`

## Notes
Running the full two Windows-focused files on the local Windows host still shows unrelated pre-existing Windows test failures around POSIX-style profile wrapper names and `ps` assumptions. The focused regression tests for this PR pass.
