### PR TITLE
fix: honor configured webhook body limit

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -135,6 +135,17 @@ class WebhookAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _create_app(self) -> Any:
+        """Build the aiohttp app with the configured webhook body cap."""
+        # aiohttp rejects reads once the accumulated body size is >=
+        # client_max_size. The adapter's own max_body_bytes check treats the
+        # cap as inclusive, so give aiohttp one extra byte and let the handler
+        # return the route-level 413 for truly oversized payloads.
+        app = web.Application(client_max_size=self._max_body_bytes + 1)
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
+        return app
+
     async def connect(self) -> bool:
         # Load agent-created subscriptions before validating
         self._reload_dynamic_routes()
@@ -173,9 +184,7 @@ class WebhookAdapter(BasePlatformAdapter):
                         f"real target (telegram, discord, slack, github_comment, etc.)."
                     )
 
-        app = web.Application()
-        app.router.add_get("/health", self._handle_health)
-        app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
+        app = self._create_app()
 
         # Port conflict detection — fail fast if port is already in use
         import socket as _socket

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -500,6 +500,51 @@ class TestRateLimiting:
 
 class TestBodySize:
 
+    def test_adapter_app_uses_configured_client_max_size(self):
+        """The aiohttp app must allow bodies up to configured max_body_bytes."""
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=2_000_000)
+
+        app = adapter._create_app()
+
+        assert app._client_max_size == 2_000_001
+
+    @pytest.mark.asyncio
+    async def test_payload_above_aiohttp_default_below_configured_cap_is_accepted(self):
+        """Configured caps above aiohttp's 1MiB default must be honored."""
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=1_200_000)
+        adapter.handle_message = AsyncMock()
+
+        app = adapter._create_app()
+        async with TestClient(TestServer(app)) as cli:
+            payload = b'{"data":"' + (b"x" * 1_100_000) + b'"}'
+            resp = await cli.post(
+                "/webhooks/big",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 202
+            adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_payload_exactly_at_configured_cap_is_accepted(self):
+        """max_body_bytes is an inclusive cap; exactly-at-limit payloads pass."""
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        payload = b'{"data":"' + (b"x" * 256) + b'"}'
+        adapter = _make_adapter(routes=routes, max_body_bytes=len(payload))
+        adapter.handle_message = AsyncMock()
+
+        app = adapter._create_app()
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/big",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 202
+            adapter.handle_message.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_oversized_payload_rejected(self):
         """Content-Length > max_body_bytes returns 413."""


### PR DESCRIPTION
## Summary
- set webhook aiohttp client_max_size from the configured max_body_bytes so large configured webhooks are not rejected by aiohttp's 1MiB default
- preserve inclusive max_body_bytes semantics at the exact-limit boundary
- add regression coverage for large payloads and exact-limit payloads

## Tests
- python -m py_compile gateway/platforms/webhook.py
- python -m pytest tests/gateway/test_webhook_adapter.py::TestBodySize -q -o 'addopts='
- python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='

Note: fork push from an upstream-main-based branch was blocked because the GitHub token lacks workflow scope for upstream workflow commits, so this PR branch is based on the fork's pushable base and cherry-picks only the verified fix.