### PR TITLE
fix(feishu): authorize approval clicks via cached aliases

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1439,6 +1439,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._dedup_state_path = get_hermes_home() / "feishu_seen_message_ids.json"
         self._dedup_lock = threading.Lock()
         self._sender_name_cache: Dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
+        self._sender_identity_alias_cache: Dict[str, frozenset[str]] = {}  # sender_id → all known aliases
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
         self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
@@ -2558,15 +2559,50 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
+    def _sender_identity_aliases(self, *ids: Optional[str]) -> frozenset[str]:
+        """Return known Feishu identity aliases for any provided id."""
+        direct = frozenset(str(v).strip() for v in ids if str(v or "").strip())
+        if not direct:
+            return frozenset()
+        expanded = set(direct)
+        for value in direct:
+            expanded.update(getattr(self, "_sender_identity_alias_cache", {}).get(value, ()))
+        return frozenset(expanded)
+
+    def _cache_sender_identity(self, sender_id: Any) -> None:
+        """Remember equivalent Feishu user ids seen on normal message events.
+
+        Card-action callbacks commonly include only ``open_id``.  Normal
+        message events can include ``open_id``, tenant-scoped ``user_id``, and
+        ``union_id`` together, so cache that relationship for later approval
+        button allowlist checks.
+        """
+        aliases = frozenset(
+            str(v).strip()
+            for v in (
+                getattr(sender_id, "open_id", None),
+                getattr(sender_id, "user_id", None),
+                getattr(sender_id, "union_id", None),
+            )
+            if str(v or "").strip()
+        )
+        if len(aliases) < 2:
+            return
+        cache = getattr(self, "_sender_identity_alias_cache", None)
+        if cache is None:
+            cache = self._sender_identity_alias_cache = {}
+        for value in aliases:
+            cache[value] = aliases
+
+    def _is_interactive_operator_authorized(self, open_id: str, user_id: str = "") -> bool:
         """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
+        operator_ids = self._sender_identity_aliases(open_id, user_id)
+        if not operator_ids:
             return False
         allowed_ids = set(self._admins) | set(self._allowed_group_users)
         if not allowed_ids:
             return True
-        return "*" in allowed_ids or normalized in allowed_ids
+        return "*" in allowed_ids or bool(operator_ids & allowed_ids)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2582,7 +2618,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        user_id = str(getattr(operator, "user_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
         if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
@@ -2641,7 +2678,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        if not self._is_interactive_operator_authorized(open_id):
+        user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_interactive_operator_authorized(open_id, user_id):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -3846,6 +3884,7 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = getattr(sender_id, "open_id", None) or None
         user_id = getattr(sender_id, "user_id", None) or None
         union_id = getattr(sender_id, "union_id", None) or None
+        self._cache_sender_identity(sender_id)
         # Prefer tenant-scoped user_id; fall back to app-scoped open_id.
         primary_id = user_id or open_id
         # bot/v3/bots/basic_batch only accepts open_id.
@@ -4079,7 +4118,7 @@ class FeishuAdapter(BasePlatformAdapter):
         """Per-group policy gate for non-DM traffic."""
         sender_open_id = getattr(sender_id, "open_id", None)
         sender_user_id = getattr(sender_id, "user_id", None)
-        sender_ids = {sender_open_id, sender_user_id} - {None}
+        sender_ids = self._sender_identity_aliases(sender_open_id, sender_user_id)
 
         if sender_ids and self._admins and (sender_ids & self._admins):
             return True

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -58,6 +58,7 @@ def _make_card_action_data(
     action_value: dict,
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
+    user_id: str = "",
     token: str = "tok_abc",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
@@ -65,7 +66,7 @@ def _make_card_action_data(
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
-            operator=SimpleNamespace(open_id=open_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=user_id),
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
@@ -393,6 +394,23 @@ class TestResolveApproval:
         assert 5 in adapter._approval_state
 
     @pytest.mark.asyncio
+    async def test_resolves_with_cached_user_id_allowlist(self):
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"u_user1"}
+        adapter._cache_sender_identity(SimpleNamespace(open_id="ou_user1", user_id="u_user1", union_id="on_user1"))
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg_007",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(7, "once", "Alice", open_id="ou_user1", chat_id="oc_12345")
+
+        mock_resolve.assert_called_once_with("sess-7", "once")
+        assert 7 not in adapter._approval_state
+
+    @pytest.mark.asyncio
     async def test_chat_mismatch_does_not_resolve(self):
         adapter = _make_adapter()
         adapter._approval_state[6] = {
@@ -523,6 +541,53 @@ class TestCardActionCallbackResponse:
         card = response.card.data
         assert card["header"]["template"] == "red"
         assert "Denied" in card["header"]["title"]["content"]
+
+    def test_returns_card_for_approve_action_with_cached_user_id_allowlist(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._cache_sender_identity(SimpleNamespace(open_id="ou_bob", user_id="u_bob", union_id="on_bob"))
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg-7",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert "Approved once" in response.card.data["header"]["title"]["content"]
+
+    def test_returns_card_for_approve_action_when_operator_includes_user_id(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._approval_state[8] = {
+            "session_key": "sess-8",
+            "message_id": "msg-8",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 8},
+            open_id="ou_bob",
+            user_id="u_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
 
     def test_ignores_missing_approval_id(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu/Lark approval and update-prompt card authorization when `FEISHU_ALLOWED_USERS` is configured with tenant-scoped `user_id` values but card-action callbacks only provide the operator `open_id`.

Normal Feishu message events can include `open_id`, `user_id`, and `union_id` for the same sender. This change caches those equivalent identity aliases after normal inbound messages and expands them during interactive card authorization. As a result, a user already admitted by `FEISHU_ALLOWED_USERS=<user_id>` can approve the command card generated from that interaction even when the later button callback only carries `open_id`.

## Related Issue

Fixes #37252

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/feishu.py`
  - Cache Feishu sender identity aliases observed on normal message events (`open_id`, `user_id`, `union_id`).
  - Expand cached aliases when authorizing approval/update-prompt card callbacks.
  - Allow group-policy checks to match a callback `open_id` against a previously observed allow-listed `user_id`.
- `tests/gateway/test_feishu_approval_buttons.py`
  - Add regression coverage for approval callbacks when only `open_id` arrives but `user_id` is allow-listed.
  - Add coverage for callbacks that include `user_id` directly.
  - Add async approval-resolution coverage for cached alias authorization.

## Duplicate / overlap check

I checked open Feishu approval-related PRs before submission. Existing PRs such as #34707, #35042, #35431, and #37025 address adjacent no-allowlist/DM/card-action consistency cases, but I did not find an open PR that maps callback-only `open_id` back to an allow-listed tenant `user_id` for #37252.

## How to Test

Validated locally:

```bash
git diff --check
/home/dev/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu_approval_buttons.py -q
/home/dev/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu_approval_buttons.py tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py -q
/home/dev/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/feishu.py
```

Results:

```text
38 passed, 2 warnings
303 passed, 2 warnings
```

Fork CI for the final head commit also passed: attribution, common ancestor, ruff enforcement, ruff+ty diff, test matrix, e2e, Nix checks, Windows footguns, and supply-chain scan.