### PR TITLE
fix: Bound Telegram httpx general-pool and drain after reconnect (#31599)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -81,6 +81,7 @@ from gateway.platforms.base import (
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
 )
+from gateway.platforms._http_client_limits import platform_httpx_limits
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
@@ -899,48 +900,56 @@ class TelegramAdapter(BasePlatformAdapter):
             return {"link_preview_options": LinkPreviewOptions(is_disabled=True)}
         return {"disable_web_page_preview": True}
 
-    async def _drain_polling_connections(self) -> None:
-        """Reset the httpx connection pool used for getUpdates polling.
+    async def _drain_request_connections(self, request_index: int, label: str) -> None:
+        """Reset one PTB HTTPXRequest connection pool by tuple index.
 
         Network errors (especially through proxies like sing-box) can leave
         httpx connections in a half-closed state that still occupy pool slots.
         After enough reconnect cycles the pool fills up entirely, causing
         ``Pool timeout: All connections in the connection pool are occupied.``
 
-        We reset ONLY ``_request[0]`` (the getUpdates request) — the general
-        request (``_request[1]``) is left untouched so concurrent
-        ``send_message`` / ``edit_message`` calls are never interrupted.
-
         Implementation note: accesses ``Bot._request[0]`` which is the
         get-updates ``BaseRequest`` in the PTB 22.x internal tuple
         ``(get_updates_request, general_request)``.  There is no public
-        accessor for the polling request; review if upgrading to PTB 23+.
+        accessor for either request; review if upgrading to PTB 23+.
         """
         if not (self._app and self._app.bot):
             return
         try:
-            # PTB 22.x: _request is a (get_updates, general) tuple;
-            # no public accessor exists for the polling request.
-            polling_req = self._app.bot._request[0]  # noqa: SLF001
+            # PTB 22.x: _request is a (get_updates, general) tuple.
+            request = self._app.bot._request[request_index]  # noqa: SLF001
         except Exception:
             return
         try:
-            await polling_req.shutdown()
+            await request.shutdown()
         except Exception:
             logger.debug(
-                "[%s] Polling request shutdown failed (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] %s request shutdown failed (non-fatal)",
+                self.name, label, exc_info=True,
             )
         try:
-            await polling_req.initialize()
+            await request.initialize()
             logger.debug(
-                "[%s] Polling request pool drained before reconnect", self.name
+                "[%s] %s request pool drained before reconnect", self.name, label
             )
         except Exception:
             logger.debug(
-                "[%s] Polling request re-initialize failed (non-fatal)",
-                self.name, exc_info=True,
+                "[%s] %s request re-initialize failed (non-fatal)",
+                self.name, label, exc_info=True,
             )
+
+    async def _drain_polling_connections(self) -> None:
+        """Reset the httpx connection pool used for getUpdates polling."""
+        await self._drain_request_connections(0, "Polling")
+
+    async def _drain_general_connections(self) -> None:
+        """Reset the httpx connection pool used for general Bot API calls.
+
+        This is intentionally not part of the normal polling drain. It runs
+        only after a successful polling reconnect, when the send path is
+        already marked degraded and callers should be using fallback delivery.
+        """
+        await self._drain_request_connections(1, "General")
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -1000,6 +1009,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Telegram polling resumed after network error (attempt %d)",
                 self.name, attempt,
             )
+            await self._drain_general_connections()
             self._polling_network_error_count = 0
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
@@ -1551,13 +1561,25 @@ class TelegramAdapter(BasePlatformAdapter):
                 except (TypeError, ValueError):
                     return default
 
+            connection_pool_size = _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 20)
             request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
+                "connection_pool_size": connection_pool_size,
                 "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
+            httpx_kwargs = {}
+            httpx_limits = platform_httpx_limits()
+            if httpx_limits is not None:
+                max_keepalive = getattr(httpx_limits, "max_keepalive_connections", None)
+                if max_keepalive is not None:
+                    max_keepalive = min(max_keepalive, connection_pool_size)
+                httpx_kwargs["limits"] = type(httpx_limits)(
+                    max_connections=connection_pool_size,
+                    max_keepalive_connections=max_keepalive,
+                    keepalive_expiry=getattr(httpx_limits, "keepalive_expiry", None),
+                )
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
@@ -1581,21 +1603,31 @@ class TelegramAdapter(BasePlatformAdapter):
                 # polling reconnect + bot API bootstrap/delete_webhook calls.
                 request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        **httpx_kwargs,
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                    },
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        **httpx_kwargs,
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                request = HTTPXRequest(
+                    **request_kwargs, proxy=proxy_url, httpx_kwargs=httpx_kwargs
+                )
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs, proxy=proxy_url, httpx_kwargs=httpx_kwargs
+                )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                request = HTTPXRequest(**request_kwargs, httpx_kwargs=httpx_kwargs)
+                get_updates_request = HTTPXRequest(**request_kwargs, httpx_kwargs=httpx_kwargs)
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -48,6 +48,128 @@ def _no_auto_discovery(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_bounds_httpx_request_pools_with_shared_limits(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+    monkeypatch.delenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE", raising=False)
+
+    captured_requests = []
+
+    def fake_httpx_request(**kwargs):
+        captured_requests.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", fake_httpx_request)
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert len(captured_requests) == 2
+    for request_kwargs in captured_requests:
+        assert request_kwargs["connection_pool_size"] == 20
+        limits = request_kwargs["httpx_kwargs"]["limits"]
+        assert limits.max_connections == 20
+        assert limits.max_keepalive_connections == 10
+        assert limits.keepalive_expiry == 2.0
+
+
+@pytest.mark.asyncio
+async def test_connect_keeps_telegram_pool_size_env_override(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+    monkeypatch.setenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", "37")
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE", raising=False)
+
+    captured_requests = []
+
+    def fake_httpx_request(**kwargs):
+        captured_requests.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", fake_httpx_request)
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert [kwargs["connection_pool_size"] for kwargs in captured_requests] == [37, 37]
+    assert [
+        kwargs["httpx_kwargs"]["limits"].max_connections
+        for kwargs in captured_requests
+    ] == [37, 37]
+
+
+@pytest.mark.asyncio
 async def test_connect_rejects_same_host_token_lock(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="secret-token"))
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -177,13 +177,17 @@ async def test_reconnect_triggers_fatal_after_max_retries():
 # ---------------------------------------------------------------------------
 
 def _make_mock_app():
-    """Build a mock Application with an explicit polling request object."""
+    """Build a mock Application with explicit PTB request objects."""
     mock_polling_req = AsyncMock()
     mock_polling_req.shutdown = AsyncMock()
     mock_polling_req.initialize = AsyncMock()
 
+    mock_general_req = AsyncMock()
+    mock_general_req.shutdown = AsyncMock()
+    mock_general_req.initialize = AsyncMock()
+
     mock_bot = MagicMock()
-    mock_bot._request = (mock_polling_req, MagicMock())  # (getUpdates, general)
+    mock_bot._request = (mock_polling_req, mock_general_req)  # (getUpdates, general)
 
     mock_updater = MagicMock()
     mock_updater.running = True
@@ -193,37 +197,49 @@ def _make_mock_app():
     mock_app = MagicMock()
     mock_app.updater = mock_updater
     mock_app.bot = mock_bot
-    return mock_app, mock_polling_req
+    return mock_app, mock_polling_req, mock_general_req
 
 
 @pytest.mark.asyncio
 async def test_reconnect_drains_polling_request_only():
-    """During reconnect, only the polling request (_request[0]) must be cycled.
+    """The polling drain helper only cycles the polling request (_request[0]).
 
-    The general request (_request[1]) must NOT be touched — doing so would
-    break concurrent send_message / edit_message calls.
+    The general pool is drained separately after successful network reconnects,
+    not as part of the ordinary polling-pool helper.
     """
     adapter = _make_adapter()
-    adapter._polling_network_error_count = 1
 
-    mock_app, mock_polling_req = _make_mock_app()
+    mock_app, mock_polling_req, mock_general_req = _make_mock_app()
     adapter._app = mock_app
 
-    general_req = mock_app.bot._request[1]
-
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        await adapter._handle_polling_network_error(Exception("Bad Gateway"))
+    await adapter._drain_polling_connections()
 
     # Polling request must be shut down and re-initialized
     mock_polling_req.shutdown.assert_called_once()
     mock_polling_req.initialize.assert_called_once()
 
-    # General request must NOT be touched
-    general_req.shutdown.assert_not_called()
-    general_req.initialize.assert_not_called()
+    # General request must not be touched by the polling-only helper.
+    mock_general_req.shutdown.assert_not_called()
+    mock_general_req.initialize.assert_not_called()
 
-    # Reconnect must still succeed
+
+@pytest.mark.asyncio
+async def test_reconnect_success_drains_general_request_after_polling_resumes():
+    """After a successful network reconnect, cycle the general Bot API pool too."""
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_app, mock_polling_req, mock_general_req = _make_mock_app()
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(Exception("Bad Gateway"))
+
     mock_app.updater.start_polling.assert_called_once()
+    mock_polling_req.shutdown.assert_called_once()
+    mock_polling_req.initialize.assert_called_once()
+    mock_general_req.shutdown.assert_called_once()
+    mock_general_req.initialize.assert_called_once()
     assert adapter._polling_network_error_count == 0
 
 
@@ -233,7 +249,7 @@ async def test_reconnect_continues_if_drain_fails():
     adapter = _make_adapter()
     adapter._polling_network_error_count = 1
 
-    mock_app, mock_polling_req = _make_mock_app()
+    mock_app, mock_polling_req, _mock_general_req = _make_mock_app()
     # Both shutdown and initialize fail
     mock_polling_req.shutdown = AsyncMock(side_effect=Exception("shutdown boom"))
     mock_polling_req.initialize = AsyncMock(side_effect=Exception("init boom"))
@@ -257,7 +273,7 @@ async def test_initialize_still_runs_when_shutdown_fails():
     adapter = _make_adapter()
     adapter._polling_network_error_count = 1
 
-    mock_app, mock_polling_req = _make_mock_app()
+    mock_app, mock_polling_req, _mock_general_req = _make_mock_app()
     mock_polling_req.shutdown = AsyncMock(side_effect=Exception("shutdown boom"))
     adapter._app = mock_app
 
@@ -275,7 +291,7 @@ async def test_conflict_retry_also_drains_polling_connections():
     adapter = _make_adapter()
     adapter._polling_conflict_count = 0
 
-    mock_app, mock_polling_req = _make_mock_app()
+    mock_app, mock_polling_req, _mock_general_req = _make_mock_app()
     adapter._app = mock_app
 
     with patch("asyncio.sleep", new_callable=AsyncMock):


### PR DESCRIPTION
## Summary

Fixes the Telegram adapter FD leak where half-closed httpx sockets accumulate in the general request pool (`_request[1]`) through proxy reconnection cycles, eventually hitting `OSError: [Errno 24] Too many open files` after ~2 days.

**Credit:** Excellent root cause analysis by @JustinHuber in #31599. The distinction between polling pool (`_request[0]`, already drained) and general pool (`_request[1]`, never drained) was the key insight.

## Root Cause

1. `connection_pool_size=512` in `request_kwargs` — far more than any single adapter needs
2. `_drain_polling_connections()` only resets `_request[0]` (polling). `_request[1]` (general, used by `send_message`/`set_my_commands`) is never drained
3. `_http_client_limits.py` already provides `platform_httpx_limits()` with tighter defaults (keepalive 2s, max 10 idle), used by Signal, WeCom, DingTalk, BlueBubbles — but Telegram wasn't using it

## Fix

**Three changes, minimal surface:**

1. **Bound the general pool** — `connection_pool_size` reduced from 512 to 20. `platform_httpx_limits()` now applied to both HTTPXRequest instances via `httpx_kwargs["limits"]`, giving `max_connections=20`, `max_keepalive_connections=10`, `keepalive_expiry=2.0`. `HERMES_TELEGRAM_HTTP_POOL_SIZE` env var still works as override.

2. **Drain general pool after reconnect** — Added `_drain_general_connections()` (calls `_drain_request_connections(1, "General")`). Called after successful polling reconnect in `_handle_polling_network_error`, when the send path is already marked degraded. Not called during normal polling drain to avoid interrupting active sends.

3. **Refactored drain helper** — `_drain_request_connections(request_index, label)` is the shared implementation. `_drain_polling_connections()` and `_drain_general_connections()` are thin wrappers.

## Tests

- `test_connect_bounds_httpx_request_pools_with_shared_limits` — verifies limits applied correctly
- `test_connect_keeps_telegram_pool_size_env_override` — verifies env var override still works
- `test_reconnect_drains_polling_request_only` — polling drain helper doesn't touch general pool
- `test_reconnect_success_drains_general_request_after_polling_resumes` — general pool drained after successful reconnect
- 567 Telegram tests pass (canonical per-file runner)

## Why not drain general pool on every reconnect attempt?

The general pool serves `send_message` / `edit_message`. Draining it mid-reconnect (before polling resumes) would interrupt in-flight user-facing sends. We drain it only after polling successfully resumes, when the send path is already degraded and callers should be using fallback delivery.

Closes #31599