### PR TITLE
fix(langfuse): add Myah session metadata

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -227,6 +227,50 @@ def _trace_key(task_id: str, session_id: str) -> str:
     return f"thread:{threading.get_ident()}"
 
 
+def _myah_session_context(*, platform: str, session_id: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Return Langfuse metadata and propagated trace attrs from Myah gateway session vars.
+
+    The Myah platform sends stable user/chat/message IDs through
+    ``SessionSource``. The gateway mirrors that source into
+    ``HERMES_SESSION_*`` contextvars so tool and plugin code can consume it
+    without the LLM hook signature having to carry platform-specific kwargs.
+
+    Only attach this correlation metadata for Myah. Other gateway platforms may
+    carry provider-native user/chat identifiers that are not part of the Myah
+    observability contract and can be more sensitive.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:  # pragma: no cover - plugin should fail open
+        return {}, {}
+
+    session_platform = get_session_env("HERMES_SESSION_PLATFORM", "") or platform
+    if session_platform != "myah":
+        return {}, {}
+
+    myah_user_id = get_session_env("HERMES_SESSION_USER_ID", "")
+    myah_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    myah_message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "")
+
+    metadata: dict[str, str] = {}
+    if myah_user_id:
+        metadata["myah_user_id"] = myah_user_id
+    if myah_chat_id:
+        metadata["myah_chat_id"] = myah_chat_id
+    if myah_message_id:
+        metadata["myah_message_id"] = myah_message_id
+    if session_id and myah_chat_id and session_id != myah_chat_id:
+        metadata["hermes_session_id"] = session_id
+
+    trace_attributes: dict[str, str] = {}
+    if myah_user_id:
+        trace_attributes["user_id"] = myah_user_id
+    if myah_chat_id:
+        trace_attributes["session_id"] = myah_chat_id
+
+    return metadata, trace_attributes
+
+
 def _truncate_text(value: str, max_chars: int) -> str:
     if len(value) <= max_chars:
         return value
@@ -552,15 +596,27 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         "api_mode": api_mode,
     }
 
+    myah_metadata, myah_trace_attributes = _myah_session_context(
+        platform=platform,
+        session_id=session_id,
+    )
+    metadata.update(myah_metadata)
+
     # session_id must be passed in trace_context for Langfuse session grouping.
     trace_ctx: Dict[str, Any] = {"trace_id": trace_id}
     if session_id:
         trace_ctx["session_id"] = session_id
 
+    effective_trace_session_id = str(
+        myah_trace_attributes.get("session_id") or session_id or task_key
+    )
+
     if propagate_attributes is not None:
         try:
             with propagate_attributes(
-                session_id=session_id or task_key,
+                user_id=myah_trace_attributes.get("user_id") or None,
+                session_id=effective_trace_session_id,
+                metadata=myah_metadata or None,
                 trace_name="Hermes turn",
                 tags=["hermes", "langfuse"],
             ):

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -445,6 +445,113 @@ class TestPlaceholderKeyDetection:
         )
 
 
+class _FakeRootSpan:
+    def __init__(self):
+        self.trace_io = {}
+        self.updates = []
+        self.ended = False
+
+    def set_trace_io(self, **kwargs):
+        self.trace_io.update(kwargs)
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+
+    def start_observation(self, **kwargs):
+        return object()
+
+    def end(self):
+        self.ended = True
+
+
+class _FakeObservationContext:
+    def __init__(self, span):
+        self.span = span
+
+    def __enter__(self):
+        return self.span
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeTraceClient:
+    def __init__(self):
+        self.started = []
+        self.root_span = _FakeRootSpan()
+
+    def create_trace_id(self, *, seed):
+        self.seed = seed
+        return "trace-123"
+
+    def start_as_current_observation(self, **kwargs):
+        self.started.append(kwargs)
+        return _FakeObservationContext(self.root_span)
+
+
+class _FakePropagateContext:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestMyahSessionMetadata:
+    def _make_mod(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_root_trace_uses_gateway_session_context_for_myah_correlation_metadata(self, monkeypatch):
+        mod = self._make_mod()
+        propagated = {}
+
+        def fake_propagate_attributes(**kwargs):
+            propagated.update(kwargs)
+            return _FakePropagateContext()
+
+        monkeypatch.setattr(mod, "propagate_attributes", fake_propagate_attributes, raising=False)
+
+        from gateway.session_context import set_session_vars
+
+        tokens = set_session_vars(
+            platform="myah",
+            chat_id="myah-chat-123",
+            user_id="myah-user-456",
+            user_name="Ada",
+            session_key="must-not-leak",
+            message_id="myah-message-789",
+        )
+        try:
+            client = _FakeTraceClient()
+            mod._start_root_trace(
+                "task-key",
+                task_id="task-1",
+                session_id="hermes-session-1",
+                platform="myah",
+                provider="openrouter",
+                model="deepseek/deepseek-v4-pro",
+                api_mode="chat_completions",
+                messages=[{"role": "user", "content": "hello"}],
+                client=client,
+            )
+        finally:
+            for token in reversed(tokens):
+                token.var.reset(token)
+
+        started = client.started[0]
+        metadata = started["metadata"]
+
+        assert metadata["myah_user_id"] == "myah-user-456"
+        assert metadata["myah_chat_id"] == "myah-chat-123"
+        assert metadata["myah_message_id"] == "myah-message-789"
+        assert propagated["user_id"] == "myah-user-456"
+        assert propagated["session_id"] == "myah-chat-123"
+        assert propagated["metadata"]["myah_message_id"] == "myah-message-789"
+        assert "myah_session_key" not in metadata
+        assert "HERMES_SESSION_KEY" not in metadata
+
+
 class TestRequestMessageCoercion:
     def test_prefers_request_messages_then_messages_then_history_then_user_message(self):
         sys.modules.pop("plugins.observability.langfuse", None)


### PR DESCRIPTION
## Summary

- Add Myah-specific correlation metadata to Langfuse root traces when the gateway session context identifies the platform as `myah`.
- Propagate Myah `user_id` and `chat_id` into Langfuse trace attributes so traces group under the platform user/chat instead of only the internal Hermes session.
- Add regression coverage for the Myah gateway session context path and verify sensitive session-key values are not copied into Langfuse metadata.

## Scope

This PR is intentionally scoped to the main Hermes gateway turn / chat-completion path.

Auxiliary Myah title/follow-up generation was checked separately and is not included here. That path currently goes through `agent.auxiliary_client.async_call_llm(...)`, outside the main Langfuse gateway turn instrumentation, so this PR does not claim auxiliary model tracing support.

## Verification

Local tests:

```bash
python3 -m pytest tests/plugins/test_langfuse_plugin.py::TestMyahSessionMetadata::test_root_trace_uses_gateway_session_context_for_myah_correlation_metadata tests/plugins/test_langfuse_plugin.py -q -o 'addopts='
```

Result:

```text
38 passed in 1.19s
```

Static added-line scan:

```text
hardcoded_secret_assignment: 0
shell_injection: 0
eval_exec: 0
unsafe_pickle_or_sql_format: 0
```

Runtime smoke evidence from local Myah hosted backend:

```text
Marker: langfuse-shared-metadata-gate-25f4b4d1bc88
Trace: ebeaa7474800e63750ee854e6819b377
Checks true:
- metadata.myah_chat_id
- metadata.myah_message_id
- metadata.myah_user_id
- trace.session_id_exact
- trace.user_id_exact
- trace.user_id_non_null
```
