### PR TITLE
fix(opencode-go): send either thinking or reasoning_effort for kimi-k2, never both

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -56,17 +56,19 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # Kimi K2 on OpenCode Go: send EITHER reasoning_effort (enabled)
+            # OR extra_body.thinking (disabled), never both — the OpenCode Go
+            # gateway rejects requests containing both fields with HTTP 400.
+            # Direct Moonshot (api.moonshot.ai/v1) accepts both; that path is
+            # handled by KimiProfile, not this provider.
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
@@ -74,6 +76,8 @@ class OpenCodeGoProfile(ProviderProfile):
                 top_level["reasoning_effort"] = "high"
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+            # For unsupported effort values (e.g. "minimal"), neither field is
+            # set — the server picks its default, which is safe.
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -17,14 +17,18 @@ def opencode_go_profile():
 
 
 class TestOpenCodeGoKimiReasoning:
-    """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
+    """Kimi K2 models send either reasoning_effort OR thinking, never both.
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    The OpenCode Go gateway (opencode.ai/zen/go/v1) rejects requests
+    containing both ``thinking`` and ``reasoning_effort`` with HTTP 400.
+    """
+
+    def test_high_effort_emits_only_effort(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -35,13 +39,14 @@ class TestOpenCodeGoKimiReasoning:
         assert extra_body == {"thinking": {"type": "disabled"}}
         assert top_level == {}
 
-    def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
+    def test_minimal_effort_emits_nothing(self, opencode_go_profile):
+        # "minimal" is not a Moonshot-supported value — emit nothing so the
+        # server picks its own default (safe for both gateway and direct API).
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "minimal"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {}
 
     @pytest.mark.parametrize(
@@ -56,7 +61,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_low_and_medium_pass_through(self, opencode_go_profile):
@@ -65,7 +70,7 @@ class TestOpenCodeGoKimiReasoning:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": effort}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
@@ -149,7 +154,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_emits_only_effort(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -160,7 +165,7 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert kwargs.get("extra_body", {}) == {}
         assert kwargs["reasoning_effort"] == "high"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(


### PR DESCRIPTION
## What does this PR do?

Fixes an HTTP 400 error when using kimi-k2 models on the OpenCode Go provider with explicit `agent.reasoning_effort` configured. The OpenCode Go gateway rejects requests containing both `thinking` and `reasoning_effort` fields; this PR sends only one at a time.

## Related Issue

Fixes #37439

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/opencode-zen/__init__.py`: When thinking is enabled for kimi-k2 models, omit `extra_body.thinking` and send only `top_level.reasoning_effort`. When thinking is disabled, send only `extra_body.thinking = {"type": "disabled"}`. This prevents the OpenCode Go gateway from rejecting the request with "cannot specify both thinking and reasoning_effort".
- `tests/plugins/model_providers/test_opencode_go_profile.py`: Updated Kimi K2 test assertions to match the new mutual-exclusion behavior. Integration test now verifies `extra_body` is empty when reasoning is enabled.

## How to Test

1. Configure `agent.reasoning_effort: high` in config.yaml with an opencode-go provider profile
2. Send a prompt using a kimi-k2.x model (e.g. kimi-k2.5 or kimi-k2.6)
3. Verify the request succeeds (no HTTP 400) and reasoning is applied
4. Run `pytest tests/plugins/model_providers/test_opencode_go_profile.py -v` — all 21 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/model_providers/test_opencode_go_profile.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `OpenCodeGoProfile.build_api_kwargs_extras` (callers: 1 transport integration, 6 unit tests)
- Blast radius: LOW — single provider profile, kimi-k2 models only, OpenCode Go path only
- Related patterns: DeepSeek path (same method) intentionally keeps both fields; direct Moonshot API (`KimiProfile`) also keeps both — only the OpenCode Go gateway has this constraint
