### PR TITLE
Fix gateway restart under macOS launchd

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10646,9 +10646,17 @@ class GatewayRunner:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
+        # Under macOS launchd, the detached helper is also fragile from a
+        # LaunchAgent process; KeepAlive.SuccessfulExit=false already provides
+        # the reliable restart path when the gateway exits non-zero.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _xpc_service_name = os.environ.get("XPC_SERVICE_NAME", "")
+        _under_launchd = (
+            sys.platform == "darwin"
+            and _xpc_service_name.startswith("ai.hermes.gateway")
+        )
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_service or _under_launchd or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -103,6 +103,53 @@ async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypat
     """Without systemd, /restart uses the detached subprocess approach."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under macOS launchd, /restart exits non-zero so KeepAlive respawns it."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_ignores_generic_xpc_service_name(tmp_path, monkeypatch):
+    """macOS shells often expose XPC_SERVICE_NAME=0; that is not launchd service ownership."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary

Fix gateway restart handling when the gateway is running as the macOS LaunchAgent.

## Problem

The `/restart` path currently uses the detached helper path outside systemd/container environments. Under macOS launchd, that detached child can be lost or killed as the parent service exits, which makes gateway restarts flaky.

Hermes already treats systemd and container-managed runs as service-managed restarts. The macOS LaunchAgent should use the same service-managed path so launchd can respawn the gateway consistently.

## Change

- Treat the Hermes gateway LaunchAgent as a service-managed runtime when `XPC_SERVICE_NAME` starts with `ai.hermes.gateway`.
- Keep ordinary local shells out of this path, including the common macOS terminal value `XPC_SERVICE_NAME=0`.
- Add regression coverage for both the LaunchAgent case and the generic XPC shell case.

## Verification

- `python -m pytest tests/gateway/test_restart_notification.py -q`
- Result: `29 passed`
