### PR TITLE
fix(memory): truncate oversized mem0 sync messages at the source

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -285,6 +285,25 @@ class Mem0MemoryProvider(MemoryProvider):
                 client.add(messages, **self._write_filters())
                 self._record_success()
             except Exception as e:
+                err_str = str(e)
+                if "INPUT_TOKEN_LIMIT_EXCEEDED" in err_str or "maximum" in err_str.lower():
+                    # Embedding model hit its token limit — truncate and retry
+                    logger.info("Mem0 sync: token limit exceeded, retrying with truncated content")
+                    try:
+                        # Truncate the longer message to ~4000 chars as a safe heuristic
+                        max_len = 4000
+                        trunc_user = user_content[:max_len] if len(user_content) > max_len else user_content
+                        trunc_asst = assistant_content[:max_len] if len(assistant_content) > max_len else assistant_content
+                        messages = [
+                            {"role": "user", "content": trunc_user},
+                            {"role": "assistant", "content": trunc_asst},
+                        ]
+                        client.add(messages, **self._write_filters())
+                        self._record_success()
+                        logger.info("Mem0 sync: retry with truncated content succeeded")
+                        return
+                    except Exception as e2:
+                        logger.warning("Mem0 sync retry after truncation also failed: %s", e2)
                 self._record_failure()
                 logger.warning("Mem0 sync failed: %s", e)
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -33,6 +33,30 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # so legacy mem0.json files written by the wizard don't override gateway-native ids.
 _DEFAULT_USER_ID = "hermes-user"
 
+# sync_turn sends the whole turn to the backend for fact extraction. OSS embedding
+# models often have small context windows (bge-small-zh-v1.5: 512 tokens ≈ 500 chars;
+# jina-embeddings-v3: 8192), and oversized turns make backend.add() raise — Ollama
+# answers HTTP 500, hosted APIs return INPUT_TOKEN_LIMIT_EXCEEDED — which _try only
+# logs, silently dropping the turn's memory extraction. Cap each message up front.
+_SYNC_MSG_MAX_CHARS = 450
+
+
+def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
+    """Cap a synced message at its last sentence boundary within ``max_len``.
+
+    Short messages pass through unchanged; long ones keep the last complete
+    sentence inside the window so fact extraction still sees coherent statements,
+    with a hard cut as fallback when no boundary exists (or one only appears in
+    the first third of the window, which usually means unsegmented input).
+    """
+    if len(text) <= max_len:
+        return text
+    for sep in ("。", "！", "？", ".\n", ".", "!", "?"):
+        cut = text[:max_len].rfind(sep)
+        if cut > max_len // 3:
+            return text[:cut + 1]
+    return text[:max_len]
+
 
 def _is_client_error(exc: Exception) -> bool:
     """True for user-caused errors (bad ID, not found) that should NOT trip circuit breaker."""
@@ -266,7 +290,10 @@ class Mem0MemoryProvider(MemoryProvider):
 
         def _sync():
             if self._backend is not None:
-                messages = [{"role": "user", "content": user_content}, {"role": "assistant", "content": assistant_content}]
+                messages = [
+                    {"role": "user", "content": _truncate_for_sync(user_content)},
+                    {"role": "assistant", "content": _truncate_for_sync(assistant_content)},
+                ]
                 self._try(lambda: self._add(messages, infer=True), logger.warning, "Mem0 sync failed: %s")
 
         with self._sync_lock:

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -15,6 +15,8 @@ import logging
 import os
 import threading
 import time
+import urllib.parse
+import urllib.request
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, List
@@ -38,7 +40,24 @@ _DEFAULT_USER_ID = "hermes-user"
 # jina-embeddings-v3: 8192), and oversized turns make backend.add() raise — Ollama
 # answers HTTP 500, hosted APIs return INPUT_TOKEN_LIMIT_EXCEEDED — which _try only
 # logs, silently dropping the turn's memory extraction. Cap each message up front.
+# The cap itself is model-aware (Mem0MemoryProvider._sync_max_chars): a flat 450
+# fits 512-token embedders but would waste ~90% of the window on 8192-token models.
 _SYNC_MSG_MAX_CHARS = 450
+
+# Official token limits for common embedding models, consulted when the running
+# Ollama server can't be probed. For these BERT/BPE tokenizers a character is a
+# reasonable proxy for a token on mixed English/CJK text, so the same window sizes
+# drive the sync char cap with a safety margin (see _chars_for_context).
+_KNOWN_EMBEDDING_CONTEXT = {
+    "text-embedding-3-small": 8191,
+    "text-embedding-3-large": 8191,
+    "text-embedding-ada-002": 8191,
+    "jina-embeddings-v3": 8192,
+    "bge-m3": 8192,
+    "nomic-embed-text": 8192,
+    "mxbai-embed-large": 512,
+    "all-minilm": 512,
+}
 
 
 def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
@@ -56,6 +75,48 @@ def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
         if cut > max_len // 3:
             return text[:cut + 1]
     return text[:max_len]
+
+
+def _chars_for_context(ctx_tokens: int) -> int:
+    """Convert an embedding context window (tokens) into a sync char cap.
+
+    Keeps ~15% headroom for tokenizer drift, rounds down to a multiple of 50,
+    and never goes below the conservative default.
+    """
+    return max(_SYNC_MSG_MAX_CHARS, int(ctx_tokens * 0.85) // 50 * 50)
+
+
+def _probe_ollama_context(base_url: str, model: str):
+    """Best-effort read of the embedding context window from a local Ollama server.
+
+    The URL comes from the user's own mem0.json - the same one the embedder
+    itself uses - so this probes the already-configured server, never an
+    arbitrary host. Returns the token limit, or None when unreachable or the
+    model info carries no context field. Never raises.
+    """
+    if not base_url or not model:
+        return None
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return None
+    try:
+        req = urllib.request.Request(
+            base_url.rstrip("/") + "/api/show",
+            data=json.dumps({"model": model}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            info = json.load(resp).get("model_info") or {}
+    except Exception:
+        return None
+    arch = info.get("general.architecture")
+    for key in filter(None, (f"{arch}.context_length" if arch else None, "context_length")):
+        val = info.get(key)
+        if val:
+            with suppress(ValueError, TypeError):
+                return int(val)
+    return None
 
 
 def _is_client_error(exc: Exception) -> bool:
@@ -118,6 +179,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._prefetch_query = self._prefetch_result = ""
         self._prefetch_done = self._atexit_registered = False
         self._consecutive_failures, self._breaker_open_until = 0, 0.0  # circuit breaker state
+        self._sync_cap = None  # resolved once on first sync_turn (see _sync_max_chars)
         self._breaker_lock, self._sync_lock, self._prefetch_lock = threading.Lock(), threading.Lock(), threading.Lock()
 
     @property
@@ -283,6 +345,38 @@ class Mem0MemoryProvider(MemoryProvider):
             thread.join(timeout=_PREFETCH_WAIT_SECS)
         return self._consume_prefetch_result(query) or ""  # slow backend: skip injection; mem0_search remains the backstop
 
+    def _sync_max_chars(self) -> int:
+        """Char cap for sync_turn messages, resolved once and cached (a probe is a network call).
+
+        Resolution order: an explicit ``sync_max_chars`` in mem0.json wins; OSS
+        mode otherwise probes the configured Ollama server for the embedder's
+        context window; a table of known models is the next fallback; the safe
+        default that fits 512-token embedders is the floor.
+        """
+        if self._sync_cap is None:
+            self._sync_cap = self._resolve_sync_cap()
+        return self._sync_cap
+
+    def _resolve_sync_cap(self) -> int:
+        cfg = self._config or {}
+        with suppress(ValueError, TypeError):
+            explicit = int(cfg.get("sync_max_chars") or 0)
+            if explicit > 0:
+                return explicit
+        embedder_cfg = {}
+        if self._mode == "oss":
+            embedder_cfg = ((cfg.get("oss") or {}).get("embedder") or {}).get("config") or {}
+        if embedder_cfg:
+            base_url = str(embedder_cfg.get("ollama_base_url") or "http://localhost:11434")
+            model = str(embedder_cfg.get("model") or "")
+            ctx = _probe_ollama_context(base_url, model)
+            if ctx:
+                return _chars_for_context(ctx)
+            known = _KNOWN_EMBEDDING_CONTEXT.get(model.split(":")[0])
+            if known:
+                return _chars_for_context(known)
+        return _SYNC_MSG_MAX_CHARS
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
         if self._backend is None or self._is_breaker_open():
@@ -290,9 +384,10 @@ class Mem0MemoryProvider(MemoryProvider):
 
         def _sync():
             if self._backend is not None:
+                cap = self._sync_max_chars()
                 messages = [
-                    {"role": "user", "content": _truncate_for_sync(user_content)},
-                    {"role": "assistant", "content": _truncate_for_sync(assistant_content)},
+                    {"role": "user", "content": _truncate_for_sync(user_content, cap)},
+                    {"role": "assistant", "content": _truncate_for_sync(assistant_content, cap)},
                 ]
                 self._try(lambda: self._add(messages, infer=True), logger.warning, "Mem0 sync failed: %s")
 

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -239,3 +239,71 @@ class TestMem0Defaults:
         provider.initialize("test")
 
         assert provider._agent_id == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# Token limit truncation retry
+# ---------------------------------------------------------------------------
+
+
+class _FakeClientTokenLimit:
+    """Fake client that raises INPUT_TOKEN_LIMIT_EXCEEDED on first add, succeeds on second."""
+
+    def __init__(self):
+        self.add_calls = []
+        self._fail_first = True
+
+    def add(self, messages, **kwargs):
+        self.add_calls.append({"messages": messages, **kwargs})
+        if self._fail_first:
+            self._fail_first = False
+            raise Exception(
+                "Error code: 400 - {'detail': {'message': \"Input text exceeds the model's "
+                "maximum of 8194 tokens. Use 'truncate: true' to automatically truncate, or "
+                "split into smaller chunks.\", 'code': 'INPUT_TOKEN_LIMIT_EXCEEDED'}}"
+            )
+
+
+class TestSyncTurnTokenLimitRetry:
+    """sync_turn must retry with truncated content on INPUT_TOKEN_LIMIT_EXCEEDED."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_retry_on_token_limit(self, monkeypatch):
+        """Truncates content and retries when embedding model rejects for token limit."""
+        client = _FakeClientTokenLimit()
+        provider = self._make_provider(monkeypatch, client)
+
+        long_content = "x" * 10000
+        provider.sync_turn("short user msg", long_content, session_id="s1")
+        provider._sync_thread.join(timeout=3)
+
+        # Should have been called twice: first fails, second succeeds with truncated content
+        assert len(client.add_calls) == 2
+        # Second call should have truncated assistant content
+        second_asst = client.add_calls[1]["messages"][1]["content"]
+        assert len(second_asst) <= 4000
+
+    def test_no_retry_when_no_token_limit(self, monkeypatch):
+        """Non-token-limit errors should NOT trigger retry."""
+        class _FailClient:
+            def __init__(self):
+                self.add_calls = []
+            def add(self, messages, **kwargs):
+                self.add_calls.append(True)
+                raise Exception("Network timeout")
+
+        client = _FailClient()
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.sync_turn("user", "assistant", session_id="s1")
+        provider._sync_thread.join(timeout=3)
+
+        # Should only be called once (no retry)
+        assert len(client.add_calls) == 1

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -146,6 +146,85 @@ class TestMem0V3Internal:
         assert call[2]["infer"] is True
 
 
+class TestSyncTurnTruncation:
+    """sync_turn must cap messages before ingestion so small-context embedding
+    backends (OSS Ollama bge-small-zh-v1.5: 512 tokens; jina-embeddings-v3 token
+    limits) don't fail the whole extraction — a failure _try only logs."""
+
+    def _make_provider(self, monkeypatch, backend):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._backend = backend
+        return provider
+
+    def test_short_messages_pass_through_unchanged(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.sync_turn("user said", "assistant replied", session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        assert backend.captured[0][1] == [
+            {"role": "user", "content": "user said"},
+            {"role": "assistant", "content": "assistant replied"},
+        ]
+
+    def test_oversized_messages_truncated_at_sentence_boundary(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        max_len = mem0_plugin._SYNC_MSG_MAX_CHARS
+        long_user = ("Important fact about the project. " * 40).strip()
+        long_assistant = "这是很长的一段回答。" * 80
+        provider.sync_turn(long_user, long_assistant, session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        sent = backend.captured[0][1]
+        assert len(sent[0]["content"]) <= max_len
+        assert sent[0]["content"].endswith(".")
+        assert len(sent[1]["content"]) <= max_len
+        assert sent[1]["content"].endswith("。")
+
+    def test_small_context_backend_never_sees_oversized_input(self, monkeypatch):
+        """Regression for #106235/#37421: an OSS embedding backend with a small
+        context window raises on oversized input; truncation up front keeps the
+        extraction from being silently dropped (no breaker failures)."""
+
+        class SmallContextBackend(FakeBackend):
+            def add(self, messages, **kwargs):
+                if any(len(m["content"]) > mem0_plugin._SYNC_MSG_MAX_CHARS for m in messages):
+                    raise RuntimeError("HTTP 500: embedding input exceeds model context")
+                return super().add(messages, **kwargs)
+
+        backend = SmallContextBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.sync_turn("x" * 5000, "y" * 5000, session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        assert len(backend.captured) == 1
+        assert all(len(m["content"]) <= mem0_plugin._SYNC_MSG_MAX_CHARS for m in backend.captured[0][1])
+        assert provider._consecutive_failures == 0
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("short text", "short text"),  # under the cap: untouched
+            ("这是很短的句子。", "这是很短的句子。"),  # CJK under the cap: untouched
+            # no sentence boundary anywhere: hard cut at the cap
+            ("x" * 600, "x" * mem0_plugin._SYNC_MSG_MAX_CHARS),
+        ],
+    )
+    def test_truncate_for_sync_pass_through_and_hard_cut(self, text, expected):
+        assert mem0_plugin._truncate_for_sync(text) == expected
+
+    def test_truncate_for_sync_keeps_last_complete_sentence(self):
+        max_len = mem0_plugin._SYNC_MSG_MAX_CHARS
+        text = "".join(f"Sentence {i}. " for i in range(100))
+        out = mem0_plugin._truncate_for_sync(text)
+        assert len(out) <= max_len
+        assert out.endswith(".")
+        assert out.startswith("Sentence 0. ")
+        # boundary only inside the first third of the window: hard cut instead
+        assert mem0_plugin._truncate_for_sync("One. " + "x" * 600) == ("One. " + "x" * 600)[:max_len]
+
+
 class TestMem0Prefetch:
     """prefetch() must recall on the CURRENT question, synchronously.
 

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -1,5 +1,6 @@
 """Tests for Mem0 v3 API — new tool names, paginated responses, update/delete tools."""
 
+import io
 import json
 import threading
 import time
@@ -154,6 +155,8 @@ class TestSyncTurnTruncation:
     def _make_provider(self, monkeypatch, backend):
         provider = Mem0MemoryProvider()
         provider.initialize("test-session")
+        provider._config = {"mode": "platform", "oss": {}}  # pin config so a local mem0.json can't skew caps
+        provider._mode = "platform"
         provider._user_id = "u123"
         provider._agent_id = "hermes"
         provider._backend = backend
@@ -223,6 +226,149 @@ class TestSyncTurnTruncation:
         assert out.startswith("Sentence 0. ")
         # boundary only inside the first third of the window: hard cut instead
         assert mem0_plugin._truncate_for_sync("One. " + "x" * 600) == ("One. " + "x" * 600)[:max_len]
+
+
+class TestSyncCapResolution:
+    """The cap is model-aware: explicit config → Ollama probe → known-model table
+    → conservative default, resolved once and cached (the probe is a network call)."""
+
+    def _make_provider(self, monkeypatch, backend):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._config = {"mode": "platform", "oss": {}}
+        provider._mode = "platform"
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._backend = backend
+        return provider
+
+    def _oss(self, provider, embedder_cfg):
+        provider._mode = "oss"
+        provider._config["oss"] = {"embedder": {"config": embedder_cfg}}
+
+    def test_explicit_config_overrides_everything(self, monkeypatch):
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        self._oss(provider, {"model": "jina-embeddings-v3"})
+        provider._config["sync_max_chars"] = 100
+        assert provider._sync_max_chars() == 100
+
+    def test_invalid_config_value_falls_through(self, monkeypatch):
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        provider._config["sync_max_chars"] = "not-a-number"
+        assert provider._sync_max_chars() == mem0_plugin._SYNC_MSG_MAX_CHARS
+
+    def test_oss_probe_large_context_lifts_cap(self, monkeypatch):
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        self._oss(provider, {"model": "bge-m3:latest", "ollama_base_url": "http://127.0.0.1:11434"})
+        monkeypatch.setattr(mem0_plugin, "_probe_ollama_context", lambda b, m: 8192)
+        assert provider._sync_max_chars() == mem0_plugin._chars_for_context(8192)
+        assert provider._sync_max_chars() > 6900  # 8192-token models must not be stuck at the 450 default
+
+    def test_oss_probe_small_context_keeps_default(self, monkeypatch):
+        # szicely's measurement on bge-small-zh-v1.5:f16 (512 tokens): 450 chars OK, 600 → HTTP 500
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        self._oss(provider, {"model": "bge-small-zh-v1.5:f16"})
+        monkeypatch.setattr(mem0_plugin, "_probe_ollama_context", lambda b, m: 512)
+        assert provider._sync_max_chars() == mem0_plugin._SYNC_MSG_MAX_CHARS
+
+    def test_known_model_table_when_probe_fails(self, monkeypatch):
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        self._oss(provider, {"model": "jina-embeddings-v3:latest"})
+        monkeypatch.setattr(mem0_plugin, "_probe_ollama_context", lambda b, m: None)
+        assert provider._sync_max_chars() == mem0_plugin._chars_for_context(8192)
+
+    def test_unknown_model_falls_back_to_default(self, monkeypatch):
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        self._oss(provider, {"model": "custom-finetune:q4"})
+        monkeypatch.setattr(mem0_plugin, "_probe_ollama_context", lambda b, m: None)
+        assert provider._sync_max_chars() == mem0_plugin._SYNC_MSG_MAX_CHARS
+
+    def test_platform_mode_never_probes(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(mem0_plugin, "_probe_ollama_context", lambda b, m: calls.append((b, m)) or 8192)
+        provider = self._make_provider(monkeypatch, FakeBackend())
+        assert provider._sync_max_chars() == mem0_plugin._SYNC_MSG_MAX_CHARS
+        assert calls == []
+
+    def test_probe_resolved_once_and_cached_across_syncs(self, monkeypatch):
+        calls = []
+
+        def fake_probe(base_url, model):
+            calls.append((base_url, model))
+            return 8192
+
+        monkeypatch.setattr(mem0_plugin, "_probe_ollama_context", fake_probe)
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        self._oss(provider, {"model": "bge-m3", "ollama_base_url": "http://127.0.0.1:11434"})
+        provider.sync_turn("x" * 9000, "y" * 9000, session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        provider.sync_turn("x" * 9000, "y" * 9000, session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        assert len(calls) == 1  # cached: the second sync must not re-probe
+        cap = mem0_plugin._chars_for_context(8192)
+        assert all(len(m["content"]) <= cap for m in backend.captured[0][1])
+
+    def test_sync_turn_uses_resolved_cap(self, monkeypatch):
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider._config["sync_max_chars"] = 120
+        provider.sync_turn("Sentence one. " * 30, "ok", session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        assert len(backend.captured[0][1][0]["content"]) <= 120
+
+
+class TestProbeOllamaContext:
+    """The probe reads the context window from Ollama's /api/show payload and
+    fails soft on any error (it runs inside the sync path)."""
+
+    def _fake_urlopen(self, monkeypatch, payload, sent=None):
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def fake_open(req, timeout=5):
+            if sent is not None:
+                sent.append((req.full_url, json.loads(req.data.decode())))
+            return _Resp(json.dumps(payload).encode())
+
+        monkeypatch.setattr(mem0_plugin.urllib.request, "urlopen", fake_open)
+
+    def test_reads_bert_context_length(self, monkeypatch):
+        sent = []
+        self._fake_urlopen(monkeypatch, {"model_info": {"general.architecture": "bert", "bert.context_length": 512}}, sent)
+        assert mem0_plugin._probe_ollama_context("http://localhost:11434/", "bge-small-zh-v1.5:f16") == 512
+        url, body = sent[0]
+        assert url == "http://localhost:11434/api/show"  # trailing slash normalized
+        assert body == {"model": "bge-small-zh-v1.5:f16"}
+
+    def test_reads_arch_prefixed_and_bare_context_length(self, monkeypatch):
+        self._fake_urlopen(monkeypatch, {"model_info": {"general.architecture": "jina", "jina.context_length": 8192}})
+        assert mem0_plugin._probe_ollama_context("http://127.0.0.1:11434", "jina-embeddings-v3") == 8192
+        self._fake_urlopen(monkeypatch, {"model_info": {"context_length": 4096}})
+        assert mem0_plugin._probe_ollama_context("http://127.0.0.1:11434", "weird-model") == 4096
+
+    def test_rejects_non_http_schemes_and_empty_inputs(self, monkeypatch):
+        opened = []
+        monkeypatch.setattr(mem0_plugin.urllib.request, "urlopen", lambda req, timeout=5: opened.append(req))
+        assert mem0_plugin._probe_ollama_context("ftp://host", "m") is None
+        assert mem0_plugin._probe_ollama_context("http://127.0.0.1:11434", "") is None
+        assert mem0_plugin._probe_ollama_context("", "m") is None
+        assert opened == []  # the scheme/netloc guard fires before any request
+
+    def test_returns_none_on_errors_and_garbage_payloads(self, monkeypatch):
+        def boom(req, timeout=5):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(mem0_plugin.urllib.request, "urlopen", boom)
+        assert mem0_plugin._probe_ollama_context("http://127.0.0.1:11434", "m") is None
+        self._fake_urlopen(monkeypatch, {"model_info": {"general.architecture": "bert", "bert.context_length": "bogus"}})
+        assert mem0_plugin._probe_ollama_context("http://127.0.0.1:11434", "m") is None
+        self._fake_urlopen(monkeypatch, {})  # no model_info at all
+        assert mem0_plugin._probe_ollama_context("http://127.0.0.1:11434", "m") is None
 
 
 class TestMem0Prefetch:


### PR DESCRIPTION
## What does this PR do?

`sync_turn()` sent the whole turn to `backend.add()` untruncated. Embedding backends with small context windows reject oversized input — OSS Ollama setups (e.g. `bge-small-zh-v1.5:f16`, 512 tokens ≈ 500 chars) fail with **HTTP 500**, and hosted APIs answer `INPUT_TOKEN_LIMIT_EXCEEDED` — and since `_try()` only logs the error, the turn's memory extraction is **silently dropped**. After long conversations, durable facts stated by the user never make it into memory.

This PR caps each synced message at its **last sentence boundary within a model-aware limit, before ingestion**: short turns pass through unchanged, long turns keep a coherent statement for fact extraction, with a hard cut as fallback when no sentence boundary exists in the window.

The cap is resolved once per provider and cached (follow-up to @szicely's review on #37427): an explicit `sync_max_chars` in `mem0.json` wins; OSS mode otherwise probes the configured Ollama server for the embedder's context window (`/api/show`); a table of known models (jina-embeddings-v3, bge-m3, nomic-embed-text: 8192; mxbai-embed-large, all-minilm: 512; OpenAI embedders: 8191) is the next fallback; the 450-char default that fits 512-token embedders (measured: 450 OK, 600 → HTTP 500 on `bge-small-zh-v1.5:f16`) stays the floor. A flat 450 would have capped every turn at ~5% of the window on 8192-token embedders — models that served full turns fine before truncation existed.

This supersedes the earlier retry-on-`INPUT_TOKEN_LIMIT_EXCEEDED` approach on this branch: string-matching the error shape cannot cover Ollama's HTTP 500 (as analyzed by @szicely in [#106235](https://github.com/NousResearch/hermes-agent/issues/106235) and on #37421), while truncating at the source avoids the failed request entirely for both backend families.

## Related Issue

Fixes #37421
Covers #106235 (OSS Ollama embedding-500 scenario, same root cause)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/__init__.py`: `_truncate_for_sync()` (sentence-boundary truncation, CJK-aware separators, hard-cut fallback) applied in `sync_turn()`'s `_sync()`; `_sync_max_chars()`/`_resolve_sync_cap()` resolve the per-message cap (explicit config → Ollama probe → known-model table → 450 floor) and cache it so the probe runs at most once; `_probe_ollama_context()` reads the embedder's context window from the configured Ollama server (http/https schemes only, same base URL the embedder itself uses, never raises); `_chars_for_context()` converts tokens→chars with 15% headroom.
- `tests/plugins/memory/test_mem0_v3.py`: `TestSyncTurnTruncation` — short messages pass through unchanged; oversized messages arrive capped at a sentence boundary; a small-context backend that raises on oversized input never sees one (regression for the silent-drop symptom, asserted via zero breaker failures). `TestSyncCapResolution` — explicit config wins; probe lifts the cap for 8192-token models (>6900) and keeps the 450 floor for 512-token ones; known-model table when the probe fails; unknown models fall back to the default; platform mode never probes; the probe result is cached across syncs; `sync_turn` truncates at the resolved cap. `TestProbeOllamaContext` — reads `bert.context_length` and arch-prefixed/bare `context_length`, normalizes the base URL, rejects non-http schemes and empty inputs before any request, fails soft on connection errors and garbage payloads.

## How to Test

1. `pytest tests/plugins/memory/test_mem0_v3.py -q` — 43 passed (13 new tests included).
2. `pytest tests/plugins/memory/ -q` — same 11 pre-existing environment failures as on clean `upstream/main` (missing optional `mem0`/`hindsight-client` packages locally); failure set verified identical with and without this change.
3. Observed result: a turn of 5000+ chars is delivered to the backend capped at the resolved limit ending at a complete sentence, so the extraction succeeds instead of being dropped; with an 8192-token embedder configured (probed or known), turns up to ~6950 chars are kept whole instead of being cut at 450.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Rebuilt on current `main` (the branch previously conflicted after the `_try()`/`_add()` refactor). Commit 1: source-side truncation replacing the retry. Commit 2: model-aware cap resolution per @szicely's review (probe + known-model table + `sync_max_chars` override), with the probe result cached so it runs at most once per provider.
