### PR TITLE
fix(desktop): prevent Enter from submitting during IME composition

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -570,7 +570,7 @@ export function ChatBar({
         return
       }
 
-      if (event.key === 'Enter' || event.key === 'Tab') {
+      if ((event.key === 'Enter' || event.key === 'Tab') && !event.nativeEvent.isComposing) {
         event.preventDefault()
         const item = triggerItems[triggerActive]
 
@@ -589,7 +589,7 @@ export function ChatBar({
       }
     }
 
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
       event.preventDefault()
 
       if (!busy && !hasComposerPayload && queuedPrompts.length > 0) {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -224,7 +224,7 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle }: Re
           disabled={submitting}
           onChange={event => setValue(event.target.value)}
           onKeyDown={event => {
-            if (event.key === 'Enter') {
+            if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
               event.preventDefault()
               void submit()
             } else if (event.key === 'Escape') {

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -1210,7 +1210,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
         return
       }
 
-      if (event.key === 'Enter' || event.key === 'Tab') {
+      if ((event.key === 'Enter' || event.key === 'Tab') && !event.nativeEvent.isComposing) {
         event.preventDefault()
         const item = triggerItems[triggerActive]
 
@@ -1236,7 +1236,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
       return
     }
 
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
       event.preventDefault()
       submitEdit(event.currentTarget)
     }

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -483,7 +483,7 @@ function ApiKeyForm({ canGoBack, ctx }: { canGoBack: boolean; ctx: OnboardingCon
           autoFocus
           className="font-mono"
           onChange={e => setValue(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submit()}
+          onKeyDown={e => e.key === 'Enter' && !e.nativeEvent.isComposing && void submit()}
           placeholder={option.placeholder || 'Paste API key'}
           type={isLocal ? 'text' : 'password'}
           value={value}
@@ -551,7 +551,7 @@ function FlowPanel({ ctx, flow }: { ctx: OnboardingContext; flow: OnboardingFlow
         <Input
           autoFocus
           onChange={e => setOnboardingCode(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && void submitOnboardingCode(ctx)}
+          onKeyDown={e => e.key === 'Enter' && !e.nativeEvent.isComposing && void submitOnboardingCode(ctx)}
           placeholder="Paste authorization code"
           value={flow.code}
         />


### PR DESCRIPTION
## What does this PR do?

Prevents the desktop app's Enter-to-submit branches from firing while an IME composition is active. Users typing in Japanese, Chinese, Korean, Vietnamese, or any other compositional input method were seeing their messages sent mid-conversion instead of committing the candidate.

The fix is a single `!event.nativeEvent.isComposing` guard added to every Enter handler in the desktop renderer that previously had none.

This is the right approach because:
- `event.nativeEvent.isComposing` is the standard Chromium signal for active IME composition, exposed as a property on every `KeyboardEvent` regardless of IME implementation.
- Referring to the native event (rather than the React synthetic `isComposing`) is safer across Electron's bundled Chromium versions.
- The five affected sites share an identical one-line pattern, so bundling them into one PR keeps reviewable context together and avoids four future duplicate issues.


## Related Issue

Fixes #37483


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

Added `!event.nativeEvent.isComposing` to the following Enter handlers:

- `apps/desktop/src/app/chat/composer/index.tsx` — main composer submit (L592) and `/` `@` trigger popover (L573)
- `apps/desktop/src/components/assistant-ui/thread.tsx` — message edit submit (L1239) and trigger popover (L1213)
- `apps/desktop/src/components/desktop-onboarding-overlay.tsx` — API key input (L486) and auth code input (L554)
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` — session rename input (L227)

Each file is a one-line change; total diff is 4 files, 7 insertions, 7 deletions.


## How to Test

**Reproduction (before fix):**

1. Launch Hermes Desktop on macOS.
2. Enable a Japanese IME (macOS "Japanese Input", ATOK, or Google Japanese Input).
3. Type `きょうは` (pre-conversion kana) in the chat composer.
4. The candidate list appears (e.g. "今日", "京は").
5. Press Enter to commit the candidate.
6. Observe: the commit fires and the message is sent immediately.

**Verification (after fix):**

1. Repeat the same reproduction steps.
2. Observe: Enter commits the selected candidate. The composer retains the committed text. No message is sent.
3. A subsequent Enter (or a click on the send button) sends the message as expected — Enter-to-send behaviour is preserved once composition has ended.

Additional verification targets:
- The `/` and `@` trigger popovers still close on Enter/Tab and commit on click when composing is not active.
- The message edit composer still submits on Enter after typing a revised message.
- The session rename dialog still submits on Enter after typing a new title.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (no Desktop-specific Python tests exist; Desktop is pure TypeScript/Electron)
- [x] I've added tests for my changes — Not added. jsdom does not model `KeyboardEvent.isComposing` reliably (it's a native Chromium property set by the IME subsystem), so a jsdom unit test here would not catch the real-world failure. Manual IME verification was preferred; I'm happy to add a jsdom test if maintainers want one.
- [x] I've tested on my platform: macOS 26.5 (darwin-arm64, Apple Silicon) with the built-in Japanese IME

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## For New Skills

N/A (this is a bug fix, not a new skill).


## Screenshots / Logs

Not applicable. This is a pure input-handling fix — no visual change. The difference is observable only with an IME active and is verified by the behavioural steps in "How to Test" above.


## Additional reviewer notes

- **Cross-platform note**: `isComposing` is a standard `KeyboardEvent` property in Chromium, WebKit, and Firefox — Windows, Linux, and macOS all behave identically here. The fix doesn't introduce any platform-specific code.
- **Tab key**: the trigger popover branches now also skip Tab during composition. This is a safety measure for symmetry; Tab is not a key users press while composing, but adding the guard keeps the Enter/Tab branches uniform.
- **Lower-priority sites**: the onboarding overlay (API key / auth code input) and session rename are rarely hit by IME users in practice, but share the same pattern and are patched for completeness to prevent duplicate future issues.
