### PR TITLE
fix: _secure_file no longer undoes permission restore in save/remove_env_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5397,13 +5397,16 @@ def save_env_value(key: str, value: str):
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            # New file — tighten to owner-only.
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
+
 
     os.environ[key] = value
     invalidate_env_cache()
@@ -5453,13 +5456,14 @@ def remove_env_value(key: str) -> bool:
                     os.chmod(env_path, original_mode)
                 except OSError:
                     pass
+            else:
+                _secure_file(env_path)
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
             raise
-        _secure_file(env_path)
 
     os.environ.pop(key, None)
     invalidate_env_cache()


### PR DESCRIPTION
## Problem

Both  and  in `hermes_cli/config.py` restore the original file permissions after `atomic_replace`, then unconditionally call `_secure_file()` which tightens permissions to `0600` — completely undoing the restore.

This breaks Docker volume mounts and any other setup that relies on custom permissions on `.env` files.

## Fix

Move `_secure_file()` inside an `else` branch so it only runs when `original_mode is None` (i.e., the file is new).

## Validation

- `pytest tests/hermes_cli/test_config.py -q` — 87/87 passed
- `git diff --stat`: `1 file changed, 6 insertions(+), 2 deletions(-)`

Closes #37495