### PR TITLE
fix: harden holographic memory recall diagnostics

### DIFF
--- a/docs/holographic-memory-recall-diagnostics.md
+++ b/docs/holographic-memory-recall-diagnostics.md
@@ -1,0 +1,53 @@
+# Holographic memory recall diagnostics
+
+Task: t_0e2fbd42
+Profile: responsible_memory_rollout
+
+## Located implementation paths
+
+- Holographic memory provider and `fact_store` / `fact_feedback` tool schemas: `plugins/memory/holographic/__init__.py`
+- SQLite fact store, entity extraction, FTS5 schema, trust scoring, HRR vector persistence: `plugins/memory/holographic/store.py`
+- Hybrid FTS/Jaccard/HRR retrieval plus `probe`, `related`, `reason`, and `contradict`: `plugins/memory/holographic/retrieval.py`
+- HRR phase-vector algebra: `plugins/memory/holographic/holographic.py`
+- Transcript ground truth tool: `tools/session_search_tool.py`
+- Transcript SQLite/FTS5 implementation: `hermes_state.py`
+
+## Root cause confirmed
+
+The false negatives are repo-owned behavior, not just an operator issue.
+
+1. Profile path ambiguity: configs that used `~/.hermes/memory_store.db` resolved through `Path.expanduser()` and process `HOME`, not the active profile `HERMES_HOME`. That can make a worker read/write a default/root store while the profile prompt claims holographic memory is active.
+2. Retrieval candidate gating: `FactRetriever.search()` previously returned empty as soon as strict FTS5 `MATCH` found no rows. FTS5 multi-token queries are effectively AND-gated, so a query with one extra operational token (`session`) could miss a fact that had all other relevant terms in content/tags.
+3. HRR-only false positives: `probe()` and `reason()` returned top-N rows even when every score was just random-vector noise. Tiny stores with unrelated rollout markers therefore looked like successful recall for entities such as `Lineage status`.
+4. Ingestion remains a policy/product gap: the provider mirrors explicit built-in memory writes and optional narrow user-message auto extraction. It does not automatically convert session_search-confirmed corrections, assistant summaries, Kanban comments, or tool handoffs into facts.
+
+## Changes made
+
+- `plugins/memory/holographic/__init__.py`
+  - Added `_resolve_profile_db_path()` so `~/.hermes/...` in holographic config resolves to active `HERMES_HOME` for profile-safe behavior.
+  - Added `min_hrr_score` config wiring for probe/reason relevance filtering.
+- `plugins/memory/holographic/retrieval.py`
+  - Added deterministic overlap fallback candidates when strict FTS5 matching finds nothing.
+  - Added a default HRR relevance floor (`min_hrr_score=0.35`) for `probe()` and `reason()` so unrelated rows are suppressed instead of returned as false positives.
+- `scripts/evaluate_memory_recall.py`
+  - Added an offline-safe JSON corpus harness that reads session_search ground truth from configured state DBs, seeds a temporary memory store, evaluates `search`/`probe`/`reason`, and emits JSON evidence. It never writes to live memory DBs.
+- `tests/plugins/memory/test_holographic_provider.py`
+  - Added regression coverage for profile-safe path resolution, fallback search recall, HRR false-positive suppression, and fact_store tool output.
+
+## Ingestion recommendation
+
+Do not automatically ingest arbitrary `session_search` results into live durable memory. Raw transcripts can contain stale task-local decisions, secrets in tool output, and context that should not survive a week.
+
+Recommended policy:
+
+1. Use `session_search` as ground truth for recall/evaluation and for human/operator review.
+2. After a correction or project decision is verified through `session_search`, the coordinator or responsible lane owner should create an explicit compact `memory`/`fact_store` entry with source-aware wording.
+3. A downstream watchdog/evaluator can periodically run `scripts/evaluate_memory_recall.py` against a reviewed corpus and produce missing-fact recommendations, but writes should remain explicit or gated until a redaction/source-classifier exists.
+
+## Fix path recommendation
+
+Primary path: upstream Hermes Agent patch. The path-resolution, FTS fallback, and HRR relevance-floor fixes are general product behavior and have tests.
+
+Secondary path: downstream Hermes Maintenance evaluator. Use the new harness with a reviewed corpus of maintenance decisions (status semantics, Matrix E2EE recovery, Kanban blocked/comment dispatch rules) to catch future ingestion and recall drift.
+
+Operational policy: keep explicit coordinator memory/fact_store writes for verified corrections; do not rely on automatic session-end extraction for assistant/Kanban/tool-derived operational decisions yet.

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from pathlib import Path
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -112,6 +113,22 @@ def _load_plugin_config() -> dict:
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
 
+def _resolve_profile_db_path(db_path: str, hermes_home: str) -> str:
+    """Resolve holographic store paths in a profile-safe way.
+
+    Historically some profile configs used ``~/.hermes/memory_store.db``.
+    ``Path.expanduser()`` resolves that against process HOME, which can point at
+    the default/root Hermes home even when HERMES_HOME is a profile directory.
+    Treat the Hermes-root shorthand as the active profile's HERMES_HOME instead;
+    leave other ``~/...`` paths alone because those may be explicit user paths.
+    """
+    normalized = db_path.strip()
+    if normalized == "~/.hermes":
+        return hermes_home
+    if normalized.startswith("~/.hermes/"):
+        return str(Path(hermes_home) / normalized.removeprefix("~/.hermes/"))
+    return normalized
+
 class HolographicMemoryProvider(MemoryProvider):
     """Holographic memory with structured facts, entity resolution, and HRR retrieval."""
 
@@ -153,6 +170,7 @@ class HolographicMemoryProvider(MemoryProvider):
             {"key": "auto_extract", "description": "Auto-extract facts at session end", "default": "false", "choices": ["true", "false"]},
             {"key": "default_trust", "description": "Default trust score for new facts", "default": "0.5"},
             {"key": "hrr_dim", "description": "HRR vector dimensions", "default": "1024"},
+            {"key": "min_hrr_score", "description": "Minimum probe/reason score before returning HRR-only matches", "default": "0.35"},
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -166,9 +184,11 @@ class HolographicMemoryProvider(MemoryProvider):
         if isinstance(db_path, str):
             db_path = db_path.replace("$HERMES_HOME", _hermes_home)
             db_path = db_path.replace("${HERMES_HOME}", _hermes_home)
+            db_path = _resolve_profile_db_path(db_path, _hermes_home)
         default_trust = float(self._config.get("default_trust", 0.5))
         hrr_dim = int(self._config.get("hrr_dim", 1024))
         hrr_weight = float(self._config.get("hrr_weight", 0.3))
+        min_hrr_score = float(self._config.get("min_hrr_score", 0.35))
         temporal_decay = int(self._config.get("temporal_decay_half_life", 0))
 
         self._store = MemoryStore(db_path=db_path, default_trust=default_trust, hrr_dim=hrr_dim)
@@ -177,6 +197,7 @@ class HolographicMemoryProvider(MemoryProvider):
             temporal_decay_half_life=temporal_decay,
             hrr_weight=hrr_weight,
             hrr_dim=hrr_dim,
+            min_hrr_score=min_hrr_score,
         )
         self._session_id = session_id
 

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -30,6 +30,7 @@ class FactRetriever:
         jaccard_weight: float = 0.3,
         hrr_weight: float = 0.3,
         hrr_dim: int = 1024,
+        min_hrr_score: float = 0.35,
     ):
         self.store = store
         self.half_life = temporal_decay_half_life
@@ -44,6 +45,7 @@ class FactRetriever:
         self.fts_weight = fts_weight
         self.jaccard_weight = jaccard_weight
         self.hrr_weight = hrr_weight
+        self.min_hrr_score = min_hrr_score
 
     def search(
         self,
@@ -66,7 +68,9 @@ class FactRetriever:
         candidates = self._fts_candidates(query, category, min_trust, limit * 3)
 
         if not candidates:
-            return []
+            candidates = self._fallback_candidates(query, category, min_trust, limit * 5)
+            if not candidates:
+                return []
 
         # Stage 2: Rerank with Jaccard + trust + optional decay
         query_tokens = self._tokenize(query)
@@ -187,7 +191,7 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        return [fact for fact in scored if fact["score"] >= self.min_hrr_score][:limit]
 
     def related(
         self,
@@ -333,7 +337,7 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        return [fact for fact in scored if fact["score"] >= self.min_hrr_score][:limit]
 
     def contradict(
         self,
@@ -476,7 +480,60 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        return [fact for fact in scored if fact["score"] >= self.min_hrr_score][:limit]
+
+    def _fallback_candidates(
+        self,
+        query: str,
+        category: str | None,
+        min_trust: float,
+        limit: int,
+    ) -> list[dict]:
+        """Return candidates when strict FTS5 AND matching finds nothing.
+
+        FTS5 MATCH uses AND semantics for multi-token queries. Operational
+        recall queries often combine related terms that are split across a fact
+        (for example, "Matrix E2EE device session recovery" vs a fact tagged
+        "matrix,e2ee,room-key,recovery"). This fallback stays local and
+        deterministic: it scans trusted facts, keeps rows with token overlap in
+        content/tags, and sorts by overlap plus trust before the main reranker
+        adds Jaccard/HRR scoring.
+        """
+        query_tokens = self._tokenize(query)
+        if not query_tokens:
+            return []
+
+        where = ["trust_score >= ?"]
+        params: list = [min_trust]
+        if category:
+            where.append("category = ?")
+            params.append(category)
+
+        rows = self.store._conn.execute(
+            f"""
+            SELECT fact_id, content, category, tags, trust_score,
+                   retrieval_count, helpful_count, created_at, updated_at,
+                   hrr_vector
+            FROM facts
+            WHERE {' AND '.join(where)}
+            ORDER BY trust_score DESC, updated_at DESC
+            LIMIT 1000
+            """,
+            params,
+        ).fetchall()
+
+        candidates = []
+        for row in rows:
+            fact = dict(row)
+            fact_tokens = self._tokenize(fact.get("content", "")) | self._tokenize(fact.get("tags", ""))
+            overlap = query_tokens & fact_tokens
+            if not overlap:
+                continue
+            fact["fts_rank"] = len(overlap) / len(query_tokens)
+            candidates.append(fact)
+
+        candidates.sort(key=lambda f: (f["fts_rank"], f["trust_score"]), reverse=True)
+        return candidates[:limit]
 
     def _fts_candidates(
         self,

--- a/scripts/evaluate_memory_recall.py
+++ b/scripts/evaluate_memory_recall.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Evaluate session_search ground truth against holographic fact recall.
+
+The harness is intentionally offline-safe: it reads configured state.db files,
+creates a temporary memory_store.db for seeded expected facts, and never writes
+to live profile memory databases.
+
+Corpus format (JSON):
+[
+  {
+    "id": "lineage_aggregate_counts",
+    "state_db": "/path/to/state.db",
+    "session_query": "working waiting",
+    "expected_session_substrings": ["working: 2 | waiting: 1"],
+    "seed_facts": [
+      {
+        "content": "Lineage status renders working: 2 | waiting: 1 | blocked: 0 | dormant: 3.",
+        "category": "project",
+        "tags": "lineage,status,working,waiting,blocked,dormant"
+      }
+    ],
+    "fact_queries": ["Lineage status working waiting blocked dormant"],
+    "probe_entities": ["Lineage status"],
+    "reason_entities": [["Lineage status", "working waiting"]],
+    "expected_fact_substrings": ["working: 2 | waiting: 1"]
+  }
+]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hermes_state import SessionDB
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+from tools.session_search_tool import session_search
+
+
+def _contains_any(results: list[dict[str, Any]], substrings: list[str]) -> bool:
+    haystack = json.dumps(results, ensure_ascii=False)
+    return all(s in haystack for s in substrings)
+
+
+def evaluate_item(item: dict[str, Any], workdir: Path) -> dict[str, Any]:
+    state_db = Path(item["state_db"])
+    session_data = json.loads(
+        session_search(
+            query=item["session_query"],
+            limit=int(item.get("session_limit", 5)),
+            sort=item.get("sort", "newest"),
+            role_filter=item.get("role_filter", "user,assistant,tool"),
+            db=SessionDB(state_db),
+        )
+    )
+
+    memory_db = workdir / f"{item['id']}.memory_store.db"
+    store = MemoryStore(memory_db, default_trust=float(item.get("default_trust", 0.8)))
+    try:
+        for fact in item.get("seed_facts", []):
+            store.add_fact(
+                fact["content"],
+                category=fact.get("category", "general"),
+                tags=fact.get("tags", ""),
+            )
+
+        retriever = FactRetriever(
+            store,
+            hrr_weight=float(item.get("hrr_weight", 0.3)),
+            min_hrr_score=float(item.get("min_hrr_score", 0.35)),
+        )
+        fact_searches = {
+            q: retriever.search(q, category=item.get("category"), min_trust=0.0, limit=5)
+            for q in item.get("fact_queries", [])
+        }
+        probes = {
+            entity: retriever.probe(entity, category=item.get("category"), limit=5)
+            for entity in item.get("probe_entities", [])
+        }
+        reasons = {
+            " | ".join(entities): retriever.reason(entities, category=item.get("category"), limit=5)
+            for entities in item.get("reason_entities", [])
+        }
+    finally:
+        store.close()
+
+    expected_session = item.get("expected_session_substrings", [])
+    expected_fact = item.get("expected_fact_substrings", [])
+    fact_result_list = [r for rows in fact_searches.values() for r in rows]
+
+    return {
+        "id": item["id"],
+        "state_db": str(state_db),
+        "memory_db": str(memory_db),
+        "session_search_ok": _contains_any(session_data.get("results", []), expected_session) if expected_session else None,
+        "fact_search_ok": _contains_any(fact_result_list, expected_fact) if expected_fact else None,
+        "session_search": {
+            "count": session_data.get("count"),
+            "matches": [
+                {
+                    "session_id": r.get("session_id"),
+                    "match_message_id": r.get("match_message_id"),
+                    "snippet": r.get("snippet"),
+                }
+                for r in session_data.get("results", [])
+            ],
+        },
+        "fact_searches": fact_searches,
+        "probes": probes,
+        "reasons": reasons,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("corpus", type=Path, help="JSON corpus path")
+    parser.add_argument("--output", type=Path, help="Write JSON report to this path")
+    args = parser.parse_args()
+
+    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory(prefix="hermes-memory-recall-") as td:
+        workdir = Path(td)
+        report = {
+            "corpus": str(args.corpus),
+            "workdir": str(workdir),
+            "items": [evaluate_item(item, workdir) for item in corpus],
+        }
+        output = json.dumps(report, indent=2, ensure_ascii=False)
+        if args.output:
+            args.output.write_text(output + "\n", encoding="utf-8")
+        else:
+            print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugins/memory/test_holographic_provider.py
+++ b/tests/plugins/memory/test_holographic_provider.py
@@ -1,0 +1,102 @@
+"""Regression tests for the bundled holographic memory provider."""
+
+import json
+from pathlib import Path
+
+from plugins.memory.holographic import HolographicMemoryProvider, _resolve_profile_db_path
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+def test_profile_shorthand_db_path_resolves_under_hermes_home(tmp_path):
+    hermes_home = tmp_path / "profiles" / "worker"
+
+    assert _resolve_profile_db_path("~/.hermes/memory_store.db", str(hermes_home)) == str(
+        hermes_home / "memory_store.db"
+    )
+    assert _resolve_profile_db_path("~/.hermes", str(hermes_home)) == str(hermes_home)
+
+
+def test_non_hermes_tilde_path_is_left_for_expanduser(tmp_path):
+    hermes_home = tmp_path / "profiles" / "worker"
+
+    assert _resolve_profile_db_path("~/custom/memory_store.db", str(hermes_home)) == "~/custom/memory_store.db"
+
+
+def test_provider_initialize_uses_profile_safe_shorthand_path(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "profiles" / "responsible_memory_rollout"
+    os_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(os_home))
+
+    provider = HolographicMemoryProvider(config={"db_path": "~/.hermes/memory_store.db"})
+    provider.initialize("session-1")
+
+    try:
+        assert provider._store is not None
+        assert provider._store.db_path == hermes_home / "memory_store.db"
+        assert not (os_home / ".hermes" / "memory_store.db").exists()
+    finally:
+        provider.shutdown()
+
+
+def test_search_fallback_recovers_partial_overlap_when_strict_fts_and_query_misses(tmp_path):
+    store = MemoryStore(tmp_path / "memory_store.db", default_trust=0.8)
+    try:
+        fact_id = store.add_fact(
+            "Matrix E2EE room key sharing requires recovery key import for the bot device.",
+            category="project",
+            tags="matrix,e2ee,device,recovery",
+        )
+        store.add_fact(
+            "Kanban blocked means human intervention is required.",
+            category="project",
+            tags="kanban,status",
+        )
+        retriever = FactRetriever(store, hrr_weight=0.0)
+
+        # The token "session" is absent, so strict FTS5 AND matching returns no
+        # rows. The deterministic overlap fallback should still surface the
+        # Matrix fact instead of producing a false negative.
+        results = retriever.search("Matrix E2EE device session recovery", category="project", limit=3)
+
+        assert results
+        assert results[0]["fact_id"] == fact_id
+        assert "Matrix E2EE" in results[0]["content"]
+    finally:
+        store.close()
+
+
+def test_probe_and_reason_suppress_unrelated_hrr_false_positives(tmp_path):
+    store = MemoryStore(tmp_path / "memory_store.db", default_trust=0.5)
+    try:
+        store.add_fact(
+            "Hermes Maintenance holographic rollout verification marker for task t_96dfd135.",
+            category="project",
+            tags="rollout,verification",
+        )
+        retriever = FactRetriever(store, min_hrr_score=0.35)
+
+        assert retriever.probe("Lineage status", category="project") == []
+        assert retriever.reason(["Lineage status", "working waiting"], category="project") == []
+    finally:
+        store.close()
+
+
+def test_fact_store_tool_returns_empty_for_unrelated_probe(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={"db_path": str(tmp_path / "memory_store.db"), "default_trust": 0.5, "min_hrr_score": 0.35}
+    )
+    provider.initialize("session-1")
+    try:
+        provider._store.add_fact(
+            "Hermes Maintenance holographic rollout verification marker for task t_96dfd135.",
+            category="project",
+            tags="rollout,verification",
+        )
+
+        result = json.loads(provider.handle_tool_call("fact_store", {"action": "probe", "entity": "Lineage status"}))
+
+        assert result == {"results": [], "count": 0}
+    finally:
+        provider.shutdown()


### PR DESCRIPTION
## Summary
- Fix profile-safe holographic memory db_path resolution under active HERMES_HOME.
- Add deterministic token-overlap fallback candidates when strict FTS misses operational multi-token queries.
- Add HRR relevance floors for probe/reason to suppress unrelated tiny-store false positives.
- Add an offline session_search-vs-fact_store recall evaluation harness and project diagnostic report.

## Verification
- python -m pytest tests/plugins/memory/test_holographic_provider.py -q -o 'addopts=' -> 6 passed
- python -m pytest tests/agent/test_memory_provider.py tests/tools/test_session_search.py tests/plugins/memory/test_holographic_provider.py -q -o 'addopts=' -> 120 passed
- python -m py_compile scripts/evaluate_memory_recall.py -> passed
- python scripts/evaluate_memory_recall.py /tmp/holographic-memory-eval-corpus-current.json --output /tmp/holographic-memory-eval-report-current.json -> session_search_ok true, fact_search_ok true

Notes: clean replacement for PR #37019, whose branch included unrelated gateway/kanban commits from another lane.