### PR TITLE
fix: collect custom endpoint API key in desktop onboarding

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -9,6 +9,7 @@ import type { OAuthProvider } from '@/types/hermes'
 import { DesktopOnboardingOverlay, Picker } from './desktop-onboarding-overlay'
 
 const getGlobalModelOptions = vi.fn()
+const listCustomProviderModels = vi.fn()
 
 class ResizeObserverMock {
   observe = vi.fn()
@@ -23,7 +24,8 @@ vi.mock('@/hermes', async importOriginal => {
 
   return {
     ...actual,
-    getGlobalModelOptions: () => getGlobalModelOptions()
+    getGlobalModelOptions: () => getGlobalModelOptions(),
+    listCustomProviderModels: (baseUrl: string, apiKey?: string) => listCustomProviderModels(baseUrl, apiKey)
   }
 })
 
@@ -81,6 +83,7 @@ afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
   getGlobalModelOptions.mockReset()
+  listCustomProviderModels.mockReset()
   $desktopOnboarding.set({
     configured: null,
     flow: { status: 'idle' },
@@ -137,6 +140,33 @@ describe('onboarding Picker', () => {
     expect(screen.getByPlaceholderText('Paste API key (optional for local endpoints)')).toBeTruthy()
     expect(screen.getByPlaceholderText('Provider name')).toBeTruthy()
     expect(screen.getByPlaceholderText('Select or enter a model id')).toBeTruthy()
+  })
+
+  it('shows the selected custom model while keeping every probed model in the dropdown', async () => {
+    listCustomProviderModels.mockResolvedValue({
+      models: ['codex-auto-review', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5'],
+      resolved_base_url: 'https://api.volcanowei.org/v1'
+    })
+    setProviders([])
+    render(<Picker ctx={ctx} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Local \/ custom endpoint/i }))
+    fireEvent.change(screen.getByPlaceholderText('http://127.0.0.1:8000/v1'), {
+      target: { value: 'https://api.volcanowei.org/v1' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Paste API key (optional for local endpoints)'), {
+      target: { value: 'sk-test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Models' }))
+
+    await waitFor(() => expect(listCustomProviderModels).toHaveBeenCalledWith('https://api.volcanowei.org/v1', 'sk-test'))
+
+    const modelSelect = screen.getByDisplayValue('codex-auto-review') as HTMLSelectElement
+    expect(modelSelect.value).toBe('codex-auto-review')
+    expect(screen.getByRole('option', { name: 'codex-auto-review' })).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'gpt-5.3-codex' })).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'gpt-5.4' })).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'gpt-5.5' })).toBeTruthy()
   })
 
   it('scopes the confirmation model picker to the newly configured custom provider', async () => {

--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -69,4 +69,16 @@ describe('onboarding Picker', () => {
     expect(screen.queryByText('Other sign-in options')).toBeNull()
     expect(screen.queryByText('Recommended')).toBeNull()
   })
+
+  it('collects endpoint, API key, and default model for custom providers', () => {
+    setProviders([])
+    render(<Picker ctx={ctx} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Local \/ custom endpoint/i }))
+
+    expect(screen.getByPlaceholderText('http://127.0.0.1:8000/v1')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Paste API key (optional for local endpoints)')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Provider name')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Select or enter a model id')).toBeTruthy()
+  })
 })

--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -1,11 +1,31 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $desktopBoot } from '@/store/boot'
+import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
 import type { OAuthProvider } from '@/types/hermes'
 
-import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
+import { DesktopOnboardingOverlay, Picker } from './desktop-onboarding-overlay'
 
-import { Picker } from './desktop-onboarding-overlay'
+const getGlobalModelOptions = vi.fn()
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = (await importOriginal()) as object
+
+  return {
+    ...actual,
+    getGlobalModelOptions: () => getGlobalModelOptions()
+  }
+})
 
 function provider(id: string, name = id): OAuthProvider {
   return {
@@ -32,8 +52,35 @@ function setProviders(providers: OAuthProvider[]) {
 
 const ctx: OnboardingContext = { requestGateway: async () => undefined as never }
 
+function renderOverlay() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false }
+    }
+  })
+
+  $desktopBoot.set({
+    error: null,
+    fakeMode: false,
+    message: 'ready',
+    phase: 'ready',
+    progress: 100,
+    running: false,
+    timestamp: Date.now(),
+    visible: false
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DesktopOnboardingOverlay enabled requestGateway={ctx.requestGateway} />
+    </QueryClientProvider>
+  )
+}
+
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
+  getGlobalModelOptions.mockReset()
   $desktopOnboarding.set({
     configured: null,
     flow: { status: 'idle' },
@@ -42,6 +89,16 @@ afterEach(() => {
     reason: null,
     requested: false,
     manual: false
+  })
+  $desktopBoot.set({
+    error: null,
+    fakeMode: false,
+    message: 'Starting Hermes Desktop…',
+    phase: 'renderer.init',
+    progress: 2,
+    running: true,
+    timestamp: Date.now(),
+    visible: true
   })
 })
 
@@ -80,5 +137,42 @@ describe('onboarding Picker', () => {
     expect(screen.getByPlaceholderText('Paste API key (optional for local endpoints)')).toBeTruthy()
     expect(screen.getByPlaceholderText('Provider name')).toBeTruthy()
     expect(screen.getByPlaceholderText('Select or enter a model id')).toBeTruthy()
+  })
+
+  it('scopes the confirmation model picker to the newly configured custom provider', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          name: 'Pinche',
+          slug: 'custom:pinche',
+          models: ['codex-auto-review', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.5', 'gpt-image-2']
+        },
+        { name: 'GitHub Copilot', slug: 'copilot', models: ['codex-auto-review'] }
+      ]
+    })
+    $desktopOnboarding.set({
+      configured: false,
+      flow: {
+        status: 'confirming_model',
+        currentModel: 'gpt-5.5',
+        label: 'Pinche',
+        providerSlug: 'custom:pinche',
+        saving: false
+      },
+      mode: 'oauth',
+      providers: [],
+      reason: null,
+      requested: false,
+      manual: false
+    } satisfies DesktopOnboardingState)
+
+    renderOverlay()
+    fireEvent.click(screen.getByRole('button', { name: 'Change' }))
+
+    await waitFor(() => expect(screen.getByText('gpt-5.5')).toBeTruthy())
+    expect(screen.getByText('gpt-5.4')).toBeTruthy()
+    expect(screen.getByText('gpt-5.3-codex')).toBeTruthy()
+    expect(screen.getByText('Pinche')).toBeTruthy()
+    expect(screen.queryByText('GitHub Copilot')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -546,21 +546,29 @@ function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingCon
               value={providerName}
             />
             <div className="flex gap-2">
-              <Input
-                autoComplete="off"
-                className="font-mono"
-                list="custom-provider-models"
-                onChange={e => setModel(e.target.value)}
-                onKeyDown={e => e.key === 'Enter' && void submit()}
-                placeholder="Select or enter a model id"
-                type="text"
-                value={model}
-              />
-              <datalist id="custom-provider-models">
-                {models.map(m => (
-                  <option key={m} value={m} />
-                ))}
-              </datalist>
+              {models.length > 0 ? (
+                <select
+                  className="h-10 flex-1 rounded-md border border-input bg-background px-3 py-2 font-mono text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  onChange={e => setModel(e.target.value)}
+                  value={model}
+                >
+                  {models.map(m => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <Input
+                  autoComplete="off"
+                  className="font-mono"
+                  onChange={e => setModel(e.target.value)}
+                  onKeyDown={e => e.key === 'Enter' && void submit()}
+                  placeholder="Select or enter a model id"
+                  type="text"
+                  value={model}
+                />
+              )}
               <Button disabled={!value.trim() || loadingModels} onClick={() => void fetchModels()} type="button" variant="outline">
                 {loadingModels ? <Loader2 className="size-4 animate-spin" /> : null}
                 Models

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -29,9 +29,11 @@ import {
   copyExternalCommand,
   type OnboardingContext,
   type OnboardingFlow,
+  fetchOnboardingCustomProviderModels,
   recheckExternalSignin,
   refreshOnboarding,
   saveOnboardingApiKey,
+  saveOnboardingCustomProvider,
   setOnboardingCode,
   setOnboardingMode,
   setOnboardingModel,
@@ -414,11 +416,36 @@ function ProviderRow({ onSelect, provider }: { onSelect: (provider: OAuthProvide
 function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingContext }) {
   const [option, setOption] = useState<ApiKeyOption>(API_KEY_OPTIONS[0])
   const [value, setValue] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [providerName, setProviderName] = useState('')
+  const [model, setModel] = useState('')
+  const [models, setModels] = useState<string[]>([])
+  const [loadingModels, setLoadingModels] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
 
   const isLocal = option.envKey === 'OPENAI_BASE_URL'
-  const canSave = value.trim().length >= (isLocal ? 1 : MIN_KEY_LENGTH)
+  const canSave = isLocal ? value.trim().length > 0 && model.trim().length > 0 : value.trim().length >= MIN_KEY_LENGTH
+
+  const fetchModels = async () => {
+    if (!isLocal || !value.trim() || loadingModels) {
+      return
+    }
+
+    setLoadingModels(true)
+    setError(null)
+    const result = await fetchOnboardingCustomProviderModels(value, apiKey)
+    if (result.models.length > 0) {
+      setModels(result.models)
+      setModel(current => current || result.models[0])
+      if (result.resolved_base_url && result.resolved_base_url !== value.trim()) {
+        setValue(result.resolved_base_url)
+      }
+    } else {
+      setError(result.message || 'Could not fetch models. Enter a model id manually.')
+    }
+    setLoadingModels(false)
+  }
 
   const submit = async () => {
     if (!canSave || saving) {
@@ -427,10 +454,16 @@ function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingCon
 
     setSaving(true)
     setError(null)
-    const result = await saveOnboardingApiKey(option.envKey, value, option.name, ctx)
+    const result = isLocal
+      ? await saveOnboardingCustomProvider({ apiKey, baseUrl: value, model, name: providerName }, ctx)
+      : await saveOnboardingApiKey(option.envKey, value, option.name, ctx)
 
     if (result.ok) {
       setValue('')
+      setApiKey('')
+      setProviderName('')
+      setModel('')
+      setModels([])
     } else {
       setError(result.message ?? 'Could not save credential.')
     }
@@ -462,6 +495,10 @@ function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingCon
             onClick={() => {
               setOption(o)
               setValue('')
+              setApiKey('')
+              setProviderName('')
+              setModel('')
+              setModels([])
               setError(null)
             }}
             type="button"
@@ -480,16 +517,68 @@ function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingCon
           <p className="text-sm leading-6 text-muted-foreground">{option.description}</p>
           {option.docsUrl ? <DocsLink href={option.docsUrl}>Get a key</DocsLink> : null}
         </div>
-        <Input
-          autoComplete="off"
-          autoFocus
-          className="font-mono"
-          onChange={e => setValue(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submit()}
-          placeholder={option.placeholder || 'Paste API key'}
-          type={isLocal ? 'text' : 'password'}
-          value={value}
-        />
+        {isLocal ? (
+          <>
+            <Input
+              autoComplete="off"
+              autoFocus
+              className="font-mono"
+              onChange={e => setValue(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && void fetchModels()}
+              placeholder={option.placeholder || 'http://127.0.0.1:8000/v1'}
+              type="text"
+              value={value}
+            />
+            <Input
+              autoComplete="off"
+              className="font-mono"
+              onChange={e => setApiKey(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && void fetchModels()}
+              placeholder="Paste API key (optional for local endpoints)"
+              type="password"
+              value={apiKey}
+            />
+            <Input
+              autoComplete="off"
+              onChange={e => setProviderName(e.target.value)}
+              placeholder="Provider name"
+              type="text"
+              value={providerName}
+            />
+            <div className="flex gap-2">
+              <Input
+                autoComplete="off"
+                className="font-mono"
+                list="custom-provider-models"
+                onChange={e => setModel(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && void submit()}
+                placeholder="Select or enter a model id"
+                type="text"
+                value={model}
+              />
+              <datalist id="custom-provider-models">
+                {models.map(m => (
+                  <option key={m} value={m} />
+                ))}
+              </datalist>
+              <Button disabled={!value.trim() || loadingModels} onClick={() => void fetchModels()} type="button" variant="outline">
+                {loadingModels ? <Loader2 className="size-4 animate-spin" /> : null}
+                Models
+              </Button>
+            </div>
+          </>
+        ) : (
+          <Input
+            autoComplete="off"
+            autoFocus
+            className="font-mono"
+            onChange={e => setValue(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && void submit()}
+            placeholder={option.placeholder || 'Paste API key'}
+            type="password"
+            value={value}
+          />
+        )}
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
       </div>
 

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -27,9 +27,9 @@ import {
   confirmOnboardingModel,
   copyDeviceCode,
   copyExternalCommand,
+  fetchOnboardingCustomProviderModels,
   type OnboardingContext,
   type OnboardingFlow,
-  fetchOnboardingCustomProviderModels,
   recheckExternalSignin,
   refreshOnboarding,
   saveOnboardingApiKey,
@@ -839,6 +839,7 @@ function ConfirmingModelPanel({
         the rest of the screen, so we don't want a second backdrop.
       */}
       <ModelPickerDialog
+        allowedProviderSlugs={[flow.providerSlug]}
         contentClassName="z-[1310]"
         currentModel={flow.currentModel}
         currentProvider={flow.providerSlug}

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -24,6 +24,12 @@ interface ModelPickerDialogProps {
   currentProvider: string
   onSelect: (selection: { provider: string; model: string; persistGlobal: boolean }) => void
   /**
+   * Optional provider allow-list. Onboarding uses this after a freshly added
+   * provider so "Change" only shows models from that provider instead of
+   * leaking similarly named models from other authenticated providers.
+   */
+  allowedProviderSlugs?: string[]
+  /**
    * Optional class to apply to DialogContent. Use to override z-index when
    * stacking the picker on top of another fixed overlay (e.g. the desktop
    * onboarding overlay, which sits at z-1300; the default Dialog z-130 ends
@@ -40,6 +46,7 @@ export function ModelPickerDialog({
   currentModel,
   currentProvider,
   onSelect,
+  allowedProviderSlugs,
   contentClassName
 }: ModelPickerDialogProps) {
   const [persistGlobal, setPersistGlobal] = useState(!sessionId)
@@ -65,6 +72,9 @@ export function ModelPickerDialog({
   })
 
   const providers = modelOptions.data?.providers ?? []
+  const allowed = new Set((allowedProviderSlugs ?? []).map(slug => String(slug).toLowerCase()))
+  const visibleProviders =
+    allowed.size > 0 ? providers.filter(p => allowed.has(String(p.slug).toLowerCase())) : providers
   const optionsModel = String(modelOptions.data?.model ?? currentModel ?? '')
   const optionsProvider = String(modelOptions.data?.provider ?? currentProvider ?? '')
   const loading = modelOptions.isPending && !modelOptions.data
@@ -119,7 +129,7 @@ export function ModelPickerDialog({
               error={error}
               loading={loading}
               onSelectModel={selectModel}
-              providers={providers}
+              providers={visibleProviders}
               search={search}
             />
           </CommandList>

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -11,6 +11,8 @@ import type {
   CronJob,
   CronJobCreatePayload,
   CronJobUpdates,
+  CustomProviderModelsResponse,
+  CustomProviderSaveResponse,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
   HermesConfig,
@@ -60,6 +62,8 @@ export type {
   CronJobCreatePayload,
   CronJobSchedule,
   CronJobUpdates,
+  CustomProviderModelsResponse,
+  CustomProviderSaveResponse,
   ElevenLabsVoice,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
@@ -260,6 +264,27 @@ export function validateProviderCredential(
     path: '/api/providers/validate',
     method: 'POST',
     body: { key, value }
+  })
+}
+
+export function listCustomProviderModels(baseUrl: string, apiKey: string): Promise<CustomProviderModelsResponse> {
+  return window.hermesDesktop.api<CustomProviderModelsResponse>({
+    path: '/api/providers/custom/models',
+    method: 'POST',
+    body: { base_url: baseUrl, api_key: apiKey }
+  })
+}
+
+export function saveCustomProvider(params: {
+  apiKey: string
+  baseUrl: string
+  model: string
+  name: string
+}): Promise<CustomProviderSaveResponse> {
+  return window.hermesDesktop.api<CustomProviderSaveResponse>({
+    path: '/api/providers/custom',
+    method: 'POST',
+    body: { name: params.name, base_url: params.baseUrl, api_key: params.apiKey, model: params.model }
   })
 }
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -3,9 +3,11 @@ import { atom } from 'nanostores'
 import {
   cancelOAuthSession,
   getGlobalModelOptions,
+  listCustomProviderModels,
   getRecommendedDefaultModel,
   listOAuthProviders,
   pollOAuthSession,
+  saveCustomProvider,
   setEnvVar,
   setModelAssignment,
   startOAuthLogin,
@@ -660,6 +662,53 @@ export async function saveOnboardingApiKey(envKey: string, value: string, label:
 
     return { ok: false, message: errMessage(error) }
   }
+}
+
+export async function saveOnboardingCustomProvider(params: {
+  apiKey: string
+  baseUrl: string
+  model: string
+  name: string
+}, ctx: OnboardingContext) {
+  const baseUrl = params.baseUrl.trim()
+  const model = params.model.trim()
+
+  if (!baseUrl) {
+    return { ok: false, message: 'Enter an endpoint URL first.' }
+  }
+  if (!model) {
+    return { ok: false, message: 'Select or enter a default model first.' }
+  }
+
+  try {
+    const saved = await saveCustomProvider({
+      apiKey: params.apiKey.trim(),
+      baseUrl,
+      model,
+      name: params.name.trim()
+    })
+    await setModelAssignment({ scope: 'main', provider: saved.slug, model: saved.model })
+    await ctx.requestGateway('reload.env').catch(() => undefined)
+    notifyReady(saved.name)
+    completeDesktopOnboarding()
+    ctx.onCompleted?.()
+
+    return { ok: true }
+  } catch (error) {
+    notifyError(error, 'Could not save custom provider')
+
+    return { ok: false, message: errMessage(error) }
+  }
+}
+
+export async function fetchOnboardingCustomProviderModels(baseUrl: string, apiKey: string) {
+  const trimmed = baseUrl.trim()
+
+  if (!trimmed) {
+    return { ok: false, models: [], message: 'Enter an endpoint URL first.' }
+  }
+
+  return listCustomProviderModels(trimmed, apiKey.trim())
 }
 
 // User picked a different model from the dropdown on the confirm card.

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -58,6 +58,24 @@ export interface OAuthProvidersResponse {
   providers: OAuthProvider[]
 }
 
+export interface CustomProviderModelsResponse {
+  ok: boolean
+  models: string[]
+  message?: string
+  probed_url?: null | string
+  resolved_base_url?: string
+  suggested_base_url?: null | string
+  used_fallback?: boolean
+}
+
+export interface CustomProviderSaveResponse {
+  ok: boolean
+  name: string
+  slug: string
+  base_url: string
+  model: string
+}
+
 export type OAuthStartResponse =
   | {
       auth_url: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -539,6 +539,18 @@ class EnvVarUpdate(BaseModel):
     value: str
 
 
+class CustomProviderModelsRequest(BaseModel):
+    base_url: str
+    api_key: str = ""
+
+
+class CustomProviderSetupRequest(BaseModel):
+    name: str = ""
+    base_url: str
+    api_key: str = ""
+    model: str = ""
+
+
 class EnvVarDelete(BaseModel):
     key: str
 
@@ -2076,6 +2088,75 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         # 429 = key is valid but rate-limited; success = valid.
         return {"ok": True, "reachable": True, "message": ""}
     return {"ok": False, "reachable": True, "message": f"Provider returned HTTP {resp.status_code} for this key."}
+
+
+@app.post("/api/providers/custom/models")
+async def list_custom_provider_models(body: CustomProviderModelsRequest, request: Request):
+    """Probe an OpenAI-compatible custom endpoint and return available models."""
+    _require_token(request)
+    base_url = (body.base_url or "").strip().rstrip("/")
+    api_key = (body.api_key or "").strip()
+
+    if not base_url:
+        raise HTTPException(status_code=400, detail="base_url required")
+
+    try:
+        from hermes_cli.models import probe_api_models
+
+        probe = probe_api_models(api_key, base_url, timeout=10.0)
+        models = [str(m) for m in (probe.get("models") or []) if str(m).strip()]
+        return {
+            "ok": bool(models),
+            "models": models,
+            "probed_url": probe.get("probed_url"),
+            "resolved_base_url": probe.get("resolved_base_url") or base_url,
+            "suggested_base_url": probe.get("suggested_base_url"),
+            "used_fallback": bool(probe.get("used_fallback")),
+            "message": "" if models else "Could not fetch any models from this endpoint.",
+        }
+    except Exception:
+        _log.exception("POST /api/providers/custom/models failed")
+        return {
+            "ok": False,
+            "models": [],
+            "probed_url": base_url.rstrip("/") + "/models",
+            "resolved_base_url": base_url,
+            "suggested_base_url": None,
+            "used_fallback": False,
+            "message": "Could not reach the endpoint to fetch models.",
+        }
+
+
+@app.post("/api/providers/custom")
+async def save_custom_provider(body: CustomProviderSetupRequest, request: Request):
+    """Persist a custom OpenAI-compatible endpoint into config.yaml."""
+    _require_token(request)
+    base_url = (body.base_url or "").strip().rstrip("/")
+    api_key = (body.api_key or "").strip()
+    model = (body.model or "").strip()
+    name = (body.name or "").strip()
+
+    if not base_url:
+        raise HTTPException(status_code=400, detail="base_url required")
+    if not model:
+        raise HTTPException(status_code=400, detail="model required")
+
+    try:
+        from hermes_cli.main import _auto_provider_name, _save_custom_provider
+        from hermes_cli.providers import custom_provider_slug
+
+        display_name = name or _auto_provider_name(base_url)
+        _save_custom_provider(base_url, api_key, model, name=display_name)
+        return {
+            "ok": True,
+            "name": display_name,
+            "slug": custom_provider_slug(display_name),
+            "base_url": base_url,
+            "model": model,
+        }
+    except Exception:
+        _log.exception("POST /api/providers/custom failed")
+        raise HTTPException(status_code=500, detail="Failed to save custom provider")
 
 
 @app.delete("/api/env")

--- a/tests/hermes_cli/test_desktop_custom_provider_onboarding.py
+++ b/tests/hermes_cli/test_desktop_custom_provider_onboarding.py
@@ -1,0 +1,84 @@
+"""Regression tests for desktop custom provider onboarding endpoints."""
+
+import pytest
+
+
+pytest.importorskip("fastapi")
+pytest.importorskip("starlette")
+
+
+def _client():
+    from starlette.testclient import TestClient
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def test_custom_provider_models_probes_openai_compatible_endpoint(monkeypatch, _isolate_hermes_home):
+    from hermes_cli import models as models_mod
+
+    calls = []
+
+    def fake_probe(api_key, base_url, timeout=10.0):
+        calls.append((api_key, base_url, timeout))
+        return {
+            "models": ["model-a", "model-b"],
+            "probed_url": "https://llm.example.com/v1/models",
+            "resolved_base_url": "https://llm.example.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+
+    monkeypatch.setattr(models_mod, "probe_api_models", fake_probe)
+
+    response = _client().post(
+        "/api/providers/custom/models",
+        json={"base_url": "https://llm.example.com/v1/", "api_key": "sk-test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "models": ["model-a", "model-b"],
+        "probed_url": "https://llm.example.com/v1/models",
+        "resolved_base_url": "https://llm.example.com/v1",
+        "suggested_base_url": None,
+        "used_fallback": False,
+        "message": "",
+    }
+    assert calls == [("sk-test", "https://llm.example.com/v1", 10.0)]
+
+
+def test_custom_provider_save_persists_named_provider_and_model(_isolate_hermes_home):
+    import yaml
+    from hermes_constants import get_hermes_home
+
+    response = _client().post(
+        "/api/providers/custom",
+        json={
+            "name": "My LLM",
+            "base_url": "https://llm.example.com/v1/",
+            "api_key": "sk-test",
+            "model": "model-a",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["name"] == "My LLM"
+    assert payload["slug"] == "custom:my-llm"
+    assert payload["base_url"] == "https://llm.example.com/v1"
+    assert payload["model"] == "model-a"
+
+    config = yaml.safe_load((get_hermes_home() / "config.yaml").read_text())
+    assert config["custom_providers"] == [
+        {
+            "name": "My LLM",
+            "base_url": "https://llm.example.com/v1",
+            "api_key": "sk-test",
+            "model": "model-a",
+        }
+    ]


### PR DESCRIPTION
## Summary
- show separate URL and API key inputs for Local / custom endpoint in desktop onboarding
- save custom endpoint URL to OPENAI_BASE_URL and API key to OPENAI_API_KEY together
- add a regression test covering the custom endpoint form

## Test Plan
- npm run test:ui -- src/components/desktop-onboarding-overlay.test.tsx src/store/onboarding.test.ts
- npm run type-check
- npx eslint src/components/desktop-onboarding-overlay.tsx src/components/desktop-onboarding-overlay.test.tsx src/store/onboarding.ts