### PR TITLE
fix(tui): support signal-exit v3 fallback

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -7,7 +7,6 @@ import throttle from 'lodash-es/throttle.js'
 import React, { type ReactNode } from 'react'
 import type { FiberRoot } from 'react-reconciler'
 import { ConcurrentRoot } from 'react-reconciler/constants.js'
-import { onExit } from 'signal-exit'
 
 import { flushInteractionTime } from '../bootstrap/state.js'
 import { getYogaCounters } from '../native-ts/yoga-layout/index.js'
@@ -75,6 +74,7 @@ import {
   startSelection,
   updateSelection
 } from './selection.js'
+import { onProcessExit } from './signal-exit-compat.js'
 import {
   needsAltScreenResizeScrollbackClear,
   supportsExtendedKeys,
@@ -376,7 +376,7 @@ export default class Ink {
     this.isUnmounted = false
 
     // Unmount when process exits
-    this.unsubscribeExit = onExit(this.unmount, {
+    this.unsubscribeExit = onProcessExit(this.unmount, {
       alwaysLast: false
     })
 

--- a/ui-tui/packages/hermes-ink/src/ink/signal-exit-compat.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/signal-exit-compat.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveOnProcessExit, type SignalExitHandler } from './signal-exit-compat.js'
+
+describe('resolveOnProcessExit', () => {
+  it('uses signal-exit v4 named onExit export', () => {
+    const unsubscribe = vi.fn()
+    const onExit = vi.fn(() => unsubscribe)
+    const handler: SignalExitHandler = () => undefined
+
+    const resolved = resolveOnProcessExit({ onExit })
+    const result = resolved(handler, { alwaysLast: false })
+
+    expect(result).toBe(unsubscribe)
+    expect(onExit).toHaveBeenCalledWith(handler, { alwaysLast: false })
+  })
+
+  it('uses signal-exit v3 default export', () => {
+    const unsubscribe = vi.fn()
+    const defaultExport = vi.fn(() => unsubscribe)
+    const handler: SignalExitHandler = () => undefined
+
+    const resolved = resolveOnProcessExit({ default: defaultExport })
+    const result = resolved(handler, { alwaysLast: true })
+
+    expect(result).toBe(unsubscribe)
+    expect(defaultExport).toHaveBeenCalledWith(handler, { alwaysLast: true })
+  })
+
+  it('throws when no compatible export exists', () => {
+    expect(() => resolveOnProcessExit({})).toThrow('Unsupported signal-exit export shape')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/signal-exit-compat.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/signal-exit-compat.ts
@@ -1,0 +1,23 @@
+import * as signalExit from 'signal-exit'
+
+export type SignalExitHandler = (code: number | null | undefined, signal: NodeJS.Signals | null) => true | void
+export type OnProcessExit = (handler: SignalExitHandler, options?: { alwaysLast?: boolean }) => () => void
+
+type SignalExitCompatModule = {
+  default?: unknown
+  onExit?: unknown
+}
+
+export function resolveOnProcessExit(signalExitModule: SignalExitCompatModule): OnProcessExit {
+  if (typeof signalExitModule.onExit === 'function') {
+    return signalExitModule.onExit as OnProcessExit
+  }
+
+  if (typeof signalExitModule.default === 'function') {
+    return signalExitModule.default as OnProcessExit
+  }
+
+  throw new TypeError('Unsupported signal-exit export shape')
+}
+
+export const onProcessExit = resolveOnProcessExit(signalExit)


### PR DESCRIPTION
## Summary
- add a small `signal-exit` compatibility resolver for `@hermes/ink`
- support both `signal-exit@4` named `onExit` and `signal-exit@3` default-function module shapes
- cover both shapes with focused unit tests

## Root cause
The bundled TUI can resolve `signal-exit@3` at runtime. The generated bundle previously called `import_signal_exit.onExit(...)`, but the v3 module exposes the exit hook as the default export, so startup could fail with `TypeError: import_signal_exit.onExit is not a function`.

## Validation
- Reproduced the failing bundled expression in a clean upstream-main worktree: esbuild-style import namespace had `typeof default === "function"` and `typeof onExit === "undefined"`, and calling `onExit` threw the reported TypeError.
- `npm run test --prefix ui-tui -- packages/hermes-ink/src/ink/signal-exit-compat.test.ts packages/hermes-ink/src/ink/log-update.test.ts`
- `npm exec -- eslint packages/hermes-ink/src/ink/ink.tsx packages/hermes-ink/src/ink/signal-exit-compat.ts packages/hermes-ink/src/ink/signal-exit-compat.test.ts` from `ui-tui/`
- `npm run build --prefix ui-tui`
- Built bundle now contains `resolveOnProcessExit(...)` and no direct `import_signal_exit.onExit` call.

## Notes
- `npm run type-check --prefix ui-tui` still fails in existing `node_modules/@hermes/ink/src/utils/execFileNoThrow.ts` overload/type errors, unrelated to this change.
- Full `npm run test --prefix ui-tui` was blocked by the local copied file dependency expecting `node_modules/@hermes/ink/dist/entry-exports.js`; focused source tests passed.
- GitNexus impact/detect checks could not complete in the clean worktree: `npx gitnexus analyze` hit a native `double free or corruption` and the repo was not registered for `detect-changes`.