### PR TITLE
fix(agent): preserve parent env session id for subagents

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -973,17 +973,6 @@ def init_agent(
         short_uuid = uuid.uuid4().hex[:6]
         agent.session_id = f"{timestamp_str}_{short_uuid}"
 
-    # Expose session ID to tools (terminal, execute_code) so agents can
-    # reference their own session for --resume commands, cross-session
-    # coordination, and logging. Keep the ContextVar and os.environ
-    # fallback synchronized because different tool paths still read both.
-    try:
-        from gateway.session_context import set_current_session_id
-
-        set_current_session_id(agent.session_id)
-    except Exception:
-        os.environ["HERMES_SESSION_ID"] = agent.session_id
-
     # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
     hermes_home = get_hermes_home()
     agent.logs_dir = hermes_home / "sessions"
@@ -1002,13 +991,33 @@ def init_agent(
     # logs_dir is retained unconditionally for request_dump_*.json (debug
     # breadcrumb path written by agent_runtime_helpers.dump_api_request_debug).
     
-    # Track conversation messages for session logging
-    agent._session_messages: List[Dict[str, Any]] = []
-    # Responses encrypted reasoning replay state.  Some OpenAI-compatible
-    # routes accept GPT-5 Responses requests but later reject replayed
-    # encrypted reasoning blobs (HTTP 400 ``invalid_encrypted_content``).
-    # When that happens we disable replay for the rest of the session and
-    # fall back to stateless continuity.  See
+    # SQLite session store (optional -- provided by CLI or gateway)
+    agent._session_db = session_db
+    agent._parent_session_id = parent_session_id
+
+    # Expose session ID to tools (terminal, execute_code) so agents can
+    # reference their own session for --resume commands, cross-session
+    # coordination, and logging. Keep the ContextVar and os.environ
+    # fallback synchronized because different tool paths still read both.
+    try:
+        from gateway.session_context import _SESSION_ID, set_current_session_id
+
+        if agent._parent_session_id:
+            _SESSION_ID.set(agent.session_id)
+        else:
+            set_current_session_id(agent.session_id)
+    except Exception:
+        if not agent._parent_session_id:
+            os.environ["HERMES_SESSION_ID"] = agent.session_id
+
+    agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+    agent._session_db_created = False  # DB row deferred to run_conversation()
+    agent._session_init_model_config = {
+        "max_iterations": agent.max_iterations,
+        "reasoning_config": reasoning_config,
+        "max_tokens": max_tokens,
+    }
+
     # agent/conversation_loop.py's invalid_encrypted_content retry branch.
     agent._codex_reasoning_replay_enabled = True
     agent._memory_write_origin = "assistant_tool"
@@ -1025,17 +1034,6 @@ def init_agent(
         max_total_size_mb=checkpoint_max_total_size_mb,
         max_file_size_mb=checkpoint_max_file_size_mb,
     )
-    
-    # SQLite session store (optional -- provided by CLI or gateway)
-    agent._session_db = session_db
-    agent._parent_session_id = parent_session_id
-    agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
-    agent._session_db_created = False  # DB row deferred to run_conversation()
-    agent._session_init_model_config = {
-        "max_iterations": agent.max_iterations,
-        "reasoning_config": reasoning_config,
-        "max_tokens": max_tokens,
-    }
     
     # In-memory todo list for task planning (one per agent/session)
     from tools.todo_tool import TodoStore

--- a/tests/run_agent/test_session_id_env.py
+++ b/tests/run_agent/test_session_id_env.py
@@ -2,11 +2,13 @@
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
+from gateway.session_context import get_session_env
 from run_agent import AIAgent
 
 
@@ -57,5 +59,24 @@ def test_session_id_contextvar_set():
         skip_context_files=True,
         skip_memory=True,
     )
-    from gateway.session_context import get_session_env
     assert get_session_env("HERMES_SESSION_ID") == custom_id
+
+
+def test_subagent_init_preserves_parent_env_session_id():
+    """Subagents should not overwrite the parent process env session id."""
+    parent_id = "20260511_140000_parent01"
+    os.environ["HERMES_SESSION_ID"] = parent_id
+
+    with patch("run_agent.AIAgent._create_openai_client", return_value=object()):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            parent_session_id=parent_id,
+        )
+
+    assert agent.session_id != parent_id
+    assert os.environ["HERMES_SESSION_ID"] == parent_id
+    assert get_session_env("HERMES_SESSION_ID") == agent.session_id


### PR DESCRIPTION
## Problem

`AIAgent.__init__` always synchronizes the newly-created agent session id into both the session ContextVar and `os.environ["HERMES_SESSION_ID"]`.

That is correct for top-level agents, but wrong for `delegate_task` subagents. A subagent should get its own ContextVar session id while preserving the parent process environment session id for any later parent-side tool calls.

## Fix

- move the session-id synchronization to after `agent._parent_session_id` is assigned
- if `parent_session_id` is present, set only the `HERMES_SESSION_ID` ContextVar
- keep the existing `set_current_session_id()` behavior for top-level agents
- keep the fallback `os.environ` write only for top-level agents

## Verification

Added regression coverage in `tests/run_agent/test_session_id_env.py`:

- top-level agent still exports `HERMES_SESSION_ID` to env
- explicit session ids still populate env + ContextVar
- subagent init preserves the parent env session id while giving the child its own ContextVar session id

Test run:

```bash
uv run --python 3.11 python -m pytest tests/run_agent/test_session_id_env.py -q
```

Actual result:

```text
....                                                                     [100%]
4 passed in 18.43s
```

Related issue: #37356
