### PR TITLE
fix(agent): continue after recoverable tool loop guardrail

### DIFF
--- a/agent/action_preamble.py
+++ b/agent/action_preamble.py
@@ -1,0 +1,86 @@
+"""Detect no-tool action preambles that should continue the same turn."""
+
+from __future__ import annotations
+
+import re
+
+_ACTION_RE = re.compile(
+    r"((?:let me|let's|i'?ll|i will|i'?m going to|i am going to|"
+    r"now i|first,?\s+i|next,?\s+i|i need to|i should)\s+"
+    r"(?:check|look|run|start|examine|search|read|list|create|write|edit|use|"
+    r"inspect|open|review)\b|going to\s+"
+    r"(?:check|look|run|start|examine|search|read|list|create|write|edit|use|"
+    r"inspect|open|review)\b)",
+    re.IGNORECASE,
+)
+_COMPLETION_RE = re.compile(
+    r"(\bdone\b|\bcomplete(d)?\b|nothing to (do|save|change|report|fix)|"
+    r"no changes?\b|no action\b|already (complete|done|finished)|\bfinished\b|"
+    r"all set\b|no further\b|nothing left\b|here('?s| is| are)\b|"
+    r"in summary\b|to summarize\b|the answer is\b)",
+    re.IGNORECASE,
+)
+_NATURAL_END_CHARS = '.!?)"\']}。！？）】」』》^'
+_MIN_INCOMPLETE_FINAL_CHARS = 80
+
+ACTION_PREAMBLE_RECOVERY_PROMPT = (
+    "Your previous assistant response announced the next action but did not "
+    "include the tool call needed to perform it. Continue the same user request "
+    "now by making the tool call immediately. Do not summarize or ask the user "
+    "to type continue."
+)
+
+
+def looks_like_action_preamble_stall(
+    content: str,
+    finish_reason: str | None,
+    has_tool_calls: bool,
+    *,
+    max_chars: int = 400,
+) -> bool:
+    """Return true for a no-tool response that reads like unfinished work."""
+    if has_tool_calls or finish_reason not in {"stop", "length"}:
+        return False
+
+    text = _visible_text(content)
+    if not text or _COMPLETION_RE.search(text):
+        return False
+
+    has_action_preamble = bool(_ACTION_RE.search(text))
+    long_open_action = (
+        len(text) > max_chars
+        and len(text) <= max(max_chars * 2, 800)
+        and has_action_preamble
+        and text.endswith(":")
+    )
+    if len(text) > max_chars and not long_open_action:
+        return False
+    if has_action_preamble:
+        return True
+    if text.endswith(":"):
+        return True
+    if len(text) >= _MIN_INCOMPLETE_FINAL_CHARS and not _has_natural_ending(text):
+        return True
+    return False
+
+
+def _visible_text(content: str) -> str:
+    text = (content or "").strip()
+    return re.sub(
+        r"^<think>.*?</think>\s*",
+        "",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    ).strip()
+
+
+def _has_natural_ending(content: str) -> bool:
+    stripped = (content or "").rstrip()
+    if not stripped:
+        return False
+    if stripped.endswith("```"):
+        return True
+    last = stripped[-1]
+    if last in _NATURAL_END_CHARS:
+        return True
+    return ord(last) >= 0x1F300

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5056,26 +5056,12 @@ def run_conversation(
                 # status from earlier failed attempts in this turn.
                 agent._clear_status_buffer()
 
-                if (
-                    agent.valid_tool_names
-                    and action_preamble_continuations < 2
-                    and looks_like_action_preamble_stall(final_response, finish_reason, False)
-                ):
-                    action_preamble_continuations += 1
-                    agent._emit_status(
-                        "Action preamble ended without a tool call; continuing the turn"
-                    )
-                    interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
-                    interim_msg["_action_preamble_recovery"] = True
-                    messages.append(interim_msg)
-                    messages.append({
-                        "role": "user",
-                        "content": ACTION_PREAMBLE_RECOVERY_PROMPT,
-                        "_action_preamble_recovery": True,
-                    })
-                    agent._stream_needs_break = True
-                    continue
-
+                # The codex intermediate-ack gate owns codex_responses acks: it
+                # has a specialized detector and its own continuation prompt that
+                # tests/tooling depend on. Run it BEFORE the general
+                # action-preamble guardrail below, otherwise codex acks that also
+                # read like action preambles (e.g. "I'll inspect ...") get the
+                # generic recovery prompt instead of the ack continuation.
                 from agent.agent_runtime_helpers import (
                     intent_ack_continuation_mode,
                 )
@@ -5106,6 +5092,28 @@ def run_conversation(
                     }
                     messages.append(continue_msg)
                     agent._session_messages = messages
+                    continue
+
+                # Fallthrough for stalls the ack gate does not handle (non-codex
+                # providers, ack_mode="off", or acks its detector misses).
+                if (
+                    agent.valid_tool_names
+                    and action_preamble_continuations < 2
+                    and looks_like_action_preamble_stall(final_response, finish_reason, False)
+                ):
+                    action_preamble_continuations += 1
+                    agent._emit_status(
+                        "Action preamble ended without a tool call; continuing the turn"
+                    )
+                    interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+                    interim_msg["_action_preamble_recovery"] = True
+                    messages.append(interim_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": ACTION_PREAMBLE_RECOVERY_PROMPT,
+                        "_action_preamble_recovery": True,
+                    })
+                    agent._stream_needs_break = True
                     continue
 
                 codex_ack_continuations = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -27,6 +27,10 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+from agent.action_preamble import (
+    ACTION_PREAMBLE_RECOVERY_PROMPT,
+    looks_like_action_preamble_stall,
+)
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
 from agent.display import KawaiiSpinner
@@ -603,6 +607,7 @@ def run_conversation(
     interrupted = False
     failed = False
     codex_ack_continuations = 0
+    action_preamble_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
@@ -5050,6 +5055,26 @@ def run_conversation(
                 # Successful content reached — drop any buffered retry
                 # status from earlier failed attempts in this turn.
                 agent._clear_status_buffer()
+
+                if (
+                    agent.valid_tool_names
+                    and action_preamble_continuations < 2
+                    and looks_like_action_preamble_stall(final_response, finish_reason, False)
+                ):
+                    action_preamble_continuations += 1
+                    agent._emit_status(
+                        "Action preamble ended without a tool call; continuing the turn"
+                    )
+                    interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+                    interim_msg["_action_preamble_recovery"] = True
+                    messages.append(interim_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": ACTION_PREAMBLE_RECOVERY_PROMPT,
+                        "_action_preamble_recovery": True,
+                    })
+                    agent._stream_needs_break = True
+                    continue
 
                 from agent.agent_runtime_helpers import (
                     intent_ack_continuation_mode,

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -145,7 +145,7 @@ class ToolCallSignature:
 class ToolGuardrailDecision:
     """Decision returned by the tool-call guardrail controller."""
 
-    action: str = "allow"  # allow | warn | block | halt
+    action: str = "allow"  # allow | warn | redirect | block | halt
     code: str = "allow"
     message: str = ""
     tool_name: str = ""
@@ -303,6 +303,26 @@ class ToolCallGuardrailController:
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
 
+            tool_block = _tool_reported_loop_block(tool_name, result)
+            if tool_block:
+                action = "halt" if self.config.hard_stop_enabled else "redirect"
+                decision = ToolGuardrailDecision(
+                    action=action,
+                    code="tool_reported_loop_block",
+                    message=(
+                        f"{tool_name} reported a repeated-call loop block after "
+                        f"{tool_block['count']} attempts. Use the information "
+                        "already returned, narrow the query, switch tool or file "
+                        "region, make the edit, or state the blocker with evidence."
+                    ),
+                    tool_name=tool_name,
+                    count=tool_block["count"],
+                    signature=signature,
+                )
+                if decision.should_halt:
+                    self._halt_decision = decision
+                return decision
+
             if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
                 decision = ToolGuardrailDecision(
                     action="halt",
@@ -393,9 +413,14 @@ def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
 
 def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> str:
     """Append runtime guidance to the current tool result content."""
-    if decision.action not in {"warn", "halt"} or not decision.message:
+    if decision.action not in {"warn", "redirect", "halt"} or not decision.message:
         return result
-    label = "Tool loop hard stop" if decision.action == "halt" else "Tool loop warning"
+    if decision.action == "halt":
+        label = "Tool loop hard stop"
+    elif decision.action == "redirect":
+        label = "Tool strategy redirect"
+    else:
+        label = "Tool loop warning"
     suffix = (
         f"\n\n[{label}: "
         f"{decision.code}; count={decision.count}; {decision.message}]"
@@ -443,6 +468,37 @@ def _result_hash(result: str | None) -> str:
     else:
         canonical = result or ""
     return _sha256(canonical)
+
+
+def _tool_reported_loop_block(tool_name: str, result: str | None) -> dict[str, int] | None:
+    """Return metadata when a tool explicitly blocked a repeated call.
+
+    File/search tools can return structured ``BLOCKED:`` errors after proving
+    that another identical read/search cannot make progress. In the default
+    soft-guardrail mode this becomes model-visible redirect guidance and the
+    same user turn continues; in hard-stop mode callers still get a controlled
+    halt.
+    """
+    parsed = safe_json_loads(result or "")
+    if not isinstance(parsed, dict):
+        return None
+
+    error = parsed.get("error")
+    if not isinstance(error, str) or not error.startswith("BLOCKED:"):
+        return None
+
+    count = parsed.get("already_searched", parsed.get("already_read"))
+    if not isinstance(count, int) or count < 1:
+        return None
+
+    if (
+        tool_name in {"search_files", "read_file", "mcp_filesystem_read_file"}
+        or "exact search" in error
+        or "exact file region" in error
+        or "exact region" in error
+    ):
+        return {"count": count}
+    return None
 
 
 def _as_bool(value: Any, default: bool) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5635,7 +5635,7 @@ class AIAgent:
             function_result,
             failed=failed,
         )
-        if decision.action in {"warn", "halt"}:
+        if decision.action in {"warn", "redirect", "halt"}:
             function_result = append_toolguard_guidance(function_result, decision)
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)

--- a/tests/agent/test_action_preamble.py
+++ b/tests/agent/test_action_preamble.py
@@ -1,0 +1,54 @@
+from agent.action_preamble import looks_like_action_preamble_stall
+
+
+def test_short_action_preamble_without_tool_call_is_stall() -> None:
+    assert looks_like_action_preamble_stall(
+        "Let me check what's on taro and figure out the right approach.",
+        "stop",
+        False,
+    )
+
+
+def test_long_colon_ended_action_preamble_is_stall() -> None:
+    content = (
+        "Now I have a clear picture. The task is to add a pre-dispatch "
+        "executable-state gate in subagent_dispatch_register_command that "
+        "checks if the linked task is in an executable state before registering "
+        "a dispatch. Currently the stale guard only runs post-dispatch during "
+        "drain and settlement. The goal is to prevent non-executable dispatches "
+        "from being registered in the first place. Let me look at the register "
+        "command's validation section and the _validate_subagent_dispatch_record "
+        "function:"
+    )
+
+    assert len(content) > 400
+    assert looks_like_action_preamble_stall(content, "stop", False)
+
+
+def test_completion_text_is_not_stall() -> None:
+    assert not looks_like_action_preamble_stall(
+        "Done. The task is complete and no further action is needed.",
+        "stop",
+        False,
+    )
+
+
+def test_explanatory_let_me_text_is_not_stall() -> None:
+    assert not looks_like_action_preamble_stall(
+        "Let me explain why this does not require another tool call.",
+        "stop",
+        False,
+    )
+
+
+def test_empty_visible_response_uses_empty_response_recovery() -> None:
+    assert not looks_like_action_preamble_stall("", "stop", False)
+    assert not looks_like_action_preamble_stall("<think>still reasoning</think>", "stop", False)
+
+
+def test_tool_call_response_is_not_stall() -> None:
+    assert not looks_like_action_preamble_stall(
+        "Let me inspect the file:",
+        "tool_calls",
+        True,
+    )

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -92,6 +92,50 @@ def test_default_repeated_identical_failed_call_warns_without_blocking():
     assert controller.halt_decision is None
 
 
+def test_tool_reported_loop_block_redirects_when_hard_stop_disabled():
+    controller = ToolCallGuardrailController()
+    args = {"pattern": "def.*drain", "path": "/repo", "target": "content"}
+    result = json.dumps(
+        {
+            "error": (
+                "BLOCKED: You have run this exact search 4 times in a row. "
+                "The results have NOT changed."
+            ),
+            "already_searched": 4,
+        }
+    )
+
+    decision = controller.after_call("search_files", args, result, failed=True)
+
+    assert decision.action == "redirect"
+    assert decision.code == "tool_reported_loop_block"
+    assert decision.count == 4
+    assert controller.halt_decision is None
+
+
+def test_tool_reported_loop_block_halts_when_hard_stop_enabled():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args = {"path": "/repo/agent.py"}
+    result = json.dumps(
+        {
+            "error": (
+                "BLOCKED: You have read this exact file region 3 times in a row. "
+                "The contents have NOT changed."
+            ),
+            "already_read": 3,
+        }
+    )
+
+    decision = controller.after_call("read_file", args, result, failed=True)
+
+    assert decision.action == "halt"
+    assert decision.code == "tool_reported_loop_block"
+    assert decision.count == 3
+    assert controller.halt_decision == decision
+
+
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -268,6 +268,127 @@ def test_default_run_conversation_warns_without_guardrail_halt():
     assert any("repeated_exact_failure_warning" in content for content in tool_contents)
 
 
+def test_tool_reported_loop_block_continues_same_turn_by_default():
+    agent = _make_agent("search_files", max_iterations=10)
+    args = {"pattern": "def.*drain", "path": "/repo", "target": "content"}
+    blocked_result = json.dumps(
+        {
+            "error": (
+                "BLOCKED: You have run this exact search 4 times in a row. "
+                "The results have NOT changed."
+            ),
+            "already_searched": 4,
+        }
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("search_files", json.dumps(args), "c-search")],
+        ),
+        _mock_response(content="done", finish_reason="stop", tool_calls=None),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value=blocked_result) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("find the drain implementation")
+
+    mock_hfc.assert_called_once()
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    assert result["api_calls"] == 2
+    assert result["final_response"] == "done"
+    assert "guardrail" not in result
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    assert any("Tool strategy redirect" in content for content in tool_contents)
+    assert any("tool_reported_loop_block" in content for content in tool_contents)
+
+
+def test_tool_reported_loop_block_halts_when_hard_stop_enabled():
+    agent = _make_agent("read_file", max_iterations=10, config=_hard_stop_config())
+    args = {"path": "/repo/agent.py"}
+    blocked_result = json.dumps(
+        {
+            "error": (
+                "BLOCKED: You have read this exact file region 3 times in a row. "
+                "The contents have NOT changed."
+            ),
+            "already_read": 3,
+        }
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("read_file", json.dumps(args), "c-read")],
+        ),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value=blocked_result) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("read the file")
+
+    mock_hfc.assert_called_once()
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["final_response"]
+    assert result["guardrail"]["code"] == "tool_reported_loop_block"
+    assert result["guardrail"]["tool_name"] == "read_file"
+
+
+def test_action_preamble_without_tool_call_continues_same_turn():
+    agent = _make_agent("terminal", max_iterations=10)
+    preamble = (
+        "Now I have a clear picture. The task is to add a pre-dispatch "
+        "executable-state gate in subagent_dispatch_register_command that "
+        "checks if the linked task is in an executable state before registering "
+        "a dispatch. Currently the stale guard only runs post-dispatch during "
+        "drain and settlement. The goal is to prevent non-executable dispatches "
+        "from being registered in the first place. Let me look at the register "
+        "command's validation section and the _validate_subagent_dispatch_record "
+        "function:"
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=preamble, finish_reason="stop", tool_calls=None),
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "terminal",
+                    json.dumps({"command": "rg -n validate_subagent_dispatch_record tools"}),
+                    "c-terminal",
+                )
+            ],
+        ),
+        _mock_response(content="done", finish_reason="stop", tool_calls=None),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 0, "stdout": "hit"})) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("fix the dispatch gate")
+
+    mock_hfc.assert_called_once()
+    assert result["api_calls"] == 3
+    assert result["final_response"] == "done"
+    recovery_prompts = [
+        msg for msg in result["messages"]
+        if msg.get("role") == "user" and msg.get("_action_preamble_recovery")
+    ]
+    assert len(recovery_prompts) == 1
+    assert "did not include the tool call" in recovery_prompts[0]["content"]
+
+
 def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error():
     agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
     same_args = {"query": "same"}


### PR DESCRIPTION
## Summary

- Rebuilt this branch on current upstream `main` as a focused replacement for the old stacked PR.
- Keep explicit `tool_reported_loop_block` tool results inside the same user turn by appending model-visible redirect guidance in default soft-guardrail mode.
- Preserve hard-stop behavior when `tool_loop_guardrails.hard_stop_enabled` is true.
- Add a bounded action-preamble recovery for no-tool responses like "Let me inspect ...:" so the agent continues with the required tool call instead of treating the preamble as a final answer.

## Review Follow-Up

- Old stacked diff is gone: this PR is now 7 files, +390/-4 on top of upstream `main`.
- `agent/tool_guardrails.py` is 531 lines.
- The unrelated stack items called out in review are not part of this diff: no `HERMES_LLM_BASE_URL`, no `HERMES_SKIP_PROFILE_OVERRIDE`, no dflash stream-timeout resolver, no progress canary, no `retry_on_stall`, and no `chat()` error fallback change.
- The `tool_reported_loop_block` path now respects `hard_stop_enabled`: default mode redirects/continues; hard-stop mode halts with the existing controlled guardrail response.

## Verification

- `python -m pytest tests/agent/test_action_preamble.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q -o addopts=` -> 32 passed, 1 warning.
- `python -m pytest tests/agent/test_action_preamble.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_streaming.py tests/agent/test_local_stream_timeout.py -q -o addopts=` -> 108 passed, 1 warning.
- `python -m py_compile agent/action_preamble.py agent/tool_guardrails.py agent/conversation_loop.py run_agent.py` -> OK.
- `git diff --check` -> OK.


Task: `hermes-dflash-post-retry-preamble-stall`

> Reviewer note: this overlaps with #37166 at the same no-tool-call decision point in `run_conversation`. If both land, the redirect-guardrail path here should be treated as canonical for guardrail-triggered loops, and #37166's stall retry for empty/stalled generations — happy to rebase whichever lands second.