### PR TITLE
fix(kanban): sort cards newest-first within each lane

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2255,7 +2255,7 @@ def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
 VALID_SORT_ORDERS: dict[str, str] = {
     "created": "created_at ASC, id ASC",
     "created-desc": "created_at DESC, id DESC",
-    "priority": "priority DESC, created_at ASC",
+    "priority": "priority DESC, created_at DESC, rowid DESC",
     "priority-desc": "priority ASC, created_at ASC",
     "status": "status ASC, created_at ASC",
     "assignee": "assignee ASC, created_at ASC",
@@ -2309,7 +2309,7 @@ def list_tasks(
             )
         query += f" ORDER BY {VALID_SORT_ORDERS[order_by]}"
     else:
-        query += " ORDER BY priority DESC, created_at ASC"
+        query += " ORDER BY priority DESC, created_at DESC, rowid DESC"
     if limit:
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -470,7 +470,7 @@ def get_board(
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks
-        # (priority DESC, created_at ASC), keep as-is.
+        # (priority DESC, created_at DESC, rowid DESC), keep as-is.
 
         # List of known tenants for the UI filter dropdown.
         tenants = [

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1153,9 +1153,9 @@ def test_list_tasks_order_by(kanban_home):
         t_b = kb.create_task(conn, title="beta", priority=2)
         t_c = kb.create_task(conn, title="gamma", priority=1)
 
-        # Default sort: priority DESC, created ASC
+        # Default sort: priority DESC, created DESC
         default = kb.list_tasks(conn)
-        assert [t.id for t in default] == [t_b, t_a, t_c]
+        assert [t.id for t in default] == [t_b, t_c, t_a]
 
         # Sort by title ASC
         by_title = kb.list_tasks(conn, order_by="title")


### PR DESCRIPTION
## What changed

Reversed the default sort order for kanban lane cards from oldest-first to newest-first, so recently created/active tasks appear at the top of each column instead of at the bottom.

## Why

The kanban dashboard displayed cards within each lane with the oldest tasks at the top. Users expect newest tasks at the top — this matches standard kanban/Trello conventions where recent activity is immediately visible.

Closes #37472

## How to test

1. Create multiple kanban tasks over a period of time (or with slight delays between them)
2. Open the kanban dashboard (`hermes dashboard`)
3. Verify that within each lane, newer cards appear above older cards
4. Verify that higher-priority cards still sort above lower-priority ones

Or run the test suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py
```

All 205 tests in `test_kanban_db.py` pass, including the updated ordering test.

## Platforms tested

- Linux (Ubuntu)

## Files changed

- `hermes_cli/kanban_db.py` — Default `ORDER BY` changed from `created_at ASC` to `created_at DESC, rowid DESC`; `VALID_SORT_ORDERS['priority']` updated to match
- `plugins/kanban/dashboard/plugin_api.py` — Comment updated to reflect new ordering
- `tests/hermes_cli/test_kanban_db.py` — Test assertion updated for reversed order