### PR TITLE
fix(acp): pass base_url to resolve_runtime_provider on session restore

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -606,7 +606,7 @@ class SessionManager:
         }
 
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            runtime = resolve_runtime_provider(requested=requested_provider or config_provider, explicit_base_url=base_url)
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),


### PR DESCRIPTION
fix(acp): pass base_url to resolve_runtime_provider on session restore

When an ACP session is restored from DB, _make_agent calls
resolve_runtime_provider with requested="custom" (from billing_provider)
but does not pass the base_url. This causes credential resolution to fail
for custom providers because _resolve_named_custom_runtime cannot match
the provider without the base_url hint.

The base_url is already persisted in the DB (billing_base_url) and passed
to _make_agent, but was not forwarded to resolve_runtime_provider. This
results in "Could not resolve authentication method" errors on every
resumed ACP session for custom provider users.

First call (new session) succeeds because config_provider="mify" resolves
correctly. Subsequent calls (restored session) fail because the DB only
stores billing_provider="custom" which is insufficient without base_url.

Fixes authentication failures on ACP session resume for custom providers.
