### PR TITLE
fix: ignore dashboard lifecycle wrapper commands in status scan

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5632,6 +5632,7 @@ def _find_stale_dashboard_pids() -> list[int]:
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
     ]
+    lifecycle_flags = (" --status", " --stop")
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5663,6 +5664,7 @@ def _find_stale_dashboard_pids() -> list[int]:
                     pid_str = line[len("ProcessId=") :]
                     if (
                         any(p in current_cmd for p in patterns)
+                        and not any(flag in current_cmd for flag in lifecycle_flags)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5695,6 +5697,8 @@ def _find_stale_dashboard_pids() -> list[int]:
                     except ValueError:
                         continue
                     command = parts[1]
+                    if any(flag in command for flag in lifecycle_flags):
+                        continue
                     if any(p in command for p in patterns) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -171,6 +171,22 @@ class TestFindStaleDashboardPids:
         assert 99999 not in pids
         assert 12345 in pids
 
+    def test_lifecycle_wrapper_commands_ignored(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(20001, "/bin/sh -lc hermes dashboard --status || true"),
+                    _ps_line(20002, "/bin/sh -lc hermes dashboard --stop || true"),
+                    _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119 --no-open"),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert 20001 not in pids
+        assert 20002 not in pids
+        assert pids == [12345]
+
     def test_invalid_pid_lines_skipped(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(


### PR DESCRIPTION
Summary:
- ignore shell wrapper commands that invoke `hermes dashboard --status` or `--stop` during dashboard PID scans
- prevent false positives where lifecycle checks report a dashboard process even when nothing is listening on port 9119
- add regression coverage for wrapper-command false positives

Test plan:
- /Users/hgv/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_dashboard_lifecycle_flags.py -q
- verified locally that `hermes dashboard --status` no longer reports a stale PID when no dashboard listener exists

Context:
This fixes a local false-positive case where status/stop commands launched via a shell wrapper were counted as real dashboard processes.