### PR TITLE
feat(agent): add AgentProfile + ContextVar for per-agent paths (1/6)

### DIFF
--- a/agent/profile.py
+++ b/agent/profile.py
@@ -1,0 +1,193 @@
+"""Agent profile + ContextVar plumbing for single-gateway-multi-agent.
+
+An ``AgentProfile`` bundles every piece of per-agent state that used to be
+process-scoped via ``HERMES_HOME``:
+
+* home directory (governs SOUL.md, memory dir, skills dir, sessions.json)
+* model / provider / api_key_env
+* enabled / disabled toolsets
+* free-form config overrides
+
+The active profile is propagated through async code via a ``ContextVar``.
+Path getters (``get_hermes_home``, ``get_skills_dir``, ``get_memory_dir``,
+SOUL.md reader, etc.) honor the ContextVar **first**, falling back to the
+``HERMES_HOME`` env var when no profile is set — so single-profile installs
+see zero behavior change.
+
+This module is import-safe: it has no module-level side effects and depends
+only on stdlib + ``hermes_constants``.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_AGENT_ID = "main"
+
+
+@dataclass
+class AgentProfile:
+    """A named agent with its own filesystem root, model, and toolset config.
+
+    ``id`` is the routing key (matches ``SessionSource.agent_id``).
+    ``home_dir`` is the root that replaces ``HERMES_HOME`` when this profile
+    is active in the current ContextVar.  When ``home_dir`` is None the
+    profile inherits the process-wide ``HERMES_HOME``, which is the right
+    default for the legacy "main" agent.
+    """
+
+    id: str = DEFAULT_AGENT_ID
+    home_dir: Optional[Path] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    base_url: Optional[str] = None
+    api_key_env: Optional[str] = None
+    enabled_toolsets: Optional[List[str]] = None
+    disabled_toolsets: Optional[List[str]] = None
+    config_overrides: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def resolved_home(self) -> Path:
+        """Return the effective home directory for this profile.
+
+        Falls back to the process-wide ``HERMES_HOME`` when ``home_dir``
+        is unset.  This keeps the default profile a thin shell over the
+        existing env-driven layout.
+        """
+        if self.home_dir is not None:
+            return Path(self.home_dir).expanduser()
+        return get_hermes_home()
+
+    @property
+    def soul_md_path(self) -> Path:
+        return self.resolved_home / "SOUL.md"
+
+    @property
+    def memory_dir(self) -> Path:
+        return self.resolved_home / "memories"
+
+    @property
+    def skills_dir(self) -> Path:
+        return self.resolved_home / "skills"
+
+    @property
+    def sessions_path(self) -> Path:
+        return self.resolved_home / "sessions.json"
+
+
+_current_agent_profile: ContextVar[Optional[AgentProfile]] = ContextVar(
+    "hermes_current_agent_profile", default=None
+)
+
+
+def get_active_profile() -> Optional[AgentProfile]:
+    """Return the profile bound to the current async context, or None.
+
+    None means "no profile bound" — callers should fall back to
+    ``HERMES_HOME`` env-var behavior, which is exactly what the legacy
+    single-profile install expects.
+    """
+    return _current_agent_profile.get()
+
+
+def set_active_profile(profile: Optional[AgentProfile]):
+    """Bind *profile* to the current ContextVar; returns the reset token.
+
+    Prefer ``use_profile()`` (context manager) over this raw setter.
+    """
+    return _current_agent_profile.set(profile)
+
+
+@contextmanager
+def use_profile(profile: Optional[AgentProfile]) -> Iterator[Optional[AgentProfile]]:
+    """Bind *profile* for the duration of the ``with`` block.
+
+    Uses ContextVar.set/reset so the binding propagates through ``await``
+    and ``asyncio.gather``, but does **not** leak to sibling tasks unless
+    they are spawned with ``copy_context()`` from within the block.
+
+    Passing ``None`` is a no-op restoration: callers that hit a route
+    without a profile (legacy single-agent path) can simply skip the
+    ``with``.
+    """
+    if profile is None:
+        yield None
+        return
+    token = _current_agent_profile.set(profile)
+    try:
+        yield profile
+    finally:
+        _current_agent_profile.reset(token)
+
+
+def load_agent_registry(config: Any) -> Dict[str, AgentProfile]:
+    """Build an ``id -> AgentProfile`` registry from a ``GatewayConfig``.
+
+    Reads ``config.agents`` (a dict of id -> kwargs) and constructs an
+    ``AgentProfile`` for each.  Always returns at least the default
+    profile under ``DEFAULT_AGENT_ID`` so single-agent installs work
+    without any config changes.
+
+    Unknown kwargs in the agent dicts are forwarded to ``config_overrides``
+    so future per-agent settings don't require a registry update.
+    """
+    registry: Dict[str, AgentProfile] = {}
+
+    raw_agents: Dict[str, Any] = {}
+    if config is not None:
+        raw_agents = getattr(config, "agents", None) or {}
+
+    for agent_id, raw in (raw_agents or {}).items():
+        if not isinstance(raw, dict):
+            logger.warning(
+                "agents.%s ignored: expected dict, got %s",
+                agent_id, type(raw).__name__,
+            )
+            continue
+        profile = _build_profile(agent_id, raw)
+        registry[agent_id] = profile
+
+    if DEFAULT_AGENT_ID not in registry:
+        registry[DEFAULT_AGENT_ID] = AgentProfile(id=DEFAULT_AGENT_ID)
+
+    return registry
+
+
+def _build_profile(agent_id: str, raw: Dict[str, Any]) -> AgentProfile:
+    """Construct an AgentProfile from a raw config dict.
+
+    Known keys are extracted; everything else lands in ``config_overrides``
+    so downstream code can pick up custom keys without touching this file.
+    """
+    raw = dict(raw)  # Copy so pops don't mutate the caller's dict.
+    home_dir_raw = raw.pop("home_dir", None)
+    home_dir = Path(home_dir_raw).expanduser() if home_dir_raw else None
+
+    model = raw.pop("model", None)
+    provider = raw.pop("provider", None)
+    base_url = raw.pop("base_url", None)
+    api_key_env = raw.pop("api_key_env", None)
+    enabled_toolsets = raw.pop("enabled_toolsets", None)
+    disabled_toolsets = raw.pop("disabled_toolsets", None)
+
+    return AgentProfile(
+        id=agent_id,
+        home_dir=home_dir,
+        model=model,
+        provider=provider,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        config_overrides=raw,
+    )

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -43,7 +43,12 @@ def get_hermes_home_override() -> str | None:
 def get_hermes_home() -> Path:
     """Return the Hermes home directory (default: ~/.hermes).
 
-    Reads HERMES_HOME env var, falls back to ~/.hermes.
+    Resolution order:
+    1. Active ``AgentProfile`` in the current async context (multi-agent
+       gateway routes per-message to a profile via ContextVar).
+    2. ``HERMES_HOME`` env var.
+    3. Fallback ``~/.hermes``.
+
     This is the single source of truth — all other copies should import this.
 
     When ``HERMES_HOME`` is unset but an ``active_profile`` file indicates
@@ -56,6 +61,17 @@ def get_hermes_home() -> Path:
     template in ``hermes_cli/gateway.py`` and the kanban dispatcher in
     ``hermes_cli/kanban_db.py``).  See https://github.com/NousResearch/hermes-agent/issues/18594.
     """
+    # 1. ContextVar — active AgentProfile wins when present.  Lazy import to
+    # avoid a circular dependency (agent.profile imports this module).
+    try:
+        from agent.profile import get_active_profile  # noqa: WPS433 (lazy)
+        profile = get_active_profile()
+    except ImportError:
+        profile = None
+    if profile is not None and profile.home_dir is not None:
+        return Path(profile.home_dir).expanduser()
+
+    # 2. Context-local override (set_hermes_home_override).
     override = get_hermes_home_override()
     if override:
         return Path(override)

--- a/tests/agent/test_profile_contextvar.py
+++ b/tests/agent/test_profile_contextvar.py
@@ -1,0 +1,232 @@
+"""Tests for agent/profile.py — AgentProfile + ContextVar isolation."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.profile import (
+    AgentProfile,
+    get_active_profile,
+    set_active_profile,
+    use_profile,
+    load_agent_registry,
+    DEFAULT_AGENT_ID,
+)
+
+
+class TestAgentProfile:
+    def test_default_profile(self):
+        p = AgentProfile()
+        assert p.id == DEFAULT_AGENT_ID
+        assert p.home_dir is None
+        assert p.model is None
+
+    def test_resolved_home_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = AgentProfile()
+        assert p.resolved_home == tmp_path
+
+    def test_resolved_home_explicit(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path / "profiles" / "coder")
+        assert p.resolved_home == tmp_path / "profiles" / "coder"
+
+    def test_resolved_home_expands_tilde(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/testuser")
+        p = AgentProfile(home_dir="~/.hermes/profiles/coder")
+        assert p.resolved_home == Path("/home/testuser/.hermes/profiles/coder")
+
+    def test_soul_md_path(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.soul_md_path == tmp_path / "SOUL.md"
+
+    def test_memory_dir(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.memory_dir == tmp_path / "memories"
+
+    def test_skills_dir(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.skills_dir == tmp_path / "skills"
+
+    def test_sessions_path(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.sessions_path == tmp_path / "sessions.json"
+
+    def test_config_overrides(self):
+        p = AgentProfile(config_overrides={"foo": "bar"})
+        assert p.config_overrides == {"foo": "bar"}
+
+
+class TestContextVar:
+    def test_get_active_profile_default_none(self):
+        """No profile set → None."""
+        assert get_active_profile() is None
+
+    def test_set_active_profile(self):
+        p = AgentProfile(id="coder")
+        token = set_active_profile(p)
+        assert get_active_profile() == p
+        # Cleanup
+        from agent.profile import _current_agent_profile
+        _current_agent_profile.reset(token)
+
+    def test_use_profile_context_manager(self):
+        p = AgentProfile(id="coder")
+        assert get_active_profile() is None
+        with use_profile(p):
+            assert get_active_profile() == p
+        assert get_active_profile() is None
+
+    def test_use_profile_none_is_noop(self):
+        """Passing None to use_profile is a no-op."""
+        with use_profile(None):
+            assert get_active_profile() is None
+
+    def test_use_profile_nested(self):
+        outer = AgentProfile(id="outer")
+        inner = AgentProfile(id="inner")
+        with use_profile(outer):
+            assert get_active_profile() == outer
+            with use_profile(inner):
+                assert get_active_profile() == inner
+            assert get_active_profile() == outer
+        assert get_active_profile() is None
+
+    def test_use_profile_exception_cleanup(self):
+        p = AgentProfile(id="coder")
+        with pytest.raises(ValueError):
+            with use_profile(p):
+                assert get_active_profile() == p
+                raise ValueError("boom")
+        assert get_active_profile() is None
+
+
+class TestContextVarAsyncIsolation:
+    """ContextVar must propagate through await but NOT leak to sibling tasks."""
+
+    @pytest.mark.asyncio
+    async def test_async_propagation(self):
+        p = AgentProfile(id="coder")
+        with use_profile(p):
+            # await should keep the profile
+            await asyncio.sleep(0)
+            assert get_active_profile() == p
+        assert get_active_profile() is None
+
+    @pytest.mark.asyncio
+    async def test_gather_isolation(self):
+        """asyncio.gather with copy_context preserves per-task profiles."""
+        async def task_a():
+            with use_profile(AgentProfile(id="a")):
+                await asyncio.sleep(0.01)
+                return get_active_profile().id if get_active_profile() else None
+
+        async def task_b():
+            with use_profile(AgentProfile(id="b")):
+                await asyncio.sleep(0.01)
+                return get_active_profile().id if get_active_profile() else None
+
+        # Tasks spawned from clean context — each sets its own profile
+        results = await asyncio.gather(task_a(), task_b())
+        assert set(results) == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_sibling_tasks_dont_leak(self):
+        """A task spawned before profile is set should not see the profile."""
+        barrier = asyncio.Event()
+
+        async def child():
+            barrier.set()
+            await asyncio.sleep(0.05)
+            return get_active_profile()
+
+        task = asyncio.create_task(child())
+        await barrier.wait()
+
+        with use_profile(AgentProfile(id="parent")):
+            await asyncio.sleep(0.01)
+            assert get_active_profile().id == "parent"
+
+        result = await task
+        # Child was created before profile was set → should not see it
+        assert result is None
+
+
+class TestLoadAgentRegistry:
+    def test_empty_config_returns_main(self):
+        registry = load_agent_registry(None)
+        assert "main" in registry
+        assert registry["main"].id == "main"
+        assert registry["main"].home_dir is None
+
+    def test_single_agent(self):
+        class FakeConfig:
+            agents = {
+                "coder": {"model": "claude-opus", "provider": "anthropic"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert "main" in registry
+        assert "coder" in registry
+        assert registry["coder"].model == "claude-opus"
+        assert registry["coder"].provider == "anthropic"
+
+    def test_multiple_agents(self):
+        class FakeConfig:
+            agents = {
+                "coder": {"model": "claude-opus"},
+                "research": {"model": "claude-sonnet"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert len(registry) == 3  # main + coder + research
+        assert registry["coder"].model == "claude-opus"
+        assert registry["research"].model == "claude-sonnet"
+
+    def test_home_dir_expansion(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/test")
+
+        class FakeConfig:
+            agents = {
+                "coder": {"home_dir": "~/.hermes/profiles/coder"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert registry["coder"].resolved_home == Path("/home/test/.hermes/profiles/coder")
+
+    def test_config_overrides(self):
+        class FakeConfig:
+            agents = {
+                "coder": {"model": "claude-opus", "custom_key": "custom_value"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert registry["coder"].config_overrides == {"custom_key": "custom_value"}
+
+    def test_non_dict_agent_ignored(self):
+        class FakeConfig:
+            agents = {
+                "coder": "not-a-dict",
+                "research": {"model": "claude-sonnet"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert "coder" not in registry
+        assert "research" in registry
+
+    def test_main_always_present(self):
+        class FakeConfig:
+            agents = {"coder": {"model": "claude-opus"}}
+
+        registry = load_agent_registry(FakeConfig())
+        assert "main" in registry
+        assert registry["main"].id == "main"
+        assert registry["main"].home_dir is None
+
+    def test_main_can_be_overridden(self):
+        class FakeConfig:
+            agents = {"main": {"model": "claude-opus"}}
+
+        registry = load_agent_registry(FakeConfig())
+        assert registry["main"].model == "claude-opus"


### PR DESCRIPTION
## What
Add `AgentProfile` dataclass and a `ContextVar` so per-agent filesystem paths and identity resolve correctly under concurrent gateway tasks.

## Why
Multi-agent routing needs each in-flight message to resolve its own agent's paths/config without threading an explicit argument through every call site; a `ContextVar` gives task-local agent binding.

## How to test
```
python -m pytest tests/agent/test_profile_contextvar.py -q
```

## Platforms tested
Linux (CT 133 / Proxmox LXC)

Part 1 of 6 in the multi-agent gateway decomposition (replaces #34741). First in the chain — based directly on `main`.
