### PR TITLE
fix(desktop): use gateway WS URL helper for local backend

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3119,7 +3119,7 @@ async function startHermes() {
       mode: 'local',
       source: 'local',
       token,
-      wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(token)}`,
+      wsUrl: buildGatewayWsUrl(baseUrl, token),
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }


### PR DESCRIPTION
## Summary
- return the canonical WebSocket URL from the desktop local backend path
- avoid a broken hand-built token URL being passed to the renderer

## Testing
- node -c apps/desktop/electron/main.cjs

This fixes Hermes Desktop local gateway startup when the renderer receives an invalid wsUrl.