### PR TITLE
feat(browser): add browser_upload to attach files to file inputs

### DIFF
--- a/tests/tools/test_browser_upload.py
+++ b/tests/tools/test_browser_upload.py
@@ -1,0 +1,106 @@
+"""Tests for browser_upload — the file-upload primitive.
+
+Before this, Hermes's browser tool had no way to attach a file to a file
+input (only navigate/click/type/etc.), so "upload a file to a website"
+tasks were impossible without bootstrapping a separate Playwright browser.
+agent-browser already supports an ``upload <selector> <files...>`` verb;
+browser_upload exposes it.
+"""
+
+import json
+
+import pytest
+
+import tools.browser_tool as bt
+
+
+def _call(monkeypatch, *, camofox=False, captured=None, success=True):
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: camofox)
+    monkeypatch.setattr(bt, "_last_session_key", lambda x: x)
+
+    def _fake_run(task_id, command, args):
+        if captured is not None:
+            captured["task_id"] = task_id
+            captured["command"] = command
+            captured["args"] = args
+        return {"success": success} if success else {"success": False, "error": "boom"}
+
+    monkeypatch.setattr(bt, "_run_browser_command", _fake_run)
+
+
+class TestBrowserUpload:
+    def test_camofox_mode_not_supported(self, monkeypatch, tmp_path):
+        _call(monkeypatch, camofox=True)
+        f = tmp_path / "p.pdf"; f.write_bytes(b"%PDF-1.4")
+        out = json.loads(bt.browser_upload("input[type=file]", [str(f)]))
+        assert out["success"] is False
+        assert "camofox" in out["error"].lower()
+
+    def test_missing_file_errors(self, monkeypatch):
+        captured = {}
+        _call(monkeypatch, captured=captured)
+        out = json.loads(bt.browser_upload("input[type=file]", ["/no/such/file.pdf"]))
+        assert out["success"] is False
+        assert "not found" in out["error"].lower()
+        assert "command" not in captured  # never reached agent-browser
+
+    def test_no_files_errors(self, monkeypatch):
+        _call(monkeypatch)
+        out = json.loads(bt.browser_upload("input[type=file]", []))
+        assert out["success"] is False
+        assert "no files" in out["error"].lower()
+
+    def test_single_string_file_normalized_and_uploaded(self, monkeypatch, tmp_path):
+        captured = {}
+        _call(monkeypatch, captured=captured)
+        f = tmp_path / "policy.pdf"; f.write_bytes(b"%PDF-1.4 x")
+        out = json.loads(bt.browser_upload("input[type=file]", str(f)))  # bare string, not list
+        assert out["success"] is True
+        assert captured["command"] == "upload"
+        # selector first, then absolute file path(s)
+        assert captured["args"][0] == "input[type=file]"
+        assert captured["args"][1] == str(f.resolve())
+        assert out["uploaded"] == [str(f.resolve())]
+
+    def test_multiple_files_all_passed(self, monkeypatch, tmp_path):
+        captured = {}
+        _call(monkeypatch, captured=captured)
+        a = tmp_path / "a.pdf"; a.write_bytes(b"a")
+        b = tmp_path / "b.pdf"; b.write_bytes(b"b")
+        out = json.loads(bt.browser_upload("@e5", [str(a), str(b)]))
+        assert out["success"] is True
+        assert captured["args"] == ["@e5", str(a.resolve()), str(b.resolve())]
+
+    def test_bare_ref_gets_at_prefix_but_css_selector_untouched(self, monkeypatch, tmp_path):
+        f = tmp_path / "x.pdf"; f.write_bytes(b"x")
+        # bare ref "e7" -> "@e7"
+        cap1 = {}
+        _call(monkeypatch, captured=cap1)
+        bt.browser_upload("e7", [str(f)])
+        assert cap1["args"][0] == "@e7"
+        # CSS selector left as-is
+        cap2 = {}
+        _call(monkeypatch, captured=cap2)
+        bt.browser_upload("input[type=file]", [str(f)])
+        assert cap2["args"][0] == "input[type=file]"
+        # already-@ ref left as-is
+        cap3 = {}
+        _call(monkeypatch, captured=cap3)
+        bt.browser_upload("@e9", [str(f)])
+        assert cap3["args"][0] == "@e9"
+
+    def test_upload_failure_surfaced(self, monkeypatch, tmp_path):
+        _call(monkeypatch, success=False)
+        f = tmp_path / "x.pdf"; f.write_bytes(b"x")
+        out = json.loads(bt.browser_upload("input[type=file]", [str(f)]))
+        assert out["success"] is False
+
+
+class TestBrowserUploadRegistered:
+    def test_schema_present(self):
+        assert "browser_upload" in bt._BROWSER_SCHEMA_MAP
+        sch = bt._BROWSER_SCHEMA_MAP["browser_upload"]
+        assert sch["parameters"]["required"] == ["ref", "files"]
+
+    def test_function_exists(self):
+        assert callable(bt.browser_upload)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1530,6 +1530,25 @@ BROWSER_TOOL_SCHEMAS = [
         }
     },
     {
+        "name": "browser_upload",
+        "description": "Attach one or more local files to a file-input element (a website's 'Choose file' / 'Upload Existing' control). Use this for ALL file uploads — clicking 'Choose file' yourself only opens an OS dialog you cannot operate; this sets the input's files directly. Target the file input by its snapshot ref (e.g. '@e5') OR, when the input is hidden behind a styled button (common), by a CSS selector like 'input[type=file]'. Requires browser_navigate first.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "The file input's snapshot ref (e.g. '@e5') or a CSS selector (e.g. 'input[type=file]')."
+                },
+                "files": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Absolute path(s) of the local file(s) to attach."
+                }
+            },
+            "required": ["ref", "files"]
+        }
+    },
+    {
         "name": "browser_scroll",
         "description": "Scroll the page in a direction. Use this to reveal more content that may be below or above the current viewport. Requires browser_navigate to be called first.",
         "parameters": {
@@ -2628,6 +2647,93 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         response = {
             "success": False,
             "error": result.get("error", f"Failed to type into {ref}")
+        }
+        return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+
+
+def browser_upload(ref: str, files, task_id: Optional[str] = None) -> str:
+    """Attach one or more local files to a file-input element.
+
+    This is the supported way to drive a website's "Choose file" / upload
+    control. Clicking "Choose file" opens an OS file picker the agent
+    cannot operate; this command sets the input's files programmatically
+    via agent-browser's ``upload`` verb (no dialog), against the same
+    already-authenticated browser session as the other ``browser_*`` tools.
+
+    Args:
+        ref: Either an element ref from the snapshot (e.g. ``"@e5"``) or a
+            CSS selector for the file input (e.g. ``"input[type=file]"``).
+            File inputs are frequently hidden behind a styled button and may
+            not appear in the accessibility snapshot — in that case target
+            them by CSS selector such as ``input[type=file]``.
+        files: A single file path, or a list of file paths, to attach. Paths
+            are validated to exist and resolved to absolute paths.
+        task_id: Task identifier for session isolation.
+
+    Returns:
+        JSON string with the upload result.
+    """
+    if _is_camofox_mode():
+        return json.dumps(
+            {
+                "success": False,
+                "error": "browser_upload is not supported in camofox mode; "
+                         "use the default agent-browser engine for file uploads.",
+            },
+            ensure_ascii=False,
+        )
+
+    effective_task_id = _last_session_key(task_id or "default")
+
+    # Normalize the files argument to a list.
+    if isinstance(files, str):
+        file_list = [files]
+    elif files is None:
+        file_list = []
+    else:
+        file_list = [str(f) for f in files]
+    if not file_list:
+        return json.dumps(
+            {"success": False, "error": "No files provided to upload"},
+            ensure_ascii=False,
+        )
+
+    # Validate + resolve to absolute paths so agent-browser receives an
+    # unambiguous location regardless of its working directory.
+    abs_files: list[str] = []
+    missing: list[str] = []
+    for f in file_list:
+        expanded = os.path.abspath(os.path.expanduser(f))
+        if os.path.isfile(expanded):
+            abs_files.append(expanded)
+        else:
+            missing.append(f)
+    if missing:
+        return json.dumps(
+            {"success": False, "error": f"File(s) not found: {missing}"},
+            ensure_ascii=False,
+        )
+
+    # agent-browser accepts a @ref or a CSS selector as the target. Only
+    # add the leading "@" for bare ref-style ids (e.g. "e5"); leave CSS
+    # selectors like "input[type=file]" untouched.
+    selector = (ref or "").strip()
+    if re.fullmatch(r"e\d+", selector):
+        selector = f"@{selector}"
+
+    result = _run_browser_command(effective_task_id, "upload", [selector, *abs_files])
+
+    if result.get("success"):
+        response = {
+            "success": True,
+            "uploaded": abs_files,
+            "element": selector,
+        }
+        return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
+    else:
+        response = {
+            "success": False,
+            "error": result.get("error", f"Failed to upload file(s) to {selector}"),
         }
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
@@ -3811,6 +3917,14 @@ registry.register(
     handler=lambda args, **kw: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="⌨️",
+)
+registry.register(
+    name="browser_upload",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_upload"],
+    handler=lambda args, **kw: browser_upload(ref=args.get("ref", ""), files=args.get("files", []), task_id=kw.get("task_id")),
+    check_fn=check_browser_requirements,
+    emoji="📎",
 )
 registry.register(
     name="browser_scroll",


### PR DESCRIPTION
## What

Adds a `browser_upload` tool that attaches local files to a file-input element through the existing browser session.

## Why

The built-in browser tools (`navigate`/`click`/`type`/`snapshot`/`scroll`/`back`/`press`/`console`/`get_images`/`vision`) had **no way to attach a file to a file input**. That makes any "upload a file to a website" task effectively impossible for an agent:

- Clicking "Choose file" only opens an OS file-picker dialog the agent can't drive.
- The workaround — bootstrapping a *separate* Playwright/chromium and scripting `setInputFiles` — starts logged-out, doesn't share the agent's session, and is fragile (browser-version mismatches, re-login, etc.).

The underlying `agent-browser` binary **already supports** an `upload <selector> <files...>` verb — Hermes just never exposed it. This wires it in.

## How

`browser_upload(ref, files)`:
- Runs against the **same already-authenticated session** as the other `browser_*` tools — no separate browser, no re-login.
- `ref` accepts a snapshot ref (`@e5`) **or** a CSS selector (`input[type=file]`). File inputs are usually hidden behind a styled button and absent from the accessibility snapshot, so CSS targeting matters; bare ref ids like `e5` are normalized to `@e5`.
- `files` accepts one path or a list; existence is validated and paths resolved to absolute.
- Clear errors on missing files and in camofox mode (unsupported there).

## Tests

`tests/tools/test_browser_upload.py` — 9 cases: single/multi-file, ref-vs-CSS handling, camofox guard, missing-file guard, upload-failure surfacing, and tool registration. No regressions in the browser test suite.

## Notes

Real-world motivation: uploading a batch of policy PDFs into a school-admin web app. With this, that's a single `browser_upload('input[type=file]', ['/path/to.pdf'])` call in the logged-in session instead of a multi-step external-Playwright workaround.
