### PR TITLE
Clarify desktop local build path

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,7 +1,7 @@
 # Hermes Desktop ☤
 
 <p align="center">
-  <a href="https://github.com/NousResearch/hermes-agent/releases"><img src="https://img.shields.io/badge/Download-macOS%20%C2%B7%20Windows%20%C2%B7%20Linux-FFD700?style=for-the-badge" alt="Download"></a>
+  <a href="https://hermes-agent.nousresearch.com/desktop"><img src="https://img.shields.io/badge/Download-macOS%20%C2%B7%20Windows%20%C2%B7%20Linux-FFD700?style=for-the-badge" alt="Download"></a>
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
@@ -38,11 +38,11 @@ hermes desktop
 
 It builds and launches the GUI against your existing install — same config, keys, sessions, and skills. On first launch Hermes walks you through picking a provider and model; nothing else to configure.
 
-This is the source-checkout path: `hermes desktop` builds a local unpacked Electron app with `npm run pack`. It does not download or run the release installers.
+This is the source-checkout path: `hermes desktop` builds a local unpacked Electron app with `npm run pack`. It does not download Hermes Desktop.
 
-### Prebuilt installers
+### Desktop Download
 
-When a release ships desktop installers they're attached to its [releases page](https://github.com/NousResearch/hermes-agent/releases) — `.dmg` (macOS), `.exe` / `.msi` (Windows), `.AppImage` / `.deb` / `.rpm` (Linux). These are published manually, so the install-with-Hermes path above is the most reliable way to get the latest.
+For the user-facing desktop download, go to [hermes-agent.nousresearch.com/desktop](https://hermes-agent.nousresearch.com/desktop).
 
 ---
 
@@ -92,7 +92,7 @@ npm run dist:linux   # AppImage + deb + rpm
 npm run pack         # unpacked app under release/ (no installer)
 ```
 
-Installers are built and uploaded to GitHub Releases manually. macOS/Windows signing & notarization happen automatically when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
+These commands build local desktop artifacts from this checkout. macOS/Windows signing and notarization happen when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
 
 ### How it works
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -38,6 +38,8 @@ hermes desktop
 
 It builds and launches the GUI against your existing install — same config, keys, sessions, and skills. On first launch Hermes walks you through picking a provider and model; nothing else to configure.
 
+This is the source-checkout path: `hermes desktop` builds a local unpacked Electron app with `npm run pack`. It does not download or run the release installers.
+
 ### Prebuilt installers
 
 When a release ships desktop installers they're attached to its [releases page](https://github.com/NousResearch/hermes-agent/releases) — `.dmg` (macOS), `.exe` / `.msi` (Windows), `.AppImage` / `.deb` / `.rpm` (Linux). These are published manually, so the install-with-Hermes path above is the most reliable way to get the latest.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6961,7 +6961,7 @@ def cmd_gui(args):
         if not npm:
             print("Desktop GUI requires Node.js/npm to build from this checkout, but npm was not found on PATH.")
             print("Install Node.js, then run:  hermes desktop")
-            print("Or download a prebuilt desktop installer from: https://github.com/NousResearch/hermes-agent/releases")
+            print("Or download Hermes Desktop from: https://hermes-agent.nousresearch.com/desktop")
             sys.exit(1)
     else:
         npm = None
@@ -14734,8 +14734,8 @@ Examples:
             "Launch the Hermes Electron desktop app from this checkout. By default "
             "this installs workspace Node dependencies, builds the current OS's "
             "unpacked Electron app with electron-builder --dir, then launches that "
-            "artifact. It does not download or run the release installers; use "
-            "GitHub Releases for .dmg/.exe/.AppImage packages."
+            "artifact. It does not download Hermes Desktop; use "
+            "https://hermes-agent.nousresearch.com/desktop for that."
         ),
     )
     gui_parser.add_argument(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6930,7 +6930,7 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
 
 
 def cmd_gui(args):
-    """Build and launch the native Electron desktop GUI."""
+    """Build and launch the local Electron desktop GUI."""
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
     if not (desktop_dir / "package.json").exists():
         print(f"Desktop GUI source not found at: {desktop_dir}")
@@ -6959,8 +6959,9 @@ def cmd_gui(args):
     if source_mode or not skip_build:
         npm = shutil.which("npm")
         if not npm:
-            print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
-            print("Install Node.js, then run:  hermes gui")
+            print("Desktop GUI requires Node.js/npm to build from this checkout, but npm was not found on PATH.")
+            print("Install Node.js, then run:  hermes desktop")
+            print("Or download a prebuilt desktop installer from: https://github.com/NousResearch/hermes-agent/releases")
             sys.exit(1)
     else:
         npm = None
@@ -6986,6 +6987,8 @@ def cmd_gui(args):
         else:
             print(f"→ Skipping desktop package build (--skip-build); using {packaged_executable}")
     else:
+        if not source_mode:
+            print("→ Building a local unpacked Electron app from this checkout (not a release installer).")
         print("→ Installing desktop workspace dependencies...")
         install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False)
         if install_result.returncode != 0:
@@ -14726,11 +14729,13 @@ Examples:
     gui_parser = subparsers.add_parser(
         "desktop",
         aliases=["gui"],
-        help="Build and launch the native desktop app",
+        help="Build and launch the local desktop app",
         description=(
-            "Launch the Hermes Electron desktop app. By default this installs "
-            "workspace Node dependencies, builds the current OS's unpacked "
-            "Electron app, then launches that packaged artifact."
+            "Launch the Hermes Electron desktop app from this checkout. By default "
+            "this installs workspace Node dependencies, builds the current OS's "
+            "unpacked Electron app with electron-builder --dir, then launches that "
+            "artifact. It does not download or run the release installers; use "
+            "GitHub Releases for .dmg/.exe/.AppImage packages."
         ),
     )
     gui_parser.add_argument(

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ Get Hermes Agent up and running in under two minutes with the one-line installer
 
 Prefer a native installer?
 
-- **Desktop downloads:** [GitHub Releases](https://github.com/NousResearch/hermes-agent/releases/latest)
+- **Desktop downloads:** [Hermes Desktop](https://hermes-agent.nousresearch.com/desktop)
 
 Desktop builds ship signed/notarized macOS artifacts and Windows installers with checksum files.
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -66,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 Prefer native installers for desktop use?
 
-- **Desktop downloads:** [GitHub Releases](https://github.com/NousResearch/hermes-agent/releases/latest)
+- **Desktop downloads:** [Hermes Desktop](https://hermes-agent.nousresearch.com/desktop)
 
 :::tip Android / Termux
 If you're installing on a phone, see the dedicated [Termux guide](./termux.md) for the tested manual path, supported extras, and current Android-specific limitations.

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -15,7 +15,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
 
 <div style={{display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap'}}>
   <Link to="/getting-started/installation" style={{display: 'inline-block', padding: '0.6rem 1.2rem', backgroundColor: '#FFD700', color: '#07070d', borderRadius: '8px', fontWeight: 600, textDecoration: 'none'}}>Get Started →</Link>
-  <a href="https://github.com/NousResearch/hermes-agent/releases/latest" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>Download Desktop</a>
+  <a href="https://hermes-agent.nousresearch.com/desktop" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>Download Desktop</a>
   <a href="https://github.com/NousResearch/hermes-agent" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>View on GitHub</a>
 </div>
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -38,11 +38,11 @@ hermes desktop
 
 That uses your current config, keys, sessions, and skills. On first launch the app walks you through picking a provider and model; there's nothing else to configure.
 
-This is the source-checkout path: `hermes desktop` builds a local unpacked Electron app with `npm run pack`. It does not download or run the release installers.
+This is the source-checkout path: `hermes desktop` builds a local unpacked Electron app with `npm run pack`. It does not download Hermes Desktop.
 
-### Prebuilt installers
+### Desktop Download
 
-When a release ships desktop installers they're attached to the [releases page](https://github.com/NousResearch/hermes-agent/releases/latest):
+For the user-facing desktop download, go to [hermes-agent.nousresearch.com/desktop](https://hermes-agent.nousresearch.com/desktop). The Desktop page provides platform downloads:
 
 | Platform | Artifacts |
 |----------|-----------|
@@ -50,7 +50,7 @@ When a release ships desktop installers they're attached to the [releases page](
 | Windows | `.exe` (NSIS) / `.msi` |
 | Linux | `.AppImage` / `.deb` / `.rpm` |
 
-These are published manually, so the install-with-Hermes path above is the most reliable way to get the latest build.
+Use `hermes desktop` when you want to build from this checkout; use the Desktop page when you want the downloadable app.
 
 ### Windows GUI installer
 
@@ -109,7 +109,7 @@ hermes update
 
 ## CLI reference: `hermes desktop`
 
-The canonical command is `hermes desktop` (the older `hermes gui` is kept as a deprecated alias). By default it installs workspace Node dependencies, builds the current OS's unpacked Electron app with `electron-builder --dir`, then launches that local artifact. It does not download or run the release installers.
+The canonical command is `hermes desktop` (the older `hermes gui` is kept as a deprecated alias). By default it installs workspace Node dependencies, builds the current OS's unpacked Electron app with `electron-builder --dir`, then launches that local artifact. It does not download Hermes Desktop.
 
 | Flag | Description |
 |------|-------------|

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -38,6 +38,8 @@ hermes desktop
 
 That uses your current config, keys, sessions, and skills. On first launch the app walks you through picking a provider and model; there's nothing else to configure.
 
+This is the source-checkout path: `hermes desktop` builds a local unpacked Electron app with `npm run pack`. It does not download or run the release installers.
+
 ### Prebuilt installers
 
 When a release ships desktop installers they're attached to the [releases page](https://github.com/NousResearch/hermes-agent/releases/latest):
@@ -107,7 +109,7 @@ hermes update
 
 ## CLI reference: `hermes desktop`
 
-The canonical command is `hermes desktop` (the older `hermes gui` is kept as a deprecated alias). By default it installs workspace Node dependencies, builds the current OS's unpacked Electron app, then launches that packaged artifact.
+The canonical command is `hermes desktop` (the older `hermes gui` is kept as a deprecated alias). By default it installs workspace Node dependencies, builds the current OS's unpacked Electron app with `electron-builder --dir`, then launches that local artifact. It does not download or run the release installers.
 
 | Flag | Description |
 |------|-------------|

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -114,7 +114,7 @@ const config: Config = {
           position: 'left',
         },
         {
-          href: 'https://github.com/NousResearch/hermes-agent/releases/latest',
+          href: 'https://hermes-agent.nousresearch.com/desktop',
           label: 'Download',
           position: 'left',
         },
@@ -162,7 +162,7 @@ const config: Config = {
         {
           title: 'More',
           items: [
-            { label: 'Desktop Download', href: 'https://github.com/NousResearch/hermes-agent/releases/latest' },
+            { label: 'Desktop Download', href: 'https://hermes-agent.nousresearch.com/desktop' },
             { label: 'GitHub', href: 'https://github.com/NousResearch/hermes-agent' },
             { label: 'Nous Research', href: 'https://nousresearch.com' },
           ],


### PR DESCRIPTION
## Summary
- Clarify that `hermes desktop` builds a local unpacked Electron app from the checkout rather than downloading a user-facing Desktop app.
- Route Desktop download links and fallback CLI guidance to https://hermes-agent.nousresearch.com/desktop.
- Keep Desktop README and website docs consistent about source builds versus downloadable Desktop.

## Test plan
- `python -m py_compile hermes_cli/main.py`
- `git diff --check`
- IDE diagnostics via ReadLints on changed files