### PR TITLE
fix(gateway): scan assistant messages for MEDIA paths in history dedup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17760,8 +17760,8 @@ class GatewayRunner:
             # even if the message list shrinks, we know which paths are old.
             _history_media_paths: set = set()
             for _hm in agent_history:
-                if _hm.get("role") in {"tool", "function"}:
-                    _hc = _hm.get("content", "")
+                if _hm.get("role") in {"tool", "function", "assistant"}:
+                    _hc = _hm.get("content", "") or ""
                     if "MEDIA:" in _hc:
                         _TOOL_MEDIA_RE = re.compile(
                             r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -371,5 +371,84 @@ class TestStaleToolMediaLeak:
         )
 
 
+def collect_history_media_paths(agent_history):
+    """Mirror of the _history_media_paths collection in gateway/run.py.
+
+    Scans history messages for MEDIA: tags across tool, function, AND
+    assistant roles.  Assistant messages are included because context
+    compression preserves MEDIA: tags from prior assistant turns in the
+    compressed summary — without scanning assistant messages, those paths
+    are missed and the files get re-delivered.  (Regression test for #37358)
+    """
+    paths = set()
+    for msg in agent_history:
+        if msg.get("role") in {"tool", "function", "assistant"}:
+            content = msg.get("content", "") or ""
+            if "MEDIA:" in content:
+                for match in re.finditer(r'MEDIA:(\S+)', content):
+                    p = match.group(1).strip().rstrip('\",}')
+                    if p:
+                        paths.add(p)
+    return paths
+
+
+class TestHistoryMediaPathCollection:
+    """Tests for _history_media_paths collection from agent history."""
+
+    def test_tool_media_paths_collected(self):
+        """Baseline: MEDIA paths from tool messages are collected."""
+        history = [
+            {"role": "user", "content": "send me the report"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "1", "function": {"name": "execute_code"}}]},
+            {"role": "tool", "tool_call_id": "1",
+             "content": "MEDIA:/tmp/report.pdf\nDone."},
+            {"role": "assistant", "content": "Here is your report."},
+        ]
+        paths = collect_history_media_paths(history)
+        assert "/tmp/report.pdf" in paths
+
+    def test_assistant_media_paths_collected_after_compression(self):
+        """After context compression, MEDIA tags in assistant messages
+        must be captured so they are not re-delivered. (#37358)"""
+        # Simulates a compressed history where the assistant's prior
+        # response (containing a MEDIA tag) is preserved in the summary.
+        history = [
+            {"role": "user", "content": "compressed session summary..."},
+            {"role": "assistant",
+             "content": "Here is the document: MEDIA:/tmp/doc.pdf"},
+        ]
+        paths = collect_history_media_paths(history)
+        assert "/tmp/doc.pdf" in paths, (
+            "Assistant MEDIA paths must be captured for dedup after "
+            f"compression, got {paths}"
+        )
+
+    def test_assistant_none_content_no_crash(self):
+        """Assistant messages with content=None (tool_calls) must not crash."""
+        history = [
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "1", "function": {"name": "execute_code"}}]},
+        ]
+        paths = collect_history_media_paths(history)
+        assert paths == set()
+
+    def test_mixed_roles_all_collected(self):
+        """MEDIA paths from all three roles are collected."""
+        history = [
+            {"role": "tool", "tool_call_id": "1",
+             "content": "MEDIA:/tmp/from_tool.png"},
+            {"role": "assistant",
+             "content": "MEDIA:/tmp/from_assistant.pdf"},
+            {"role": "function", "name": "fn",
+             "content": "MEDIA:/tmp/from_function.zip"},
+        ]
+        paths = collect_history_media_paths(history)
+        assert len(paths) == 3
+        assert "/tmp/from_tool.png" in paths
+        assert "/tmp/from_assistant.pdf" in paths
+        assert "/tmp/from_function.zip" in paths
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What does this PR do?

Fixes a file descriptor / MEDIA re-delivery bug where `_history_media_paths` in `gateway/run.py` only scanned `tool` and `function` roles, missing MEDIA: tags preserved in `assistant` messages after context compression. When the compressed summary includes prior assistant responses with MEDIA: tags, the model re-emits them and the files get re-delivered because the dedup set never captured the paths.

## Related Issue

Fixes #37358

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `"assistant"` to the role set in `_history_media_paths` collection (line ~17763). Also guard against `None` content on assistant messages that have `tool_calls` but no text content.
- `tests/gateway/test_media_extraction.py`: Add `TestHistoryMediaPathCollection` class with 4 regression tests:
  - `test_tool_media_paths_collected` — baseline: tool MEDIA paths are captured
  - `test_assistant_media_paths_collected_after_compression` — the core regression test for #37358
  - `test_assistant_none_content_no_crash` — assistant messages with `content=None` don't crash
  - `test_mixed_roles_all_collected` — all three roles (tool, function, assistant) are scanned

## How to Test

1. Run `pytest tests/gateway/test_media_extraction.py -v` — all 13 tests should pass
2. The new `test_assistant_media_paths_collected_after_compression` test directly verifies the fix: an assistant message containing `MEDIA:/tmp/doc.pdf` is now captured in the dedup set
3. In a live gateway session: send a message that triggers MEDIA delivery, wait for context compression, then verify the file is NOT re-delivered in subsequent turns

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_media_extraction.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py:_history_media_paths` collection loop (line ~17761)
- Callers: `_handle_message()` in gateway/run.py — single call site
- Blast radius: LOW — adds one role to an existing set-membership check; no behavioral change for tool/function messages
- Related patterns: `extract_media_tags_production` in `tests/gateway/test_media_extraction.py` (current-turn extraction, unchanged); #160 compression-safe dedup; #34608 stale tool media leak fix
