### PR TITLE
fix(skills): remove stale related skill references

### DIFF
--- a/skills/apple/macos-computer-use/SKILL.md
+++ b/skills/apple/macos-computer-use/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   hermes:
     tags: [computer-use, macos, desktop, automation, gui]
     category: desktop
-    related_skills: [browser]
+    related_skills: []
 ---
 
 # macOS Computer Use (universal, any-model)

--- a/skills/creative/architecture-diagram/SKILL.md
+++ b/skills/creative/architecture-diagram/SKILL.md
@@ -9,7 +9,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [architecture, diagrams, SVG, HTML, visualization, infrastructure, cloud]
-    related_skills: [concept-diagrams, excalidraw]
+    related_skills: [excalidraw]
 ---
 
 # Architecture Diagram Skill

--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -23,7 +23,7 @@ metadata:
       - creative
       - generative-ai
       - video-generation
-    related_skills: [stable-diffusion-image-generation, image_gen]
+    related_skills: []
     category: creative
 ---
 

--- a/skills/creative/touchdesigner-mcp/SKILL.md
+++ b/skills/creative/touchdesigner-mcp/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [TouchDesigner, MCP, twozero, creative-coding, real-time-visuals, generative-art, audio-reactive, VJ, installation, GLSL]
-    related_skills: [native-mcp, ascii-video, manim-video, hermes-video]
+    related_skills: [native-mcp, ascii-video, manim-video]
 
 ---
 

--- a/skills/mcp/native-mcp/SKILL.md
+++ b/skills/mcp/native-mcp/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [MCP, Tools, Integrations]
-    related_skills: [mcporter]
+    related_skills: []
 ---
 
 # Native MCP Client
@@ -23,8 +23,6 @@ Use this whenever you want to:
 - Run local stdio-based MCP servers (npx, uvx, or any command)
 - Connect to remote HTTP/StreamableHTTP MCP servers
 - Have MCP tools auto-discovered and available in every conversation
-
-For ad-hoc, one-off MCP tool calls from the terminal without configuring anything, see the `mcporter` skill instead.
 
 ## Prerequisites
 
@@ -352,6 +350,5 @@ Disable sampling for untrusted servers with `sampling: { enabled: false }`.
 
 - MCP tools are called synchronously from the agent's perspective but run asynchronously on a dedicated background event loop
 - Tool results are returned as JSON with either `{"result": "..."}` or `{"error": "..."}`
-- The native MCP client is independent of `mcporter` -- you can use both simultaneously
 - Server connections are persistent and shared across all conversations in the same agent process
 - Adding or removing servers requires restarting the agent (no hot-reload currently)

--- a/skills/media/heartmula/SKILL.md
+++ b/skills/media/heartmula/SKILL.md
@@ -6,7 +6,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [music, audio, generation, ai, heartmula, heartcodec, lyrics, songs]
-    related_skills: [audiocraft]
+    related_skills: [audiocraft-audio-generation]
 ---
 
 # HeartMuLa - Open-Source Music Generation

--- a/skills/mlops/inference/obliteratus/SKILL.md
+++ b/skills/mlops/inference/obliteratus/SKILL.md
@@ -9,7 +9,7 @@ platforms: [linux, macos]
 metadata:
   hermes:
     tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]
-    related_skills: [vllm, gguf, huggingface-tokenizers]
+    related_skills: [serving-llms-vllm, llama-cpp]
 ---
 
 # OBLITERATUS Skill

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   hermes:
     tags: [Research, Paper Writing, Experiments, ML, AI, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Citations, Statistical Analysis]
     category: research
-    related_skills: [arxiv, ml-paper-writing, subagent-driven-development, plan]
+    related_skills: [arxiv, subagent-driven-development, plan]
     requires_toolsets: [terminal, files]
 
 ---
@@ -824,7 +824,7 @@ Every successful ML paper centers on what Neel Nanda calls "the narrative": a sh
 
 ### The Sources Behind This Guidance
 
-This skill synthesizes writing philosophy from researchers who have published extensively at top venues. The writing philosophy layer was originally compiled by [Orchestra Research](https://github.com/orchestra-research) as the `ml-paper-writing` skill.
+This skill synthesizes writing philosophy from researchers who have published extensively at top venues. The writing philosophy layer was originally compiled by [Orchestra Research](https://github.com/orchestra-research) for ML paper-writing workflows.
 
 | Source | Key Contribution | Link |
 |--------|-----------------|------|
@@ -2131,7 +2131,7 @@ Compose this skill with other Hermes skills for specific phases:
 | **diagramming** | Phase 4-5: creating Excalidraw-based figures and architecture diagrams | `skill_view("diagramming")` |
 | **data-science** | Phase 4 (Analysis): Jupyter live kernel for interactive analysis and visualization | `skill_view("data-science")` |
 
-**This skill supersedes `ml-paper-writing`** — it contains all of ml-paper-writing's content plus the full experiment/analysis pipeline and autoreason methodology.
+**This skill supersedes the earlier ML paper-writing workflow** — it adds the full experiment/analysis pipeline and autoreason methodology.
 
 ### Hermes Tools Reference
 

--- a/skills/research/research-paper-writing/references/sources.md
+++ b/skills/research/research-paper-writing/references/sources.md
@@ -6,7 +6,7 @@ This document lists all authoritative sources used to build this skill, organize
 
 ## Origin & Attribution
 
-The writing philosophy, citation verification workflow, and conference reference materials in this skill were originally compiled by **[Orchestra Research](https://github.com/orchestra-research)** as the `ml-paper-writing` skill (January 2026), drawing on Neel Nanda's blog post and other researcher guides listed below. The skill was integrated into hermes-agent by teknium (January 2026), then expanded into the current `research-paper-writing` pipeline by SHL0MS (April 2026, PR #4654), which added experiment design, execution monitoring, iterative refinement, and submission phases while preserving the original writing philosophy and reference files.
+The writing philosophy, citation verification workflow, and conference reference materials in this skill were originally compiled by **[Orchestra Research](https://github.com/orchestra-research)** for ML paper-writing workflows (January 2026), drawing on Neel Nanda's blog post and other researcher guides listed below. The material was integrated into hermes-agent by teknium (January 2026), then expanded into the current `research-paper-writing` pipeline by SHL0MS (April 2026, PR #4654), which added experiment design, execution monitoring, iterative refinement, and submission phases while preserving the original writing philosophy and reference files.
 
 ---
 

--- a/skills/software-development/hermes-s6-container-supervision/SKILL.md
+++ b/skills/software-development/hermes-s6-container-supervision/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 metadata:
   hermes:
     tags: [docker, s6, supervision, gateway, profiles]
-    related_skills: [hermes-agent, hermes-agent-dev]
+    related_skills: [hermes-agent]
 ---
 
 # Hermes s6-overlay Container Supervision
@@ -172,5 +172,4 @@ Check whether something is invoking `s6-svscanctl -t` or `/run/s6/basedir/bin/ha
 
 ## Related skills
 
-- `hermes-agent-dev`: General hermes-agent codebase navigation
-- `hermes-tool-quirks`: Specific Hermes-tool workarounds (sed/grep/etc.) — load when debugging the s6 stack's interaction with hermes built-in tools.
+- `hermes-agent`: General Hermes Agent configuration and codebase navigation


### PR DESCRIPTION
Closes #37338

## Summary
- remove broken related_skills entries that point at non-existent skills or toolset names
- replace renamed skill references where a valid built-in skill exists
- remove stale body references to mcporter, hermes-agent-dev, hermes-tool-quirks, and ml-paper-writing

## Verification
- custom related_skills validator: 0 missing references across built-in skills
- ./scripts/run_tests.sh tests/tools/test_skills_tool.py tests/agent/test_skill_utils.py tests/website/test_generate_skill_docs.py
- 108 tests passed
