### PR TITLE
feat(stt): add Deepgram transcription provider

### DIFF
--- a/agent/transcription_provider.py
+++ b/agent/transcription_provider.py
@@ -8,14 +8,14 @@ register instances via
 (selected via ``stt.provider`` in ``config.yaml``) services every
 :func:`tools.transcription_tools.transcribe_audio` call **when the
 configured name is neither a built-in (``local``, ``local_command``,
-``groq``, ``openai``, ``mistral``, ``xai``) nor disabled**.
+``groq``, ``openai``, ``mistral``, ``xai``, ``deepgram``) nor disabled**.
 
 Two coexisting STT extension surfaces — in resolution order:
 
 1. **Built-in providers** (``BUILTIN_STT_PROVIDERS`` in
    :mod:`tools.transcription_tools`) — native Python implementations
-   for the 6 backends shipped today (faster-whisper, local_command,
-   Groq, OpenAI, Mistral, xAI). **Always win** — plugins cannot
+   for the 7 backends shipped today (faster-whisper, local_command,
+   Groq, OpenAI, Mistral, xAI, Deepgram). **Always win** — plugins cannot
    shadow them. The single-env-var shell escape hatch
    ``HERMES_LOCAL_STT_COMMAND`` is preserved via the built-in
    ``local_command`` path.
@@ -74,7 +74,7 @@ class TranscriptionProvider(abc.ABC):
         Lowercase, no spaces. Examples: ``openrouter``, ``sensaudio``,
         ``gemini``, ``deepgram``. Names that collide with a built-in STT
         provider (``local``, ``local_command``, ``groq``, ``openai``,
-        ``mistral``, ``xai``) are rejected at registration time.
+        ``mistral``, ``xai``, ``deepgram``) are rejected at registration time.
         """
 
     @property

--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -11,7 +11,8 @@ the configured ``stt.provider`` name is not a built-in.
 Built-ins-always-win
 --------------------
 Plugin names that collide with a built-in STT provider (``local``,
-``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``) are
+``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``,
+``deepgram``) are
 rejected at registration with a warning. This invariant is also
 re-checked at dispatch time in
 :func:`tools.transcription_tools._dispatch_to_plugin_provider`.
@@ -44,6 +45,7 @@ _BUILTIN_NAMES = frozenset({
     "openai",
     "mistral",
     "xai",
+    "deepgram",
 })
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -816,8 +816,8 @@ platform_toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe)
-# Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
+# Providers: local (free, faster-whisper) | groq (free tier) | deepgram (Listen API) | openai (Whisper API) | mistral (Voxtral Transcribe)
+# Set the corresponding API key in .env: GROQ_API_KEY, DEEPGRAM_API_KEY, VOICE_TOOLS_OPENAI_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
   # provider: "local"          # auto-detected if omitted
@@ -826,6 +826,16 @@ stt:
     # language: ""             # auto-detect; set to "en", "es", "fr", etc. to force
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  # deepgram:
+  #   model: "nova-3"          # nova-3 | nova-2 | enhanced | base
+  #   language: ""             # auto-detect (detect_language=true); set to "en", "es", "fr", etc. to force
+  #   language_hint: "pt"      # retry hint if auto-detect returns an empty transcript
+  #   smart_format: true        # format numbers, dates, punctuation-friendly text
+  #   punctuate: true
+  #   diarize: false
+  #   detect_language: true
+  #   # base_url: "https://api.deepgram.com/v1"  # optional; env fallback: DEEPGRAM_STT_BASE_URL
+  #   # timeout: 120
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -202,6 +202,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
     "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
     "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
+    "DEEPGRAM_API_KEY", "DEEPGRAM_STT_BASE_URL",
     "IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL",
     "IRC_USE_TLS", "IRC_SERVER_PASSWORD", "IRC_NICKSERV_PASSWORD",
     "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
@@ -1499,7 +1500,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "deepgram" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -1509,6 +1510,15 @@ DEFAULT_CONFIG = {
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "deepgram": {
+            "model": "nova-3",  # nova-3, nova-2, enhanced, base
+            "language": "",  # auto-detect by default (detect_language=true); set to "en", "es", "fr", etc. to force
+            "language_hint": "pt",  # retry hint when auto-detect returns an empty transcript
+            "smart_format": True,
+            "punctuate": True,
+            "diarize": False,
+            "detect_language": True,
         },
         "elevenlabs": {
             "model_id": "scribe_v2",  # scribe_v2, scribe_v1
@@ -2886,6 +2896,14 @@ OPTIONAL_ENV_VARS = {
         "description": "Mistral API key for Voxtral TTS and transcription (STT)",
         "prompt": "Mistral API key",
         "url": "https://console.mistral.ai/",
+        "password": True,
+        "category": "tool",
+    },
+    "DEEPGRAM_API_KEY": {
+        "description": "Deepgram API key for speech-to-text transcription (STT)",
+        "prompt": "Deepgram API key",
+        "url": "https://console.deepgram.com/",
+        "tools": ["voice_transcription"],
         "password": True,
         "category": "tool",
     },
@@ -5573,6 +5591,7 @@ def show_config():
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
+        ("DEEPGRAM_API_KEY", "Deepgram STT"),
         ("EXA_API_KEY", "Exa"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
@@ -5765,6 +5784,7 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
+        'DEEPGRAM_API_KEY',
         'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
         'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -369,7 +369,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "groq", "openai", "xai", "elevenlabs"],
+        "options": ["local", "groq", "deepgram", "openai", "xai", "elevenlabs"],
     },
     "stt.elevenlabs.model_id": {
         "type": "select",

--- a/tests/agent/test_transcription_registry.py
+++ b/tests/agent/test_transcription_registry.py
@@ -91,7 +91,7 @@ class TestRegistration:
 
     @pytest.mark.parametrize(
         "builtin",
-        ["local", "local_command", "groq", "openai", "mistral", "xai"],
+        ["local", "local_command", "groq", "openai", "mistral", "xai", "deepgram"],
     )
     def test_rejects_builtin_shadow_with_warning(self, builtin, caplog):
         p = _FakeProvider(name=builtin)

--- a/tests/plugins/transcription/check_parity_vs_main.py
+++ b/tests/plugins/transcription/check_parity_vs_main.py
@@ -25,6 +25,8 @@ Acceptable diffs:
   ``command-provider-installed`` scenario (registry shipped with this PR).
 - ``no_provider_error → command_provider`` for
   ``command-vs-plugin-same-name`` (command wins precedence, same as TTS).
+- ``no_provider_error → builtin_deepgram`` for ``explicit-deepgram``
+  (Deepgram is built-in on this branch).
 
 Run from the PR worktree::
 
@@ -70,8 +72,8 @@ os.environ["HERMES_HOME"] = home
 # Clear STT-related env so dispatch decisions are config-driven.
 for k in (
     "GROQ_API_KEY", "OPENAI_API_KEY", "VOICE_TOOLS_OPENAI_KEY",
-    "MISTRAL_API_KEY", "XAI_API_KEY",
-    "HERMES_LOCAL_STT_COMMAND",
+    "MISTRAL_API_KEY", "XAI_API_KEY", "DEEPGRAM_API_KEY",
+    "DEEPGRAM_STT_BASE_URL", "HERMES_LOCAL_STT_COMMAND",
 ):
     os.environ.pop(k, None)
 
@@ -149,6 +151,7 @@ tt._transcribe_groq = _Stub("groq")
 tt._transcribe_openai = _Stub("openai")
 tt._transcribe_mistral = _Stub("mistral")
 tt._transcribe_xai = _Stub("xai")
+tt._transcribe_deepgram = _Stub("deepgram")
 
 # Force _get_provider to honor the explicit config since we don't have
 # real creds. The provider-resolution gates check _HAS_OPENAI /
@@ -185,7 +188,7 @@ elif not success and "is not available" in error_text:
     dispatch_kind = "plugin_unavailable"
 elif not success and "No STT provider" in error_text:
     dispatch_kind = "no_provider_error"
-elif provider_name in ("local", "local_command", "groq", "openai", "mistral", "xai"):
+elif provider_name in ("local", "local_command", "groq", "openai", "mistral", "xai", "deepgram"):
     dispatch_kind = "builtin_" + provider_name
 elif success and isinstance(result, dict) and result.get("transcript", "").startswith("CMD:"):
     # Command-provider scenarios below emit transcripts prefixed with "CMD:"
@@ -194,7 +197,7 @@ elif success and isinstance(result, dict) and result.get("transcript", "").start
     dispatch_kind = "command_provider"
 elif success and isinstance(result, dict) and result.get("transcript", "").startswith("PLUGIN:"):
     dispatch_kind = "plugin"
-elif success and provider_name and provider_name not in ("local", "local_command", "groq", "openai", "mistral", "xai"):
+elif success and provider_name and provider_name not in ("local", "local_command", "groq", "openai", "mistral", "xai", "deepgram"):
     dispatch_kind = "plugin"
 else:
     dispatch_kind = "other"
@@ -241,6 +244,7 @@ SCENARIOS: list[tuple[str, str, dict[str, str], str]] = [
     # (label, config.yaml body, scenario_env, plugin_register)
     ("stt-disabled", "stt:\n  enabled: false\n", {}, "no"),
     ("explicit-groq", "stt:\n  provider: groq\n", {}, "no"),
+    ("explicit-deepgram", "stt:\n  provider: deepgram\n", {}, "no"),
     ("explicit-openai", "stt:\n  provider: openai\n", {}, "no"),
     ("explicit-local", "stt:\n  provider: local\n", {}, "no"),
     ("explicit-xai", "stt:\n  provider: xai\n", {}, "no"),
@@ -392,6 +396,11 @@ def main() -> int:
             and pr_reduced.get("dispatch_kind") == "command_provider"
             and label in {"command-provider-installed", "command-vs-plugin-same-name"}
         )
+        no_provider_to_deepgram = (
+            main_reduced.get("dispatch_kind") == "no_provider_error"
+            and pr_reduced.get("dispatch_kind") == "builtin_deepgram"
+            and label == "explicit-deepgram"
+        )
         if no_provider_to_plugin:
             print(f"  [DIFF] {label}: no_provider_error → plugin — expected")
             intentional_diffs.append((label, main_reduced, pr_reduced))
@@ -400,6 +409,9 @@ def main() -> int:
             intentional_diffs.append((label, main_reduced, pr_reduced))
         elif no_provider_to_command:
             print(f"  [DIFF] {label}: no_provider_error → command_provider — expected")
+            intentional_diffs.append((label, main_reduced, pr_reduced))
+        elif no_provider_to_deepgram:
+            print(f"  [DIFF] {label}: no_provider_error → builtin_deepgram — expected")
             intentional_diffs.append((label, main_reduced, pr_reduced))
         else:
             print(f"  [FAIL] {label}")

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1,8 +1,9 @@
-"""Tests for tools.transcription_tools — three-provider STT pipeline.
+"""Tests for tools.transcription_tools — built-in STT provider pipeline.
 
-Covers the full provider matrix (local, groq, openai), fallback chains,
-model auto-correction, config loading, validation edge cases, and
-end-to-end dispatch.  All external dependencies are mocked.
+Covers the provider matrix (local, groq, deepgram, openai, mistral, xai,
+elevenlabs), fallback chains, model auto-correction, config loading,
+validation edge cases, and end-to-end dispatch. All external dependencies
+are mocked.
 """
 
 import os
@@ -65,6 +66,8 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
     monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPGRAM_STT_BASE_URL", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -1120,6 +1123,298 @@ class TestTranscribeAudioMistralDispatch:
             transcribe_audio(sample_ogg, model="voxtral-mini-2602")
 
         assert mock_mistral.call_args[0][1] == "voxtral-mini-2602"
+
+
+# ============================================================================
+# _transcribe_deepgram
+# ============================================================================
+
+
+class TestTranscribeDeepgram:
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+        with patch("requests.post") as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram("/tmp/test.ogg", "nova-3")
+        assert result["success"] is False
+        assert "DEEPGRAM_API_KEY" in result["error"]
+        mock_post.assert_not_called()
+
+    def test_blank_key_is_treated_as_missing_without_network(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "   ")
+        with patch("requests.post") as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+        assert result == {"success": False, "transcript": "", "error": "DEEPGRAM_API_KEY not set"}
+        mock_post.assert_not_called()
+
+    def test_successful_transcription(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": {"channels": [{"alternatives": [{"transcript": "hello from deepgram"}]}]},
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello from deepgram"
+        assert result["provider"] == "deepgram"
+        call = mock_post.call_args
+        assert call.args[0] == "https://api.deepgram.com/v1/listen"
+        assert call.kwargs["headers"]["Authorization"] == "Token dg-test-key"
+        assert call.kwargs["params"]["model"] == "nova-3"
+        assert call.kwargs["params"]["smart_format"] == "true"
+        assert call.kwargs["params"]["detect_language"] == "true"
+
+    def test_mocked_listen_request_sends_audio_body_and_parses_response(self, monkeypatch, sample_ogg):
+        """Repeatable Deepgram coverage: request payload + response parsing, no live API."""
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        observed = {}
+
+        def fake_post(url, *, headers, params, data, timeout):
+            observed["url"] = url
+            observed["headers"] = dict(headers)
+            observed["params"] = dict(params)
+            observed["body"] = data.read()
+            observed["timeout"] = timeout
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {
+                "results": {"channels": [{"alternatives": [{"transcript": "mock deepgram transcript"}]}]},
+            }
+            return response
+
+        config = {"deepgram": {"timeout": 12, "punctuate": False}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("requests.post", side_effect=fake_post) as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result == {"success": True, "transcript": "mock deepgram transcript", "provider": "deepgram"}
+        assert mock_post.call_count == 1
+        assert observed["url"] == "https://api.deepgram.com/v1/listen"
+        assert observed["headers"] == {
+            "Authorization": "Token dg-test-key",
+            "Content-Type": "audio/ogg",
+        }
+        assert observed["params"] == {
+            "model": "nova-3",
+            "smart_format": "true",
+            "punctuate": "false",
+            "detect_language": "true",
+        }
+        assert observed["body"] == b"fake audio data"
+        assert observed["timeout"] == 12.0
+
+    def test_successful_transcription_normalizes_multichannel_response(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": {
+                "channels": [
+                    {"alternatives": [{"transcript": "  first channel  "}]},
+                    {"alternatives": [{"transcript": "second channel\n"}]},
+                    {"alternatives": [{"transcript": "   "}]},
+                ]
+            },
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result == {"success": True, "transcript": "first channel second channel", "provider": "deepgram"}
+
+    def test_config_params_and_custom_base_url(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        config = {
+            "deepgram": {
+                "base_url": "https://proxy.example/v1/",
+                "language": "pt-BR",
+                "diarize": True,
+                "detect_language": False,
+                "smart_format": False,
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": {"channels": [{"alternatives": [{"transcript": "oi"}]}]},
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+            _transcribe_deepgram(sample_ogg, "nova-2")
+
+        call = mock_post.call_args
+        assert call.args[0] == "https://proxy.example/v1/listen"
+        assert call.kwargs["params"]["language"] == "pt-BR"
+        assert "detect_language" not in call.kwargs["params"]
+        assert call.kwargs["params"]["diarize"] == "true"
+        assert call.kwargs["params"]["smart_format"] == "false"
+
+    def test_api_error_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"err_msg": "Invalid API key"}
+        mock_response.text = '{"err_msg":"Invalid API key"}'
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result["success"] is False
+        assert result["provider"] == "deepgram"
+        assert "HTTP 401" in result["error"]
+        assert "Invalid API key" in result["error"]
+
+    def test_api_error_uses_text_fallback_when_json_is_invalid(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.json.side_effect = ValueError("not json")
+        mock_response.text = "rate limit exceeded"
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result["success"] is False
+        assert result["provider"] == "deepgram"
+        assert "HTTP 429" in result["error"]
+        assert "rate limit exceeded" in result["error"]
+
+    def test_network_error_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", side_effect=ConnectionError("connection reset")):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result["success"] is False
+        assert result["provider"] == "deepgram"
+        assert "connection reset" in result["error"]
+
+    def test_retries_empty_auto_detect_with_portuguese_language_hint(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        empty_response = MagicMock()
+        empty_response.status_code = 200
+        empty_response.json.return_value = {"results": {"channels": []}}
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "results": {"channels": [{"alternatives": [{"transcript": "olá do deepgram"}]}]},
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", side_effect=[empty_response, success_response]) as mock_post:
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result == {"success": True, "transcript": "olá do deepgram", "provider": "deepgram"}
+        first_params = mock_post.call_args_list[0].kwargs["params"]
+        retry_params = mock_post.call_args_list[1].kwargs["params"]
+        assert first_params["detect_language"] == "true"
+        assert "language" not in first_params
+        assert retry_params["language"] == "pt"
+        assert "detect_language" not in retry_params
+
+    def test_empty_transcript_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": {"channels": []}}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_deepgram
+            result = _transcribe_deepgram(sample_ogg, "nova-3")
+
+        assert result["success"] is False
+        assert "empty transcript" in result["error"]
+
+
+# ============================================================================
+# _get_provider — Deepgram
+# ============================================================================
+
+
+class TestGetProviderDeepgram:
+    def test_deepgram_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "deepgram"}) == "deepgram"
+
+    def test_deepgram_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "deepgram"}) == "none"
+
+    def test_deepgram_explicit_blank_key_returns_none(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "   ")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "deepgram"}) == "none"
+
+    def test_auto_detect_deepgram_after_groq_before_openai(self, monkeypatch):
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-test")
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "deepgram"
+
+
+# ============================================================================
+# transcribe_audio — Deepgram dispatch
+# ============================================================================
+
+
+class TestTranscribeAudioDeepgramDispatch:
+    def test_dispatches_to_deepgram(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "deepgram"}), \
+             patch("tools.transcription_tools._get_provider", return_value="deepgram"), \
+             patch("tools.transcription_tools._transcribe_deepgram",
+                   return_value={"success": True, "transcript": "hi", "provider": "deepgram"}) as mock_deepgram:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "deepgram"
+        mock_deepgram.assert_called_once()
+
+    def test_config_deepgram_model_used(self, sample_ogg):
+        config = {"provider": "deepgram", "deepgram": {"model": "nova-2"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="deepgram"), \
+             patch("tools.transcription_tools._transcribe_deepgram",
+                   return_value={"success": True, "transcript": "hi"}) as mock_deepgram:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_deepgram.call_args[0][1] == "nova-2"
+
+    def test_model_override_passed_to_deepgram(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="deepgram"), \
+             patch("tools.transcription_tools._transcribe_deepgram",
+                   return_value={"success": True, "transcript": "hi"}) as mock_deepgram:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="nova-3-medical")
+
+        assert mock_deepgram.call_args[0][1] == "nova-3-medical"
 
 
 # ============================================================================

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,7 +2,7 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
@@ -12,6 +12,7 @@ Provides speech-to-text transcription with six providers:
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
   - **elevenlabs** — ElevenLabs Scribe API, requires ``ELEVENLABS_API_KEY``.
+  - **deepgram** — Deepgram Listen API, requires ``DEEPGRAM_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -28,6 +29,7 @@ Usage::
 """
 
 import logging
+import mimetypes
 import os
 import shlex
 import shutil
@@ -90,6 +92,7 @@ DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
 DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
+DEFAULT_DEEPGRAM_STT_MODEL = os.getenv("STT_DEEPGRAM_MODEL", "nova-3")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -98,6 +101,7 @@ GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
+DEEPGRAM_STT_BASE_URL = os.getenv("DEEPGRAM_STT_BASE_URL", "https://api.deepgram.com/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -224,7 +228,7 @@ def _try_lazy_install_stt() -> bool:
     return False
 
 
-# Names of the 6 STT providers with native handlers in this module.
+# Names of the 7 STT providers with native handlers in this module.
 # Kept in sync with ``agent.transcription_registry._BUILTIN_NAMES`` —
 # a regression test fails if they drift. The plugin hook from
 # issue #30398-style follow-up rejects plugins registering under any
@@ -237,6 +241,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
     "openai",
     "mistral",
     "xai",
+    "deepgram",
 })
 
 
@@ -251,7 +256,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
 #
 # Resolution order:
 #   1. Built-in (``local``, ``local_command``, ``groq``, ``openai``,
-#      ``mistral``, ``xai``)              → native handler. **Always wins.**
+#      ``mistral``, ``xai``, ``deepgram``) → native handler. **Always wins.**
 #   2. ``stt.providers.<name>: type: command``  → command-provider runner.
 #   3. Plugin-registered TranscriptionProvider  → plugin dispatch.
 #   4. No match                                 → "No STT provider available".
@@ -742,7 +747,8 @@ def _get_provider(stt_config: dict) -> str:
 
     When ``stt.provider`` is explicitly set in config, that choice is
     honoured — no silent cloud fallback.  When no provider is configured,
-    auto-detect tries: local > groq (free) > openai (paid).
+    auto-detect tries: local > groq (free) > deepgram > openai (paid) >
+    mistral > xai > elevenlabs.
     """
     if not is_stt_enabled(stt_config):
         return "none"
@@ -821,11 +827,18 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "deepgram":
+            if str(get_env_value("DEEPGRAM_API_KEY") or "").strip():
+                return "deepgram"
+            logger.warning(
+                "STT provider 'deepgram' configured but DEEPGRAM_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > xai > elevenlabs -
-    # mistral is intentionally skipped while `mistralai` is quarantined on
-    # PyPI (malicious 2.4.6 release on 2026-05-12).
+    # --- Auto-detect (no explicit provider): local > groq > deepgram > openai >
+    # mistral > xai > elevenlabs.
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -837,6 +850,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and get_env_value("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
+    if str(get_env_value("DEEPGRAM_API_KEY") or "").strip():
+        logger.info("No local STT available, using Deepgram Listen API")
+        return "deepgram"
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
@@ -1608,6 +1624,153 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: Deepgram (Listen API)
+# ---------------------------------------------------------------------------
+
+
+def _extract_deepgram_transcript(result: Dict[str, Any]) -> str:
+    """Return Deepgram's best transcript from a Listen API JSON response."""
+    channels = result.get("results", {}).get("channels", [])
+    if isinstance(channels, list):
+        transcripts = []
+        for channel in channels:
+            alternatives = channel.get("alternatives", []) if isinstance(channel, dict) else []
+            if alternatives and isinstance(alternatives[0], dict):
+                text = str(alternatives[0].get("transcript") or "").strip()
+                if text:
+                    transcripts.append(text)
+        if transcripts:
+            return " ".join(transcripts).strip()
+    if isinstance(result.get("text"), str):
+        return _extract_transcript_text(result)
+    return ""
+
+
+def _deepgram_bool_param(config: Dict[str, Any], name: str, default: bool) -> str:
+    return "true" if is_truthy_value(config.get(name, default), default=default) else "false"
+
+
+def _transcribe_deepgram(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Deepgram's REST Listen API.
+
+    Uses ``POST /v1/listen`` with the audio file as the request body and
+    ``Authorization: Token <DEEPGRAM_API_KEY>``. Supported config keys live
+    under ``stt.deepgram``: ``model``, ``language``, ``language_hint``,
+    ``base_url``, ``timeout``, ``smart_format``, ``punctuate``, ``diarize``,
+    and ``detect_language``.
+    """
+    api_key = str(get_env_value("DEEPGRAM_API_KEY") or "").strip()
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "DEEPGRAM_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    deepgram_config = stt_config.get("deepgram", {}) if isinstance(stt_config.get("deepgram"), dict) else {}
+    base_url = str(
+        deepgram_config.get("base_url")
+        or get_env_value("DEEPGRAM_STT_BASE_URL")
+        or DEEPGRAM_STT_BASE_URL
+    ).strip().rstrip("/")
+    timeout_raw = deepgram_config.get("timeout", deepgram_config.get("timeout_seconds", 120))
+    try:
+        timeout = float(timeout_raw)
+    except (TypeError, ValueError):
+        timeout = 120.0
+    if timeout <= 0:
+        timeout = 120.0
+
+    params: Dict[str, str] = {
+        "model": model_name,
+        "smart_format": _deepgram_bool_param(deepgram_config, "smart_format", True),
+        "punctuate": _deepgram_bool_param(deepgram_config, "punctuate", True),
+    }
+    language = str(deepgram_config.get("language") or "").strip()
+    if language:
+        params["language"] = language
+
+    # Deepgram nova-3 does not reliably auto-detect non-English speech unless
+    # detect_language is sent explicitly. Always enable it when no fixed
+    # language is configured so existing configs generated with the old
+    # ``detect_language: false`` default still work for multilingual voice.
+    if not language:
+        params["detect_language"] = "true"
+    if is_truthy_value(deepgram_config.get("diarize", False), default=False):
+        params["diarize"] = "true"
+
+    try:
+        import requests
+
+        content_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+
+        def post_listen(request_params: Dict[str, str]):
+            with open(file_path, "rb") as audio_file:
+                return requests.post(
+                    f"{base_url}/listen",
+                    headers={
+                        "Authorization": f"Token {api_key}",
+                        "Content-Type": content_type,
+                    },
+                    params=request_params,
+                    data=audio_file,
+                    timeout=timeout,
+                )
+
+        def api_error(response) -> Dict[str, Any]:
+            try:
+                err_body = response.json()
+                detail = str(
+                    err_body.get("err_msg")
+                    or err_body.get("message")
+                    or err_body.get("error")
+                    or response.text[:300]
+                )
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": "deepgram",
+                "error": f"Deepgram STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        response = post_listen(params)
+        if response.status_code != 200:
+            return api_error(response)
+
+        result = response.json()
+        transcript_text = _extract_deepgram_transcript(result)
+        if not transcript_text and not language:
+            retry_params = dict(params)
+            retry_params.pop("detect_language", None)
+            retry_params["language"] = str(deepgram_config.get("language_hint") or "pt").strip() or "pt"
+            retry_response = post_listen(retry_params)
+            if retry_response.status_code != 200:
+                return api_error(retry_response)
+            transcript_text = _extract_deepgram_transcript(retry_response.json())
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "provider": "deepgram",
+                "error": "Deepgram STT returned empty transcript",
+            }
+
+        logger.info(
+            "Transcribed %s via Deepgram Listen API (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "deepgram"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "provider": "deepgram", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Deepgram STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "provider": "deepgram", "error": f"Deepgram STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1618,7 +1781,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     Provider priority:
       1. User config (``stt.provider`` in config.yaml)
-      2. Auto-detect: local > Groq > OpenAI > Mistral > xAI > ElevenLabs
+      2. Auto-detect: local > Groq > Deepgram > OpenAI > Mistral > xAI > ElevenLabs
 
     Args:
         file_path: Absolute path to the audio file to transcribe.
@@ -1685,6 +1848,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
         return _transcribe_elevenlabs(file_path, model_name)
 
+    if provider == "deepgram":
+        deepgram_cfg = stt_config.get("deepgram", {})
+        model_name = model or deepgram_cfg.get("model", DEFAULT_DEEPGRAM_STT_MODEL)
+        return _transcribe_deepgram(file_path, model_name)
+
     # User-declared command-type provider
     # (``stt.providers.<name>: type: command``). Fires after the built-in
     # elif chain — built-in names short-circuit upstream so a user's
@@ -1734,8 +1902,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
+            "set GROQ_API_KEY for free Groq Whisper, set DEEPGRAM_API_KEY for Deepgram, "
+            "set MISTRAL_API_KEY for Mistral Voxtral Transcribe, "
+            "configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
             "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -129,7 +129,9 @@ Add to `~/.hermes/.env`:
 ```bash
 # Cloud STT options (local needs no key)
 GROQ_API_KEY=***
+DEEPGRAM_API_KEY=***
 VOICE_TOOLS_OPENAI_KEY=***
+MISTRAL_API_KEY=***
 
 # Premium TTS (optional)
 ELEVENLABS_API_KEY=***
@@ -141,7 +143,32 @@ ELEVENLABS_API_KEY=***
 
 - `local` → best default for privacy and zero-cost use
 - `groq` → very fast cloud transcription
+- `deepgram` → cloud transcription via Deepgram Listen API; set `DEEPGRAM_API_KEY`, then `stt.provider: deepgram`
 - `openai` → good paid fallback
+- `mistral` → Voxtral transcription
+
+Deepgram needs no extra Python package beyond Hermes' normal dependencies. Minimal Deepgram config:
+
+```yaml
+stt:
+  enabled: true
+  provider: "deepgram"
+  deepgram:
+    model: "nova-3"
+    language: ""         # auto-detect; set "en", "es", "fr", etc. to force
+    language_hint: "pt"  # retry hint if auto-detect returns an empty transcript
+    smart_format: true
+    punctuate: true
+    diarize: false
+    detect_language: true
+```
+
+Optional Deepgram environment overrides:
+
+```bash
+STT_DEEPGRAM_MODEL=nova-3
+DEEPGRAM_STT_BASE_URL=https://api.deepgram.com/v1
+```
 
 #### Text-to-speech
 

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -68,7 +68,7 @@ Text-to-speech and speech-to-text across all messaging platforms:
 | **xAI TTS** | Good | Paid | `XAI_API_KEY` |
 | **NeuTTS** | Good | Free | None needed |
 
-Speech-to-text supports six providers: local faster-whisper (free, runs on-device), a local command wrapper, Groq, OpenAI Whisper API, Mistral, and xAI. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/user-guide/features/tts) and [Voice Mode](/user-guide/features/voice-mode) for details.
+Speech-to-text supports cloud and local providers: local faster-whisper (free, runs on-device), a local command wrapper, Groq, Deepgram Listen API, OpenAI Whisper API, Mistral, xAI, and ElevenLabs Scribe. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/user-guide/features/tts) and [Voice Mode](/user-guide/features/voice-mode) for details.
 
 ## IDE & Editor Integration
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -143,11 +143,14 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `AGENT_BROWSER_ARGS` | Extra Chromium launch flags (comma- or newline-separated). Hermes auto-injects `--no-sandbox,--disable-dev-shm-usage` when running as root or on AppArmor-restricted unprivileged user namespaces (Ubuntu 23.10+, DGX Spark, many container images); set this manually only to override or add other flags. |
 | `FAL_KEY` | Image generation ([fal.ai](https://fal.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
+| `DEEPGRAM_API_KEY` | Deepgram Listen API key for speech-to-text transcription ([console.deepgram.com](https://console.deepgram.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |
 | `STT_GROQ_MODEL` | Override the Groq STT model (default: `whisper-large-v3-turbo`) |
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |
 | `STT_OPENAI_BASE_URL` | Override the OpenAI-compatible STT endpoint |
+| `STT_DEEPGRAM_MODEL` | Override the Deepgram STT model (default: `nova-3`) |
+| `DEEPGRAM_STT_BASE_URL` | Override the Deepgram STT endpoint (default: `https://api.deepgram.com/v1`) |
 | `GITHUB_TOKEN` | GitHub token for Skills Hub (higher API rate limits, skill publish) |
 | `HONCHO_API_KEY` | Cross-session user modeling ([honcho.dev](https://honcho.dev/)) |
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1319,11 +1319,23 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 
 ```yaml
 stt:
-  provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  enabled: true
+  provider: "local"            # "local" | "local_command" | "groq" | "deepgram" | "openai" | "mistral" | "xai" | "elevenlabs"
   local:
     model: "base"              # tiny, base, small, medium, large-v3
+    language: ""               # auto-detect; set "en", "es", "fr", etc. to force
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  deepgram:
+    model: "nova-3"            # nova-3 | nova-2 | enhanced | base
+    language: ""               # auto-detect; set "en", "es", "fr", etc. to force
+    language_hint: "pt"        # retry hint if auto-detect returns an empty transcript
+    smart_format: true          # format numbers, dates, punctuation-friendly text
+    punctuate: true
+    diarize: false
+    detect_language: true
+    # base_url: "https://api.deepgram.com/v1"  # optional override; env fallback: DEEPGRAM_STT_BASE_URL
+    # timeout: 120              # request timeout seconds
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
@@ -1331,17 +1343,34 @@ Provider behavior:
 
 - `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`.
+- `deepgram` uses Deepgram's Listen API and reads `DEEPGRAM_API_KEY`. No Deepgram SDK is required; Hermes uses the existing `requests` dependency.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
+- `mistral` uses Mistral Voxtral Transcribe and reads `MISTRAL_API_KEY`.
+- `xai` uses xAI STT and reads `XAI_API_KEY`.
+- `elevenlabs` uses ElevenLabs Scribe and reads `ELEVENLABS_API_KEY`.
 
-If the requested provider is unavailable, Hermes falls back automatically in this order: `local` → `groq` → `openai`.
+When `stt.provider` is set explicitly, Hermes respects that choice and returns an error if the required key or dependency is missing. When no provider is configured, Hermes auto-detects in this order: `local` → `groq` → `deepgram` → `openai` → `mistral` → `xai` → `elevenlabs`.
 
-Groq and OpenAI model overrides are environment-driven:
+Deepgram minimal setup:
+
+```bash
+# ~/.hermes/.env
+DEEPGRAM_API_KEY=your-deepgram-key
+
+hermes config set stt.enabled true
+hermes config set stt.provider deepgram
+hermes config set stt.deepgram.model nova-3
+```
+
+Provider model and endpoint overrides can also be environment-driven:
 
 ```bash
 STT_GROQ_MODEL=whisper-large-v3-turbo
 STT_OPENAI_MODEL=whisper-1
+STT_DEEPGRAM_MODEL=nova-3
 GROQ_BASE_URL=https://api.groq.com/openai/v1
 STT_OPENAI_BASE_URL=https://api.openai.com/v1
+DEEPGRAM_STT_BASE_URL=https://api.deepgram.com/v1
 ```
 
 ## Voice Mode (CLI)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -385,6 +385,7 @@ Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automat
 |----------|---------|------|---------| 
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
+| **Deepgram Listen API** | Good–Best | Paid / free trial | `DEEPGRAM_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
 
 :::info Zero Config
@@ -396,11 +397,22 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai"
+  enabled: true
+  provider: "local"           # "local" | "local_command" | "groq" | "deepgram" | "openai" | "mistral" | "xai" | "elevenlabs"
   local:
     model: "base"             # tiny, base, small, medium, large-v3
   openai:
     model: "whisper-1"        # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+  deepgram:
+    model: "nova-3"           # nova-3, nova-2, enhanced, base
+    language: ""              # auto-detect; set "en", "es", "fr", etc. to force
+    language_hint: "pt"       # retry hint if auto-detect returns an empty transcript
+    smart_format: true
+    punctuate: true
+    diarize: false
+    detect_language: true
+    # base_url: "https://api.deepgram.com/v1"  # optional; env fallback: DEEPGRAM_STT_BASE_URL
+    # timeout: 120
   mistral:
     model: "voxtral-mini-latest"  # voxtral-mini-latest, voxtral-mini-2602
   xai:
@@ -420,6 +432,8 @@ stt:
 | `large-v3` | ~3 GB | Slowest | Best |
 
 **Groq API** — Requires `GROQ_API_KEY`. Good cloud fallback when you want a free hosted STT option.
+
+**Deepgram Listen API** — Requires `DEEPGRAM_API_KEY`. Hermes posts audio to `https://api.deepgram.com/v1/listen` with `Authorization: Token <key>` and does not require the Deepgram SDK. Defaults to `stt.deepgram.model: nova-3` and `detect_language: true` when no fixed `language` is configured; if auto-detect returns an empty transcript, Hermes retries once with `stt.deepgram.language_hint` (`pt` by default). Optional keys include `language`, `language_hint`, `smart_format`, `punctuate`, `diarize`, `detect_language`, `base_url`, and `timeout`. Set `DEEPGRAM_STT_BASE_URL` or `stt.deepgram.base_url` only if you need a proxy/custom endpoint.
 
 **OpenAI API** — Accepts `VOICE_TOOLS_OPENAI_KEY` first and falls back to `OPENAI_API_KEY`. Supports `whisper-1`, `gpt-4o-mini-transcribe`, and `gpt-4o-transcribe`.
 
@@ -449,10 +463,10 @@ Hermes writes the incoming voice message to `{input_path}`, runs the command, an
 
 ### Fallback Behavior
 
-If your configured provider isn't available, Hermes automatically falls back:
+When `stt.provider` is set explicitly, Hermes respects that choice and returns an error if the provider key or dependency is missing. When no provider is configured, Hermes auto-detects:
 - **Local faster-whisper unavailable** → Tries a local `whisper` CLI or `HERMES_LOCAL_STT_COMMAND` before cloud providers
-- **Groq key not set** → Falls back to local transcription, then OpenAI
-- **OpenAI key not set** → Falls back to local transcription, then Groq
+- **Cloud auto-detect order** → `groq` → `deepgram` → `openai` → `mistral` → `xai` → `elevenlabs`
+- **Deepgram key not set** → Skipped in auto-detect; explicit `stt.provider: deepgram` returns a `DEEPGRAM_API_KEY not set` style error
 - **Mistral key/SDK not set** → Skipped in auto-detect; falls through to next available provider
 - **Nothing available** → Voice messages pass through with an accurate note to the user
 
@@ -534,7 +548,7 @@ The shell command runs under the same user as Hermes with full filesystem access
 
 ### Python plugin providers (STT)
 
-For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 6 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
+For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the built-in providers (`local`, `local_command`, `groq`, `deepgram`, `openai`, `mistral`, `xai`, `elevenlabs`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugin providers when both exist for the same custom name.
 
 #### When to pick which (STT)
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -94,7 +94,9 @@ Add to `~/.hermes/.env`:
 # Speech-to-Text — local provider needs NO key at all
 # pip install faster-whisper          # Free, runs locally, recommended
 GROQ_API_KEY=your-key                 # Groq Whisper — fast, free tier (cloud)
+DEEPGRAM_API_KEY=your-key             # Deepgram Listen API — cloud STT
 VOICE_TOOLS_OPENAI_KEY=your-key       # OpenAI Whisper — paid (cloud)
+MISTRAL_API_KEY=your-key              # Mistral Voxtral — cloud STT/TTS
 
 # Text-to-Speech (optional — Edge TTS and NeuTTS work without any key)
 ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
@@ -104,6 +106,43 @@ ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
 :::tip
 If `faster-whisper` is installed, voice mode works with **zero API keys** for STT. The model (~150 MB for `base`) downloads automatically on first use.
 :::
+
+### Deepgram STT
+
+Deepgram is a cloud speech-to-text provider. Hermes calls Deepgram's REST Listen API directly, so there is no Deepgram Python SDK to install. The only required setup is the API key plus `stt.provider: deepgram`:
+
+```bash
+# ~/.hermes/.env
+DEEPGRAM_API_KEY=your-deepgram-key
+
+hermes config set stt.enabled true
+hermes config set stt.provider deepgram
+```
+
+Optional Deepgram settings live under `stt.deepgram`:
+
+```yaml
+stt:
+  enabled: true
+  provider: "deepgram"
+  deepgram:
+    model: "nova-3"          # default; also supports nova-2, enhanced, base
+    language: ""             # auto-detect; set "en", "es", "fr", etc. to force
+    language_hint: "pt"      # retry hint if auto-detect returns an empty transcript
+    smart_format: true
+    punctuate: true
+    diarize: false
+    detect_language: true
+    # base_url: "https://api.deepgram.com/v1"
+    # timeout: 120
+```
+
+You can also override the model or endpoint from `~/.hermes/.env`:
+
+```bash
+STT_DEEPGRAM_MODEL=nova-3
+DEEPGRAM_STT_BASE_URL=https://api.deepgram.com/v1
+```
 
 ---
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -375,7 +375,7 @@ Edit with `hermes config edit` or `hermes config set section.key value`.
 | `terminal` | `backend` (local/docker/ssh/modal), `cwd`, `timeout` (180) |
 | `compression` | `enabled`, `threshold` (0.50), `target_ratio` (0.20) |
 | `display` | `skin`, `tool_progress`, `show_reasoning`, `show_cost` |
-| `stt` | `enabled`, `provider` (local/groq/openai/mistral) |
+| `stt` | `enabled`, `provider` (local/groq/deepgram/openai/mistral/xai/elevenlabs) |
 | `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts) |
 | `memory` | `memory_enabled`, `user_profile_enabled`, `provider` |
 | `security` | `tirith_enabled`, `website_blocklist` |
@@ -523,16 +523,24 @@ Voice messages from messaging platforms are auto-transcribed.
 Provider priority (auto-detected):
 1. **Local faster-whisper** — free, no API key: `pip install faster-whisper`
 2. **Groq Whisper** — free tier: set `GROQ_API_KEY`
-3. **OpenAI Whisper** — paid: set `VOICE_TOOLS_OPENAI_KEY`
-4. **Mistral Voxtral** — set `MISTRAL_API_KEY`
+3. **Deepgram Listen API** — set `DEEPGRAM_API_KEY`
+4. **OpenAI Whisper** — paid: set `VOICE_TOOLS_OPENAI_KEY`
+5. **Mistral Voxtral** — set `MISTRAL_API_KEY`
+6. **xAI / ElevenLabs** — set `XAI_API_KEY` or `ELEVENLABS_API_KEY`
 
 Config:
 ```yaml
 stt:
   enabled: true
-  provider: local        # local, groq, openai, mistral
+  provider: local        # local, groq, deepgram, openai, mistral, xai, elevenlabs
   local:
     model: base          # tiny, base, small, medium, large-v3
+  deepgram:
+    model: nova-3        # nova-3, nova-2, enhanced, base
+    language: ""         # auto-detect; set en/es/fr/etc. to force
+    language_hint: "pt"  # retry hint if auto-detect returns an empty transcript
+    smart_format: true
+    punctuate: true
 ```
 
 ### TTS (Text → Voice)


### PR DESCRIPTION
## Summary
- Add Deepgram as a selectable speech-to-text provider alongside the existing transcription providers.
- Wire Deepgram through the transcription registry, CLI/config examples, web server configuration, and transcription tools.
- Update voice-mode, environment variable, integration, and bundled-skill documentation for Deepgram configuration.

## Validation
- `python -m pytest tests/tools/test_transcription_tools.py tests/agent/test_transcription_registry.py -q` — 153 tests passed.
- Verified the pushed branch `jaysonsantos:feat/deepgram-stt` matches local commit `fa8c0ff20f72947ea4054c893e8e6762f0d75b54`.

## Known follow-ups
- Live Deepgram usage still requires a valid `DEEPGRAM_API_KEY` in the runtime environment.
- Broader end-to-end voice-mode coverage can be expanded once provider credentials are available in CI.