### PR TITLE
fix(ddgs): add 30s overall timeout to prevent indefinite search hang

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -70,14 +70,23 @@ class DDGSWebSearchProvider(WebSearchProvider):
         # in case the package ignores the hint.
         safe_limit = max(1, int(limit))
 
-        try:
-            web_results = []
-            with DDGS() as client:
+        # Overall search timeout so a slow/rate-limited DuckDuckGo response
+        # cannot hang the agent loop indefinitely.  The DDGS constructor's
+        # ``timeout`` parameter only covers individual HTTP requests; the
+        # multi-engine retry loop inside ddgs has no wall-clock cap of its
+        # own.  We enforce one here via concurrent.futures so the provider
+        # always returns within a bounded time regardless of ddgs internals.
+        _SEARCH_TIMEOUT = 30  # seconds; covers the full text() call
+        import concurrent.futures as _cf
+
+        def _search_sync() -> list:
+            results = []
+            with DDGS(timeout=10) as client:
                 for i, hit in enumerate(client.text(query, max_results=safe_limit)):
                     if i >= safe_limit:
                         break
                     url = str(hit.get("href") or hit.get("url") or "")
-                    web_results.append(
+                    results.append(
                         {
                             "title": str(hit.get("title", "")),
                             "url": url,
@@ -85,6 +94,27 @@ class DDGSWebSearchProvider(WebSearchProvider):
                             "position": i + 1,
                         }
                     )
+            return results
+
+        try:
+            web_results = []
+            with _cf.ThreadPoolExecutor(max_workers=1) as _pool:
+                _future = _pool.submit(_search_sync)
+                try:
+                    web_results = _future.result(timeout=_SEARCH_TIMEOUT)
+                except _cf.TimeoutError:
+                    logger.warning(
+                        "DDGS search timed out after %ds for query: %r",
+                        _SEARCH_TIMEOUT, query,
+                    )
+                    return {
+                        "success": False,
+                        "error": (
+                            f"DuckDuckGo search timed out after {_SEARCH_TIMEOUT}s — "
+                            "DuckDuckGo may be rate-limiting or slow. "
+                            "Try again later or switch to a different search provider."
+                        ),
+                    }
         except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
             logger.warning("DDGS search error: %s", exc)
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -12,6 +12,7 @@ whether the package is importable; the plugin still registers either way so
 
 from __future__ import annotations
 
+import concurrent.futures as _cf
 import logging
 from typing import Any, Dict
 
@@ -77,7 +78,6 @@ class DDGSWebSearchProvider(WebSearchProvider):
         # own.  We enforce one here via concurrent.futures so the provider
         # always returns within a bounded time regardless of ddgs internals.
         _SEARCH_TIMEOUT = 30  # seconds; covers the full text() call
-        import concurrent.futures as _cf
 
         def _search_sync() -> list:
             results = []

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -96,28 +96,29 @@ class DDGSWebSearchProvider(WebSearchProvider):
                     )
             return results
 
+        _pool = _cf.ThreadPoolExecutor(max_workers=1)
         try:
-            web_results = []
-            with _cf.ThreadPoolExecutor(max_workers=1) as _pool:
-                _future = _pool.submit(_search_sync)
-                try:
-                    web_results = _future.result(timeout=_SEARCH_TIMEOUT)
-                except _cf.TimeoutError:
-                    logger.warning(
-                        "DDGS search timed out after %ds for query: %r",
-                        _SEARCH_TIMEOUT, query,
-                    )
-                    return {
-                        "success": False,
-                        "error": (
-                            f"DuckDuckGo search timed out after {_SEARCH_TIMEOUT}s — "
-                            "DuckDuckGo may be rate-limiting or slow. "
-                            "Try again later or switch to a different search provider."
-                        ),
-                    }
+            _future = _pool.submit(_search_sync)
+            try:
+                web_results = _future.result(timeout=_SEARCH_TIMEOUT)
+            except _cf.TimeoutError:
+                logger.warning(
+                    "DDGS search timed out after %ds for query: %r",
+                    _SEARCH_TIMEOUT, query,
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"DuckDuckGo search timed out after {_SEARCH_TIMEOUT}s — "
+                        "DuckDuckGo may be rate-limiting or slow. "
+                        "Try again later or switch to a different search provider."
+                    ),
+                }
         except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
             logger.warning("DDGS search error: %s", exc)
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}
+        finally:
+            _pool.shutdown(wait=False, cancel_futures=True)
 
         logger.info("DDGS search '%s': %d results (limit %d)", query, len(web_results), limit)
         return {"success": True, "data": {"web": web_results}}

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -27,6 +27,8 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None):
     fake = types.ModuleType("ddgs")
 
     class _FakeDDGS:
+        def __init__(self, **kwargs):
+            pass  # accept timeout= and any other constructor kwargs
         def __enter__(self):
             return self
         def __exit__(self, *_a):


### PR DESCRIPTION
## What does this PR do?

Fixes DuckDuckGo search hanging indefinitely and blocking the entire agent loop.

**Root cause:** The `DDGS` constructor's `timeout=` parameter only covers individual HTTP requests. The multi-engine retry loop inside ddgs has no wall-clock cap when DuckDuckGo rate-limits or returns slow responses, engines can chain multiple slow requests and block the agent process indefinitely (23+ minutes observed in the wild).

**Fix:** Wrap the `text()` call in a `ThreadPoolExecutor` future with a 30s overall timeout. If the search exceeds the limit, return a clear actionable error instead of hanging. Also set a per-request timeout of 10s on the `DDGS` constructor.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## References
Fixes #36776

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix