### PR TITLE
fix(cli): suppress OAuth provider warnings in doctor when provider not in use

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -637,6 +637,10 @@ def run_doctor(args):
                 check_info("Run 'hermes setup' to create one")
                 issues.append("Run 'hermes setup' to create .env")
     
+    # Tracks the model.provider from config.yaml so the Auth Providers section
+    # can suppress warnings for OAuth providers the user is not using.
+    _doctor_configured_provider: str = ""
+
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'
     if config_path.exists():
@@ -649,6 +653,7 @@ def run_doctor(args):
             model_section = cfg.get("model") or {}
             provider_raw = (model_section.get("provider") or "").strip()
             provider = provider_raw.lower()
+            _doctor_configured_provider = provider
             default_model = (model_section.get("default") or model_section.get("model") or "").strip()
 
             known_providers: set = set()
@@ -936,6 +941,42 @@ def run_doctor(args):
 
     _section("Auth Providers")
 
+    # Map each OAuth provider's stable key to the set of model.provider values
+    # that require its credential. Only emit a warning when the user's
+    # configured provider is in the relevant set; otherwise demote to an info
+    # line so it doesn't look like something that needs fixing.
+    _OAUTH_PROVIDER_IDS: dict[str, set[str]] = {
+        "nous": {"nous"},
+        "openai-codex": {"openai-codex", "codex"},
+        "gemini": {"gemini", "google", "google-gemini"},
+        "minimax": {"minimax"},
+        "xai": {"xai", "grok"},
+    }
+
+    def _oauth_check(name: str, oauth_key: str, logged_in: bool, detail_ok: str = "(logged in)") -> bool:
+        """Print ok / warn / info for an OAuth provider.
+
+        Returns True when the row was printed as ok or warn (i.e. the provider
+        is relevant to the user's current config), so callers can attach
+        follow-up hint lines only for actionable rows.
+        """
+        relevant_ids = _OAUTH_PROVIDER_IDS.get(oauth_key, set())
+        is_active = (
+            not _doctor_configured_provider  # no provider set — show all
+            or _doctor_configured_provider in {"auto"}
+            or _doctor_configured_provider in relevant_ids
+        )
+        if logged_in:
+            check_ok(name, detail_ok)
+            return True
+        if is_active:
+            check_warn(name, "(not logged in)")
+            return True
+        # Not the active provider — demote to info; still visible but not
+        # flagged as something the user needs to act on.
+        check_info(f"{name}: not logged in (not your active provider — skipped)")
+        return False
+
     try:
         from hermes_cli.auth import (
             get_nous_auth_status,
@@ -945,16 +986,11 @@ def run_doctor(args):
         )
 
         nous_status = get_nous_auth_status()
-        if nous_status.get("logged_in"):
-            check_ok("Nous Portal auth", "(logged in)")
-        else:
-            check_warn("Nous Portal auth", "(not logged in)")
+        _oauth_check("Nous Portal auth", "nous", nous_status.get("logged_in", False))
 
         codex_status = get_codex_auth_status()
-        if codex_status.get("logged_in"):
-            check_ok("OpenAI Codex auth", "(logged in)")
-        else:
-            check_warn("OpenAI Codex auth", "(not logged in)")
+        codex_active = _oauth_check("OpenAI Codex auth", "openai-codex", codex_status.get("logged_in", False))
+        if codex_active and not codex_status.get("logged_in"):
             if codex_status.get("error"):
                 check_info(codex_status["error"])
             # Native OAuth uses Hermes' own device-code flow — the Codex CLI is
@@ -978,16 +1014,16 @@ def run_doctor(args):
             if project:
                 pieces.append(f"project={project}")
             suffix = f" ({', '.join(pieces)})" if pieces else ""
-            check_ok("Google Gemini OAuth", f"(logged in{suffix})")
+            _oauth_check("Google Gemini OAuth", "gemini", True, f"(logged in{suffix})")
         else:
-            check_warn("Google Gemini OAuth", "(not logged in)")
+            _oauth_check("Google Gemini OAuth", "gemini", False)
 
         minimax_status = get_minimax_oauth_auth_status()
         if minimax_status.get("logged_in"):
             region = minimax_status.get("region", "global")
-            check_ok("MiniMax OAuth", f"(logged in, region={region})")
+            _oauth_check("MiniMax OAuth", "minimax", True, f"(logged in, region={region})")
         else:
-            check_warn("MiniMax OAuth", "(not logged in)")
+            _oauth_check("MiniMax OAuth", "minimax", False)
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
@@ -996,12 +1032,9 @@ def run_doctor(args):
     try:
         from hermes_cli.auth import get_xai_oauth_auth_status
         xai_oauth_status = get_xai_oauth_auth_status() or {}
-        if xai_oauth_status.get("logged_in"):
-            check_ok("xAI OAuth", "(logged in)")
-        else:
-            check_warn("xAI OAuth", "(not logged in)")
-            if xai_oauth_status.get("error"):
-                check_info(xai_oauth_status["error"])
+        xai_active = _oauth_check("xAI OAuth", "xai", xai_oauth_status.get("logged_in", False))
+        if xai_active and not xai_oauth_status.get("logged_in") and xai_oauth_status.get("error"):
+            check_info(xai_oauth_status["error"])
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1274,3 +1274,98 @@ class TestDoctorCodexCliHintPlacement:
         minimax_idx = next(i for i, l in enumerate(lines) if "MiniMax OAuth" in l)
         assert self._hint_line() not in lines[minimax_idx - 1]
         assert minimax_idx + 1 >= len(lines) or self._hint_line() not in lines[minimax_idx + 1]
+
+
+# ---------------------------------------------------------------------------
+# ◆ Auth Providers — suppress warnings for OAuth providers not in use
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorOAuthSkippedForUnusedProviders:
+    """OAuth provider rows should be warnings only for the active provider.
+
+    When model.provider is set to something that doesn't use a given OAuth
+    flow (e.g. ``custom`` pointing at a local endpoint), showing ``⚠ not
+    logged in`` for every OAuth provider is noise. Those rows should be
+    demoted to informational ``→`` lines so they don't appear as actionable
+    issues.
+    """
+
+    _OAUTH_NAMES = [
+        "Nous Portal auth",
+        "OpenAI Codex auth",
+        "Google Gemini OAuth",
+        "MiniMax OAuth",
+        "xAI OAuth",
+    ]
+
+    def _run(self, monkeypatch, tmp_path, provider: str) -> str:
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        config_text = f"model:\n  provider: {provider}\n  default: my-model\n" if provider else "memory: {}\n"
+        (home / "config.yaml").write_text(config_text, encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+        # Suppress credential-missing error for the custom provider check
+        monkeypatch.setattr(_auth_mod, "get_auth_status", lambda p: {"logged_in": False, "configured": True})
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_custom_provider_demotes_all_oauth_rows_to_info(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, provider="custom")
+        # All OAuth rows must appear (as info, not as warnings).
+        for name in self._OAUTH_NAMES:
+            assert name in out, f"Expected '{name}' in output"
+        # None of them should carry a ⚠ warning symbol.
+        warn_symbol = "⚠"
+        for line in out.splitlines():
+            if any(name in line for name in self._OAUTH_NAMES):
+                assert warn_symbol not in line, (
+                    f"OAuth row unexpectedly shown as warning for 'custom' provider: {line!r}"
+                )
+
+    def test_nous_provider_shows_nous_as_warning_not_others(self, monkeypatch, tmp_path):
+        out = self._run(monkeypatch, tmp_path, provider="nous")
+        lines = out.splitlines()
+        nous_line = next(l for l in lines if "Nous Portal auth" in l)
+        assert "⚠" in nous_line, "Nous Portal auth should be a warning when provider=nous"
+        for name in self._OAUTH_NAMES:
+            if name == "Nous Portal auth":
+                continue
+            oauth_line = next((l for l in lines if name in l), None)
+            assert oauth_line is not None, f"Expected '{name}' in output"
+            assert "⚠" not in oauth_line, (
+                f"'{name}' should be demoted to info when provider=nous, got: {oauth_line!r}"
+            )
+
+    def test_no_provider_configured_shows_all_as_warnings(self, monkeypatch, tmp_path):
+        # When no model.provider is set, all OAuth rows should still warn —
+        # we have no basis to suppress any of them.
+        out = self._run(monkeypatch, tmp_path, provider="")
+        warn_symbol = "⚠"
+        for name in self._OAUTH_NAMES:
+            oauth_line = next((l for l in out.splitlines() if name in l), None)
+            assert oauth_line is not None, f"Expected '{name}' in output"
+            assert warn_symbol in oauth_line, (
+                f"'{name}' should warn when no provider is configured, got: {oauth_line!r}"
+            )


### PR DESCRIPTION
## What changed and why

`hermes doctor` was unconditionally showing `⚠ not logged in` warnings for every OAuth provider it knows about (Nous Portal, OpenAI Codex, Google Gemini, MiniMax, xAI), regardless of which provider the user actually had configured.

For users running a local/custom OpenAI-compatible endpoint (`model.provider: custom`) or any API-key provider, these warnings are pure noise — there is nothing to act on.

**Root cause:** The Auth Providers section had no knowledge of `model.provider`, so it always warned for every OAuth provider that wasn't logged in.

**Fix:** Read `model.provider` from `config.yaml` before the Auth Providers section runs, and pass it to a new `_oauth_check()` helper. Providers whose `relevant_ids` set does not include the configured provider are demoted from `⚠` warnings to `→` info lines. All providers still appear in the output (for discoverability); only the severity changes.

**Behaviour summary:**

| Configured provider | Result |
|---|---|
| `custom` / any API-key provider | All OAuth rows → `→` info lines |
| `nous` | Nous Portal → `⚠` warn; others → `→` info |
| `xai` | xAI OAuth → `⚠` warn; others → `→` info |
| No `model.provider` set | All OAuth rows → `⚠` warn (safe default) |

## How to test

```bash
# Reproduce the original issue:
hermes config set model.provider custom
hermes config set model.base_url http://127.0.0.1:8080/v1
hermes doctor
# Before: all OAuth rows show ⚠ warnings
# After:  all OAuth rows show → info lines

# Verify warnings still appear for the active OAuth provider:
hermes config set model.provider nous
hermes doctor
# Nous Portal auth shows ⚠; others show → info
```

Unit tests:
```bash
pytest tests/hermes_cli/test_doctor.py::TestDoctorOAuthSkippedForUnusedProviders -v
```

## Platforms tested

Linux (Ubuntu 24.04). The change touches only output formatting logic with no platform-specific syscalls.

## Notes

- Existing tests (`TestDoctorXaiOAuthStatus`, `TestDoctorCodexCliHintPlacement`) all pass unchanged — they use configs with no `model.provider`, which correctly falls through to the "show all as warnings" path.
- The `_oauth_check()` helper is a local function inside `run_doctor()`; no new public API is added.