### PR TITLE
fix(gateway): add explicit utf-8 encoding to read_text/write_text in run.py (Windows)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3261,7 +3261,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
-            data = json.loads(self._VOICE_MODE_PATH.read_text())
+            data = json.loads(self._VOICE_MODE_PATH.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             return {}
 
@@ -3289,7 +3289,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             self._VOICE_MODE_PATH.parent.mkdir(parents=True, exist_ok=True)
             self._VOICE_MODE_PATH.write_text(
-                json.dumps(self._voice_mode, indent=2)
+                json.dumps(self._voice_mode, indent=2), encoding="utf-8"
             )
         except OSError as e:
             logger.warning("Failed to save voice modes: %s", e)
@@ -6165,7 +6165,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         path = _hermes_home / self._STUCK_LOOP_FILE
         try:
-            counts = json.loads(path.read_text()) if path.exists() else {}
+            counts = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
         except Exception:
             counts = {}
 
@@ -6195,7 +6195,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return 0
 
         try:
-            counts = json.loads(path.read_text())
+            counts = json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             return 0
 
@@ -6241,7 +6241,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not path.exists():
             return
         try:
-            counts = json.loads(path.read_text())
+            counts = json.loads(path.read_text(encoding="utf-8"))
             if session_key in counts:
                 del counts[session_key]
                 if counts:
@@ -9119,7 +9119,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text(response_text)
+                    tmp.write_text(response_text, encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                 except OSError as e:
@@ -9139,7 +9139,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 prompt_path = _hermes_home / ".update_prompt.json"
                 try:
                     tmp = response_path.with_suffix(".tmp")
-                    tmp.write_text("")
+                    tmp.write_text("", encoding="utf-8")
                     tmp.replace(response_path)
                     prompt_path.unlink(missing_ok=True)
                     logger.info(
@@ -12666,7 +12666,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._booted_from_restart = False
                     return True
                 return False
-            data = json.loads(marker_path.read_text())
+            data = json.loads(marker_path.read_text(encoding="utf-8"))
         except Exception:
             return False
 
@@ -14587,7 +14587,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for path in (claimed_path, pending_path):
             if path.exists():
                 try:
-                    pending = json.loads(path.read_text())
+                    pending = json.loads(path.read_text(encoding="utf-8"))
                     platform_str = pending.get("platform")
                     chat_id = pending.get("chat_id")
                     chat_type = pending.get("chat_type")
@@ -14626,7 +14626,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 await asyncio.sleep(poll_interval)
             if (pending_path.exists() or claimed_path.exists()) and not exit_code_path.exists():
-                exit_code_path.write_text("124")
+                exit_code_path.write_text("124", encoding="utf-8")
                 await self._send_update_notification()
             return
 
@@ -14668,7 +14668,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Read any remaining output
                 if output_path.exists():
                     try:
-                        content = output_path.read_text()
+                        content = output_path.read_text(encoding="utf-8")
                         if len(content) > bytes_sent:
                             buffer += content[bytes_sent:]
                             bytes_sent = len(content)
@@ -14678,7 +14678,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 # Send final status
                 try:
-                    exit_code_raw = exit_code_path.read_text().strip() or "1"
+                    exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
                     exit_code = int(exit_code_raw)
                     if exit_code == 0:
                         await adapter.send(
@@ -14707,7 +14707,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check for new output
             if output_path.exists():
                 try:
-                    content = output_path.read_text()
+                    content = output_path.read_text(encoding="utf-8")
                     if len(content) > bytes_sent:
                         buffer += content[bytes_sent:]
                         bytes_sent = len(content)
@@ -14725,7 +14725,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if (prompt_path.exists() and session_key
                     and not self._update_prompt_pending.get(session_key)):
                 try:
-                    prompt_data = json.loads(prompt_path.read_text())
+                    prompt_data = json.loads(prompt_path.read_text(encoding="utf-8"))
                     prompt_text = prompt_data.get("prompt", "")
                     default = prompt_data.get("default", "")
                     if prompt_text:
@@ -14773,7 +14773,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Timeout
         if not exit_code_path.exists():
             logger.warning("Update watcher timed out after %.0fs", timeout)
-            exit_code_path.write_text("124")
+            exit_code_path.write_text("124", encoding="utf-8")
             await _flush_buffer()
             try:
                 await adapter.send(
@@ -14819,7 +14819,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             elif not claimed_path.exists():
                 return True
 
-            pending = json.loads(claimed_path.read_text())
+            pending = json.loads(claimed_path.read_text(encoding="utf-8"))
             platform_str = pending.get("platform")
             chat_id = pending.get("chat_id")
             chat_type = pending.get("chat_type")
@@ -14833,13 +14833,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 claimed_path.replace(pending_path)
                 return False
 
-            exit_code_raw = exit_code_path.read_text().strip() or "1"
+            exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
             exit_code = int(exit_code_raw)
 
             # Read the captured update output
             output = ""
             if output_path.exists():
-                output = output_path.read_text()
+                output = output_path.read_text(encoding="utf-8")
 
             # Resolve adapter
             platform = Platform(platform_str)
@@ -14914,7 +14914,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None
 
         try:
-            data = json.loads(notify_path.read_text())
+            data = json.loads(notify_path.read_text(encoding="utf-8"))
             platform_str = data.get("platform")
             chat_id = data.get("chat_id")
             chat_type = data.get("chat_type")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4583,7 +4583,7 @@ class GatewaySlashCommandsMixin:
         if event.message_id:
             pending["message_id"] = event.message_id
         _tmp_pending = pending_path.with_suffix(".tmp")
-        _tmp_pending.write_text(json.dumps(pending))
+        _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
         _tmp_pending.replace(pending_path)
         exit_code_path.unlink(missing_ok=True)
 

--- a/tests/gateway/test_update_encoding_footgun.py
+++ b/tests/gateway/test_update_encoding_footgun.py
@@ -1,0 +1,68 @@
+"""Regression guard: the gateway core must not use bare read_text()/write_text().
+
+On Windows (and any host where ``locale.getpreferredencoding()`` is not UTF-8 —
+cp1252 on US locales, GBK/CP936 on Chinese locales, etc.), ``Path.read_text()``
+and ``Path.write_text()`` without an explicit ``encoding=`` use the locale
+codec. In the ``hermes update``-over-gateway flow this surfaces as:
+
+* ``UnicodeEncodeError`` when writing the user's reply (emoji / CJK) to the
+  ``.update_response`` file, and
+* ``UnicodeDecodeError`` / mojibake when reading the update subprocess's
+  captured UTF-8 stdout.
+
+Both are ``UnicodeError`` subclasses, so the surrounding ``except OSError``
+guards do NOT catch them — the gateway command handler / update-stream
+coroutine crashes.
+
+``ruff``'s PLW1514 and ``scripts/check-windows-footguns.py`` both miss these:
+PLW1514 does not resolve ``.read_text``/``.write_text`` on a variable/attribute
+receiver, and the footgun script scans builtin ``open()`` only.
+
+The ``/update`` coordination files are written and read from *both* modules
+below — the handlers were extracted into ``GatewaySlashCommandsMixin``, but the
+prompt/response and output-streaming halves still live in ``run.py`` — so the
+guard covers both rather than a single file.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+GUARDED_FILES = (
+    PROJECT_ROOT / "gateway" / "run.py",
+    PROJECT_ROOT / "gateway" / "slash_commands.py",
+)
+
+_ENCODING_SENSITIVE = {"read_text", "write_text"}
+
+
+def _calls_without_encoding(filepath: Path) -> list[tuple[int, str]]:
+    """Return (lineno, method) for read_text/write_text calls lacking encoding=."""
+    source = filepath.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(filepath))
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in _ENCODING_SENSITIVE:
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        offenders.append((node.lineno, func.attr))
+    return sorted(offenders)
+
+
+@pytest.mark.parametrize("path", GUARDED_FILES, ids=lambda p: p.name)
+def test_gateway_core_has_no_bare_read_write_text(path: Path):
+    if not path.exists():
+        pytest.skip(f"{path.name} not found")
+    offenders = _calls_without_encoding(path)
+    assert not offenders, (
+        f"{path.name} has read_text()/write_text() calls without an explicit "
+        'encoding= (Windows cp1252/GBK footgun). Add encoding="utf-8":\n'
+        + "\n".join(f"  {path.name}:{ln}  .{attr}()" for ln, attr in offenders)
+    )


### PR DESCRIPTION
## What & why

On native Windows with a non-UTF-8 locale (cp1252 on US installs, GBK/CP936 on Chinese installs), the `hermes update`-over-gateway flow crashed. The gateway read/wrote its coordination files with bare `Path.read_text()` / `Path.write_text()`, so Python used the **locale codec** instead of UTF-8:

- writing the user's update-prompt reply (emoji/CJK) → `UnicodeEncodeError`;
- reading the `hermes update` subprocess's captured UTF-8 stdout → `UnicodeDecodeError` / mojibake.

Both subclass `ValueError`, so the surrounding `except OSError` did not catch them and the handler / update-stream coroutine crashed.

Fixes #37423

## Rebased onto current HEAD (addresses @teknium1's review)

The original branch was cut before `619bd7827` (*"extract 42 slash-command handlers into GatewaySlashCommandsMixin"*), which moved the `/update` handler out of `run.py`. This PR is now rebuilt on current `main` (`89bd0fba9`):

- **`gateway/run.py`** — `encoding="utf-8"` on the 19 remaining bare `read_text`/`write_text` calls. Both live crash sites are still here: the reply write (`run.py:9122`) and the subprocess-stdout reads (`run.py:14671`, `14710`, `14842`).
- **`gateway/slash_commands.py:4586`** — the pending-marker write in the **extracted** handler, which the old diff no longer covered. This one goes through `json.dumps` (`ensure_ascii=True`), so it is ASCII-safe today and **the bytes on disk are unchanged**; it is fixed to match the project's "always pass `encoding`" policy and to stay safe if `ensure_ascii=False` is ever introduced.
- **`tests/gateway/test_update_encoding_footgun.py`** — the AST guard now scans **both** files, so the two halves of the `/update` path cannot regress independently. (Replaces the old `run.py`-only guard.)

## Why these aren't caught today

- `ruff` `PLW1514` doesn't resolve `.read_text()` on a variable/attribute receiver — `ruff check --select PLW1514 gateway/run.py` reports **"All checks passed!"** on the unfixed file.
- `scripts/check-windows-footguns.py` scans builtin `open()` only (its own comment: *"…can be audited separately"*).

## Verification

Reproduced on Windows with `locale.getpreferredencoding() == 'cp1252'`:

| site | before | after |
|---|---|---|
| `run.py:9122` write reply `"yes 🎉 更新"` | `UnicodeEncodeError: 'charmap' codec can't encode '\U0001f389'` — and `isinstance(e, OSError)` is `False`, so `except OSError` misses it | writes, round-trips exactly |
| `run.py:14671` read UTF-8 stdout | silent mojibake: `Обновление` → `Ð�Ð±Ð½Ð¾Ð²Ð»ÐµÐ½Ð¸Ðµ` | decodes exactly |

- New guard: **20 offenders before, 0 after**; passes on both files.
- `ruff check` on all three changed files → clean.
- `python scripts/check-windows-footguns.py --all` → clean (760 files).
- No regressions: `tests/gateway/test_update_command.py`, `test_update_streaming.py`, `test_telegram_pending_update_probe.py`, `test_voice_command.py` produce **identical** pass/fail counts before and after this change (the pre-existing failures are Windows-local dependency issues present on unmodified `main` too).

## Scope

Limited to the two gateway-core files on the `/update` coordination path. Complementary to #36828 (`scripts/`) and #50655 (`hermes_cli/`).

## Related (distinct) issues

#36649 / #36828 (`scripts/`), #28579 (`status.py::_read_json_file` — missing `except`, already encoded), #34083 item 3 (subprocess stdout-pipe decode).
