### PR TITLE
fix(cli): accumulate multiple --env flags in hermes mcp add

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13861,9 +13861,10 @@ Examples:
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
         "--env",
-        nargs="*",
+        action="append",
         default=[],
-        help="Environment variables for stdio servers (KEY=VALUE)",
+        help="Environment variables for stdio servers (KEY=VALUE). "
+        "Repeat for multiple variables, e.g. --env KEY1=VAL1 --env KEY2=VAL2",
     )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")

--- a/tests/hermes_cli/test_mcp_add_env_flag.py
+++ b/tests/hermes_cli/test_mcp_add_env_flag.py
@@ -1,0 +1,91 @@
+"""Regression test for ``hermes mcp add --env`` repeated flag support.
+
+Verifies that multiple ``--env KEY=VALUE`` flags accumulate correctly,
+rather than only keeping the last one (the ``nargs=\"*\"`` bug).
+See: https://github.com/NousResearch/hermes-agent/issues/37501
+"""
+
+import argparse
+
+
+def _build_mcp_add_parser() -> argparse.ArgumentParser:
+    """Reproduce the relevant subset of the ``hermes mcp add`` parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("name")
+    parser.add_argument("--command", dest="mcp_command")
+    parser.add_argument("--args", nargs="*", default=[])
+    parser.add_argument("--env", action="append", default=[],
+                        help="Environment variables (KEY=VALUE)")
+    return parser
+
+
+class TestMcpAddEnvFlag:
+    """Tests for ``--env`` flag parsing in ``hermes mcp add``."""
+
+    def test_single_env(self):
+        parser = _build_mcp_add_parser()
+        args = parser.parse_args(["myserver", "--command", "npx",
+                                  "--env", "KEY=VALUE"])
+        assert args.env == ["KEY=VALUE"]
+
+    def test_multiple_env_flags(self):
+        """The core regression: repeated --env flags must accumulate."""
+        parser = _build_mcp_add_parser()
+        args = parser.parse_args([
+            "myserver", "--command", "npx",
+            "--env", "ALPACA_API_KEY=sk-test",
+            "--env", "ALPACA_SECRET_KEY=secret123",
+        ])
+        assert args.env == ["ALPACA_API_KEY=sk-test", "ALPACA_SECRET_KEY=secret123"]
+
+    def test_three_env_flags(self):
+        parser = _build_mcp_add_parser()
+        args = parser.parse_args([
+            "myserver", "--command", "npx",
+            "--env", "A=1", "--env", "B=2", "--env", "C=3",
+        ])
+        assert args.env == ["A=1", "B=2", "C=3"]
+
+    def test_no_env_flag(self):
+        parser = _build_mcp_add_parser()
+        args = parser.parse_args(["myserver", "--command", "npx"])
+        assert args.env == []
+
+    def test_env_value_with_equals(self):
+        """Values containing '=' must be preserved (split on first '=' only)."""
+        parser = _build_mcp_add_parser()
+        args = parser.parse_args([
+            "myserver", "--command", "npx",
+            "--env", "CONNECTION_STRING=host=localhost;port=5432",
+        ])
+        assert args.env == ["CONNECTION_STRING=host=localhost;port=5432"]
+
+
+class TestMcpAddEnvParsing:
+    """Tests for ``_parse_env_assignments`` with the new list format."""
+
+    def test_parse_accumulated_env(self):
+        """Verify _parse_env_assignments handles the accumulated list."""
+        from hermes_cli.mcp_config import _parse_env_assignments
+
+        result = _parse_env_assignments([
+            "ALPACA_API_KEY=sk-test",
+            "ALPACA_SECRET_KEY=secret123",
+        ])
+        assert result == {
+            "ALPACA_API_KEY": "sk-test",
+            "ALPACA_SECRET_KEY": "secret123",
+        }
+
+    def test_parse_empty_list(self):
+        from hermes_cli.mcp_config import _parse_env_assignments
+        assert _parse_env_assignments([]) == {}
+
+    def test_parse_none(self):
+        from hermes_cli.mcp_config import _parse_env_assignments
+        assert _parse_env_assignments(None) == {}
+
+    def test_parse_value_with_equals(self):
+        from hermes_cli.mcp_config import _parse_env_assignments
+        result = _parse_env_assignments(["DB_URL=host=localhost;port=5432"])
+        assert result == {"DB_URL": "host=localhost;port=5432"}


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes mcp add --env` so that multiple `--env` flags are all accumulated, instead of only the last one being kept. The root cause was using `nargs="*"` instead of `action="append"` in the argparse definition.

## Related Issue

Fixes #37501

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Changed `--env` argument from `nargs="*"` to `action="append"` so repeated `--env KEY=VALUE` flags accumulate correctly
- `tests/hermes_cli/test_mcp_add_env_flag.py`: Added 9 regression tests covering single, multiple, and edge-case `--env` flag parsing

## How to Test

1. Run `python3 -m pytest tests/hermes_cli/test_mcp_add_env_flag.py -v` — all 9 tests should pass
2. Manual test: `hermes mcp add test-server --command npx --env A=1 --env B=2 --env C=3` then check `config.yaml` — all three env vars should be present under `mcp_servers.test-server.env`
3. Verify single `--env` still works: `hermes mcp add test2 --command npx --env KEY=VALUE`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/main.py:add_mcp_args` (argparse definition) + `hermes_cli/mcp_config.py:_parse_env_assignments` (consumer)
- Blast radius: LOW — single argparse flag change, no API/schema impact
- Related patterns: `--args` also uses `nargs="*"` but is typically used once; `--env` specifically needs repeated-flag semantics
