### PR TITLE
fix(desktop): map GUI log requests to desktop log

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -32,8 +32,11 @@ LOG_FILES = {
     "agent": "agent.log",
     "errors": "errors.log",
     "gateway": "gateway.log",
-    "gui": "gui.log",
+    "desktop": "desktop.log",
+    # Backward-compatible alias used by the desktop GUI status snapshot.
+    "gui": "desktop.log",
 }
+
 
 # Log line timestamp regex — matches "2026-04-05 22:35:00,123" or
 # "2026-04-05 22:35:00" at the start of a line.

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -250,4 +250,6 @@ class TestLogFiles:
         assert "agent" in LOG_FILES
         assert "errors" in LOG_FILES
         assert "gateway" in LOG_FILES
-        assert "gui" in LOG_FILES
+        assert "desktop" in LOG_FILES
+        assert LOG_FILES["desktop"] == "desktop.log"
+        assert LOG_FILES["gui"] == "desktop.log"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1177,6 +1177,13 @@ class TestNewEndpoints:
         assert "lines" in data
         assert isinstance(data["lines"], list)
 
+    def test_get_logs_gui_alias(self):
+        resp = self.client.get("/api/logs?file=gui")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["file"] == "gui"
+        assert isinstance(data["lines"], list)
+
     def test_get_logs_invalid_file(self):
         resp = self.client.get("/api/logs?file=nonexistent")
         assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- map desktop GUI log requests to the actual desktop.log file
- add a desktop log key and keep gui as a compatibility alias
- cover both the log registry and /api/logs?file=gui endpoint with tests

## Testing
- /Users/flyfish/.hermes/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_logs.py::TestLogFiles tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_get_logs_default tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_get_logs_gui_alias tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_get_logs_invalid_file -q

This prevents Hermes Desktop from repeatedly logging 400 Unknown log file: gui.