### PR TITLE
Discord 메시지 수정과 스레드 기록 흐름 추가

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1445,9 +1445,62 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._is_forum_parent(channel):
                 return await self._send_to_forum(channel, content)
 
-            # Format and split message if needed
+            # Format and split message if needed.
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+            # Thread-first outgoing mode: for regular text channels, send a
+            # short launcher message in the parent channel, create a thread
+            # anchored to it, and place the actual content inside the thread.
+            # This keeps the parent channel as an index while preserving the
+            # real record in the thread.
+            auto_thread_outgoing = (
+                os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
+                and reply_to is None
+                and not isinstance(channel, discord.DMChannel)
+                and not isinstance(channel, discord.Thread)
+            )
+            if auto_thread_outgoing:
+                thread_name = _derive_forum_thread_name(formatted)
+                launcher_content = f"🧵 {thread_name}"
+                try:
+                    starter_msg = await channel.send(content=launcher_content)
+                    if hasattr(starter_msg, "create_thread"):
+                        thread = await starter_msg.create_thread(name=thread_name)
+                    elif hasattr(channel, "create_thread"):
+                        thread = await channel.create_thread(name=thread_name, message=starter_msg)
+                    else:
+                        raise RuntimeError("Thread creation is not supported for this Discord channel")
+                except Exception as e:
+                    logger.error("[%s] Failed to create outgoing thread in %s: %s", self.name, chat_id, e)
+                    return SendResult(success=False, error=f"Thread creation failed: {e}")
+
+                thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+                if thread_channel is None:
+                    return SendResult(success=False, error="Thread creation failed: no thread channel returned")
+
+                message_ids = []
+                for chunk in chunks:
+                    try:
+                        msg = await thread_channel.send(content=chunk)
+                    except Exception as e:
+                        logger.error("[%s] Failed to send content to auto-created thread %s: %s", self.name, getattr(thread, 'id', '?'), e)
+                        return SendResult(success=False, error=str(e))
+                    message_ids.append(str(msg.id))
+
+                thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
+                if message_ids:
+                    self._last_self_message_id[thread_id or chat_id] = message_ids[-1]
+
+                return SendResult(
+                    success=True,
+                    message_id=message_ids[0] if message_ids else str(getattr(starter_msg, "id", "")),
+                    raw_response={
+                        "message_ids": message_ids,
+                        "thread_id": thread_id,
+                        "parent_message_id": str(getattr(starter_msg, "id", "")),
+                    },
+                )
 
             message_ids = []
             reference = None
@@ -5838,6 +5891,7 @@ async def _standalone_send(
         media_files = media_files or []
         last_data = None
         warnings = []
+        auto_thread_parent_id = None
 
         # Thread endpoint: Discord threads are channels; send directly to the thread ID.
         if thread_id:
@@ -5950,7 +6004,48 @@ async def _standalone_send(
                     result["warnings"] = warnings
                 return result
 
-            url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
+            # Thread-first outgoing mode for ordinary text channels: send a
+            # launcher message, create a thread from it, then post the actual
+            # content inside the thread.
+            auto_thread_outgoing = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
+            if auto_thread_outgoing and not thread_id:
+                parent_url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
+                thread_name = _derive_forum_thread_name(message)
+                launcher_content = f"🧵 {thread_name}"
+
+                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60), **_sess_kw) as session:
+                    async with session.post(parent_url, headers=json_headers, json={"content": launcher_content}, **_req_kw) as resp:
+                        if resp.status not in {200, 201}:
+                            body = await resp.text()
+                            return {"error": f"Discord launcher send error ({resp.status}): {body}"}
+                        parent_msg = await resp.json()
+
+                    parent_message_id = parent_msg.get("id")
+                    if not parent_message_id:
+                        return {"error": "Discord launcher send succeeded but no parent message id was returned"}
+
+                    thread_create_url = f"https://discord.com/api/v10/channels/{chat_id}/messages/{parent_message_id}/threads"
+                    async with session.post(
+                        thread_create_url,
+                        headers=json_headers,
+                        json={"name": thread_name},
+                        **_req_kw,
+                    ) as resp:
+                        if resp.status not in {200, 201}:
+                            body = await resp.text()
+                            return {"error": f"Discord thread creation error ({resp.status}): {body}"}
+                        data = await resp.json()
+
+                thread_id_created = data.get("id")
+                if not thread_id_created:
+                    return {"error": "Discord thread creation succeeded but no thread id was returned"}
+
+                url = f"https://discord.com/api/v10/channels/{thread_id_created}/messages"
+                thread_id = thread_id_created
+                auto_thread_parent_id = parent_message_id
+            else:
+                url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
+                auto_thread_parent_id = None
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
@@ -5993,6 +6088,10 @@ async def _standalone_send(
             return {"error": error}
 
         result = {"success": True, "platform": "discord", "chat_id": chat_id, "message_id": last_data.get("id")}
+        if thread_id:
+            result["thread_id"] = thread_id
+        if auto_thread_parent_id:
+            result["parent_message_id"] = auto_thread_parent_id
         if warnings:
             result["warnings"] = warnings
         return result

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 import sys
@@ -258,6 +259,36 @@ async def test_send_to_forum_sends_remaining_chunks():
     assert result.message_id == "500"
     # Should have sent at least one follow-up chunk
     assert thread_ch.send.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_send_auto_threads_regular_text_channel(monkeypatch):
+    """Regular text channels should get launcher -> thread -> thread body."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    thread_msg = SimpleNamespace(id=7001)
+    thread_ch = SimpleNamespace(id=8001, send=AsyncMock(return_value=thread_msg))
+
+    starter_msg = SimpleNamespace(id=6001, create_thread=AsyncMock(return_value=thread_ch))
+    channel = SimpleNamespace(send=AsyncMock(return_value=starter_msg))
+
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+
+    result = await adapter.send("555", "hello thread world")
+
+    assert result.success is True
+    assert result.raw_response["thread_id"] == "8001"
+    assert result.message_id == "7001"
+    assert channel.send.await_count == 1
+    assert starter_msg.create_thread.await_count == 1
+    assert thread_ch.send.await_count == 1
+    assert channel.send.await_args.kwargs["content"].startswith("🧵 ")
+    assert thread_ch.send.await_args.kwargs["content"] == "hello thread world"
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -440,6 +440,33 @@ class TestPinUnpinDelete:
         assert "deleted" in result["message"]
         mock_req.assert_called_once_with("DELETE", "/channels/11/messages/500", "test-token")
 
+    @patch("tools.discord_tool._discord_request")
+    def test_edit_message(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "500",
+            "channel_id": "11",
+            "content": "수정된 본문",
+            "edited_timestamp": "2026-06-02T12:34:56Z",
+        }
+        result = json.loads(
+            discord_core(
+                action="edit_message",
+                channel_id="11",
+                message_id="500",
+                content="수정된 본문",
+            )
+        )
+        assert result["success"] is True
+        assert result["content"] == "수정된 본문"
+        assert result["message_id"] == "500"
+        mock_req.assert_called_once_with(
+            "PATCH",
+            "/channels/11/messages/500",
+            "test-token",
+            body={"content": "수정된 본문"},
+        )
+
 
 # ---------------------------------------------------------------------------
 # Action: create_thread
@@ -558,14 +585,14 @@ class TestRegistration:
         from tools.registry import registry
         entry = registry._tools["discord"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == {"fetch_messages", "search_members", "create_thread"}
+        assert actions == {"fetch_messages", "search_members", "create_thread", "edit_message"}
 
     def test_admin_schema_actions(self):
         """Admin static schema should list only admin actions."""
         from tools.registry import registry
         entry = registry._tools["discord_admin"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
+        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread", "edit_message"}
         assert actions == expected_admin
 
     def test_all_actions_covered(self):
@@ -589,6 +616,7 @@ class TestRegistration:
         assert "fetch_messages(channel_id)" in desc
         assert "search_members(guild_id, query)" in desc
         assert "create_thread(channel_id, name)" in desc
+        assert "edit_message(channel_id, message_id, content)" in desc
         # Admin actions should NOT be in core description
         assert "list_guilds()" not in desc
         assert "add_role(" not in desc
@@ -604,6 +632,7 @@ class TestRegistration:
         # Core actions should NOT be in admin description
         assert "fetch_messages(" not in desc
         assert "create_thread(" not in desc
+        assert "edit_message(" not in desc
 
     def test_handler_callable(self):
         from tools.registry import registry

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -375,6 +375,47 @@ class TestSendMessageTool:
             user_id="user-123",
         )
 
+    def test_edit_discord_message_uses_thread_channel(self):
+        discord_cfg = SimpleNamespace(enabled=True, token="discord-token", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.DISCORD: discord_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch(
+                 "tools.send_message_tool._edit_discord_message",
+                 return_value={"success": True, "message_id": "m1", "channel_id": "456", "content": "수정됨"},
+             ) as edit_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "edit",
+                        "target": "discord:123:456",
+                        "message_id": "m1",
+                        "message": "수정됨",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["thread_id"] == "456"
+        edit_mock.assert_called_once_with("discord-token", "456", "m1", "수정됨")
+
+    def test_edit_requires_message_id(self):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "edit",
+                    "target": "discord:123",
+                    "message": "수정됨",
+                }
+            )
+        )
+        assert "error" in result
+        assert "message_id" in result["error"]
+
     def test_media_tag_outside_allowed_roots_is_not_sent(self, tmp_path, monkeypatch):
         # This test exercises the strict-allowlist path; force strict mode on
         # and disable recency trust so the freshly-written tmp_path file is

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -424,6 +424,24 @@ def _delete_message(token: str, channel_id: str, message_id: str, **_kwargs: Any
     return json.dumps({"success": True, "message": f"Message {message_id} deleted."})
 
 
+def _edit_message(token: str, channel_id: str, message_id: str, content: str, **_kwargs: Any) -> str:
+    """Edit an existing message in a channel or thread."""
+    message = _discord_request(
+        "PATCH",
+        f"/channels/{channel_id}/messages/{message_id}",
+        token,
+        body={"content": content},
+    )
+    return json.dumps({
+        "success": True,
+        "message": f"Message {message_id} edited.",
+        "message_id": message.get("id", message_id),
+        "channel_id": message.get("channel_id", channel_id),
+        "content": message.get("content", content),
+        "edited_timestamp": message.get("edited_timestamp"),
+    })
+
+
 def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
@@ -483,12 +501,13 @@ _ACTIONS = {
     "pin_message": _pin_message,
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
+    "edit_message": _edit_message,
     "create_thread": _create_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread", "edit_message"})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -510,6 +529,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
+    ("edit_message", "(channel_id, message_id, content)", "edit a bot-authored message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
@@ -531,6 +551,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "pin_message": ["channel_id", "message_id"],
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
+    "edit_message": ["channel_id", "message_id", "content"],
     "create_thread": ["channel_id", "name"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
@@ -685,6 +706,10 @@ def _build_schema(
             "type": "string",
             "description": "Discord message ID.",
         },
+        "content": {
+            "type": "string",
+            "description": "Message content to use when editing an existing Discord message (edit_message).",
+        },
         "query": {
             "type": "string",
             "description": "Member name prefix to search for (search_members).",
@@ -833,6 +858,7 @@ def _run_discord_action(
     user_id: str = "",
     role_id: str = "",
     message_id: str = "",
+    content: str = "",
     query: str = "",
     name: str = "",
     limit: int = 50,
@@ -870,6 +896,7 @@ def _run_discord_action(
         "user_id": user_id,
         "role_id": role_id,
         "message_id": message_id,
+        "content": content,
         "query": query,
         "name": name,
     }
@@ -888,6 +915,7 @@ def _run_discord_action(
             user_id=user_id,
             role_id=role_id,
             message_id=message_id,
+            content=content,
             query=query,
             name=name,
             limit=limit,
@@ -921,7 +949,7 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
-    "role_id": "", "message_id": "", "query": "", "name": "",
+    "role_id": "", "message_id": "", "content": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -80,6 +80,25 @@ def _error(message: str) -> dict:
     return {"error": _sanitize_error_text(message)}
 
 
+def _edit_discord_message(token: str, channel_id: str, message_id: str, message: str) -> dict:
+    """Edit an existing Discord message via REST API."""
+    from tools.discord_tool import _discord_request
+
+    edited = _discord_request(
+        "PATCH",
+        f"/channels/{channel_id}/messages/{message_id}",
+        token,
+        body={"content": message},
+    )
+    return {
+        "success": True,
+        "message_id": edited.get("id", message_id),
+        "channel_id": edited.get("channel_id", channel_id),
+        "content": edited.get("content", message),
+        "edited_timestamp": edited.get("edited_timestamp"),
+    }
+
+
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
     retry_after = getattr(exc, "retry_after", None)
     if retry_after is not None:
@@ -138,8 +157,8 @@ SEND_MESSAGE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["send", "list"],
-                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms."
+                "enum": ["send", "list", "edit"],
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns available targets. 'edit' edits an existing message (currently Discord only)."
             },
             "target": {
                 "type": "string",
@@ -147,7 +166,11 @@ SEND_MESSAGE_SCHEMA = {
             },
             "message": {
                 "type": "string",
-                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
+                "description": "The message text to send, or the replacement text when action='edit'. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
+            },
+            "message_id": {
+                "type": "string",
+                "description": "Existing platform message ID to edit when action='edit' (currently Discord only)."
             }
         },
         "required": []
@@ -161,6 +184,9 @@ def send_message_tool(args, **kw):
 
     if action == "list":
         return _handle_list()
+
+    if action == "edit":
+        return _handle_edit(args)
 
     return _handle_send(args)
 
@@ -349,6 +375,90 @@ def _handle_send(args):
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _handle_edit(args):
+    """Edit an existing platform message."""
+    target = args.get("target", "")
+    message = args.get("message", "")
+    message_id = args.get("message_id", "")
+    if not target or not message or not message_id:
+        return tool_error("'target', 'message', and 'message_id' are required when action='edit'")
+
+    parts = target.split(":", 1)
+    platform_name = parts[0].strip().lower()
+    target_ref = parts[1].strip() if len(parts) > 1 else None
+    chat_id = None
+    thread_id = None
+
+    if target_ref:
+        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+    else:
+        is_explicit = False
+
+    if target_ref and not is_explicit:
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            resolved = resolve_channel_name(platform_name, target_ref)
+            if resolved:
+                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+            else:
+                return json.dumps({
+                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    f"Use send_message(action='list') to see available targets."
+                })
+        except Exception:
+            return json.dumps({
+                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                f"Try using a numeric channel ID instead."
+            })
+
+    if platform_name != "discord":
+        return tool_error("send_message(action='edit') currently supports only Discord targets")
+
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return tool_error("Interrupted")
+
+    try:
+        from gateway.config import load_gateway_config, Platform, PlatformConfig
+        config = load_gateway_config()
+    except Exception as e:
+        return json.dumps(_error(f"Failed to load gateway config: {e}"))
+
+    try:
+        platform = Platform(platform_name)
+    except (ValueError, KeyError):
+        return tool_error(f"Unknown platform: {platform_name}")
+
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+        if token:
+            pconfig = PlatformConfig(enabled=True, token=token, extra={})
+        else:
+            return tool_error("Platform 'discord' is not configured. Set DISCORD_BOT_TOKEN or enable Discord in gateway config.")
+
+    if not chat_id:
+        home = config.get_home_channel(platform)
+        if home:
+            chat_id = home.chat_id
+        else:
+            return json.dumps({
+                "error": "No Discord channel was resolved for editing. Specify a target like 'discord:<channel_id>' or 'discord:<channel_id>:<thread_id>'."
+            })
+
+    try:
+        effective_channel_id = thread_id or chat_id
+        token = getattr(pconfig, "token", None)
+        if not token:
+            return tool_error("Discord bot token is missing for edit operation")
+        result = _edit_discord_message(token, effective_channel_id, message_id, message)
+        if thread_id:
+            result["thread_id"] = thread_id
+        return json.dumps(result)
+    except Exception as e:
+        return json.dumps(_error(f"Edit failed: {e}"))
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -8,6 +8,8 @@ description: "Set up Hermes Agent as a Discord bot"
 
 Hermes Agent integrates with Discord as a bot, letting you chat with your AI assistant through direct messages or server channels. The bot receives your messages, processes them through the Hermes Agent pipeline (including tool use, memory, and reasoning), and responds in real time. It supports text, voice messages, file attachments, and slash commands.
 
+For durable records, prefer thread-first storage: keep the parent channel as an index or launcher, and put the actual record in a thread.
+
 Before setup, here's the part most people want to know: how Hermes behaves once it's in your server.
 
 ## How Hermes Behaves
@@ -15,9 +17,9 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | Context | Behavior |
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
-| **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
-| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline — auto-threading is skipped so the channel stays a lightweight chat. |
-| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
+| **Server channels** | By default, Hermes only responds when you `@mention` it. For durable records, use the channel as an index/launcher and keep the actual record in a thread. |
+| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline, but long-form records should still move into a thread. |
+| **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads are the canonical place for durable Discord records and stay isolated from the parent channel for session history. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
@@ -47,6 +49,8 @@ By default:
 - each user in a shared channel gets their own session inside that channel
 
 So if Alice and Bob both talk to Hermes in `#research`, Hermes treats those as separate conversations by default even though they are using the same visible Discord channel.
+
+For Discord records, treat the thread as the storage unit and the parent channel as an index or entry point.
 
 This is controlled by `config.yaml`:
 


### PR DESCRIPTION
## 요약\n- Discord 도구와 send_message 도구에 기존 메시지 수정 경로를 추가했습니다.\n- 일반 채널에서 기록성 응답을 스레드 우선으로 남기도록 Discord 전송 어댑터를 보강했습니다.\n- 관련 테스트와 Discord 사용자 문서를 함께 업데이트했습니다.\n\n## 테스트\n- python3 -m pytest tests/tools/test_discord_tool.py -q\n- python3 -m pytest tests/tools/test_send_message_tool.py -q -k "edit_discord_message_uses_thread_channel or edit_requires_message_id"\n- python3 -m pytest tests/gateway/test_discord_send.py -q -k "edit or patch or thread"\n- python3 -m py_compile tools/discord_tool.py tools/send_message_tool.py plugins/platforms/discord/adapter.py