### PR TITLE
fix(recap): backtick-wrap /status "Files touched" paths to stop gateway auto-attach

### DIFF
--- a/hermes_cli/session_recap.py
+++ b/hermes_cli/session_recap.py
@@ -293,7 +293,15 @@ def build_recap(
     if files:
         shown = files[:_MAX_FILES_LISTED]
         extra = len(files) - len(shown)
-        entry = ", ".join(shown)
+        # Wrap each path in inline-code backticks. The recap is rendered into
+        # gateway messages (Telegram/Discord/...) whose outbound text is scanned
+        # for bare local file paths and auto-uploaded as native attachments
+        # (see gateway/platforms/base.py). An absolute/``~`` path touched
+        # outside the gateway cwd would otherwise match that detector and leak
+        # the file's contents into the chat. Inline-code spans are explicitly
+        # skipped by the detector's ``_in_code`` filter, so backticks keep the
+        # recap informational instead of triggering an upload.
+        entry = ", ".join(f"`{path}`" for path in shown)
         if extra > 0:
             entry += f" (+{extra} more)"
         lines.append(f"  Files touched: {entry}")

--- a/tests/hermes_cli/test_session_recap.py
+++ b/tests/hermes_cli/test_session_recap.py
@@ -177,3 +177,62 @@ def test_ignores_non_mapping_entries_gracefully():
     # Should not raise.
     out = build_recap(msgs)
     assert "Session recap" in out
+
+
+def test_files_touched_are_backtick_wrapped():
+    """Recap file paths must be inline-code wrapped.
+
+    The gateway scans outbound message text for bare local file paths and
+    auto-uploads matches as native attachments. An absolute/``~`` path in the
+    recap would otherwise leak the file's contents into the chat. Wrapping in
+    backticks puts the path inside an inline-code span, which the gateway's
+    bare-path detector explicitly skips.
+    """
+    msgs = [
+        _user("read the config"),
+        _assistant(
+            tool_calls=[_tool_call("read_file", {"path": "/etc/some_config.yaml"})]
+        ),
+        _tool_result(),
+        _assistant("done"),
+    ]
+    out = build_recap(msgs)
+    files_line = [l for l in out.splitlines() if "Files touched" in l][0]
+    assert "`/etc/some_config.yaml`" in files_line
+    # The path must not appear un-backticked: stripping all inline-code spans
+    # from the line should leave no trace of the path.
+    import re
+
+    stripped = re.sub(r"`[^`\n]+`", "", files_line)
+    assert "/etc/some_config.yaml" not in stripped
+
+
+def test_recap_paths_survive_gateway_bare_path_detector():
+    """End-to-end-ish: recap paths must live inside an inline-code span.
+
+    Reproduces the original bug where ``/status`` attached config.yaml: a
+    touched file outside the gateway cwd rendered as a bare absolute path and
+    the gateway's outbound bare-path detector auto-uploaded it. That detector
+    skips paths inside inline-code spans, so the structural guarantee we pin
+    here is that every recap file path sits inside backticks.
+    """
+    import re
+
+    msgs = [
+        _user("read the config"),
+        _assistant(
+            tool_calls=[
+                _tool_call("read_file", {"path": "/Users/nobody/.hermes/config.yaml"})
+            ]
+        ),
+        _tool_result(),
+        _assistant("done"),
+    ]
+    recap = build_recap(msgs)
+    code_spans = [(m.start(), m.end()) for m in re.finditer(r"`[^`\n]+`", recap)]
+    path_pos = recap.find("/Users/nobody/.hermes/config.yaml")
+    assert path_pos != -1
+    assert any(s <= path_pos < e for s, e in code_spans), (
+        "recap file path must live inside an inline-code span so the gateway "
+        "bare-path auto-attach detector skips it"
+    )


### PR DESCRIPTION
## Summary

The `/status` session recap lists touched file paths via `_shortened_path`, which emits a **bare absolute or `~`-relative path** for any file located outside the gateway's working directory. The gateway scans outbound message text for bare local file paths and auto-uploads matches as native attachments (`gateway/platforms/base.py` `_extract_local_media_paths`, whose extension allowlist includes `.yaml`, `.json`, `.txt`, `.md`, etc.).

Net effect: running `/status` in a messaging gateway (Telegram/Discord/...) could **silently upload the contents of a touched file** -- e.g. `~/.hermes/config.yaml` -- into the chat. A data-exposure footgun, and confusing UX (an unexpected file attachment appears under `/status`).

Files *inside* the gateway cwd render as relative paths (`hermes_cli/commands.py`) which the detector deliberately ignores, so only outside-cwd absolute paths leaked -- which is why this is easy to miss.

## Fix

Wrap each recap file path in inline-code backticks. The detector's `_in_code` filter explicitly skips paths inside inline-code spans, so `Files touched` stays readable but no longer triggers an upload. Single-layer fix at the source (the recap formatter); the auto-attach feature itself is untouched.

## Test plan

- [x] `tests/hermes_cli/test_session_recap.py` -- 15 passed (13 existing + 2 new)
- `test_files_touched_are_backtick_wrapped` pins the backtick wrapping
- `test_recap_paths_survive_gateway_bare_path_detector` pins the inline-code-span structural guarantee the detector relies on
