### PR TITLE
feat: add smart gateway model routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2624,12 +2624,19 @@ class GatewayRunner:
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
 
-        Always uses the session's primary model/provider.  If `/fast` is
-        enabled and the model supports Priority Processing / Anthropic fast
-        mode, attach `request_overrides` so the API call is marked
-        accordingly.
+        By default this uses the session's primary model/provider.  When
+        ``model_routing.enabled`` is set in config.yaml, lightweight heuristics
+        can promote an individual turn from the configured base model to a
+        premium model without making every routine message pay the premium-model
+        tax.
+
+        If `/fast` is enabled and the effective model supports Priority
+        Processing / Anthropic fast mode, attach `request_overrides` so the API
+        call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        effective_model = self._route_model_for_turn(user_message, model)
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -2641,10 +2648,10 @@ class GatewayRunner:
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
         route = {
-            "model": model,
+            "model": effective_model,
             "runtime": runtime,
             "signature": (
-                model,
+                effective_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
@@ -2664,6 +2671,78 @@ class GatewayRunner:
             overrides = None
         route["request_overrides"] = overrides or {}
         return route
+
+    @staticmethod
+    def _model_routing_match_reason(message: str) -> Optional[str]:
+        """Return the smart-routing reason for a premium-model turn, if any."""
+        import re
+
+        text = (message or "").lower()
+        if not text.strip():
+            return None
+
+        # Explicit cheap-model / no-premium requests win over heuristics.
+        cheap_or_no_premium = (
+            r"\b(use|stay on|keep|force)\s+(the\s+)?(mini|cheap|cheap(er)? model|base model|default model|gpt-5\.4-mini)\b",
+            r"\b(do not|don't|dont|avoid|skip|no)\s+(use\s+)?(the\s+)?(premium|expensive|best|strongest|gpt-5\.5|5\.5)\b",
+        )
+        if any(re.search(pattern, text) for pattern in cheap_or_no_premium):
+            return None
+
+        explicit_premium = (
+            "use 5.5", "use gpt-5.5", "gpt-5.5", "best model",
+            "strongest model", "think harder", "deep work", "deep reasoning",
+        )
+        if any(marker in text for marker in explicit_premium):
+            return "explicit premium-model request"
+
+        # Tasks where the cost of a bad answer exceeds the premium-model tax.
+        hard_patterns = [
+            ("debugging/root-cause work", r"\b(debug|root cause|root-cause|rca|traceback|stack trace|failing tests?|test failure|regression|bisect)\b"),
+            ("implementation/coding work", r"\b(implement|refactor|code review|review pr|pull request|patch|write tests?|fix bug|ship|ci|migration)\b"),
+            ("architecture/planning work", r"\b(architecture|design doc|system design|technical plan|implementation plan|multi-step plan|decompose|roadmap)\b"),
+            ("security/risky operations", r"\b(security|auth|oauth|token|secret|credential|production|backup|restore|delete|destructive|launchd|cron|gateway|\.env)\b"),
+        ]
+        for reason, pattern in hard_patterns:
+            if re.search(pattern, text):
+                return reason
+
+        # Long, ambiguous asks often benefit from the stronger model even when
+        # they don't contain the exact trigger words above.
+        word_count = len(re.findall(r"\w+", text))
+        ambiguity_markers = ("what should", "recommend", "tradeoff", "trade-off", "pros and cons", "decide", "strategy")
+        if word_count >= 80 and any(marker in text for marker in ambiguity_markers):
+            return "long ambiguous strategy request"
+
+        return None
+
+    def _route_model_for_turn(self, user_message: str, model: str) -> str:
+        """Optionally promote a turn to the configured premium model."""
+        try:
+            cfg = _load_gateway_runtime_config()
+            routing = cfg.get("model_routing") if isinstance(cfg, dict) else None
+            if not isinstance(routing, dict) or not routing.get("enabled"):
+                return model
+
+            base_model = str(routing.get("base_model") or "").strip()
+            premium_model = str(routing.get("premium_model") or "").strip()
+            if not premium_model or model == premium_model:
+                return model
+            if base_model and model != base_model:
+                return model
+
+            reason = self._model_routing_match_reason(user_message)
+            if not reason:
+                return model
+
+            logger.info(
+                "Smart model routing: %s -> %s for this turn (%s)",
+                model, premium_model, reason,
+            )
+            return premium_model
+        except Exception as exc:
+            logger.debug("Smart model routing skipped after error: %s", exc)
+            return model
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -739,6 +739,15 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    # Optional gateway-only per-turn model promotion. Disabled by default;
+    # when enabled, turns matching the smart heuristic route from base_model
+    # to premium_model while routine turns keep using the session model.
+    "model_routing": {
+        "enabled": False,
+        "strategy": "smart_heuristic",
+        "base_model": "",
+        "premium_model": "",
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     "agent": {

--- a/tests/gateway/test_smart_model_routing.py
+++ b/tests/gateway/test_smart_model_routing.py
@@ -1,0 +1,129 @@
+"""Tests for optional gateway smart model routing."""
+
+import gateway.run as gateway_run
+
+
+def _runner():
+    return object.__new__(gateway_run.GatewayRunner)
+
+
+def test_model_routing_disabled_keeps_session_model(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+
+    routed = _runner()._route_model_for_turn("debug this failing test", "gpt-5.4-mini")
+
+    assert routed == "gpt-5.4-mini"
+
+
+def test_model_routing_promotes_hard_turn_when_enabled(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "model_routing": {
+                "enabled": True,
+                "base_model": "gpt-5.4-mini",
+                "premium_model": "gpt-5.5",
+            }
+        },
+    )
+
+    routed = _runner()._route_model_for_turn("debug this failing test traceback", "gpt-5.4-mini")
+
+    assert routed == "gpt-5.5"
+
+
+def test_model_routing_does_not_promote_routine_turn(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "model_routing": {
+                "enabled": True,
+                "base_model": "gpt-5.4-mini",
+                "premium_model": "gpt-5.5",
+            }
+        },
+    )
+
+    routed = _runner()._route_model_for_turn("what time is it?", "gpt-5.4-mini")
+
+    assert routed == "gpt-5.4-mini"
+
+
+def test_model_routing_respects_explicit_cheap_model_request(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "model_routing": {
+                "enabled": True,
+                "base_model": "gpt-5.4-mini",
+                "premium_model": "gpt-5.5",
+            }
+        },
+    )
+
+    runner = _runner()
+
+    assert runner._route_model_for_turn(
+        "use mini and debug this failing test traceback",
+        "gpt-5.4-mini",
+    ) == "gpt-5.4-mini"
+    assert runner._route_model_for_turn(
+        "do not use gpt-5.5 for this architecture question",
+        "gpt-5.4-mini",
+    ) == "gpt-5.4-mini"
+    assert runner._route_model_for_turn(
+        "avoid the best model and debug this",
+        "gpt-5.4-mini",
+    ) == "gpt-5.4-mini"
+
+
+def test_model_routing_only_promotes_configured_base_model(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "model_routing": {
+                "enabled": True,
+                "base_model": "gpt-5.4-mini",
+                "premium_model": "gpt-5.5",
+            }
+        },
+    )
+
+    routed = _runner()._route_model_for_turn("debug this failing test", "claude-sonnet-4")
+
+    assert routed == "claude-sonnet-4"
+
+
+def test_resolve_turn_agent_config_uses_routed_model_in_signature(monkeypatch):
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {
+            "model_routing": {
+                "enabled": True,
+                "base_model": "gpt-5.4-mini",
+                "premium_model": "gpt-5.5",
+            }
+        },
+    )
+
+    route = _runner()._resolve_turn_agent_config(
+        "think harder about this architecture",
+        "gpt-5.4-mini",
+        {"provider": "openai-api", "api_key": "***"},
+    )
+
+    assert route["model"] == "gpt-5.5"
+    assert route["signature"][0] == "gpt-5.5"
+
+
+def test_model_routing_match_reason_covers_long_ambiguous_strategy():
+    message = " ".join(["word"] * 80) + " what should we recommend as the strategy?"
+
+    reason = gateway_run.GatewayRunner._model_routing_match_reason(message)
+
+    assert reason == "long ambiguous strategy request"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -77,6 +77,26 @@ Multiple references in a single value work: `url: "${HOST}:${PORT}"`. If a refer
 
 For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/integrations/providers).
 
+### Smart Model Routing
+
+Gateway sessions can keep a cheaper default model for routine turns while automatically promoting hard turns to a stronger model. This is opt-in and only affects live gateway turns; CLI `--model`, `/model` session overrides, cron job model pins, and explicit non-base session models are respected.
+
+```yaml
+model:
+  default: gpt-5.4-mini
+  provider: openai-api
+
+model_routing:
+  enabled: true
+  strategy: smart_heuristic
+  base_model: gpt-5.4-mini
+  premium_model: gpt-5.5
+```
+
+With `strategy: smart_heuristic`, Hermes promotes a turn when the user explicitly asks for the stronger model (`use 5.5`, `think harder`, `best model`) or when the message looks like debugging/root-cause work, implementation/refactoring, architecture/planning, security/risky operations, or a long ambiguous strategy question. Routine messages stay on `base_model`. Explicit cheap-model requests such as `use mini` prevent promotion for that turn.
+
+Changing `model_routing` in a running gateway takes effect on the next message. A promoted turn rebuilds the cached agent for that session because the effective model is part of the gateway agent-cache signature.
+
 ### Provider Timeouts
 
 You can set `providers.<id>.request_timeout_seconds` for a provider-wide request timeout, plus `providers.<id>.models.<model>.timeout_seconds` for a model-specific override. Applies to the primary turn client on every transport (OpenAI-wire, native Anthropic, Anthropic-compatible), the fallback chain, rebuilds after credential rotation, and (for OpenAI-wire) the per-request timeout kwarg — so the configured value wins over the legacy `HERMES_API_TIMEOUT` env var.


### PR DESCRIPTION
## Summary
- add optional gateway `model_routing` config for per-turn promotion from a base model to a premium model
- route hard/debugging/coding/architecture/risky/long ambiguous turns to the premium model while routine turns stay on the session model
- respect explicit cheap/no-premium requests and non-base session models
- document the config and add gateway routing tests

## Test Plan
- `python -m pytest tests/gateway/test_smart_model_routing.py -q -o 'addopts='` — 7 passed
- `python -m pytest tests/gateway/test_smart_model_routing.py tests/gateway/test_session_model_override_routing.py tests/gateway/test_agent_cache.py tests/gateway/test_runtime_config_env_expansion.py -q -o 'addopts='` — 81 passed
- `python -m py_compile gateway/run.py hermes_cli/config.py`

Note: broader `tests/gateway` run surfaced unrelated existing/flaky failures outside this patch area (Matrix/Telegram formatting flakes on first run, and `test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output` still failing when rerun locally).