### PR TITLE
Disable WhatsApp link previews by default

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -87,6 +87,12 @@ function formatOutgoingMessage(message) {
   return REPLY_PREFIX ? `${REPLY_PREFIX}${message}` : message;
 }
 
+function textMessagePayload(text, extra = {}) {
+  // Baileys dynamically imports link-preview-js when link previews are enabled.
+  // Keep Hermes text sends simple and avoid that optional dependency/path.
+  return { text, linkPreview: null, ...extra };
+}
+
 function splitLongMessage(message, maxLength = MAX_MESSAGE_LENGTH) {
   const text = String(message || '');
   if (!text) return [];
@@ -504,7 +510,7 @@ app.post('/send', async (req, res) => {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
-      const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+      const sent = await sendWithTimeout(chatId, textMessagePayload(chunks[i]));
       trackSentMessageId(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
       if (chunks.length > 1 && i < chunks.length - 1) {
@@ -538,10 +544,10 @@ app.post('/edit', async (req, res) => {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
 
-    await sendWithTimeout(chatId, { text: chunks[0], edit: key });
+    await sendWithTimeout(chatId, textMessagePayload(chunks[0], { edit: key }));
     if (chunks.length > 1) {
       for (let i = 1; i < chunks.length; i += 1) {
-        const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+        const sent = await sendWithTimeout(chatId, textMessagePayload(chunks[i]));
         trackSentMessageId(sent);
         if (sent?.key?.id) messageIds.push(sent.key.id);
         if (i < chunks.length - 1) {


### PR DESCRIPTION
## Summary

Disable WhatsApp link previews by default for text sends/edits in the bridge.

## Problem

Baileys attempts to generate URL previews for text messages through the optional `link-preview-js` dependency. When that package is missing, URL sends can produce noisy failures/retries. Adding the dependency is not ideal because the current package audit reports a high vulnerability path with no available fix.

## Change

- Add a small text payload helper that sets `linkPreview: null`.
- Use it for text `/send` and `/edit` calls.
- Keep existing non-text message behavior unchanged.

## Verification

- `node --check scripts/whatsapp-bridge/bridge.js`
- `node scripts/whatsapp-bridge/allowlist.test.mjs`
- `npm audit --prefix scripts/whatsapp-bridge --audit-level=high`

The audit passes at the high threshold; only existing moderate dependency findings remain.
