### PR TITLE
fix(model_switch): detect google-gemini-cli OAuth creds in provider picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1435,6 +1435,17 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
+        # google-gemini-cli uses OAuth credentials stored in a separate
+        # google_oauth.json file (not the credential pool).  Check it
+        # directly so the /model picker and web UI can surface this
+        # provider when the user has an active OAuth session.
+        if not has_creds and hermes_slug == "google-gemini-cli":
+            try:
+                from agent.google_oauth import load_credentials
+                if load_credentials() is not None:
+                    has_creds = True
+            except Exception as exc:
+                logger.debug("Google OAuth creds check failed: %s", exc)
         if not has_creds:
             continue
 
@@ -1559,6 +1570,16 @@ def list_authenticated_providers(
         # ~/.aws/credentials, instance roles, etc.)
         if not _cp_has_creds and _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
             _cp_has_creds = _has_aws_sdk_creds_for_listing(_cp.slug)
+
+        # Special case: google-gemini-cli OAuth — credentials stored in
+        # google_oauth.json, not in the credential pool or auth store.
+        if not _cp_has_creds and _cp.slug == "google-gemini-cli":
+            try:
+                from agent.google_oauth import load_credentials
+                if load_credentials() is not None:
+                    _cp_has_creds = True
+            except Exception as exc:
+                logger.debug("Google OAuth creds check failed: %s", exc)
 
         if not _cp_has_creds:
             continue


### PR DESCRIPTION
## Problem

`google-gemini-cli` (Google Gemini via OAuth + Code Assist) was not appearing in:
- The `/model` picker (CLI and TUI)
- The `/api/model/options` endpoint
- The web UI model dropdown  
- The `/models` dashboard page

Even though the provider works correctly as the active model (credentials stored in `~/.hermes/auth/google_oauth.json` and resolved by `resolve_runtime_provider()`), `list_authenticated_providers()` could not detect it.

## Root Cause

`list_authenticated_providers()` checks three credential sources:
1. Environment variables (via `PROVIDER_REGISTRY.api_key_env_vars`)
2. The auth store (`auth.json`)
3. The credential pool

`google-gemini-cli` uses `auth_type="oauth_external"` — its credentials live in a separate `google_oauth.json` file that none of these three sources check. The only external OAuth credential file check was for Anthropic (Claude Code / Hermes OAuth).

## Fix

Added Google OAuth credential detection in two places where `list_authenticated_providers()` checks credentials:

1. **HERMES_OVERLAYS section** (Section 2) — after the existing Anthropic check
2. **CANONICAL_PROVIDERS cross-check** (Section 2b) — after the `aws_sdk` check

Both use `agent.google_oauth.load_credentials()` which returns `None` when the credential file is missing, expired, or corrupted — so there is no performance penalty when the user has not set up Google OAuth.

## Verification

Before fix: `google-gemini-cli` absent from provider list (6 providers)
After fix: `google-gemini-cli` present with `is_current=True` and 3 models (7 providers)

```python
# Before: [openrouter, custom:imyai, copilot, gemini, openai-codex, deepseek]
# After:  [google-gemini-cli, openrouter, custom:imyai, copilot, gemini, openai-codex, deepseek]
```

Both `google-gemini-cli` (OAuth) and `gemini` (API key) are now correctly detected.