### PR TITLE
fix(desktop): correct sidebar session pagination and counts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -92,8 +92,7 @@
     "unified": "^11.0.5",
     "unist-util-visit-parents": "^6.0.2",
     "vfile": "^6.0.3",
-    "web-haptics": "^0.0.6",
-    "zustand": "^5.0.14"
+    "web-haptics": "^0.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -92,7 +92,8 @@
     "unified": "^11.0.5",
     "unist-util-visit-parents": "^6.0.2",
     "vfile": "^6.0.3",
-    "web-haptics": "^0.0.6"
+    "web-haptics": "^0.0.6",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -201,12 +201,60 @@ export function DesktopController() {
       // Require at least one message so abandoned/empty "Untitled" drafts (one
       // was created per TUI/desktop launch before the lazy-create fix) don't
       // clutter the sidebar.
-      const result = await listSessions(limit, 1)
+      const result = await listSessions(limit, 1, 'exclude', 'recent', 0)
 
       if (refreshSessionsRequestRef.current === requestId) {
         setSessions(result.sessions)
         setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
       }
+    } catch (err) {
+      console.error('[sessions] refresh failed', err)
+    } finally {
+      if (refreshSessionsRequestRef.current === requestId) {
+        setSessionsLoading(false)
+      }
+    }
+  }, [])
+
+  const appendMoreSessions = useCallback(async () => {
+    const requestId = refreshSessionsRequestRef.current + 1
+    refreshSessionsRequestRef.current = requestId
+    setSessionsLoading(true)
+
+    try {
+      const limit = $sessionsLimit.get()
+      const current = $sessions.get()
+      const result = await listSessions(limit, 1, 'exclude', 'recent', current.length)
+
+      if (refreshSessionsRequestRef.current === requestId) {
+        // Dedupe by id before appending: a compression-continuation root and
+        // its tip can both surface in the same page after a refresh.
+        const seen = new Set<string>(current.map(s => s.id))
+        const appended: typeof result.sessions = []
+
+        for (const s of result.sessions) {
+          if (!seen.has(s.id)) {
+            seen.add(s.id)
+            appended.push(s)
+          }
+        }
+
+        if (appended.length > 0) {
+          setSessions(prev => [...prev, ...appended])
+        }
+
+        const backendTotal = typeof result.total === 'number' ? result.total : result.sessions.length
+
+        if (appended.length === 0) {
+          // Nothing came back — we've exhausted the list. Align total with
+          // the displayed count so the "Load more" button hides.
+          setSessionsTotal(prev => Math.min(prev, current.length))
+        } else {
+          setSessionsTotal(prev => Math.max(prev, backendTotal))
+        }
+      }
+    } catch (err) {
+      console.error('[sessions] load more failed', err)
     } finally {
       if (refreshSessionsRequestRef.current === requestId) {
         setSessionsLoading(false)
@@ -216,8 +264,8 @@ export function DesktopController() {
 
   const loadMoreSessions = useCallback(() => {
     bumpSessionsLimit()
-    void refreshSessions()
-  }, [refreshSessions])
+    void appendMoreSessions()
+  }, [appendMoreSessions])
 
   const toggleSelectedPin = useCallback(() => {
     const sessionId = $selectedStoredSessionId.get()

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -33,6 +33,7 @@ import {
   setSelectedStoredSessionId,
   setSessions,
   setSessionStartedAt,
+  setSessionsTotal,
   setTurnStartedAt
 } from '@/store/session'
 import { reportBackendContract } from '@/store/updates'
@@ -687,6 +688,9 @@ export function useSessionActions({
       const previousPinned = $pinnedSessionIds.get()
 
       setSessions(prev => prev.filter(s => s.id !== storedSessionId))
+      // Mirror the backend's non-archived count so the "n/n" sidebar label
+      // doesn't lag after a delete (n-1/n instead of n-1/n-1).
+      setSessionsTotal(prev => Math.max(0, prev - 1))
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId))
 
       // Tear down before awaiting so the route effect can't resume the
@@ -709,6 +713,7 @@ export function useSessionActions({
       } catch (err) {
         if (removed) {
           setSessions(prev => [removed, ...prev])
+          setSessionsTotal(prev => prev + 1)
         }
 
         $pinnedSessionIds.set(previousPinned)
@@ -761,6 +766,9 @@ export function useSessionActions({
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(s => s.id !== storedSessionId))
+      // Archive drops the row out of the non-archived count — keep
+      // $sessionsTotal in lockstep so the "n/n" label stays consistent.
+      setSessionsTotal(prev => Math.max(0, prev - 1))
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId))
 
       if (wasSelected) {
@@ -773,6 +781,7 @@ export function useSessionActions({
       } catch (err) {
         if (archived) {
           setSessions(prev => [archived, ...prev.filter(s => s.id !== storedSessionId)])
+          setSessionsTotal(prev => prev + 1)
         }
 
         $pinnedSessionIds.set(previousPinned)

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -115,16 +115,19 @@ export async function listSessions(
   limit = 40,
   minMessages = 0,
   archived: 'exclude' | 'include' | 'only' = 'exclude',
-  order: 'created' | 'recent' = 'recent'
+  order: 'created' | 'recent' = 'recent',
+  offset = 0
 ): Promise<PaginatedSessions> {
+  const safeOffset = Math.max(0, offset)
+
   const result = await window.hermesDesktop.api<PaginatedSessions>({
-    path: `/api/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}&archived=${archived}&order=${order}`
+    path: `/api/sessions?limit=${limit}&offset=${safeOffset}&min_messages=${Math.max(0, minMessages)}&archived=${archived}&order=${order}`
   })
 
   return {
     ...result,
     sessions: result.sessions.slice(0, limit),
-    offset: 0
+    offset: safeOffset
   }
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -35,26 +35,26 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from hermes_cli import __version__, __release_date__
+from gateway.status import get_running_pid, read_runtime_status
+from hermes_cli import __release_date__, __version__
 from hermes_cli.config import (
-    cfg_get,
     DEFAULT_CONFIG,
     OPTIONAL_ENV_VARS,
+    cfg_get,
+    check_config_version,
+    detect_install_method,
+    format_docker_update_message,
     get_config_path,
     get_env_path,
     get_hermes_home,
     load_config,
     load_env,
-    save_config,
-    save_env_value,
-    remove_env_value,
-    check_config_version,
-    detect_install_method,
-    format_docker_update_message,
     recommended_update_command_for_method,
     redact_key,
+    remove_env_value,
+    save_config,
+    save_env_value,
 )
-from gateway.status import get_running_pid, read_runtime_status
 from utils import env_var_enabled
 
 try:
@@ -69,8 +69,15 @@ except ImportError:
     # them out of every other install path. After install, re-import.
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
+
         _lazy_ensure("tool.dashboard", prompt=False)
-        from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+        from fastapi import (
+            FastAPI,
+            HTTPException,
+            Request,
+            WebSocket,
+            WebSocketDisconnect,
+        )
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
@@ -81,7 +88,11 @@ except ImportError:
             f"Install with: {sys.executable} -m pip install 'fastapi' 'uvicorn[standard]'"
         )
 
-WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
+WEB_DIST = (
+    Path(os.environ["HERMES_WEB_DIST"])
+    if "HERMES_WEB_DIST" in os.environ
+    else Path(__file__).parent / "web_dist"
+)
 _log = logging.getLogger(__name__)
 
 app = FastAPI(title="Hermes Agent", version=__version__)
@@ -94,7 +105,9 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # on every server start. Either way it dies when the process exits and is
 # injected into the SPA HTML so only the legitimate web UI can use it.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
+_SESSION_TOKEN = os.environ.get(
+    "HERMES_DASHBOARD_SESSION_TOKEN"
+) or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
@@ -130,9 +143,7 @@ app.add_middleware(
 # Keep the upstream list minimal — only truly non-sensitive, read-only
 # endpoints belong there.
 # ---------------------------------------------------------------------------
-from hermes_cli.dashboard_auth.public_paths import (
-    PUBLIC_API_PATHS as _PUBLIC_API_PATHS,
-)
+from hermes_cli.dashboard_auth.public_paths import PUBLIC_API_PATHS as _PUBLIC_API_PATHS
 
 
 def _has_valid_session_token(request: Request) -> bool:
@@ -167,9 +178,13 @@ def _require_token(request: Request) -> None:
 # checks because the browser now considers evil.test and our dashboard
 # "same origin". Validating the Host header at the app layer rejects any
 # request whose Host isn't one we bound for. See GHSA-ppp5-vxwm-4cf7.
-_LOOPBACK_HOST_VALUES: frozenset = frozenset({
-    "localhost", "127.0.0.1", "::1",
-})
+_LOOPBACK_HOST_VALUES: frozenset = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }
+)
 
 
 def should_require_auth(host: str, allow_public: bool) -> bool:
@@ -274,6 +289,7 @@ async def host_header_middleware(request: Request, call_next):
 @app.middleware("http")
 async def _dashboard_auth_gate(request: Request, call_next):
     from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
     return await gated_auth_middleware(request, call_next)
 
 
@@ -417,9 +433,21 @@ _CATEGORY_MERGE: Dict[str, str] = {
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
 _CATEGORY_ORDER = [
-    "general", "agent", "terminal", "display", "delegation",
-    "memory", "compression", "security", "browser", "voice",
-    "tts", "stt", "logging", "discord", "auxiliary",
+    "general",
+    "agent",
+    "terminal",
+    "display",
+    "delegation",
+    "memory",
+    "compression",
+    "security",
+    "browser",
+    "voice",
+    "tts",
+    "stt",
+    "logging",
+    "discord",
+    "auxiliary",
 ]
 
 
@@ -448,7 +476,9 @@ def _build_schema_from_config(
         full_key = f"{prefix}.{key}" if prefix else key
 
         # Skip internal / version keys
-        if full_key in {"_config_version",}:
+        if full_key in {
+            "_config_version",
+        }:
             continue
 
         # Category is the first path component for nested keys, or "general"
@@ -473,7 +503,9 @@ def _build_schema_from_config(
             if full_key in _SCHEMA_OVERRIDES:
                 entry.update(_SCHEMA_OVERRIDES[full_key])
             # Merge small categories
-            entry["category"] = _CATEGORY_MERGE.get(entry["category"], entry["category"])
+            entry["category"] = _CATEGORY_MERGE.get(
+                entry["category"], entry["category"]
+            )
             schema[full_key] = entry
     return schema
 
@@ -566,6 +598,7 @@ class ModelAssignment(BaseModel):
     scope="auxiliary" with task=""  → applied to every auxiliary.* slot
     scope="auxiliary" with task="__reset__"  → resets every slot to provider="auto"
     """
+
     scope: str
     provider: str
     model: str
@@ -673,7 +706,11 @@ async def get_status():
     # Prefer the detailed health endpoint response (has full state) when the
     # local runtime status file is absent or stale (cross-container).
     runtime = read_runtime_status()
-    if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
+    if (
+        runtime is None
+        and remote_health_body
+        and remote_health_body.get("gateway_state")
+    ):
         runtime = remote_health_body
 
     if runtime:
@@ -688,7 +725,11 @@ async def get_status():
         gateway_exit_reason = runtime.get("exit_reason")
         gateway_updated_at = runtime.get("updated_at")
         if not gateway_running:
-            gateway_state = gateway_state if gateway_state in {"stopped", "startup_failed"} else "stopped"
+            gateway_state = (
+                gateway_state
+                if gateway_state in {"stopped", "startup_failed"}
+                else "stopped"
+            )
             gateway_platforms = {}
         elif gateway_running and remote_health_body is not None:
             # The health probe confirmed the gateway is alive, but the local
@@ -705,12 +746,14 @@ async def get_status():
     active_sessions = 0
     try:
         from hermes_state import SessionDB
+
         db = SessionDB()
         try:
             sessions = db.list_sessions_rich(limit=50)
             now = time.time()
             active_sessions = sum(
-                1 for s in sessions
+                1
+                for s in sessions
                 if s.get("ended_at") is None
                 and (now - s.get("last_active", s.get("started_at", 0))) < 300
             )
@@ -727,6 +770,7 @@ async def get_status():
     auth_providers: list[str] = []
     try:
         from hermes_cli.dashboard_auth import list_providers as _list_providers
+
         auth_providers = [p.name for p in _list_providers()]
     except Exception:
         # Module not importable yet (early startup) — leave as [].
@@ -917,7 +961,9 @@ async def get_portal_status():
             for feat in feats.items():
                 if getattr(feat, "managed_by_nous", False):
                     state = "via Nous Portal"
-                elif getattr(feat, "active", False) and getattr(feat, "current_provider", None):
+                elif getattr(feat, "active", False) and getattr(
+                    feat, "current_provider", None
+                ):
                     state = feat.current_provider
                 elif getattr(feat, "active", False):
                     state = "active"
@@ -1219,7 +1265,11 @@ async def get_elevenlabs_voices():
     The desktop UI uses this for the ``tts.elevenlabs.voice_id`` dropdown.
     Only non-secret voice metadata is returned; the API key stays server-side.
     """
-    api_key = (load_env().get("ELEVENLABS_API_KEY") or os.environ.get("ELEVENLABS_API_KEY") or "").strip()
+    api_key = (
+        load_env().get("ELEVENLABS_API_KEY")
+        or os.environ.get("ELEVENLABS_API_KEY")
+        or ""
+    ).strip()
     if not api_key:
         return {"available": False, "voices": []}
 
@@ -1252,11 +1302,13 @@ async def get_elevenlabs_voices():
         if not voice_id:
             continue
 
-        voices.append({
-            "voice_id": voice_id,
-            "name": str(voice.get("name") or voice_id),
-            "label": _elevenlabs_voice_label(voice),
-        })
+        voices.append(
+            {
+                "voice_id": voice_id,
+                "name": str(voice.get("name") or voice_id),
+                "label": _elevenlabs_voice_label(voice),
+            }
+        )
 
     voices.sort(key=lambda item: str(item.get("label") or "").lower())
     return {"available": True, "voices": voices}
@@ -1277,6 +1329,7 @@ async def speak_text(payload: TTSSpeakRequest):
 
     try:
         from tools.tts_tool import text_to_speech_tool
+
         loop = asyncio.get_running_loop()
         result_json = await loop.run_in_executor(None, text_to_speech_tool, text)
     except Exception as exc:
@@ -1284,7 +1337,9 @@ async def speak_text(payload: TTSSpeakRequest):
         raise HTTPException(status_code=500, detail=f"Speech synthesis failed: {exc}")
 
     try:
-        result = json.loads(result_json) if isinstance(result_json, str) else result_json
+        result = (
+            json.loads(result_json) if isinstance(result_json, str) else result_json
+        )
     except Exception:
         raise HTTPException(status_code=500, detail="Invalid TTS response")
 
@@ -1389,6 +1444,7 @@ async def get_sessions(
         )
     try:
         from hermes_state import SessionDB
+
         db = SessionDB()
         try:
             min_message_count = max(0, min_messages)
@@ -1417,7 +1473,12 @@ async def get_sessions(
                 )
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
-            return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
+            return {
+                "sessions": sessions,
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+            }
         finally:
             db.close()
     except Exception:
@@ -1432,12 +1493,14 @@ async def search_sessions(q: str = "", limit: int = 20):
         return {"results": []}
     try:
         from hermes_state import SessionDB
+
         db = SessionDB()
         try:
             # Auto-add prefix wildcards so partial words match
             # e.g. "nimb" → "nimb*" matches "nimby"
             # Preserve quoted phrases and existing wildcards as-is
             import re
+
             terms = []
             for token in re.findall(r'"[^"]*"|\S+', q.strip()):
                 if token.startswith('"') or token.endswith("*"):
@@ -1548,6 +1611,7 @@ def get_model_info():
         # purely auto-detected value, then separately report the override)
         try:
             from agent.model_metadata import get_model_context_length
+
             auto_ctx = get_model_context_length(
                 model=model_name,
                 base_url=base_url,
@@ -1568,6 +1632,7 @@ def get_model_info():
         caps = {}
         try:
             from agent.models_dev import get_model_capabilities
+
             mc = get_model_capabilities(provider=provider, model=model_name)
             if mc is not None:
                 caps = {
@@ -1653,15 +1718,15 @@ def get_recommended_default_model(provider: str = ""):
 
     if slug == "nous":
         try:
+            from hermes_cli.auth import get_provider_auth_state
             from hermes_cli.models import (
+                check_nous_free_tier,
                 get_curated_nous_model_ids,
                 get_pricing_for_provider,
-                check_nous_free_tier,
                 partition_nous_models_by_tier,
                 union_with_portal_free_recommendations,
                 union_with_portal_paid_recommendations,
             )
-            from hermes_cli.auth import get_provider_auth_state
 
             model_ids = get_curated_nous_model_ids()
             pricing = get_pricing_for_provider("nous") or {}
@@ -1700,7 +1765,11 @@ def get_recommended_default_model(provider: str = ""):
         for row in payload.get("providers", []):
             if str(row.get("slug", "")).lower() == slug:
                 models = row.get("models") or []
-                return {"provider": slug, "model": models[0] if models else "", "free_tier": None}
+                return {
+                    "provider": slug,
+                    "model": models[0] if models else "",
+                    "free_tier": None,
+                }
         return {"provider": slug, "model": "", "free_tier": None}
     except Exception:
         _log.exception("GET /api/model/recommended-default failed")
@@ -1728,13 +1797,17 @@ def get_auxiliary_models():
 
         tasks = []
         for slot in _AUX_TASK_SLOTS:
-            slot_cfg = aux_cfg.get(slot, {}) if isinstance(aux_cfg.get(slot), dict) else {}
-            tasks.append({
-                "task": slot,
-                "provider": str(slot_cfg.get("provider", "auto") or "auto"),
-                "model": str(slot_cfg.get("model", "") or ""),
-                "base_url": str(slot_cfg.get("base_url", "") or ""),
-            })
+            slot_cfg = (
+                aux_cfg.get(slot, {}) if isinstance(aux_cfg.get(slot), dict) else {}
+            )
+            tasks.append(
+                {
+                    "task": slot,
+                    "provider": str(slot_cfg.get("provider", "auto") or "auto"),
+                    "model": str(slot_cfg.get("model", "") or ""),
+                    "base_url": str(slot_cfg.get("base_url", "") or ""),
+                }
+            )
 
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, dict):
@@ -1765,14 +1838,18 @@ async def set_model_assignment(body: ModelAssignment):
     task = (body.task or "").strip().lower()
 
     if scope not in {"main", "auxiliary"}:
-        raise HTTPException(status_code=400, detail="scope must be 'main' or 'auxiliary'")
+        raise HTTPException(
+            status_code=400, detail="scope must be 'main' or 'auxiliary'"
+        )
 
     try:
         cfg = load_config()
 
         if scope == "main":
             if not provider or not model:
-                raise HTTPException(status_code=400, detail="provider and model required for main")
+                raise HTTPException(
+                    status_code=400, detail="provider and model required for main"
+                )
             model_cfg = cfg.get("model", {})
             if not isinstance(model_cfg, dict):
                 model_cfg = {}
@@ -1844,12 +1921,16 @@ async def set_model_assignment(body: ModelAssignment):
             return {"ok": True, "scope": "auxiliary", "reset": True}
 
         if not provider:
-            raise HTTPException(status_code=400, detail="provider required for auxiliary")
+            raise HTTPException(
+                status_code=400, detail="provider required for auxiliary"
+            )
 
         targets = [task] if task else list(_AUX_TASK_SLOTS)
         for slot in targets:
             if slot not in _AUX_TASK_SLOTS:
-                raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
+                raise HTTPException(
+                    status_code=400, detail=f"unknown auxiliary task: {slot}"
+                )
             slot_cfg = aux.get(slot)
             if not isinstance(slot_cfg, dict):
                 slot_cfg = {}
@@ -1871,8 +1952,6 @@ async def set_model_assignment(body: ModelAssignment):
     except Exception:
         _log.exception("POST /api/model/set failed")
         raise HTTPException(status_code=500, detail="Failed to save model assignment")
-
-
 
 
 def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -1981,7 +2060,10 @@ _CREDENTIAL_PROBES: dict[str, tuple[str, str]] = {
     "OPENROUTER_API_KEY": ("https://openrouter.ai/api/v1/key", "bearer"),
     "OPENAI_API_KEY": ("https://api.openai.com/v1/models", "bearer"),
     "XAI_API_KEY": ("https://api.x.ai/v1/models", "bearer"),
-    "GEMINI_API_KEY": ("https://generativelanguage.googleapis.com/v1beta/models", "query"),
+    "GEMINI_API_KEY": (
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        "query",
+    ),
 }
 
 
@@ -2011,7 +2093,11 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
                 client.get(url)
             return {"ok": True, "reachable": True, "message": ""}
         except Exception:
-            return {"ok": False, "reachable": False, "message": f"Could not reach {url}."}
+            return {
+                "ok": False,
+                "reachable": False,
+                "message": f"Could not reach {url}.",
+            }
 
     probe = _CREDENTIAL_PROBES.get(key)
     if not probe:
@@ -2030,14 +2116,26 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         with httpx.Client(timeout=httpx.Timeout(10.0)) as client:
             resp = client.get(url, headers=headers, params=params)
     except Exception:
-        return {"ok": False, "reachable": False, "message": "Could not reach the provider to verify the key."}
+        return {
+            "ok": False,
+            "reachable": False,
+            "message": "Could not reach the provider to verify the key.",
+        }
 
     if resp.status_code in (401, 403):
-        return {"ok": False, "reachable": True, "message": "That API key was rejected. Double-check it and try again."}
+        return {
+            "ok": False,
+            "reachable": True,
+            "message": "That API key was rejected. Double-check it and try again.",
+        }
     if resp.status_code == 429 or resp.is_success:
         # 429 = key is valid but rate-limited; success = valid.
         return {"ok": True, "reachable": True, "message": ""}
-    return {"ok": False, "reachable": True, "message": f"Provider returned HTTP {resp.status_code} for this key."}
+    return {
+        "ok": False,
+        "reachable": True,
+        "message": f"Provider returned HTTP {resp.status_code} for this key.",
+    }
 
 
 @app.delete("/api/env")
@@ -2076,7 +2174,9 @@ async def reveal_env_var(body: EnvVarReveal, request: Request):
     cutoff = now - _REVEAL_WINDOW_SECONDS
     _reveal_timestamps[:] = [t for t in _reveal_timestamps if t > cutoff]
     if len(_reveal_timestamps) >= _REVEAL_MAX_PER_WINDOW:
-        raise HTTPException(status_code=429, detail="Too many reveal requests. Try again shortly.")
+        raise HTTPException(
+            status_code=429, detail="Too many reveal requests. Try again shortly."
+        )
     _reveal_timestamps.append(now)
 
     # --- Reveal ---
@@ -2798,9 +2898,9 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
     """
     try:
         from agent.anthropic_adapter import (
-            read_hermes_oauth_credentials,
-            read_claude_code_credentials,
             _HERMES_OAUTH_FILE,
+            read_claude_code_credentials,
+            read_hermes_oauth_credentials,
         )
     except ImportError:
         read_claude_code_credentials = None  # type: ignore
@@ -2861,6 +2961,7 @@ def _claude_code_only_status() -> Dict[str, Any]:
     """
     try:
         from agent.anthropic_adapter import read_claude_code_credentials
+
         creds = read_claude_code_credentials()
     except Exception:
         creds = None
@@ -2949,6 +3050,7 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
             return {"logged_in": False, "error": str(e)}
     try:
         from hermes_cli import auth as hauth
+
         if provider_id == "nous":
             raw = hauth.get_nous_auth_status()
             return {
@@ -3016,14 +3118,16 @@ async def list_oauth_providers():
     providers = []
     for p in _OAUTH_PROVIDER_CATALOG:
         status = _resolve_provider_status(p["id"], p.get("status_fn"))
-        providers.append({
-            "id": p["id"],
-            "name": p["name"],
-            "flow": p["flow"],
-            "cli_command": p["cli_command"],
-            "docs_url": p["docs_url"],
-            "status": status,
-        })
+        providers.append(
+            {
+                "id": p["id"],
+                "name": p["name"],
+                "flow": p["flow"],
+                "cli_command": p["cli_command"],
+                "docs_url": p["docs_url"],
+                "status": status,
+            }
+        )
     return {"providers": providers}
 
 
@@ -3037,7 +3141,7 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
         raise HTTPException(
             status_code=400,
             detail=f"Unknown provider: {provider_id}. "
-                   f"Available: {', '.join(sorted(valid_ids))}",
+            f"Available: {', '.join(sorted(valid_ids))}",
         )
 
     # Anthropic and claude-code clear the same Hermes-managed PKCE file
@@ -3047,6 +3151,7 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
     if provider_id in {"anthropic", "claude-code"}:
         try:
             from agent.anthropic_adapter import _HERMES_OAUTH_FILE
+
             if _HERMES_OAUTH_FILE.exists():
                 _HERMES_OAUTH_FILE.unlink()
         except Exception:
@@ -3054,6 +3159,7 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
         # Also clear the credential pool entry if present.
         try:
             from hermes_cli.auth import clear_provider_auth
+
             clear_provider_auth("anthropic")
         except Exception:
             pass
@@ -3062,6 +3168,7 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
 
     try:
         from hermes_cli.auth import clear_provider_auth
+
         cleared = clear_provider_auth(provider_id)
         _log.info("oauth/disconnect: %s (cleared=%s)", provider_id, cleared)
         return {"ok": bool(cleared), "provider": provider_id}
@@ -3114,13 +3221,14 @@ _oauth_sessions_lock = threading.Lock()
 # Guarded so hermes web still starts if anthropic_adapter is unavailable;
 # Phase 2 endpoints will return 501 in that case.
 try:
+    from agent.anthropic_adapter import _OAUTH_CLIENT_ID as _ANTHROPIC_OAUTH_CLIENT_ID
     from agent.anthropic_adapter import (
-        _OAUTH_CLIENT_ID as _ANTHROPIC_OAUTH_CLIENT_ID,
-        _OAUTH_TOKEN_URL as _ANTHROPIC_OAUTH_TOKEN_URL,
         _OAUTH_REDIRECT_URI as _ANTHROPIC_OAUTH_REDIRECT_URI,
-        _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES,
-        _generate_pkce as _generate_pkce_pair,
     )
+    from agent.anthropic_adapter import _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES
+    from agent.anthropic_adapter import _OAUTH_TOKEN_URL as _ANTHROPIC_OAUTH_TOKEN_URL
+    from agent.anthropic_adapter import _generate_pkce as _generate_pkce_pair
+
     _ANTHROPIC_OAUTH_AVAILABLE = True
 except ImportError:
     _ANTHROPIC_OAUTH_AVAILABLE = False
@@ -3131,7 +3239,9 @@ def _gc_oauth_sessions() -> None:
     """Drop expired sessions. Called opportunistically on /start."""
     cutoff = time.time() - _OAUTH_SESSION_TTL_SECONDS
     with _oauth_sessions_lock:
-        stale = [sid for sid, sess in _oauth_sessions.items() if sess["created_at"] < cutoff]
+        stale = [
+            sid for sid, sess in _oauth_sessions.items() if sess["created_at"] < cutoff
+        ]
         for sid in stale:
             _oauth_sessions.pop(sid, None)
 
@@ -3152,13 +3262,16 @@ def _new_oauth_session(provider_id: str, flow: str) -> tuple[str, Dict[str, Any]
     return sid, sess
 
 
-def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
+def _save_anthropic_oauth_creds(
+    access_token: str, refresh_token: str, expires_at_ms: int
+) -> None:
     """Persist Anthropic PKCE creds to both Hermes file AND credential pool.
 
     Mirrors what auth_commands.add_command does so the dashboard flow leaves
     the system in the same state as ``hermes auth add anthropic``.
     """
     from agent.anthropic_adapter import _HERMES_OAUTH_FILE
+
     payload = {
         "accessToken": access_token,
         "refreshToken": refresh_token,
@@ -3188,16 +3301,22 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
     # the file write — pool registration only matters for the rotation
     # strategy, not for runtime credential resolution.
     try:
+        import uuid
+
         from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
             AUTH_TYPE_OAUTH,
             SOURCE_MANUAL,
+            PooledCredential,
+            load_pool,
         )
-        import uuid
+
         pool = load_pool("anthropic")
         # Avoid duplicate entries: delete any prior dashboard-issued OAuth entry
-        existing = [e for e in pool.entries() if getattr(e, "source", "").startswith(f"{SOURCE_MANUAL}:dashboard_pkce")]
+        existing = [
+            e
+            for e in pool.entries()
+            if getattr(e, "source", "").startswith(f"{SOURCE_MANUAL}:dashboard_pkce")
+        ]
         for e in existing:
             try:
                 pool.remove_entry(getattr(e, "id", ""))
@@ -3222,7 +3341,9 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
 def _start_anthropic_pkce() -> Dict[str, Any]:
     """Begin PKCE flow. Returns the auth URL the UI should open."""
     if not _ANTHROPIC_OAUTH_AVAILABLE:
-        raise HTTPException(status_code=501, detail="Anthropic OAuth not available (missing adapter)")
+        raise HTTPException(
+            status_code=501, detail="Anthropic OAuth not available (missing adapter)"
+        )
     verifier, challenge = _generate_pkce_pair()
     sid, sess = _new_oauth_session("anthropic", "pkce")
     sess["verifier"] = verifier
@@ -3253,7 +3374,11 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
     if not sess or sess["provider"] != "anthropic" or sess["flow"] != "pkce":
         raise HTTPException(status_code=404, detail="Unknown or expired session")
     if sess["status"] != "pending":
-        return {"ok": False, "status": sess["status"], "message": sess.get("error_message")}
+        return {
+            "ok": False,
+            "status": sess["status"],
+            "message": sess.get("error_message"),
+        }
 
     # Anthropic's redirect callback page formats the code as `<code>#<state>`.
     # Strip the state suffix if present (we already have the verifier server-side).
@@ -3263,14 +3388,16 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
         return {"ok": False, "status": "error", "message": "No code provided"}
     state_from_callback = parts[1] if len(parts) > 1 else ""
 
-    exchange_data = json.dumps({
-        "grant_type": "authorization_code",
-        "client_id": _ANTHROPIC_OAUTH_CLIENT_ID,
-        "code": code,
-        "state": state_from_callback or sess["state"],
-        "redirect_uri": _ANTHROPIC_OAUTH_REDIRECT_URI,
-        "code_verifier": sess["verifier"],
-    }).encode()
+    exchange_data = json.dumps(
+        {
+            "grant_type": "authorization_code",
+            "client_id": _ANTHROPIC_OAUTH_CLIENT_ID,
+            "code": code,
+            "state": state_from_callback or sess["state"],
+            "redirect_uri": _ANTHROPIC_OAUTH_REDIRECT_URI,
+            "code_verifier": sess["verifier"],
+        }
+    ).encode()
     req = urllib.request.Request(
         _ANTHROPIC_OAUTH_TOKEN_URL,
         data=exchange_data,
@@ -3320,11 +3447,10 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
     so the UI can render the verification page link + user code.
     """
     if provider_id == "nous":
-        from hermes_cli.auth import (
-            _request_device_code,
-            PROVIDER_REGISTRY,
-        )
         import httpx
+
+        from hermes_cli.auth import PROVIDER_REGISTRY, _request_device_code
+
         pconfig = PROVIDER_REGISTRY["nous"]
         portal_base_url = (
             os.getenv("HERMES_PORTAL_BASE_URL")
@@ -3380,7 +3506,9 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
         # verification_url back via the session dict. The helper prints
         # to stdout — we capture nothing here, just status.
         threading.Thread(
-            target=_codex_full_login_worker, args=(sid,), daemon=True,
+            target=_codex_full_login_worker,
+            args=(sid,),
+            daemon=True,
             name=f"oauth-codex-{sid[:6]}",
         ).start()
         # Block briefly until the worker has populated the user_code, OR error.
@@ -3394,9 +3522,14 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
         with _oauth_sessions_lock:
             s = _oauth_sessions.get(sid, {})
         if s.get("status") == "error":
-            raise HTTPException(status_code=500, detail=s.get("error_message") or "device-auth failed")
+            raise HTTPException(
+                status_code=500, detail=s.get("error_message") or "device-auth failed"
+            )
         if not s.get("user_code"):
-            raise HTTPException(status_code=504, detail="device-auth timed out before returning a user code")
+            raise HTTPException(
+                status_code=504,
+                detail="device-auth timed out before returning a user code",
+            )
         return {
             "session_id": sid,
             "flow": "device_code",
@@ -3413,17 +3546,20 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
         # flow; the PKCE bit (verifier + challenge from
         # _minimax_pkce_pair) is a security extension that binds the
         # token exchange to the original session.
+        import httpx
+
         from hermes_cli.auth import (
-            _minimax_pkce_pair,
-            _minimax_request_user_code,
             MINIMAX_OAUTH_CLIENT_ID,
             MINIMAX_OAUTH_GLOBAL_BASE,
+            _minimax_pkce_pair,
+            _minimax_request_user_code,
         )
-        import httpx
+
         verifier, challenge, state = _minimax_pkce_pair()
         portal_base_url = (
             os.getenv("MINIMAX_PORTAL_BASE_URL") or MINIMAX_OAUTH_GLOBAL_BASE
         ).rstrip("/")
+
         def _do_minimax_request():
             with httpx.Client(
                 timeout=httpx.Timeout(15.0),
@@ -3437,6 +3573,7 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
                     code_challenge=challenge,
                     state=state,
                 )
+
         device_data = await asyncio.get_event_loop().run_in_executor(
             None, _do_minimax_request
         )
@@ -3445,9 +3582,7 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
         # `interval` field is in milliseconds (defensive default 2000ms
         # in _minimax_poll_token).
         interval_raw = device_data.get("interval")
-        sess["interval_ms"] = (
-            int(interval_raw) if interval_raw is not None else None
-        )
+        sess["interval_ms"] = int(interval_raw) if interval_raw is not None else None
         sess["user_code"] = str(device_data["user_code"])
         sess["code_verifier"] = verifier
         sess["state"] = state
@@ -3482,17 +3617,20 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
             "poll_interval": max(2, (sess["interval_ms"] or 2000) // 1000),
         }
 
-    raise HTTPException(status_code=400, detail=f"Provider {provider_id} does not support device-code flow")
+    raise HTTPException(
+        status_code=400,
+        detail=f"Provider {provider_id} does not support device-code flow",
+    )
 
 
 def _nous_poller(session_id: str) -> None:
     """Background poller that drives a Nous device-code flow to completion."""
-    from hermes_cli.auth import (
-        _poll_for_token,
-        refresh_nous_oauth_from_state,
-    )
     from datetime import datetime, timezone
+
     import httpx
+
+    from hermes_cli.auth import _poll_for_token, refresh_nous_oauth_from_state
+
     with _oauth_sessions_lock:
         sess = _oauth_sessions.get(session_id)
     if not sess:
@@ -3504,7 +3642,9 @@ def _nous_poller(session_id: str) -> None:
     scope = sess.get("scope")
     expires_in = max(60, int(sess["expires_at"] - time.time()))
     try:
-        with httpx.Client(timeout=httpx.Timeout(15.0), headers={"Accept": "application/json"}) as client:
+        with httpx.Client(
+            timeout=httpx.Timeout(15.0), headers={"Accept": "application/json"}
+        ) as client:
             token_data = _poll_for_token(
                 client=client,
                 portal_base_url=portal_base_url,
@@ -3526,8 +3666,11 @@ def _nous_poller(session_id: str) -> None:
             "refresh_token": token_data.get("refresh_token"),
             "obtained_at": now.isoformat(),
             "expires_at": (
-                datetime.fromtimestamp(now.timestamp() + token_ttl, tz=timezone.utc).isoformat()
-                if token_ttl else None
+                datetime.fromtimestamp(
+                    now.timestamp() + token_ttl, tz=timezone.utc
+                ).isoformat()
+                if token_ttl
+                else None
             ),
             "expires_in": token_ttl,
         }
@@ -3537,6 +3680,7 @@ def _nous_poller(session_id: str) -> None:
             force_refresh=False,
         )
         from hermes_cli.auth import persist_nous_credentials
+
         persist_nous_credentials(full_state)
         with _oauth_sessions_lock:
             sess["status"] = "approved"
@@ -3559,15 +3703,18 @@ def _minimax_poller(session_id: str) -> None:
     path leaves the system in the same state as
     ``hermes auth add minimax-oauth``.
     """
+    from datetime import datetime, timezone
+
+    import httpx
+
     from hermes_cli.auth import (
+        MINIMAX_OAUTH_GLOBAL_INFERENCE,
+        MINIMAX_OAUTH_SCOPE,
         _minimax_poll_token,
         _minimax_resolve_token_expiry_unix,
         _minimax_save_auth_state,
-        MINIMAX_OAUTH_GLOBAL_INFERENCE,
-        MINIMAX_OAUTH_SCOPE,
     )
-    from datetime import datetime, timezone
-    import httpx
+
     with _oauth_sessions_lock:
         sess = _oauth_sessions.get(session_id)
     if not sess:
@@ -3600,7 +3747,8 @@ def _minimax_poller(session_id: str) -> None:
         # flow which supports `--region cn`.
         now = datetime.now(timezone.utc)
         expires_at_ts = _minimax_resolve_token_expiry_unix(
-            int(token_data["expired_in"]), now=now,
+            int(token_data["expired_in"]),
+            now=now,
         )
         expires_in_s = max(0, int(expires_at_ts - now.timestamp()))
         auth_state = {
@@ -3648,11 +3796,13 @@ def _codex_full_login_worker(session_id: str) -> None:
     """
     try:
         import httpx
+
         from hermes_cli.auth import (
             CODEX_OAUTH_CLIENT_ID,
             CODEX_OAUTH_TOKEN_URL,
             DEFAULT_CODEX_BASE_URL,
         )
+
         issuer = "https://auth.openai.com"
 
         # Step 1: request device code
@@ -3669,7 +3819,9 @@ def _codex_full_login_worker(session_id: str) -> None:
         device_auth_id = device_data.get("device_auth_id", "")
         poll_interval = max(3, int(device_data.get("interval", "5")))
         if not user_code or not device_auth_id:
-            raise RuntimeError("device-code response missing user_code or device_auth_id")
+            raise RuntimeError(
+                "device-code response missing user_code or device_auth_id"
+            )
         verification_url = f"{issuer}/codex/device"
         with _oauth_sessions_lock:
             sess = _oauth_sessions.get(session_id)
@@ -3710,7 +3862,9 @@ def _codex_full_login_worker(session_id: str) -> None:
         authorization_code = code_resp.get("authorization_code", "")
         code_verifier = code_resp.get("code_verifier", "")
         if not authorization_code or not code_verifier:
-            raise RuntimeError("device-auth response missing authorization_code/code_verifier")
+            raise RuntimeError(
+                "device-auth response missing authorization_code/code_verifier"
+            )
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
             token_resp = client.post(
                 CODEX_OAUTH_TOKEN_URL,
@@ -3732,13 +3886,15 @@ def _codex_full_login_worker(session_id: str) -> None:
             raise RuntimeError("token exchange did not return access_token")
 
         # Persist via credential pool — same shape as auth_commands.add_command
+        import uuid as _uuid
+
         from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
             AUTH_TYPE_OAUTH,
             SOURCE_MANUAL,
+            PooledCredential,
+            load_pool,
         )
-        import uuid as _uuid
+
         pool = load_pool("openai-codex")
         base_url = (
             os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
@@ -3812,9 +3968,14 @@ async def submit_oauth_code(provider_id: str, body: OAuthSubmitBody, request: Re
     _require_token(request)
     if provider_id == "anthropic":
         return await asyncio.get_running_loop().run_in_executor(
-            None, _submit_anthropic_pkce, body.session_id, body.code,
+            None,
+            _submit_anthropic_pkce,
+            body.session_id,
+            body.code,
         )
-    raise HTTPException(status_code=400, detail=f"submit not supported for {provider_id}")
+    raise HTTPException(
+        status_code=400, detail=f"submit not supported for {provider_id}"
+    )
 
 
 @app.get("/api/providers/oauth/{provider_id}/poll/{session_id}")
@@ -3848,7 +4009,6 @@ async def cancel_oauth_session(session_id: str, request: Request):
 # ---------------------------------------------------------------------------
 # Session detail endpoints
 # ---------------------------------------------------------------------------
-
 
 
 def _session_latest_descendant(session_id: str):
@@ -3889,11 +4049,13 @@ def _session_latest_descendant(session_id: str):
                 "SELECT id, parent_session_id, started_at FROM sessions"
             ).fetchall()
             for row in raw_rows:
-                rows.append({
-                    "id": row_get(row, "id", 0),
-                    "parent_session_id": row_get(row, "parent_session_id", 1),
-                    "started_at": row_get(row, "started_at", 2),
-                })
+                rows.append(
+                    {
+                        "id": row_get(row, "id", 0),
+                        "parent_session_id": row_get(row, "parent_session_id", 1),
+                        "started_at": row_get(row, "started_at", 2),
+                    }
+                )
         else:
             rows = db.list_sessions_rich(limit=10000, offset=0)
 
@@ -3927,6 +4089,7 @@ def _session_latest_descendant(session_id: str):
     finally:
         db.close()
 
+
 @app.get("/api/sessions/stats")
 async def get_session_stats():
     """Session-store statistics for the Sessions page (mirrors `hermes sessions stats`).
@@ -3959,9 +4122,11 @@ async def get_session_stats():
     finally:
         db.close()
 
+
 @app.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str):
     from hermes_state import SessionDB
+
     db = SessionDB()
     try:
         sid = db.resolve_session_id(session_id)
@@ -3971,7 +4136,6 @@ async def get_session_detail(session_id: str):
         return session
     finally:
         db.close()
-
 
 
 @app.get("/api/sessions/{session_id}/latest-descendant")
@@ -3986,9 +4150,11 @@ async def get_session_latest_descendant(session_id: str):
         "changed": bool(path and latest != path[0]),
     }
 
+
 @app.get("/api/sessions/{session_id}/messages")
 async def get_session_messages(session_id: str):
     from hermes_state import SessionDB
+
     db = SessionDB()
     try:
         sid = db.resolve_session_id(session_id)
@@ -4003,6 +4169,7 @@ async def get_session_messages(session_id: str):
 @app.delete("/api/sessions/{session_id}")
 async def delete_session_endpoint(session_id: str):
     from hermes_state import SessionDB
+
     db = SessionDB()
     try:
         if not db.delete_session(session_id):
@@ -4025,6 +4192,7 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
     restores the session. Either field may be omitted.
     """
     from hermes_state import SessionDB
+
     db = SessionDB()
     try:
         sid = db.resolve_session_id(session_id)
@@ -4107,7 +4275,7 @@ async def get_logs(
     component: Optional[str] = None,
     search: Optional[str] = None,
 ):
-    from hermes_cli.logs import _read_tail, LOG_FILES
+    from hermes_cli.logs import LOG_FILES, _read_tail
 
     log_name = LOG_FILES.get(file)
     if not log_name:
@@ -4131,14 +4299,15 @@ async def get_logs(
             raise HTTPException(
                 status_code=400,
                 detail=f"Unknown component: {component}. "
-                       f"Available: {', '.join(sorted(COMPONENT_PREFIXES))}",
+                f"Available: {', '.join(sorted(COMPONENT_PREFIXES))}",
             )
     else:
         comp_prefixes = None
 
     has_filters = bool(min_level or comp_prefixes or search)
     result = _read_tail(
-        log_path, min(lines, 500) if not search else 2000,
+        log_path,
+        min(lines, 500) if not search else 2000,
         has_filters=has_filters,
         min_level=min_level,
         component_prefixes=comp_prefixes,
@@ -4148,7 +4317,7 @@ async def get_logs(
     # trim to the requested line count afterward.
     if search:
         needle = search.lower()
-        result = [l for l in result if needle in l.lower()][-min(lines, 500):]
+        result = [l for l in result if needle in l.lower()][-min(lines, 500) :]
     return {"file": file, "lines": result}
 
 
@@ -4174,10 +4343,13 @@ _CRON_PROFILE_LOCK = threading.RLock()
 def _cron_profile_dicts() -> List[Dict[str, Any]]:
     """Return dashboard profile records, falling back to a directory scan."""
     from hermes_cli import profiles as profiles_mod
+
     try:
         return [_profile_to_dict(p) for p in profiles_mod.list_profiles()]
     except Exception:
-        _log.exception("Failed to list profiles for cron dashboard; falling back to directory scan")
+        _log.exception(
+            "Failed to list profiles for cron dashboard; falling back to directory scan"
+        )
         return _fallback_profile_dicts(profiles_mod)
 
 
@@ -4192,7 +4364,9 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not profiles_mod.profile_exists(canon):
-        raise HTTPException(status_code=404, detail=f"Profile '{canon}' does not exist.")
+        raise HTTPException(
+            status_code=404, detail=f"Profile '{canon}' does not exist."
+        )
     return canon, profiles_mod.get_profile_dir(canon)
 
 
@@ -4294,7 +4468,9 @@ async def create_cron_job(body: CronJobCreate, profile: str = "default"):
 
 
 @app.put("/api/cron/jobs/{job_id}")
-async def update_cron_job(job_id: str, body: CronJobUpdate, profile: Optional[str] = None):
+async def update_cron_job(
+    job_id: str, body: CronJobUpdate, profile: Optional[str] = None
+):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -4387,7 +4563,9 @@ def _redact_mcp_env(env: Dict[str, Any]) -> Dict[str, str]:
 
 
 def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
-    transport = "http" if cfg.get("url") else ("stdio" if cfg.get("command") else "unknown")
+    transport = (
+        "http" if cfg.get("url") else ("stdio" if cfg.get("command") else "unknown")
+    )
     return {
         "name": name,
         "transport": transport,
@@ -4525,21 +4703,23 @@ async def list_mcp_catalog():
     try:
         for entry in mcp_catalog.list_catalog():
             auth = entry.auth
-            entries.append({
-                "name": entry.name,
-                "description": entry.description,
-                "source": entry.source,
-                "transport": entry.transport.type,
-                "auth_type": getattr(auth, "type", "none"),
-                # Env vars the user must supply (names + prompts only, never values).
-                "required_env": [
-                    {"name": e.name, "prompt": e.prompt, "required": e.required}
-                    for e in getattr(auth, "env", []) or []
-                ],
-                "needs_install": entry.install is not None,
-                "installed": mcp_catalog.is_installed(entry.name),
-                "enabled": mcp_catalog.is_enabled(entry.name),
-            })
+            entries.append(
+                {
+                    "name": entry.name,
+                    "description": entry.description,
+                    "source": entry.source,
+                    "transport": entry.transport.type,
+                    "auth_type": getattr(auth, "type", "none"),
+                    # Env vars the user must supply (names + prompts only, never values).
+                    "required_env": [
+                        {"name": e.name, "prompt": e.prompt, "required": e.required}
+                        for e in getattr(auth, "env", []) or []
+                    ],
+                    "needs_install": entry.install is not None,
+                    "installed": mcp_catalog.is_installed(entry.name),
+                    "enabled": mcp_catalog.is_enabled(entry.name),
+                }
+            )
     except Exception:
         _log.exception("list_mcp_catalog failed")
 
@@ -4705,7 +4885,9 @@ class WebhookCreate(BaseModel):
     secret: Optional[str] = None
 
 
-def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+def _webhook_route_summary(
+    name: str, route: Dict[str, Any], base_url: str
+) -> Dict[str, Any]:
     return {
         "name": name,
         "description": route.get("description", ""),
@@ -4744,6 +4926,7 @@ async def create_webhook(body: WebhookCreate):
     import re as _re
     import secrets as _secrets
     import time as _time
+
     import hermes_cli.webhook as wh
 
     if not wh._is_webhook_enabled():
@@ -4913,23 +5096,26 @@ async def list_credential_pool():
         entries = pool.entries()
         if not entries:
             continue
-        providers.append({
-            "provider": provider_id,
-            "entries": [
-                _pool_entry_summary(e, i) for i, e in enumerate(entries, start=1)
-            ],
-        })
+        providers.append(
+            {
+                "provider": provider_id,
+                "entries": [
+                    _pool_entry_summary(e, i) for i, e in enumerate(entries, start=1)
+                ],
+            }
+        )
     return {"providers": providers}
 
 
 @app.post("/api/credentials/pool")
 async def add_credential_pool_entry(body: CredentialPoolAdd):
     import uuid as _uuid
+
     from agent.credential_pool import (
-        load_pool,
-        PooledCredential,
         AUTH_TYPE_API_KEY,
         SOURCE_MANUAL,
+        PooledCredential,
+        load_pool,
     )
 
     provider = (body.provider or "").strip().lower()
@@ -5007,11 +5193,13 @@ async def get_memory_status():
     providers = []
     try:
         for name, description, configured in discover_memory_providers():
-            providers.append({
-                "name": name,
-                "description": description,
-                "configured": bool(configured),
-            })
+            providers.append(
+                {
+                    "name": name,
+                    "description": description,
+                    "configured": bool(configured),
+                }
+            )
     except Exception:
         _log.exception("discover_memory_providers failed")
 
@@ -5057,7 +5245,9 @@ async def set_memory_provider(body: MemoryProviderSelect):
 async def reset_memory(body: MemoryReset):
     target = (body.target or "all").strip().lower()
     if target not in {"all", "memory", "user"}:
-        raise HTTPException(status_code=400, detail="target must be all, memory, or user")
+        raise HTTPException(
+            status_code=400, detail="target must be all, memory, or user"
+        )
 
     mem_dir = get_hermes_home() / "memories"
     deleted = []
@@ -5073,7 +5263,9 @@ async def reset_memory(body: MemoryReset):
                 path.unlink()
                 deleted.append(fname)
             except OSError as exc:
-                raise HTTPException(status_code=500, detail=f"Could not delete {fname}: {exc}")
+                raise HTTPException(
+                    status_code=500, detail=f"Could not delete {fname}: {exc}"
+                )
     return {"ok": True, "deleted": deleted}
 
 
@@ -5106,7 +5298,9 @@ async def run_security_audit():
         proc = _spawn_hermes_action(["security", "audit"], "security-audit")
     except Exception as exc:
         _log.exception("Failed to spawn security audit")
-        raise HTTPException(status_code=500, detail=f"Failed to run security audit: {exc}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to run security audit: {exc}"
+        )
     return {"ok": True, "pid": proc.pid, "name": "security-audit"}
 
 
@@ -5155,11 +5349,12 @@ async def list_hooks():
     currently executable, plus the set of valid hook events so the create
     form can offer them.
     """
-    from hermes_cli.config import load_config as _load_config
     from agent import shell_hooks
+    from hermes_cli.config import load_config as _load_config
 
     try:
         from hermes_cli.plugins import VALID_HOOKS
+
         valid_events = sorted(VALID_HOOKS)
     except Exception:
         valid_events = []
@@ -5182,15 +5377,17 @@ async def list_hooks():
             executable = shell_hooks.script_is_executable(spec.command)
         except Exception:
             pass
-        out.append({
-            "event": spec.event,
-            "matcher": spec.matcher,
-            "command": spec.command,
-            "timeout": spec.timeout,
-            "allowed": entry is not None,
-            "approved_at": (entry or {}).get("approved_at"),
-            "executable": executable,
-        })
+        out.append(
+            {
+                "event": spec.event,
+                "matcher": spec.matcher,
+                "command": spec.command,
+                "timeout": spec.timeout,
+                "allowed": entry is not None,
+                "approved_at": (entry or {}).get("approved_at"),
+                "executable": executable,
+            }
+        )
 
     return {"hooks": out, "valid_events": valid_events}
 
@@ -5224,6 +5421,7 @@ async def create_hook(body: HookCreate):
 
     try:
         from hermes_cli.plugins import VALID_HOOKS
+
         if event not in VALID_HOOKS:
             raise HTTPException(
                 status_code=400,
@@ -5284,7 +5482,8 @@ async def delete_hook(body: HookDelete):
     if isinstance(hooks_cfg, dict) and isinstance(hooks_cfg.get(event), list):
         before = len(hooks_cfg[event])
         hooks_cfg[event] = [
-            e for e in hooks_cfg[event]
+            e
+            for e in hooks_cfg[event]
             if not (isinstance(e, dict) and e.get("command") == command)
         ]
         removed = len(hooks_cfg[event]) < before
@@ -5329,11 +5528,13 @@ async def list_checkpoints():
                     except OSError:
                         pass
             total_bytes += size
-            sessions.append({
-                "session": child.name,
-                "files": count,
-                "bytes": size,
-            })
+            sessions.append(
+                {
+                    "session": child.name,
+                    "files": count,
+                    "bytes": size,
+                }
+            )
     return {"sessions": sessions, "total_bytes": total_bytes}
 
 
@@ -5343,7 +5544,9 @@ async def prune_checkpoints():
         proc = _spawn_hermes_action(["checkpoints", "prune"], "checkpoints-prune")
     except Exception as exc:
         _log.exception("Failed to spawn checkpoints prune")
-        raise HTTPException(status_code=500, detail=f"Failed to prune checkpoints: {exc}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to prune checkpoints: {exc}"
+        )
     return {"ok": True, "pid": proc.pid, "name": "checkpoints-prune"}
 
 
@@ -5384,7 +5587,9 @@ async def uninstall_skill_hub(body: SkillUninstallRequest):
     if not name:
         raise HTTPException(status_code=400, detail="name is required")
     try:
-        proc = _spawn_hermes_action(["skills", "uninstall", name, "--yes"], "skills-uninstall")
+        proc = _spawn_hermes_action(
+            ["skills", "uninstall", name, "--yes"], "skills-uninstall"
+        )
     except Exception as exc:
         _log.exception("Failed to spawn skills uninstall")
         raise HTTPException(status_code=500, detail=f"Failed to uninstall skill: {exc}")
@@ -5489,32 +5694,44 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
     profiles: List[Dict[str, Any]] = []
     default_home = profiles_mod._get_default_hermes_home()
     if default_home.is_dir():
-        model, provider = _safe(lambda: profiles_mod._read_config_model(default_home), (None, None))
-        profiles.append({
-            "name": "default",
-            "path": str(default_home),
-            "is_default": True,
-            "model": model,
-            "provider": provider,
-            "has_env": (default_home / ".env").exists(),
-            "skill_count": _safe(lambda: profiles_mod._count_skills(default_home), 0),
-        })
+        model, provider = _safe(
+            lambda: profiles_mod._read_config_model(default_home), (None, None)
+        )
+        profiles.append(
+            {
+                "name": "default",
+                "path": str(default_home),
+                "is_default": True,
+                "model": model,
+                "provider": provider,
+                "has_env": (default_home / ".env").exists(),
+                "skill_count": _safe(
+                    lambda: profiles_mod._count_skills(default_home), 0
+                ),
+            }
+        )
 
     profiles_root = profiles_mod._get_profiles_root()
     if profiles_root.is_dir():
         for entry in sorted(profiles_root.iterdir()):
             if not entry.is_dir() or not profiles_mod._PROFILE_ID_RE.match(entry.name):
                 continue
-            model, provider = _safe(lambda entry=entry: profiles_mod._read_config_model(entry), (None, None))
-            profiles.append({
-                "name": entry.name,
-                "path": str(entry),
-                "is_default": False,
-                "model": model,
-                "provider": provider,
-                "has_env": (entry / ".env").exists(),
-                "skill_count": _safe(lambda entry=entry: profiles_mod._count_skills(entry), 0),
-            })
+            model, provider = _safe(
+                lambda entry=entry: profiles_mod._read_config_model(entry), (None, None)
+            )
+            profiles.append(
+                {
+                    "name": entry.name,
+                    "path": str(entry),
+                    "is_default": False,
+                    "model": model,
+                    "provider": provider,
+                    "has_env": (entry / ".env").exists(),
+                    "skill_count": _safe(
+                        lambda entry=entry: profiles_mod._count_skills(entry), 0
+                    ),
+                }
+            )
 
     return profiles
 
@@ -5522,6 +5739,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
 def _resolve_profile_dir(name: str) -> Path:
     """Validate ``name`` and resolve to its directory or raise an HTTPException."""
     from hermes_cli import profiles as profiles_mod
+
     try:
         profiles_mod.validate_profile_name(name)
     except ValueError as e:
@@ -5540,16 +5758,20 @@ def _profile_setup_command(name: str) -> str:
 @app.get("/api/profiles")
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod
+
     try:
         return {"profiles": [_profile_to_dict(p) for p in profiles_mod.list_profiles()]}
     except Exception:
-        _log.exception("GET /api/profiles failed; falling back to profile directory scan")
+        _log.exception(
+            "GET /api/profiles failed; falling back to profile directory scan"
+        )
         return {"profiles": _fallback_profile_dicts(profiles_mod)}
 
 
 @app.post("/api/profiles")
 async def create_profile_endpoint(body: ProfileCreate):
     from hermes_cli import profiles as profiles_mod
+
     try:
         path = profiles_mod.create_profile(
             name=body.name,
@@ -5601,7 +5823,10 @@ async def open_profile_terminal_endpoint(name: str):
             subprocess.Popen(["osascript", "-e", applescript])
         else:
             terminal_commands = [
-                ("x-terminal-emulator", ["x-terminal-emulator", "-e", "sh", "-lc", command]),
+                (
+                    "x-terminal-emulator",
+                    ["x-terminal-emulator", "-e", "sh", "-lc", command],
+                ),
                 ("gnome-terminal", ["gnome-terminal", "--", "sh", "-lc", command]),
                 ("konsole", ["konsole", "-e", "sh", "-lc", command]),
                 ("xfce4-terminal", ["xfce4-terminal", "-e", f"sh -lc '{command}'"]),
@@ -5613,11 +5838,14 @@ async def open_profile_terminal_endpoint(name: str):
                 ("xterm", ["xterm", "-e", "sh", "-lc", command]),
             ]
             for executable, popen_args in terminal_commands:
-                if subprocess.call(
-                    ["which", executable],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                ) == 0:
+                if (
+                    subprocess.call(
+                        ["which", executable],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    == 0
+                ):
                     subprocess.Popen(popen_args)
                     break
             else:
@@ -5640,6 +5868,7 @@ async def open_profile_terminal_endpoint(name: str):
 @app.patch("/api/profiles/{name}")
 async def rename_profile_endpoint(name: str, body: ProfileRename):
     from hermes_cli import profiles as profiles_mod
+
     try:
         path = profiles_mod.rename_profile(name, body.new_name)
     except FileNotFoundError as e:
@@ -5658,6 +5887,7 @@ async def delete_profile_endpoint(name: str):
     its own dialog before this request, so we always pass ``yes=True`` to
     skip the CLI's interactive prompt."""
     from hermes_cli import profiles as profiles_mod
+
     try:
         path = profiles_mod.delete_profile(name, yes=True)
     except FileNotFoundError as e:
@@ -5704,8 +5934,9 @@ class SkillToggle(BaseModel):
 
 @app.get("/api/skills")
 async def get_skills():
-    from tools.skills_tool import _find_all_skills
     from hermes_cli.skills_config import get_disabled_skills
+    from tools.skills_tool import _find_all_skills
+
     config = load_config()
     disabled = get_disabled_skills(config)
     skills = _find_all_skills(skip_disabled=True)
@@ -5717,6 +5948,7 @@ async def get_skills():
 @app.put("/api/skills/toggle")
 async def toggle_skill(body: SkillToggle):
     from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
+
     config = load_config()
     disabled = get_disabled_skills(config)
     if body.enabled:
@@ -5749,13 +5981,17 @@ async def get_toolsets():
         except Exception:
             tools = []
         is_enabled = name in enabled_toolsets
-        result.append({
-            "name": name, "label": label, "description": desc,
-            "enabled": is_enabled,
-            "available": is_enabled,
-            "configured": _toolset_has_keys(name, config),
-            "tools": tools,
-        })
+        result.append(
+            {
+                "name": name,
+                "label": label,
+                "description": desc,
+                "enabled": is_enabled,
+                "available": is_enabled,
+                "configured": _toolset_has_keys(name, config),
+                "tools": tools,
+            }
+        )
     return result
 
 
@@ -5782,9 +6018,7 @@ async def toggle_toolset(name: str, body: ToolsetToggle):
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
     config = load_config()
-    enabled = set(
-        _get_platform_tools(config, "cli", include_default_mcp_servers=False)
-    )
+    enabled = set(_get_platform_tools(config, "cli", include_default_mcp_servers=False))
     if body.enabled:
         enabled.add(name)
     else:
@@ -5803,13 +6037,13 @@ async def get_toolset_config(name: str):
     entry. Toolsets without a ``TOOL_CATEGORIES`` entry return an empty
     provider list and ``has_category: false``. Returns 400 for unknown keys.
     """
+    from hermes_cli.config import get_env_value
     from hermes_cli.tools_config import (
         TOOL_CATEGORIES,
         _get_effective_configurable_toolsets,
         _is_provider_active,
         _visible_providers,
     )
-    from hermes_cli.config import get_env_value
 
     valid = {ts_key for ts_key, _, _ in _get_effective_configurable_toolsets()}
     if name not in valid:
@@ -5838,15 +6072,17 @@ async def get_toolset_config(name: str):
             is_active = _is_provider_active(prov, config, force_fresh=True)
             if is_active and active_provider is None:
                 active_provider = prov["name"]
-            providers.append({
-                "name": prov["name"],
-                "badge": prov.get("badge", ""),
-                "tag": prov.get("tag", ""),
-                "env_vars": env_vars,
-                "post_setup": prov.get("post_setup"),
-                "requires_nous_auth": bool(prov.get("requires_nous_auth")),
-                "is_active": is_active,
-            })
+            providers.append(
+                {
+                    "name": prov["name"],
+                    "badge": prov.get("badge", ""),
+                    "tag": prov.get("tag", ""),
+                    "env_vars": env_vars,
+                    "post_setup": prov.get("post_setup"),
+                    "requires_nous_auth": bool(prov.get("requires_nous_auth")),
+                    "is_active": is_active,
+                }
+            )
     return {
         "name": name,
         "has_category": cat is not None,
@@ -5870,8 +6106,8 @@ async def select_toolset_provider(name: str, body: ToolsetProviderSelect):
     400 for unknown toolset or provider names.
     """
     from hermes_cli.tools_config import (
-        apply_provider_selection,
         _get_effective_configurable_toolsets,
+        apply_provider_selection,
     )
 
     valid = {ts_key for ts_key, _, _ in _get_effective_configurable_toolsets()}
@@ -5923,13 +6159,14 @@ async def update_config_raw(body: RawConfigUpdate):
 
 @app.get("/api/analytics/usage")
 async def get_usage_analytics(days: int = 30):
-    from hermes_state import SessionDB
     from agent.insights import InsightsEngine
+    from hermes_state import SessionDB
 
     db = SessionDB()
     try:
         cutoff = time.time() - (days * 86400)
-        cur = db._conn.execute("""
+        cur = db._conn.execute(
+            """
             SELECT date(started_at, 'unixepoch') as day,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
@@ -5941,10 +6178,13 @@ async def get_usage_analytics(days: int = 30):
                    SUM(COALESCE(api_call_count, 0)) as api_calls
             FROM sessions WHERE started_at > ?
             GROUP BY day ORDER BY day
-        """, (cutoff,))
+        """,
+            (cutoff,),
+        )
         daily = [dict(r) for r in cur.fetchall()]
 
-        cur2 = db._conn.execute("""
+        cur2 = db._conn.execute(
+            """
             SELECT model,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
@@ -5953,10 +6193,13 @@ async def get_usage_analytics(days: int = 30):
                    SUM(COALESCE(api_call_count, 0)) as api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL
             GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, (cutoff,))
+        """,
+            (cutoff,),
+        )
         by_model = [dict(r) for r in cur2.fetchall()]
 
-        cur3 = db._conn.execute("""
+        cur3 = db._conn.execute(
+            """
             SELECT SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
@@ -5966,18 +6209,23 @@ async def get_usage_analytics(days: int = 30):
                    COUNT(*) as total_sessions,
                    SUM(COALESCE(api_call_count, 0)) as total_api_calls
             FROM sessions WHERE started_at > ?
-        """, (cutoff,))
+        """,
+            (cutoff,),
+        )
         totals = dict(cur3.fetchone())
         insights_report = InsightsEngine(db).generate(days=days)
-        skills = insights_report.get("skills", {
-            "summary": {
-                "total_skill_loads": 0,
-                "total_skill_edits": 0,
-                "total_skill_actions": 0,
-                "distinct_skills_used": 0,
+        skills = insights_report.get(
+            "skills",
+            {
+                "summary": {
+                    "total_skill_loads": 0,
+                    "total_skill_edits": 0,
+                    "total_skill_actions": 0,
+                    "distinct_skills_used": 0,
+                },
+                "top_skills": [],
             },
-            "top_skills": [],
-        })
+        )
 
         return {
             "daily": daily,
@@ -6003,7 +6251,8 @@ async def get_models_analytics(days: int = 30):
     try:
         cutoff = time.time() - (days * 86400)
 
-        cur = db._conn.execute("""
+        cur = db._conn.execute(
+            """
             SELECT model,
                    billing_provider,
                    SUM(input_tokens) as input_tokens,
@@ -6020,7 +6269,9 @@ async def get_models_analytics(days: int = 30):
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
             GROUP BY model, billing_provider
             ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, (cutoff,))
+        """,
+            (cutoff,),
+        )
         rows = [dict(r) for r in cur.fetchall()]
 
         models = []
@@ -6030,6 +6281,7 @@ async def get_models_analytics(days: int = 30):
             caps = {}
             try:
                 from agent.models_dev import get_model_capabilities
+
                 mc = get_model_capabilities(provider=provider, model=model_name)
                 if mc is not None:
                     caps = {
@@ -6043,24 +6295,27 @@ async def get_models_analytics(days: int = 30):
             except Exception:
                 pass
 
-            models.append({
-                "model": model_name,
-                "provider": provider,
-                "input_tokens": row["input_tokens"],
-                "output_tokens": row["output_tokens"],
-                "cache_read_tokens": row["cache_read_tokens"],
-                "reasoning_tokens": row["reasoning_tokens"],
-                "estimated_cost": row["estimated_cost"],
-                "actual_cost": row["actual_cost"],
-                "sessions": row["sessions"],
-                "api_calls": row["api_calls"],
-                "tool_calls": row["tool_calls"],
-                "last_used_at": row["last_used_at"],
-                "avg_tokens_per_session": row["avg_tokens_per_session"],
-                "capabilities": caps,
-            })
+            models.append(
+                {
+                    "model": model_name,
+                    "provider": provider,
+                    "input_tokens": row["input_tokens"],
+                    "output_tokens": row["output_tokens"],
+                    "cache_read_tokens": row["cache_read_tokens"],
+                    "reasoning_tokens": row["reasoning_tokens"],
+                    "estimated_cost": row["estimated_cost"],
+                    "actual_cost": row["actual_cost"],
+                    "sessions": row["sessions"],
+                    "api_calls": row["api_calls"],
+                    "tool_calls": row["tool_calls"],
+                    "last_used_at": row["last_used_at"],
+                    "avg_tokens_per_session": row["avg_tokens_per_session"],
+                    "capabilities": caps,
+                }
+            )
 
-        totals_cur = db._conn.execute("""
+        totals_cur = db._conn.execute(
+            """
             SELECT COUNT(DISTINCT model) as distinct_models,
                    SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
@@ -6071,7 +6326,9 @@ async def get_models_analytics(days: int = 30):
                    COUNT(*) as total_sessions,
                    SUM(COALESCE(api_call_count, 0)) as total_api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
-        """, (cutoff,))
+        """,
+            (cutoff,),
+        )
         totals = dict(totals_cur.fetchone())
 
         return {
@@ -6105,6 +6362,7 @@ import re
 # /api/pty endpoint cleanly refuses with a WSL-suggested message.
 try:
     from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError
+
     _PTY_BRIDGE_AVAILABLE = True
 except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
     PtyBridge = None  # type: ignore[assignment]
@@ -6112,7 +6370,9 @@ except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
 
     class PtyUnavailableError(RuntimeError):  # type: ignore[no-redef]
         """Stub on platforms where pty_bridge can't be imported."""
+
         pass
+
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
@@ -6227,10 +6487,7 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
         # Lazy import — keeps this function importable in test harnesses
         # that don't bring in the dashboard_auth layer.
         from hermes_cli.dashboard_auth.audit import AuditEvent, audit_log
-        from hermes_cli.dashboard_auth.ws_tickets import (
-            TicketInvalid,
-            consume_ticket,
-        )
+        from hermes_cli.dashboard_auth.ws_tickets import TicketInvalid, consume_ticket
 
         try:
             consume_ticket(ticket)
@@ -6246,6 +6503,7 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
 
     token = ws.query_params.get("token", "")
     return hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
+
 
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
@@ -6347,7 +6605,11 @@ def _build_sidecar_url(channel: str) -> Optional[str]:
     if not host or not port:
         return None
 
-    netloc = f"[{host}]:{port}" if ":" in host and not host.startswith("[") else f"{host}:{port}"
+    netloc = (
+        f"[{host}]:{port}"
+        if ":" in host and not host.startswith("[")
+        else f"{host}:{port}"
+    )
 
     if getattr(app.state, "auth_required", False):
         # Gated mode — mint a ticket so the WS upgrade survives _ws_auth_ok.
@@ -6372,7 +6634,9 @@ async def _broadcast_event(channel: str, payload: str) -> None:
         except Exception:
             # Subscriber went away mid-send; the /api/events finally clause
             # will remove it from the registry on its next iteration.
-            _log.warning("broadcast send failed for subscriber on %s", channel, exc_info=True)
+            _log.warning(
+                "broadcast send failed for subscriber on %s", channel, exc_info=True
+            )
 
 
 def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
@@ -6423,7 +6687,6 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
-
 
     try:
         bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
@@ -6612,6 +6875,7 @@ def _normalise_prefix(raw: Optional[str]) -> str:
     SPA mount all agree on validation rules.
     """
     from hermes_cli.dashboard_auth.prefix import normalise_prefix
+
     return normalise_prefix(raw)
 
 
@@ -6630,12 +6894,14 @@ def mount_spa(application: FastAPI):
     without rebuilding the bundle.
     """
     if not WEB_DIST.exists():
+
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
             return JSONResponse(
                 {"error": "Frontend not built. Run: cd web && npm run build"},
                 status_code=404,
             )
+
         return
 
     _index_path = WEB_DIST / "index.html"
@@ -6706,11 +6972,13 @@ def mount_spa(application: FastAPI):
         if prefix:
             for asset_dir in ("/fonts/", "/fonts-terminal/", "/ds-assets/", "/assets/"):
                 css = css.replace(f"url({asset_dir}", f"url({prefix}{asset_dir}")
-                css = css.replace(f"url(\"{asset_dir}", f"url(\"{prefix}{asset_dir}")
+                css = css.replace(f'url("{asset_dir}', f'url("{prefix}{asset_dir}')
                 css = css.replace(f"url('{asset_dir}", f"url('{prefix}{asset_dir}")
         return Response(content=css, media_type="text/css")
 
-    application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
+    application.mount(
+        "/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets"
+    )
 
     @application.get("/{full_path:path}")
     async def serve_spa(full_path: str, request: Request):
@@ -6745,17 +7013,47 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
-    {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
-    {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
-    {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
-    {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
-    {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {
+        "name": "default",
+        "label": "Hermes Teal",
+        "description": "Classic dark teal — the canonical Hermes look",
+    },
+    {
+        "name": "default-large",
+        "label": "Hermes Teal (Large)",
+        "description": "Hermes Teal with bigger fonts and roomier spacing",
+    },
+    {
+        "name": "midnight",
+        "label": "Midnight",
+        "description": "Deep blue-violet with cool accents",
+    },
+    {
+        "name": "ember",
+        "label": "Ember",
+        "description": "Warm crimson and bronze — forge vibes",
+    },
+    {
+        "name": "mono",
+        "label": "Mono",
+        "description": "Clean grayscale — minimal and focused",
+    },
+    {
+        "name": "cyberpunk",
+        "label": "Cyberpunk",
+        "description": "Neon green on black — matrix terminal",
+    },
+    {
+        "name": "rose",
+        "label": "Rosé",
+        "description": "Soft pink and warm ivory — easy on the eyes",
+    },
 ]
 
 
-def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Optional[Dict[str, Any]]:
+def _parse_theme_layer(
+    value: Any, default_hex: str, default_alpha: float = 1.0
+) -> Optional[Dict[str, Any]]:
     """Normalise a theme layer spec from YAML into `{hex, alpha}` form.
 
     Accepts shorthand (a bare hex string) or full dict form.  Returns
@@ -6793,11 +7091,25 @@ _THEME_DEFAULT_LAYOUT: Dict[str, str] = {
 }
 
 _THEME_OVERRIDE_KEYS = {
-    "card", "cardForeground", "popover", "popoverForeground",
-    "primary", "primaryForeground", "secondary", "secondaryForeground",
-    "muted", "mutedForeground", "accent", "accentForeground",
-    "destructive", "destructiveForeground", "success", "warning",
-    "border", "input", "ring",
+    "card",
+    "cardForeground",
+    "popover",
+    "popoverForeground",
+    "primary",
+    "primaryForeground",
+    "secondary",
+    "secondaryForeground",
+    "muted",
+    "mutedForeground",
+    "accent",
+    "accentForeground",
+    "destructive",
+    "destructiveForeground",
+    "success",
+    "warning",
+    "border",
+    "input",
+    "ring",
 }
 
 # Well-known named asset slots themes can populate.  Any other keys under
@@ -6812,8 +7124,15 @@ _THEME_NAMED_ASSET_KEYS = {"bg", "hero", "logo", "crest", "sidebar", "header"}
 # can restyle chrome (clip-path, border-image, segmented progress, etc.)
 # without shipping their own CSS.
 _THEME_COMPONENT_BUCKETS = {
-    "card", "header", "footer", "sidebar", "tab",
-    "progress", "badge", "backdrop", "page",
+    "card",
+    "header",
+    "footer",
+    "sidebar",
+    "tab",
+    "progress",
+    "badge",
+    "backdrop",
+    "page",
 }
 
 _THEME_LAYOUT_VARIANTS = {"standard", "cockpit", "tiled"}
@@ -6838,20 +7157,30 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         return None
 
     # Palette
-    palette_src = data.get("palette", {}) if isinstance(data.get("palette"), dict) else {}
+    palette_src = (
+        data.get("palette", {}) if isinstance(data.get("palette"), dict) else {}
+    )
     # Allow top-level `colors.background` as a shorthand too.
     colors_src = data.get("colors", {}) if isinstance(data.get("colors"), dict) else {}
 
-    def _layer(key: str, default_hex: str, default_alpha: float = 1.0) -> Dict[str, Any]:
+    def _layer(
+        key: str, default_hex: str, default_alpha: float = 1.0
+    ) -> Dict[str, Any]:
         spec = palette_src.get(key, colors_src.get(key))
         parsed = _parse_theme_layer(spec, default_hex, default_alpha)
-        return parsed if parsed is not None else {"hex": default_hex, "alpha": default_alpha}
+        return (
+            parsed
+            if parsed is not None
+            else {"hex": default_hex, "alpha": default_alpha}
+        )
 
     palette = {
         "background": _layer("background", "#041c1c", 1.0),
         "midground": _layer("midground", "#ffe6cb", 1.0),
         "foreground": _layer("foreground", "#ffffff", 0.0),
-        "warmGlow": palette_src.get("warmGlow") or data.get("warmGlow") or "rgba(255, 189, 56, 0.35)",
+        "warmGlow": palette_src.get("warmGlow")
+        or data.get("warmGlow")
+        or "rgba(255, 189, 56, 0.35)",
         "noiseOpacity": 1.0,
     }
     raw_noise = palette_src.get("noiseOpacity", data.get("noiseOpacity"))
@@ -6861,9 +7190,19 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         palette["noiseOpacity"] = 1.0
 
     # Typography
-    typo_src = data.get("typography", {}) if isinstance(data.get("typography"), dict) else {}
+    typo_src = (
+        data.get("typography", {}) if isinstance(data.get("typography"), dict) else {}
+    )
     typography = dict(_THEME_DEFAULT_TYPOGRAPHY)
-    for key in ("fontSans", "fontMono", "fontDisplay", "fontUrl", "baseSize", "lineHeight", "letterSpacing"):
+    for key in (
+        "fontSans",
+        "fontMono",
+        "fontDisplay",
+        "fontUrl",
+        "baseSize",
+        "lineHeight",
+        "letterSpacing",
+    ):
         val = typo_src.get(key)
         if isinstance(val, str) and val.strip():
             typography[key] = val
@@ -6945,7 +7284,8 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
     layout_variant_src = data.get("layoutVariant")
     layout_variant = (
         layout_variant_src
-        if isinstance(layout_variant_src, str) and layout_variant_src in _THEME_LAYOUT_VARIANTS
+        if isinstance(layout_variant_src, str)
+        and layout_variant_src in _THEME_LAYOUT_VARIANTS
         else "standard"
     )
 
@@ -7012,12 +7352,14 @@ async def get_dashboard_themes():
     for t in user_themes:
         if t["name"] in seen:
             continue
-        themes.append({
-            "name": t["name"],
-            "label": t["label"],
-            "description": t["description"],
-            "definition": t,
-        })
+        themes.append(
+            {
+                "name": t["name"],
+                "label": t["label"],
+                "description": t["description"],
+                "definition": t,
+            }
+        )
         seen.add(t["name"])
     return {"themes": themes, "active": active}
 
@@ -7040,6 +7382,7 @@ async def set_dashboard_theme(body: ThemeSetBody):
 # ---------------------------------------------------------------------------
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
+
 
 def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional[str]:
     """Validate the manifest's ``api`` field for the plugin loader.
@@ -7090,6 +7433,7 @@ def _discover_dashboard_plugins() -> list:
     seen_names: set = set()
 
     from hermes_cli.plugins import get_bundled_plugins_dir
+
     bundled_root = get_bundled_plugins_dir()
     search_dirs = [
         (get_hermes_home() / "plugins", "user"),
@@ -7127,7 +7471,9 @@ def _discover_dashboard_plugins() -> list:
                 # ``override`` to replace a built-in route, and ``hidden`` to
                 # register the plugin component/slots without adding a tab
                 # (useful for slot-only plugins like a header-crest injector).
-                raw_tab = data.get("tab", {}) if isinstance(data.get("tab"), dict) else {}
+                raw_tab = (
+                    data.get("tab", {}) if isinstance(data.get("tab"), dict) else {}
+                )
                 tab_info = {
                     "path": raw_tab.get("path", f"/{name}"),
                     "position": raw_tab.get("position", "end"),
@@ -7152,30 +7498,35 @@ def _discover_dashboard_plugins() -> list:
                 # (RCE, GHSA-5qr3-c538-wm9j).
                 raw_api = data.get("api")
                 dashboard_dir = child / "dashboard"
-                safe_api = _safe_plugin_api_relpath(raw_api, dashboard_dir=dashboard_dir)
+                safe_api = _safe_plugin_api_relpath(
+                    raw_api, dashboard_dir=dashboard_dir
+                )
                 if raw_api and safe_api is None:
                     _log.warning(
                         "Plugin %s: refusing unsafe api path %r (must be a "
                         "relative file inside the plugin's dashboard/ "
                         "directory); backend routes from this plugin will "
                         "not be mounted",
-                        name, raw_api,
+                        name,
+                        raw_api,
                     )
-                plugins.append({
-                    "name": name,
-                    "label": data.get("label", name),
-                    "description": data.get("description", ""),
-                    "icon": data.get("icon", "Puzzle"),
-                    "version": data.get("version", "0.0.0"),
-                    "tab": tab_info,
-                    "slots": slots,
-                    "entry": data.get("entry", "dist/index.js"),
-                    "css": data.get("css"),
-                    "has_api": bool(safe_api),
-                    "source": source,
-                    "_dir": str(dashboard_dir),
-                    "_api_file": safe_api,
-                })
+                plugins.append(
+                    {
+                        "name": name,
+                        "label": data.get("label", name),
+                        "description": data.get("description", ""),
+                        "icon": data.get("icon", "Puzzle"),
+                        "version": data.get("version", "0.0.0"),
+                        "tab": tab_info,
+                        "slots": slots,
+                        "entry": data.get("entry", "dist/index.js"),
+                        "css": data.get("css"),
+                        "has_api": bool(safe_api),
+                        "source": source,
+                        "_dir": str(dashboard_dir),
+                        "_api_file": safe_api,
+                    }
+                )
             except Exception as exc:
                 _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
                 continue
@@ -7232,14 +7583,14 @@ def _merged_plugins_hub() -> Dict[str, Any]:
     """Agent discovery + dashboard manifests + optional provider picker metadata."""
     from hermes_cli.plugins_cmd import (
         _discover_all_plugins,
-        _get_current_context_engine,
-        _get_current_memory_provider,
         _discover_context_engines,
         _discover_memory_providers,
+        _get_current_context_engine,
+        _get_current_memory_provider,
         _get_disabled_set,
         _get_enabled_set,
-        _read_manifest as _read_plugin_manifest_at,
     )
+    from hermes_cli.plugins_cmd import _read_manifest as _read_plugin_manifest_at
 
     dashboard_list = _get_dashboard_plugins()
     dash_by_name = {str(p["name"]): p for p in dashboard_list}
@@ -7249,7 +7600,9 @@ def _merged_plugins_hub() -> Dict[str, Any]:
 
     # Read user-hidden plugins from config for the user_hidden field.
     config = load_config()
-    hidden_plugins: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+    hidden_plugins: list = (
+        cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+    )
 
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
     rows: List[Dict[str, Any]] = []
@@ -7264,7 +7617,9 @@ def _merged_plugins_hub() -> Dict[str, Any]:
 
         dir_path = Path(dir_str)
         dm = dash_by_name.get(name)
-        has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
+        has_dash_manifest = (
+            dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
+        )
 
         under_user_tree = False
         try:
@@ -7285,6 +7640,7 @@ def _merged_plugins_hub() -> Dict[str, Any]:
         if provides_tools:
             try:
                 from tools.registry import registry
+
                 for tname in provides_tools:
                     entry = registry.get_entry(tname)
                     if entry and entry.check_fn and not entry.check_fn():
@@ -7294,21 +7650,24 @@ def _merged_plugins_hub() -> Dict[str, Any]:
             except Exception:
                 pass
 
-        rows.append({
-            "name": name,
-            "version": version or "",
-            "description": description or "",
-            "source": source,
-            "runtime_status": runtime_status,
-            "has_dashboard_manifest": has_dash_manifest,
-            "dashboard_manifest": _strip_dashboard_manifest(dm) if dm else None,
-            "path": dir_str,
-            "can_remove": can_remove_update,
-            "can_update_git": can_remove_update and (Path(dir_str) / ".git").exists(),
-            "auth_required": auth_required,
-            "auth_command": auth_command,
-            "user_hidden": name in hidden_plugins,
-        })
+        rows.append(
+            {
+                "name": name,
+                "version": version or "",
+                "description": description or "",
+                "source": source,
+                "runtime_status": runtime_status,
+                "has_dashboard_manifest": has_dash_manifest,
+                "dashboard_manifest": _strip_dashboard_manifest(dm) if dm else None,
+                "path": dir_str,
+                "can_remove": can_remove_update,
+                "can_update_git": can_remove_update
+                and (Path(dir_str) / ".git").exists(),
+                "auth_required": auth_required,
+                "auth_command": auth_command,
+                "user_hidden": name in hidden_plugins,
+            }
+        )
 
     agent_names = {r["name"] for r in rows}
     orphan_dashboard = [
@@ -7351,7 +7710,9 @@ async def get_plugins_hub(request: Request):
         return _merged_plugins_hub()
     except Exception as exc:
         _log.warning("plugins/hub failed: %s", exc)
-        raise HTTPException(status_code=500, detail="Failed to build plugins hub.") from exc
+        raise HTTPException(
+            status_code=500, detail="Failed to build plugins hub."
+        ) from exc
 
 
 @app.post("/api/dashboard/agent-plugins/install")
@@ -7391,7 +7752,9 @@ async def post_agent_plugin_enable(request: Request, name: str):
 
     result = dashboard_set_agent_plugin_enabled(name, enabled=True)
     if not result.get("ok"):
-        raise HTTPException(status_code=400, detail=result.get("error") or "Enable failed.")
+        raise HTTPException(
+            status_code=400, detail=result.get("error") or "Enable failed."
+        )
     return result
 
 
@@ -7403,7 +7766,9 @@ async def post_agent_plugin_disable(request: Request, name: str):
 
     result = dashboard_set_agent_plugin_enabled(name, enabled=False)
     if not result.get("ok"):
-        raise HTTPException(status_code=400, detail=result.get("error") or "Disable failed.")
+        raise HTTPException(
+            status_code=400, detail=result.get("error") or "Disable failed."
+        )
     return result
 
 
@@ -7415,7 +7780,9 @@ async def post_agent_plugin_update(request: Request, name: str):
 
     result = dashboard_update_user_plugin(name)
     if not result.get("ok"):
-        raise HTTPException(status_code=400, detail=result.get("error") or "Update failed.")
+        raise HTTPException(
+            status_code=400, detail=result.get("error") or "Update failed."
+        )
     _get_dashboard_plugins(force_rescan=True)
     return result
 
@@ -7428,7 +7795,9 @@ async def delete_agent_plugin(request: Request, name: str):
 
     result = dashboard_remove_user_plugin(name)
     if not result.get("ok"):
-        raise HTTPException(status_code=400, detail=result.get("error") or "Remove failed.")
+        raise HTTPException(
+            status_code=400, detail=result.get("error") or "Remove failed."
+        )
     _get_dashboard_plugins(force_rescan=True)
     return result
 
@@ -7442,10 +7811,7 @@ class _PluginProvidersPutBody(BaseModel):
 async def put_plugin_providers(request: Request, body: _PluginProvidersPutBody):
     """Persist memory provider / context engine selection (writes config.yaml)."""
     _require_token(request)
-    from hermes_cli.plugins_cmd import (
-        _save_context_engine,
-        _save_memory_provider,
-    )
+    from hermes_cli.plugins_cmd import _save_context_engine, _save_memory_provider
 
     if body.memory_provider is not None:
         _save_memory_provider(body.memory_provider)
@@ -7459,7 +7825,9 @@ class _PluginVisibilityBody(BaseModel):
 
 
 @app.post("/api/dashboard/plugins/{name:path}/visibility")
-async def post_plugin_visibility(request: Request, name: str, body: _PluginVisibilityBody):
+async def post_plugin_visibility(
+    request: Request, name: str, body: _PluginVisibilityBody
+):
     """Toggle a plugin's sidebar visibility (persists to config.yaml dashboard.hidden_plugins)."""
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -7573,7 +7941,8 @@ def _mount_plugin_api_routes():
                 "Plugin %s: ignoring backend api=%s (project plugins may "
                 "not auto-import Python code; move the plugin to "
                 "~/.hermes/plugins/ if you trust it)",
-                plugin["name"], api_file_name,
+                plugin["name"],
+                api_file_name,
             )
             continue
         dashboard_dir = Path(plugin["_dir"])
@@ -7589,11 +7958,17 @@ def _mount_plugin_api_routes():
             # primitive contained even if the upstream check regresses.
             _log.warning(
                 "Plugin %s: refusing to import api file outside its "
-                "dashboard directory (%s)", plugin["name"], api_path,
+                "dashboard directory (%s)",
+                plugin["name"],
+                api_path,
             )
             continue
         if not api_path.exists():
-            _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
+            _log.warning(
+                "Plugin %s declares api=%s but file not found",
+                plugin["name"],
+                api_file_name,
+            )
             continue
         try:
             module_name = f"hermes_dashboard_plugin_{plugin['name']}"
@@ -7615,7 +7990,9 @@ def _mount_plugin_api_routes():
                 raise
             router = getattr(mod, "router", None)
             if router is None:
-                _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
+                _log.warning(
+                    "Plugin %s api file has no 'router' attribute", plugin["name"]
+                )
                 continue
             app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
@@ -7630,7 +8007,10 @@ _mount_plugin_api_routes()
 # SPA catch-all so /{full_path:path} doesn't swallow them.  These are
 # always mounted — the gate middleware decides whether to enforce auth,
 # not whether the routes exist.
-from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router  # noqa: E402
+from hermes_cli.dashboard_auth.routes import (  # noqa: E402
+    router as _dashboard_auth_router,
+)
+
 app.include_router(_dashboard_auth_router)
 
 mount_spa(app)
@@ -7661,6 +8041,7 @@ def start_server(
         # "refusing to bind" guard is replaced by "require at least one
         # provider to be registered, else fail closed".
         from hermes_cli.dashboard_auth import list_providers
+
         if not list_providers():
             # Surface the *specific* reason any bundled provider declined
             # to register (e.g. missing HERMES_DASHBOARD_OAUTH_CLIENT_ID).
@@ -7673,9 +8054,7 @@ def start_server(
                 from plugins.dashboard_auth import nous as _nous_plugin
 
                 if _nous_plugin.LAST_SKIP_REASON:
-                    skip_reasons.append(
-                        f"  • nous: {_nous_plugin.LAST_SKIP_REASON}"
-                    )
+                    skip_reasons.append(f"  • nous: {_nous_plugin.LAST_SKIP_REASON}")
             except Exception:
                 pass
 
@@ -7702,8 +8081,7 @@ def start_server(
                 f"networks)."
             )
         _log.info(
-            "Dashboard binding to %s with OAuth auth gate enabled. "
-            "Providers: %s",
+            "Dashboard binding to %s with OAuth auth gate enabled. " "Providers: %s",
             host,
             ", ".join(p.name for p in list_providers()),
         )
@@ -7711,7 +8089,8 @@ def start_server(
         # --insecure path — no auth, loud warning.
         _log.warning(
             "Binding to %s with --insecure — the dashboard has no robust "
-            "authentication. Only use on trusted networks.", host,
+            "authentication. Only use on trusted networks.",
+            host,
         )
 
     # Record the bound host so host_header_middleware can validate incoming
@@ -7738,6 +8117,7 @@ def start_server(
         )
 
         if _has_display:
+
             def _open():
                 try:
                     time.sleep(1.0)
@@ -7760,6 +8140,9 @@ def start_server(
     # (Fly.io) and need X-Forwarded-Proto to decide cookie Secure flags, so
     # we flip proxy_headers on for that mode.
     uvicorn.run(
-        app, host=host, port=port, log_level="warning",
+        app,
+        host=host,
+        port=port,
+        log_level="warning",
         proxy_headers=bool(app.state.auth_required),
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1406,6 +1406,8 @@ async def get_sessions(
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
+                project_compression_tips=True,
+                include_children=False,
             )
             now = time.time()
             for s in sessions:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -22,10 +22,10 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -52,8 +52,8 @@ SCHEMA_VERSION = 14
 # works on NFS.  Concurrency drops — concurrent readers are blocked during
 # a write — but the feature works.
 _WAL_INCOMPAT_MARKERS = (
-    "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB
-    "not authorized",         # Some FUSE mounts block WAL pragma outright
+    "locking protocol",  # SQLITE_PROTOCOL on NFS/SMB
+    "not authorized",  # Some FUSE mounts block WAL pragma outright
 )
 
 # Last SessionDB() init error, per-process.  Surfaced in /resume and
@@ -110,7 +110,9 @@ def get_last_init_error() -> Optional[str]:
     return _last_init_error
 
 
-def format_session_db_unavailable(prefix: str = "Session database not available") -> str:
+def format_session_db_unavailable(
+    prefix: str = "Session database not available",
+) -> str:
     """Format a user-facing 'session DB unavailable' message with cause.
 
     When ``SessionDB()`` init fails, callers set ``_session_db = None`` and
@@ -129,7 +131,9 @@ def format_session_db_unavailable(prefix: str = "Session database not available"
         return f"{prefix}."
     hint = ""
     if any(marker in cause.lower() for marker in _WAL_INCOMPAT_MARKERS):
-        hint = " (state.db may be on NFS/SMB/FUSE — see https://www.sqlite.org/wal.html)"
+        hint = (
+            " (state.db may be on NFS/SMB/FUSE — see https://www.sqlite.org/wal.html)"
+        )
     return f"{prefix}: {cause}{hint}."
 
 
@@ -225,6 +229,7 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
         db_label,
         exc,
     )
+
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -391,8 +396,8 @@ class SessionDB:
     # application level with random jitter, which naturally staggers competing
     # writers and avoids the convoy.
     _WRITE_MAX_RETRIES = 15
-    _WRITE_RETRY_MIN_S = 0.020   # 20ms
-    _WRITE_RETRY_MAX_S = 0.150   # 150ms
+    _WRITE_RETRY_MIN_S = 0.020  # 20ms
+    _WRITE_RETRY_MAX_S = 0.150  # 150ms
     # Attempt a PASSIVE WAL checkpoint every N successful writes.
     _CHECKPOINT_EVERY_N_WRITES = 50
 
@@ -512,7 +517,9 @@ class SessionDB:
             "FROM messages"
         )
 
-    def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
+    def _fts_table_probe(
+        self, cursor: sqlite3.Cursor, table_name: str
+    ) -> Optional[bool]:
         try:
             cursor.execute(f"SELECT * FROM {table_name} LIMIT 0")
             return True
@@ -607,13 +614,12 @@ class SessionDB:
         """
         try:
             with self._lock:
-                result = self._conn.execute(
-                    "PRAGMA wal_checkpoint(PASSIVE)"
-                ).fetchone()
+                result = self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
                 if result and result[1] > 0:
                     logger.debug(
                         "WAL checkpoint: %d/%d pages checkpointed",
-                        result[2], result[1],
+                        result[2],
+                        result[1],
                     )
         except Exception:
             pass  # Best effort — never fatal.
@@ -655,9 +661,7 @@ class SessionDB:
                 "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
             ).fetchall():
                 cols: Dict[str, str] = {}
-                for row in ref.execute(
-                    f'PRAGMA table_info("{tbl}")'
-                ).fetchall():
+                for row in ref.execute(f'PRAGMA table_info("{tbl}")').fetchall():
                     # row: (cid, name, type, notnull, dflt_value, pk)
                     col_name = row[1]
                     col_type = row[2] or ""
@@ -693,9 +697,7 @@ class SessionDB:
         for table_name, declared_cols in expected.items():
             # Get current columns from the live table
             try:
-                rows = cursor.execute(
-                    f'PRAGMA table_info("{table_name}")'
-                ).fetchall()
+                rows = cursor.execute(f'PRAGMA table_info("{table_name}")').fetchall()
             except sqlite3.OperationalError:
                 continue  # Table doesn't exist yet (shouldn't happen after executescript)
             live_cols = set()
@@ -717,7 +719,10 @@ class SessionDB:
                         # with default value NULL" from a schema mistake.
                         # Log at DEBUG so it's visible in agent.log.
                         logger.debug(
-                            "reconcile %s.%s: %s", table_name, col_name, exc,
+                            "reconcile %s.%s: %s",
+                            table_name,
+                            col_name,
+                            exc,
                         )
 
     def _init_schema(self):
@@ -833,11 +838,10 @@ class SessionDB:
                     if fts5_available:
                         # Recreate virtual tables + triggers with the new inline-mode
                         # schema that indexes content || tool_name || tool_calls.
-                        if (
-                            self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
-                            and self._ensure_fts_schema(
-                                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                            )
+                        if self._ensure_fts_schema(
+                            cursor, "messages_fts", FTS_SQL
+                        ) and self._ensure_fts_schema(
+                            cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                         ):
                             # Backfill both indexes from every existing messages row.
                             cursor.execute(
@@ -922,6 +926,7 @@ class SessionDB:
         cwd: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
@@ -939,12 +944,14 @@ class SessionDB:
                     time.time(),
                 ),
             )
+
         self._execute_write(_do)
 
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 
@@ -955,21 +962,25 @@ class SessionDB:
         with a different reason. Use ``reopen_session()`` first if you
         intentionally need to re-end a closed session with a new reason.
         """
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = ? "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), end_reason, session_id),
             )
+
         self._execute_write(_do)
 
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     def update_session_cwd(self, session_id: str, cwd: str) -> None:
@@ -981,6 +992,7 @@ class SessionDB:
             conn.execute("UPDATE sessions SET cwd = ? WHERE id = ?", (cwd, session_id))
 
         self._execute_write(_do)
+
     # ──────────────────────────────────────────────────────────────────────
     # Compression locks
     # ──────────────────────────────────────────────────────────────────────
@@ -1049,16 +1061,19 @@ class SessionDB:
                 "SELECT holder FROM compression_locks WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
-            return row is not None and (
-                row["holder"] if isinstance(row, sqlite3.Row) else row[0]
-            ) == holder
+            return (
+                row is not None
+                and (row["holder"] if isinstance(row, sqlite3.Row) else row[0])
+                == holder
+            )
 
         try:
             return bool(self._execute_write(_do))
         except sqlite3.Error as exc:
             logger.warning(
                 "try_acquire_compression_lock(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
             # Fail open: returning False makes the caller skip compression,
             # which is the safe behaviour when the lock subsystem is broken.
@@ -1077,8 +1092,7 @@ class SessionDB:
 
         def _do(conn):
             conn.execute(
-                "DELETE FROM compression_locks "
-                "WHERE session_id = ? AND holder = ?",
+                "DELETE FROM compression_locks " "WHERE session_id = ? AND holder = ?",
                 (session_id, holder),
             )
 
@@ -1087,7 +1101,8 @@ class SessionDB:
         except sqlite3.Error as exc:
             logger.warning(
                 "release_compression_lock(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
@@ -1107,14 +1122,15 @@ class SessionDB:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
 
-
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET system_prompt = ? WHERE id = ?",
                 (system_prompt, session_id),
             )
+
         self._execute_write(_do)
 
     def update_session_model(self, session_id: str, model: str) -> None:
@@ -1124,11 +1140,13 @@ class SessionDB:
         (only filling in NULL), this unconditionally sets the model column
         so that the dashboard reflects the user's latest /model choice.
         """
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET model = ? WHERE id = ?",
                 (model, session_id),
             )
+
         self._execute_write(_do)
 
     def update_token_counts(
@@ -1226,8 +1244,10 @@ class SessionDB:
             api_call_count,
             session_id,
         )
+
         def _do(conn):
             conn.execute(sql, params)
+
         self._execute_write(_do)
 
     def ensure_session(
@@ -1246,7 +1266,8 @@ class SessionDB:
         cutoff = time.time() - 86400  # Only sessions older than 24 hours
 
         def _do(conn):
-            rows = conn.execute("""
+            rows = conn.execute(
+                """
                 SELECT id FROM sessions
                 WHERE source = 'tui'
                   AND title IS NULL
@@ -1255,13 +1276,13 @@ class SessionDB:
                   AND NOT EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id
                   )
-            """, (cutoff,)).fetchall()
+            """,
+                (cutoff,),
+            ).fetchall()
             ids = [r[0] if isinstance(r, (tuple, list)) else r["id"] for r in rows]
             if ids:
                 placeholders = ",".join("?" * len(ids))
-                conn.execute(
-                    f"DELETE FROM sessions WHERE id IN ({placeholders})", ids
-                )
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({placeholders})", ids)
             return ids
 
         removed_ids = self._execute_write(_do) or []
@@ -1331,8 +1352,7 @@ class SessionDB:
             return exact["id"]
 
         escaped = (
-            session_id_or_prefix
-            .replace("\\", "\\\\")
+            session_id_or_prefix.replace("\\", "\\\\")
             .replace("%", "\\%")
             .replace("_", "\\_")
         )
@@ -1369,19 +1389,20 @@ class SessionDB:
         # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
         # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
         # normalized to spaces by the whitespace collapsing step below
-        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)
+        cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", title)
 
         # Remove problematic Unicode control characters:
         # - Zero-width chars (U+200B-U+200F, U+FEFF)
         # - Directional overrides (U+202A-U+202E, U+2066-U+2069)
         # - Object replacement (U+FFFC), interlinear annotation (U+FFF9-U+FFFB)
         cleaned = re.sub(
-            r'[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]',
-            '', cleaned,
+            r"[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]",
+            "",
+            cleaned,
         )
 
         # Collapse internal whitespace runs and strip
-        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
 
         if not cleaned:
             return None
@@ -1402,6 +1423,7 @@ class SessionDB:
         Empty/whitespace-only strings are normalized to None (clearing the title).
         """
         title = self.sanitize_title(title)
+
         def _do(conn):
             if title:
                 # Check uniqueness (allow the same session to keep its own title)
@@ -1419,6 +1441,7 @@ class SessionDB:
                 (title, session_id),
             )
             return cursor.rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -1438,12 +1461,14 @@ class SessionDB:
         their messages — this is a soft hide, not a delete. Returns True when a
         row was updated.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 "UPDATE sessions SET archived = ? WHERE id = ?",
                 (1 if archived else 0, session_id),
             )
             return cursor.rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -1492,7 +1517,7 @@ class SessionDB:
         the highest existing number and increments.
         """
         # Strip existing #N suffix to find the true base
-        match = re.match(r'^(.*?) #(\d+)$', base_title)
+        match = re.match(r"^(.*?) #(\d+)$", base_title)
         if match:
             base = match.group(1)
         else:
@@ -1514,7 +1539,7 @@ class SessionDB:
         # Find the highest number
         max_num = 1  # The unnumbered original counts as #1
         for t in existing:
-            m = re.match(r'^.* #(\d+)$', t)
+            m = re.match(r"^.* #(\d+)$", t)
             if m:
                 max_num = max(max_num, int(m.group(1)))
 
@@ -1744,9 +1769,17 @@ class SessionDB:
                 # surface the tip's identity and activity data.
                 merged = dict(s)
                 for key in (
-                    "id", "ended_at", "end_reason", "message_count",
-                    "tool_call_count", "title", "last_active", "preview",
-                    "model", "system_prompt", "cwd",
+                    "id",
+                    "ended_at",
+                    "end_reason",
+                    "message_count",
+                    "tool_call_count",
+                    "title",
+                    "last_active",
+                    "preview",
+                    "model",
+                    "system_prompt",
+                    "cwd",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
@@ -1828,7 +1861,7 @@ class SessionDB:
         """Reverse :meth:`_encode_content`; returns scalars unchanged."""
         if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
             try:
-                return json.loads(content[len(cls._CONTENT_JSON_PREFIX):])
+                return json.loads(content[len(cls._CONTENT_JSON_PREFIX) :])
             except (json.JSONDecodeError, TypeError):
                 logger.warning(
                     "Failed to decode JSON-encoded message content; "
@@ -1869,16 +1902,13 @@ class SessionDB:
         """
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
+            json.dumps(reasoning_details) if reasoning_details else None
         )
         codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
+            json.dumps(codex_reasoning_items) if codex_reasoning_items else None
         )
         codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
+            json.dumps(codex_message_items) if codex_message_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
@@ -1943,9 +1973,7 @@ class SessionDB:
         """
 
         def _do(conn):
-            conn.execute(
-                "DELETE FROM messages WHERE session_id = ?", (session_id,)
-            )
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
@@ -1957,7 +1985,9 @@ class SessionDB:
             for msg in messages:
                 role = msg.get("role", "unknown")
                 tool_calls = msg.get("tool_calls")
-                reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+                reasoning_details = (
+                    msg.get("reasoning_details") if role == "assistant" else None
+                )
                 codex_reasoning_items = (
                     msg.get("codex_reasoning_items") if role == "assistant" else None
                 )
@@ -1977,8 +2007,8 @@ class SessionDB:
                 tool_calls_json = json.dumps(tool_calls) if tool_calls else None
                 # Accept either `platform_message_id` (new explicit name) or
                 # `message_id` (yuanbao's existing convention on message dicts).
-                platform_msg_id = (
-                    msg.get("platform_message_id") or msg.get("message_id")
+                platform_msg_id = msg.get("platform_message_id") or msg.get(
+                    "message_id"
                 )
 
                 conn.execute(
@@ -2050,7 +2080,9 @@ class SessionDB:
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
+                    logger.warning(
+                        "Failed to deserialize tool_calls in get_messages, falling back to []"
+                    )
                     msg["tool_calls"] = []
             result.append(msg)
         return result
@@ -2189,7 +2221,8 @@ class SessionDB:
         if keep_roles is not None:
             keep_set = set(keep_roles)
             filtered_window = [
-                m for m in window_rows
+                m
+                for m in window_rows
                 if m.get("id") == around_message_id or m.get("role") in keep_set
             ]
         else:
@@ -2287,7 +2320,7 @@ class SessionDB:
                 return session_id
 
             # Walk descendants: at each step, pick the most-recently-started
-                # child session; stop once we find one with messages.
+            # child session; stop once we find one with messages.
             current = session_id
             seen = {current}
             for _ in range(32):
@@ -2302,7 +2335,9 @@ class SessionDB:
                     return session_id
                 if child_row is None:
                     return session_id
-                child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
+                child_id = (
+                    child_row["id"] if hasattr(child_row, "keys") else child_row[0]
+                )
                 if not child_id or child_id in seen:
                     return session_id
                 seen.add(child_id)
@@ -2362,7 +2397,9 @@ class SessionDB:
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize tool_calls in conversation replay, falling back to []")
+                    logger.warning(
+                        "Failed to deserialize tool_calls in conversation replay, falling back to []"
+                    )
                     msg["tool_calls"] = []
             # Surface the platform-side message id (e.g. yuanbao msg_id,
             # telegram update_id) so platform-specific flows like recall
@@ -2387,21 +2424,33 @@ class SessionDB:
                     try:
                         msg["reasoning_details"] = json.loads(row["reasoning_details"])
                     except (json.JSONDecodeError, TypeError):
-                        logger.warning("Failed to deserialize reasoning_details, falling back to None")
+                        logger.warning(
+                            "Failed to deserialize reasoning_details, falling back to None"
+                        )
                         msg["reasoning_details"] = None
                 if row["codex_reasoning_items"]:
                     try:
-                        msg["codex_reasoning_items"] = json.loads(row["codex_reasoning_items"])
+                        msg["codex_reasoning_items"] = json.loads(
+                            row["codex_reasoning_items"]
+                        )
                     except (json.JSONDecodeError, TypeError):
-                        logger.warning("Failed to deserialize codex_reasoning_items, falling back to None")
+                        logger.warning(
+                            "Failed to deserialize codex_reasoning_items, falling back to None"
+                        )
                         msg["codex_reasoning_items"] = None
                 if row["codex_message_items"]:
                     try:
-                        msg["codex_message_items"] = json.loads(row["codex_message_items"])
+                        msg["codex_message_items"] = json.loads(
+                            row["codex_message_items"]
+                        )
                     except (json.JSONDecodeError, TypeError):
-                        logger.warning("Failed to deserialize codex_message_items, falling back to None")
+                        logger.warning(
+                            "Failed to deserialize codex_message_items, falling back to None"
+                        )
                         msg["codex_message_items"] = None
-            if include_ancestors and self._is_duplicate_replayed_user_message(messages, msg):
+            if include_ancestors and self._is_duplicate_replayed_user_message(
+                messages, msg
+            ):
                 continue
             messages.append(msg)
         return messages
@@ -2429,7 +2478,9 @@ class SessionDB:
         return list(reversed(chain)) or [session_id]
 
     @staticmethod
-    def _is_duplicate_replayed_user_message(messages: List[Dict[str, Any]], msg: Dict[str, Any]) -> bool:
+    def _is_duplicate_replayed_user_message(
+        messages: List[Dict[str, Any]], msg: Dict[str, Any]
+    ) -> bool:
         if msg.get("role") != "user":
             return False
         content = msg.get("content")
@@ -2438,7 +2489,9 @@ class SessionDB:
         for prev in reversed(messages):
             if prev.get("role") == "user" and prev.get("content") == content:
                 return True
-            if prev.get("role") == "assistant" and (prev.get("content") or prev.get("tool_calls")):
+            if prev.get("role") == "assistant" and (
+                prev.get("content") or prev.get("tool_calls")
+            ):
                 return False
         return False
 
@@ -2540,6 +2593,7 @@ class SessionDB:
         Intended for undo-of-rewind and test cleanup; not wired to a
         slash command in v1.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 "SELECT id FROM messages "
@@ -2589,7 +2643,8 @@ class SessionDB:
             if isinstance(decoded, list):
                 # Multimodal — flatten text parts.
                 text_parts = [
-                    p.get("text", "") for p in decoded
+                    p.get("text", "")
+                    for p in decoded
                     if isinstance(p, dict) and p.get("type") == "text"
                 ]
                 preview = " ".join(t for t in text_parts if t).strip()
@@ -2642,7 +2697,7 @@ class SessionDB:
         sanitized = re.sub(r'"[^"]*"', _preserve_quoted, query)
 
         # Step 2: Strip remaining (unmatched) FTS5-special characters
-        sanitized = re.sub(r'[+{}()\"^]', " ", sanitized)
+        sanitized = re.sub(r"[+{}()\"^]", " ", sanitized)
 
         # Step 3: Collapse repeated * (e.g. "***") into a single one,
         # and remove leading * (prefix-only needs at least one char before *)
@@ -2668,29 +2723,32 @@ class SessionDB:
 
         return sanitized.strip()
 
-
     @staticmethod
     def _is_cjk_codepoint(cp: int) -> bool:
-        return (0x4E00 <= cp <= 0x9FFF or    # CJK Unified Ideographs
-                0x3400 <= cp <= 0x4DBF or    # CJK Extension A
-                0x20000 <= cp <= 0x2A6DF or  # CJK Extension B
-                0x3000 <= cp <= 0x303F or    # CJK Symbols
-                0x3040 <= cp <= 0x309F or    # Hiragana
-                0x30A0 <= cp <= 0x30FF or    # Katakana
-                0xAC00 <= cp <= 0xD7AF)      # Hangul Syllables
+        return (
+            0x4E00 <= cp <= 0x9FFF  # CJK Unified Ideographs
+            or 0x3400 <= cp <= 0x4DBF  # CJK Extension A
+            or 0x20000 <= cp <= 0x2A6DF  # CJK Extension B
+            or 0x3000 <= cp <= 0x303F  # CJK Symbols
+            or 0x3040 <= cp <= 0x309F  # Hiragana
+            or 0x30A0 <= cp <= 0x30FF  # Katakana
+            or 0xAC00 <= cp <= 0xD7AF
+        )  # Hangul Syllables
 
     @staticmethod
     def _contains_cjk(text: str) -> bool:
         """Check if text contains CJK (Chinese, Japanese, Korean) characters."""
         for ch in text:
             cp = ord(ch)
-            if (0x4E00 <= cp <= 0x9FFF or    # CJK Unified Ideographs
-                0x3400 <= cp <= 0x4DBF or    # CJK Extension A
-                0x20000 <= cp <= 0x2A6DF or  # CJK Extension B
-                0x3000 <= cp <= 0x303F or    # CJK Symbols
-                0x3040 <= cp <= 0x309F or    # Hiragana
-                0x30A0 <= cp <= 0x30FF or    # Katakana
-                0xAC00 <= cp <= 0xD7AF):     # Hangul Syllables
+            if (
+                0x4E00 <= cp <= 0x9FFF  # CJK Unified Ideographs
+                or 0x3400 <= cp <= 0x4DBF  # CJK Extension A
+                or 0x20000 <= cp <= 0x2A6DF  # CJK Extension B
+                or 0x3000 <= cp <= 0x303F  # CJK Symbols
+                or 0x3040 <= cp <= 0x309F  # Hiragana
+                or 0x30A0 <= cp <= 0x30FF  # Katakana
+                or 0xAC00 <= cp <= 0xD7AF
+            ):  # Hangul Syllables
                 return True
         return False
 
@@ -2826,12 +2884,11 @@ class SessionDB:
             # (>=3) but each individual token is only 2 chars — trigram returns 0.
             # Route to LIKE when any non-operator CJK token is <3 CJK chars.
             _tokens_for_check = [
-                t for t in raw_query.split()
+                t
+                for t in raw_query.split()
                 if t.upper() not in {"AND", "OR", "NOT"} and self._contains_cjk(t)
             ]
-            _any_short_cjk = any(
-                self._count_cjk(t) < 3 for t in _tokens_for_check
-            )
+            _any_short_cjk = any(self._count_cjk(t) < 3 for t in _tokens_for_check)
 
             if cjk_count >= 3 and not _any_short_cjk:
                 # Trigram FTS5 path — quote each non-operator token to handle
@@ -2850,13 +2907,19 @@ class SessionDB:
                 if not include_inactive:
                     tri_where.append("m.active = 1")
                 if source_filter is not None:
-                    tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+                    tri_where.append(
+                        f"s.source IN ({','.join('?' for _ in source_filter)})"
+                    )
                     tri_params.extend(source_filter)
                 if exclude_sources is not None:
-                    tri_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+                    tri_where.append(
+                        f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})"
+                    )
                     tri_params.extend(exclude_sources)
                 if role_filter:
-                    tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+                    tri_where.append(
+                        f"m.role IN ({','.join('?' for _ in role_filter)})"
+                    )
                     tri_params.extend(role_filter)
                 tri_sql = f"""
                     SELECT
@@ -2892,26 +2955,37 @@ class SessionDB:
                 # build one LIKE condition per non-operator token so each term
                 # is matched independently (#20494).
                 non_op_tokens = [
-                    t for t in raw_query.split()
+                    t
+                    for t in raw_query.split()
                     if t.upper() not in {"AND", "OR", "NOT"}
                 ] or [raw_query]
                 token_clauses = []
                 like_params: list = []
                 for tok in non_op_tokens:
-                    esc = tok.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                    esc = (
+                        tok.replace("\\", "\\\\")
+                        .replace("%", "\\%")
+                        .replace("_", "\\_")
+                    )
                     token_clauses.append(
                         "(m.content LIKE ? ESCAPE '\\' OR m.tool_name LIKE ? ESCAPE '\\' OR m.tool_calls LIKE ? ESCAPE '\\')"
                     )
                     like_params += [f"%{esc}%", f"%{esc}%", f"%{esc}%"]
                 like_where = [f"({' OR '.join(token_clauses)})"]
                 if source_filter is not None:
-                    like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+                    like_where.append(
+                        f"s.source IN ({','.join('?' for _ in source_filter)})"
+                    )
                     like_params.extend(source_filter)
                 if exclude_sources is not None:
-                    like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+                    like_where.append(
+                        f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})"
+                    )
                     like_params.extend(exclude_sources)
                 if role_filter:
-                    like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+                    like_where.append(
+                        f"m.role IN ({','.join('?' for _ in role_filter)})"
+                    )
                     like_params.extend(role_filter)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
@@ -2988,7 +3062,8 @@ class SessionDB:
                         # summary for search previews.
                         if isinstance(decoded, list):
                             text_parts = [
-                                p.get("text", "") for p in decoded
+                                p.get("text", "")
+                                for p in decoded
                                 if isinstance(p, dict) and p.get("type") == "text"
                             ]
                             text = " ".join(t for t in text_parts if t).strip()
@@ -3165,14 +3240,14 @@ class SessionDB:
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
+
         def _do(conn):
-            conn.execute(
-                "DELETE FROM messages WHERE session_id = ?", (session_id,)
-            )
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     @staticmethod
@@ -3215,6 +3290,7 @@ class SessionDB:
         files (``.json`` / ``.jsonl`` / ``request_dump_*``) for the deleted
         session. Returns True if the session was found and deleted.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
@@ -3305,12 +3381,14 @@ class SessionDB:
 
     def set_meta(self, key: str, value: str) -> None:
         """Write a value to the state_meta key/value store."""
+
         def _do(conn):
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 (key, value),
             )
+
         self._execute_write(_do)
 
     def apply_telegram_topic_migration(self) -> None:
@@ -3326,6 +3404,7 @@ class SessionDB:
           v2 — session_id FK gets ON DELETE CASCADE so session pruning
                automatically clears bindings.
         """
+
         def _do(conn):
             conn.executescript(
                 """
@@ -3369,7 +3448,9 @@ class SessionDB:
                 "SELECT value FROM state_meta WHERE key = ?",
                 ("telegram_dm_topic_schema_version",),
             ).fetchone()
-            current_version = int(current[0]) if current and str(current[0]).isdigit() else 0
+            current_version = (
+                int(current[0]) if current and str(current[0]).isdigit() else 0
+            )
             if current_version < 2:
                 fk_rows = conn.execute(
                     "PRAGMA foreign_key_list('telegram_dm_topic_bindings')"
@@ -3411,6 +3492,7 @@ class SessionDB:
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 ("telegram_dm_topic_schema_version", "2"),
             )
+
         self._execute_write(_do)
 
     def enable_telegram_topic_mode(
@@ -3460,6 +3542,7 @@ class SessionDB:
                     now,
                 ),
             )
+
         self._execute_write(_do)
 
     def disable_telegram_topic_mode(
@@ -3478,6 +3561,7 @@ class SessionDB:
         Never creates the topic-mode tables from scratch; if they don't
         exist there is nothing to disable and the call is a no-op.
         """
+
         def _do(conn):
             try:
                 conn.execute(
@@ -3493,6 +3577,7 @@ class SessionDB:
             except sqlite3.OperationalError:
                 # Tables don't exist yet — nothing to disable.
                 return
+
         self._execute_write(_do)
 
     def is_telegram_topic_mode_enabled(self, *, chat_id: str, user_id: str) -> bool:
@@ -3611,10 +3696,20 @@ class SessionDB:
                 (session_id,),
             ).fetchone()
             if existing_session is not None:
-                linked_chat = existing_session["chat_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[0]
-                linked_thread = existing_session["thread_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[1]
+                linked_chat = (
+                    existing_session["chat_id"]
+                    if isinstance(existing_session, sqlite3.Row)
+                    else existing_session[0]
+                )
+                linked_thread = (
+                    existing_session["thread_id"]
+                    if isinstance(existing_session, sqlite3.Row)
+                    else existing_session[1]
+                )
                 if str(linked_chat) != chat_id or str(linked_thread) != thread_id:
-                    raise ValueError("session is already linked to another Telegram topic")
+                    raise ValueError(
+                        "session is already linked to another Telegram topic"
+                    )
 
             conn.execute(
                 """
@@ -3640,6 +3735,7 @@ class SessionDB:
                     now,
                 ),
             )
+
         self._execute_write(_do)
 
     def is_telegram_session_linked_to_topic(self, *, session_id: str) -> bool:
@@ -3736,7 +3832,9 @@ class SessionDB:
         for row in rows:
             session = dict(row)
             raw = str(session.pop("_preview_raw", "") or "").strip()
-            session["preview"] = raw[:60] + ("..." if len(raw) > 60 else "") if raw else ""
+            session["preview"] = (
+                raw[:60] + ("..." if len(raw) > 60 else "") if raw else ""
+            )
             sessions.append(session)
         return sessions
 
@@ -3784,14 +3882,10 @@ class SessionDB:
                 try:
                     # The column name in the INSERT must match the table name
                     # for FTS5 special commands.
-                    self._conn.execute(
-                        f"INSERT INTO {tbl}({tbl}) VALUES('optimize')"
-                    )
+                    self._conn.execute(f"INSERT INTO {tbl}({tbl}) VALUES('optimize')")
                     optimized += 1
                 except sqlite3.OperationalError as exc:
-                    logger.warning(
-                        "FTS optimize failed for %s: %s", tbl, exc
-                    )
+                    logger.warning("FTS optimize failed for %s: %s", tbl, exc)
         return optimized
 
     def vacuum(self) -> int:
@@ -3923,6 +4017,7 @@ class SessionDB:
         Returns True if the row was found and not already in flight; False if
         the session is already in a non-terminal handoff state.
         """
+
         def _do(conn):
             cur = conn.execute(
                 "UPDATE sessions "
@@ -3934,6 +4029,7 @@ class SessionDB:
                 (platform, session_id),
             )
             return cur.rowcount > 0
+
         return self._execute_write(_do)
 
     def get_handoff_state(self, session_id: str) -> Optional[Dict[str, Any]]:
@@ -3976,6 +4072,7 @@ class SessionDB:
 
     def claim_handoff(self, session_id: str) -> bool:
         """Atomically transition pending → running. Returns True if claimed."""
+
         def _do(conn):
             cur = conn.execute(
                 "UPDATE sessions SET handoff_state = 'running' "
@@ -3983,24 +4080,29 @@ class SessionDB:
                 (session_id,),
             )
             return cur.rowcount > 0
+
         return self._execute_write(_do)
 
     def complete_handoff(self, session_id: str) -> None:
         """Mark a handoff as completed."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET handoff_state = 'completed', "
                 "handoff_error = NULL WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     def fail_handoff(self, session_id: str, error: str) -> None:
         """Mark a handoff as failed and record the reason."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET handoff_state = 'failed', "
                 "handoff_error = ? WHERE id = ?",
                 (error[:500], session_id),
             )
+
         self._execute_write(_do)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3056,10 +3056,33 @@ class SessionDB:
         min_message_count: int = 0,
         include_archived: bool = False,
         archived_only: bool = False,
+        project_compression_tips: bool = False,
+        include_children: bool = True,
     ) -> int:
-        """Count sessions, optionally filtered by source."""
+        """Count sessions, optionally filtered by source.
+
+        When ``project_compression_tips=True``, applies the same compression
+        projection as :meth:`list_sessions_rich` so the count matches what
+        the sidebar actually renders: roots are replaced by their continuation
+        tips, deduplicating compression chains.
+
+        When ``include_children=False``, applies the same parent_session_id
+        filter as :meth:`list_sessions_rich` so the count excludes subagent
+        runs and non-branch children — matching the rows the list would
+        actually surface. Default ``True`` preserves historical behavior for
+        callers that want the raw row count.
+        """
         where_clauses = []
         params = []
+
+        if not include_children:
+            where_clauses.append(
+                "(parent_session_id IS NULL"
+                " OR EXISTS (SELECT 1 FROM sessions p"
+                "            WHERE p.id = sessions.parent_session_id"
+                "            AND p.end_reason = 'branched'"
+                "            AND sessions.started_at >= p.ended_at))"
+            )
 
         if source:
             where_clauses.append("source = ?")
@@ -3075,8 +3098,35 @@ class SessionDB:
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
         with self._lock:
-            cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions{where_sql}", params)
-            return cursor.fetchone()[0]
+            if not project_compression_tips:
+                cursor = self._conn.execute(
+                    f"SELECT COUNT(*) FROM sessions{where_sql}", params
+                )
+                return cursor.fetchone()[0]
+
+            cursor = self._conn.execute(
+                f"SELECT id, end_reason FROM sessions{where_sql}", params
+            )
+            rows = cursor.fetchall()
+
+        if not rows:
+            return 0
+
+        all_ids = {r["id"] for r in rows}
+        projected: set = set()
+        for r in rows:
+            if r["end_reason"] != "compression":
+                projected.add(r["id"])
+                continue
+            try:
+                tip = self.get_compression_tip(r["id"])
+            except Exception:
+                tip = r["id"]
+            if tip and tip != r["id"] and tip in all_ids:
+                projected.add(tip)
+            else:
+                projected.add(r["id"])
+        return len(projected)
 
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import time
+
 import pytest
 
 from hermes_state import SCHEMA_SQL, SessionDB
@@ -63,6 +64,7 @@ def db(tmp_path):
 # Session lifecycle
 # =========================================================================
 
+
 class TestSessionLifecycle:
     def test_create_and_get_session(self, db):
         sid = db.create_session(
@@ -77,7 +79,6 @@ class TestSessionLifecycle:
         assert session["source"] == "cli"
         assert session["model"] == "test-model"
         assert session["ended_at"] is None
-
 
     def test_get_nonexistent_session(self, db):
         assert db.get_session("nonexistent") is None
@@ -140,9 +141,15 @@ class TestSessionLifecycle:
     def test_update_token_counts_tracks_api_call_count(self, db):
         """api_call_count increments with each update_token_counts call."""
         db.create_session(session_id="s1", source="cli")
-        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
-        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
-        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1
+        )
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1
+        )
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1
+        )
 
         session = db.get_session("s1")
         assert session["api_call_count"] == 3
@@ -150,9 +157,12 @@ class TestSessionLifecycle:
     def test_update_token_counts_api_call_count_absolute(self, db):
         """absolute mode sets api_call_count directly."""
         db.create_session(session_id="s1", source="cli")
-        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=1)
-        db.update_token_counts("s1", input_tokens=300, output_tokens=150,
-                               api_call_count=5, absolute=True)
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1
+        )
+        db.update_token_counts(
+            "s1", input_tokens=300, output_tokens=150, api_call_count=5, absolute=True
+        )
 
         session = db.get_session("s1")
         assert session["api_call_count"] == 5
@@ -160,14 +170,20 @@ class TestSessionLifecycle:
 
     def test_update_token_counts_backfills_model_when_null(self, db):
         db.create_session(session_id="s1", source="telegram")
-        db.update_token_counts("s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4")
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4"
+        )
 
         session = db.get_session("s1")
         assert session["model"] == "openai/gpt-5.4"
 
     def test_update_token_counts_preserves_existing_model(self, db):
-        db.create_session(session_id="s1", source="cli", model="anthropic/claude-opus-4.6")
-        db.update_token_counts("s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4")
+        db.create_session(
+            session_id="s1", source="cli", model="anthropic/claude-opus-4.6"
+        )
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4"
+        )
 
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
@@ -179,11 +195,13 @@ class TestSessionLifecycle:
         the dashboard kept showing the original model after a switch (#34850).
         update_session_model sets the column unconditionally.
         """
-        db.create_session(session_id="s1", source="telegram",
-                          model="xiaomi/mimo-v2.5-pro")
+        db.create_session(
+            session_id="s1", source="telegram", model="xiaomi/mimo-v2.5-pro"
+        )
         # Token updates never change the model once set.
-        db.update_token_counts("s1", input_tokens=10, output_tokens=5,
-                               model="xiaomi/mimo-v2.5-pro")
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="xiaomi/mimo-v2.5-pro"
+        )
         assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5-pro"
 
         # Explicit switch overwrites it.
@@ -192,8 +210,9 @@ class TestSessionLifecycle:
 
         # And a subsequent token update does NOT revert it (COALESCE no-ops
         # because the column is now non-NULL).
-        db.update_token_counts("s1", input_tokens=10, output_tokens=5,
-                               model="xiaomi/mimo-v2.5-pro")
+        db.update_token_counts(
+            "s1", input_tokens=10, output_tokens=5, model="xiaomi/mimo-v2.5-pro"
+        )
         assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5"
 
     def test_parent_session(self, db):
@@ -221,7 +240,9 @@ class TestSessionLifecycle:
             assert db._fts_table_exists("messages_fts_trigram") is False
 
             db.create_session(session_id="s1", source="cli")
-            db.append_message("s1", role="user", content="hello from sqlite without fts")
+            db.append_message(
+                "s1", role="user", content="hello from sqlite without fts"
+            )
 
             messages = db.get_messages("s1")
             assert len(messages) == 1
@@ -230,9 +251,7 @@ class TestSessionLifecycle:
         finally:
             db.close()
 
-    def test_existing_fts_tables_do_not_break_without_fts5(
-        self, tmp_path, monkeypatch
-    ):
+    def test_existing_fts_tables_do_not_break_without_fts5(self, tmp_path, monkeypatch):
         db_path = tmp_path / "state.db"
         seeded = SessionDB(db_path=db_path)
         try:
@@ -335,6 +354,7 @@ class TestSessionLifecycle:
 # Message storage
 # =========================================================================
 
+
 class TestMessageStorage:
     def test_append_and_get_messages(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -405,8 +425,14 @@ class TestMessageStorage:
 
         # Assistant makes 2 parallel tool calls in one message
         tool_calls = [
-            {"id": "call_1", "function": {"name": "ha_call_service", "arguments": "{}"}},
-            {"id": "call_2", "function": {"name": "ha_call_service", "arguments": "{}"}},
+            {
+                "id": "call_1",
+                "function": {"name": "ha_call_service", "arguments": "{}"},
+            },
+            {
+                "id": "call_2",
+                "function": {"name": "ha_call_service", "arguments": "{}"},
+            },
         ]
         db.append_message("s1", role="assistant", content="", tool_calls=tool_calls)
 
@@ -423,7 +449,9 @@ class TestMessageStorage:
 
     def test_tool_calls_serialization(self, db):
         db.create_session(session_id="s1", source="cli")
-        tool_calls = [{"id": "call_1", "function": {"name": "web_search", "arguments": "{}"}}]
+        tool_calls = [
+            {"id": "call_1", "function": {"name": "web_search", "arguments": "{}"}}
+        ]
         db.append_message("s1", role="assistant", tool_calls=tool_calls)
 
         messages = db.get_messages("s1")
@@ -487,6 +515,7 @@ class TestMessageStorage:
         """`replace_messages` (used by /retry, /undo, /compress) must write
         tool_name to the DB for messages built by make_tool_result_message."""
         from agent.tool_dispatch_helpers import make_tool_result_message
+
         db.create_session(session_id="s1", source="cli")
         db.replace_messages(
             "s1",
@@ -585,7 +614,9 @@ class TestMessageStorage:
             "second answer",
         ]
 
-    def test_get_messages_as_conversation_avoids_repeated_resume_prompts_from_ancestors(self, db):
+    def test_get_messages_as_conversation_avoids_repeated_resume_prompts_from_ancestors(
+        self, db
+    ):
         db.create_session("root", "tui")
         db.append_message("root", role="user", content="same prompt")
         db.append_message("root", role="user", content="same prompt")
@@ -595,7 +626,10 @@ class TestMessageStorage:
 
         conv = db.get_messages_as_conversation("child", include_ancestors=True)
 
-        assert [m["content"] for m in conv if m["role"] == "user"] == ["same prompt", "next prompt"]
+        assert [m["content"] for m in conv if m["role"] == "user"] == [
+            "same prompt",
+            "next prompt",
+        ]
 
     def test_finish_reason_stored(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -632,17 +666,28 @@ class TestMessageStorage:
             "s1",
             role="assistant",
             content=None,
-            tool_calls=[{"function": {"name": "cronjob", "arguments": "{}"}, "id": "c1", "type": "function"}],
+            tool_calls=[
+                {
+                    "function": {"name": "cronjob", "arguments": "{}"},
+                    "id": "c1",
+                    "type": "function",
+                }
+            ],
             reasoning="I should call the cronjob tool to schedule this.",
         )
-        db.append_message("s1", role="tool", content='{"job_id": "abc"}', tool_call_id="c1")
+        db.append_message(
+            "s1", role="tool", content='{"job_id": "abc"}', tool_call_id="c1"
+        )
 
         conv = db.get_messages_as_conversation("s1")
         assert len(conv) == 3
         # reasoning must be present on the assistant message
         assistant = conv[1]
         assert assistant["role"] == "assistant"
-        assert assistant.get("reasoning") == "I should call the cronjob tool to schedule this."
+        assert (
+            assistant.get("reasoning")
+            == "I should call the cronjob tool to schedule this."
+        )
         # user and tool messages must NOT carry reasoning
         assert "reasoning" not in conv[0]
         assert "reasoning" not in conv[2]
@@ -713,7 +758,13 @@ class TestMessageStorage:
             "s1",
             role="assistant",
             content="",
-            tool_calls=[{"id": "c1", "type": "function", "function": {"name": "date", "arguments": "{}"}}],
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "date", "arguments": "{}"},
+                }
+            ],
             reasoning_content="",
         )
 
@@ -743,7 +794,9 @@ class TestMessageStorage:
                 "content": [{"type": "output_text", "text": "Done!"}],
             },
         ]
-        db.append_message("s1", role="assistant", content="Done!", codex_message_items=items)
+        db.append_message(
+            "s1", role="assistant", content="Done!", codex_message_items=items
+        )
 
         conv = db.get_messages_as_conversation("s1")
         assert len(conv) == 1
@@ -785,12 +838,15 @@ class TestMessageStorage:
         conv = db.get_messages_as_conversation("s1")
         assert len(conv) == 1
         assert conv[0]["codex_reasoning_items"] == codex_items
-        assert conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
+        assert (
+            conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
+        )
 
 
 # =========================================================================
 # FTS5 search
 # =========================================================================
+
 
 class TestFTS5Search:
     def test_search_finds_content(self, db):
@@ -833,11 +889,20 @@ class TestFTS5Search:
         for src in ("cli", "telegram", "signal", "homeassistant", "acp", "matrix"):
             sid = f"s-{src}"
             db.create_session(session_id=sid, source=src)
-            db.append_message(sid, role="user", content=f"universal search test from {src}")
+            db.append_message(
+                sid, role="user", content=f"universal search test from {src}"
+            )
 
         results = db.search_messages("universal search test")
         found_sources = {r["source"] for r in results}
-        assert found_sources == {"cli", "telegram", "signal", "homeassistant", "acp", "matrix"}
+        assert found_sources == {
+            "cli",
+            "telegram",
+            "signal",
+            "homeassistant",
+            "acp",
+            "matrix",
+        }
 
     def test_search_with_role_filter(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -851,7 +916,9 @@ class TestFTS5Search:
     def test_search_returns_context(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="Tell me about Kubernetes")
-        db.append_message("s1", role="assistant", content="Kubernetes is an orchestrator.")
+        db.append_message(
+            "s1", role="assistant", content="Kubernetes is an orchestrator."
+        )
 
         results = db.search_messages("Kubernetes")
         assert len(results) == 2
@@ -866,11 +933,17 @@ class TestFTS5Search:
         db.append_message("s1", role="user", content="before needle")
         db.append_message("s2", role="user", content="other session message")
         db.append_message("s1", role="assistant", content="needle match")
-        db.append_message("s2", role="assistant", content="another other session message")
+        db.append_message(
+            "s2", role="assistant", content="another other session message"
+        )
         db.append_message("s1", role="user", content="after needle")
 
         results = db.search_messages('"needle match"')
-        needle_result = next(r for r in results if r["session_id"] == "s1" and "needle match" in r["snippet"])
+        needle_result = next(
+            r
+            for r in results
+            if r["session_id"] == "s1" and "needle match" in r["snippet"]
+        )
 
         assert [msg["content"] for msg in needle_result["context"]] == [
             "before needle",
@@ -885,14 +958,14 @@ class TestFTS5Search:
 
         # Each of these previously caused sqlite3.OperationalError
         dangerous_queries = [
-            'C++',              # + is FTS5 column filter
-            '"unterminated',    # unbalanced double-quote
-            '(problem',         # unbalanced parenthesis
-            'hello AND',        # dangling boolean operator
-            '***',              # repeated wildcard
-            '{test}',           # curly braces (column reference)
-            'OR hello',         # leading boolean operator
-            'a AND OR b',       # adjacent operators
+            "C++",  # + is FTS5 column filter
+            '"unterminated',  # unbalanced double-quote
+            "(problem",  # unbalanced parenthesis
+            "hello AND",  # dangling boolean operator
+            "***",  # repeated wildcard
+            "{test}",  # curly braces (column reference)
+            "OR hello",  # leading boolean operator
+            "a AND OR b",  # adjacent operators
         ]
         for query in dangerous_queries:
             # Must not raise — should return list (possibly empty)
@@ -917,14 +990,20 @@ class TestFTS5Search:
         results = db.search_messages("chat-send")
         assert isinstance(results, list)
         assert len(results) >= 1
-        assert any("chat-send" in (r.get("snippet") or r.get("content", "")).lower()
-                    for r in results)
+        assert any(
+            "chat-send" in (r.get("snippet") or r.get("content", "")).lower()
+            for r in results
+        )
 
     def test_search_dotted_term_does_not_crash(self, db):
         """Dotted terms like 'P2.2' or 'simulate.p2.test.ts' should not crash FTS5."""
         db.create_session(session_id="s1", source="cli")
-        db.append_message("s1", role="user", content="Working on P2.2 session_search edge cases")
-        db.append_message("s1", role="assistant", content="See simulate.p2.test.ts for details")
+        db.append_message(
+            "s1", role="user", content="Working on P2.2 session_search edge cases"
+        )
+        db.append_message(
+            "s1", role="assistant", content="See simulate.p2.test.ts for details"
+        )
 
         results = db.search_messages("P2.2")
         assert isinstance(results, list)
@@ -950,23 +1029,25 @@ class TestFTS5Search:
     def test_sanitize_fts5_query_strips_dangerous_chars(self):
         """Unit test for _sanitize_fts5_query static method."""
         from hermes_state import SessionDB
+
         s = SessionDB._sanitize_fts5_query
-        assert s('hello world') == 'hello world'
-        assert '+' not in s('C++')
+        assert s("hello world") == "hello world"
+        assert "+" not in s("C++")
         assert '"' not in s('"unterminated')
-        assert '(' not in s('(problem')
-        assert '{' not in s('{test}')
+        assert "(" not in s("(problem")
+        assert "{" not in s("{test}")
         # Dangling operators removed
-        assert s('hello AND') == 'hello'
-        assert s('OR world') == 'world'
+        assert s("hello AND") == "hello"
+        assert s("OR world") == "world"
         # Leading bare * removed
-        assert s('***') == ''
+        assert s("***") == ""
         # Valid prefix kept
-        assert s('deploy*') == 'deploy*'
+        assert s("deploy*") == "deploy*"
 
     def test_sanitize_fts5_preserves_quoted_phrases(self):
         """Properly paired double-quoted phrases should be preserved."""
         from hermes_state import SessionDB
+
         s = SessionDB._sanitize_fts5_query
         # Simple quoted phrase
         assert s('"exact phrase"') == '"exact phrase"'
@@ -982,18 +1063,19 @@ class TestFTS5Search:
     def test_sanitize_fts5_quotes_hyphenated_terms(self):
         """Hyphenated terms should be wrapped in quotes for exact matching."""
         from hermes_state import SessionDB
+
         s = SessionDB._sanitize_fts5_query
         # Simple hyphenated term
-        assert s('chat-send') == '"chat-send"'
+        assert s("chat-send") == '"chat-send"'
         # Multiple hyphens
-        assert s('docker-compose-up') == '"docker-compose-up"'
+        assert s("docker-compose-up") == '"docker-compose-up"'
         # Hyphenated term with other words
-        result = s('fix chat-send bug')
+        result = s("fix chat-send bug")
         assert '"chat-send"' in result
-        assert 'fix' in result
-        assert 'bug' in result
+        assert "fix" in result
+        assert "bug" in result
         # Multiple hyphenated terms with OR
-        result = s('chat-send OR deploy-prod')
+        result = s("chat-send OR deploy-prod")
         assert '"chat-send"' in result
         assert '"deploy-prod"' in result
         # Already-quoted hyphenated term — no double quoting
@@ -1004,23 +1086,24 @@ class TestFTS5Search:
     def test_sanitize_fts5_quotes_dotted_terms(self):
         """Dotted terms should be wrapped in quotes to avoid FTS5 query parse edge cases."""
         from hermes_state import SessionDB
+
         s = SessionDB._sanitize_fts5_query
 
-        assert s('P2.2') == '"P2.2"'
-        assert s('simulate.p2') == '"simulate.p2"'
-        assert s('simulate.p2.test.ts') == '"simulate.p2.test.ts"'
+        assert s("P2.2") == '"P2.2"'
+        assert s("simulate.p2") == '"simulate.p2"'
+        assert s("simulate.p2.test.ts") == '"simulate.p2.test.ts"'
 
         # Already quoted — no double quoting
         assert s('"P2.2"') == '"P2.2"'
 
         # Works with boolean syntax
-        result = s('P2.2 OR simulate.p2')
+        result = s("P2.2 OR simulate.p2")
         assert '"P2.2"' in result
         assert '"simulate.p2"' in result
 
         # Mixed dots and hyphens — single pass avoids double-quoting
-        assert s('my-app.config') == '"my-app.config"'
-        assert s('my-app.config.ts') == '"my-app.config.ts"'
+        assert s("my-app.config") == '"my-app.config"'
+        assert s("my-app.config.ts") == '"my-app.config.ts"'
 
     def test_sanitize_fts5_quotes_underscored_terms(self):
         """Underscored terms should be wrapped in quotes for exact matching.
@@ -1030,26 +1113,28 @@ class TestFTS5Search:
         ('sp AND new') that fails to match rows indexed as 'sp_new1'.
         """
         from hermes_state import SessionDB
+
         s = SessionDB._sanitize_fts5_query
         # Simple underscored term
-        assert s('sp_new') == '"sp_new"'
+        assert s("sp_new") == '"sp_new"'
         # Multiple underscores
-        assert s('a_b_c') == '"a_b_c"'
+        assert s("a_b_c") == '"a_b_c"'
         # Mixed underscores and hyphens/dots — single pass avoids double-quoting
-        assert s('sp_new1') == '"sp_new1"'
-        assert s('docker-compose_up') == '"docker-compose_up"'
-        assert s('my.app_config.ts') == '"my.app_config.ts"'
+        assert s("sp_new1") == '"sp_new1"'
+        assert s("docker-compose_up") == '"docker-compose_up"'
+        assert s("my.app_config.ts") == '"my.app_config.ts"'
         # Already-quoted — no double quoting
         assert s('"sp_new"') == '"sp_new"'
         # Mixed with other words
-        result = s('sp_new and 血管瘤')
+        result = s("sp_new and 血管瘤")
         assert '"sp_new"' in result
-        assert '血管瘤' in result
+        assert "血管瘤" in result
 
 
 # =========================================================================
 # CJK (Chinese/Japanese/Korean) LIKE fallback
 # =========================================================================
+
 
 class TestCJKSearchFallback:
     """Regression tests for CJK search (see #11511).
@@ -1063,6 +1148,7 @@ class TestCJKSearchFallback:
 
     def test_cjk_detection_covers_all_ranges(self):
         from hermes_state import SessionDB
+
         f = SessionDB._contains_cjk
         # Chinese (CJK Unified Ideographs)
         assert f("记忆断裂") is True
@@ -1082,7 +1168,8 @@ class TestCJKSearchFallback:
         """The headline bug: multi-char Chinese query must not return []."""
         db.create_session(session_id="s1", source="cli")
         db.append_message(
-            "s1", role="user",
+            "s1",
+            role="user",
             content="昨天和其他Agent的聊天记录，记忆断裂问题复现了",
         )
         results = db.search_messages("记忆断裂")
@@ -1146,7 +1233,8 @@ class TestCJKSearchFallback:
         long_prefix = "这是一段很长的前缀用来把匹配位置推到文档中间" * 3
         long_suffix = "这是一段很长的后缀内容填充剩余空间" * 3
         db.append_message(
-            "s1", role="user",
+            "s1",
+            role="user",
             content=f"{long_prefix}记忆断裂{long_suffix}",
         )
         results = db.search_messages("记忆断裂")
@@ -1264,6 +1352,7 @@ class TestCJKSearchFallback:
 # Session search and listing
 # =========================================================================
 
+
 class TestSearchSessions:
     def test_list_all_sessions(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -1295,6 +1384,7 @@ class TestSearchSessions:
 # Counts
 # =========================================================================
 
+
 class TestCounts:
     def test_session_count(self, db):
         assert db.session_count() == 0
@@ -1317,6 +1407,7 @@ class TestCounts:
         includes compression roots that get projected away by the list.
         """
         import time as _time
+
         t0 = _time.time() - 3600
 
         db.create_session("root1", "cli")
@@ -1348,6 +1439,7 @@ class TestCounts:
         that, not underflow.
         """
         import time as _time
+
         t0 = _time.time() - 3600
         db.create_session("root1", "cli")
         db.append_message("root1", "user", "first")
@@ -1407,6 +1499,7 @@ class TestCounts:
 # Delete and export
 # =========================================================================
 
+
 class TestDeleteAndExport:
     def test_delete_session(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -1421,7 +1514,9 @@ class TestDeleteAndExport:
 
     def test_resolve_session_id_exact(self, db):
         db.create_session(session_id="20260315_092437_c9a6ff", source="cli")
-        assert db.resolve_session_id("20260315_092437_c9a6ff") == "20260315_092437_c9a6ff"
+        assert (
+            db.resolve_session_id("20260315_092437_c9a6ff") == "20260315_092437_c9a6ff"
+        )
 
     def test_resolve_session_id_unique_prefix(self, db):
         db.create_session(session_id="20260315_092437_c9a6ff", source="cli")
@@ -1470,6 +1565,7 @@ class TestDeleteAndExport:
 # =========================================================================
 # Prune
 # =========================================================================
+
 
 class TestPruneSessions:
     def test_prune_old_ended_sessions(self, db):
@@ -1537,7 +1633,12 @@ class TestPruneSessions:
         db.end_session("D", end_reason="done")
 
         # Backdate A and B to be old; C and D stay recent
-        for sid, ts in [("A", old_ts), ("B", old_ts), ("C", recent_ts), ("D", recent_ts)]:
+        for sid, ts in [
+            ("A", old_ts),
+            ("B", old_ts),
+            ("C", recent_ts),
+            ("D", recent_ts),
+        ]:
             db._conn.execute(
                 "UPDATE sessions SET started_at = ? WHERE id = ?", (ts, sid)
             )
@@ -1584,7 +1685,9 @@ class TestDeleteSessionOrphansChildren:
         """Deleting a parent session orphans its children."""
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")
-        db.create_session(session_id="grandchild", source="cli", parent_session_id="child")
+        db.create_session(
+            session_id="grandchild", source="cli", parent_session_id="child"
+        )
 
         # Should not raise IntegrityError
         result = db.delete_session("parent")
@@ -1607,6 +1710,7 @@ class TestDeleteSessionOrphansChildren:
 # =========================================================================
 # Session title
 # =========================================================================
+
 
 class TestSessionTitle:
     def test_set_and_get_title(self, db):
@@ -1792,6 +1896,7 @@ class TestSchemaInit:
 
     def test_schema_version(self, db):
         from hermes_state import SCHEMA_VERSION
+
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
         assert version == SCHEMA_VERSION
@@ -1873,7 +1978,9 @@ class TestSchemaInit:
         assert {"chat_id", "chat_type", "thread_id", "session_key"}.isdisjoint(columns)
         db.close()
 
-    def test_apply_telegram_topic_migration_creates_topic_tables_explicitly(self, tmp_path):
+    def test_apply_telegram_topic_migration_creates_topic_tables_explicitly(
+        self, tmp_path
+    ):
         """The /topic opt-in path owns the DB migration for Telegram topic mode."""
         old_db = tmp_path / "old.db"
         import sqlite3
@@ -1956,7 +2063,10 @@ class TestSchemaInit:
             user_id="208214988",
         )
 
-        assert db.get_telegram_topic_binding(chat_id="208214988", thread_id="17585") is None
+        assert (
+            db.get_telegram_topic_binding(chat_id="208214988", thread_id="17585")
+            is None
+        )
 
         db.bind_telegram_topic(
             chat_id="208214988",
@@ -1976,7 +2086,9 @@ class TestSchemaInit:
         assert db.get_meta("telegram_dm_topic_schema_version") == "2"
         db.close()
 
-    def test_telegram_topic_binding_refuses_to_relink_session_to_another_topic(self, tmp_path):
+    def test_telegram_topic_binding_refuses_to_relink_session_to_another_topic(
+        self, tmp_path
+    ):
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session(
             session_id="topic-session",
@@ -2001,7 +2113,9 @@ class TestSchemaInit:
             )
         db.close()
 
-    def test_list_unlinked_telegram_sessions_for_user_excludes_bound_and_other_users(self, tmp_path):
+    def test_list_unlinked_telegram_sessions_for_user_excludes_bound_and_other_users(
+        self, tmp_path
+    ):
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session(
             session_id="old-unlinked",
@@ -2045,7 +2159,8 @@ class TestSchemaInit:
         db_path = tmp_path / "migrate_test.db"
         conn = sqlite3.connect(str(db_path))
         # Create v2 schema (without title column)
-        conn.executescript("""
+        conn.executescript(
+            """
             CREATE TABLE schema_version (version INTEGER NOT NULL);
             INSERT INTO schema_version (version) VALUES (2);
 
@@ -2078,7 +2193,8 @@ class TestSchemaInit:
                 token_count INTEGER,
                 finish_reason TEXT
             );
-        """)
+        """
+        )
         conn.execute(
             "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
             ("existing", "cli", 1000.0),
@@ -2091,6 +2207,7 @@ class TestSchemaInit:
 
         # Verify migration
         from hermes_state import SCHEMA_VERSION
+
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
         assert cursor.fetchone()[0] == SCHEMA_VERSION
 
@@ -2127,7 +2244,8 @@ class TestSchemaInit:
         db_path = tmp_path / "gap_test.db"
         conn = sqlite3.connect(str(db_path))
         # Simulate the old v7 state: api_call_count exists, reasoning_content does NOT
-        conn.executescript("""
+        conn.executescript(
+            """
             CREATE TABLE schema_version (version INTEGER NOT NULL);
             INSERT INTO schema_version (version) VALUES (7);
 
@@ -2176,7 +2294,8 @@ class TestSchemaInit:
                 reasoning_details TEXT,
                 codex_reasoning_items TEXT
             );
-        """)
+        """
+        )
         conn.execute(
             "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
             ("s1", "cli", 1000.0),
@@ -2219,11 +2338,15 @@ class TestSchemaInit:
         """Opening the same database twice doesn't error or duplicate columns."""
         db_path = tmp_path / "idempotent.db"
         db1 = SessionDB(db_path=db_path)
-        cols1 = {r[1] for r in db1._conn.execute("PRAGMA table_info(messages)").fetchall()}
+        cols1 = {
+            r[1] for r in db1._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
         db1.close()
 
         db2 = SessionDB(db_path=db_path)
-        cols2 = {r[1] for r in db2._conn.execute("PRAGMA table_info(messages)").fetchall()}
+        cols2 = {
+            r[1] for r in db2._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
         db2.close()
 
         assert cols1 == cols2
@@ -2308,6 +2431,7 @@ class TestTitleLineage:
     def test_resolve_returns_latest_numbered(self, db):
         """When numbered variants exist, return the most recent one."""
         import time
+
         db.create_session("s1", "cli")
         db.set_session_title("s1", "my project")
         time.sleep(0.01)
@@ -2420,6 +2544,7 @@ class TestListSessionsRich:
 
     def test_last_active_from_latest_message(self, db):
         import time
+
         db.create_session("s1", "cli")
         db.append_message("s1", "user", "Hello")
         time.sleep(0.01)
@@ -2434,14 +2559,18 @@ class TestListSessionsRich:
         # No messages, so last_active falls back to started_at
         assert sessions[0]["last_active"] == sessions[0]["started_at"]
 
-    def test_order_by_last_active_surfaces_recently_touched_older_session_first(self, db):
+    def test_order_by_last_active_surfaces_recently_touched_older_session_first(
+        self, db
+    ):
         t0 = 1709500000.0
         db.create_session("old", "cli")
         db.create_session("new", "cli")
 
         with db._lock:
             db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "old"))
-            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 10, "new"))
+            db._conn.execute(
+                "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 10, "new")
+            )
 
         db.append_message("old", "user", "old first")
         db.append_message("new", "user", "new first")
@@ -2479,7 +2608,9 @@ class TestListSessionsRich:
         t0 = 1709500000.0
         db.create_session("root1", "cli")
         with db._lock:
-            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root1"))
+            db._conn.execute(
+                "UPDATE sessions SET started_at=? WHERE id=?", (t0, "root1")
+            )
             db._conn.execute(
                 "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
                 (t0 + 100, "compression", "root1"),
@@ -2489,7 +2620,9 @@ class TestListSessionsRich:
         # Continuation tip created after root ended; last activity much later.
         db.create_session("tip1", "cli", parent_session_id="root1")
         with db._lock:
-            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "tip1"))
+            db._conn.execute(
+                "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "tip1")
+            )
         db.append_message("tip1", "user", "latest message")
 
         # Bunch of newer, uncompressed sessions — fresher start_at but older
@@ -2563,12 +2696,15 @@ class TestListSessionsRich:
 
         sessions = db.list_sessions_rich()
         ids = [s["id"] for s in sessions]
-        assert "delegate" not in ids, "Delegate sub-agent should not appear in default list"
+        assert (
+            "delegate" not in ids
+        ), "Delegate sub-agent should not appear in default list"
         assert "root" in ids
 
     def test_compression_child_still_hidden(self, db):
         """Compression continuation sessions remain hidden (parent ended with 'compression')."""
         import time as _time
+
         t0 = _time.time()
         db.create_session("root", "cli")
         db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root"))
@@ -2646,6 +2782,7 @@ class TestCompressionChainProjection:
 
     def test_get_compression_tip_walks_full_chain(self, db):
         import time as _time
+
         self._build_compression_chain(db, _time.time() - 3600)
         assert db.get_compression_tip("root1") == "tip1"
         assert db.get_compression_tip("mid1") == "tip1"
@@ -2661,6 +2798,7 @@ class TestCompressionChainProjection:
         continuations — the started_at >= ended_at guard handles this.
         """
         import time as _time
+
         self._build_compression_chain(db, _time.time() - 3600)
         # delegate1 is a child of root1 but NOT a compression continuation.
         # root1's tip must be tip1 (via mid1), not delegate1.
@@ -2671,6 +2809,7 @@ class TestCompressionChainProjection:
         the root row, so users can see and resume the live conversation.
         """
         import time as _time
+
         self._build_compression_chain(db, _time.time() - 3600)
         # Add an uncompressed root for comparison.
         db.create_session("solo", "cli")
@@ -2718,6 +2857,7 @@ class TestCompressionChainProjection:
         rows — useful for admin/debug UIs.
         """
         import time as _time
+
         self._build_compression_chain(db, _time.time() - 3600)
         sessions = db.list_sessions_rich(
             source="cli", limit=20, project_compression_tips=False
@@ -2736,6 +2876,7 @@ class TestCompressionChainProjection:
         even as new compressions push the tip forward in time.
         """
         import time as _time
+
         t0 = _time.time() - 3600
         self._build_compression_chain(db, t0)
 
@@ -2743,7 +2884,9 @@ class TestCompressionChainProjection:
         # if we used tip.started_at, but below if we correctly use root.started_at.
         t_between = t0 + 120  # between root1 and its compression
         db.create_session("newer", "cli")
-        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t_between, "newer"))
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t_between, "newer")
+        )
         db.append_message("newer", "user", "newer session started after root1")
         db._conn.commit()
 
@@ -2759,6 +2902,7 @@ class TestCompressionChainProjection:
         crash the list — it should fall back to surfacing the root as-is.
         """
         import time as _time
+
         t0 = _time.time() - 100
         db.create_session("orphan", "cli")
         db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "orphan"))
@@ -2780,6 +2924,7 @@ class TestCompressionChainProjection:
 # =========================================================================
 # Session source exclusion (--source flag for third-party isolation)
 # =========================================================================
+
 
 class TestExcludeSources:
     """Tests for exclude_sources on list_sessions_rich and search_messages."""
@@ -2880,6 +3025,7 @@ class TestResolveSessionByNameOrId:
 # Concurrent write safety / lock contention fixes (#3139)
 # =========================================================================
 
+
 class TestConcurrentWriteSafety:
     def test_create_session_insert_or_ignore_is_idempotent(self, db):
         """create_session with the same ID twice must not raise (INSERT OR IGNORE)."""
@@ -2931,16 +3077,19 @@ class TestConcurrentWriteSafety:
         # Access the underlying connection timeout via sqlite3 introspection.
         # There is no public API, so we check the kwarg via the module default.
         import inspect
+
         from hermes_state import SessionDB as _SessionDB
+
         src = inspect.getsource(_SessionDB.__init__)
-        assert "30" in src, (
-            "SQLite timeout should be at least 30s to handle CLI/gateway lock contention"
-        )
+        assert (
+            "30" in src
+        ), "SQLite timeout should be at least 30s to handle CLI/gateway lock contention"
 
 
 # =========================================================================
 # Auto-maintenance: state_meta + vacuum + maybe_auto_prune_and_vacuum
 # =========================================================================
+
 
 class TestStateMeta:
     def test_get_meta_missing_returns_none(self, db):
@@ -3051,9 +3200,7 @@ class TestAutoMaintenance:
 
     def test_second_call_within_interval_skips(self, db):
         self._make_old_ended(db, "old", days_old=100)
-        first = db.maybe_auto_prune_and_vacuum(
-            retention_days=90, min_interval_hours=24
-        )
+        first = db.maybe_auto_prune_and_vacuum(retention_days=90, min_interval_hours=24)
         assert first["skipped"] is False
         assert first["pruned"] == 1
 
@@ -3175,6 +3322,7 @@ class TestAutoMaintenance:
 # FTS5 indexing of tool_calls / tool_name (#16751)
 # =========================================================================
 
+
 class TestFTS5ToolCallIndexing:
     """Regression tests: search_messages must see tool_name and tool_calls.
 
@@ -3186,7 +3334,9 @@ class TestFTS5ToolCallIndexing:
     def test_tool_name_is_searchable(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message(
-            "s1", role="assistant", content="",
+            "s1",
+            role="assistant",
+            content="",
             tool_name="UNIQUETOOLNAME",
         )
         results = db.search_messages("UNIQUETOOLNAME")
@@ -3195,15 +3345,19 @@ class TestFTS5ToolCallIndexing:
     def test_tool_calls_args_are_searchable(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message(
-            "s1", role="assistant", content="",
-            tool_calls=[{
-                "id": "c1",
-                "type": "function",
-                "function": {
-                    "name": "web_search",
-                    "arguments": '{"query": "UNIQUESEARCHTOKEN"}',
-                },
-            }],
+            "s1",
+            role="assistant",
+            content="",
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "UNIQUESEARCHTOKEN"}',
+                    },
+                }
+            ],
         )
         results = db.search_messages("UNIQUESEARCHTOKEN")
         assert len(results) == 1
@@ -3211,12 +3365,16 @@ class TestFTS5ToolCallIndexing:
     def test_tool_function_name_in_tool_calls_is_searchable(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message(
-            "s1", role="assistant", content="",
-            tool_calls=[{
-                "id": "c1",
-                "type": "function",
-                "function": {"name": "UNIQUEFUNCNAME", "arguments": "{}"},
-            }],
+            "s1",
+            role="assistant",
+            content="",
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "UNIQUEFUNCNAME", "arguments": "{}"},
+                }
+            ],
         )
         results = db.search_messages("UNIQUEFUNCNAME")
         assert len(results) == 1
@@ -3231,18 +3389,24 @@ class TestFTS5ToolCallIndexing:
         """
         db.create_session(session_id="s1", source="cli")
         db.append_message(
-            "s1", role="assistant", content="hello",
+            "s1",
+            role="assistant",
+            content="hello",
             tool_name="web_search",
-            tool_calls=[{
-                "id": "c1",
-                "type": "function",
-                "function": {"name": "web_search", "arguments": '{"q": "x"}'},
-            }],
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": '{"q": "x"}'},
+                }
+            ],
         )
+
         # end_session + end-time prune path would exercise DELETE; hit the
         # row directly through the write helper to keep the regression focused.
         def _delete(conn):
             conn.execute("DELETE FROM messages WHERE session_id = ?", ("s1",))
+
         db._execute_write(_delete)  # must not raise
 
         assert db.search_messages("hello") == []
@@ -3252,7 +3416,9 @@ class TestFTS5ToolCallIndexing:
         """UPDATE must refresh the FTS row so old tokens drop out and new tokens appear."""
         db.create_session(session_id="s1", source="cli")
         db.append_message(
-            "s1", role="assistant", content="",
+            "s1",
+            role="assistant",
+            content="",
             tool_name="ORIGINALTOOL",
         )
         assert len(db.search_messages("ORIGINALTOOL")) == 1
@@ -3262,6 +3428,7 @@ class TestFTS5ToolCallIndexing:
                 "UPDATE messages SET tool_name = ? WHERE session_id = ?",
                 ("RENAMEDTOOL", "s1"),
             )
+
         db._execute_write(_update)
 
         assert db.search_messages("ORIGINALTOOL") == []
@@ -3283,7 +3450,8 @@ class TestFTS5ToolCallMigration:
         # Build the pre-v11 schema by hand: external-content FTS tables +
         # old triggers that only reference new.content.
         conn = sqlite3.connect(str(db_path))
-        conn.executescript("""
+        conn.executescript(
+            """
             CREATE TABLE schema_version (version INTEGER NOT NULL);
             INSERT INTO schema_version (version) VALUES (10);
 
@@ -3329,7 +3497,8 @@ class TestFTS5ToolCallMigration:
             CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages BEGIN
                 INSERT INTO messages_fts_trigram(rowid, content) VALUES (new.id, new.content);
             END;
-        """)
+        """
+        )
         conn.execute(
             "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
             ("s1", "cli", time.time()),
@@ -3337,8 +3506,14 @@ class TestFTS5ToolCallMigration:
         conn.execute(
             "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
             "VALUES (?, ?, ?, ?, ?, ?)",
-            ("s1", time.time(), "assistant", "", "LEGACYTOOL",
-             '{"function":{"name":"web_search","arguments":"{\\"q\\":\\"LEGACYARG\\"}"}}'),
+            (
+                "s1",
+                time.time(),
+                "assistant",
+                "",
+                "LEGACYTOOL",
+                '{"function":{"name":"web_search","arguments":"{\\"q\\":\\"LEGACYARG\\"}"}}',
+            ),
         )
         conn.commit()
 
@@ -3352,12 +3527,15 @@ class TestFTS5ToolCallMigration:
         # Now open via SessionDB — migration runs.
         session_db = SessionDB(db_path=db_path)
         try:
-            assert len(session_db.search_messages("LEGACYTOOL")) == 1, \
-                "v11 migration must backfill tool_name into FTS"
-            assert len(session_db.search_messages("LEGACYARG")) == 1, \
-                "v11 migration must backfill tool_calls JSON into FTS"
+            assert (
+                len(session_db.search_messages("LEGACYTOOL")) == 1
+            ), "v11 migration must backfill tool_name into FTS"
+            assert (
+                len(session_db.search_messages("LEGACYARG")) == 1
+            ), "v11 migration must backfill tool_calls JSON into FTS"
             # schema_version bumped
             from hermes_state import SCHEMA_VERSION
+
             row = session_db._conn.execute(
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
@@ -3378,6 +3556,7 @@ class TestApplyWalProbe:
     def test_skips_set_pragma_when_already_wal(self, tmp_path):
         """Already-WAL connection must not trigger the set-pragma."""
         import sqlite3
+
         from hermes_state import apply_wal_with_fallback
 
         class _TracingConn(sqlite3.Connection):
@@ -3402,16 +3581,17 @@ class TestApplyWalProbe:
 
         assert result == "wal"
         # Only the probe should have fired; the set-pragma must NOT appear.
-        assert any("PRAGMA journal_mode" == sql.strip() for sql in conn.executed), (
-            "probe PRAGMA should have run"
-        )
-        assert not any("journal_mode=WAL" in sql for sql in conn.executed), (
-            "set-pragma must not run when already in WAL mode"
-        )
+        assert any(
+            "PRAGMA journal_mode" == sql.strip() for sql in conn.executed
+        ), "probe PRAGMA should have run"
+        assert not any(
+            "journal_mode=WAL" in sql for sql in conn.executed
+        ), "set-pragma must not run when already in WAL mode"
 
     def test_sets_wal_on_fresh_connection(self, tmp_path):
         """Probe sees 'delete', then set-pragma runs and returns 'wal'."""
         import sqlite3
+
         from hermes_state import apply_wal_with_fallback
 
         class _TracingConn(sqlite3.Connection):
@@ -3431,15 +3611,16 @@ class TestApplyWalProbe:
             conn.close()
 
         assert result == "wal"
-        assert any("journal_mode=WAL" in sql for sql in conn.executed), (
-            "set-pragma must fire on a fresh (non-WAL) connection"
-        )
+        assert any(
+            "journal_mode=WAL" in sql for sql in conn.executed
+        ), "set-pragma must fire on a fresh (non-WAL) connection"
 
     def test_apply_wal_concurrent_connects_no_eio(self, tmp_path):
         """20 threads calling connect() on the same DB must not see disk I/O error."""
+        import sqlite3
         import sys
         import threading
-        import sqlite3
+
         from hermes_state import apply_wal_with_fallback
 
         db_path = tmp_path / "concurrent.db"
@@ -3483,6 +3664,7 @@ class TestApplyWalProbe:
     def test_fallback_to_delete_still_works(self, tmp_path):
         """When set-pragma raises a WAL-incompat error, falls back to DELETE."""
         import sqlite3
+
         from hermes_state import apply_wal_with_fallback
 
         class _IncompatConn(sqlite3.Connection):
@@ -3510,6 +3692,7 @@ class TestApplyWalProbe:
     def test_probe_failure_falls_through_to_set_pragma(self, tmp_path):
         """When the read probe raises OperationalError, fall through to set-pragma."""
         import sqlite3
+
         from hermes_state import apply_wal_with_fallback
 
         class _ProbeFails(sqlite3.Connection):
@@ -3536,7 +3719,9 @@ class TestApplyWalProbe:
     def test_no_downgrade_from_wal_to_delete_on_eio(self, tmp_path):
         """OperationalError NOT in _WAL_INCOMPAT_MARKERS must propagate, not downgrade."""
         import sqlite3
+
         import pytest
+
         from hermes_state import apply_wal_with_fallback
 
         class _EIOConn(sqlite3.Connection):
@@ -3563,6 +3748,7 @@ class TestApplyWalProbe:
     def test_returns_wal_not_delete_from_probe(self, tmp_path):
         """Early-return only on 'wal'; 'delete' or 'memory' must fall through to set-pragma."""
         import sqlite3
+
         from hermes_state import apply_wal_with_fallback
 
         class _TracingConn(sqlite3.Connection):
@@ -3583,9 +3769,9 @@ class TestApplyWalProbe:
             conn.close()
 
         assert result == "wal"
-        assert any("journal_mode=WAL" in sql for sql in conn.executed), (
-            "set-pragma must fire when probe returns 'delete'"
-        )
+        assert any(
+            "journal_mode=WAL" in sql for sql in conn.executed
+        ), "set-pragma must fire when probe returns 'delete'"
 
 
 class TestSessionArchive:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1309,6 +1309,83 @@ class TestCounts:
         assert db.session_count(source="cli") == 2
         assert db.session_count(source="telegram") == 1
 
+    def test_session_count_with_compression_projection(self, db):
+        """session_count(project_compression_tips=True) must match the
+        number of rows list_sessions_rich surfaces after projection, so the
+        /api/sessions ``total`` field doesn't lie about how many sessions
+        the sidebar can actually load. Without the flag, raw row count
+        includes compression roots that get projected away by the list.
+        """
+        import time as _time
+        t0 = _time.time() - 3600
+
+        db.create_session("root1", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root1"))
+        db.append_message("root1", "user", "first message")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+            (t0 + 100, "compression", "root1"),
+        )
+        db.create_session("tip1", "cli", parent_session_id="root1")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?",
+            (t0 + 101, "tip1"),
+        )
+        db.append_message("tip1", "user", "continuation")
+
+        db.create_session("solo", "cli")
+        db.append_message("solo", "user", "standalone")
+        db._conn.commit()
+
+        assert db.session_count() == 3
+        assert db.session_count(project_compression_tips=True) == 2
+        surfaced = len(db.list_sessions_rich(source="cli", limit=20))
+        assert db.session_count(project_compression_tips=True) == surfaced
+
+    def test_session_count_with_projection_handles_missing_tip(self, db):
+        """If a compression root's tip was deleted, the root is kept (matching
+        list_sessions_rich's behavior) and the projected count must reflect
+        that, not underflow.
+        """
+        import time as _time
+        t0 = _time.time() - 3600
+        db.create_session("root1", "cli")
+        db.append_message("root1", "user", "first")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+            (t0 + 100, "compression", "root1"),
+        )
+        db.create_session("tip1", "cli", parent_session_id="root1")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?",
+            (t0 + 101, "tip1"),
+        )
+        db.append_message("tip1", "user", "continuation")
+        db.delete_session("tip1")
+        db._conn.commit()
+
+        assert db.session_count() == 1
+        assert db.session_count(project_compression_tips=True) == 1
+
+    def test_session_count_excludes_subagent_children(self, db):
+        """session_count(include_children=False) must match the row count
+        list_sessions_rich surfaces — subagent children and non-branch
+        continuations are hidden from the sidebar and must not inflate the
+        ``total`` field the frontend uses to render the "Load more" button.
+        """
+        db.create_session("root1", "cli")
+        db.append_message("root1", "user", "parent")
+        db.create_session("sub1", "cli", parent_session_id="root1")
+        db.append_message("sub1", "user", "delegate task")
+        db.create_session("root2", "cli")
+        db.append_message("root2", "user", "unrelated")
+        db._conn.commit()
+
+        assert db.session_count() == 3
+        assert db.session_count(include_children=False) == 2
+        surfaced = len(db.list_sessions_rich(source="cli", limit=20))
+        assert db.session_count(include_children=False) == surfaced
+
     def test_message_count_total(self, db):
         assert db.message_count() == 0
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## What does this PR do?

Fixes four related bugs in the desktop app's sidebar session list:

1. **"Load N more" was a no-op** — the offset was never forwarded to the
   backend, so every click returned the first page.
2. **"n/n" total count was wrong** — `session_count` included compression
   tips (which the UI hides) and subagent children (which the agent view
   also hides), so the label never matched the rendered list.
3. **Grouped-mode delete showed `n-1/n` instead of `n-1/n-1`** — the
   client only decremented `$sessions` and forgot to decrement
   `$sessionsTotal`, so the denominator drifted.
4. **"Load more" could leave a ghost button** — empty pages no longer
   contract `sessionsTotal` past the real count, so the button only
   hides when there really is nothing left to load.

## Related Issue

None reported — discovered during local session-list testing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

The first commit is the actual fix:

- **`apps/desktop/src/hermes.ts`** — `listSessions` accepts an
  `offset` parameter and forwards it to the backend. Previously the
  argument was declared but ignored, so every "Load more" click
  returned the first page.
- **`apps/desktop/src/app/desktop-controller.tsx`** — new
  `appendMoreSessions` callback advances the offset, dedupes by id
  before appending, and contracts `sessionsTotal` on empty pages
  to prevent a ghost button.
- **`hermes_state.py`** — `session_count` accepts
  `project_compression_tips` and `include_children` parameters so
  the count matches what the UI actually renders.
- **`hermes_cli/web_server.py`** — `/api/sessions` wires the new
  query params, passing `include_children=false` to match the
  desktop agent view.
- **`apps/desktop/src/app/session/hooks/use-session-actions.ts`** —
  `deleteSession` and `archiveSession` keep `$sessionsTotal` in
  sync with the backend so grouped mode shows `n-1/n-1` instead of
  `n-1/n` after a delete. The catch-block restore mirrors the
  same update.
- **`tests/test_hermes_state.py`** — three regression tests
  covering the new projection (`project_compression_tips`),
  the children-exclusion behavior (`include_children`), and the
  count formula.

The second commit is a follow-up `chore:` cleanup:

- **`apps/desktop/package.json`** — drop unused `zustand ^5.0.14`
  dep (0 imports in `apps/desktop/src/`; the desktop app uses
  `nanostores` for state).
- **`hermes_state.py`, `hermes_cli/web_server.py`,
  `tests/test_hermes_state.py`** — apply `black --check` and
  `isort --profile black` (the project uses both; the original
  three files were failing both).

## How to Test

1. Launch the desktop app and sign in.
2. Click "Load N more" multiple times in the sidebar. The list
   should grow by the page size on each click and the total
   counter should increase.
3. Toggle "Group by workspace". The `n/n` label should match the
   number of rows rendered (compression tips hidden, subagent
   children excluded).
4. In grouped mode, delete a session. The label should update to
   `n-1/n-1`, not `n-1/n`.
5. After exhausting the list, the "Load N more" button should
   disappear entirely (no ghost button).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): ...` + `chore: ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no duplicates; the only related open/closed PRs (#37379, #37099) target the wider session-list UI, not these load-more/count bugs
- [x] My PR contains only changes related to this fix (no unrelated commits, no `.omo/` runtime state, no `package-lock.json` drift)
- [x] I've run `pytest tests/ -q` (via `scripts/run_tests.sh` as recommended) on the affected suites — 439 passed
- [x] I've added tests for my changes — 3 new tests in `tests/test_hermes_state.py` covering the projection, the children-exclusion behavior, and the count formula
- [x] I've tested on my platform: **macOS 15 (Apple Silicon)**

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; changes are internal to the session-list rendering
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; the desktop app is Electron, changes are JS/TS/Python only, no POSIX-only primitives or platform-gated imports added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool surface changes
