### PR TITLE
fix(config): parse bracket-delimited list values in config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5800,6 +5800,16 @@ def set_config_value(key: str, value: str):
         value = int(value)
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
+    elif isinstance(value, str) and value.startswith('[') and value.endswith(']'):
+        # Parse bracket-delimited strings as YAML lists so that
+        # ``hermes config set enabled '[icarus]'`` stores a proper list
+        # instead of a literal string.  (#37455)
+        try:
+            parsed = yaml.safe_load(value)
+            if isinstance(parsed, list):
+                value = parsed
+        except Exception:
+            pass  # Keep as string if YAML parse fails
 
     _set_nested(user_config, key, value)
     

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -247,3 +247,54 @@ class TestListNavigation:
         assert isinstance(allowlist, list)
         assert allowlist[0] == {"name": "alice", "role": "admin"}
         assert allowlist[1] == {"name": "bob", "role": "admin"}
+
+
+# ---------------------------------------------------------------------------
+# Bracket-delimited list values — regression tests for #37455
+# ---------------------------------------------------------------------------
+
+class TestBracketListValues:
+    """hermes config set should parse '[item]' syntax as a YAML list."""
+
+    def test_single_element_list(self, _isolated_hermes_home):
+        """hermes config set enabled '[icarus]' → list with one item."""
+        import yaml
+        set_config_value("enabled", "[icarus]")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["enabled"] == ["icarus"]
+
+    def test_multi_element_list(self, _isolated_hermes_home):
+        """hermes config set enabled '[icarus, zeus]' → list with two items."""
+        import yaml
+        set_config_value("enabled", "[icarus, zeus]")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["enabled"] == ["icarus", "zeus"]
+
+    def test_quoted_items_in_list(self, _isolated_hermes_home):
+        """Quoted strings inside brackets should parse correctly."""
+        import yaml
+        set_config_value("enabled", "['icarus', 'zeus']")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["enabled"] == ["icarus", "zeus"]
+
+    def test_non_list_bracket_string_kept_as_string(self, _isolated_hermes_home):
+        """Invalid YAML inside brackets should fall back to string."""
+        import yaml
+        set_config_value("model", "[not: valid: yaml")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        # Invalid YAML → kept as original string
+        assert reloaded["model"] == "[not: valid: yaml"
+
+    def test_empty_list(self, _isolated_hermes_home):
+        """hermes config set enabled '[]' → empty list."""
+        import yaml
+        set_config_value("enabled", "[]")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["enabled"] == []
+
+    def test_nested_key_list_value(self, _isolated_hermes_home):
+        """hermes config set plugins.enabled '[icarus]' → proper list."""
+        import yaml
+        set_config_value("plugins.enabled", "[icarus]")
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["plugins"]["enabled"] == ["icarus"]


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes config set` so that bracket-delimited values like `[icarus]` are parsed as YAML lists instead of being stored as literal strings. Previously, `hermes config set enabled '[icarus]'` wrote `enabled: '[icarus]'` (a string), silently breaking plugin loading.

## Related Issue

Fixes #37455

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Added YAML list parsing for values matching `[...]` syntax in `set_config_value()`. When the value starts with `[` and ends with `]`, it is parsed via `yaml.safe_load()`; if the result is a list, it replaces the raw string. Invalid YAML falls back to the original string behavior.
- `tests/hermes_cli/test_set_config_value.py`: Added `TestBracketListValues` class with 6 regression tests: single-element list, multi-element list, quoted items, invalid YAML fallback, empty list, and nested key list value.

## How to Test

1. Run `hermes config set enabled '[icarus]'` and verify `config.yaml` contains `enabled:\n- icarus` (a YAML list, not a string)
2. Run `hermes config set enabled '[icarus, zeus]'` and verify both items appear as a list
3. Run `python3 -m pytest tests/hermes_cli/test_set_config_value.py -v` — all 38 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_set_config_value.py -q` and all 38 tests pass
- [x] I've added tests for my changes (6 new regression tests)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/config.py:set_config_value` (called from `config_command` CLI handler)
- Blast radius: LOW — only affects `config set` value parsing; no impact on config reading, migration, or other commands
- Related patterns: Similar to #33145 (bare-string home_channel handling); both extend `set_config_value` type coercion
