### PR TITLE
Make session reset notifications configurable by reason

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -513,6 +513,11 @@ session_reset:
   mode: both           # "both", "idle", "daily", or "none"
   idle_minutes: 1440   # Inactivity timeout in minutes (default: 1440 = 24 hours)
   at_hour: 4           # Daily reset hour, 0-23 local time (default: 4 AM)
+  notify: true         # Send a user-facing notice when an auto-reset clears an active session
+  notify_exclude_platforms: [api_server, webhook]
+  notify_reasons: [idle, daily, suspended]
+  # To suppress stopped/interrupted-session notices but keep idle/daily notices:
+  # notify_reasons: [idle, daily]
 
 # When true, group/channel chats use one session per participant when the platform
 # provides a user ID. This is the secure default and prevents users in the same

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -234,6 +234,38 @@ class HomeChannel:
         )
 
 
+DEFAULT_SESSION_RESET_NOTIFY_REASONS: tuple[str, ...] = ("idle", "daily", "suspended")
+
+
+def _normalize_reset_notify_reasons(value: Any) -> tuple[str, ...]:
+    """Normalize session_reset.notify_reasons config.
+
+    Missing/null preserves the current default: all known auto-reset reasons
+    produce notices. Operators can set []/"none" to suppress reason-based
+    notices, or omit "suspended" to avoid stopped/interrupted-session chatter
+    while keeping idle/daily reset notifications.
+    """
+    if value is None:
+        return DEFAULT_SESSION_RESET_NOTIFY_REASONS
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized or normalized == "none":
+            return ()
+        if normalized == "all":
+            return DEFAULT_SESSION_RESET_NOTIFY_REASONS
+        return (normalized,)
+    if isinstance(value, (list, tuple, set)):
+        reasons: list[str] = []
+        for item in value:
+            if item is None:
+                continue
+            reason = str(item).strip().lower()
+            if reason:
+                reasons.append(reason)
+        return tuple(reasons)
+    return DEFAULT_SESSION_RESET_NOTIFY_REASONS
+
+
 @dataclass
 class SessionResetPolicy:
     """
@@ -250,6 +282,7 @@ class SessionResetPolicy:
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
     notify_exclude_platforms: tuple = ("api_server", "webhook")  # Platforms that don't get reset notifications
+    notify_reasons: tuple = DEFAULT_SESSION_RESET_NOTIFY_REASONS  # Auto-reset reasons that get notifications
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -258,6 +291,7 @@ class SessionResetPolicy:
             "idle_minutes": self.idle_minutes,
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
+            "notify_reasons": list(self.notify_reasons),
         }
     
     @classmethod
@@ -274,6 +308,7 @@ class SessionResetPolicy:
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
+            notify_reasons=_normalize_reset_notify_reasons(data.get("notify_reasons")),
         )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1118,11 +1118,13 @@ from gateway.config import (
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
     HomeChannel,
+    SessionResetPolicy,
     PlatformConfig,
     load_gateway_config,
 )
 from gateway.session import (
     SessionStore,
+    SessionEntry,
     SessionSource,
     SessionContext,
     build_session_context,
@@ -1779,6 +1781,29 @@ class GatewayRunner:
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+
+    @staticmethod
+    def _should_notify_auto_reset(
+        policy: SessionResetPolicy,
+        source: SessionSource,
+        session_entry: SessionEntry,
+        reset_reason: str,
+    ) -> bool:
+        """Return whether an auto-reset notice should be sent to the user.
+
+        This centralizes the policy gate so all reset reasons, including
+        stopped/interrupted-session (``suspended``) resets, honor the same
+        operator-configurable notification settings.
+        """
+        platform_name = source.platform.value if source.platform else ""
+        had_activity = getattr(session_entry, "reset_had_activity", False)
+        reason = (reset_reason or "idle").strip().lower()
+        return (
+            policy.notify
+            and had_activity
+            and platform_name not in policy.notify_exclude_platforms
+            and reason in policy.notify_reasons
+        )
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -8800,14 +8825,11 @@ class GatewayRunner:
                     platform=source.platform,
                     session_type=getattr(source, 'chat_type', 'dm'),
                 )
-                platform_name = source.platform.value if source.platform else ""
-                had_activity = getattr(session_entry, 'reset_had_activity', False)
-                # Suspended sessions always notify (they were explicitly stopped
-                # or crashed mid-operation) — skip the policy check.
-                should_notify = reset_reason == "suspended" or (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
+                should_notify = self._should_notify_auto_reset(
+                    policy=policy,
+                    source=source,
+                    session_entry=session_entry,
+                    reset_reason=reset_reason,
                 )
                 if should_notify:
                     adapter = self.adapters.get(source.platform)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -162,6 +162,14 @@ class TestSessionResetPolicy:
         restored = SessionResetPolicy.from_dict({"notify": "false"})
         assert restored.notify is False
 
+    def test_from_dict_parses_notify_reasons(self):
+        restored = SessionResetPolicy.from_dict({"notify_reasons": ["idle", "daily"]})
+        assert restored.notify_reasons == ("idle", "daily")
+
+    def test_from_dict_empty_notify_reasons_suppresses_reason_notices(self):
+        restored = SessionResetPolicy.from_dict({"notify_reasons": []})
+        assert restored.notify_reasons == ()
+
 
 class TestStreamingConfig:
     def test_defaults_to_auto_transport(self):
@@ -272,6 +280,24 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
+
+    def test_bridges_session_reset_notify_reasons_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  notify_reasons:\n"
+            "    - idle\n"
+            "    - daily\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.notify_reasons == ("idle", "daily")
 
     def test_bridges_group_sessions_per_user_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -30,6 +30,17 @@ def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):
     )
 
 
+def _make_entry_with_activity(had_activity: bool) -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key="test",
+        session_id="s1",
+        created_at=now,
+        updated_at=now,
+        reset_had_activity=had_activity,
+    )
+
+
 def _make_store(policy=None, tmp_path=None):
     config = GatewayConfig()
     if policy:
@@ -192,16 +203,77 @@ class TestResetPolicyNotify:
         assert policy.notify is True
         assert "api_server" in policy.notify_exclude_platforms
 
+    def test_notify_reasons_defaults(self):
+        policy = SessionResetPolicy()
+        assert policy.notify_reasons == ("idle", "daily", "suspended")
+
+    def test_from_dict_with_notify_reasons_list(self):
+        policy = SessionResetPolicy.from_dict({"notify_reasons": ["idle", "daily"]})
+        assert policy.notify_reasons == ("idle", "daily")
+
+    def test_from_dict_with_notify_reasons_none_string(self):
+        policy = SessionResetPolicy.from_dict({"notify_reasons": "none"})
+        assert policy.notify_reasons == ()
+
+    def test_from_dict_with_notify_reasons_all_string(self):
+        policy = SessionResetPolicy.from_dict({"notify_reasons": "all"})
+        assert policy.notify_reasons == ("idle", "daily", "suspended")
+
     def test_to_dict_roundtrip(self):
         original = SessionResetPolicy(
             mode="idle",
             notify=False,
             notify_exclude_platforms=("api_server",),
+            notify_reasons=("idle", "daily"),
         )
         restored = SessionResetPolicy.from_dict(original.to_dict())
         assert restored.notify == original.notify
         assert restored.notify_exclude_platforms == original.notify_exclude_platforms
+        assert restored.notify_reasons == original.notify_reasons
         assert restored.mode == original.mode
+
+    def test_suspended_respects_notify_false(self):
+        from gateway.run import GatewayRunner
+
+        entry = _make_entry_with_activity(True)
+        policy = SessionResetPolicy(notify=False)
+        assert GatewayRunner._should_notify_auto_reset(
+            policy, _make_source(Platform.DISCORD), entry, "suspended"
+        ) is False
+
+    def test_suspended_respects_excluded_platform(self):
+        from gateway.run import GatewayRunner
+
+        entry = _make_entry_with_activity(True)
+        policy = SessionResetPolicy(notify_exclude_platforms=("discord",))
+        assert GatewayRunner._should_notify_auto_reset(
+            policy, _make_source(Platform.DISCORD), entry, "suspended"
+        ) is False
+
+    def test_suspended_respects_notify_reasons(self):
+        from gateway.run import GatewayRunner
+
+        entry = _make_entry_with_activity(True)
+        policy = SessionResetPolicy(notify_reasons=("idle", "daily"))
+        assert GatewayRunner._should_notify_auto_reset(
+            policy, _make_source(Platform.DISCORD), entry, "suspended"
+        ) is False
+
+    def test_suspended_notifies_by_default_when_active(self):
+        from gateway.run import GatewayRunner
+
+        entry = _make_entry_with_activity(True)
+        assert GatewayRunner._should_notify_auto_reset(
+            SessionResetPolicy(), _make_source(Platform.DISCORD), entry, "suspended"
+        ) is True
+
+    def test_idle_does_not_notify_without_activity(self):
+        from gateway.run import GatewayRunner
+
+        entry = _make_entry_with_activity(False)
+        assert GatewayRunner._should_notify_auto_reset(
+            SessionResetPolicy(), _make_source(Platform.DISCORD), entry, "idle"
+        ) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `session_reset.notify_reasons` so reset notices can be controlled by reset reason (`idle`, `daily`, `suspended`)
- centralize the auto-reset notification policy gate so suspended/stopped sessions honor the same notification settings as idle/daily resets
- document the new config option in `cli-config.yaml.example`

## Why
Operators may want idle/daily reset notices while suppressing stopped/interrupted-session chatter, or may disable all reset notices. Previously suspended resets bypassed the policy check and always notified.

## Tests
- `pytest -q tests/gateway/test_session_reset_notify.py tests/gateway/test_config.py`
