### PR TITLE
feat(session): thread agent_id through session identity & DB schema (2/6)

### DIFF
--- a/agent/profile.py
+++ b/agent/profile.py
@@ -1,0 +1,193 @@
+"""Agent profile + ContextVar plumbing for single-gateway-multi-agent.
+
+An ``AgentProfile`` bundles every piece of per-agent state that used to be
+process-scoped via ``HERMES_HOME``:
+
+* home directory (governs SOUL.md, memory dir, skills dir, sessions.json)
+* model / provider / api_key_env
+* enabled / disabled toolsets
+* free-form config overrides
+
+The active profile is propagated through async code via a ``ContextVar``.
+Path getters (``get_hermes_home``, ``get_skills_dir``, ``get_memory_dir``,
+SOUL.md reader, etc.) honor the ContextVar **first**, falling back to the
+``HERMES_HOME`` env var when no profile is set — so single-profile installs
+see zero behavior change.
+
+This module is import-safe: it has no module-level side effects and depends
+only on stdlib + ``hermes_constants``.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_AGENT_ID = "main"
+
+
+@dataclass
+class AgentProfile:
+    """A named agent with its own filesystem root, model, and toolset config.
+
+    ``id`` is the routing key (matches ``SessionSource.agent_id``).
+    ``home_dir`` is the root that replaces ``HERMES_HOME`` when this profile
+    is active in the current ContextVar.  When ``home_dir`` is None the
+    profile inherits the process-wide ``HERMES_HOME``, which is the right
+    default for the legacy "main" agent.
+    """
+
+    id: str = DEFAULT_AGENT_ID
+    home_dir: Optional[Path] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    base_url: Optional[str] = None
+    api_key_env: Optional[str] = None
+    enabled_toolsets: Optional[List[str]] = None
+    disabled_toolsets: Optional[List[str]] = None
+    config_overrides: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def resolved_home(self) -> Path:
+        """Return the effective home directory for this profile.
+
+        Falls back to the process-wide ``HERMES_HOME`` when ``home_dir``
+        is unset.  This keeps the default profile a thin shell over the
+        existing env-driven layout.
+        """
+        if self.home_dir is not None:
+            return Path(self.home_dir).expanduser()
+        return get_hermes_home()
+
+    @property
+    def soul_md_path(self) -> Path:
+        return self.resolved_home / "SOUL.md"
+
+    @property
+    def memory_dir(self) -> Path:
+        return self.resolved_home / "memories"
+
+    @property
+    def skills_dir(self) -> Path:
+        return self.resolved_home / "skills"
+
+    @property
+    def sessions_path(self) -> Path:
+        return self.resolved_home / "sessions.json"
+
+
+_current_agent_profile: ContextVar[Optional[AgentProfile]] = ContextVar(
+    "hermes_current_agent_profile", default=None
+)
+
+
+def get_active_profile() -> Optional[AgentProfile]:
+    """Return the profile bound to the current async context, or None.
+
+    None means "no profile bound" — callers should fall back to
+    ``HERMES_HOME`` env-var behavior, which is exactly what the legacy
+    single-profile install expects.
+    """
+    return _current_agent_profile.get()
+
+
+def set_active_profile(profile: Optional[AgentProfile]):
+    """Bind *profile* to the current ContextVar; returns the reset token.
+
+    Prefer ``use_profile()`` (context manager) over this raw setter.
+    """
+    return _current_agent_profile.set(profile)
+
+
+@contextmanager
+def use_profile(profile: Optional[AgentProfile]) -> Iterator[Optional[AgentProfile]]:
+    """Bind *profile* for the duration of the ``with`` block.
+
+    Uses ContextVar.set/reset so the binding propagates through ``await``
+    and ``asyncio.gather``, but does **not** leak to sibling tasks unless
+    they are spawned with ``copy_context()`` from within the block.
+
+    Passing ``None`` is a no-op restoration: callers that hit a route
+    without a profile (legacy single-agent path) can simply skip the
+    ``with``.
+    """
+    if profile is None:
+        yield None
+        return
+    token = _current_agent_profile.set(profile)
+    try:
+        yield profile
+    finally:
+        _current_agent_profile.reset(token)
+
+
+def load_agent_registry(config: Any) -> Dict[str, AgentProfile]:
+    """Build an ``id -> AgentProfile`` registry from a ``GatewayConfig``.
+
+    Reads ``config.agents`` (a dict of id -> kwargs) and constructs an
+    ``AgentProfile`` for each.  Always returns at least the default
+    profile under ``DEFAULT_AGENT_ID`` so single-agent installs work
+    without any config changes.
+
+    Unknown kwargs in the agent dicts are forwarded to ``config_overrides``
+    so future per-agent settings don't require a registry update.
+    """
+    registry: Dict[str, AgentProfile] = {}
+
+    raw_agents: Dict[str, Any] = {}
+    if config is not None:
+        raw_agents = getattr(config, "agents", None) or {}
+
+    for agent_id, raw in (raw_agents or {}).items():
+        if not isinstance(raw, dict):
+            logger.warning(
+                "agents.%s ignored: expected dict, got %s",
+                agent_id, type(raw).__name__,
+            )
+            continue
+        profile = _build_profile(agent_id, raw)
+        registry[agent_id] = profile
+
+    if DEFAULT_AGENT_ID not in registry:
+        registry[DEFAULT_AGENT_ID] = AgentProfile(id=DEFAULT_AGENT_ID)
+
+    return registry
+
+
+def _build_profile(agent_id: str, raw: Dict[str, Any]) -> AgentProfile:
+    """Construct an AgentProfile from a raw config dict.
+
+    Known keys are extracted; everything else lands in ``config_overrides``
+    so downstream code can pick up custom keys without touching this file.
+    """
+    raw = dict(raw)  # Copy so pops don't mutate the caller's dict.
+    home_dir_raw = raw.pop("home_dir", None)
+    home_dir = Path(home_dir_raw).expanduser() if home_dir_raw else None
+
+    model = raw.pop("model", None)
+    provider = raw.pop("provider", None)
+    base_url = raw.pop("base_url", None)
+    api_key_env = raw.pop("api_key_env", None)
+    enabled_toolsets = raw.pop("enabled_toolsets", None)
+    disabled_toolsets = raw.pop("disabled_toolsets", None)
+
+    return AgentProfile(
+        id=agent_id,
+        home_dir=home_dir,
+        model=model,
+        provider=provider,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        config_overrides=raw,
+    )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -91,6 +91,7 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    agent_id: Optional[str] = None  # Resolved agent identity (None == default "main")
     
     @property
     def description(self) -> str:
@@ -134,6 +135,8 @@ class SessionSource:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
             d["message_id"] = self.message_id
+        if self.agent_id:
+            d["agent_id"] = self.agent_id
         return d
 
     @classmethod
@@ -152,6 +155,7 @@ class SessionSource:
             guild_id=data.get("guild_id"),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            agent_id=data.get("agent_id"),
         )
     
 
@@ -440,6 +444,11 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+
+    # Agent identity for this session.  Defaults to ``"main"`` so single-agent
+    # installs keep behaving identically; multi-agent installs set it to the
+    # agent_id resolved by the routes table at message-dispatch time.
+    agent_id: str = "main"
     
     # Token tracking
     input_tokens: int = 0
@@ -500,6 +509,7 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "agent_id": self.agent_id,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_read_tokens": self.cache_read_tokens,
@@ -556,6 +566,7 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            agent_id=data.get("agent_id", "main"),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_read_tokens=data.get("cache_read_tokens", 0),
@@ -624,7 +635,15 @@ def build_session_key(
       - Without participant identifiers, or when isolation is disabled, messages fall back to one
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
+
+    Agent identity:
+      - When ``source.agent_id`` is set (via routing in the adapter), the
+        key is prefixed with ``agent:<id>:``.  Unset (the single-agent default)
+        produces ``agent:main:``, preserving every key string generated before
+        the multi-agent feature shipped.
     """
+    agent_id = getattr(source, "agent_id", None) or "main"
+    agent_prefix = f"agent:{agent_id}"
     platform = source.platform.value
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
@@ -633,11 +652,11 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_chat_id}"
+                return f"{agent_prefix}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+            return f"{agent_prefix}:{platform}:dm:{dm_chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{agent_prefix}:{platform}:dm:{source.thread_id}"
+        return f"{agent_prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -645,7 +664,7 @@ def build_session_key(
         # single group member gets two isolated per-user sessions when the
         # bridge reshuffles alias forms.
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [agent_prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)
@@ -926,6 +945,7 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                agent_id=source.agent_id or "main",
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
@@ -937,6 +957,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "agent_id": source.agent_id or "main",
             }
 
         # SQLite operations outside the lock
@@ -1154,6 +1175,7 @@ class SessionStore:
                 display_name=display_name if display_name is not None else old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                agent_id=old_entry.agent_id or "main",
                 is_fresh_reset=True,
             )
 
@@ -1163,6 +1185,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "agent_id": old_entry.agent_id or "main",
             }
 
         if self._db and db_end_session_id:
@@ -1215,6 +1238,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                agent_id=old_entry.agent_id or "main",
             )
 
             self._entries[session_key] = new_entry

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -43,7 +43,12 @@ def get_hermes_home_override() -> str | None:
 def get_hermes_home() -> Path:
     """Return the Hermes home directory (default: ~/.hermes).
 
-    Reads HERMES_HOME env var, falls back to ~/.hermes.
+    Resolution order:
+    1. Active ``AgentProfile`` in the current async context (multi-agent
+       gateway routes per-message to a profile via ContextVar).
+    2. ``HERMES_HOME`` env var.
+    3. Fallback ``~/.hermes``.
+
     This is the single source of truth — all other copies should import this.
 
     When ``HERMES_HOME`` is unset but an ``active_profile`` file indicates
@@ -56,6 +61,17 @@ def get_hermes_home() -> Path:
     template in ``hermes_cli/gateway.py`` and the kanban dispatcher in
     ``hermes_cli/kanban_db.py``).  See https://github.com/NousResearch/hermes-agent/issues/18594.
     """
+    # 1. ContextVar — active AgentProfile wins when present.  Lazy import to
+    # avoid a circular dependency (agent.profile imports this module).
+    try:
+        from agent.profile import get_active_profile  # noqa: WPS433 (lazy)
+        profile = get_active_profile()
+    except ImportError:
+        profile = None
+    if profile is not None and profile.home_dir is not None:
+        return Path(profile.home_dir).expanduser()
+
+    # 2. Context-local override (set_hermes_home_override).
     override = get_hermes_home_override()
     if override:
         return Path(override)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -234,6 +234,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     source TEXT NOT NULL,
+    agent_id TEXT NOT NULL DEFAULT 'main',
     user_id TEXT,
     model TEXT,
     model_config TEXT,
@@ -884,6 +885,15 @@ class SessionDB:
         except sqlite3.OperationalError:
             pass  # Index already exists
 
+        # agent_id index — created after _reconcile_columns has ensured the
+        # column exists on legacy databases.
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent_id)"
+            )
+        except sqlite3.OperationalError:
+            pass
+
         if fts5_available:
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
@@ -917,16 +927,18 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
+        agent_id: str = "main",
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
+                """INSERT OR IGNORE INTO sessions (id, source, agent_id, user_id, model, model_config,
                    system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
+                    agent_id or "main",
                     user_id,
                     model,
                     json.dumps(model_config) if model_config else None,

--- a/tests/agent/test_profile_contextvar.py
+++ b/tests/agent/test_profile_contextvar.py
@@ -1,0 +1,232 @@
+"""Tests for agent/profile.py — AgentProfile + ContextVar isolation."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.profile import (
+    AgentProfile,
+    get_active_profile,
+    set_active_profile,
+    use_profile,
+    load_agent_registry,
+    DEFAULT_AGENT_ID,
+)
+
+
+class TestAgentProfile:
+    def test_default_profile(self):
+        p = AgentProfile()
+        assert p.id == DEFAULT_AGENT_ID
+        assert p.home_dir is None
+        assert p.model is None
+
+    def test_resolved_home_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = AgentProfile()
+        assert p.resolved_home == tmp_path
+
+    def test_resolved_home_explicit(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path / "profiles" / "coder")
+        assert p.resolved_home == tmp_path / "profiles" / "coder"
+
+    def test_resolved_home_expands_tilde(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/testuser")
+        p = AgentProfile(home_dir="~/.hermes/profiles/coder")
+        assert p.resolved_home == Path("/home/testuser/.hermes/profiles/coder")
+
+    def test_soul_md_path(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.soul_md_path == tmp_path / "SOUL.md"
+
+    def test_memory_dir(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.memory_dir == tmp_path / "memories"
+
+    def test_skills_dir(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.skills_dir == tmp_path / "skills"
+
+    def test_sessions_path(self, tmp_path):
+        p = AgentProfile(home_dir=tmp_path)
+        assert p.sessions_path == tmp_path / "sessions.json"
+
+    def test_config_overrides(self):
+        p = AgentProfile(config_overrides={"foo": "bar"})
+        assert p.config_overrides == {"foo": "bar"}
+
+
+class TestContextVar:
+    def test_get_active_profile_default_none(self):
+        """No profile set → None."""
+        assert get_active_profile() is None
+
+    def test_set_active_profile(self):
+        p = AgentProfile(id="coder")
+        token = set_active_profile(p)
+        assert get_active_profile() == p
+        # Cleanup
+        from agent.profile import _current_agent_profile
+        _current_agent_profile.reset(token)
+
+    def test_use_profile_context_manager(self):
+        p = AgentProfile(id="coder")
+        assert get_active_profile() is None
+        with use_profile(p):
+            assert get_active_profile() == p
+        assert get_active_profile() is None
+
+    def test_use_profile_none_is_noop(self):
+        """Passing None to use_profile is a no-op."""
+        with use_profile(None):
+            assert get_active_profile() is None
+
+    def test_use_profile_nested(self):
+        outer = AgentProfile(id="outer")
+        inner = AgentProfile(id="inner")
+        with use_profile(outer):
+            assert get_active_profile() == outer
+            with use_profile(inner):
+                assert get_active_profile() == inner
+            assert get_active_profile() == outer
+        assert get_active_profile() is None
+
+    def test_use_profile_exception_cleanup(self):
+        p = AgentProfile(id="coder")
+        with pytest.raises(ValueError):
+            with use_profile(p):
+                assert get_active_profile() == p
+                raise ValueError("boom")
+        assert get_active_profile() is None
+
+
+class TestContextVarAsyncIsolation:
+    """ContextVar must propagate through await but NOT leak to sibling tasks."""
+
+    @pytest.mark.asyncio
+    async def test_async_propagation(self):
+        p = AgentProfile(id="coder")
+        with use_profile(p):
+            # await should keep the profile
+            await asyncio.sleep(0)
+            assert get_active_profile() == p
+        assert get_active_profile() is None
+
+    @pytest.mark.asyncio
+    async def test_gather_isolation(self):
+        """asyncio.gather with copy_context preserves per-task profiles."""
+        async def task_a():
+            with use_profile(AgentProfile(id="a")):
+                await asyncio.sleep(0.01)
+                return get_active_profile().id if get_active_profile() else None
+
+        async def task_b():
+            with use_profile(AgentProfile(id="b")):
+                await asyncio.sleep(0.01)
+                return get_active_profile().id if get_active_profile() else None
+
+        # Tasks spawned from clean context — each sets its own profile
+        results = await asyncio.gather(task_a(), task_b())
+        assert set(results) == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_sibling_tasks_dont_leak(self):
+        """A task spawned before profile is set should not see the profile."""
+        barrier = asyncio.Event()
+
+        async def child():
+            barrier.set()
+            await asyncio.sleep(0.05)
+            return get_active_profile()
+
+        task = asyncio.create_task(child())
+        await barrier.wait()
+
+        with use_profile(AgentProfile(id="parent")):
+            await asyncio.sleep(0.01)
+            assert get_active_profile().id == "parent"
+
+        result = await task
+        # Child was created before profile was set → should not see it
+        assert result is None
+
+
+class TestLoadAgentRegistry:
+    def test_empty_config_returns_main(self):
+        registry = load_agent_registry(None)
+        assert "main" in registry
+        assert registry["main"].id == "main"
+        assert registry["main"].home_dir is None
+
+    def test_single_agent(self):
+        class FakeConfig:
+            agents = {
+                "coder": {"model": "claude-opus", "provider": "anthropic"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert "main" in registry
+        assert "coder" in registry
+        assert registry["coder"].model == "claude-opus"
+        assert registry["coder"].provider == "anthropic"
+
+    def test_multiple_agents(self):
+        class FakeConfig:
+            agents = {
+                "coder": {"model": "claude-opus"},
+                "research": {"model": "claude-sonnet"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert len(registry) == 3  # main + coder + research
+        assert registry["coder"].model == "claude-opus"
+        assert registry["research"].model == "claude-sonnet"
+
+    def test_home_dir_expansion(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/home/test")
+
+        class FakeConfig:
+            agents = {
+                "coder": {"home_dir": "~/.hermes/profiles/coder"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert registry["coder"].resolved_home == Path("/home/test/.hermes/profiles/coder")
+
+    def test_config_overrides(self):
+        class FakeConfig:
+            agents = {
+                "coder": {"model": "claude-opus", "custom_key": "custom_value"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert registry["coder"].config_overrides == {"custom_key": "custom_value"}
+
+    def test_non_dict_agent_ignored(self):
+        class FakeConfig:
+            agents = {
+                "coder": "not-a-dict",
+                "research": {"model": "claude-sonnet"},
+            }
+
+        registry = load_agent_registry(FakeConfig())
+        assert "coder" not in registry
+        assert "research" in registry
+
+    def test_main_always_present(self):
+        class FakeConfig:
+            agents = {"coder": {"model": "claude-opus"}}
+
+        registry = load_agent_registry(FakeConfig())
+        assert "main" in registry
+        assert registry["main"].id == "main"
+        assert registry["main"].home_dir is None
+
+    def test_main_can_be_overridden(self):
+        class FakeConfig:
+            agents = {"main": {"model": "claude-opus"}}
+
+        registry = load_agent_registry(FakeConfig())
+        assert registry["main"].model == "claude-opus"

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1238,3 +1238,116 @@ class TestRewriteTranscriptPreservesReasoning:
             "before user",
             "before assistant",
         ]
+
+
+class TestBuildSessionKeyAgentId:
+    """build_session_key must prefix with agent:<id> when source.agent_id is set."""
+
+    def test_default_agent_id_is_main(self):
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        key = build_session_key(source)
+        assert key.startswith("agent:main:")
+
+    def test_explicit_agent_id(self):
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source.agent_id = "coder"
+        key = build_session_key(source)
+        assert key == "agent:coder:telegram:dm:123"
+
+    def test_agent_id_none_defaults_to_main(self):
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source.agent_id = None
+        key = build_session_key(source)
+        assert key == "agent:main:telegram:dm:123"
+
+    def test_agent_id_empty_string_defaults_to_main(self):
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        source.agent_id = ""
+        key = build_session_key(source)
+        assert key == "agent:main:telegram:dm:123"
+
+    def test_dm_with_agent_id(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="99",
+            chat_type="dm",
+            thread_id="topic-1",
+        )
+        source.agent_id = "coder"
+        key = build_session_key(source)
+        assert key == "agent:coder:telegram:dm:99:topic-1"
+
+    def test_group_with_agent_id(self):
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="group",
+            user_id="alice",
+        )
+        source.agent_id = "research"
+        key = build_session_key(source)
+        assert key == "agent:research:discord:group:guild-123:alice"
+
+    def test_group_thread_with_agent_id(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1002285219667",
+            chat_type="group",
+            thread_id="17585",
+        )
+        source.agent_id = "coder"
+        key = build_session_key(source)
+        assert key == "agent:coder:telegram:group:-1002285219667:17585"
+
+    def test_whatsapp_dm_with_agent_id(self):
+        source = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="15551234567@s.whatsapp.net",
+            chat_type="dm",
+        )
+        source.agent_id = "wecom-agent"
+        key = build_session_key(source)
+        assert key == "agent:wecom-agent:whatsapp:dm:15551234567"
+
+    def test_shared_group_with_agent_id(self):
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="group",
+        )
+        source.agent_id = "main"
+        key = build_session_key(source, group_sessions_per_user=False)
+        assert key == "agent:main:discord:group:guild-123"
+
+    def test_distinct_agents_same_chat_get_distinct_keys(self):
+        """Same chat, different agent_id → different session keys."""
+        base = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+        base.agent_id = "coder"
+        key_coder = build_session_key(base)
+
+        base.agent_id = "research"
+        key_research = build_session_key(base)
+
+        assert key_coder == "agent:coder:telegram:dm:123"
+        assert key_research == "agent:research:telegram:dm:123"
+        assert key_coder != key_research
+
+    def test_session_source_roundtrip_with_agent_id(self):
+        """agent_id should survive to_dict/from_dict roundtrip."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            agent_id="coder",
+        )
+        d = source.to_dict()
+        assert d["agent_id"] == "coder"
+        restored = SessionSource.from_dict(d)
+        assert restored.agent_id == "coder"
+
+    def test_session_source_roundtrip_without_agent_id(self):
+        """agent_id omitted from dict → restored as None."""
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+        d = source.to_dict()
+        assert "agent_id" not in d
+        restored = SessionSource.from_dict(d)
+        assert restored.agent_id is None


### PR DESCRIPTION
## What
Thread `agent_id` through session identity and the SQLite session schema (new `agent_id` column + index, INSERT path, and session helpers).

## Why
Sessions must be attributable to a specific agent so routing, history, and per-agent behavior stay isolated when one gateway serves multiple agents.

## How to test
```
python -m pytest tests/gateway/test_session.py tests/gateway/test_session_boundary_hooks.py tests/cli/test_session_boundary_hooks.py -q
```

## Platforms tested
Linux (CT 133 / Proxmox LXC)

Part 2 of 6 in the multi-agent gateway decomposition (replaces #34741). Depends on: #37495

Note on conflict resolution: cherry-picking onto current `main` conflicted in `hermes_state.py` where `main` had since added the `fts5_available`-guarded FTS5/trigram setup and a `cwd` session column. Resolved by keeping both — the new `agent_id` index is created before the FTS block, and the INSERT column list/placeholders now carry both `agent_id` and `cwd` (10 columns).
