### PR TITLE
fix: scope reasoning effort across fallback providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1633,6 +1633,7 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "reasoning_config": dict(agent.reasoning_config) if isinstance(agent.reasoning_config, dict) else agent.reasoning_config,
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -913,6 +913,8 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        _reasoning_config = rt.get("reasoning_config")
+        agent.reasoning_config = dict(_reasoning_config) if isinstance(_reasoning_config, dict) else _reasoning_config
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).
@@ -1557,6 +1559,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "reasoning_config": dict(agent.reasoning_config) if isinstance(agent.reasoning_config, dict) else agent.reasoning_config,
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1141,6 +1141,37 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             agent._transport_cache.clear()
         agent._fallback_activated = True
 
+        # Optional per-fallback reasoning override. This lets the chain keep
+        # cheaper defaults for primary providers while making an expensive
+        # rescue model run at a different thinking budget, e.g.
+        # ``reasoning_effort: max`` on Claude Opus.
+        fb_reasoning_effort = str(fb.get("reasoning_effort") or "").strip()
+        if fb_reasoning_effort:
+            try:
+                from hermes_constants import parse_reasoning_effort
+
+                parsed_reasoning = parse_reasoning_effort(fb_reasoning_effort)
+                if parsed_reasoning is not None:
+                    agent.reasoning_config = parsed_reasoning
+                else:
+                    logger.warning(
+                        "Fallback %s/%s ignored invalid reasoning_effort=%r",
+                        fb_provider,
+                        fb_model,
+                        fb_reasoning_effort,
+                    )
+            except Exception as _reasoning_err:
+                logger.warning(
+                    "Fallback %s/%s could not apply reasoning_effort=%r: %s",
+                    fb_provider,
+                    fb_model,
+                    fb_reasoning_effort,
+                    _reasoning_err,
+                )
+        else:
+            _primary_reasoning = (agent._primary_runtime or {}).get("reasoning_config")
+            agent.reasoning_config = dict(_primary_reasoning) if isinstance(_primary_reasoning, dict) else _primary_reasoning
+
         # Clear the credential pool when the fallback provider doesn't match
         # the pool's provider.  The pool was seeded for the primary provider;
         # leaving it attached means downstream recovery (rate_limit / billing /

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -29,7 +29,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -1494,14 +1494,18 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
-        _cfg = {}
+        _cfg: Dict[str, Any] = {}
         try:
             import yaml
             _cfg_path = str(_get_hermes_home() / "config.yaml")
             if os.path.exists(_cfg_path):
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
-                _cfg = _expand_env_vars(_cfg)
+                if not isinstance(_cfg, dict):
+                    _cfg = {}
+                _cfg = cast(Dict[str, Any], _expand_env_vars(_cfg))
+                if not isinstance(_cfg, dict):
+                    _cfg = {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
                     if isinstance(_model_cfg, str):
@@ -1520,9 +1524,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception:
             pass
 
-        # Reasoning config from config.yaml
+        # Reasoning config. Jobs may override the profile default with a
+        # top-level `reasoning_effort` field while existing jobs keep using
+        # config.yaml's agent.reasoning_effort.
         from hermes_constants import parse_reasoning_effort
-        effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else {}
+        if not isinstance(_agent_cfg, dict):
+            _agent_cfg = {}
+        effort = str(job.get("reasoning_effort") or _agent_cfg.get("reasoning_effort", "")).strip()
         reasoning_config = parse_reasoning_effort(effort)
 
         # Prefill messages from env or config.yaml
@@ -1641,7 +1650,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,
-            fallback_model=fallback_model,
+            fallback_model=cast(Any, fallback_model),
             credential_pool=credential_pool,
             providers_allowed=pr.get("only"),
             providers_ignored=pr.get("ignore"),

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1352,7 +1352,10 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     except Exception:
         pass
 
-    # 2. Check config.yaml model.provider
+    # 2. Check config.yaml model.provider and fallback_providers. A provider in
+    # the fallback chain is an explicit user choice too; without this, Anthropic
+    # fallback entries cannot import Claude Code credentials even when the user
+    # deliberately configured Opus as a fallback.
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -1361,6 +1364,14 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
             cfg_provider = (model_cfg.get("provider") or "").strip().lower()
             if cfg_provider == normalized:
                 return True
+        fallback_cfg = cfg.get("fallback_providers")
+        if isinstance(fallback_cfg, list):
+            for entry in fallback_cfg:
+                if not isinstance(entry, dict):
+                    continue
+                fb_provider = (entry.get("provider") or "").strip().lower()
+                if fb_provider == normalized:
+                    return True
     except Exception:
         pass
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -331,6 +331,21 @@ def _run_agent(
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
+    # Match normal CLI/gateway behavior: oneshot calls must honor the profile's
+    # reasoning_effort, otherwise `hermes chat -q -m claude-opus-4-8` silently
+    # runs Opus without adaptive thinking.
+    try:
+        import importlib
+
+        constants_mod = importlib.import_module("hermes_constants")
+        agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else {}
+        if not isinstance(agent_cfg, dict):
+            agent_cfg = {}
+        reasoning_config = constants_mod.parse_reasoning_effort(
+            str(agent_cfg.get("reasoning_effort", "")).strip()
+        )
+    except Exception:
+        reasoning_config = None
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),
@@ -344,6 +359,7 @@ def _run_agent(
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
+        reasoning_config=reasoning_config,
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -300,13 +300,13 @@ def get_subprocess_home() -> str | None:
     return None
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -65,6 +65,25 @@ def test_returns_false_when_config_provider_is_different(tmp_path, monkeypatch):
     assert is_provider_explicitly_configured("anthropic") is False
 
 
+def test_returns_true_when_fallback_provider_matches(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_config(tmp_path, {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "fallback_providers": [
+            {"provider": "gemini", "model": "gemini-3.5-flash"},
+            {"provider": "anthropic", "model": "claude-opus-4-8"},
+        ],
+    })
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+    })
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("anthropic") is True
+
+
 def test_returns_true_when_anthropic_env_var_set(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-realkey")

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -182,6 +182,75 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_applies_per_fallback_reasoning_effort(self):
+        """Fallback entries can override the active reasoning budget."""
+        fbs = [
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "reasoning_effort": "max",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "reasoning_config", {"enabled": True, "effort": "high"})
+        agent._primary_runtime["reasoning_config"] = {"enabled": True, "effort": "high"}
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client("https://api.anthropic.com"), "claude-opus-4-8"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "model") == "claude-opus-4-8"
+        assert getattr(agent, "reasoning_config") == {"enabled": True, "effort": "max"}
+
+    def test_fallback_without_reasoning_effort_resets_to_primary_reasoning(self):
+        """Reasoning overrides are scoped to the fallback entry that sets them."""
+        fbs = [
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "reasoning_effort": "max",
+            },
+            {"provider": "openai", "model": "gpt-5.5"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        primary_reasoning = {"enabled": True, "effort": "high"}
+        agent.reasoning_config = dict(primary_reasoning)
+        agent._primary_runtime["reasoning_config"] = dict(primary_reasoning)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client("https://api.openai.com/v1"), "resolved"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.reasoning_config == {"enabled": True, "effort": "max"}
+            assert agent._try_activate_fallback() is True
+
+        assert agent.model == "gpt-5.5"
+        assert agent.reasoning_config == primary_reasoning
+
+    def test_restore_primary_runtime_restores_primary_reasoning_config(self):
+        """Per-fallback reasoning overrides must not leak into future turns."""
+        fbs = [
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "reasoning_effort": "max",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        primary_reasoning = {"enabled": True, "effort": "high"}
+        agent.reasoning_config = dict(primary_reasoning)
+        agent._primary_runtime["reasoning_config"] = dict(primary_reasoning)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client("https://api.anthropic.com"), "claude-opus-4-8"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "max"}
+        assert agent._restore_primary_runtime() is True
+        assert agent.reasoning_config == primary_reasoning
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
## Summary
- add `fallback_providers[].reasoning_effort` so fallback entries can opt into a different thinking budget
- preserve/restore the primary runtime's reasoning config so fallback overrides stay turn-scoped
- honor profile reasoning defaults in `hermes chat -q` oneshot runs and cron jobs
- treat providers listed in `fallback_providers` as explicitly configured for auth gating

## Test Plan
- `python -m pytest tests/hermes_cli/test_auth_provider_gate.py tests/run_agent/test_provider_fallback.py tests/cron -o 'addopts=' -q`

## Notes
This keeps expensive rescue models like Claude Opus on a higher reasoning budget without forcing the primary provider/session to run at that budget.
