### PR TITLE
fix(gemini): strip tool call extra_content from chat requests

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -119,6 +119,10 @@ class ChatCompletionsTransport(ProviderTransport):
         - Codex Responses API fields: ``codex_reasoning_items`` /
           ``codex_message_items`` on the message, ``call_id`` /
           ``response_item_id`` on ``tool_calls`` entries.
+        - Gemini response-side metadata: ``extra_content`` on
+          ``tool_calls`` entries. Gemini 3 thinking models emit this
+          metadata with thought signatures, but non-Gemini chat-completions
+          providers reject it when historical tool-call messages are replayed.
         - ``tool_name`` on tool-result messages — written by
           ``make_tool_result_message()`` for the SQLite FTS index, but not
           part of the Chat Completions schema. Strict providers (Fireworks,
@@ -155,7 +159,9 @@ class ChatCompletionsTransport(ProviderTransport):
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
-                        "call_id" in tc or "response_item_id" in tc
+                        "call_id" in tc
+                        or "response_item_id" in tc
+                        or "extra_content" in tc
                     ):
                         needs_sanitize = True
                         break
@@ -183,6 +189,7 @@ class ChatCompletionsTransport(ProviderTransport):
                     if isinstance(tc, dict):
                         tc.pop("call_id", None)
                         tc.pop("response_item_id", None)
+                        tc.pop("extra_content", None)
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,31 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_strips_tool_call_extra_content(self, transport):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_gemini",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                        "extra_content": {
+                            "google": {"thought_signature": "SIG_ABC123"},
+                        },
+                    },
+                ],
+            },
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert "extra_content" not in result[0]["tool_calls"][0]
+        assert msgs[0]["tool_calls"][0]["extra_content"] == {
+            "google": {"thought_signature": "SIG_ABC123"},
+        }
+
     def test_convert_messages_strips_tool_name(self, transport):
         """Internal `tool_name` (used for FTS indexing in the SQLite store) is
         not part of the OpenAI Chat Completions schema. Strict providers like

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -116,7 +116,7 @@ class TestBuildApiKwargsOpenRouter:
         assert "instructions" not in kwargs
         assert "store" not in kwargs
 
-    def test_strips_codex_only_tool_call_fields_from_chat_messages(self, monkeypatch):
+    def test_strips_internal_tool_call_fields_from_chat_messages(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openrouter")
         messages = [
             {"role": "user", "content": "hi"},
@@ -148,13 +148,14 @@ class TestBuildApiKwargsOpenRouter:
         assert "codex_reasoning_items" not in assistant_msg
         assert tool_call["id"] == "call_123"
         assert tool_call["function"]["name"] == "terminal"
-        assert tool_call["extra_content"] == {"thought_signature": "opaque"}
         assert "call_id" not in tool_call
         assert "response_item_id" not in tool_call
+        assert "extra_content" not in tool_call
 
-        # Original stored history must remain unchanged for Responses replay mode.
+        # Original stored history must remain unchanged for provider-specific replay modes.
         assert messages[1]["tool_calls"][0]["call_id"] == "call_123"
         assert messages[1]["tool_calls"][0]["response_item_id"] == "fc_123"
+        assert messages[1]["tool_calls"][0]["extra_content"] == {"thought_signature": "opaque"}
         assert "codex_reasoning_items" in messages[1]
 
     def test_gemini_native_passes_base_url_for_top_level_thinking_config(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Strip Gemini `extra_content` metadata from replayed chat-completions tool-call requests.
- Keep response-side preservation intact while preventing non-Gemini fallback providers from receiving unknown thought-signature fields.
- Update provider parity expectations so original stored history remains unchanged but outgoing payloads are sanitized.

Fixes #36907

## Testing
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/agent/transports/test_chat_completions.py::TestChatCompletionsBasic::test_convert_messages_strips_tool_call_extra_content`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/agent/transports/test_chat_completions.py`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/run_agent/test_provider_parity.py::TestBuildApiKwargsOpenRouter::test_strips_internal_tool_call_fields_from_chat_messages tests/run_agent/test_provider_parity.py::TestBuildApiKwargsOpenRouter::test_should_sanitize_tool_calls_codex_vs_chat tests/run_agent/test_provider_parity.py::TestBuildApiKwargsCustomEndpoint::test_fireworks_tool_call_payload_strips_codex_only_fields tests/run_agent/test_strict_api_validation.py`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/agent/transports`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/run_agent/test_provider_parity.py`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check agent/transports/chat_completions.py tests/agent/transports/test_chat_completions.py tests/run_agent/test_provider_parity.py`
- `git diff --check`