### PR TITLE
fix(gateway): preserve Discord session origin in resumed context

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -16,7 +16,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -1380,12 +1380,27 @@ def build_session_context(
         if home:
             home_channels[platform] = home
     
+    context_source = source
+    if session_entry and session_entry.origin:
+        origin = session_entry.origin
+        # The persisted origin is the stable routing lane for this session.
+        # Keep per-turn sender/message fields from the current event so shared
+        # sessions still attribute the active user correctly.
+        context_source = replace(
+            origin,
+            user_id=source.user_id,
+            user_name=source.user_name,
+            user_id_alt=source.user_id_alt,
+            is_bot=source.is_bot,
+            message_id=source.message_id,
+        )
+
     context = SessionContext(
-        source=source,
+        source=context_source,
         connected_platforms=connected,
         home_channels=home_channels,
         shared_multi_user_session=is_shared_multi_user_session(
-            source,
+            context_source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         ),

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -2,10 +2,12 @@
 import json
 import pytest
 from pathlib import Path
+from datetime import datetime
 from unittest.mock import patch, MagicMock
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import (
+    SessionEntry,
     SessionSource,
     SessionStore,
     build_session_context,
@@ -279,6 +281,60 @@ class TestBuildSessionContextPrompt:
 
         assert "Discord" in prompt
         assert "**Channel Topic:** Planning and coordination for Project X" in prompt
+
+    def test_discord_context_prefers_persisted_thread_origin_after_resume(self):
+        """Persisted thread metadata should drive the prompt after resume."""
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    token="fake-discord-token",
+                ),
+            },
+        )
+        original = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1488119232100175973",
+            chat_name="Hermes Agent discussion",
+            chat_type="thread",
+            user_id="alice",
+            user_name="Alice",
+            thread_id="1488119232100175973",
+            chat_topic="Hermes Agent discussion",
+            guild_id="guild-1",
+            parent_chat_id="parent-1",
+        )
+        stale_current = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="wrong-thread",
+            chat_name="Claude Code discussion",
+            chat_type="thread",
+            user_id="bob",
+            user_name="Bob",
+            thread_id="wrong-thread",
+            chat_topic="Claude Code discussion",
+            guild_id="guild-2",
+            parent_chat_id="parent-2",
+        )
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="agent:main:discord:thread:1488119232100175973:1488119232100175973",
+            session_id="compressed-child",
+            created_at=now,
+            updated_at=now,
+            origin=original,
+            platform=Platform.DISCORD,
+            chat_type="thread",
+        )
+
+        ctx = build_session_context(stale_current, config, entry)
+        prompt = build_session_context_prompt(ctx)
+
+        assert ctx.source.thread_id == "1488119232100175973"
+        assert ctx.source.parent_chat_id == "parent-1"
+        assert ctx.source.user_name == "Bob"
+        assert "Hermes Agent discussion" in prompt
+        assert "Claude Code discussion" not in prompt
 
     def test_prompt_omits_channel_topic_when_none(self):
         """Channel Topic line should NOT appear when chat_topic is None."""


### PR DESCRIPTION
## What does this PR do?

Preserves the original Discord session origin when building gateway session context for resumed sessions. This keeps the system prompt/header anchored to the persisted thread, channel, topic, guild, and parent-channel metadata after compression or resume, while still attributing the current turn to the active sender.

## Related Issue

Fixes #3964

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/session.py`: use the persisted `SessionEntry.origin` as the stable context source when available, copying only per-turn sender/message fields from the current event.
- `tests/gateway/test_session.py`: add a Discord regression test proving resumed thread context keeps the original thread/topic metadata and does not leak the wrong current-event thread header.

## How to Test

1. `pytest tests/gateway/test_session.py -q` → 75 passed.
2. `scripts/run_tests.sh` → ran the broad suite; exited non-zero with 25,440 passing tests and 768 failures across unrelated files. The failures were outside this diff and included sandbox-only socket bind `PermissionError`, restricted writes to `/Users/kon5i/.hermes`, live-system guard process-kill blocks, package import timeouts, and network lookup failures. Relevant gateway session coverage passed, including `tests/gateway/test_session.py` and `tests/gateway/test_resume_command.py` inside the wrapper.
3. `python scripts/check-windows-footguns.py gateway/session.py tests/gateway/test_session.py` → passed.
4. `git diff --check` → passed.
5. `ruff check gateway/session.py tests/gateway/test_session.py` → passed.
6. `ruff format --check gateway/session.py tests/gateway/test_session.py` → failed because both touched files have broad pre-existing formatting drift; not applied to avoid unrelated reformat churn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS/darwin-arm64 sandbox

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-c9fa0004 kind=pr-open -->