### PR TITLE
feat: add fact-store skill — SQLite-backed long-term knowledge base

### DIFF
--- a/skills/productivity/fact-store/SKILL.md
+++ b/skills/productivity/fact-store/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: fact-store
+description: SQLite-backed long-term fact store for persistent knowledge. Search, add, update, delete facts with metadata tags, categories, and auto-cleanup. Replaces limited in-memory storage with an unlimited, searchable database.
+version: 1.1.0
+author: SamimKonjicija
+license: MIT
+metadata:
+  hermes:
+    tags: [memory, sqlite, facts, knowledge, persistence, search]
+    homepage: https://github.com/SamimKonjicija/fact-store
+    related_skills: []
+---
+
+# Long-Term Fact Store
+
+A lightweight, zero-dependency SQLite knowledge base for AI agents. Store persistent facts with metadata tags, categories, and automatic usage tracking — unlimited storage that survives across sessions.
+
+## Why?
+
+AI agent memory systems are typically limited to a few KB of injected context per turn. This fact store provides **unlimited persistent storage** for reference data that doesn't need to be in every conversation but must be available on demand: device configs, IP addresses, known bugs, procedures, credentials references, and any long-lived knowledge.
+
+## Quick Start
+
+```bash
+# Copy the script to your Hermes scripts directory
+cp scripts/fact_store.py ~/.hermes/scripts/fact_store.py
+chmod +x ~/.hermes/scripts/fact_store.py
+
+# The database is created automatically on first use.
+# Or initialize it manually:
+sqlite3 ~/.hermes/facts.db < templates/schema.sql
+```
+
+## Database Location
+
+Default: `~/.hermes/facts.db`
+
+Override with the `FACT_STORE_DB` environment variable:
+```bash
+export FACT_STORE_DB=/path/to/custom.db
+python3 ~/.hermes/scripts/fact_store.py stats
+```
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment ID |
+| fact | TEXT | The fact/knowledge string |
+| meta_tags | TEXT (JSON array) | Searchable tags for categorization |
+| category | TEXT | Grouping (e.g., "devices", "presence", "system") |
+| date_created | TEXT (ISO 8601) | When the fact was added |
+| last_used | TEXT (ISO 8601) | When the fact was last accessed via search |
+| use_count | INTEGER | Times the fact was returned in search results |
+
+Indexes on `meta_tags`, `category`, `last_used`, and `date_created` for fast queries.
+
+## Commands
+
+### Add a fact
+```bash
+python3 ~/.hermes/scripts/fact_store.py add "Server has passwordless sudo for deploy user" --tags server sudo system --category system
+```
+
+### Search facts
+```bash
+python3 ~/.hermes/scripts/fact_store.py search "sudo" [--category system] [--limit 10]
+```
+Search uses LIKE matching on `fact`, `meta_tags`, and `category`. Auto-updates `last_used` and increments `use_count` for accessed facts.
+
+### List facts
+```bash
+python3 ~/.hermes/scripts/fact_store.py list [--category system] [--limit 50] [--offset 0] [--order last_used|date_created|use_count|id]
+```
+
+### Delete a fact
+```bash
+python3 ~/.hermes/scripts/fact_store.py delete 42
+```
+
+### Update a fact
+```bash
+python3 ~/.hermes/scripts/fact_store.py update 42 --fact "Updated text" --tags new tags --category category
+```
+
+### Cleanup stale facts
+```bash
+python3 ~/.hermes/scripts/fact_store.py cleanup --days 730
+```
+Removes facts not accessed for more than N days. Default: 365. Recommended: 730 (2 years).
+
+### Statistics
+```bash
+python3 ~/.hermes/scripts/fact_store.py stats [--json]
+```
+Shows total facts, categories breakdown, oldest/newest, most-used facts.
+
+### JSON output
+All commands support `--json` for machine-readable output.
+
+## Auto-Cleanup (Optional)
+
+Set up a cron job to periodically remove stale facts:
+
+```bash
+# Via Hermes cron (recommended):
+hermes cron create "every 10d" --name "fact-store-cleanup" \
+  --script "python3 ~/.hermes/scripts/fact_store.py cleanup --days 730" \
+  --no-agent
+
+# Or via system crontab:
+# 0 3 */10 * * python3 ~/.hermes/scripts/fact_store.py cleanup --days 730 >> ~/.hermes/logs/fact_store_cleanup.log 2>&1
+```
+
+The `--no-agent` flag means no LLM invocation — the script runs directly and its stdout is delivered as a notification. Adjust `--days` to your needs.
+
+## Example Categories
+
+- `devices` — hardware, cameras, TV, network devices
+- `camera` — camera config, alerts, YOLO detection
+- `presence` — detection rules, MAC addresses, lag notes
+- `system` — host info, logging, logrotate, Gateway
+- `network` — IP assignments, network config
+- `bugs` — known bugs and pitfalls
+- `home` — home automation, sensors, smart devices
+- `project` — project-specific conventions and configs
+
+## When to Use: Fact Store vs. Agent Memory
+
+| | Agent Memory | Fact Store |
+|---|---|---|
+| **Size limit** | 8–16 KB | Unlimited |
+| **Availability** | Injected every turn | Searched on demand |
+| **Best for** | Rules, preferences, persona | Reference data, configs, procedures |
+| **Context cost** | Always paid | Only when searched |
+| **Persistence** | Across sessions | Across sessions |
+
+**Rule of thumb:** If you need it in *every* conversation → Agent Memory. If you need it *when asked* → Fact Store.
+
+## Integration Pattern
+
+In your agent's configuration or system prompt, add:
+
+> When searching for information and not finding it in Agent Memory, always check the Fact Store as a fallback.
+
+This ensures the agent falls back to `fact_store.py search` for reference data that isn't worth burning context tokens on every turn.
+
+## Requirements
+
+- Python 3.8+
+- SQLite3 (bundled with Python)
+- No external dependencies
+
+## Files
+
+- `scripts/fact_store.py` — Main script (add, search, list, delete, update, cleanup, stats)
+- `templates/schema.sql` — Database schema (DDL only, no data). Auto-created by the script on first run.

--- a/skills/productivity/fact-store/scripts/fact_store.py
+++ b/skills/productivity/fact-store/scripts/fact_store.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Long-term memory — SQLite-backed fact store for Hermes Agent.
+
+Provides: add, search, list, delete, update, cleanup, stats
+with metadata tags, categories, and automatic last_used tracking.
+
+DB path: ~/.hermes/facts.db (override with FACT_STORE_DB env var)
+
+Usage:
+    python3 fact_store.py add "fact text" --tags tag1 tag2 --category cat
+    python3 fact_store.py search "query" [--category cat] [--limit N]
+    python3 fact_store.py list [--category cat] [--limit N] [--order last_used]
+    python3 fact_store.py delete <ID>
+    python3 fact_store.py update <ID> --fact "new text" --tags t1 t2 --category c
+    python3 fact_store.py cleanup --days 730
+    python3 fact_store.py stats [--json]
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+
+DB_PATH = os.environ.get("FACT_STORE_DB", os.path.expanduser("~/.hermes/facts.db"))
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS facts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fact TEXT NOT NULL,
+    meta_tags TEXT NOT NULL DEFAULT '[]',
+    category TEXT DEFAULT NULL,
+    date_created TEXT NOT NULL,
+    last_used TEXT NOT NULL,
+    use_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_meta_tags ON facts(meta_tags);
+CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_facts_last_used ON facts(last_used);
+CREATE INDEX IF NOT EXISTS idx_facts_date_created ON facts(date_created);
+"""
+
+
+def get_db():
+    """Get database connection with schema initialized."""
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    return conn
+
+
+def add_fact(fact, tags=None, category=None):
+    """Add a new fact to the database."""
+    if tags is None:
+        tags = []
+    now = datetime.now(timezone.utc).isoformat()
+    conn = get_db()
+    try:
+        cur = conn.execute(
+            "INSERT INTO facts (fact, meta_tags, category, date_created, last_used) VALUES (?, ?, ?, ?, ?)",
+            (fact, json.dumps(tags), category, now, now)
+        )
+        conn.commit()
+        return {"id": cur.lastrowid, "fact": fact, "tags": tags, "category": category, "created": now}
+    finally:
+        conn.close()
+
+
+def search_facts(query, limit=20, category=None):
+    """Search facts by keyword match in fact text, tags, or category."""
+    conn = get_db()
+    try:
+        # Mark results as used
+        now = datetime.now(timezone.utc).isoformat()
+        like_query = f"%{query}%"
+        params = [like_query, like_query, like_query]
+        where_cat = ""
+        if category:
+            where_cat = " AND category = ?"
+            params.append(category)
+        
+        rows = conn.execute(
+            f"""SELECT * FROM facts 
+            WHERE (fact LIKE ? OR meta_tags LIKE ? OR category LIKE ?){where_cat}
+            ORDER BY last_used DESC LIMIT ?""",
+            params + [limit]
+        ).fetchall()
+        
+        result_ids = [r["id"] for r in rows]
+        if result_ids:
+            conn.execute(
+                f"UPDATE facts SET last_used = ?, use_count = use_count + 1 WHERE id IN ({','.join('?' * len(result_ids))})",
+                [now] + result_ids
+            )
+            conn.commit()
+        
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def list_facts(category=None, limit=50, offset=0, order_by="last_used"):
+    """List all facts, optionally filtered by category."""
+    conn = get_db()
+    try:
+        where = ""
+        params = []
+        if category:
+            where = "WHERE category = ?"
+            params.append(category)
+        
+        valid_orders = {"last_used", "date_created", "use_count", "id"}
+        if order_by not in valid_orders:
+            order_by = "last_used"
+        
+        rows = conn.execute(
+            f"SELECT * FROM facts {where} ORDER BY {order_by} DESC LIMIT ? OFFSET ?",
+            params + [limit, offset]
+        ).fetchall()
+        
+        total = conn.execute(f"SELECT COUNT(*) as cnt FROM facts {where}", params).fetchone()["cnt"]
+        
+        return {"total": total, "facts": [dict(r) for r in rows]}
+    finally:
+        conn.close()
+
+
+def delete_fact(fact_id):
+    """Delete a fact by ID."""
+    conn = get_db()
+    try:
+        cur = conn.execute("DELETE FROM facts WHERE id = ?", (fact_id,))
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def update_fact(fact_id, fact=None, tags=None, category=None):
+    """Update a fact's text, tags, or category."""
+    conn = get_db()
+    try:
+        sets = []
+        params = []
+        if fact is not None:
+            sets.append("fact = ?")
+            params.append(fact)
+        if tags is not None:
+            sets.append("meta_tags = ?")
+            params.append(json.dumps(tags))
+        if category is not None:
+            sets.append("category = ?")
+            params.append(category)
+        
+        if not sets:
+            return None
+        
+        params.append(fact_id)
+        cur = conn.execute(f"UPDATE facts SET {', '.join(sets)} WHERE id = ?", params)
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def cleanup_stale(days=365):
+    """Remove facts not used for more than `days` days."""
+    conn = get_db()
+    try:
+        from datetime import timedelta
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        cur = conn.execute("DELETE FROM facts WHERE last_used < ?", (cutoff,))
+        conn.commit()
+        return cur.rowcount
+    finally:
+        conn.close()
+
+
+def format_output(data, json_output=False):
+    """Format output for display."""
+    if json_output:
+        return json.dumps(data, indent=2, ensure_ascii=False)
+    
+    if isinstance(data, list):
+        lines = []
+        for f in data:
+            tags = json.loads(f.get("meta_tags", "[]"))
+            tag_str = ", ".join(tags) if tags else ""
+            cat = f.get("category") or ""
+            lines.append(f"[{f['id']}] {f['fact']}")
+            if tag_str:
+                lines.append(f"     tags: {tag_str}")
+            if cat:
+                lines.append(f"     cat: {cat}")
+            lines.append(f"     created: {f['date_created'][:10]} | last_used: {f['last_used'][:10]} | uses: {f['use_count']}")
+        return "\n".join(lines)
+    
+    if isinstance(data, dict):
+        if "total" in data:
+            lines = [f"Total: {data['total']} facts"]
+            lines.append("")
+            lines.append(format_output(data["facts"]))
+            return "\n".join(lines)
+        return json.dumps(data, indent=2, ensure_ascii=False)
+    
+    return str(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Long-term memory fact store")
+    sub = parser.add_subparsers(dest="command", help="Command")
+    
+    # add
+    p_add = sub.add_parser("add", help="Add a fact")
+    p_add.add_argument("fact", help="Fact text")
+    p_add.add_argument("--tags", nargs="*", default=[], help="Metadata tags")
+    p_add.add_argument("--category", "-c", help="Category")
+    
+    # search
+    p_search = sub.add_parser("search", help="Search facts")
+    p_search.add_argument("query", help="Search query")
+    p_search.add_argument("--category", "-c", help="Filter by category")
+    p_search.add_argument("--limit", "-n", type=int, default=20, help="Max results")
+    
+    # list
+    p_list = sub.add_parser("list", help="List facts")
+    p_list.add_argument("--category", "-c", help="Filter by category")
+    p_list.add_argument("--limit", "-n", type=int, default=50, help="Max results")
+    p_list.add_argument("--offset", type=int, default=0, help="Offset")
+    p_list.add_argument("--order", default="last_used", choices=["last_used", "date_created", "use_count", "id"])
+    
+    # delete
+    p_delete = sub.add_parser("delete", help="Delete a fact by ID")
+    p_delete.add_argument("id", type=int, help="Fact ID to delete")
+    
+    # update
+    p_update = sub.add_parser("update", help="Update a fact")
+    p_update.add_argument("id", type=int, help="Fact ID")
+    p_update.add_argument("--fact", "-f", help="New fact text")
+    p_update.add_argument("--tags", nargs="*", help="New tags (replaces all)")
+    p_update.add_argument("--category", "-c", help="New category")
+    
+    # cleanup
+    p_cleanup = sub.add_parser("cleanup", help="Remove stale facts")
+    p_cleanup.add_argument("--days", "-d", type=int, default=365, help="Remove facts not used for N days")
+    
+    # stats
+    p_stats = sub.add_parser("stats", help="Show database statistics")
+    
+    # json output flag for all commands
+    for p in [p_add, p_search, p_list, p_delete, p_update, p_cleanup, p_stats]:
+        p.add_argument("--json", action="store_true", help="JSON output")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return 1
+    
+    try:
+        if args.command == "add":
+            result = add_fact(args.fact, args.tags, args.category)
+            print(format_output(result, args.json))
+        
+        elif args.command == "search":
+            results = search_facts(args.query, limit=args.limit, category=args.category)
+            print(format_output(results, args.json))
+        
+        elif args.command == "list":
+            data = list_facts(category=args.category, limit=args.limit, offset=args.offset, order_by=args.order)
+            print(format_output(data, args.json))
+        
+        elif args.command == "delete":
+            ok = delete_fact(args.id)
+            print(json.dumps({"deleted": ok}))
+        
+        elif args.command == "update":
+            ok = update_fact(args.id, fact=args.fact, tags=args.tags, category=args.category)
+            print(json.dumps({"updated": ok}))
+        
+        elif args.command == "cleanup":
+            count = cleanup_stale(args.days)
+            print(json.dumps({"removed": count, "older_than_days": args.days}))
+        
+        elif args.command == "stats":
+            conn = get_db()
+            try:
+                total = conn.execute("SELECT COUNT(*) as cnt FROM facts").fetchone()["cnt"]
+                categories = conn.execute("SELECT category, COUNT(*) as cnt FROM facts GROUP BY category").fetchall()
+                oldest = conn.execute("SELECT MIN(date_created) as d FROM facts").fetchone()["d"]
+                newest = conn.execute("SELECT MAX(date_created) as d FROM facts").fetchone()["d"]
+                most_used = conn.execute("SELECT fact, use_count FROM facts ORDER BY use_count DESC LIMIT 5").fetchall()
+                stats = {
+                    "total_facts": total,
+                    "categories": {r["category"] or "(none)": r["cnt"] for r in categories},
+                    "oldest": oldest,
+                    "newest": newest,
+                    "most_used": [dict(r) for r in most_used]
+                }
+                print(format_output(stats, args.json))
+            finally:
+                conn.close()
+        
+        return 0
+    
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/productivity/fact-store/templates/schema.sql
+++ b/skills/productivity/fact-store/templates/schema.sql
@@ -1,0 +1,18 @@
+-- Long-Term Fact Store — Database Schema
+-- Create this database with: sqlite3 ~/.hermes/facts.db < schema.sql
+-- Or let the script auto-create it on first use.
+
+CREATE TABLE IF NOT EXISTS facts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fact TEXT NOT NULL,
+    meta_tags TEXT NOT NULL DEFAULT '[]',
+    category TEXT DEFAULT NULL,
+    date_created TEXT NOT NULL,
+    last_used TEXT NOT NULL,
+    use_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_meta_tags ON facts(meta_tags);
+CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_facts_last_used ON facts(last_used);
+CREATE INDEX IF NOT EXISTS idx_facts_date_created ON facts(date_created);


### PR DESCRIPTION
A lightweight, zero-dependency SQLite knowledge base for AI agents.

Features:
- CRUD operations: add, search, list, delete, update facts
- Metadata tags (JSON array), categories, usage tracking
- Auto-cleanup of stale facts via cron
- Zero dependencies (Python 3.8+ sqlite3)
- FACT_STORE_DB env var for custom database path
- JSON output on all commands (--json)

Files:
- SKILL.md — Full documentation and integration guide
- scripts/fact_store.py — Main script (316 lines)
- templates/schema.sql — Database DDL (no data)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

