### PR TITLE
fix(gateway): close adapter resources on failed reconnect to prevent fd leak

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4197,6 +4197,12 @@ class APIServerAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop the aiohttp web server."""
         self._mark_disconnected()
+        if self._response_store is not None:
+            try:
+                self._response_store.close()
+            except Exception:
+                pass
+            self._response_store = None
         if self._site:
             await self._site.stop()
             self._site = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5904,6 +5904,7 @@ class GatewayRunner:
                     platform.value, attempt,
                 )
 
+                adapter = None
                 try:
                     adapter = self._create_adapter(platform, platform_config)
                     if not adapter:
@@ -5953,8 +5954,16 @@ class GatewayRunner:
                             "Reconnect %s: non-retryable error (%s), removing from retry queue",
                             platform.value, adapter.fatal_error_message,
                         )
+                        try:
+                            await adapter.disconnect()
+                        except Exception:
+                            pass
                         del self._failed_platforms[platform]
                     else:
+                        try:
+                            await adapter.disconnect()
+                        except Exception:
+                            pass
                         self._update_platform_runtime_status(
                             platform.value,
                             platform_state="retrying",
@@ -5977,6 +5986,11 @@ class GatewayRunner:
                                 ),
                             )
                 except Exception as e:
+                    if adapter is not None:
+                        try:
+                            await adapter.disconnect()
+                        except Exception:
+                            pass
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",


### PR DESCRIPTION
## Summary

- Every failed reconnect attempt in `_platform_reconnect_watcher` creates an `APIServerAdapter` that opens 2 sqlite3 file descriptors via `ResponseStore()`, then silently drops the adapter without cleanup — leaking those fds permanently.
- At the 300 s backoff cap this is ~12 fds/hour; a gateway with a persistently failing platform exhausts the 2560 fd limit after ~26 h, killing all file I/O silently.
- This PR adds cleanup at all three failure paths in `run.py` and ensures `APIServerAdapter.disconnect()` always closes the sqlite connection.

## Root Cause

`_create_adapter` constructs an `APIServerAdapter` whose `__init__` calls `ResponseStore()` → `sqlite3.connect()` (2 fds). On all three failure paths — non-retryable fatal error, retryable failure, raised exception — the adapter goes out of scope without `disconnect()`. `disconnect()` itself also never called `self._response_store.close()`.

Introduced by the auto-reconnect feature (commit `3b509da57`).

## Fix

**`gateway/platforms/api_server.py`** — `APIServerAdapter.disconnect()`: close and null out `self._response_store` before tearing down the HTTP server.

**`gateway/run.py`** — `_platform_reconnect_watcher()`: initialise `adapter = None` before the try block; call `await adapter.disconnect()` (wrapped in try/except) in all three failure branches before the reference drops.

## Test Plan

- [ ] Start the gateway with a platform configured to fail on connect (e.g. `API_SERVER` with key unset).
- [ ] Let the reconnect watcher run for several cycles.
- [ ] Confirm `lsof -p <pid> | grep response_store | wc -l` stays at 0 — previously it grew by 2 per retry.
- [ ] Confirm normal gateway operation is unaffected after fixing the platform config.
- [ ] Confirm gateway remains functional after 24 h+ uptime with a persistently failing platform configured.

Closes #37011