### PR TITLE
fix(deps): keep lazy dependency pins aligned

### DIFF
--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -88,6 +88,49 @@ def test_lazy_installable_extras_excluded_from_all():
         )
 
 
+def test_lazy_dependency_specs_match_packaged_extras():
+    """Lazy install specs must not drift from matching packaged extras."""
+    from tools.lazy_deps import LAZY_DEPS
+
+    optional_dependencies = _load_optional_dependencies()
+    feature_to_extras = {
+        "provider.anthropic": ("anthropic",),
+        "provider.bedrock": ("bedrock",),
+        "provider.azure_identity": ("azure-identity",),
+        "search.exa": ("exa",),
+        "search.firecrawl": ("firecrawl",),
+        "search.parallel": ("parallel-web",),
+        "tts.edge": ("edge-tts",),
+        "tts.elevenlabs": ("tts-premium",),
+        "stt.faster_whisper": ("voice",),
+        "image.fal": ("fal",),
+        "memory.honcho": ("honcho",),
+        "memory.hindsight": ("hindsight",),
+        "platform.telegram": ("messaging",),
+        "platform.discord": ("messaging",),
+        "platform.slack": ("slack", "messaging"),
+        "platform.matrix": ("matrix",),
+        "platform.dingtalk": ("dingtalk",),
+        "platform.feishu": ("feishu",),
+        "platform.wecom_callback": ("wecom",),
+        "terminal.modal": ("modal",),
+        "terminal.daytona": ("daytona",),
+        "skill.google_workspace": ("google",),
+        "skill.youtube": ("youtube",),
+        "tool.acp": ("acp",),
+        "tool.dashboard": ("web",),
+    }
+
+    for feature, extras in feature_to_extras.items():
+        lazy_specs = set(LAZY_DEPS[feature])
+        for extra in extras:
+            extra_specs = set(optional_dependencies[extra])
+            assert lazy_specs <= extra_specs, (
+                f"{feature} lazy specs must be present in [{extra}] extra. "
+                f"Missing: {sorted(lazy_specs - extra_specs)}"
+            )
+
+
 def _exact_pins(specs):
     pins = {}
     for spec in specs:


### PR DESCRIPTION
## Summary
- Add a packaging metadata test that checks lazy dependency specs are present in their matching packaged extras.
- Align packaged `anthropic` with `LAZY_DEPS["provider.anthropic"]` at `0.87.0`.
- Align packaged `aiohttp` extras with the Slack lazy install pin at `3.13.4`, then refresh `uv.lock`.

Fixes #36654

## Testing
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/test_project_metadata.py::test_lazy_dependency_specs_match_packaged_extras`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/test_project_metadata.py`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/tools/test_lazy_deps.py`
- `uv lock --check`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check tests/test_project_metadata.py`
- `git diff --check`