### PR TITLE
fix(agent): truncate Codex app-server exec output to prevent context bloat

### DIFF
--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -34,6 +34,33 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
+def _truncate_command_output(output: str) -> str:
+    """Cap projected command output to the configured tool-output limit.
+
+    Codex app-server runs shell commands through its own runtime, so command
+    output is projected here rather than passing through
+    ``tools/terminal_tool.py`` (which already truncates via
+    ``get_max_bytes()``). Without this cap a single large result -- e.g. a
+    repo-wide ``grep`` returning hundreds of KB -- lands in the conversation
+    history at full size, saturating the model context window and forcing
+    near-constant compression (context loss). Mirror terminal_tool's
+    head+tail truncation so behaviour is consistent across runtimes.
+    """
+    from tools.tool_output_limits import get_max_bytes
+
+    max_chars = get_max_bytes()
+    if len(output) <= max_chars:
+        return output
+    head_chars = int(max_chars * 0.4)  # errors often appear early
+    tail_chars = max_chars - head_chars  # keep the most recent output
+    omitted = len(output) - head_chars - tail_chars
+    truncated_notice = (
+        f"\n\n... [OUTPUT TRUNCATED - {omitted} chars omitted "
+        f"out of {len(output)} total] ...\n\n"
+    )
+    return output[:head_chars] + truncated_notice + output[-tail_chars:]
+
+
 def _deterministic_call_id(item_type: str, item_id: str) -> str:
     """Stable id for tool_call message correlation.
 
@@ -163,6 +190,7 @@ class CodexEventProjector:
             assistant_msg["reasoning"] = "\n".join(self._pending_reasoning)
             self._pending_reasoning = []
         output = item.get("aggregatedOutput") or ""
+        output = _truncate_command_output(output)
         exit_code = item.get("exitCode")
         if exit_code is not None and exit_code != 0:
             output = f"[exit {exit_code}]\n{output}"

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -300,3 +300,54 @@ class TestRoleAlternationInvariant:
         assert msgs[0]["role"] == "assistant"
         assert msgs[1]["role"] == "tool"
         assert msgs[1]["tool_call_id"] == msgs[0]["tool_calls"][0]["id"]
+
+
+class TestCommandOutputTruncation:
+    """Codex app-server command output must be capped like terminal_tool's.
+
+    Codex runs shell commands through its own runtime, so output is projected
+    here instead of going through ``tools/terminal_tool.py``. A single large
+    result (e.g. a repo-wide ``grep``) must not land in history at full size
+    and saturate the context window. See ``_truncate_command_output``.
+    """
+
+    def _make_notif(self, output: str, exit_code: int = 0) -> dict:
+        item = {
+            **COMMAND_EXEC_COMPLETED["params"]["item"],
+            "id": "trunc-test",
+            "aggregatedOutput": output,
+            "exitCode": exit_code,
+        }
+        return {
+            "method": "item/completed",
+            "params": {**COMMAND_EXEC_COMPLETED["params"], "item": item},
+        }
+
+    def test_large_output_is_truncated(self) -> None:
+        from tools.tool_output_limits import get_max_bytes
+
+        max_chars = get_max_bytes()
+        huge = "x" * (max_chars * 3)
+        p = CodexEventProjector()
+        tool = p.project(self._make_notif(huge)).messages[1]
+        assert tool["role"] == "tool"
+        # Truncated well below the original, near the configured cap.
+        assert len(tool["content"]) < len(huge)
+        assert len(tool["content"]) <= max_chars + 200  # + notice overhead
+        assert "OUTPUT TRUNCATED" in tool["content"]
+
+    def test_small_output_not_truncated(self) -> None:
+        p = CodexEventProjector()
+        tool = p.project(self._make_notif("hello\nworld\n")).messages[1]
+        assert tool["content"] == "hello\nworld\n"
+        assert "OUTPUT TRUNCATED" not in tool["content"]
+
+    def test_truncation_preserves_nonzero_exit_prefix(self) -> None:
+        from tools.tool_output_limits import get_max_bytes
+
+        huge = "e" * (get_max_bytes() * 3)
+        p = CodexEventProjector()
+        tool = p.project(self._make_notif(huge, exit_code=2)).messages[1]
+        # Exit prefix is added after truncation, so it survives at the head.
+        assert tool["content"].startswith("[exit 2]\n")
+        assert "OUTPUT TRUNCATED" in tool["content"]


### PR DESCRIPTION
## What does this PR do?

`_project_command` in `agent/transports/codex_event_projector.py` copied a command's full `aggregatedOutput` straight into the tool-result message content with **no size cap**.

When Hermes runs under the **Codex app-server runtime** (`openai_runtime: codex_app_server`), shell commands execute inside Codex's own runtime and their output is projected here — it never passes through `tools/terminal_tool.py`, which truncates output via `tools/tool_output_limits.py:get_max_bytes()` (default 50 KB, head+tail). `tools/code_execution_tool.py` truncates too.

So a single large command result — e.g. a repo-wide `grep -rn` returning hundreds of KB — landed in conversation history **at full size**. In a real session this produced individual tool messages of **800 KB–1 MB** (~200k tokens each), instantly saturating the model context window. Because such a message also tends to sit inside the `compression.protect_last_n` window, it survives compression and is carried forward across compression session-splits, so the model then compresses *everything else* every turn — i.e. it continuously loses earlier conversation context.

The sibling `_project_file_change` already deliberately avoids inlining large payloads ("those can be huge"); command output was the one projection path left uncapped, inconsistent with the terminal / file-change / MCP / dynamic-tool paths.

## Related Issue

Fixes #37414

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/codex_event_projector.py`: add `_truncate_command_output()` (mirrors `terminal_tool.py`'s head+tail truncation, reuses the existing `tool_output.max_bytes` config) and apply it in `_project_command` **before** the non-zero `[exit N]` prefix so the prefix is preserved at the head.
- `tests/agent/transports/test_codex_event_projector.py`: add `TestCommandOutputTruncation` — large output is capped + carries the truncation notice, small output is untouched, and the non-zero exit prefix survives truncation.

## How to Test

1. `scripts/run_tests.sh tests/agent/transports/test_codex_event_projector.py -q` (or `pytest` with the project venv) → 26 passed.
2. Behaviorally: under `openai_runtime: codex_app_server`, run a command with very large stdout (e.g. a repo-wide `grep -rn`). Before: the full output is stored in history and the context window saturates, forcing repeated compression. After: the tool result is capped to `tool_output.max_bytes` with a `... [OUTPUT TRUNCATED - N chars omitted ...] ...` notice.

## Platforms tested

- macOS (Apple Silicon), Python 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
