### PR TITLE
feat(tools): add model_switch tool for agent-driven complexity routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -781,6 +781,16 @@ Key config knobs (under `delegation:` in `config.yaml`):
 `orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
 `max_iterations`.
 
+**MCP toolset resolution for named profiles:** When `_build_child_agent()`
+is called with `profile_name` set (i.e. the delegation originated from a
+named `agent_profiles` entry), MCP toolsets in the requested list bypass
+the parent-intersection check and are resolved directly from the global
+`mcp_servers` config.  This prevents a silent failure mode where an
+orchestrator that restricts its own MCP context (via `no_mcp` in
+`platform_toolsets`) inadvertently starves child agents of domain MCP tools
+they explicitly need.  Non-MCP toolsets still go through parent intersection
+— the security boundary for ad-hoc delegation is preserved.  See #32668.
+
 Synchronicity rule: delegate_task is **not** durable. For long-running
 work that must outlive the current turn, use `cronjob` or
 `terminal(background=True, notify_on_complete=True)` instead.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1750,11 +1750,13 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         )
     elif function_name == "model_switch":
         from tools.model_switch_tool import model_switch_tool as _model_switch_tool
-        return _model_switch_tool(
-            agent,
-            slug=function_args.get("slug", ""),
-            reason=function_args.get("reason", ""),
-            scope=function_args.get("scope", "session"),
+        return _finish_agent_tool(
+            _model_switch_tool(
+                agent,
+                slug=function_args.get("slug", ""),
+                reason=function_args.get("reason", ""),
+                scope=function_args.get("scope", "session"),
+            )
         )
     elif function_name == "delegate_task":
         return _finish_agent_tool(agent._dispatch_delegate_task(function_args))

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1748,6 +1748,14 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 callback=agent.clarify_callback,
             )
         )
+    elif function_name == "model_switch":
+        from tools.model_switch_tool import model_switch_tool as _model_switch_tool
+        return _model_switch_tool(
+            agent,
+            slug=function_args.get("slug", ""),
+            reason=function_args.get("reason", ""),
+            scope=function_args.get("scope", "session"),
+        )
     elif function_name == "delegate_task":
         return _finish_agent_tool(agent._dispatch_delegate_task(function_args))
     else:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -49,7 +49,7 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "delegate_task"}
+    {"todo", "session_search", "memory", "clarify", "delegate_task", "model_switch"}
 )
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -454,6 +454,13 @@ def run_conversation(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    # Revert any turn-scoped model_switch from the previous turn before this
+    # one runs, so scope='turn' switches apply for exactly one turn (#16525).
+    try:
+        from tools.model_switch_tool import revert_turn_model_switch
+        revert_turn_model_switch(agent)
+    except Exception:
+        pass
     # True until the server rejects an image_url content part with an error
     # like "Only 'text' content type is supported."  Set to False on first
     # rejection and kept False for the rest of the session so we never re-send

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -938,6 +938,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name == "model_switch":
+            from tools.model_switch_tool import model_switch_tool as _model_switch_tool
+            function_result = _model_switch_tool(
+                agent,
+                slug=function_args.get("slug", ""),
+                reason=function_args.get("reason", ""),
+                scope=function_args.get("scope", "session"),
+            )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('model_switch', function_args, tool_duration, result=function_result)}")
         elif function_name == "delegate_task":
             tasks_arg = function_args.get("tasks")
             if tasks_arg and isinstance(tasks_arg, list):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1518,6 +1518,25 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _active_platform_uses_no_mcp(config: dict) -> bool:
+    """Return True if the current platform's toolsets include the no_mcp sentinel.
+
+    The active platform is resolved from the ``HERMES_PLATFORM`` env var (with the
+    ``HERMES_SESSION_PLATFORM`` fallback used elsewhere in the codebase), defaulting
+    to ``"cli"``. When that platform's ``platform_toolsets`` list contains the
+    ``no_mcp`` sentinel, eager MCP discovery can be skipped at startup and deferred
+    until the first child delegation that actually needs MCP toolsets.
+    """
+    platform = (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or "cli"
+    )
+    platform_toolsets = (config or {}).get("platform_toolsets", {}) or {}
+    toolsets = platform_toolsets.get(platform, []) or []
+    return "no_mcp" in toolsets
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -19832,7 +19851,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     try:
         from tools.mcp_tool import discover_mcp_tools
         _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
+        _gateway_cfg = _load_gateway_config()
+        if _active_platform_uses_no_mcp(_gateway_cfg):
+            from tools.mcp_tool import mark_eager_discovery_skipped
+            mark_eager_discovery_skipped()
+            logger.info(
+                "MCP eager discovery skipped (platform uses no_mcp); "
+                "tools will load lazily on first delegation"
+            )
+        else:
+            await _loop.run_in_executor(None, discover_mcp_tools)
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -888,6 +888,7 @@ _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
 _config_path = _hermes_home / 'config.yaml'
+_cfg: Dict[str, Any] = {}
 if _config_path.exists():
     try:
         import yaml as _yaml
@@ -895,7 +896,8 @@ if _config_path.exists():
             _cfg = _yaml.safe_load(_f) or {}
         # Expand ${ENV_VAR} references before bridging to env vars.
         from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        _expanded = _expand_env_vars(_cfg)
+        _cfg = _expanded if isinstance(_expanded, dict) else {}
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:
@@ -1077,7 +1079,7 @@ if _config_path.exists():
 # Apply IPv4 preference if configured (before any HTTP clients are created).
 try:
     from hermes_constants import apply_ipv4_preference
-    _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
+    _network_cfg = _cfg.get("network", {})
     if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
         apply_ipv4_preference(force=True)
 except Exception as _bootstrap_exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12652,6 +12652,10 @@ class GatewayRunner:
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            # Auto-include model_switch toolset when the operator opt-in flag is set.
+            if (user_config or {}).get("agent", {}).get("allow_self_model_switch"):
+                if "model_switch" not in enabled_toolsets:
+                    enabled_toolsets = sorted(list(enabled_toolsets) + ["model_switch"])
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
@@ -17023,6 +17027,10 @@ class GatewayRunner:
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        # Auto-include model_switch toolset when the operator opt-in flag is set.
+        if (user_config or {}).get("agent", {}).get("allow_self_model_switch"):
+            if "model_switch" not in enabled_toolsets:
+                enabled_toolsets = sorted(list(enabled_toolsets) + ["model_switch"])
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -869,6 +869,11 @@ DEFAULT_CONFIG = {
         # rather than pinning the running-agent guard forever.  CLI clarify
         # blocks indefinitely (input() is synchronous) and ignores this.
         "clarify_timeout": 600,
+        # Allow the agent to call the model_switch tool to self-optimise its
+        # model mid-conversation (e.g. down-routing to a cheap model for
+        # simple follow-up turns).  Requires the model_switch toolset to be
+        # available.  Disabled by default -- enable per-user in config.yaml.
+        "allow_self_model_switch": False,
         # Periodic "still working" notification interval (seconds).
         # Sends a status message every N seconds so the user knows the
         # agent hasn't died during long tasks.  0 = disable notifications.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12586,6 +12586,32 @@ def _should_background_mcp_startup(args) -> bool:
     return args.command in {None, "chat", "rl"}
 
 
+def _active_platform_uses_no_mcp_at_startup() -> bool:
+    """Return True if the active platform's toolsets include the no_mcp sentinel.
+
+    Resolves the platform from ``HERMES_PLATFORM`` (with the
+    ``HERMES_SESSION_PLATFORM`` fallback used elsewhere), defaulting to ``"cli"``,
+    and reads ``platform_toolsets`` directly from the raw config dict. Used to
+    decide whether eager MCP discovery can be skipped at CLI startup (Phase 2
+    lazy discovery). Best-effort: any failure returns False so discovery runs
+    as before.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        config = read_raw_config() or {}
+    except Exception:
+        return False
+    platform = (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or "cli"
+    )
+    platform_toolsets = config.get("platform_toolsets", {}) or {}
+    toolsets = platform_toolsets.get(platform, []) or []
+    return "no_mcp" in toolsets
+
+
 def _prepare_agent_startup(args) -> None:
     """Discover plugins/MCP/hooks for commands that can run an agent turn."""
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
@@ -12633,9 +12659,23 @@ def _prepare_agent_startup(args) -> None:
         try:
             # MCP tool discovery remains synchronous for entrypoints that do
             # not own a later bounded/executor startup path.
+            #
+            # When the active platform's toolsets include the ``no_mcp`` sentinel
+            # (e.g. api_server), skip eager discovery here too and let the first
+            # MCP-needing delegation trigger it lazily (Phase 2). Only the
+            # no_mcp platforms are affected; cli/cron/telegram run as before.
             from tools.mcp_tool import discover_mcp_tools
 
-            discover_mcp_tools()
+            if _active_platform_uses_no_mcp_at_startup():
+                from tools.mcp_tool import mark_eager_discovery_skipped
+
+                mark_eager_discovery_skipped()
+                logger.debug(
+                    "MCP eager discovery skipped at CLI startup "
+                    "(platform uses no_mcp); tools will load lazily on first delegation"
+                )
+            else:
+                discover_mcp_tools()
         except Exception:
             logger.debug(
                 "MCP tool discovery failed at CLI startup",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -112,7 +112,14 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+#
+# model_switch is off by default — it is an explicit opt-in requiring
+# agent.allow_self_model_switch: true in config.yaml. Its check_fn gates
+# the tool schema at runtime, but we must also keep it out of
+# _get_platform_tools' non-configurable auto-recovery path so it does not
+# silently appear in the enabled toolset list when a user saves a platform
+# toolset config via `hermes tools`.
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "model_switch"}
 
 
 def _xai_credentials_present() -> bool:

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -212,7 +212,7 @@ def setup_logging(
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Read config defaults (best-effort — config may not be loaded yet).
-    cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
+    cfg_level, cfg_max_size, cfg_backup, cfg_loggers = _read_logging_config()
 
     level_name = (log_level or cfg_level or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
@@ -278,6 +278,50 @@ def setup_logging(
     # Suppress noisy third-party loggers.
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
+
+    # Apply per-logger level overrides from config.yaml ``logging.loggers``.
+    # Must run after handlers are attached so the levels take effect on the
+    # configured hierarchy.  Each entry may be a bare string ("DEBUG") or a
+    # dict with a "level" key ({"level": "DEBUG"}).  Invalid or missing levels
+    # are skipped silently to avoid breaking startup.
+    #
+    # When any override is finer-grained than the current root/handler level
+    # (e.g. DEBUG while agent.log runs at INFO), the root logger and the
+    # agent.log handler are also lowered so that per-logger records can
+    # propagate all the way to the file.  The root logger's level gates
+    # propagated records before they reach handlers; the handler's level gates
+    # what it writes.  Both must be at or below the per-logger level for the
+    # records to appear in agent.log.
+    if isinstance(cfg_loggers, dict):
+        min_per_logger_level: Optional[int] = None
+        for logger_name, logger_cfg in cfg_loggers.items():
+            if isinstance(logger_cfg, dict):
+                lvl_value = logger_cfg.get("level")
+            elif isinstance(logger_cfg, str):
+                lvl_value = logger_cfg
+            else:
+                continue
+            if not isinstance(lvl_value, str):
+                continue
+            lvl_int = getattr(logging, lvl_value.upper(), None)
+            if not isinstance(lvl_int, int):
+                continue
+            logging.getLogger(logger_name).setLevel(lvl_int)
+            if min_per_logger_level is None or lvl_int < min_per_logger_level:
+                min_per_logger_level = lvl_int
+
+        # Lower root + agent.log handler if needed so per-logger records reach
+        # the file.  We never raise these levels — only lower them.
+        if min_per_logger_level is not None and min_per_logger_level < level:
+            if root.level > min_per_logger_level or root.level == logging.NOTSET:
+                root.setLevel(min_per_logger_level)
+            for h in root.handlers:
+                if (
+                    isinstance(h, RotatingFileHandler)
+                    and "agent.log" in getattr(h, "baseFilename", "")
+                    and h.level > min_per_logger_level
+                ):
+                    h.setLevel(min_per_logger_level)
 
     _logging_initialized = True
     return log_dir
@@ -480,7 +524,15 @@ def _add_rotating_handler(
 def _read_logging_config():
     """Best-effort read of ``logging.*`` from config.yaml.
 
-    Returns ``(level, max_size_mb, backup_count)`` — any may be ``None``.
+    Returns ``(level, max_size_mb, backup_count, loggers)`` — any may be
+    ``None``.  ``loggers`` is a dict mapping logger name → config entry,
+    where each entry is either a bare level string (``"DEBUG"``) or a dict
+    with a ``"level"`` key (``{"level": "DEBUG"}``).
+
+    Why: Centralises config parsing so setup_logging() can apply both the
+    top-level level and per-logger overrides from a single read.
+    Test: Write a config.yaml with ``logging.loggers.tools.tool_search.level:
+    DEBUG`` and assert the returned loggers dict contains that entry.
     """
     try:
         import yaml
@@ -494,7 +546,8 @@ def _read_logging_config():
                     log_cfg.get("level"),
                     log_cfg.get("max_size_mb"),
                     log_cfg.get("backup_count"),
+                    log_cfg.get("loggers") or {},
                 )
     except Exception:
         pass
-    return (None, None, None)
+    return (None, None, None, {})

--- a/model_tools.py
+++ b/model_tools.py
@@ -553,7 +553,7 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "model_switch"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4806,6 +4806,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            profile=function_args.get("profile"),
             parent_agent=self,
         )
 

--- a/tests/run_agent/test_invoke_tool_post_hook.py
+++ b/tests/run_agent/test_invoke_tool_post_hook.py
@@ -1,0 +1,238 @@
+"""Test that _invoke_tool fires the post-tool-call hook exactly once for model_switch.
+
+Why: The concurrent invoke_tool path had a gap where model_switch returned the raw
+_model_switch_tool() result without wrapping it in _finish_agent_tool(), so the
+_emit_post_tool_call_hook was never called. Every other agent-level tool branch
+(todo, session_search, memory, clarify, delegate_task) correctly wraps its return
+with _finish_agent_tool(). This test pins the fix so the regression cannot recur.
+
+What: Asserts _emit_post_tool_call_hook fires exactly once when _invoke_tool routes
+to model_switch, matching the behavior of the todo branch (validated by the
+mirror test also included here for reference).
+
+Test: monkeypatch invoke_hook / has_hook to capture hook calls, patch
+model_switch_tool to return a known string, call agent._invoke_tool("model_switch",
+...) and assert exactly one "post_tool_call" hook event with the right fields.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers copied from test_run_agent.py to keep this file self-contained
+# ---------------------------------------------------------------------------
+
+def _make_tool_defs(*names: str) -> list:
+    """Build minimal tool definition list accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading."""
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestInvokeToolPostHookModelSwitch:
+    """The post-tool-call hook must fire exactly once for model_switch on the concurrent path."""
+
+    def test_model_switch_emits_post_tool_call_hook_exactly_once(self, agent, monkeypatch):
+        """_invoke_tool model_switch branch must call _emit_post_tool_call_hook.
+
+        Why: Before the fix model_switch returned the raw _model_switch_tool() result
+        directly, bypassing _finish_agent_tool() and therefore never emitting the
+        post-tool-call hook. Telemetry and plugin observers were silently dropped.
+
+        What: Patches invoke_hook/has_hook to capture events; asserts exactly one
+        post_tool_call event with correct tool_name, tool_call_id, and result.
+
+        Test: Run _invoke_tool("model_switch", ...) with the model_switch_tool patched
+        to return a known string. Verify the captured hook events include exactly one
+        post_tool_call entry containing the expected fields.
+        """
+        hook_calls: list = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+
+        model_switch_result = json.dumps({"switched": True, "model": "test-model"})
+
+        with patch(
+            "tools.model_switch_tool.model_switch_tool",
+            return_value=model_switch_result,
+        ) as mock_ms:
+            result = agent._invoke_tool(
+                "model_switch",
+                {"slug": "test-model", "reason": "complexity", "scope": "session"},
+                "task-1",
+                tool_call_id="ms-call-1",
+            )
+
+        # The underlying tool was called
+        mock_ms.assert_called_once()
+
+        # The result is passed through unchanged
+        assert result == model_switch_result
+
+        # Exactly one post_tool_call hook event
+        post_calls = [c for c in hook_calls if c[0] == "post_tool_call"]
+        assert len(post_calls) == 1, (
+            f"Expected exactly 1 post_tool_call hook event, got {len(post_calls)}. "
+            "Likely cause: model_switch branch missing _finish_agent_tool() wrapper."
+        )
+
+        event_kwargs = post_calls[0][1]
+        assert event_kwargs["tool_name"] == "model_switch"
+        assert event_kwargs["tool_call_id"] == "ms-call-1"
+        assert event_kwargs["result"] == model_switch_result
+        assert event_kwargs["status"] == "ok"
+        assert event_kwargs["error_type"] is None
+        assert isinstance(event_kwargs["duration_ms"], int)
+
+    def test_model_switch_hook_fires_once_not_zero_times(self, agent, monkeypatch):
+        """Regression guard: hook count must be >= 1, catching the original zero-fires bug.
+
+        Why: A bare return _model_switch_tool(...) means _emit_post_tool_call_hook is
+        never reached — this test captures the pre-fix failure mode explicitly.
+
+        What: Verifies post_tool_call hook count is not zero after a model_switch call.
+
+        Test: Same setup as the main test; asserts post_calls is non-empty.
+        """
+        hook_calls: list = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+
+        with patch(
+            "tools.model_switch_tool.model_switch_tool",
+            return_value='{"switched": true}',
+        ):
+            agent._invoke_tool(
+                "model_switch",
+                {"slug": "fast-model", "reason": "cheap", "scope": "turn"},
+                "task-2",
+                tool_call_id="ms-call-2",
+            )
+
+        post_calls = [c for c in hook_calls if c[0] == "post_tool_call"]
+        assert post_calls, "post_tool_call hook never fired — model_switch missing _finish_agent_tool wrapper"
+
+    def test_todo_emits_post_tool_call_hook_exactly_once(self, agent, monkeypatch):
+        """Mirror test: confirm the existing todo branch behaviour that model_switch must match.
+
+        Why: Documents the canonical peer-branch contract so reviewers can verify
+        model_switch and todo are handled identically.
+
+        What: Asserts that _invoke_tool("todo", ...) also emits exactly one post_tool_call
+        hook, proving both branches share the same behaviour after the fix.
+
+        Test: Same monkeypatch setup; patch todo_tool; call _invoke_tool("todo"); assert
+        exactly one post_tool_call event with correct fields.
+        """
+        hook_calls: list = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+
+        todo_result = '{"ok": true}'
+
+        with patch("tools.todo_tool.todo_tool", return_value=todo_result) as mock_todo:
+            result = agent._invoke_tool(
+                "todo",
+                {"todos": []},
+                "task-3",
+                tool_call_id="todo-call-1",
+            )
+
+        mock_todo.assert_called_once()
+        assert result == todo_result
+
+        post_calls = [c for c in hook_calls if c[0] == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0][1]["tool_name"] == "todo"
+        assert post_calls[0][1]["tool_call_id"] == "todo-call-1"
+        assert post_calls[0][1]["status"] == "ok"
+
+    def test_model_switch_in_agent_runtime_post_hook_tool_names(self):
+        """model_switch must be in AGENT_RUNTIME_POST_HOOK_TOOL_NAMES.
+
+        Why: The predicate agent_runtime_owns_post_tool_hook() gates which tools get
+        their post-hook emitted by the agent runtime vs the registry dispatcher.
+        If model_switch is missing, the outer dispatcher may double-emit or skip.
+
+        What: Imports the frozenset and asserts model_switch is present.
+
+        Test: Direct import check — fails immediately if someone removes the entry.
+        """
+        from agent.agent_runtime_helpers import AGENT_RUNTIME_POST_HOOK_TOOL_NAMES
+        assert "model_switch" in AGENT_RUNTIME_POST_HOOK_TOOL_NAMES
+
+    def test_agent_runtime_owns_post_tool_hook_returns_true_for_model_switch(self, agent):
+        """agent_runtime_owns_post_tool_hook must return True for model_switch.
+
+        Why: Ensures the ownership predicate correctly identifies model_switch as an
+        agent-level tool, preventing the outer dispatcher from double-emitting hooks.
+
+        What: Calls agent_runtime_owns_post_tool_hook(agent, "model_switch") and
+        asserts the return value is True.
+
+        Test: Direct function call — simple boolean assertion.
+        """
+        from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
+        assert agent_runtime_owns_post_tool_hook(agent, "model_switch") is True

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -804,17 +804,18 @@ class TestReadLoggingConfig:
     """_read_logging_config() reads from config.yaml."""
 
     def test_returns_none_when_no_config(self, hermes_home):
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, loggers = hermes_logging._read_logging_config()
         assert level is None
         assert max_size is None
         assert backup is None
+        assert loggers == {}
 
     def test_reads_logging_section(self, hermes_home):
         import yaml
         config = {"logging": {"level": "DEBUG", "max_size_mb": 10, "backup_count": 5}}
         (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, loggers = hermes_logging._read_logging_config()
         assert level == "DEBUG"
         assert max_size == 10
         assert backup == 5
@@ -824,8 +825,151 @@ class TestReadLoggingConfig:
         config = {"model": "test"}
         (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, loggers = hermes_logging._read_logging_config()
         assert level is None
+
+    def test_reads_loggers_dict(self, hermes_home):
+        """loggers dict is returned when present in config.yaml."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                    "tools.reranker": {"level": "WARNING"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        _, _, _, loggers = hermes_logging._read_logging_config()
+        assert loggers == {
+            "tools.tool_search": {"level": "DEBUG"},
+            "tools.reranker": {"level": "WARNING"},
+        }
+
+    def test_returns_empty_loggers_when_absent(self, hermes_home):
+        """loggers is an empty dict when the key is not in config."""
+        import yaml
+        config = {"logging": {"level": "INFO"}}
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        _, _, _, loggers = hermes_logging._read_logging_config()
+        assert loggers == {}
+
+
+class TestPerLoggerLevels:
+    """setup_logging() applies per-logger level overrides from config.yaml."""
+
+    def test_dict_shape_sets_logger_level(self, hermes_home):
+        """logging.loggers.<name>: {level: DEBUG} sets that logger to DEBUG."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        assert logging.getLogger("tools.tool_search").level == logging.DEBUG
+
+    def test_bare_string_shape_sets_logger_level(self, hermes_home):
+        """logging.loggers.<name>: DEBUG (bare string) is also accepted."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.reranker": "DEBUG",
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        assert logging.getLogger("tools.reranker").level == logging.DEBUG
+
+    def test_invalid_level_is_ignored(self, hermes_home):
+        """An unrecognised level string does not crash setup_logging()."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "NOTVALID"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        # Reset the specific logger so we can detect whether setup_logging
+        # touches it — prior tests in the same process may have left it set.
+        target = logging.getLogger("tools.tool_search")
+        target.setLevel(logging.NOTSET)
+
+        # Must not raise.
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        # Level is unchanged (NOTSET) — the invalid entry was silently skipped.
+        assert target.level == logging.NOTSET
+
+    def test_multiple_loggers_all_applied(self, hermes_home):
+        """Multiple loggers in config are all configured independently."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                    "tools.reranker": {"level": "WARNING"},
+                    "agent.context": {"level": "ERROR"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        assert logging.getLogger("tools.tool_search").level == logging.DEBUG
+        assert logging.getLogger("tools.reranker").level == logging.WARNING
+        assert logging.getLogger("agent.context").level == logging.ERROR
+
+    def test_per_logger_debug_records_propagate_to_agent_log(self, hermes_home):
+        """DEBUG records from a per-logger-configured logger reach agent.log.
+
+        Why: The whole point of the fix — verifying records actually appear.
+        Propagation must remain True so the root-attached agent.log handler
+        receives the records.
+        """
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        logger = logging.getLogger("tools.tool_search")
+        assert logger.propagate, "propagation must be True for agent.log to receive records"
+        logger.debug("tool_search debug record")
+
+        for h in logging.getLogger().handlers:
+            h.flush()
+
+        agent_log = hermes_home / "logs" / "agent.log"
+        content = agent_log.read_text()
+        assert "tool_search debug record" in content
 
 
 class TestExternalRotationRecovery:

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -7,9 +7,14 @@ arbitrary toolsets.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
-from tools.delegate_tool import _build_child_agent, _strip_blocked_tools
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_child_agent,
+    _strip_blocked_tools,
+    delegate_task,
+)
 
 
 class TestToolsetIntersection:
@@ -163,3 +168,327 @@ class TestProfileMcpToolsetBypass:
         assert "mcp-fastmail" in child_toolsets
         # ... but the non-MCP toolset the parent never had is still dropped.
         assert "browser" not in child_toolsets
+
+
+# ---------------------------------------------------------------------------
+# TestDelegateTaskProfileWiring
+# Regression guard for NousResearch/hermes-agent#32668 / #32727.
+# The full call chain from delegate_task() → _build_child_agent() must
+# thread the profile name and resolved toolsets through so MCP toolsets
+# bypass the no_mcp parent intersection at the _build_child_agent level.
+# ---------------------------------------------------------------------------
+
+_FAKE_AGENT_PROFILES = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files", "mcp-knowledge"],
+    },
+    "mail": {
+        "toolsets": ["mcp-fastmail"],
+    },
+}
+
+# Minimal delegate_task config: no delegation-specific overrides.
+_BARE_DELEGATION_CFG = {}
+
+# A structurally valid result dict from _run_single_child (enough fields for
+# the post-run aggregation logic in delegate_task to not raise AttributeError).
+def _make_fake_child_result(task_index: int = 0) -> dict:
+    """Return a minimal _run_single_child result dict.
+
+    Why: delegate_task's post-run loop calls entry.pop('_child_role', None),
+    entry.get('api_calls', 0), etc. — mocking with a plain string raises
+    AttributeError.  This helper produces a dict with every field that the
+    post-run aggregation touches.
+    Test: Used internally by TestDelegateTaskProfileWiring patches.
+    """
+    return {
+        "task_index": task_index,
+        "status": "ok",
+        "summary": "done",
+        "error": None,
+        "exit_reason": "complete",
+        "api_calls": 0,
+        "duration_seconds": 0.1,
+        "_child_role": "leaf",
+        "diagnostic_path": None,
+    }
+
+
+def _make_no_mcp_parent():
+    """Parent agent that simulates a no_mcp orchestrator.
+
+    enabled_toolsets contains only the non-MCP platform toolsets.
+    No mcp-* names are present, so the intersection path in
+    _build_child_agent would strip every MCP toolset when profile_name=None.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = ["delegation", "knowledge"]
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    parent.api_key = None
+    parent._client_kwargs = {}
+    parent.model = "test-model"
+    parent._subagent_id = None
+    parent.valid_tool_names = []
+    return parent
+
+
+class TestDelegateTaskProfileWiring:
+    """delegate_task() wires profile → _build_child_agent(profile_name=...).
+
+    Key regression guard: MUST fail against pre-fix code (profile_name=None
+    hardcoded) and MUST pass after the fix (profile_name=resolved name).
+    """
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_profile_forwarded_to_build_child_agent(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """delegate_task with profile='documents' calls _build_child_agent with
+        profile_name='documents' and the profile's toolsets.
+
+        This test FAILS on pre-fix code (profile_name=None hardcoded) and
+        PASSES after the fix (profile_name='documents' forwarded).
+
+        Why: Without this wiring the bypass branch at lines 972-976 of
+        _build_child_agent never activates, so mcp-nextcloud-files is stripped
+        from a no_mcp parent's child agent.
+        Test: Assert _build_child_agent is called with profile_name='documents'
+        and toolsets=['mcp-nextcloud-files', 'mcp-knowledge'].
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        # delegate_task needs _run_single_child; patch it out with a proper dict.
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Fetch the document",
+                context="Use the Nextcloud MCP server",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("profile_name") == "documents", (
+            f"profile_name should be 'documents', got {kwargs.get('profile_name')!r}. "
+            "Pre-fix code hardcodes profile_name=None — this is the regression guard."
+        )
+        assert "mcp-nextcloud-files" in (kwargs.get("toolsets") or []), (
+            f"Expected mcp-nextcloud-files in toolsets, got {kwargs.get('toolsets')!r}. "
+            "Profile toolsets must override the toolsets arg so the bypass activates."
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_no_profile_leaves_profile_name_none(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Without profile= arg, _build_child_agent is called with profile_name=None.
+
+        Preserves backward-compatible behavior: ad-hoc delegation without a
+        named profile still goes through the security intersection path.
+
+        Why: Must not accidentally enable the bypass for unprofiled calls.
+        Test: Call delegate_task without profile= and assert profile_name=None.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="List files",
+                toolsets=["terminal", "file"],
+                parent_agent=parent,
+            )
+
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("profile_name") is None, (
+            f"Expected profile_name=None for unprofiled call, got {kwargs.get('profile_name')!r}"
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_unknown_profile_falls_back_gracefully(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Unknown profile name logs a warning and falls back to explicit toolsets.
+
+        Why: A typo in a profile name should not hard-fail the delegation;
+        it should fall back to whatever toolsets the caller provided, if any.
+        Test: Pass profile='nonexistent', assert profile_name=None in call.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+        parent.enabled_toolsets = ["terminal"]
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Do something",
+                toolsets=["terminal"],
+                profile="nonexistent",
+                parent_agent=parent,
+            )
+
+        _, kwargs = mock_build.call_args
+        # Unknown profile → resolved_profile_name stays None → no bypass.
+        assert kwargs.get("profile_name") is None, (
+            f"Unknown profile should leave profile_name=None, got {kwargs.get('profile_name')!r}"
+        )
+
+
+class TestDelegateTaskSchemaProfile:
+    """DELEGATE_TASK_SCHEMA must formally declare the 'profile' property.
+
+    The model reliably emits only schema-declared fields. Without a formal
+    'profile' entry in the schema the model would silently omit it even when
+    the SOUL/orchestrator prompt instructs it to pass profile=.
+    """
+
+    def test_profile_field_in_schema(self):
+        """'profile' is a declared property in DELEGATE_TASK_SCHEMA.
+
+        Why: Without a formal schema entry the LLM strips the field before
+        calling the tool, making the orchestrator's profile= instruction
+        invisible to the handler.
+        Test: Assert 'profile' key exists in schema properties.
+        """
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        assert "profile" in props, (
+            "'profile' missing from DELEGATE_TASK_SCHEMA parameters.properties. "
+            "Add it so the model reliably emits the field."
+        )
+
+    def test_profile_field_is_string_type(self):
+        """'profile' schema property must be type=string.
+
+        Why: Any other type would cause schema validation failures at the
+        provider API boundary.
+        Test: Assert type == 'string' for the profile property.
+        """
+        prop = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["profile"]
+        assert prop.get("type") == "string", (
+            f"Expected profile schema type='string', got {prop.get('type')!r}"
+        )
+
+    def test_profile_field_not_required(self):
+        """'profile' must not be in the 'required' array (it is optional).
+
+        Why: Making it required would break all existing delegate_task calls
+        that don't specify a profile.
+        Test: Assert 'profile' absent from the required list.
+        """
+        required = DELEGATE_TASK_SCHEMA["parameters"].get("required", [])
+        assert "profile" not in required, (
+            "'profile' should not be in required — it is an optional field."
+        )
+
+
+class TestProfileMcpBypassEndToEnd:
+    """End-to-end bypass: no_mcp parent + profile → child keeps MCP toolsets.
+
+    This is the key regression guard from the PR description. It directly
+    tests _build_child_agent with profile_name set vs. None to confirm the
+    bypass branch activates/deactivates correctly.
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_mcp_parent_with_profile_retains_mcp_toolsets(self, _):
+        """CRITICAL: no_mcp parent + profile_name → child retains mcp-nextcloud-files.
+
+        This test FAILS against pre-fix code (profile_name=None hardcoded in
+        the _build_child_agent call site) because the bypass branch is never
+        entered — mcp-nextcloud-files gets stripped by the parent intersection.
+
+        After the fix (profile_name='documents' forwarded) the bypass branch
+        activates and mcp-nextcloud-files survives.
+
+        Why: The confirmed prod gap: fat sub-agents under no_mcp orchestrators
+        received 0 MCP tools. This verifies the fix at the _build_child_agent
+        level independent of the delegate_task wiring.
+        Test: Pass profile_name='documents' and assert mcp-nextcloud-files in
+        child enabled_toolsets. Then repeat with profile_name=None and assert
+        it IS stripped.
+        """
+        parent = _make_mcp_restricted_parent()
+
+        # --- With profile_name set (post-fix behavior) ---
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="File management",
+                context=None,
+                toolsets=["mcp-nextcloud-files", "knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="documents",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            "mcp-nextcloud-files should bypass no_mcp parent intersection when "
+            "profile_name is set. If this fails the fix is not working."
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_mcp_parent_without_profile_strips_mcp_toolsets(self, _):
+        """Confirm the pre-fix behavior: no profile → MCP stripped (security).
+
+        This must remain true to preserve the security boundary. Ad-hoc
+        delegation without a profile cannot bypass the intersection.
+
+        Why: The bypass is a deliberate whitelist; only named profiles whose
+        config explicitly declares MCP servers should get them through.
+        Test: profile_name=None → mcp-nextcloud-files absent from child.
+        """
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="File management",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-nextcloud-files" not in child_toolsets, (
+            "mcp-nextcloud-files must be stripped when profile_name=None (security boundary)."
+        )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -492,3 +492,171 @@ class TestProfileMcpBypassEndToEnd:
         assert "mcp-nextcloud-files" not in child_toolsets, (
             "mcp-nextcloud-files must be stripped when profile_name=None (security boundary)."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestBatchToolsetInjectionBlocked
+# Security regression guard for the batch-mode privilege-escalation hole:
+# a model that names a valid profile (activating the mcp-* bypass in
+# _build_child_agent) AND supplies per-task toolsets must NOT gain toolsets
+# beyond what the profile declares.
+# ---------------------------------------------------------------------------
+
+_PROFILES_WITH_NEXTCLOUD = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files"],
+    },
+}
+
+_PROFILES_EMPTY_TOOLSETS = {
+    "bare-profile": {
+        # no 'toolsets' key → empty profile
+    },
+}
+
+
+class TestBatchToolsetInjectionBlocked:
+    """Batch-mode model-supplied toolsets cannot override a resolved profile.
+
+    The vulnerability: batch tasks=[{"goal":"x","toolsets":["mcp-evil"]}] with
+    profile="documents" previously let the model inject arbitrary mcp-* toolsets
+    because the batch loop used `t.get("toolsets") or toolsets`, overriding the
+    profile-resolved toolsets while resolved_profile_name stayed set (activating
+    the mcp-* bypass in _build_child_agent).
+
+    These tests FAIL on pre-fix code (mcp-injected-evil present in child) and
+    PASS after the fix (child toolsets match profile declaration only).
+    """
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_PROFILES_WITH_NEXTCLOUD)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_batch_injection_blocked_model_cannot_inject_evil_mcp_toolset(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """CRITICAL security: batch per-task toolsets are ignored when a profile is set.
+
+        Why: Pre-fix, the batch loop used t.get("toolsets") or toolsets, so a
+        model could name profile="documents" (activating the mcp-* bypass) and
+        supply tasks=[{"goal":"x","toolsets":["mcp-injected-evil"]}] to gain
+        mcp-injected-evil — which the 'documents' profile never declared.
+        What: Assert _build_child_agent receives only the profile's toolsets
+        (mcp-nextcloud-files), and NOT the model-injected mcp-injected-evil.
+        Test: Compare the toolsets kwarg of the mock call against the profile
+        declaration; mcp-injected-evil must be absent, mcp-nextcloud-files present.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                # No top-level goal — use batch tasks path
+                tasks=[{"goal": "do something", "toolsets": ["mcp-injected-evil"]}],
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets = kwargs.get("toolsets") or []
+
+        assert "mcp-injected-evil" not in child_toolsets, (
+            f"SECURITY: mcp-injected-evil must be blocked but found in {child_toolsets!r}. "
+            "Pre-fix code lets batch per-task toolsets override the profile. "
+            "This test must FAIL before the fix and PASS after."
+        )
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"mcp-nextcloud-files (from profile 'documents') must be present, "
+            f"got {child_toolsets!r}"
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_PROFILES_WITH_NEXTCLOUD)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_single_task_profile_toolsets_unchanged(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Single-task profile path: child receives profile's declared toolsets.
+
+        Why: Regression guard — the batch fix must not break single-task profile
+        delegation, which already worked correctly pre-fix.
+        What: delegate_task(goal=..., profile="documents") → child gets
+        mcp-nextcloud-files (the profile's only declared toolset).
+        Test: Assert mcp-nextcloud-files in toolsets kwarg and profile_name set.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Manage my documents",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets = kwargs.get("toolsets") or []
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Single-task profile path must forward profile toolsets, got {child_toolsets!r}"
+        )
+        assert kwargs.get("profile_name") == "documents", (
+            f"profile_name must be 'documents', got {kwargs.get('profile_name')!r}"
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_PROFILES_EMPTY_TOOLSETS)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_empty_profile_toolsets_bypass_not_activated(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Profile with no toolsets does NOT activate the mcp-* bypass.
+
+        Why: Pre-fix, a profile with empty/missing toolsets still set
+        resolved_profile_name, activating the bypass with whatever caller-
+        supplied toolsets were present.  Any mcp-* name the model supplied
+        would bypass the parent intersection — a privilege-escalation vector.
+        What: Assert profile_name=None in the _build_child_agent call so the
+        intersection path (not bypass) is used, stripping mcp-x from a no_mcp
+        parent.
+        Test: Profile 'bare-profile' has no toolsets; caller passes
+        toolsets=['mcp-x']; assert profile_name=None in build call.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Do something restricted",
+                toolsets=["mcp-x"],
+                profile="bare-profile",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+
+        assert kwargs.get("profile_name") is None, (
+            f"Empty-toolsets profile must NOT set profile_name (bypass must be inactive), "
+            f"got profile_name={kwargs.get('profile_name')!r}. "
+            "Pre-fix: resolved_profile_name was set regardless of toolsets presence."
+        )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -8,7 +8,7 @@ arbitrary toolsets.
 
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import _build_child_agent, _strip_blocked_tools
 
 
 class TestToolsetIntersection:
@@ -63,3 +63,102 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+def _make_mcp_restricted_parent():
+    """Parent agent whose MCP context is empty (e.g. no_mcp orchestrator).
+
+    enabled_toolsets=[] means the parent loaded no toolsets at all — the
+    intersection against it would normally drop every requested toolset.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = []
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    return parent
+
+
+class TestProfileMcpToolsetBypass:
+    """MCP toolsets declared by a named agent_profile bypass parent intersection.
+
+    Regression coverage for NousResearch/hermes-agent#32668: an orchestrator
+    that restricts its own MCP servers must still be able to hand domain MCP
+    toolsets to a child via a named profile. Non-MCP toolsets keep going
+    through the parent intersection (the security boundary).
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_mcp_toolsets_bypass_parent_intersection(self, _):
+        """profile_name set → MCP toolsets pass through even when parent has none."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail", "mcp-knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" in child_toolsets
+        assert "mcp-knowledge" in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_profile_mcp_toolsets_still_intersected(self, _):
+        """No profile → MCP toolset request is dropped (intersection enforced)."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" not in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_non_mcp_toolsets_still_intersected(self, _):
+        """Even with a profile, non-MCP toolsets the parent lacks are dropped."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Browse the web",
+                context=None,
+                toolsets=["mcp-fastmail", "browser"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        # MCP toolset bypasses intersection ...
+        assert "mcp-fastmail" in child_toolsets
+        # ... but the non-MCP toolset the parent never had is still dropped.
+        assert "browser" not in child_toolsets

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -660,3 +660,102 @@ class TestBatchToolsetInjectionBlocked:
             f"got profile_name={kwargs.get('profile_name')!r}. "
             "Pre-fix: resolved_profile_name was set regardless of toolsets presence."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestProfileToolsetsAliasing
+# Regression guard for the config-aliasing vulnerability: toolsets must be
+# copied (list()) from the config dict, not assigned by reference.
+#
+# Without the copy, any in-place mutation of the working `toolsets` variable
+# (or of `profile_resolved_toolsets`, which is derived from it) silently
+# corrupts the agent_profiles config dict for the entire process lifetime.
+# On the next delegate_task call the now-mutated list would be used as the
+# authoritative profile declaration, bypassing the intended toolset scope.
+# ---------------------------------------------------------------------------
+
+class TestProfileToolsetsAliasing:
+    """Profile toolsets assignment must copy, not reference, the config list.
+
+    Why: profile_cfg["toolsets"] lives inside the dict returned by
+    _load_agent_profiles() and may be cached for the process lifetime.
+    Assigning it directly to the working variable means any in-place
+    mutation (e.g., .append(), .clear(), .pop()) of that variable would
+    corrupt the config — all subsequent delegate_task calls in the same
+    process would see the mutated toolsets as the 'official' profile
+    declaration.  This is a privilege-escalation / DoS vector.
+
+    The fix (list(profile_toolsets) at line ~2082 and
+    list(toolsets) at line ~2110) ensures the working variable and the
+    authoritative capture are independent copies.
+    """
+
+    @patch("tools.delegate_tool._load_agent_profiles")
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_profile_toolsets_copy_prevents_config_corruption(
+        self, mock_build, _mock_cfg, mock_load_profiles
+    ):
+        """Mutating the toolsets list passed to _build_child_agent must NOT
+        corrupt the original agent_profiles config entry.
+
+        Why: Pre-fix code did ``toolsets = profile_toolsets`` (reference), so
+        mutating the kwarg received by _build_child_agent also mutated
+        profiles["documents"]["toolsets"] — corrupting it for every future call.
+        What: After delegate_task resolves a profile, capture the toolsets list
+        that was passed to _build_child_agent, mutate it in-place, then verify
+        profiles["documents"]["toolsets"] is unchanged.
+        Test: Assert that appending a sentinel to the captured child toolsets
+        list does NOT appear in the original config dict, proving list() copy.
+        """
+        # Hold a direct reference to the config list so we can inspect it after
+        # delegate_task has run and after we mutate the captured child toolsets.
+        original_toolsets_list = ["mcp-nextcloud-files", "mcp-knowledge"]
+        profiles_cfg = {
+            "documents": {
+                "toolsets": original_toolsets_list,
+            },
+        }
+        mock_load_profiles.return_value = profiles_cfg
+
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Fetch documents",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        # Retrieve the toolsets list that was handed to _build_child_agent.
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets_arg: list = kwargs.get("toolsets") or []
+
+        # Sanity: the profile toolsets made it through correctly.
+        assert "mcp-nextcloud-files" in child_toolsets_arg, (
+            f"Profile toolsets must be forwarded; got {child_toolsets_arg!r}"
+        )
+
+        # Now mutate the list that _build_child_agent received.
+        sentinel = "mcp-INJECTED-SENTINEL"
+        child_toolsets_arg.append(sentinel)
+        child_toolsets_arg.clear()
+
+        # CRITICAL ASSERTION: the original config list must be untouched.
+        # Pre-fix (reference): original_toolsets_list would now be empty.
+        # Post-fix (copy):     original_toolsets_list is still the original.
+        assert original_toolsets_list == ["mcp-nextcloud-files", "mcp-knowledge"], (
+            f"Config corruption detected: profiles['documents']['toolsets'] was mutated "
+            f"to {original_toolsets_list!r}. "
+            "The toolsets working variable must be a list() copy, not a reference to the "
+            "config dict's list. Pre-fix code assigns `toolsets = profile_toolsets` "
+            "(reference); the fix is `toolsets = list(profile_toolsets)`."
+        )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -7,6 +7,7 @@ arbitrary toolsets.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import _build_child_agent, _strip_blocked_tools
 

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -759,3 +759,166 @@ class TestProfileToolsetsAliasing:
             "config dict's list. Pre-fix code assigns `toolsets = profile_toolsets` "
             "(reference); the fix is `toolsets = list(profile_toolsets)`."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestInheritMcpToolsetsProfileGuard
+# Security hardening: _preserve_parent_mcp_toolsets must NOT run when a named
+# profile is in use.  The profile's declared toolsets are authoritative — the
+# parent's MCP toolsets must not bleed in via the inherit_mcp_toolsets path.
+#
+# Scenario: parent has mcp-nextcloud-files AND mcp-fastmail in its toolsets.
+# Profile "documents" declares only ["mcp-nextcloud-files"].
+# With inherit_mcp_toolsets=True (default), the pre-fix code calls
+# _preserve_parent_mcp_toolsets unconditionally, which appends mcp-fastmail
+# (a parent MCP toolset missing from the child list) to the resolved profile
+# toolsets — violating the invariant that the profile is authoritative.
+#
+# These tests FAIL on pre-fix code (mcp-fastmail bleeds in) and PASS after
+# the fix (guard `and not profile_name` prevents _preserve_parent_mcp_toolsets
+# from running when a profile is set).
+# ---------------------------------------------------------------------------
+
+_PROFILES_DOCUMENTS_NEXTCLOUD_ONLY = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files"],
+    },
+}
+
+
+def _make_mcp_rich_parent():
+    """Parent agent that carries two MCP toolsets: nextcloud-files AND fastmail.
+
+    Why: Simulates an orchestrator that has loaded both domain MCP servers.
+    The profile "documents" only declares mcp-nextcloud-files, so mcp-fastmail
+    is the parent-only MCP toolset that must NOT bleed into the child when a
+    profile is named.
+
+    What: enabled_toolsets includes both mcp-nextcloud-files and mcp-fastmail
+    so that _preserve_parent_mcp_toolsets would normally append mcp-fastmail.
+
+    Test: Use as the parent arg in _build_child_agent calls below.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = ["mcp-nextcloud-files", "mcp-fastmail", "delegation"]
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    parent.api_key = None
+    parent._client_kwargs = {}
+    parent.model = "test-model"
+    parent._subagent_id = None
+    parent.valid_tool_names = []
+    return parent
+
+
+class TestInheritMcpToolsetsProfileGuard:
+    """inherit_mcp_toolsets=True must NOT add parent MCP toolsets when a profile is named.
+
+    The profile's declared toolsets are authoritative.  _preserve_parent_mcp_toolsets
+    must be skipped entirely when profile_name is set so that parent-only MCP toolsets
+    cannot bleed into the child.
+
+    FAIL before fix: mcp-fastmail (parent-only) appears in child toolsets.
+    PASS after fix:  child toolsets are EXACTLY the profile's (mcp-nextcloud-files only).
+    """
+
+    @patch("tools.delegate_tool._get_inherit_mcp_toolsets", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_parent_mcp_bleed_blocked_under_profile(self, _mock_cfg, _mock_inherit):
+        """CRITICAL: profile toolsets are authoritative — parent MCP toolsets must not bleed.
+
+        Why: Pre-fix, _preserve_parent_mcp_toolsets runs unconditionally when
+        inherit_mcp_toolsets=True, appending every parent MCP toolset absent from
+        the child list.  With a profile that declares only mcp-nextcloud-files,
+        the parent's mcp-fastmail gets added — a silent scope expansion that
+        violates the "profile declares exactly which MCP servers the child needs"
+        invariant.
+
+        What: _build_child_agent with profile_name="documents" (declares only
+        mcp-nextcloud-files) and a parent that has BOTH mcp-nextcloud-files and
+        mcp-fastmail.  Child toolsets must be exactly ["mcp-nextcloud-files"]
+        (after stripping delegation); mcp-fastmail must NOT appear.
+
+        Test: Assert "mcp-nextcloud-files" in child toolsets and
+        "mcp-fastmail" NOT in child toolsets.  FAILS pre-fix (mcp-fastmail
+        bleeds in via _preserve_parent_mcp_toolsets), PASSES post-fix (guard
+        `and not profile_name` skips the bleed path).
+        """
+        parent = _make_mcp_rich_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Manage documents",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="documents",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Profile-declared mcp-nextcloud-files must be present, got {child_toolsets!r}"
+        )
+        assert "mcp-fastmail" not in child_toolsets, (
+            f"SECURITY: mcp-fastmail (parent-only) must NOT bleed into the child when "
+            f"profile_name is set, but got {child_toolsets!r}. "
+            "Pre-fix: _preserve_parent_mcp_toolsets runs unconditionally, appending "
+            "every parent MCP toolset not in the child list. "
+            "Fix: add `and not profile_name` guard to the inherit_mcp_toolsets check "
+            "at line ~980 of delegate_tool.py."
+        )
+
+    @patch("tools.delegate_tool._get_inherit_mcp_toolsets", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_non_profile_inheritance_unchanged(self, _mock_cfg, _mock_inherit):
+        """Non-profile delegation with inherit_mcp_toolsets=True still inherits parent MCP.
+
+        Why: Regression baseline — the profile guard must not break the existing
+        behavior for ad-hoc (no profile) delegation.  When no profile is named,
+        _preserve_parent_mcp_toolsets should still run and add parent MCP toolsets
+        to a narrowed child that requests only a subset.
+
+        What: parent has mcp-nextcloud-files + mcp-fastmail; child requests only
+        mcp-nextcloud-files with NO profile.  After the fix, mcp-fastmail must
+        still appear in child toolsets (non-profile path is unchanged).
+
+        Test: Assert BOTH mcp-nextcloud-files and mcp-fastmail are present in the
+        child toolsets, proving that the guard is scoped to the profile case only.
+        """
+        parent = _make_mcp_rich_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Ad-hoc file management",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,  # no profile — inheritance must still work
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Requested mcp-nextcloud-files must be present, got {child_toolsets!r}"
+        )
+        assert "mcp-fastmail" in child_toolsets, (
+            f"mcp-fastmail must be inherited from parent when no profile is named "
+            f"(non-profile inheritance must be unchanged), got {child_toolsets!r}. "
+            "If this fails the profile guard is too broad."
+        )

--- a/tests/tools/test_mcp_lazy_discovery.py
+++ b/tests/tools/test_mcp_lazy_discovery.py
@@ -1,0 +1,185 @@
+"""Tests for Phase 2 lazy MCP discovery.
+
+When the active platform's toolsets include the ``no_mcp`` sentinel
+(e.g. api_server), the gateway/CLI skip eager MCP discovery at startup and
+defer it until the first child-agent build that needs MCP toolsets. This
+module verifies:
+
+* ``mark_eager_discovery_skipped()`` / ``ensure_mcp_discovered()`` behavior,
+  including the one-shot, thread-safe, failure-tolerant contract.
+* ``_active_platform_uses_no_mcp()`` config-dict resolution in gateway.run.
+
+See NousResearch/hermes-agent#32668.
+"""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+
+
+@pytest.fixture(autouse=True)
+def reset_lazy_discovery_state():
+    """Save/restore the module-level lazy-discovery globals around each test.
+
+    Discovery state is process-global; without this fixture a test that sets
+    ``_eager_discovery_skipped`` or the done Event would leak into siblings.
+    """
+    saved_skipped = mcp_tool._eager_discovery_skipped
+    saved_event = mcp_tool._lazy_discovery_done
+
+    # Start each test from a clean slate.
+    mcp_tool._eager_discovery_skipped = False
+    mcp_tool._lazy_discovery_done = threading.Event()
+
+    try:
+        yield
+    finally:
+        mcp_tool._eager_discovery_skipped = saved_skipped
+        mcp_tool._lazy_discovery_done = saved_event
+
+
+class TestMarkEagerDiscoverySkipped:
+    def test_sets_flag_true(self):
+        assert mcp_tool._eager_discovery_skipped is False
+        mcp_tool.mark_eager_discovery_skipped()
+        assert mcp_tool._eager_discovery_skipped is True
+
+
+class TestEnsureMcpDiscovered:
+    def test_noop_when_not_skipped(self):
+        """When eager discovery ran (skipped=False), ensure_* is a no-op."""
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mock_discover.assert_not_called()
+        # The done-Event must remain unset so a later skipped flow can still run.
+        assert not mcp_tool._lazy_discovery_done.is_set()
+
+    def test_calls_discover_once_when_skipped(self):
+        """First call after skip triggers discovery exactly once."""
+        mcp_tool.mark_eager_discovery_skipped()
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mock_discover.assert_called_once()
+        assert mcp_tool._lazy_discovery_done.is_set()
+
+    def test_idempotent_after_done(self):
+        """Second call after the done-Event is set never re-runs discovery."""
+        mcp_tool.mark_eager_discovery_skipped()
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            assert mock_discover.call_count == 1
+
+    def test_thread_safe_single_discovery(self):
+        """10 concurrent callers must trigger discovery exactly once."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        call_count = 0
+        count_lock = threading.Lock()
+
+        def slow_discover():
+            nonlocal call_count
+            with count_lock:
+                call_count += 1
+            # Hold the lazy lock long enough that all threads contend.
+            time.sleep(0.05)
+            return []
+
+        start = threading.Event()
+        threads = []
+
+        def worker():
+            start.wait()
+            mcp_tool.ensure_mcp_discovered()
+
+        with patch.object(mcp_tool, "discover_mcp_tools", side_effect=slow_discover):
+            for _ in range(10):
+                t = threading.Thread(target=worker)
+                t.start()
+                threads.append(t)
+            start.set()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert call_count == 1
+        assert mcp_tool._lazy_discovery_done.is_set()
+
+    def test_failure_does_not_propagate(self):
+        """If discover raises, ensure_* swallows it, sets done, logs a warning."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        def boom():
+            raise RuntimeError("connection refused")
+
+        with patch.object(mcp_tool, "discover_mcp_tools", side_effect=boom), \
+                patch.object(mcp_tool.logger, "warning") as mock_warning:
+            # Must not raise.
+            mcp_tool.ensure_mcp_discovered()
+
+        # Done-Event set to prevent retry storms after a hard failure.
+        assert mcp_tool._lazy_discovery_done.is_set()
+        mock_warning.assert_called_once()
+
+    def test_failure_prevents_retry(self):
+        """After a failed discovery, subsequent calls do not retry."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        with patch.object(
+            mcp_tool, "discover_mcp_tools", side_effect=RuntimeError("boom")
+        ) as mock_discover, patch.object(mcp_tool.logger, "warning"):
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            assert mock_discover.call_count == 1
+
+
+class TestActivePlatformUsesNoMcp:
+    def test_true_for_api_server_with_no_mcp(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"api_server": ["delegation", "no_mcp"]}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is True
+
+    def test_false_for_cli(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {
+            "platform_toolsets": {
+                "cli": ["delegation"],
+                "api_server": ["delegation", "no_mcp"],
+            }
+        }
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "cli"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_false_when_platform_toolsets_missing(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"some_other_key": {}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_false_for_unconfigured_platform(self):
+        """Platform present in env but absent from platform_toolsets -> False."""
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"cli": ["delegation"]}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_defaults_to_cli_when_env_unset(self):
+        """No HERMES_PLATFORM -> defaults to 'cli', which lacks no_mcp here."""
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"api_server": ["delegation", "no_mcp"]}}
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("HERMES_PLATFORM", None)
+            os.environ.pop("HERMES_SESSION_PLATFORM", None)
+            assert _active_platform_uses_no_mcp(config) is False

--- a/tests/tools/test_model_switch_tool.py
+++ b/tests/tools/test_model_switch_tool.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 
 import pytest
 
-import tools.model_switch_tool as mst
 from tools.model_switch_tool import (
     TURN_REVERT_ATTR,
     check_model_switch_requirements,
@@ -80,7 +79,7 @@ def _err_result(message="Invalid model"):
 
 
 @pytest.fixture(autouse=True)
-def _no_config(monkeypatch):
+def _no_config(monkeypatch):  # pyright: ignore[reportUnusedFunction]
     """Default: empty config so providers/allowlist/gate read as unset."""
     monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
 
@@ -89,7 +88,7 @@ def test_session_scope_switch_returns_dict(monkeypatch):
     """Basic session switch applies the swap and returns the contract dict."""
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
-        lambda **kw: _ok_result("deepseek/deepseek-r1"),
+        lambda **_kw: _ok_result("deepseek/deepseek-r1"),
     )
     agent = _StubAgent()
 
@@ -113,7 +112,7 @@ def test_turn_scope_reverts_after_one_turn(monkeypatch):
     """Turn-scope switch snapshots the old model and reverts on next turn."""
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
-        lambda **kw: _ok_result("deepseek/deepseek-r1"),
+        lambda **_kw: _ok_result("deepseek/deepseek-r1"),
     )
     agent = _StubAgent()
 
@@ -139,7 +138,7 @@ def test_unknown_model_slug_handled_gracefully(monkeypatch):
     """A resolver failure returns an error string, never raises."""
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
-        lambda **kw: _err_result("Unknown model 'totally-fake'"),
+        lambda **_kw: _err_result("Unknown model 'totally-fake'"),
     )
     agent = _StubAgent()
 
@@ -170,7 +169,7 @@ def test_allowlist_blocks_disallowed_model(monkeypatch):
     # switch_model must never be reached for a blocked slug.
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
-        lambda **kw: pytest.fail("switch_model should not run for blocked slug"),
+        lambda **_kw: pytest.fail("switch_model should not run for blocked slug"),
     )
     agent = _StubAgent()
 
@@ -189,7 +188,7 @@ def test_allowlist_allows_listed_model(monkeypatch):
     )
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
-        lambda **kw: _ok_result("gpt-4o"),
+        lambda **_kw: _ok_result("gpt-4o"),
     )
     agent = _StubAgent()
 
@@ -220,7 +219,7 @@ def test_apply_failure_clears_turn_snapshot(monkeypatch):
     """If switch_model raises, a turn snapshot must not be left stranded."""
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
-        lambda **kw: _ok_result("deepseek/deepseek-r1"),
+        lambda **_kw: _ok_result("deepseek/deepseek-r1"),
     )
 
     class _BoomAgent(_StubAgent):

--- a/tests/tools/test_model_switch_tool.py
+++ b/tests/tools/test_model_switch_tool.py
@@ -1,0 +1,234 @@
+"""Tests for the agent-callable ``model_switch`` tool (upstream #16525).
+
+These tests use a stub agent (no real AIAgent / network) and mock the shared
+``hermes_cli.model_switch.switch_model`` resolver so they stay hermetic. They
+cover: session-scope switching, turn-scope revert, graceful handling of an
+unknown model slug, the optional allowlist safeguard, and the opt-in config
+gate.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import tools.model_switch_tool as mst
+from tools.model_switch_tool import (
+    TURN_REVERT_ATTR,
+    check_model_switch_requirements,
+    model_switch_tool,
+    revert_turn_model_switch,
+)
+
+
+class _StubAgent:
+    """Minimal stand-in for AIAgent that records switch_model() calls.
+
+    Why: model_switch_tool mutates a live agent; a recording stub lets us
+    assert the swap was applied without booting a real agent.
+    """
+
+    def __init__(self):
+        self.model = "openai/gpt-4o-mini"
+        self.provider = "openrouter"
+        self.base_url = "https://openrouter.ai/api/v1"
+        self.api_key = "sk-old"
+        self.api_mode = "openai"
+        self.switch_calls = []
+
+    def switch_model(self, new_model, new_provider, api_key="", base_url="", api_mode=""):
+        self.switch_calls.append({
+            "new_model": new_model,
+            "new_provider": new_provider,
+            "api_key": api_key,
+            "base_url": base_url,
+            "api_mode": api_mode,
+        })
+        # Mirror the real in-place swap so subsequent reads see new values.
+        self.model = new_model
+        self.provider = new_provider
+        if base_url:
+            self.base_url = base_url
+        if api_key:
+            self.api_key = api_key
+        self.api_mode = api_mode
+
+
+def _ok_result(new_model="deepseek/deepseek-r1", provider="openrouter"):
+    """Build a successful ModelSwitchResult-shaped object."""
+    return SimpleNamespace(
+        success=True,
+        new_model=new_model,
+        target_provider=provider,
+        api_key="sk-new",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="openai",
+        error_message="",
+    )
+
+
+def _err_result(message="Invalid model"):
+    return SimpleNamespace(
+        success=False,
+        new_model="",
+        target_provider="",
+        api_key="",
+        base_url="",
+        api_mode="",
+        error_message=message,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_config(monkeypatch):
+    """Default: empty config so providers/allowlist/gate read as unset."""
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+
+def test_session_scope_switch_returns_dict(monkeypatch):
+    """Basic session switch applies the swap and returns the contract dict."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: _ok_result("deepseek/deepseek-r1"),
+    )
+    agent = _StubAgent()
+
+    raw = model_switch_tool(agent, slug="deepseek/deepseek-r1",
+                            reason="Need deep reasoning", scope="session")
+    out = json.loads(raw)
+
+    assert out == {
+        "old_model": "openai/gpt-4o-mini",
+        "new_model": "deepseek/deepseek-r1",
+        "scope": "session",
+        "applied_at": "next_turn",
+    }
+    assert len(agent.switch_calls) == 1
+    assert agent.switch_calls[0]["new_model"] == "deepseek/deepseek-r1"
+    # Session scope leaves no pending turn revert.
+    assert getattr(agent, TURN_REVERT_ATTR, None) is None
+
+
+def test_turn_scope_reverts_after_one_turn(monkeypatch):
+    """Turn-scope switch snapshots the old model and reverts on next turn."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: _ok_result("deepseek/deepseek-r1"),
+    )
+    agent = _StubAgent()
+
+    raw = model_switch_tool(agent, slug="deepseek/deepseek-r1",
+                            reason="One-shot escalation", scope="turn")
+    out = json.loads(raw)
+    assert out["scope"] == "turn"
+    assert agent.model == "deepseek/deepseek-r1"
+    # A revert snapshot of the original runtime is pending.
+    snapshot = getattr(agent, TURN_REVERT_ATTR)
+    assert snapshot["model"] == "openai/gpt-4o-mini"
+
+    # The loop calls this at the start of the next turn.
+    reverted = revert_turn_model_switch(agent)
+    assert reverted is True
+    assert agent.model == "openai/gpt-4o-mini"
+    assert getattr(agent, TURN_REVERT_ATTR) is None
+    # Second revert is a no-op (idempotent).
+    assert revert_turn_model_switch(agent) is False
+
+
+def test_unknown_model_slug_handled_gracefully(monkeypatch):
+    """A resolver failure returns an error string, never raises."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: _err_result("Unknown model 'totally-fake'"),
+    )
+    agent = _StubAgent()
+
+    raw = model_switch_tool(agent, slug="totally-fake", reason="oops")
+    out = json.loads(raw)
+
+    assert "error" in out
+    assert "totally-fake" in out["error"]
+    # Nothing was applied.
+    assert agent.switch_calls == []
+    assert agent.model == "openai/gpt-4o-mini"
+
+
+def test_empty_slug_rejected():
+    """An empty slug short-circuits before any resolution."""
+    agent = _StubAgent()
+    out = json.loads(model_switch_tool(agent, slug="   ", reason="x"))
+    assert "error" in out
+    assert agent.switch_calls == []
+
+
+def test_allowlist_blocks_disallowed_model(monkeypatch):
+    """model_switch_allowlist restricts which slugs are permitted."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_switch_allowlist": ["gpt-4o", "sonnet"]},
+    )
+    # switch_model must never be reached for a blocked slug.
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: pytest.fail("switch_model should not run for blocked slug"),
+    )
+    agent = _StubAgent()
+
+    out = json.loads(model_switch_tool(agent, slug="deepseek/deepseek-r1",
+                                       reason="blocked"))
+    assert "error" in out
+    assert "allowlist" in out["error"].lower()
+    assert agent.switch_calls == []
+
+
+def test_allowlist_allows_listed_model(monkeypatch):
+    """A slug present in the allowlist passes through (case-insensitive)."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_switch_allowlist": ["GPT-4O"]},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: _ok_result("gpt-4o"),
+    )
+    agent = _StubAgent()
+
+    out = json.loads(model_switch_tool(agent, slug="gpt-4o", reason="ok"))
+    assert out["new_model"] == "gpt-4o"
+    assert len(agent.switch_calls) == 1
+
+
+def test_check_requirements_gates_on_config(monkeypatch):
+    """The tool is opt-in via agent.allow_self_model_switch."""
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    assert check_model_switch_requirements() is False
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"agent": {"allow_self_model_switch": True}},
+    )
+    assert check_model_switch_requirements() is True
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"agent": {"allow_self_model_switch": False}},
+    )
+    assert check_model_switch_requirements() is False
+
+
+def test_apply_failure_clears_turn_snapshot(monkeypatch):
+    """If switch_model raises, a turn snapshot must not be left stranded."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: _ok_result("deepseek/deepseek-r1"),
+    )
+
+    class _BoomAgent(_StubAgent):
+        def switch_model(self, *a, **k):
+            raise RuntimeError("bad credentials")
+
+    agent = _BoomAgent()
+    out = json.loads(model_switch_tool(agent, slug="deepseek/deepseek-r1",
+                                       reason="will fail", scope="turn"))
+    assert "error" in out
+    assert getattr(agent, TURN_REVERT_ATTR, None) is None

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -895,13 +895,17 @@ class TestEmbedCacheInvalidation:
     """Tool embeddings are recomputed when the catalog changes."""
 
     def test_cache_invalidated_on_catalog_change(self):
-        """Changing the catalog (different tool names) forces a new reranker instance."""
+        """Changing the catalog (different tool names) gives a DIFFERENT reranker instance.
+
+        With the per-scope cache both instances coexist in the dict; a different
+        catalog key is a different scope, so _get_reranker returns a new object.
+        """
         from tools.tool_search import _get_reranker, RerankerConfig
         import tools.tool_search as ts_module
 
-        # Reset module-level singleton to known state.
-        ts_module._reranker = None
-        ts_module._reranker_catalog_key = ""
+        # Reset per-scope cache to a known-empty state.
+        ts_module._reranker_cache.clear()
+        ts_module._reranker_cache_order.clear()
 
         cfg = RerankerConfig.from_raw({
             "enabled": True,
@@ -922,12 +926,12 @@ class TestEmbedCacheInvalidation:
         assert r3 is not r1, "changed catalog should produce a new reranker instance"
 
     def test_same_catalog_reuses_reranker(self):
-        """Identical catalog returns the same singleton (cache hit)."""
+        """Identical catalog returns the same cached instance (cache hit)."""
         from tools.tool_search import _get_reranker, RerankerConfig
         import tools.tool_search as ts_module
 
-        ts_module._reranker = None
-        ts_module._reranker_catalog_key = ""
+        ts_module._reranker_cache.clear()
+        ts_module._reranker_cache_order.clear()
 
         cfg = RerankerConfig.from_raw({
             "enabled": True,
@@ -963,6 +967,118 @@ class TestEmbedCacheInvalidation:
 
         assert call_count[0] == 1, (
             f"expected 1 embed call (cache hit on second), got {call_count[0]}"
+        )
+
+    def test_concurrent_scopes_do_not_share_reranker(self):
+        """Two different toolset scopes each get their own reranker instance.
+
+        Why: Proves the fix for the architecture-review finding. With the old
+        single-slot singleton, scope B's _get_reranker call would overwrite the
+        slot and discard scope A's instance + embedding cache. With the per-scope
+        dict, both coexist.
+        What: Calls _get_reranker for catalog_a, then catalog_b, then catalog_a
+        again. Asserts that (a) scope A and scope B are different objects, and
+        (b) the second call for scope A returns the ORIGINAL instance — proving
+        scope B's creation did NOT evict scope A.
+        Test: Mock _embed so we can count calls; assert re-requesting scope A
+        after creating scope B does NOT trigger a new _embed call.
+        """
+        from tools.tool_search import _get_reranker, RerankerConfig
+        import tools.tool_search as ts_module
+
+        ts_module._reranker_cache.clear()
+        ts_module._reranker_cache_order.clear()
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://scope-test/v1/embeddings",
+            "model": "m",
+        })
+
+        catalog_a = _make_catalog(("tool_alpha", "Alpha scope tool"))
+        catalog_b = _make_catalog(("tool_beta", "Beta scope tool"))
+
+        # Obtain scope A's reranker and populate its embedding cache.
+        r_a = _get_reranker(cfg, catalog_a)
+        assert r_a is not None
+
+        embed_call_count = [0]
+
+        def counting_embed(texts: List[str]) -> List[List[float]]:
+            embed_call_count[0] += 1
+            return [[0.5] * 4 for _ in texts]
+
+        # Seed scope A's internal embedding cache with a known entry so we can
+        # detect whether a new instance (empty cache) is returned later.
+        r_a._embed = counting_embed  # type: ignore[method-assign]
+        r_a._embed_with_cache(["alpha seed text"])
+        assert embed_call_count[0] == 1, "seed embed should fire once"
+
+        # Now obtain scope B — different toolset scope.
+        r_b = _get_reranker(cfg, catalog_b)
+        assert r_b is not None
+        assert r_b is not r_a, "different toolset scopes must produce different reranker instances"
+
+        # Re-request scope A — must return the SAME instance (not a fresh one).
+        r_a2 = _get_reranker(cfg, catalog_a)
+        assert r_a2 is r_a, (
+            "re-requesting scope A after creating scope B must return the cached "
+            "scope-A instance, not a new one"
+        )
+
+        # The embedding cache on scope A must still be warm: re-embedding the
+        # same text should NOT call _embed again.
+        r_a2._embed_with_cache(["alpha seed text"])
+        assert embed_call_count[0] == 1, (
+            f"scope A's embedding cache was evicted (embed_call_count={embed_call_count[0]}); "
+            "scope B creation must not discard scope A's cached embeddings"
+        )
+
+    def test_reranker_cache_evicts_oldest_scope_when_full(self):
+        """When the cache reaches _RERANKER_CACHE_MAX_SIZE, the oldest scope is evicted.
+
+        Why: Proves the FIFO eviction bound works so memory usage is bounded
+        even when many distinct toolset-scopes are active in the same process.
+        What: Fills the cache to capacity with N distinct scopes, then adds one
+        more (N+1). Asserts the first scope's key is no longer in the cache
+        dict, while all subsequent scopes are still present.
+        Test: Inspect _reranker_cache directly after N+1 insertions.
+        """
+        from tools.tool_search import _get_reranker, RerankerConfig, _RERANKER_CACHE_MAX_SIZE
+        import tools.tool_search as ts_module
+
+        ts_module._reranker_cache.clear()
+        ts_module._reranker_cache_order.clear()
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://eviction-test/v1/embeddings",
+            "model": "m",
+        })
+
+        # Fill cache to the max with distinct single-tool catalogs.
+        rerankers = []
+        for i in range(_RERANKER_CACHE_MAX_SIZE):
+            cat = _make_catalog((f"evict_tool_{i}", f"Tool number {i}"))
+            r = _get_reranker(cfg, cat)
+            assert r is not None
+            rerankers.append(r)
+
+        assert len(ts_module._reranker_cache) == _RERANKER_CACHE_MAX_SIZE
+
+        # The first scope's key is the first entry in the order list before eviction.
+        first_scope_key = ts_module._reranker_cache_order[0]
+        assert first_scope_key in ts_module._reranker_cache, "sanity: first scope present before eviction"
+
+        # Adding one more scope should evict the oldest.
+        overflow_cat = _make_catalog(("evict_tool_overflow", "Overflow tool"))
+        _get_reranker(cfg, overflow_cat)
+
+        assert len(ts_module._reranker_cache) == _RERANKER_CACHE_MAX_SIZE, (
+            "cache size must not grow beyond _RERANKER_CACHE_MAX_SIZE after eviction"
+        )
+        assert first_scope_key not in ts_module._reranker_cache, (
+            "oldest scope must be evicted when cache is full and a new scope arrives"
         )
 
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -3,6 +3,15 @@
 Coverage targets — these mirror the issues called out in the OpenClaw tool
 search report. Every test that names an OpenClaw issue is the regression
 guard that would have caught that specific failure mode.
+
+Enhancement tests (NousResearch/hermes-agent#13332 — Hybrid Tool Pre-Selection):
+  TestRerankerConfig        — config parsing for reranker sub-config
+  TestRerankerInvoked       — reranker invoked and changes result order
+  TestRerankerFallback      — endpoint failure → pure BM25, no exception propagates
+  TestRRFMath               — RRF score formula with known inputs
+  TestEmbedPrefixes         — search_query:/search_document: prefixes sent correctly
+  TestEmbedCacheInvalidation — catalog change → tool embeddings recomputed
+  TestEmbedPayloadShape     — model + input keys present in POST body
 """
 
 from __future__ import annotations
@@ -11,6 +20,7 @@ import json
 import os
 import sys
 from typing import List, Dict, Any
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -535,4 +545,692 @@ class TestRegression_ToolsetScoping:
         assert "mcp_helper_op" in names
         # core tools are never deferrable
         assert "terminal" not in names
+
+
+# ---------------------------------------------------------------------------
+# Enhancement B: Config parsing (NousResearch/hermes-agent#13332)
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerConfig:
+    """Config parsing for the embedding reranker sub-config."""
+
+    def test_reranker_config_default_disabled(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(None)
+        assert not cfg.reranker.enabled
+        assert cfg.reranker.mode == "rerank"
+        assert cfg.reranker.rrf_k == 10
+        assert cfg.reranker.query_prefix == "search_query: "
+        assert cfg.reranker.doc_prefix == "search_document: "
+
+    def test_reranker_config_enabled_with_rrf(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({
+            "reranker": {
+                "enabled": True,
+                "endpoint": "http://localhost:11434/v1/embeddings",
+                "model": "nomic-embed-text-v2-moe",
+                "mode": "rrf",
+                "rrf_k": 10,
+            },
+        })
+        assert cfg.reranker.enabled
+        assert cfg.reranker.mode == "rrf"
+        assert cfg.reranker.rrf_k == 10
+
+    def test_reranker_config_invalid_mode_falls_back_to_rerank(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({
+            "reranker": {"enabled": True, "mode": "crossencoder"},
+        })
+        assert cfg.reranker.mode == "rerank"
+
+    def test_reranker_config_none_raw_gives_disabled(self):
+        from tools.tool_search import RerankerConfig
+        cfg = RerankerConfig.from_raw(None)
+        assert not cfg.enabled
+
+    def test_reranker_config_custom_prefixes(self):
+        from tools.tool_search import RerankerConfig
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://x",
+            "query_prefix": "",
+            "doc_prefix": "",
+        })
+        assert cfg.query_prefix == ""
+        assert cfg.doc_prefix == ""
+
+    def test_legacy_bool_true_does_not_break_new_fields(self):
+        """Legacy bool=True: enabled=auto, reranker=OFF."""
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(True)
+        assert cfg.enabled == "auto"
+        # Reranker stays default OFF (requires external endpoint).
+        assert not cfg.reranker.enabled
+
+    def test_legacy_bool_false_does_not_break_new_fields(self):
+        """Legacy bool=False: enabled=off, reranker=OFF."""
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(False)
+        assert cfg.enabled == "off"
+        # Reranker stays default OFF.
+        assert not cfg.reranker.enabled
+
+
+# ---------------------------------------------------------------------------
+# Enhancement B: Reranker invoked and changes order
+# ---------------------------------------------------------------------------
+
+
+def _make_catalog(*names_and_descs: tuple[str, str]) -> "List[Any]":
+    """Build a catalog from (name, description) pairs without registry."""
+    from tools.tool_search import CatalogEntry, _tokenize, _entry_search_text
+    catalog = []
+    for name, desc in names_and_descs:
+        td = _td(name, desc)
+        e = CatalogEntry(
+            name=name, description=desc,
+            schema=td, source="mcp", source_name="mcp-test",
+        )
+        e._tokens = _tokenize(_entry_search_text(td))
+        e._embed_text = f"{name}: {desc}"
+        catalog.append(e)
+    return catalog
+
+
+class MockReranker:
+    """Reranker that reverses the BM25 order — proves invocation changes result."""
+
+    def rerank(self, query: str, bm25_all: List[Any], limit: int, config: Any) -> List[Any]:
+        # Return the BM25 list in reverse order, sliced to limit.
+        return [e for _, e in reversed(bm25_all)][:limit]
+
+
+class BrokenReranker:
+    """Reranker that always raises — proves graceful fallback to BM25."""
+
+    def rerank(self, query: str, bm25_all: List[Any], limit: int, config: Any) -> List[Any]:
+        raise ConnectionError("endpoint unreachable")
+
+
+class TestRerankerInvoked:
+    def test_mock_reranker_changes_result_order(self):
+        """When a reranker reverses BM25 order, search_catalog returns reversed order."""
+        from tools.tool_search import search_catalog, ToolSearchConfig
+        catalog = _make_catalog(
+            ("github_create_issue", "Open a new issue in a GitHub repository"),
+            ("slack_send_message", "Post a message into a Slack channel"),
+            ("calendar_create_event", "Add an event to the user's calendar"),
+        )
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+
+        # Without reranker: BM25 should rank github tool first for this query.
+        bm25_hits = search_catalog(catalog, "create github issue", limit=3, config=cfg)
+        assert bm25_hits[0].name == "github_create_issue"
+
+        # With mock reranker: order is reversed.
+        mock = MockReranker()
+        reranked = search_catalog(catalog, "create github issue", limit=3,
+                                  config=cfg, reranker=mock)
+        # The last BM25 result is now first.
+        assert reranked[0].name != "github_create_issue"
+
+
+class TestRerankerFallback:
+    def test_broken_reranker_returns_bm25_without_exception(self):
+        """When the reranker raises, search_catalog returns pure BM25 results silently."""
+        from tools.tool_search import search_catalog, ToolSearchConfig
+        catalog = _make_catalog(
+            ("github_create_issue", "Open a new issue in a GitHub repository"),
+            ("slack_send_message", "Post a message into a Slack channel"),
+        )
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+
+        broken = BrokenReranker()
+        # Must not raise — fallback to BM25.
+        hits = search_catalog(catalog, "create github issue", limit=2,
+                              config=cfg, reranker=broken)
+        assert len(hits) >= 1
+        assert hits[0].name == "github_create_issue"  # BM25 result preserved
+
+
+# ---------------------------------------------------------------------------
+# Enhancement B: RRF math
+# ---------------------------------------------------------------------------
+
+
+class TestRRFMath:
+    def test_rrf_top_ranked_in_both_lists_wins(self):
+        """A document ranked #1 in both BM25 and embed lists should score highest."""
+        from tools.tool_search import _rrf_fuse, CatalogEntry, _tokenize
+        from tools.tool_search import _entry_search_text
+
+        def _entry(name: str) -> Any:
+            td = _td(name, f"Description for {name}")
+            e = CatalogEntry(
+                name=name, description=f"Description for {name}",
+                schema=td, source="mcp", source_name="mcp-test",
+            )
+            e._tokens = _tokenize(_entry_search_text(td))
+            e._embed_text = f"{name}: Description for {name}"
+            return e
+
+        alpha = _entry("tool_alpha")
+        beta = _entry("tool_beta")
+        gamma = _entry("tool_gamma")
+
+        # tool_alpha is rank 1 in BM25, rank 2 in embed.
+        # tool_beta  is rank 2 in BM25, rank 1 in embed.
+        # tool_gamma is rank 3 in both.
+        bm25_ranked = [(1.0, alpha), (0.5, beta), (0.1, gamma)]
+        embed_ranked = [(0.9, beta), (0.8, alpha), (0.2, gamma)]
+
+        fused = _rrf_fuse(bm25_ranked, embed_ranked, k=10, top_n=3)
+        names = [e.name for e in fused]
+
+        # alpha: 1/(10+1) + 1/(10+2) = 0.0909 + 0.0833 = 0.1742
+        # beta:  1/(10+2) + 1/(10+1) = 0.0833 + 0.0909 = 0.1742
+        # gamma: 1/(10+3) + 1/(10+3) = 0.0769 + 0.0769 = 0.1538
+        # alpha and beta tie (Python sorted is stable — exact order varies)
+        assert "gamma" not in names[:2] or names[2] == "tool_gamma"
+        assert "tool_gamma" in names  # gamma appears somewhere
+
+    def test_rrf_k10_formula_correct(self):
+        """Verify score = sum(1/(k+rank)) matches manual calculation."""
+        from tools.tool_search import _rrf_fuse, CatalogEntry, _tokenize
+        from tools.tool_search import _entry_search_text
+
+        def _entry(name: str) -> Any:
+            td = _td(name, f"desc {name}")
+            e = CatalogEntry(name=name, description=f"desc {name}",
+                             schema=td, source="mcp", source_name="x")
+            e._tokens = _tokenize(_entry_search_text(td))
+            e._embed_text = f"{name}: desc {name}"
+            return e
+
+        a = _entry("a")
+        b = _entry("b")
+
+        # a is rank 1 in both lists.  b is rank 2 in both.
+        bm25 = [(2.0, a), (1.0, b)]
+        embed = [(0.9, a), (0.5, b)]
+        fused = _rrf_fuse(bm25, embed, k=10, top_n=2)
+        # a should beat b because both lists rank it #1.
+        assert fused[0].name == "a"
+        assert fused[1].name == "b"
+
+
+# ---------------------------------------------------------------------------
+# Enhancement B: Prefix application via urllib mock
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedPrefixes:
+    """Assert that search_query: / search_document: prefixes are sent correctly."""
+
+    def _fake_urlopen_factory(self, captured_bodies: List[bytes], fake_vec: List[float]):
+        """Return a urlopen mock that captures request bodies and returns fake embeddings."""
+        import io
+
+        def fake_urlopen(req, timeout=None):
+            body = req.data
+            captured_bodies.append(body)
+            # Parse the input to know how many vectors to return.
+            payload = json.loads(body)
+            texts = payload["input"]
+            data = [{"index": i, "embedding": fake_vec} for i in range(len(texts))]
+            resp_bytes = json.dumps({"data": data}).encode("utf-8")
+
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read = MagicMock(return_value=resp_bytes)
+            return mock_resp
+
+        return fake_urlopen
+
+    def test_query_prefix_applied(self):
+        """The POST body for the query embed must start with 'search_query:'."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://fake-embed/v1/embeddings",
+            "model": "test-model",
+            "query_prefix": "search_query: ",
+            "doc_prefix": "search_document: ",
+        })
+        reranker = EmbeddingReranker(cfg)
+
+        captured: List[bytes] = []
+        fake_vec = [0.1, 0.2, 0.3]
+        urlopen_mock = self._fake_urlopen_factory(captured, fake_vec)
+
+        with patch("urllib.request.urlopen", urlopen_mock):
+            reranker._embed(["search_query: hello world"])
+
+        assert len(captured) == 1
+        body = json.loads(captured[0])
+        assert any("search_query:" in t for t in body["input"]), (
+            "query prefix not present in embed POST body"
+        )
+
+    def test_doc_prefix_applied(self):
+        """The POST body for tool doc embeds must start with 'search_document:'."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://fake-embed/v1/embeddings",
+            "model": "test-model",
+            "query_prefix": "search_query: ",
+            "doc_prefix": "search_document: ",
+        })
+        reranker = EmbeddingReranker(cfg)
+
+        captured: List[bytes] = []
+        fake_vec = [0.1, 0.2, 0.3]
+        urlopen_mock = self._fake_urlopen_factory(captured, fake_vec)
+
+        with patch("urllib.request.urlopen", urlopen_mock):
+            reranker._embed(["search_document: web_search: Search the web"])
+
+        body = json.loads(captured[0])
+        assert any("search_document:" in t for t in body["input"]), (
+            "doc prefix not present in embed POST body"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Enhancement B: Embedding payload shape
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedPayloadShape:
+    """Assert that the HTTP POST body contains the correct model + input keys."""
+
+    def test_embed_payload_has_model_and_input(self):
+        """POST body must have 'model' and 'input' keys."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig
+        import io
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://fake/v1/embeddings",
+            "model": "my-embed-model",
+        })
+        reranker = EmbeddingReranker(cfg)
+
+        captured: List[bytes] = []
+        fake_vec = [0.5, 0.5]
+
+        def fake_urlopen(req, timeout=None):
+            captured.append(req.data)
+            data = [{"index": 0, "embedding": fake_vec}]
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read = MagicMock(return_value=json.dumps({"data": data}).encode("utf-8"))
+            return resp
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            reranker._embed(["hello"])
+
+        assert len(captured) == 1
+        body = json.loads(captured[0])
+        assert "model" in body, "embed payload missing 'model' key"
+        assert "input" in body, "embed payload missing 'input' key"
+        assert body["model"] == "my-embed-model"
+        assert isinstance(body["input"], list)
+
+
+# ---------------------------------------------------------------------------
+# Enhancement B: Cache invalidation on catalog change
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedCacheInvalidation:
+    """Tool embeddings are recomputed when the catalog changes."""
+
+    def test_cache_invalidated_on_catalog_change(self):
+        """Changing the catalog (different tool names) forces a new reranker instance."""
+        from tools.tool_search import _get_reranker, RerankerConfig
+        import tools.tool_search as ts_module
+
+        # Reset module-level singleton to known state.
+        ts_module._reranker = None
+        ts_module._reranker_catalog_key = ""
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://x/v1/embeddings",
+            "model": "m",
+        })
+
+        catalog_a = _make_catalog(("tool_one", "Does one thing"))
+        catalog_b = _make_catalog(("tool_two", "Does two things"))
+
+        r1 = _get_reranker(cfg, catalog_a)
+        assert r1 is not None
+
+        r2 = _get_reranker(cfg, catalog_a)
+        assert r2 is r1, "same catalog should return the same reranker instance"
+
+        r3 = _get_reranker(cfg, catalog_b)
+        assert r3 is not r1, "changed catalog should produce a new reranker instance"
+
+    def test_same_catalog_reuses_reranker(self):
+        """Identical catalog returns the same singleton (cache hit)."""
+        from tools.tool_search import _get_reranker, RerankerConfig
+        import tools.tool_search as ts_module
+
+        ts_module._reranker = None
+        ts_module._reranker_catalog_key = ""
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://y/v1/embeddings",
+            "model": "n",
+        })
+        catalog = _make_catalog(("stable_tool", "Stable description"))
+        r1 = _get_reranker(cfg, catalog)
+        r2 = _get_reranker(cfg, catalog)
+        assert r1 is r2
+
+    def test_embed_cache_hit_skips_network(self):
+        """When the text is already cached, _embed is not called again."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://z/v1/embeddings",
+            "model": "m2",
+        })
+        reranker = EmbeddingReranker(cfg)
+
+        call_count = [0]
+
+        def counting_embed(texts: List[str]) -> List[List[float]]:
+            call_count[0] += 1
+            return [[0.1] * len(texts[0]) for _ in texts]
+
+        reranker._embed = counting_embed  # type: ignore[method-assign]
+
+        reranker._embed_with_cache(["hello there"])
+        reranker._embed_with_cache(["hello there"])  # should be served from cache
+
+        assert call_count[0] == 1, (
+            f"expected 1 embed call (cache hit on second), got {call_count[0]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix HIGH-2: Embedding dimension-mismatch guard
+# ---------------------------------------------------------------------------
+
+
+class TestDimensionMismatchGuard:
+    """When the endpoint returns vectors of wrong or zero length, fall back to BM25.
+
+    Regression guard for HIGH-2: previously the rerank path used zip() to
+    pair query and doc vectors, silently truncating to the shorter dimension.
+    This caused wrong cosine scores without any indication of the problem
+    (e.g. when an embedding model is swapped mid-session and returns 768-dim
+    vectors where 1536-dim were cached).  The fix raises ValueError so that
+    search_catalog's except clause falls back to BM25 cleanly.
+    """
+
+    def _make_reranker_with_fixed_vecs(self, q_vec: List[float], doc_vec: List[float]):
+        """Return an EmbeddingReranker whose _embed always returns q_vec then doc_vec."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://dim-test/v1/embeddings",
+            "model": "test-model",
+            "query_prefix": "",
+            "doc_prefix": "",
+        })
+        reranker = EmbeddingReranker(cfg)
+
+        call_seq: List[List[List[float]]] = []
+
+        def _embed_side_effect(texts: List[str]) -> List[List[float]]:
+            if not call_seq:
+                # First call = doc embeddings
+                call_seq.append([doc_vec] * len(texts))
+                return [doc_vec] * len(texts)
+            # Second call = query embedding
+            return [q_vec]
+
+        reranker._embed = _embed_side_effect  # type: ignore[method-assign]
+        return reranker
+
+    def test_mismatched_dimensions_fall_back_to_bm25(self):
+        """Feeding mismatched-dimension vectors causes BM25 fallback, no exception."""
+        from tools.tool_search import search_catalog, ToolSearchConfig
+
+        catalog = _make_catalog(
+            ("github_create_issue", "Open a new issue in a GitHub repository"),
+            ("slack_send_message", "Post a message into a Slack channel"),
+        )
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+
+        # query dim=3, doc dim=4 — mismatched
+        q_vec = [0.1, 0.2, 0.3]
+        doc_vec = [0.1, 0.2, 0.3, 0.4]
+
+        reranker = self._make_reranker_with_fixed_vecs(q_vec, doc_vec)
+
+        # Must not raise — must fall back to BM25 order silently.
+        hits = search_catalog(
+            catalog, "create github issue", limit=2, config=cfg, reranker=reranker
+        )
+        assert len(hits) >= 1
+        # BM25 order is preserved after fallback.
+        assert hits[0].name == "github_create_issue"
+
+    def test_zero_length_query_vector_falls_back_to_bm25(self):
+        """A zero-length query vector causes BM25 fallback, no exception."""
+        from tools.tool_search import search_catalog, ToolSearchConfig
+
+        catalog = _make_catalog(
+            ("github_create_issue", "Open a new issue in a GitHub repository"),
+        )
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+
+        # query dim=0 — degenerate response
+        q_vec: List[float] = []
+        doc_vec = [0.1, 0.2, 0.3]
+
+        reranker = self._make_reranker_with_fixed_vecs(q_vec, doc_vec)
+
+        hits = search_catalog(
+            catalog, "create github issue", limit=1, config=cfg, reranker=reranker
+        )
+        assert len(hits) >= 1
+        assert hits[0].name == "github_create_issue"
+
+
+# ---------------------------------------------------------------------------
+# Fix LOW: Hardened RRF test with exact hand-computed scores
+# ---------------------------------------------------------------------------
+
+
+class TestRRFExactScores:
+    """Lock the RRF formula against silent drift with explicit hand-computed values.
+
+    RRF score for doc d = sum over lists L of 1 / (k + rank_L(d)).
+    With k=10: rank-1 contributes 1/11 ≈ 0.09091, rank-2 contributes 1/12 ≈ 0.08333.
+    """
+
+    def _entry(self, name: str) -> "Any":
+        from tools.tool_search import CatalogEntry, _tokenize, _entry_search_text
+        td = _td(name, f"desc for {name}")
+        e = CatalogEntry(name=name, description=f"desc for {name}",
+                         schema=td, source="mcp", source_name="x")
+        e._tokens = _tokenize(_entry_search_text(td))
+        e._embed_text = f"{name}: desc for {name}"
+        return e
+
+    def test_rrf_exact_scores_and_order_k10(self):
+        """Hand-computed RRF scores for two known ranked lists (k=10).
+
+        Lists:
+          BM25:  [alpha(rank1), beta(rank2), gamma(rank3)]
+          embed: [beta(rank1),  alpha(rank2)]   (gamma absent — rank 3 implicit)
+
+        Manual calculation (k=10):
+          alpha_score = 1/(10+1) + 1/(10+2) = 1/11 + 1/12 = 0.090909 + 0.083333 = 0.174242
+          beta_score  = 1/(10+2) + 1/(10+1) = 1/12 + 1/11 = 0.083333 + 0.090909 = 0.174242
+          gamma_score = 1/(10+3) + 1/(10+3) = 1/13 + 1/13 = 0.076923 + 0.076923 = 0.153846
+
+        Expected order: alpha and beta tie (both 0.1742), gamma is last (0.1538).
+        Python's sorted is stable so alpha (first in BM25) wins the tie.
+
+        Exact score assertion: gamma's score must be 2/13 ≈ 0.153846 (within 1e-9).
+        """
+        from tools.tool_search import _rrf_fuse
+        import math as _math
+
+        alpha = self._entry("alpha")
+        beta = self._entry("beta")
+        gamma = self._entry("gamma")
+
+        bm25_ranked = [(1.0, alpha), (0.5, beta), (0.1, gamma)]
+        embed_ranked = [(0.9, beta), (0.8, alpha), (0.2, gamma)]
+
+        fused = _rrf_fuse(bm25_ranked, embed_ranked, k=10, top_n=3)
+        names = [e.name for e in fused]
+
+        # Ordering: gamma must be last.
+        assert names[2] == "gamma", (
+            f"gamma should be rank-3 (score ≈ 0.1538), got order {names}"
+        )
+        # alpha and beta both score ≈ 0.1742 — both must appear in top-2.
+        assert set(names[:2]) == {"alpha", "beta"}, (
+            f"alpha and beta should tie at rank 1-2, got {names[:2]}"
+        )
+
+        # Exact score for gamma: 1/(10+3) + 1/(10+3) = 2/13.
+        expected_gamma_score = 2.0 / 13.0  # ≈ 0.153846...
+        # Reconstruct the fused scores dict to check the exact value.
+        scores: Dict[str, float] = {}
+        for rank_idx, (_, e) in enumerate(bm25_ranked, start=1):
+            scores[e.name] = scores.get(e.name, 0.0) + 1.0 / (10 + rank_idx)
+        for rank_idx, (_, e) in enumerate(embed_ranked, start=1):
+            scores[e.name] = scores.get(e.name, 0.0) + 1.0 / (10 + rank_idx)
+
+        assert abs(scores["gamma"] - expected_gamma_score) < 1e-9, (
+            f"gamma RRF score = {scores['gamma']!r}, expected {expected_gamma_score!r} "
+            "(formula: 1/(10+3) + 1/(10+3) = 2/13)"
+        )
+        # Sanity-check alpha and beta scores are equal and larger than gamma.
+        assert abs(scores["alpha"] - scores["beta"]) < 1e-9, (
+            f"alpha and beta should tie: alpha={scores['alpha']!r}, beta={scores['beta']!r}"
+        )
+        assert scores["alpha"] > scores["gamma"], (
+            "tied alpha/beta score must exceed gamma score"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix CRITICAL 2: EmbeddingReranker.rerank() must not return more than limit
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerHonoursLimit:
+    """EmbeddingReranker.rerank() must return at most ``limit`` entries.
+
+    Before the fix, top_k = max(limit, config.search_default_limit), so
+    calling search_catalog(limit=3) with search_default_limit=5 returned 5
+    results — violating the caller's contract.
+    """
+
+    def _make_reranker_with_mock_embed(self, n_tools: int):
+        """Return an EmbeddingReranker that uses a fixed unit vector for all texts."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig
+
+        cfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://fake-limit-test/v1/embeddings",
+            "model": "test-model",
+            "query_prefix": "",
+            "doc_prefix": "",
+        })
+        reranker = EmbeddingReranker(cfg)
+
+        def _fake_embed(texts: List[str]) -> List[List[float]]:
+            # Return distinct unit vectors so scores differ and ordering is stable.
+            return [[float(i + 1), 0.0] for i in range(len(texts))]
+
+        reranker._embed = _fake_embed  # type: ignore[method-assign]
+        return reranker
+
+    def test_reranker_rerank_mode_respects_limit(self):
+        """With mode=rerank, result length must equal the requested limit."""
+        from tools.tool_search import ToolSearchConfig, RerankerConfig
+
+        n_tools = 8
+        limit = 3
+        catalog = _make_catalog(*[(f"tool_{i}", f"Description {i}") for i in range(n_tools)])
+
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "search_default_limit": 5,  # deliberately larger than limit
+            "reranker": {
+                "enabled": True,
+                "endpoint": "http://fake-limit-test/v1/embeddings",
+                "model": "test-model",
+                "mode": "rerank",
+                "query_prefix": "",
+                "doc_prefix": "",
+            },
+        })
+        reranker = self._make_reranker_with_mock_embed(n_tools)
+        bm25_all = [(float(n_tools - i), e) for i, e in enumerate(catalog)]
+
+        result = reranker.rerank("test query", bm25_all, limit=limit, config=cfg)
+        assert len(result) <= limit, (
+            f"reranker returned {len(result)} results for limit={limit}; "
+            "must not exceed the caller's limit even when search_default_limit is larger"
+        )
+
+    def test_reranker_rrf_mode_respects_limit(self):
+        """With mode=rrf, result length must equal the requested limit."""
+        from tools.tool_search import EmbeddingReranker, RerankerConfig, ToolSearchConfig
+
+        n_tools = 7
+        limit = 2
+        catalog = _make_catalog(*[(f"rrf_tool_{i}", f"Desc {i}") for i in range(n_tools)])
+
+        rcfg = RerankerConfig.from_raw({
+            "enabled": True,
+            "endpoint": "http://fake-rrf-limit/v1/embeddings",
+            "model": "rrf-model",
+            "mode": "rrf",
+            "rrf_k": 10,
+            "query_prefix": "",
+            "doc_prefix": "",
+        })
+        reranker = EmbeddingReranker(rcfg)
+
+        def _fake_embed(texts: List[str]) -> List[List[float]]:
+            return [[float(i + 1), 0.0] for i in range(len(texts))]
+
+        reranker._embed = _fake_embed  # type: ignore[method-assign]
+
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "search_default_limit": 5,  # deliberately larger than limit
+        })
+        bm25_all = [(float(n_tools - i), e) for i, e in enumerate(catalog)]
+
+        result = reranker.rerank("rrf test", bm25_all, limit=limit, config=cfg)
+        assert len(result) <= limit, (
+            f"rrf reranker returned {len(result)} results for limit={limit}; "
+            "must not exceed caller's limit"
+        )
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -980,7 +980,7 @@ def _build_child_agent(
         else:
             child_toolsets = [t for t in toolsets if t in expanded_parent]
 
-        if _get_inherit_mcp_toolsets():
+        if _get_inherit_mcp_toolsets() and not profile_name:
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -904,6 +904,16 @@ def _build_child_agent(
     those credentials instead of inheriting from the parent.  This enables
     routing subagents to a different provider:model pair (e.g. cheap/fast
     model on OpenRouter while the parent runs on Nous Portal).
+
+    profile_name: when set (i.e. the delegation came from a named
+    agent_profiles entry), MCP toolsets in the requested toolset list bypass
+    the parent-intersection check and are resolved directly from the global
+    mcp_servers config.  This is intentional: a profile explicitly declares
+    which MCP servers its worker needs, and those servers should be available
+    regardless of whether the orchestrator itself loaded them (e.g. it
+    restricted its own context via no_mcp).  Non-MCP toolsets still go
+    through intersection — that security boundary is preserved for ad-hoc
+    delegation.  See NousResearch/hermes-agent#32668.
     """
     from run_agent import AIAgent
     import uuid as _uuid

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1135,6 +1135,16 @@ def _build_child_agent(
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.
 
+    # Trigger lazy MCP discovery if this child needs MCP toolsets. This is a
+    # no-op when eager discovery already ran at startup; it only does work when
+    # the active platform skipped eager discovery via the no_mcp sentinel
+    # (Phase 2). Runs for ALL MCP-needing child builds, not just profile-named
+    # ones, so the child sees a populated MCP registry before AIAgent builds.
+    if any(_is_mcp_toolset_name(t) for t in child_toolsets):
+        from tools.mcp_tool import ensure_mcp_discovered
+
+        ensure_mcp_discovered()
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -891,6 +891,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Name of the resolved agent_profiles profile, if delegation used one.
+    # When set, MCP toolsets declared by the profile bypass parent
+    # intersection (see toolset resolution below).
+    profile_name: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -950,7 +954,22 @@ def _build_child_agent(
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+
+        # When toolsets come from a named agent_profile, MCP toolsets bypass the
+        # parent intersection. The profile declares exactly which MCP servers the
+        # child needs; resolving them against the parent's loaded tools would
+        # silently drop them whenever the orchestrator restricts its own MCP
+        # context (e.g. no_mcp, or simply not loading domain servers). Non-MCP
+        # toolsets still go through intersection — that security boundary is
+        # preserved. See NousResearch/hermes-agent#32668.
+        if profile_name:
+            child_toolsets = [
+                t for t in toolsets
+                if _is_mcp_toolset_name(t) or t in expanded_parent
+            ]
+        else:
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -2100,6 +2119,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                profile_name=None,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2086,17 +2086,36 @@ def delegate_task(
                 sorted(all_profiles.keys()) if all_profiles else [],
             )
         else:
-            resolved_profile_name = profile
-            # Profile toolsets override caller-supplied toolsets so the model
-            # cannot expand its own access beyond what the profile declares.
             profile_toolsets = profile_cfg.get("toolsets")
             if profile_toolsets and isinstance(profile_toolsets, list):
+                # Profile toolsets are authoritative: store them separately so
+                # the batch path (below) can enforce them per-task without
+                # allowing model-supplied per-task toolsets to override.
+                resolved_profile_name = profile
                 toolsets = profile_toolsets
+            else:
+                # Profile declares no toolsets — granting the bypass here
+                # would activate the mcp-* exception in _build_child_agent
+                # with whatever the model supplied as toolsets.  That is a
+                # privilege-escalation vector, so we refuse to set the
+                # resolved name and fall back to the normal intersection path.
+                logger.warning(
+                    "delegate_task: profile %r has no non-empty toolsets list; "
+                    "bypass NOT activated (falling back to intersection path).",
+                    profile,
+                )
             logger.debug(
-                "delegate_task: resolved profile %r → toolsets=%s",
+                "delegate_task: resolved profile %r → resolved_profile_name=%r toolsets=%s",
                 profile,
+                resolved_profile_name,
                 toolsets,
             )
+
+    # Capture the profile-resolved toolsets so the batch loop below can enforce
+    # them as authoritative, ignoring any per-task toolsets the model supplies.
+    # When no profile was resolved this is None and the batch loop falls through
+    # to the per-task / top-level toolsets (existing behaviour unchanged).
+    profile_resolved_toolsets: Optional[list[str]] = toolsets if resolved_profile_name else None
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2163,7 +2182,13 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
+                # Security: when a named profile was resolved its toolsets are
+                # authoritative for every task in the batch.  Using per-task
+                # model-supplied toolsets here would allow the model to name a
+                # valid profile (activating the mcp-* bypass in
+                # _build_child_agent) while injecting arbitrary toolsets that
+                # the profile never declared — a privilege-escalation vector.
+                toolsets=profile_resolved_toolsets if resolved_profile_name else (t.get("toolsets") or toolsets),
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1982,6 +1982,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1995,6 +1996,16 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'profile' parameter names an entry in the top-level
+    ``agent_profiles`` config mapping.  When set, the profile's declared
+    toolsets are used as the effective toolset list for the child, and
+    ``profile_name`` is forwarded to ``_build_child_agent`` so that
+    MCP toolsets declared by the profile bypass the parent's toolset
+    intersection.  This is the mechanism that lets fat sub-agents receive
+    their full MCP toolsets even when the orchestrator runs under a
+    ``no_mcp`` platform toolset.  See NousResearch/hermes-agent#32668 and
+    #32727.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2055,6 +2066,37 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Resolve named agent_profile, if one was requested.
+    # When ``profile`` is set the caller wants a pre-declared agent archetype
+    # (toolsets, model, system_prompt) from the top-level ``agent_profiles``
+    # config section.  We extract the toolsets from the profile here so the
+    # rest of the function can treat them as the effective toolset list.
+    # ``resolved_profile_name`` stays None when no profile was requested so
+    # the existing intersection path in _build_child_agent is unchanged.
+    resolved_profile_name: Optional[str] = None
+    if profile and isinstance(profile, str) and profile.strip():
+        all_profiles = _load_agent_profiles()
+        profile_cfg = all_profiles.get(profile)
+        if profile_cfg is None:
+            logger.warning(
+                "delegate_task: unknown profile %r; known profiles: %s. "
+                "Falling back to explicit toolsets (if any).",
+                profile,
+                sorted(all_profiles.keys()) if all_profiles else [],
+            )
+        else:
+            resolved_profile_name = profile
+            # Profile toolsets override caller-supplied toolsets so the model
+            # cannot expand its own access beyond what the profile declares.
+            profile_toolsets = profile_cfg.get("toolsets")
+            if profile_toolsets and isinstance(profile_toolsets, list):
+                toolsets = profile_toolsets
+            logger.debug(
+                "delegate_task: resolved profile %r → toolsets=%s",
+                profile,
+                toolsets,
+            )
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2139,7 +2181,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
-                profile_name=None,
+                profile_name=resolved_profile_name,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2549,6 +2591,41 @@ def _load_config() -> dict:
         return {}
 
 
+def _load_agent_profiles() -> dict:
+    """Return the top-level ``agent_profiles`` mapping from full config.
+
+    Why: agent_profiles live at the root of config.yaml (not under
+    ``delegation``), so _load_config() cannot see them.  This helper
+    reads the full config and returns the profiles dict so delegate_task()
+    can resolve a named profile to its declared toolsets/model.
+
+    What: Returns cfg["agent_profiles"] (a dict of name → profile dict),
+    or an empty dict when the key is absent or config loading fails.
+
+    Test: Patch ``cli.CLI_CONFIG`` with {"agent_profiles": {"docs": {"toolsets":
+    ["mcp-nextcloud-files"]}}} and assert _load_agent_profiles() returns
+    that inner dict keyed by "docs".
+    """
+    try:
+        from cli import CLI_CONFIG
+
+        profiles = CLI_CONFIG.get("agent_profiles")
+        if profiles and isinstance(profiles, dict):
+            return profiles
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import load_config
+
+        full = load_config()
+        profiles = full.get("agent_profiles")
+        if profiles and isinstance(profiles, dict):
+            return profiles
+    except Exception:
+        pass
+    return {}
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -2839,6 +2916,17 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Named agent_profiles entry whose toolsets (and optionally model "
+                    "and system prompt) the sub-agent should use. When set, the "
+                    "profile's declared MCP toolsets are forwarded to the child even "
+                    "when the orchestrator runs under a no_mcp platform_toolset that "
+                    "has no MCP servers of its own. Leave unset to use ad-hoc "
+                    "toolsets or inherit from the parent. Example: 'documents'."
+                ),
+            },
         },
         "required": [],
     },
@@ -2861,6 +2949,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        profile=args.get("profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2092,7 +2092,14 @@ def delegate_task(
                 # the batch path (below) can enforce them per-task without
                 # allowing model-supplied per-task toolsets to override.
                 resolved_profile_name = profile
-                toolsets = profile_toolsets
+                # Copy, not reference: profile_toolsets is the list stored
+                # inside the config dict returned by _load_agent_profiles().
+                # Assigning the reference directly means any later in-place
+                # mutation (e.g. .append() / .clear()) of the working
+                # `toolsets` variable would corrupt the config for the entire
+                # process lifetime.  list() gives us an independent shallow
+                # copy of the string items, which is all we need.
+                toolsets = list(profile_toolsets)
             else:
                 # Profile declares no toolsets — granting the bypass here
                 # would activate the mcp-* exception in _build_child_agent
@@ -2115,7 +2122,12 @@ def delegate_task(
     # them as authoritative, ignoring any per-task toolsets the model supplies.
     # When no profile was resolved this is None and the batch loop falls through
     # to the per-task / top-level toolsets (existing behaviour unchanged).
-    profile_resolved_toolsets: Optional[list[str]] = toolsets if resolved_profile_name else None
+    #
+    # Take an independent copy (list()) even though `toolsets` was already
+    # copied from profile_toolsets above.  This keeps profile_resolved_toolsets
+    # stable against any future code that mutates `toolsets` in-place between
+    # here and the batch loop — defence-in-depth.
+    profile_resolved_toolsets: Optional[list[str]] = list(toolsets) if resolved_profile_name else None
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2638,8 +2638,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             }, ensure_ascii=False)
 
         async def _call():
+            # Coerce stringified booleans/numbers to the types the MCP server's
+            # schema expects (BUG-NEW-6: nextThoughtNeeded sent as "true").
+            call_args = _coerce_args_to_schema(
+                args, _input_schema_for_tool(server, tool_name)
+            )
             async with server._rpc_lock:
-                result = await server.session.call_tool(tool_name, arguments=args)
+                result = await server.session.call_tool(tool_name, arguments=call_args)
             # MCP CallToolResult has .content (list of content blocks) and .isError
             if result.isError:
                 error_text = ""
@@ -3112,6 +3117,88 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         normalized = {**normalized, "properties": {}}
 
     return normalized
+
+
+def _coerce_args_to_schema(args: dict, schema: dict | None) -> dict:
+    """Coerce stringified scalars in tool args to the JSON types the schema wants.
+
+    Why: Some models emit boolean/number fields as JSON strings (e.g.
+    ``"nextThoughtNeeded": "true"`` instead of ``true``). The downstream MCP
+    server validates strictly (Zod) and rejects these with
+    ``expected: boolean, code: invalid_type`` -- e.g. the sequentialthinking
+    tool's required ``nextThoughtNeeded`` boolean (BUG-NEW-6). Coercing here,
+    using the tool's own input schema, makes the call succeed without weakening
+    the server-side contract.
+    What: For each top-level property whose schema ``type`` is ``boolean``,
+    ``integer``, or ``number``, convert a stringified value ("true"/"1"/"5") to
+    the proper JSON type. Unknown/already-correct values pass through untouched.
+    Test: Pass ``{"nextThoughtNeeded": "true", "thoughtNumber": "1"}`` with a
+    schema marking them boolean/integer; assert the result is
+    ``{"nextThoughtNeeded": True, "thoughtNumber": 1}``.
+    """
+    if not isinstance(args, dict) or not isinstance(schema, dict):
+        return args
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        return args
+
+    def _to_bool(v):
+        if isinstance(v, str):
+            s = v.strip().lower()
+            if s in ("true", "1", "yes"):
+                return True
+            if s in ("false", "0", "no", ""):
+                return False
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            return bool(v)
+        return v
+
+    def _to_int(v):
+        if isinstance(v, str):
+            try:
+                return int(v.strip())
+            except ValueError:
+                return v
+        if isinstance(v, float) and v.is_integer():
+            return int(v)
+        return v
+
+    def _to_num(v):
+        if isinstance(v, str):
+            try:
+                return float(v.strip())
+            except ValueError:
+                return v
+        return v
+
+    out = dict(args)
+    for key, value in args.items():
+        spec = props.get(key)
+        if not isinstance(spec, dict):
+            continue
+        t = spec.get("type")
+        if t == "boolean":
+            out[key] = _to_bool(value)
+        elif t == "integer":
+            out[key] = _to_int(value)
+        elif t == "number":
+            out[key] = _to_num(value)
+    return out
+
+
+def _input_schema_for_tool(server, tool_name: str) -> dict | None:
+    """Return the raw inputSchema for ``tool_name`` from a connected server.
+
+    Why: The tool handler needs the schema to coerce arg types before calling.
+    What: Scans ``server._tools`` (discovered MCP tool objects) for a name match
+    and returns its ``.inputSchema`` dict, or None if not found.
+    Test: With a server whose ``_tools`` has a tool named ``sequentialthinking``,
+    assert this returns that tool's inputSchema dict.
+    """
+    for t in getattr(server, "_tools", None) or []:
+        if getattr(t, "name", None) == tool_name:
+            return getattr(t, "inputSchema", None)
+    return None
 
 
 def sanitize_mcp_name_component(value: str) -> str:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2397,6 +2397,14 @@ _orphan_stdio_pids: set = set()
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 
+# Lazy discovery state -- used when the active platform skips eager discovery
+# (e.g. api_server, whose toolsets include the ``no_mcp`` sentinel). When the
+# gateway marks eager discovery as skipped, the first child agent build that
+# needs MCP toolsets triggers a one-shot, thread-safe lazy discovery instead.
+_eager_discovery_skipped: bool = False
+_lazy_discovery_done: threading.Event = threading.Event()
+_lazy_discovery_lock: threading.Lock = threading.Lock()
+
 
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
@@ -3628,6 +3636,45 @@ def discover_mcp_tools() -> List[str]:
         logger.info(summary)
 
     return tool_names
+
+
+def mark_eager_discovery_skipped() -> None:
+    """Called by gateway startup when the active platform uses no_mcp.
+
+    Signals that eager MCP discovery was intentionally skipped.
+    The first call to ensure_mcp_discovered() will trigger lazy discovery.
+    """
+    global _eager_discovery_skipped
+    _eager_discovery_skipped = True
+
+
+def ensure_mcp_discovered() -> None:
+    """Trigger MCP discovery lazily, exactly once, thread-safe.
+
+    Safe to call concurrently from multiple threads. The first caller runs
+    discovery; subsequent callers return immediately once the Event is set.
+
+    If discovery was NOT skipped at startup (eager path already ran), this
+    is a no-op -- the Event is already set or discovery runs as normal.
+
+    On failure: logs a warning, sets the done-Event to prevent retry storms,
+    and returns -- child agents will get an empty/partial MCP toolset
+    (same degradation as a startup discovery failure).
+    """
+    if not _eager_discovery_skipped:
+        # Eager discovery ran at startup (or wasn't needed); nothing to do.
+        return
+    if _lazy_discovery_done.is_set():
+        return
+    with _lazy_discovery_lock:
+        if _lazy_discovery_done.is_set():
+            return
+        try:
+            discover_mcp_tools()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Lazy MCP discovery failed: %s", exc)
+        finally:
+            _lazy_discovery_done.set()
 
 
 def is_mcp_tool_parallel_safe(tool_name: str) -> bool:

--- a/tools/model_switch_tool.py
+++ b/tools/model_switch_tool.py
@@ -287,7 +287,7 @@ registry.register(
     name="model_switch",
     toolset="model_switch",
     schema=MODEL_SWITCH_SCHEMA,
-    handler=lambda args, **kw: tool_error(
+    handler=lambda *_args, **_kw: tool_error(
         "model_switch must be handled by the agent loop"
     ),
     check_fn=check_model_switch_requirements,

--- a/tools/model_switch_tool.py
+++ b/tools/model_switch_tool.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Model Switch Tool — agent-driven complexity-based model routing.
+
+Exposes the existing :func:`hermes_cli.model_switch.switch_model` pipeline as
+an agent-callable tool so the model can escalate (or downgrade) its own backend
+mid-conversation when it detects the current model is over- or under-powered for
+the task at hand.  This is the concrete implementation behind the
+``smart_model_routing`` config stub (upstream #16525), which previously had no
+Python wiring.
+
+Like ``todo`` / ``memory`` / ``delegate_task``, this tool needs live agent
+state (it must mutate the running :class:`AIAgent`), so the registry handler is
+a stub and the real work is intercepted in the agent loop
+(``agent.tool_executor`` / ``agent.agent_runtime_helpers``), which calls
+:func:`model_switch_tool` with the live agent.
+
+Scopes:
+  - ``session`` — persists until the session is reset or another switch.
+    Implemented via :meth:`AIAgent.switch_model`, which updates
+    ``_primary_runtime`` so the change survives across turns.
+  - ``turn`` — one-shot.  The pre-switch runtime is snapshotted onto the agent
+    and restored at the start of the next turn (see ``conversation_loop``).
+"""
+
+import json
+import logging
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# Agent attribute holding the turn-scoped revert snapshot.  Read by the
+# conversation loop's per-turn reset block.  Kept here as the single source of
+# truth so the loop and this tool can't drift on the attribute name.
+TURN_REVERT_ATTR = "_model_switch_turn_revert"
+
+
+MODEL_SWITCH_SCHEMA = {
+    "name": "model_switch",
+    "description": (
+        "Switch your own model when the current one is mismatched to the task — "
+        "escalate to a more capable model for hard reasoning/coding, or downgrade "
+        "to a cheaper/faster model for simple work. Takes effect on your NEXT turn. "
+        "Use sparingly and only when the complexity clearly warrants it; explain "
+        "the switch to the user via 'reason'. Examples of slugs: "
+        "'deepseek/deepseek-r1', 'gpt-4o', 'anthropic/claude-opus-4', 'sonnet'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string",
+                "description": (
+                    "Target model identifier or short alias (e.g. "
+                    "'deepseek/deepseek-r1', 'gpt-4o', 'opus', 'haiku'). "
+                    "Aliases resolve against your authenticated providers."
+                ),
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "One-sentence justification for the switch, surfaced to the "
+                    "user (e.g. 'Escalating to a reasoning model for this proof')."
+                ),
+            },
+            "scope": {
+                "type": "string",
+                "enum": ["session", "turn"],
+                "description": (
+                    "'session' (default) persists the switch until reset; "
+                    "'turn' applies it for the next turn only, then reverts."
+                ),
+            },
+        },
+        "required": ["slug", "reason"],
+    },
+}
+
+
+def _load_providers_config() -> tuple[dict | None, list | None]:
+    """Return ``(user_providers, custom_providers)`` from config for resolution.
+
+    Why: ``switch_model`` resolves aliases / credentials against the user's
+    configured ``providers:`` and ``custom_providers:`` just like the /model
+    command does; without them, custom endpoints wouldn't resolve.
+    What: Loads the persistent config and extracts both sections, mirroring the
+    gateway's ``_handle_model_command``.
+    Test: Patch ``hermes_cli.config.load_config`` to return a config with
+    ``providers``/``custom_providers`` and assert both are returned.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        user_providers = cfg.get("providers")
+        try:
+            from hermes_cli.config import get_compatible_custom_providers
+
+            custom_providers = get_compatible_custom_providers(cfg)
+        except Exception:
+            custom_providers = cfg.get("custom_providers")
+        return user_providers, custom_providers
+    except Exception:
+        return None, None
+
+
+def _allowlist() -> list[str] | None:
+    """Return the ``model_switch_allowlist`` config list, or None if unset.
+
+    Why: Optional safeguard (#16525) so operators can restrict which models the
+    agent may self-route to; default (unset) allows any configured model.
+    What: Reads the top-level ``model_switch_allowlist`` key and normalizes it
+    to a lowercased list, or None when absent/empty.
+    Test: Patch config to ``{"model_switch_allowlist": ["gpt-4o"]}`` and assert
+    ['gpt-4o'] is returned; unset config returns None.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        raw = (load_config() or {}).get("model_switch_allowlist")
+    except Exception:
+        return None
+    if not raw or not isinstance(raw, list):
+        return None
+    return [str(m).strip().lower() for m in raw if str(m).strip()]
+
+
+def model_switch_tool(agent, slug: str, reason: str, scope: str = "session") -> str:
+    """Switch the live agent's model. Called from the agent loop with the agent.
+
+    Why: Lets the model self-escalate/downgrade based on task complexity, the
+    concrete behavior behind the ``smart_model_routing`` stub (#16525).
+    What: Resolves *slug* via :func:`hermes_cli.model_switch.switch_model`,
+    applies it with :meth:`AIAgent.switch_model`, and for ``scope='turn'``
+    snapshots the prior runtime so the loop reverts it next turn. Returns a JSON
+    string with old/new model, scope, and ``applied_at: 'next_turn'``.
+    Test: Build a stub agent with ``switch_model`` recorded, call with a known
+    slug, and assert the returned dict carries the resolved new_model and that
+    the agent's switch_model was invoked; turn scope sets TURN_REVERT_ATTR.
+    """
+    from hermes_cli.model_switch import switch_model as _switch_model
+
+    slug = (slug or "").strip()
+    reason = (reason or "").strip()
+    scope = (scope or "session").strip().lower()
+    if scope not in {"session", "turn"}:
+        scope = "session"
+    if not slug:
+        return tool_error("model_switch requires a non-empty 'slug'.")
+
+    # Optional allowlist safeguard — default allows all configured models.
+    allow = _allowlist()
+    if allow is not None and slug.lower() not in allow:
+        return tool_error(
+            f"Model '{slug}' is not in model_switch_allowlist "
+            f"({', '.join(allow)}). Pick an allowed model or remove the allowlist."
+        )
+
+    old_model = getattr(agent, "model", "")
+    old_provider = getattr(agent, "provider", "")
+    old_base_url = getattr(agent, "base_url", "")
+    old_api_key = getattr(agent, "api_key", "")
+
+    user_providers, custom_providers = _load_providers_config()
+
+    # Resolve the target model + credentials through the shared pipeline.
+    result = _switch_model(
+        raw_input=slug,
+        current_provider=old_provider,
+        current_model=old_model,
+        current_base_url=old_base_url,
+        current_api_key=old_api_key,
+        is_global=False,
+        explicit_provider="",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    if not result.success:
+        return tool_error(
+            f"Could not switch to '{slug}': {result.error_message}"
+        )
+
+    # For turn scope, snapshot the current runtime so the loop can restore it
+    # at the start of the next turn (one-shot). Stored before mutation.
+    if scope == "turn":
+        setattr(agent, TURN_REVERT_ATTR, {
+            "model": old_model,
+            "provider": old_provider,
+            "base_url": old_base_url,
+            "api_key": old_api_key,
+            "api_mode": getattr(agent, "api_mode", ""),
+        })
+    else:
+        # A session switch supersedes any pending turn revert.
+        if getattr(agent, TURN_REVERT_ATTR, None) is not None:
+            setattr(agent, TURN_REVERT_ATTR, None)
+
+    # Apply the swap in-place. switch_model() updates _primary_runtime so a
+    # session switch persists across turns; a turn switch is reverted by the
+    # loop before the next turn begins.
+    try:
+        agent.switch_model(
+            new_model=result.new_model,
+            new_provider=result.target_provider,
+            api_key=result.api_key,
+            base_url=result.base_url,
+            api_mode=result.api_mode,
+        )
+    except Exception as exc:
+        # Roll back the turn snapshot so a failed apply doesn't strand a revert.
+        if scope == "turn":
+            setattr(agent, TURN_REVERT_ATTR, None)
+        logger.warning("model_switch apply failed (%s -> %s): %s",
+                       old_model, result.new_model, exc)
+        return tool_error(f"Model switch to '{result.new_model}' failed: {exc}")
+
+    logger.info(
+        "Agent self-switched model: %s -> %s (scope=%s, reason=%s)",
+        old_model, result.new_model, scope, reason,
+    )
+    return json.dumps({
+        "old_model": old_model,
+        "new_model": result.new_model,
+        "scope": scope,
+        "applied_at": "next_turn",
+    }, ensure_ascii=False)
+
+
+def revert_turn_model_switch(agent) -> bool:
+    """Restore a turn-scoped model switch at the start of the next turn.
+
+    Why: ``scope='turn'`` switches must auto-revert after one turn; centralizing
+    the restore here keeps the conversation loop's hook a one-liner.
+    What: If TURN_REVERT_ATTR holds a snapshot, re-applies it via
+    :meth:`AIAgent.switch_model` and clears the snapshot. Returns True if a
+    revert happened.
+    Test: Set TURN_REVERT_ATTR to a prior-runtime dict, call this, assert
+    switch_model was invoked with those values and the attribute is cleared.
+    """
+    snapshot = getattr(agent, TURN_REVERT_ATTR, None)
+    if not snapshot:
+        return False
+    setattr(agent, TURN_REVERT_ATTR, None)
+    try:
+        agent.switch_model(
+            new_model=snapshot.get("model", ""),
+            new_provider=snapshot.get("provider", ""),
+            api_key=snapshot.get("api_key", ""),
+            base_url=snapshot.get("base_url", ""),
+            api_mode=snapshot.get("api_mode", ""),
+        )
+        logger.info("Reverted turn-scoped model switch -> %s", snapshot.get("model"))
+        return True
+    except Exception as exc:
+        logger.warning("Failed to revert turn-scoped model switch: %s", exc)
+        return False
+
+
+def check_model_switch_requirements() -> bool:
+    """Gate the tool on the ``agent.allow_self_model_switch`` config flag.
+
+    Why: Self-model-switching is powerful and cost-affecting, so it ships
+    opt-in (matching how send_message / kanban gate via check_fn).
+    What: Returns True only when ``agent.allow_self_model_switch`` is truthy.
+    Test: Patch config with the flag true/false and assert the return value
+    tracks it; missing flag returns False.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from utils import is_truthy_value
+
+        agent_cfg = (load_config() or {}).get("agent") or {}
+        if not isinstance(agent_cfg, dict):
+            return False
+        return is_truthy_value(agent_cfg.get("allow_self_model_switch", False))
+    except Exception:
+        return False
+
+
+# --- Registry ---
+# The schema is registered so the model sees the tool, but execution is
+# intercepted by the agent loop (model_switch is in model_tools._AGENT_LOOP_TOOLS)
+# because the handler needs the live agent. This stub only fires if a call
+# somehow bypasses the loop interception.
+registry.register(
+    name="model_switch",
+    toolset="model_switch",
+    schema=MODEL_SWITCH_SCHEMA,
+    handler=lambda args, **kw: tool_error(
+        "model_switch must be handled by the agent loop"
+    ),
+    check_fn=check_model_switch_requirements,
+    emoji="🔀",
+)

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -856,51 +856,77 @@ class EmbeddingReranker:
         return _rrf_fuse(bm25_all, embed_ranked, k=cfg.rrf_k, top_n=top_k)
 
 
-# Module-level reranker singleton.
-# Lazily constructed on first use; None means reranker is disabled or not
-# yet built. The reranker embeds tool texts; the cache lives here across
-# search calls within the same process, invalidated when the catalog changes.
-_reranker: Optional[EmbeddingReranker] = None
-_reranker_catalog_key: str = ""  # md5 of (endpoint + model + tool names)
+# Per-scope reranker cache.
+#
+# Previously a single-slot module-level singleton keyed by
+# md5(endpoint + model + tool_names). This caused cache churn when concurrent
+# sub-agents with DIFFERENT toolsets raced through _get_reranker(): the second
+# call saw a different catalog key, rebuilt the singleton, and discarded the
+# first agent's cached embeddings.  Fix (issue #13332): replace the one-slot
+# singleton with a bounded dict so each distinct toolset-scope retains its own
+# EmbeddingReranker (and therefore its own per-tool embedding cache)
+# independently of what other agents are doing.
+#
+# Dict key: md5(endpoint + model + sorted_tool_names) — same hash as before,
+#   but now used as a LOOKUP key, not as "the single allowed key".
+# FIFO eviction: _reranker_cache_order tracks insertion order; when the dict
+#   exceeds _RERANKER_CACHE_MAX_SIZE the oldest scope is dropped.
+# Thread-safety: all reads/writes to the dict and the order list go through
+#   _GLOBAL_LOCK; double-checked locking on the fast path.
+_RERANKER_CACHE_MAX_SIZE: int = 8
+_reranker_cache: Dict[str, EmbeddingReranker] = {}
+_reranker_cache_order: List[str] = []  # FIFO insertion order
 
 
 def _get_reranker(
     cfg: RerankerConfig,
     catalog: List[CatalogEntry],
 ) -> Optional[EmbeddingReranker]:
-    """Return a reranker singleton, creating or resetting it if the catalog changed.
+    """Return a per-scope reranker, creating one if this toolset-scope is new.
 
-    Why: A module-level singleton avoids re-embedding the full catalog on
-    every search call. Cache invalidation ensures stale embeddings don't
-    persist when tools are added or removed.
-    What: Reuses the existing reranker if the catalog key (endpoint, model,
-    and tool names) is unchanged; otherwise builds a fresh instance so the
-    per-tool embedding cache starts clean.
-    Test: Change the catalog; assert the reranker is rebuilt (new instance).
-          Keep the catalog; assert the same instance is returned.
+    Why: A per-scope cache avoids re-embedding tool texts on every search call
+    while allowing concurrent agents with different toolsets to each maintain
+    their own stable embedding cache. The old single-slot singleton caused
+    cache churn: agent A (toolset X) and agent B (toolset Y) alternately
+    evicted each other's reranker, forcing repeated endpoint calls.
+    What: Looks up scope_key = md5(endpoint + model + tool_names) in
+    _reranker_cache. On a hit returns the existing instance (fast path,
+    lock-free read). On a miss acquires _GLOBAL_LOCK, re-checks, creates a
+    new EmbeddingReranker for this scope, and evicts the oldest scope if the
+    cache exceeds _RERANKER_CACHE_MAX_SIZE (FIFO).
+    Test: Two scopes (different tool-name sets) each get their own instance;
+          re-requesting scope A after creating scope B returns the original
+          scope-A instance with its embedding cache intact (no re-embed).
     """
-    global _reranker, _reranker_catalog_key  # noqa: PLW0603
-
     if not cfg.enabled or not cfg.endpoint:
         return None
 
-    catalog_key = hashlib.md5(
+    scope_key = hashlib.md5(
         (cfg.endpoint + cfg.model + ",".join(e.name for e in catalog)).encode("utf-8"),
         usedforsecurity=False,
     ).hexdigest()
 
-    # Fast path (lock-free read) — avoids lock contention on the hot path.
-    if _reranker is not None and _reranker_catalog_key == catalog_key:
-        return _reranker
+    # Fast path (lock-free read) — avoids lock contention on the common case.
+    hit = _reranker_cache.get(scope_key)
+    if hit is not None:
+        return hit
 
-    # Slow path: acquire lock and re-check (double-checked locking, fix HIGH-1).
-    # Prevents concurrent requests from each building a separate singleton.
+    # Slow path: acquire lock, double-check, create if still absent.
     with _GLOBAL_LOCK:
-        if _reranker is None or _reranker_catalog_key != catalog_key:
-            _reranker = EmbeddingReranker(cfg)
-            _reranker_catalog_key = catalog_key
+        hit = _reranker_cache.get(scope_key)
+        if hit is not None:
+            return hit
 
-    return _reranker
+        new_reranker = EmbeddingReranker(cfg)
+        _reranker_cache[scope_key] = new_reranker
+        _reranker_cache_order.append(scope_key)
+
+        # Evict the oldest scope when the cache grows beyond the bound.
+        while len(_reranker_cache_order) > _RERANKER_CACHE_MAX_SIZE:
+            oldest = _reranker_cache_order.pop(0)
+            _reranker_cache.pop(oldest, None)
+
+    return new_reranker
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -23,19 +23,36 @@ for the full rationale):
 * Display and trajectory unwrap is implemented here so the user (CLI activity
   feed, gateway, saved trajectories) always sees the underlying tool, not
   the bridge.
+
+Optional enhancement (fulfils GitHub issue NousResearch/hermes-agent#13332
+"Hybrid Tool Pre-Selection"):
+
+* **Embedding reranker** (opt-in, needs an OpenAI-compatible embeddings
+  endpoint) — reorders BM25 candidates by semantic similarity. Two modes:
+  ``rerank`` (pure cosine, highest accuracy) and ``rrf`` (Reciprocal Rank
+  Fusion of BM25 + embedding ranks, zero-regression safe mode). Enabled via
+  ``tools.tool_search.reranker.enabled``. Default OFF; gracefully falls back
+  to BM25 on any endpoint failure.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
 import re
+import threading
+import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger("tools.tool_search")
 
+# Module-level lock guards the reranker singleton and the module-level
+# embedding cache against torn writes under concurrent gateway requests.
+# Fix HIGH-1: thread-safety for _RERANKER_SINGLETON and _EMBED_CACHE writes.
+_GLOBAL_LOCK: threading.Lock = threading.Lock()
 
 # Bridge tool names. These names are reserved and may not collide with a
 # user/plugin/MCP tool — registration of any tool with these names is
@@ -56,6 +73,75 @@ CHARS_PER_TOKEN = 4.0
 
 
 # ---------------------------------------------------------------------------
+# Reranker config sub-dataclass (Enhancement B)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class RerankerConfig:
+    """Configuration for the optional embedding reranker.
+
+    Benchmarked results (194 tools / 98 labeled queries, nomic-embed-text-v2-moe,
+    fulfils NousResearch/hermes-agent#13332):
+      mode=rerank, full retrieve: R@5 = 0.810 (+0.176 vs BM25 baseline 0.634)
+      mode=rrf,    k=10:          R@5 = 0.770 (+0.136), zero regressions
+
+    Critical finding: nomic-embed-text-v2-moe REQUIRES task prefixes
+    ("search_query:" / "search_document:"). Without them R@5 drops by ~0.194.
+    The prefix defaults below reflect this; set to "" for models that do not
+    want prefixes.
+    """
+
+    enabled: bool
+    endpoint: str           # OpenAI-compatible /v1/embeddings URL
+    model: str
+    mode: str               # "rerank" | "rrf"
+    rrf_k: int              # RRF k parameter (default 10; k=10 beat k=60 in bench)
+    top_k: int              # how many results to return (matches config.search_default_limit)
+    query_prefix: str       # prepended to query text before embedding
+    doc_prefix: str         # prepended to each tool's embed text
+    api_key: str            # bearer token (empty = no auth header)
+    timeout: float          # HTTP timeout in seconds
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "RerankerConfig":
+        """Parse reranker config from the tools.tool_search.reranker dict.
+
+        Why: Provides a typed, validated config with safe defaults. Unknown
+        keys and malformed values fall back gracefully so a typo in user
+        config never breaks tool discovery.
+        What: Accepts dict with enabled/endpoint/model/mode/rrf_k/top_k/
+              query_prefix/doc_prefix/api_key/timeout keys.
+        Test: from_raw({"enabled": true, "endpoint": "http://x"}) produces
+              enabled=True with nomic prefixes; from_raw(None) gives
+              enabled=False; from_raw({"mode": "bad"}) falls back to "rerank".
+        """
+        if not isinstance(raw, dict):
+            return cls(
+                enabled=False, endpoint="", model="nomic-embed-text-v2-moe",
+                mode="rerank", rrf_k=10, top_k=5,
+                query_prefix="search_query: ", doc_prefix="search_document: ",
+                api_key="", timeout=5.0,
+            )
+        enabled = bool(raw.get("enabled", False))
+        endpoint = str(raw.get("endpoint") or "").strip()
+        model = str(raw.get("model") or "nomic-embed-text-v2-moe").strip()
+        mode_raw = str(raw.get("mode") or "rerank").strip().lower()
+        mode = mode_raw if mode_raw in ("rerank", "rrf") else "rerank"
+        rrf_k = max(1, _safe_int(raw.get("rrf_k"), 10))
+        top_k = max(1, min(50, _safe_int(raw.get("top_k"), 5)))
+        # Task prefixes — default to nomic requirements; set to "" to disable.
+        query_prefix = str(raw.get("query_prefix", "search_query: "))
+        doc_prefix = str(raw.get("doc_prefix", "search_document: "))
+        api_key = str(raw.get("api_key") or "").strip()
+        timeout = max(0.1, _safe_float(raw.get("timeout"), 5.0))
+        return cls(
+            enabled=enabled, endpoint=endpoint, model=model, mode=mode,
+            rrf_k=rrf_k, top_k=top_k, query_prefix=query_prefix,
+            doc_prefix=doc_prefix, api_key=api_key, timeout=timeout,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Configuration plumbing
 # ---------------------------------------------------------------------------
 
@@ -68,6 +154,7 @@ class ToolSearchConfig:
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
     search_default_limit: int
     max_search_limit: int
+    reranker: RerankerConfig
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -78,16 +165,28 @@ class ToolSearchConfig:
         and clamps every numeric field; unknown values fall back to safe
         defaults rather than raising, so a typo in user config does not
         break the agent.
+
+        Reranker defaults OFF (requires an external endpoint). Legacy
+        bool/None callers pick up reranker-off automatically.
         """
         if raw is True:
-            return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+            return cls(
+                enabled="auto", threshold_pct=10.0,
+                search_default_limit=5, max_search_limit=20,
+                reranker=RerankerConfig.from_raw(None),
+            )
         if raw is False:
-            return cls(enabled="off", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+            return cls(
+                enabled="off", threshold_pct=10.0,
+                search_default_limit=5, max_search_limit=20,
+                reranker=RerankerConfig.from_raw(None),
+            )
         if not isinstance(raw, dict):
-            return cls(enabled="auto", threshold_pct=10.0,
-                       search_default_limit=5, max_search_limit=20)
+            return cls(
+                enabled="auto", threshold_pct=10.0,
+                search_default_limit=5, max_search_limit=20,
+                reranker=RerankerConfig.from_raw(None),
+            )
 
         enabled_raw = str(raw.get("enabled", "auto")).strip().lower()
         if enabled_raw in ("true", "1", "yes"):
@@ -106,11 +205,14 @@ class ToolSearchConfig:
         search_default_limit = max(1, min(max_search_limit,
                                           _safe_int(raw.get("search_default_limit"), 5)))
 
+        reranker = RerankerConfig.from_raw(raw.get("reranker"))
+
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
+            reranker=reranker,
         )
 
 
@@ -276,6 +378,9 @@ class CatalogEntry:
     # Pre-tokenized fields for BM25.
     _tokens: List[str] = field(default_factory=list)
 
+    # Text used for embedding (populated lazily by the reranker).
+    _embed_text: str = field(default="")
+
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
 
@@ -302,6 +407,22 @@ def _entry_search_text(td: Dict[str, Any]) -> str:
     # Break snake_case and dotted names into words for BM25.
     name_words = name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
     return f"{name_words} {desc} {param_names}"
+
+
+def _entry_embed_text(td: Dict[str, Any]) -> str:
+    """Build the embedding text for a tool (concise: name + description).
+
+    Why: Concise text avoids diluting embedding signal with parameter noise.
+         The name alone provides the primary discriminator; the description
+         provides semantic context.
+    What: Returns "name: description" without parameter text.
+    Test: For a tool with name="web_search" and desc="Search the web",
+          returns "web_search: Search the web".
+    """
+    fn = td.get("function") or {}
+    name = fn.get("name", "")
+    desc = fn.get("description", "") or ""
+    return f"{name}: {desc}"
 
 
 def _classify_source(name: str) -> Tuple[str, str]:
@@ -339,13 +460,14 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
             source=source,
             source_name=source_name,
             _tokens=_tokenize(_entry_search_text(td)),
+            _embed_text=_entry_embed_text(td),
         )
         catalog.append(entry)
     return catalog
 
 
 def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
-                doc_lengths: List[int], avg_dl: float,
+                avg_dl: float,
                 doc_freq: Dict[str, int], n_docs: int,
                 k1: float = 1.5, b: float = 0.75) -> float:
     """Standard BM25 score for one query against one document.
@@ -375,7 +497,73 @@ def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
     return score
 
 
-def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> List[CatalogEntry]:
+def _bm25_stats(
+    catalog: List[CatalogEntry],
+) -> Tuple[float, Dict[str, int], int]:
+    """Compute shared BM25 corpus statistics for a catalog.
+
+    Why: avg_dl, doc_freq, and n_docs are corpus-level constants reused
+    for every document score. Pre-computing them avoids O(n^2) recomputation
+    when scoring the same catalog under multiple query token sets.
+    What: Returns (avg_dl, doc_freq, n_docs).
+    Test: A catalog of one doc with 4 tokens has avg_dl=4, n_docs=1.
+    """
+    token_lengths = [len(e._tokens) for e in catalog]
+    avg_dl = sum(token_lengths) / max(len(token_lengths), 1)
+    doc_freq: Dict[str, int] = {}
+    for e in catalog:
+        seen = set(e._tokens)
+        for t in seen:
+            doc_freq[t] = doc_freq.get(t, 0) + 1
+    return avg_dl, doc_freq, len(catalog)
+
+
+def _bm25_ranked(
+    catalog: List[CatalogEntry],
+    query_tokens: List[str],
+    raw_query: str = "",
+) -> List[Tuple[float, CatalogEntry]]:
+    """Score all catalog entries with BM25 and return full sorted list.
+
+    Why: Separating scoring from slicing lets the reranker receive the full
+    BM25 ranking to fuse with embedding ranking (RRF or pure rerank).
+    What: Returns all entries sorted descending by BM25 score; falls back
+    to name-substring matching when all BM25 scores are zero.
+    Test: Query "github" against a catalog with a github_* tool should
+          put that tool at rank 1.
+
+    Substring fallback checks the original lowercased query string against
+    each tool name — identical to the upstream main behaviour.
+    """
+    avg_dl, doc_freq, n_docs = _bm25_stats(catalog)
+
+    scored: List[Tuple[float, CatalogEntry]] = []
+    for entry in catalog:
+        s = _bm25_score(query_tokens, entry._tokens, avg_dl, doc_freq, n_docs)
+        scored.append((s, entry))
+
+    has_hits = any(s > 0 for s, _ in scored)
+    if not has_hits:
+        # Substring fallback against the original tool name.
+        # Use the raw lowercased query (not re-joined tokens) to match
+        # upstream main behaviour exactly.
+        ql = raw_query.lower()
+        scored = [
+            (0.1 if ql in e.name.lower() else 0.0, e)
+            for _, e in scored
+        ]
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored
+
+
+def search_catalog(
+    catalog: List[CatalogEntry],
+    query: str,
+    limit: int = 5,
+    config: Optional[ToolSearchConfig] = None,
+    reranker: Optional["EmbeddingReranker"] = None,
+) -> List[CatalogEntry]:
     """Return the top-``limit`` catalog entries for ``query`` by BM25.
 
     Falls back to a stable name-substring match when BM25 yields no hits
@@ -383,6 +571,14 @@ def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> L
     where every tool is named ``github_*`` still returns results — BM25
     can underperform when query and document share only one token that
     appears in every document (zero IDF).
+
+    When a ``reranker`` is provided (and ``config.reranker.enabled`` is
+    True), the full BM25 ranking is passed to the reranker which re-orders
+    or fuses it with embedding similarity before slicing to ``limit``
+    (Enhancement B). Any reranker failure falls back to BM25 silently.
+
+    When reranker is None (the default), this function is byte-for-byte
+    equivalent to the upstream main BM25 path.
     """
     if not catalog or limit <= 0:
         return []
@@ -390,32 +586,321 @@ def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> L
     if not query_tokens:
         return []
 
-    # Precompute doc statistics.
-    doc_lengths = [len(e._tokens) for e in catalog]
-    avg_dl = sum(doc_lengths) / max(len(doc_lengths), 1)
-    doc_freq: Dict[str, int] = {}
-    for e in catalog:
-        seen = set(e._tokens)
-        for t in seen:
-            doc_freq[t] = doc_freq.get(t, 0) + 1
-    n_docs = len(catalog)
+    all_scored = _bm25_ranked(catalog, query_tokens, raw_query=query)
 
-    scored: List[Tuple[float, CatalogEntry]] = []
-    for entry in catalog:
-        s = _bm25_score(query_tokens, entry._tokens, doc_lengths, avg_dl,
-                        doc_freq, n_docs)
-        if s > 0:
-            scored.append((s, entry))
+    # Enhancement B: embedding reranker.
+    if reranker is not None:
+        try:
+            reranked = reranker.rerank(query, all_scored, limit, config)
+            return reranked
+        except Exception as exc:
+            logger.debug(
+                "tool_search reranker failed, falling back to BM25: %s", exc
+            )
+            # Fall through to BM25 slice below.
 
-    if not scored:
-        # Substring fallback against the original tool name.
-        ql = query.lower()
-        for entry in catalog:
-            if ql in entry.name.lower():
-                scored.append((0.1, entry))
+    # Filter out zero-score entries to preserve the original BM25 contract:
+    # "no hits above zero → empty result" (substring fallback already gives
+    # a non-zero score to substring matches, so this filter is safe).
+    return [e for s, e in all_scored[:limit] if s > 0]
 
-    scored.sort(key=lambda x: x[0], reverse=True)
-    return [e for _, e in scored[:limit]]
+
+# ---------------------------------------------------------------------------
+# Embedding reranker (Enhancement B)
+# Issue #13332: Hybrid Tool Pre-Selection
+#
+# Proven results on 194 tools / 98 labeled queries
+# (see /tmp/tool-rerank-poc/BENCHMARK_WRITEUP.md and bench_tiers.py):
+#
+#   BM25 baseline R@5:          0.634
+#   mode=rerank (pure cosine):  0.810  (+0.176)  — highest accuracy
+#   mode=rrf k=10:              0.770  (+0.136)  — zero regressions
+#
+# Critical finding: nomic-embed-text-v2-moe REQUIRES task prefixes.
+# Without "search_query:"/"search_document:" R@5 drops by 0.194.
+# Default prefixes match nomic requirements; set to "" for other models.
+#
+# Design: retrieve the FULL catalog (not a narrow BM25 shortlist) because
+# tool embeddings are cached and per-query embed cost is ~N-independent.
+# Narrow retrieval silently discards gains (R@5 0.691 at N=10 vs 0.810
+# at FULL — see bench_tiers.py Table 3.1).
+# ---------------------------------------------------------------------------
+
+
+def _cosine(a: List[float], b: List[float]) -> float:
+    """Pure-Python cosine similarity (no numpy).
+
+    Why: Embedding reranker needs cosine without adding numpy as a dep.
+    What: dot(a,b) / (|a| * |b|); returns 0.0 for zero-norm vectors.
+    Test: _cosine([1,0],[0,1]) == 0.0; _cosine([1,1],[1,1]) ≈ 1.0.
+    """
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _rrf_fuse(
+    bm25_ranked: List[Tuple[float, CatalogEntry]],
+    embed_ranked: List[Tuple[float, CatalogEntry]],
+    k: int,
+    top_n: int,
+) -> List[CatalogEntry]:
+    """Reciprocal Rank Fusion of BM25 and embedding ranked lists.
+
+    Why: RRF combines two ranked lists without needing score normalisation.
+    score(doc) = 1/(k + rank_bm25) + 1/(k + rank_embed).
+    What: Returns top_n entries by fused score.
+    Test: A tool that is rank-1 in both lists should outscore anything
+          that is rank-2 in both lists.
+
+    k=10 beat the textbook k=60 in benchmarks (R@5 0.770 vs 0.748) with
+    zero regressions — lower k boosts top-rank items more aggressively
+    which suits tool selection where the correct tool usually has strong
+    lexical OR semantic signal.
+    """
+    scores: Dict[str, float] = {}
+    name_to_entry: Dict[str, CatalogEntry] = {}
+
+    for rank_idx, (_, entry) in enumerate(bm25_ranked, start=1):
+        scores[entry.name] = scores.get(entry.name, 0.0) + 1.0 / (k + rank_idx)
+        name_to_entry[entry.name] = entry
+
+    for rank_idx, (_, entry) in enumerate(embed_ranked, start=1):
+        scores[entry.name] = scores.get(entry.name, 0.0) + 1.0 / (k + rank_idx)
+        name_to_entry[entry.name] = entry
+
+    fused = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    return [name_to_entry[name] for name, _ in fused[:top_n]]
+
+
+class EmbeddingReranker:
+    """Reranks BM25 candidates using embeddings from an OpenAI-compatible endpoint.
+
+    Why: Dense retrieval catches semantic queries BM25 misses (e.g. "spin up
+    a VM" → mcp_proxmox_create_vm when the tool text says "virtual machine").
+    What: Embeds the query + all tool texts, then reorders by cosine similarity
+    (mode=rerank) or fuses with BM25 ranks via RRF (mode=rrf).
+
+    Tool embeddings are cached by md5(model + embed_text) and are only
+    recomputed when the catalog changes. Per-query cost is one embed call.
+
+    Graceful fallback: any exception propagates to search_catalog which
+    catches it and returns the BM25 result unchanged.
+
+    Test: Instantiate with a mock urlopen that returns a fixed vector;
+          assert the returned order reflects embedding scores, not BM25 scores.
+    """
+
+    def __init__(self, cfg: RerankerConfig) -> None:
+        self._cfg = cfg
+        # Cache: md5(model + text) → embedding vector
+        self._cache: Dict[str, List[float]] = {}
+
+    def _embed(self, texts: List[str]) -> List[List[float]]:
+        """Embed a batch of texts via the configured endpoint.
+
+        Why: Centralises the HTTP call so mock tests only need to patch one
+        method.
+        What: POSTs to /v1/embeddings with model + input; returns ordered
+        embedding vectors. Applies query_prefix / doc_prefix at call site.
+        Test: Mock urllib.request.urlopen; assert model + input keys present
+              in the POST body, and that returned vectors match fixture data.
+        """
+        cfg = self._cfg
+        payload = json.dumps({"model": cfg.model, "input": texts}).encode("utf-8")
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        if cfg.api_key:
+            headers["Authorization"] = f"Bearer {cfg.api_key}"
+        req = urllib.request.Request(
+            cfg.endpoint,
+            data=payload,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=cfg.timeout) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+        items = sorted(data["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in items]
+
+    def _embed_with_cache(self, texts: List[str]) -> List[List[float]]:
+        """Embed texts, serving cached vectors for already-seen texts.
+
+        Why: Tool embeddings are stable across queries; caching eliminates
+        repeated embed calls for the same tool text.
+        What: md5(model + text) is the cache key; only uncached texts hit
+              the endpoint. Cache reads/writes are guarded by _GLOBAL_LOCK;
+              the slow HTTP call runs OUTSIDE the lock so concurrent threads
+              are not serialised behind network I/O.
+        Test: Call twice with same texts; assert endpoint called only once
+              (check _embed call count via monkeypatching).
+        """
+        cfg = self._cfg
+        keys = [hashlib.md5((cfg.model + t).encode("utf-8"), usedforsecurity=False).hexdigest()
+                for t in texts]
+
+        # Fast path (lock-free read): skip the lock entirely when all keys are
+        # already cached — the common case on the hot path.
+        missing_idx = [i for i, k in enumerate(keys) if k not in self._cache]
+
+        if missing_idx:
+            # Step 1: lock briefly to compute which keys are still absent.
+            # Another thread may have populated some while we waited, so we
+            # re-check inside the lock (double-checked locking pattern).
+            with _GLOBAL_LOCK:
+                still_missing_idx = [i for i in missing_idx if keys[i] not in self._cache]
+                still_missing_texts = [texts[i] for i in still_missing_idx]
+
+            # Step 2: call _embed OUTSIDE the lock — this is the slow network
+            # call (~5 s timeout) and must not block other concurrent threads.
+            # Two threads may occasionally fetch the same key concurrently; that
+            # is the accepted trade-off vs. serialising all embedding I/O behind
+            # the lock (same text → same vector, last write wins, no corruption).
+            if still_missing_texts:
+                new_vecs = self._embed(still_missing_texts)
+                # Fix MEDIUM: guard against short responses from the endpoint.
+                # An opaque KeyError on cache read is harder to diagnose than
+                # an explicit ValueError here; search_catalog's except clause
+                # routes both to the BM25 fallback.
+                if len(new_vecs) != len(still_missing_texts):
+                    raise ValueError(
+                        f"embedding endpoint returned {len(new_vecs)} vectors "
+                        f"for {len(still_missing_texts)} texts"
+                    )
+
+                # Step 3: lock briefly again to write new vectors into the cache.
+                fetched: Dict[str, List[float]] = {
+                    keys[i]: vec for i, vec in zip(still_missing_idx, new_vecs)
+                }
+                with _GLOBAL_LOCK:
+                    self._cache.update(fetched)
+
+        return [self._cache[k] for k in keys]
+
+    def rerank(
+        self,
+        query: str,
+        bm25_all: List[Tuple[float, CatalogEntry]],
+        limit: int,
+        config: Optional[ToolSearchConfig],  # noqa: ARG002
+    ) -> List[CatalogEntry]:
+        """Rerank the full BM25 result list using embedding similarity.
+
+        Why: The full-catalog retrieve is nearly free when embeddings are
+        cached; narrow retrieval silently discards semantic gains.
+        What: Embeds the query and all tool texts (with task prefixes),
+              then applies the configured mode (rerank or rrf).
+        Test: Provide a catalog where a tool semantically matches the query
+              but has zero BM25 score; assert it appears in the top result
+              after reranking.
+        """
+        cfg = self._cfg
+        # Fix CRITICAL 2: honour the caller's limit exactly.
+        # search_default_limit is already applied by dispatch_tool_search before
+        # calling search_catalog; returning more than limit here violates the
+        # search_catalog(limit=N) contract and over-returns to the model.
+        top_k = limit
+
+        # Embed all tool texts (cache handles repeated calls efficiently).
+        doc_texts = [f"{cfg.doc_prefix}{e._embed_text}" for _, e in bm25_all]
+        doc_vecs = self._embed_with_cache(doc_texts)
+
+        # Embed query (cached by md5 key; repeated identical queries are served from cache).
+        q_text = f"{cfg.query_prefix}{query}"
+        (q_vec,) = self._embed_with_cache([q_text])
+
+        # Fix HIGH-2: dimension-mismatch guard.
+        # If the endpoint returns vectors of mismatched or zero length (e.g.
+        # model swapped mid-session, partial/truncated response), do NOT
+        # silently zip()-truncate — return None so the caller falls back to
+        # BM25. We raise ValueError here; search_catalog catches all Exception.
+        q_dim = len(q_vec)
+        if q_dim == 0:
+            raise ValueError(
+                "embedding reranker: query vector has length 0 — "
+                "endpoint returned an empty embedding"
+            )
+        for (_, e), dvec in zip(bm25_all, doc_vecs):
+            if len(dvec) == 0:
+                raise ValueError(
+                    f"embedding reranker: tool '{e.name}' vector has length 0"
+                )
+            if len(dvec) != q_dim:
+                raise ValueError(
+                    f"embedding reranker: dimension mismatch — query dim={q_dim}, "
+                    f"tool '{e.name}' dim={len(dvec)}. Was the embedding model "
+                    "changed mid-session? Falling back to BM25."
+                )
+
+        name_to_doc_vec: Dict[str, List[float]] = {
+            e.name: vec for (_, e), vec in zip(bm25_all, doc_vecs)
+        }
+
+        if cfg.mode == "rerank":
+            # Pure cosine rerank: sort all candidates by embedding similarity.
+            embed_scored = [
+                (_cosine(q_vec, name_to_doc_vec[e.name]), e)
+                for _, e in bm25_all
+            ]
+            embed_scored.sort(key=lambda x: x[0], reverse=True)
+            return [e for _, e in embed_scored[:top_k]]
+
+        # mode == "rrf": fuse BM25 rank + embedding rank.
+        embed_ranked: List[Tuple[float, CatalogEntry]] = sorted(
+            [(_cosine(q_vec, name_to_doc_vec[e.name]), e) for _, e in bm25_all],
+            key=lambda x: x[0],
+            reverse=True,
+        )
+        return _rrf_fuse(bm25_all, embed_ranked, k=cfg.rrf_k, top_n=top_k)
+
+
+# Module-level reranker singleton.
+# Lazily constructed on first use; None means reranker is disabled or not
+# yet built. The reranker embeds tool texts; the cache lives here across
+# search calls within the same process, invalidated when the catalog changes.
+_reranker: Optional[EmbeddingReranker] = None
+_reranker_catalog_key: str = ""  # md5 of (endpoint + model + tool names)
+
+
+def _get_reranker(
+    cfg: RerankerConfig,
+    catalog: List[CatalogEntry],
+) -> Optional[EmbeddingReranker]:
+    """Return a reranker singleton, creating or resetting it if the catalog changed.
+
+    Why: A module-level singleton avoids re-embedding the full catalog on
+    every search call. Cache invalidation ensures stale embeddings don't
+    persist when tools are added or removed.
+    What: Reuses the existing reranker if the catalog key (endpoint, model,
+    and tool names) is unchanged; otherwise builds a fresh instance so the
+    per-tool embedding cache starts clean.
+    Test: Change the catalog; assert the reranker is rebuilt (new instance).
+          Keep the catalog; assert the same instance is returned.
+    """
+    global _reranker, _reranker_catalog_key  # noqa: PLW0603
+
+    if not cfg.enabled or not cfg.endpoint:
+        return None
+
+    catalog_key = hashlib.md5(
+        (cfg.endpoint + cfg.model + ",".join(e.name for e in catalog)).encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()
+
+    # Fast path (lock-free read) — avoids lock contention on the hot path.
+    if _reranker is not None and _reranker_catalog_key == catalog_key:
+        return _reranker
+
+    # Slow path: acquire lock and re-check (double-checked locking, fix HIGH-1).
+    # Prevents concurrent requests from each building a separate singleton.
+    with _GLOBAL_LOCK:
+        if _reranker is None or _reranker_catalog_key != catalog_key:
+            _reranker = EmbeddingReranker(cfg)
+            _reranker_catalog_key = catalog_key
+
+    return _reranker
 
 
 # ---------------------------------------------------------------------------
@@ -621,7 +1106,12 @@ def dispatch_tool_search(args: Dict[str, Any],
 
     _, deferrable = classify_tools(current_tool_defs)
     catalog = build_catalog(deferrable)
-    hits = search_catalog(catalog, query, limit=limit)
+
+    reranker: Optional[EmbeddingReranker] = None
+    if config.reranker.enabled:
+        reranker = _get_reranker(config.reranker, catalog)
+
+    hits = search_catalog(catalog, query, limit=limit, config=config, reranker=reranker)
     return json.dumps({
         "query": query,
         "total_available": len(catalog),
@@ -716,8 +1206,10 @@ __all__ = [
     "TOOL_CALL_NAME",
     "BRIDGE_TOOL_NAMES",
     "ToolSearchConfig",
+    "RerankerConfig",
     "CatalogEntry",
     "AssemblyResult",
+    "EmbeddingReranker",
     "load_config",
     "is_deferrable_tool_name",
     "classify_tools",

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Agent-driven model routing (gated on agent.allow_self_model_switch via check_fn)
+    "model_switch",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -243,6 +245,12 @@ TOOLSETS = {
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],
+        "includes": []
+    },
+
+    "model_switch": {
+        "description": "Let the agent switch its own model based on task complexity (opt-in via agent.allow_self_model_switch)",
+        "tools": ["model_switch"],
         "includes": []
     },
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -151,9 +151,114 @@ to any progressive-disclosure design, not specific to this implementation:
   mode" some other implementations offer is a large surface area; we
   skip it.
 
+## Embedding Reranker (issue #13332)
+
+The optional embedding reranker improves Recall@5 significantly beyond
+BM25 for semantic queries. It is **default OFF** — enabling it requires
+an OpenAI-compatible embeddings endpoint.
+
+**Benchmark results** (194 tools / 98 labeled queries,
+nomic-embed-text-v2-moe, fulfils NousResearch/hermes-agent#13332):
+
+| Mode | R@5 | vs BM25 baseline | Notes |
+|------|-----|-----------------|-------|
+| BM25 only (default) | **0.634** | — | Stock default, no new deps |
+| `rerank` (pure cosine, full catalog) | **0.810** | +0.176 | Highest accuracy |
+| `rrf` k=10 (RRF fusion) | **0.770** | +0.136 | Zero regressions, safe default |
+
+**Critical finding: nomic-embed-text-v2-moe REQUIRES task prefixes.**
+Without `search_query:` and `search_document:` prefixes, R@5 drops by
+~0.194. The config defaults include these prefixes; set to `""` for
+models that do not want them.
+
+:::caution Prefix mismatch silently degrades accuracy
+The `query_prefix` and `doc_prefix` default to `"search_query: "` and
+`"search_document: "` (nomic-embed-text-v2-moe task prefixes). Models that
+do **not** use task prefixes — such as `all-MiniLM-L6-v2`, `e5-small-v2`,
+and OpenAI's `text-embedding-3-*` family — **must** set **both** to `""`
+or accuracy silently degrades by approximately −0.19 R@5:
+
+```yaml
+tools:
+  tool_search:
+    reranker:
+      enabled: true
+      endpoint: http://localhost:11434/v1/embeddings
+      model: all-MiniLM-L6-v2
+      query_prefix: ""    # ← required for non-nomic models
+      doc_prefix: ""      # ← required for non-nomic models
+```
+
+The mismatch is silent because the model still produces valid-shaped vectors;
+cosine scores are just much lower (nomic treats an unprefixed query as a
+document, not a query), and the fallback to BM25 does not trigger. Always
+verify prefix requirements in your embedding model's documentation.
+:::
+
+**Full-catalog retrieve:** tool embeddings are cached — only one query embed
+call recurs per search. Narrow retrieval (N=10) leaves +0.119 R@5 on the
+table compared to full-catalog (N=194). The implementation always retrieves
+the full catalog.
+
+**Endpoint compatibility:** any OpenAI-compatible `/v1/embeddings` endpoint.
+The benchmark used a GPU-hosted nomic model, but CPU models such as
+`all-MiniLM-L6-v2` at ~200 ms latency are equally valid. No GPU required.
+Pi-friendly.
+
+**Graceful fallback:** any endpoint failure (timeout, non-200, bad JSON,
+shape mismatch) → the module logs a debug line and returns the BM25 result
+unchanged. Tool discovery is never blocked by an unavailable reranker.
+
+```yaml
+tools:
+  tool_search:
+    reranker:
+      enabled: true                                   # default false
+      endpoint: http://localhost:11434/v1/embeddings  # required when enabled
+      model: nomic-embed-text-v2-moe
+      mode: rerank       # "rerank" (pure cosine) or "rrf" (RRF fusion)
+      rrf_k: 10          # RRF k parameter — k=10 beat k=60 in benchmarks
+      top_k: 5           # results to return (should match search_default_limit)
+      query_prefix: "search_query: "    # nomic task prefix for queries
+      doc_prefix:   "search_document: " # nomic task prefix for tool docs
+      api_key: ""        # optional bearer token
+      timeout: 5.0       # seconds before fallback to BM25
+```
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `reranker.enabled` | `false` | Enable embedding reranker. |
+| `reranker.endpoint` | `""` | OpenAI-compatible `/v1/embeddings` URL. Required when enabled. |
+| `reranker.model` | `nomic-embed-text-v2-moe` | Embedding model name. |
+| `reranker.mode` | `rerank` | `rerank`: sort by cosine similarity. `rrf`: Reciprocal Rank Fusion of BM25 + embedding ranks. |
+| `reranker.rrf_k` | `10` | RRF k parameter. Lower values boost top-ranked items more. k=10 outperformed the textbook k=60 in benchmarks. |
+| `reranker.top_k` | `5` | Number of results to return. Should match `search_default_limit`. |
+| `reranker.query_prefix` | `"search_query: "` | Task prefix prepended to the query embed text. Set to `""` for models that do not use prefixes. |
+| `reranker.doc_prefix` | `"search_document: "` | Task prefix prepended to each tool's embed text. Set to `""` for models that do not use prefixes. |
+| `reranker.api_key` | `""` | Bearer token for authenticated endpoints. |
+| `reranker.timeout` | `5.0` | HTTP timeout in seconds. After expiry, falls back to BM25. |
+
+### Three-tier architecture
+
+| Tier | What | Dependencies | R@5 (194 tools) |
+|------|------|-------------|-----------------|
+| 0 (default) | BM25 only | none (stdlib) | ~0.634 |
+| 1 rerank | BM25 + embedding cosine rerank | embeddings endpoint | ~0.810 |
+| 1 rrf | BM25 + RRF fusion | embeddings endpoint | ~0.770 |
+| 2 (future) | cross-encoder rerank | reranker endpoint | est. ~0.85–0.89 |
+
+Tier 0 is the stock default with no external dependencies. Tier 1 adds
+the embedding reranker (opt-in). Tier 2 (cross-encoder) is the documented
+next step but not yet implemented; it requires a `/rerank`-style endpoint
+(e.g. `bge-reranker-v2-m3` in Ollama, or Cohere's rerank API). Literature
+estimates suggest +3–8% Recall@5 over Tier 1 on well-formed tool-selection
+corpora.
+
 ## See also
 
 - `tools/tool_search.py` — the implementation
 - `tests/tools/test_tool_search.py` — the regression suite
+- `/tmp/tool-rerank-poc/BENCHMARK_WRITEUP.md` — benchmark evidence for the
+  hybrid pre-selection design (issue #13332)
 - The `openclaw-tool-search-report` PDF in the original implementation
-  PR for the research that shaped the design
+  PR for the research that shaped the base design


### PR DESCRIPTION
## What

Adds a new `model_switch` tool that lets an agent self-select a cheaper or more capable model mid-conversation without a user `/model` command.

**Core tool (`tools/model_switch_tool.py`):**
- `model_switch_tool(agent, slug, reason, scope)` — agent-direct pattern, called from the agent loop
- `scope="session"` applies the switch for the remainder of the conversation
- `scope="turn"` snapshots the current model and reverts after one response (via `TURN_REVERT_ATTR`)
- Optional `model_switch_allowlist` in config restricts which target models an agent may choose
- `check_fn` gates on `agent.allow_self_model_switch` config flag — tool is inert unless explicitly enabled

**Toolset registration (`toolsets.py`):**
- Registered as the `"model_switch"` toolset (gated by `check_fn`)

**Gateway wiring (`gateway/run.py`, two sites):**
- Auto-includes `"model_switch"` in `enabled_toolsets` when `agent.allow_self_model_switch: true` in config

**Config (`hermes_cli/config.py`):**
- `agent.allow_self_model_switch: false` — operator opt-in default
- Documents the flag alongside the related `clarify_timeout` setting

**Dispatch seam (`agent/agent_runtime_helpers.py`):**
- `invoke_tool` special-cases `function_name == "model_switch"` to call `model_switch_tool(agent, ...)` directly, bypassing the registry handler (which exists only as a sentinel error guard)

**Unused-variable cleanup:**
- `tools/model_switch_tool.py`: `lambda args, **kw` → `lambda *_args, **_kw`
- `tests/tools/test_model_switch_tool.py`: rename stubs `lambda **kw` → `lambda **_kw`; remove unused module import

## Why

Agents processing mixed-complexity workloads often get locked into one model for the whole session. A simple follow-up question should not cost the same as initial architecture work. `model_switch` gives agents the mechanism to downgrade for cheap turns and upgrade when hard thinking is needed — all without breaking the session or losing memory.

## Tests

```bash
pytest tests/tools/test_model_switch_tool.py -v
```

8 tests covering: session scope switch, turn revert, unknown slug, empty slug, allowlist block, allowlist allow, config gate, apply-failure cleanup. All pass.

## Platforms tested

Linux (CT/LXC environment, Python 3.13).