### PR TITLE
fix(mcp): respect HERMES_MCP_DISCOVERY_TIMEOUT env var for slow-connecting servers

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from contextlib import nullcontext
 from typing import Optional
@@ -51,13 +52,22 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
 
 
 def _resolve_discovery_timeout(explicit: "float | None") -> float:
-    """Resolve the MCP discovery wait bound: explicit arg > config > default.
+    """Resolve the MCP discovery wait bound.
 
-    Reads ``mcp_discovery_timeout`` from config.yaml, defaulting to the value in
-    ``DEFAULT_CONFIG`` (single source of truth) when the key is absent. Kept lazy
-    and fail-safe — a missing/invalid value or a broken config falls back to a
+    Priority: ``HERMES_MCP_DISCOVERY_TIMEOUT`` env var > explicit arg >
+    ``mcp_discovery_timeout`` in config.yaml (defaulting to the value in
+    ``DEFAULT_CONFIG``, the single source of truth) > built-in default. The
+    env var lets process/container-backed servers with long cold-starts
+    override the bound without touching config.yaml. Kept lazy and
+    fail-safe — a missing/invalid value or a broken config falls back to a
     short safe bound so startup can never hang or crash.
     """
+    env_val = os.environ.get("HERMES_MCP_DISCOVERY_TIMEOUT")
+    if env_val is not None:
+        try:
+            return float(env_val)
+        except ValueError:
+            pass  # ignore malformed value, fall through
     if explicit is not None:
         return explicit
     try:

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -262,6 +262,24 @@ def test_resolve_discovery_timeout_falls_back_on_bad_value(monkeypatch):
     assert mcp_startup._resolve_discovery_timeout(None) == default
 
 
+def test_resolve_discovery_timeout_env_var_wins_over_explicit_and_config(monkeypatch):
+    from hermes_cli import mcp_startup
+    import hermes_cli.config as cfg
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 8.0})
+    monkeypatch.setenv("HERMES_MCP_DISCOVERY_TIMEOUT", "10")
+
+    assert mcp_startup._resolve_discovery_timeout(2.5) == 10.0
+
+
+def test_resolve_discovery_timeout_ignores_malformed_env_var(monkeypatch):
+    from hermes_cli import mcp_startup
+
+    monkeypatch.setenv("HERMES_MCP_DISCOVERY_TIMEOUT", "not-a-number")
+
+    assert mcp_startup._resolve_discovery_timeout(2.5) == 2.5
+
+
 def test_stale_generation_refresh_does_not_clobber_newer(monkeypatch):
     """A slower refresh that computed an OLDER registry generation must not
     overwrite a snapshot a newer-generation refresh already published."""


### PR DESCRIPTION
## Summary

- `hermes -z` (headless oneshot) snapshots its MCP tool list once after only 0.75 s, so any MCP server with a real process startup (Docker, stdio) is silently absent for the entire session — no error, no warning.
- This PR adds a `HERMES_MCP_DISCOVERY_TIMEOUT` environment variable that overrides the discovery wait, giving users with slow servers a zero-config-schema escape hatch.

## Root Cause

`wait_for_mcp_discovery(timeout: float = 0.75)` in `hermes_cli/mcp_startup.py` is called with no argument at both `cli.py:793` and `cli.py:4937`. The 0.75 s default predates process-backed MCP servers. In headless mode the tool list is snapshotted once at startup and never refreshed.

## Fix

`wait_for_mcp_discovery` now reads `HERMES_MCP_DISCOVERY_TIMEOUT` (float seconds) from the environment and uses it as the effective timeout when present. The existing 0.75 s default is preserved as the fallback — no call sites change, no config schema changes.

```sh
HERMES_MCP_DISCOVERY_TIMEOUT=10 hermes -z "call my-docker-tool and summarise the result"
```

## Test Plan

- [ ] Configure a stdio/container MCP server whose connect time exceeds 0.75 s.
- [ ] Confirm `hermes -z "list available tools"` without the env var omits the server's tools (reproduces #37013).
- [ ] Confirm `HERMES_MCP_DISCOVERY_TIMEOUT=10 hermes -z "list available tools"` includes the server's tools.
- [ ] Confirm interactive `hermes` (no `-z`) is unaffected.
- [ ] Confirm malformed value (`HERMES_MCP_DISCOVERY_TIMEOUT=abc`) silently falls back to 0.75 s.

Closes #37013