### PR TITLE
test(macos): resolve /tmp symlink in file_tools path assertions

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,8 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        expected = os.path.realpath("/tmp/out.txt")
+        mock_ops.write_file.assert_called_once_with(expected, "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -155,7 +157,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "foo", "bar", False)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -168,7 +170,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):


### PR DESCRIPTION
## What does this PR do?
On macOS, `/tmp` is a symlink to `/private/tmp`. `file_tools` resolves paths via `Path.resolve()` (correct, symlink-safe behavior), so an absolute input like `/tmp/out.txt` reaches the ops layer as `/private/tmp/out.txt`. Three tests in `tests/tools/test_file_tools.py` asserted against the unresolved `/tmp/...` path and therefore failed on macOS / Apple Silicon. Test-only fix: the assertions now compare against the resolved path, so the file passes on macOS while staying identical on Linux.

## Related Issue
N/A — no existing issue; small cross-platform test fix.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `tests/tools/test_file_tools.py`: added `import os`; in `test_writes_content`, `test_replace_mode_calls_patch_replace`, and `test_replace_mode_replace_all_flag`, wrap the expected path in `os.path.realpath(...)` so assertions match the symlink-resolved path the tool produces.

## How to Test
On macOS / Apple Silicon (`/tmp` → `/private/tmp`):
1. On `main`: `python -m pytest tests/tools/test_file_tools.py -k "test_writes_content or test_replace_mode" -q` → 3 failures (expected `/tmp/...`, actual `/private/tmp/...`).
2. On this branch: same command → all pass.

On Linux the assertions are unchanged (`realpath("/tmp/...")` == `/tmp/...`), so behavior is identical there.

Note: the full file also shows pre-existing, unrelated failures in `TestSensitivePathCheck` only under the default macOS temp dir (`/var/folders/...`); those are out of scope here and CI (Linux) is unaffected.

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — *affected file passes; the full suite has pre-existing macOS-only failures (systemd / keychain / default-tmpdir) unrelated to this change. CI runs on Linux.*
- [ ] I've added tests for my changes — *test-only fix; corrects existing assertions, no new production behavior to cover.*
- [x] I've tested on my platform: macOS (Apple Silicon, M4)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — this change targets macOS/Linux path-resolution parity
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs
Verified on macOS (Apple Silicon): `TMPDIR=/tmp python -m pytest tests/tools/test_file_tools.py -q` → `36 passed`