### PR TITLE
fix(vision,gateway): wall-clock timeout for vision calls + 502/503/504 error hint

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -440,6 +440,8 @@ prompt_caching:
 #     timeout: 30            # LLM API call timeout (seconds)
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
+#     hard_timeout: 0        # Wall-clock cap on the whole vision call (seconds); 0 = auto (timeout + 60s)
+#                            # Bounds a hung/stalled provider so it can't block the agent turn
 #
 #   # Web page scraping / summarization + browser page text extraction
 #   web_extract:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9716,6 +9716,8 @@ class GatewayRunner:
                     status_hint = " You are being rate-limited. Please wait a moment and try again."
             elif status_code == 529:
                 status_hint = " The API is temporarily overloaded. Please try again shortly."
+            elif status_code in {502, 503, 504}:
+                status_hint = " The provider is temporarily unavailable (5xx). This is usually transient — please try again shortly."
             elif status_code in {400, 500}:
                 # 400 with a large session is context overflow.
                 # 500 with a large session often means the payload is too large

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1159,6 +1159,7 @@ DEFAULT_CONFIG = {
             "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
             "extra_body": {},      # OpenAI-compatible provider-specific request fields
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
+            "hard_timeout": 0,     # seconds — wall-clock cap on the whole vision call (asyncio.wait_for); 0 = auto (timeout + 60s). Bounds a hung/stalled provider so it can't block the turn.
         },
         "web_extract": {
             "provider": "auto",

--- a/tests/gateway/test_gateway_5xx_hint.py
+++ b/tests/gateway/test_gateway_5xx_hint.py
@@ -1,0 +1,27 @@
+"""Hermetic contract guard for the gateway 502/503/504 error hint.
+
+When the agent turn fails with an upstream 5xx (502/503/504), the gateway
+error handler appends a transient-unavailability hint so the user knows to
+retry rather than reading a raw traceback. The mapping lives inline in the
+GatewayRunner error handler; this pins the code→hint contract without driving
+the full inbound-message pipeline.
+"""
+
+import inspect
+
+from gateway.run import GatewayRunner
+
+
+def test_5xx_codes_map_to_transient_hint():
+    src = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    # The three gateway/proxy 5xx codes are handled together.
+    assert "status_code in {502, 503, 504}" in src
+    # ...and produce a user-facing "transient, retry" hint, not a raw error.
+    assert "temporarily unavailable (5xx)" in src
+
+
+def test_5xx_hint_is_distinct_from_overload_hint():
+    """529 (overloaded) and 5xx (unavailable) stay separate branches."""
+    src = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    assert "status_code == 529" in src
+    assert src.index("status_code == 529") < src.index("status_code in {502, 503, 504}")

--- a/tests/tools/test_vision_hard_timeout.py
+++ b/tests/tools/test_vision_hard_timeout.py
@@ -1,0 +1,45 @@
+"""Hermetic test for the vision wall-clock hard timeout.
+
+vision_analyze_tool wraps the auxiliary LLM call in asyncio.wait_for so a hung
+or stalled provider cannot block the agent turn indefinitely. This exercises
+that bound end-to-end with a stalled coroutine and a tiny hard_timeout, with no
+network and no real provider.
+"""
+
+import asyncio
+import json
+
+from unittest.mock import patch
+
+import hermes_cli.config as hermes_config
+import tools.vision_tools as vision_tools
+
+
+# Minimal PNG header — enough for _image_to_base64_data_url to encode.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+
+# Config with a tiny hard_timeout so the stalled call is bounded fast.
+_VISION_CFG = {"auxiliary": {"vision": {"timeout": 120, "hard_timeout": 0.05}}}
+
+
+def test_stalled_vision_call_is_bounded_by_hard_timeout(tmp_path):
+    img = tmp_path / "stall.png"
+    img.write_bytes(_PNG_BYTES)
+
+    async def _stalled_call(*args, **kwargs):
+        # Never returns — simulates a hung/stalled provider socket. wait_for
+        # cancels this at hard_timeout, so the test finishes near-instantly.
+        await asyncio.sleep(30)
+
+    # load_config/cfg_get are imported inside the function from hermes_cli.config;
+    # async_call_llm is a module-level import on vision_tools.
+    with patch.object(hermes_config, "load_config", return_value=_VISION_CFG), \
+            patch.object(vision_tools, "async_call_llm", side_effect=_stalled_call):
+        result_json = asyncio.run(
+            vision_tools.vision_analyze_tool(str(img), "describe this image")
+        )
+
+    result = json.loads(result_json)
+    assert result["success"] is False
+    # The user-facing message on a wall-clock timeout, not a raw traceback.
+    assert "taking too long" in result["analysis"].lower()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -867,6 +867,7 @@ async def vision_analyze_tool(
         # Local vision models (llama.cpp, ollama) can take well over 30s.
         vision_timeout = 120.0
         vision_temperature = 0.1
+        vision_hard_timeout = None
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
@@ -877,8 +878,13 @@ async def vision_analyze_tool(
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
                 vision_temperature = float(_vtemp)
+            _vht = _vision_cfg.get("hard_timeout")
+            if _vht is not None:
+                vision_hard_timeout = float(_vht)
         except Exception:
             pass
+        if vision_hard_timeout is None or vision_hard_timeout <= 0:
+            vision_hard_timeout = vision_timeout + 60.0
         call_kwargs = {
             "task": "vision",
             "messages": messages,
@@ -888,9 +894,16 @@ async def vision_analyze_tool(
         }
         if model:
             call_kwargs["model"] = model
+
+        import asyncio
+
+        async def _bounded_vision_call():
+            return await asyncio.wait_for(
+                async_call_llm(**call_kwargs), timeout=vision_hard_timeout)
+
         # Try full-size image first; on size-related rejection, downscale and retry.
         try:
-            response = await async_call_llm(**call_kwargs)
+            response = await _bounded_vision_call()
         except Exception as _api_err:
             if (_is_image_size_error(_api_err)
                     and len(image_data_url) > _RESIZE_TARGET_BYTES):
@@ -903,17 +916,17 @@ async def vision_analyze_tool(
                 image_data_url = _resize_image_for_vision(
                     temp_image_path, mime_type=detected_mime_type)
                 messages[0]["content"][1]["image_url"]["url"] = image_data_url
-                response = await async_call_llm(**call_kwargs)
+                response = await _bounded_vision_call()
             else:
                 raise
-        
+
         # Extract the analysis — fall back to reasoning if content is empty
         analysis = extract_content_or_reasoning(response)
 
         # Retry once on empty content (reasoning-only response)
         if not analysis:
             logger.warning("Vision LLM returned empty content, retrying once")
-            response = await async_call_llm(**call_kwargs)
+            response = await _bounded_vision_call()
             analysis = extract_content_or_reasoning(response)
 
         analysis_length = len(analysis)
@@ -938,11 +951,17 @@ async def vision_analyze_tool(
     except Exception as e:
         error_msg = f"Error analyzing image: {str(e)}"
         logger.error("%s", error_msg, exc_info=True)
-        
+
         # Detect vision capability errors — give the model a clear message
         # so it can inform the user instead of a cryptic API error.
         err_str = str(e).lower()
-        if any(hint in err_str for hint in (
+        if isinstance(e, TimeoutError):
+            analysis = (
+                "I couldn't analyze the image in time — the vision provider is "
+                "taking too long, which usually means it's temporarily "
+                "overloaded. Please try again in a moment."
+            )
+        elif any(hint in err_str for hint in (
             "402", "insufficient", "payment required", "credits", "billing",
         )):
             analysis = (

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -879,6 +879,7 @@ auxiliary:
     api_key: ""                # API key for base_url (falls back to OPENAI_API_KEY)
     timeout: 120               # seconds — LLM API call timeout; vision payloads need generous timeout
     download_timeout: 30       # seconds — image HTTP download; increase for slow connections
+    hard_timeout: 0            # seconds — wall-clock cap on the whole vision call; 0 = auto (timeout + 60s)
 
   # Web page summarization + browser page text extraction
   web_extract:
@@ -930,7 +931,7 @@ auxiliary:
 ```
 
 :::tip
-Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
+Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers. A `hard_timeout` (default `0` = auto, resolving to `timeout + 60s`) puts a wall-clock cap on the entire vision call so a hung or stalled provider can't block the agent turn indefinitely.
 :::
 
 :::info


### PR DESCRIPTION
## What

Two small resilience/UX fixes for provider degradation:

1. **Bound vision calls with a wall-clock timeout** (`tools/vision_tools.py`).
   `vision_analyze_tool` awaited `async_call_llm` with only the per-attempt SDK/transport timeout. When a provider degrades — a 503 storm, or a stalled socket the transport read-timeout never trips — the `await` can hang far past the configured `timeout`. Vision runs inside the agent turn, so a hung call blocks the entire conversation and the user gets no response at all. Fix: wrap the call in `asyncio.wait_for` with a wall-clock bound (`auxiliary.vision.hard_timeout`, default = per-attempt `timeout` + 60s) and return a clear "provider taking too long, try again" message on timeout, instead of hanging the turn silently.

2. **Add a 502/503/504 hint to the agent error handler** (`gateway/run.py`).
   The per-status hint ladder covered 401/402/429/529/400/500 but not the common 502/503/504 "provider temporarily unavailable" class, so a transient provider 5xx surfaced as a bare "Sorry, I encountered an error" with no actionable guidance. Adds a 5xx branch telling the user it's transient and to retry.

## Why

A turn that exhausts providers/retries — or stalls on a slow vision provider — should never leave the user in silence, and a single stalled image-analysis turn should not block the whole conversation.

## Notes

- Minimal + backward-compatible: `hard_timeout` defaults to `timeout + 60s` when unset, so existing configs are unchanged.
- Validated: the wall-clock guard fires and returns the timeout message through the real `vision_analyze_tool` path; both files compile.
