### PR TITLE
fix(dashboard): allow desktop websocket origins on remote binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6171,13 +6171,16 @@ def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
 
     parsed = urllib.parse.urlparse(origin)
     if parsed.scheme not in {"http", "https"}:
-        # Packaged Electron loads the desktop renderer over file://, so its
-        # WebSocket handshake carries a non-web Origin such as file:// or null.
-        # DNS-rebinding attacks originate from an http(s) site; they cannot
-        # forge a file:// origin and still hold the loopback session token.
-        # Public/gated binds have no legitimate non-web client, so keep
-        # rejecting these origins there.
-        return bound_host.lower() in _LOOPBACK_HOST_VALUES
+        # Packaged Electron loads the desktop renderer over a non-web origin
+        # such as file:// or null. This helper is called only after _ws_auth_ok
+        # has accepted the WS credential; in non-gated mode that credential is
+        # the legacy dashboard session token, including for explicit Tailscale /
+        # LAN binds opened with --insecure. Real DNS-rebinding attacks arrive
+        # from http(s) origins and still have to match the bound host below.
+        #
+        # OAuth-gated public dashboards authenticate with cookies/tickets and
+        # have no legitimate file:// client, so keep them strict.
+        return not getattr(app.state, "auth_required", False)
 
     if not parsed.netloc:
         return False

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -381,8 +381,9 @@ class TestWsHostOriginGuardOrigins:
     Electron loads the packaged renderer over ``file://``, so its WebSocket
     handshake carries ``Origin: file://`` (or the opaque ``null``). The
     DNS-rebinding guard only needs to block cross-site http(s) origins. On a
-    loopback bind these non-web origins are trusted because the session token
-    is the real gate. Public/gated binds keep rejecting them.
+    loopback or explicit non-loopback insecure bind these non-web origins are
+    trusted because the session token is the real gate. OAuth-gated public
+    binds keep rejecting them.
     """
 
     def _ws(self, *, origin, host):
@@ -413,8 +414,29 @@ class TestWsHostOriginGuardOrigins:
         ws = self._ws(origin="http://evil.test", host="127.0.0.1:8080")
         assert web_server._ws_host_origin_is_allowed(ws) is False
 
+    def test_explicit_non_loopback_file_origin_allowed(self, insecure_explicit_host_app):
+        """Packaged Hermes Desktop also uses file:// when connecting to a
+        Tailscale/LAN dashboard bind.
+
+        The WebSocket route calls _ws_auth_ok before this guard, so in
+        non-gated mode the legacy session token remains the auth boundary.
+        """
+        ws = self._ws(origin="file://", host="100.64.0.10:9119")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_explicit_non_loopback_null_origin_allowed(self, insecure_explicit_host_app):
+        ws = self._ws(origin="null", host="100.64.0.10:9119")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_explicit_non_loopback_cross_site_http_origin_rejected(
+        self, insecure_explicit_host_app
+    ):
+        ws = self._ws(origin="http://localhost:9119", host="100.64.0.10:9119")
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
     def test_gated_file_origin_rejected(self, gated_app):
-        # A public/gated bind has no legitimate file:// client.
+        # OAuth-gated public dashboards authenticate with cookies/tickets,
+        # not the legacy desktop session token.
         ws = self._ws(origin="file://", host="fly-app.fly.dev")
         assert web_server._ws_host_origin_is_allowed(ws) is False
 


### PR DESCRIPTION
## What does this PR do?

Fixes Hermes Desktop remote mode when the dashboard is bound to an explicit non-loopback address, such as a Tailscale or LAN IP with `--host ... --insecure --tui`.

The packaged Electron app opens `/api/ws` with a non-web Origin (`file://` or `null`). The WebSocket handler already validates credentials first with `_ws_auth_ok`, but the later origin guard only trusted those non-web origins on loopback binds. That made remote Desktop sessions fail even with a valid dashboard session token.

This keeps the existing strict behavior for OAuth-gated public dashboards and for real `http(s)` origins, while allowing authenticated non-web Electron origins on non-gated dashboard binds.

## Related Issue

Fixes #37399

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/web_server.py`: allow non-web WebSocket origins (`file://` / `null`) after WebSocket credentials have already authenticated, when `app.state.auth_required` is false.
- `hermes_cli/web_server.py`: keep OAuth-gated public dashboards strict, and keep `http(s)` origins subject to the bound-host match.
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: add regression coverage for explicit non-loopback binds accepting `file://` and `null` origins.
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: add coverage that an explicit non-loopback bind still rejects a mismatched `http://localhost:...` origin.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Red/green focused origin guard test:
   - Before the production change, the new explicit non-loopback `file://` and `null` tests failed.
   - After the production change: `python -m pytest tests/hermes_cli/test_dashboard_auth_ws_auth.py::TestWsHostOriginGuardOrigins -q` -> `9 passed`.
2. Adjacent dashboard auth/host verification:
   - `python -m pytest tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_ws_auth.py -q` -> `44 passed`.
3. CONTRIBUTING wrapper on the touched dashboard auth test file:
   - `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_ws_auth.py` -> `33/33 passed`.
4. Full wrapper attempt:
   - `scripts/run_tests.sh -j 4` -> `28092 passed, 26 failed` across 10 unrelated files on macOS.
   - The touched file `tests/hermes_cli/test_dashboard_auth_ws_auth.py` passed in the full wrapper run.
   - Failing files were:
     - `tests/agent/test_anthropic_adapter.py` (5)
     - `tests/gateway/test_gateway_shutdown.py` (1)
     - `tests/gateway/test_shutdown_forensics.py` (1)
     - `tests/hermes_cli/test_gateway_wsl.py` (2)
     - `tests/hermes_cli/test_gateway_service.py` (6)
     - `tests/hermes_cli/test_service_manager.py` (2)
     - `tests/hermes_cli/test_signal_handler_kanban_worker.py` (1)
     - `tests/test_live_system_guard_self_test.py` (4)
     - `tests/test_tui_gateway_server.py` (1)
     - `tests/tools/test_file_tools.py` (3)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 / Darwin 24.6.0

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The relevant runtime symptom was a Hermes Desktop WebSocket failure on macOS remote mode. Local log evidence showed the WebSocket request reaching the remote dashboard with:

- `Origin=file://` from the packaged Electron app.
- A valid `token=...` credential in the WebSocket URL.
- Rejection at the origin guard after credential auth.

The new regression tests cover that token-authenticated Electron-origin path without including any secret values.
