### PR TITLE
fix(skills): don't hang on install when a third-party source stalls

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3692,8 +3692,9 @@ def parallel_search_sources(
     if not active:
         return all_results, source_counts, timed_out_ids
 
-    with ThreadPoolExecutor(max_workers=min(len(active), 8)) as pool:
-        futures = {}
+    pool = ThreadPoolExecutor(max_workers=min(len(active), 8))
+    futures = {}
+    try:
         for src in active:
             lim = per_source_limits.get(src.source_id(), 50)
             fut = pool.submit(_search_one_source, src, query, lim)
@@ -3714,10 +3715,16 @@ def parallel_search_sources(
                 futures[f] for f in futures if not f.done()
             ]
             if timed_out_ids:
-                logger.debug(
-                    "Skills browse timed out waiting for: %s",
+                logger.warning(
+                    "Skills search timed out waiting for: %s — results from "
+                    "these sources are excluded. Use --source to skip them.",
                     ", ".join(timed_out_ids),
                 )
+    finally:
+        # shutdown(wait=False) so a stuck worker thread cannot block the
+        # caller after the timeout fires. cancel_futures=True (Python >=3.9)
+        # prevents queued-but-not-yet-started futures from dispatching.
+        pool.shutdown(wait=False, cancel_futures=True)
 
     return all_results, source_counts, timed_out_ids
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3700,6 +3700,12 @@ def parallel_search_sources(
             fut = pool.submit(_search_one_source, src, query, lim)
             futures[fut] = src.source_id()
 
+        # submit() spins up worker threads synchronously; mark them as daemons
+        # so a stalled network connect cannot prevent the process from exiting
+        # after the CLI command completes.
+        for t in pool._threads:
+            t.daemon = True
+
         try:
             for fut in as_completed(futures, timeout=overall_timeout):
                 try:


### PR DESCRIPTION
## Summary

- `hermes skills install <name>` hangs indefinitely when a third-party registry (e.g. ClawHub) stalls — even if the skill is available from a completely different source.
- Root cause: `with ThreadPoolExecutor(...) as pool:` calls `pool.shutdown(wait=True)` on exit, blocking until every worker finishes — even after the `as_completed` timeout fires.
- This PR replaces the context manager with explicit `pool.shutdown(wait=False, cancel_futures=True)` in a `finally` block and upgrades the timeout log from `debug` to `warning`.

## Root Cause

`parallel_search_sources` in `tools/skills_hub.py` guards `as_completed` with a 30 s `overall_timeout`, but the surrounding `with ThreadPoolExecutor(...) as pool:` block calls `pool.shutdown(wait=True)` on exit. A worker thread stuck in a TCP connect that never RSTs (bypassing httpx's own timeout) blocks `shutdown` indefinitely.

## Fix

Replace the context manager with an explicit `pool = ThreadPoolExecutor(...)`, process results inside a `try:` block, and call `pool.shutdown(wait=False, cancel_futures=True)` in the `finally:` clause. The function now always returns within `overall_timeout + ε` seconds with whatever partial results were collected. The timeout log is upgraded from `debug` to `warning` so users see which source stalled and how to work around it (`--source github`).

## Test Plan

- [ ] Block ClawHub at the network level and run `hermes skills install pptx` — confirm it returns within ~35 s with a warning, not indefinitely.
- [ ] Run `hermes skills install pptx --source github` — confirm it resolves without touching ClawHub.
- [ ] Run `hermes skills search python` with all sources healthy — confirm results still arrive from every source.

Closes #37008