### PR TITLE
fix(nix): add opt-in local browser runtime

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -7,6 +7,7 @@
   perSystem = { pkgs, lib, self', ... }:
     let
       hermes-agent = self'.packages.default;
+      hermes-browser = self'.packages.browser;
       hermesVenv = hermes-agent.hermesVenv;
 
       configMergeScript = pkgs.callPackage ./configMergeScript.nix { };
@@ -247,6 +248,31 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
           echo "PASS: Node v$NODE_MAJOR >= 20"
 
           echo "=== All HERMES_NODE checks passed ==="
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+
+        # Verify the opt-in local browser runtime without bloating the default package.
+        browser-runtime = pkgs.runCommand "hermes-browser-runtime" { } ''
+          set -e
+          echo "=== Checking agent-browser CLI ==="
+          ${lib.getExe hermes-browser.agentBrowser} --version
+          echo "PASS: agent-browser CLI runs"
+
+          echo "=== Checking Chromium wiring ==="
+          test -x ${lib.getExe pkgs.chromium} || \
+            (echo "FAIL: Chromium binary missing"; exit 1)
+          grep -q "${hermes-browser.agentBrowser}/bin" ${hermes-browser}/bin/hermes || \
+            (echo "FAIL: agent-browser not present in browser wrapper PATH"; exit 1)
+          grep -q "AGENT_BROWSER_EXECUTABLE_PATH='${lib.getExe pkgs.chromium}'" ${hermes-browser}/bin/hermes || \
+            (echo "FAIL: AGENT_BROWSER_EXECUTABLE_PATH not set in browser wrapper"; exit 1)
+          grep -q "HERMES_BUNDLED_LOCALES" ${hermes-browser}/bin/hermes || \
+            (echo "FAIL: HERMES_BUNDLED_LOCALES not set in browser wrapper"; exit 1)
+          if grep -q "AGENT_BROWSER_EXECUTABLE_PATH" ${hermes-agent}/bin/hermes; then
+            echo "FAIL: default package unexpectedly includes Chromium"; exit 1
+          fi
+          echo "PASS: Chromium and wrapper wiring present"
+
           mkdir -p $out
           echo "ok" > $out/result
         '';

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -11,6 +11,8 @@
   callPackage,
   python312,
   nodejs_22,
+  agent-browser,
+  chromium,
   electron,
   ripgrep,
   git,
@@ -34,6 +36,7 @@
   # Overridable parameters
   extraPythonPackages ? [ ],
   extraDependencyGroups ? [ ],
+  withBrowser ? false,
 }:
 let
   nodejs = nodejs_22;
@@ -97,6 +100,10 @@ let
   ++ lib.optionals stdenv.isLinux [
     wl-clipboard
     xclip
+  ]
+  ++ lib.optionals (withBrowser && stdenv.isLinux) [
+    agent-browser
+    chromium
   ];
 
   runtimePath = lib.makeBinPath runtimeDeps;
@@ -170,25 +177,34 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/ui-tui
     cp -r ${hermesTui}/lib/hermes-tui/* $out/ui-tui/
 
-    ${lib.concatMapStringsSep "\n"
-      (name: ''
-        makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
-          --suffix PATH : "${runtimePath}" \
-          --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills \
-          --set HERMES_BUNDLED_PLUGINS $out/share/hermes-agent/plugins \
-          --set HERMES_BUNDLED_LOCALES $out/share/hermes-agent/locales \
-          --set HERMES_WEB_DIST $out/share/hermes-agent/web_dist \
-          --set HERMES_TUI_DIR $out/ui-tui \
-          --set HERMES_PYTHON ${hermesVenv}/bin/python3 \
-          --set HERMES_NODE ${lib.getExe nodejs} \
-          ${lib.optionalString (rev != null) ''--set HERMES_REVISION ${rev} \''}
-          ${lib.optionalString (extraPythonPackages != [ ]) ''--suffix PYTHONPATH : "${pythonPath}"''}
-      '')
-      [
-        "hermes"
-        "hermes-agent"
-        "hermes-acp"
-      ]
+    ${
+      let
+        wrapperArgs =
+          [
+            ''--suffix PATH : "${runtimePath}"''
+            "--set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills"
+            "--set HERMES_BUNDLED_PLUGINS $out/share/hermes-agent/plugins"
+            "--set HERMES_BUNDLED_LOCALES $out/share/hermes-agent/locales"
+            "--set HERMES_WEB_DIST $out/share/hermes-agent/web_dist"
+            "--set HERMES_TUI_DIR $out/ui-tui"
+            "--set HERMES_PYTHON ${hermesVenv}/bin/python3"
+            "--set HERMES_NODE ${lib.getExe nodejs}"
+          ]
+          ++ lib.optional (withBrowser && stdenv.isLinux)
+            "--set AGENT_BROWSER_EXECUTABLE_PATH ${lib.getExe chromium}"
+          ++ lib.optional (rev != null) "--set HERMES_REVISION ${rev}"
+          ++ lib.optional (extraPythonPackages != [ ]) ''--suffix PYTHONPATH : "${pythonPath}"'';
+      in
+      lib.concatMapStringsSep "\n"
+        (name: ''
+          makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
+            ${lib.concatStringsSep " \\\n" wrapperArgs}
+        '')
+        [
+          "hermes"
+          "hermes-agent"
+          "hermes-acp"
+        ]
     }
 
     ${lib.optionalString (extraPythonPackages != [ ]) ''
@@ -211,6 +227,7 @@ stdenv.mkDerivation (finalAttrs: {
         hermesNpmLib
         hermesVenv
         ;
+      agentBrowser = agent-browser;
 
       # `hermesDesktop` references `finalAttrs.finalPackage` (this whole
       # derivation, after all overrides are applied) so the desktop wrapper

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -29,9 +29,12 @@
   let
     cfg = config.services.hermes-agent;
     effectivePackage =
-      if cfg.extraPythonPackages == [ ] && cfg.extraDependencyGroups == [ ]
+      if cfg.extraPythonPackages == [ ] && cfg.extraDependencyGroups == [ ] && !cfg.enableBrowser
       then cfg.package
-      else cfg.package.override { inherit (cfg) extraPythonPackages extraDependencyGroups; };
+      else cfg.package.override {
+        inherit (cfg) extraPythonPackages extraDependencyGroups;
+        withBrowser = cfg.enableBrowser;
+      };
     hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
@@ -216,6 +219,16 @@
         type = types.package;
         default = hermes-agent;
         description = "The hermes-agent package to use.";
+      };
+
+      enableBrowser = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Include the Nixpkgs agent-browser CLI and Chromium for local browser
+          tools. Chromium remains opt-in because it significantly increases the
+          package closure size.
+        '';
       };
 
       # ── Service identity ─────────────────────────────────────────────────

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -58,6 +58,11 @@
         tui = full.hermesTui;
         web = full.hermesWeb;
         desktop = full.hermesDesktop;
+      } // lib.optionalAttrs pkgs.stdenv.isLinux {
+        # Local browser tools with the Nixpkgs agent-browser CLI and Chromium.
+        browser = full.override {
+          withBrowser = true;
+        };
       };
     };
 }

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -63,6 +63,12 @@ The default package includes ALL libraries hermes-agent might need. if you want 
 
 The `default` package adds ~700 MB to the closure. If you only need messaging platforms, `#messaging` adds just ~33 MB.
 
+For local browser tools on Linux, install the `browser` variant. It adds the
+Nixpkgs `agent-browser` CLI and Chromium, avoiding runtime browser downloads:
+
+```bash
+nix profile install github:NousResearch/hermes-agent#browser
+```
 :::
 
 <details>
@@ -344,6 +350,7 @@ Quick reference for the most common things Nix users want to customize:
 | Use Podman instead of Docker | `container.backend` | `"podman"` |
 | Share state between host CLI and container | `container.hostUsers` | `[ "sidbin" ]` |
 | Make extra tools available to the agent | `extraPackages` | `[ pkgs.pandoc pkgs.imagemagick ]` |
+| Enable local browser tools | `enableBrowser` | `true` |
 | Use a custom base image | `container.image` | `"ubuntu:24.04"` |
 | Override the hermes package | `package` | `inputs.hermes-agent.packages.${system}.default.override { ... }` |
 | Change state directory | `stateDir` | `"/opt/hermes"` |
@@ -803,6 +810,7 @@ nix build .#checks.x86_64-linux.entry-points-sync  # pyproject.toml ↔ Nix pack
 nix build .#checks.x86_64-linux.cli-commands        # gateway/config subcommands
 nix build .#checks.x86_64-linux.managed-guard       # HERMES_MANAGED blocks mutation
 nix build .#checks.x86_64-linux.bundled-skills      # skills present in package
+nix build .#checks.x86_64-linux.browser-runtime     # agent-browser + Chromium
 nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves user keys
 ```
 
@@ -816,6 +824,7 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 | `cli-commands` | `hermes --help` exposes `gateway` and `config` subcommands |
 | `managed-guard` | `HERMES_MANAGED=true hermes config set ...` prints the NixOS error |
 | `bundled-skills` | Skills directory exists, contains SKILL.md files, `HERMES_BUNDLED_SKILLS` is set in wrapper |
+| `browser-runtime` | Browser variant adds `agent-browser`, configures Nixpkgs Chromium, and keeps the default package lightweight |
 | `config-roundtrip` | 7 merge scenarios: fresh install, Nix override, user key preservation, mixed merge, MCP additive merge, nested deep merge, idempotency |
 
 </details>
@@ -830,6 +839,7 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 |---|---|---|---|
 | `enable` | `bool` | `false` | Enable the hermes-agent service |
 | `package` | `package` | `hermes-agent` | The hermes-agent package to use |
+| `enableBrowser` | `bool` | `false` | Include the Nixpkgs `agent-browser` CLI and Chromium for local browser tools |
 | `user` | `str` | `"hermes"` | System user |
 | `group` | `str` | `"hermes"` | System group |
 | `createUser` | `bool` | `true` | Auto-create user/group |


### PR DESCRIPTION
## What does this PR do?

Fix local browser tools for NixOS users by adding an opt-in packaged browser
runtime.

Without this variant, Hermes can discover or install the generic Linux
`agent-browser` executable, but it fails on vanilla NixOS before browser
automation starts:

```text
NixOS cannot run dynamically linked executables intended for generic linux
environments out of the box.
```

The new Linux-only `.#browser` package and
`services.hermes-agent.enableBrowser = true` option provide the Nixpkgs
`agent-browser` package and Chromium, then set
`AGENT_BROWSER_EXECUTABLE_PATH` explicitly.

Browser support remains opt-in because Chromium increases the closure size
from `1.8 GiB` to `2.5 GiB`.

Adding the optional browser wrapper argument also exposed an existing wrapper-generation
bug: optional `makeWrapper` fragments were interpolated with manual trailing shell line
continuations. When an optional argument was absent, the generated command could retain
a malformed continuation. This PR builds a `wrapperArgs` list and joins only emitted
arguments, keeping the browser path, revision, and optional Python path independent.

## Related Issue

Related: #23380

PR #23380 addresses the same observed NixOS dynamic-linker failure by setting:

```nix
programs.nix-ld.enable = lib.mkDefault true;
```

That enables `nix-ld` system-wide on the host, allowing generic dynamically
linked Linux executables to run beyond Hermes itself.

This PR takes a narrower packaging approach:

- Browser support remains opt-in per Hermes installation.
- Hermes uses the Nixpkgs `agent-browser` package instead of relying on a
  generic Linux binary.
- Chromium is packaged and selected deterministically.
- It does not enable a host-wide compatibility loader or change how unrelated
  executables run on the system.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add a Linux-only `.#browser` package variant.
- Add `services.hermes-agent.enableBrowser`.
- Package Nixpkgs `agent-browser` 0.27.0 and Chromium.
- Wire `AGENT_BROWSER_EXECUTABLE_PATH` into Hermes wrappers.
- Build wrapper arguments as a list so omitted optional arguments cannot leave broken
  shell line continuations.
- Add a browser runtime regression check.
- Refresh the Nixpkgs pin and document Nix usage.

## How to Test

1. Run `nix build --no-link --print-build-logs`.
2. Run `nix build --no-link --print-build-logs .#browser .#checks.x86_64-linux.browser-runtime`.
3. Enable `services.hermes-agent.enableBrowser = true`.
4. Confirm the service wrapper contains `agent-browser` and
   `AGENT_BROWSER_EXECUTABLE_PATH`.
5. Confirm default and browser wrappers build when optional wrapper arguments are
   present or absent.
6. Launch the configured Chromium with
   `--headless --no-sandbox --disable-gpu --dump-dom about:blank`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64 with Nix 2.34.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the browser variant is Linux-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

- `agent-browser 0.27.0`
- Headless Chromium successfully opens `about:blank`.
- All individual `x86_64-linux` Nix checks pass.
- `nix flake show --all-systems --no-write-lock-file` passes.
- `git diff --check origin/main...HEAD` passes.
- Default closure: `1.8 GiB`
- Browser closure: `2.5 GiB`

`nix flake check --print-build-logs` currently fails while evaluating the
existing dev shell because `passthru.npmLockfile` is missing. The same failure
reproduces on untouched `origin/main`; open PR #37234 addresses that separate
issue. All individual Linux flake checks pass when built directly.