### PR TITLE
fix(desktop): codex OAuth onboarding resolves on fresh install

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3717,31 +3717,23 @@ def _codex_full_login_worker(session_id: str) -> None:
         if not access_token:
             raise RuntimeError("token exchange did not return access_token")
 
-        # Persist via credential pool — same shape as auth_commands.add_command
-        from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
-            AUTH_TYPE_OAUTH,
-            SOURCE_MANUAL,
-        )
-        import uuid as _uuid
-        pool = load_pool("openai-codex")
-        base_url = (
-            os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
-            or DEFAULT_CODEX_BASE_URL
-        )
-        entry = PooledCredential(
-            provider="openai-codex",
-            id=_uuid.uuid4().hex[:6],
-            label="dashboard device_code",
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:dashboard_device_code",
-            access_token=access_token,
-            refresh_token=refresh_token,
-            base_url=base_url,
-        )
-        pool.add_entry(entry)
+        # Persist via the canonical Codex token store. _save_codex_tokens writes
+        # the providers.openai-codex singleton (which sets active_provider via
+        # _save_provider_state) AND syncs the credential pool. The previous
+        # hand-rolled pool.add_entry() only seeded credential_pool.openai-codex,
+        # leaving active_provider=None — so on a fresh install the immediately-
+        # following setup.runtime_check resolved provider "auto", couldn't detect
+        # the Codex OAuth session, and raised "No inference provider configured"
+        # while setup.status (which sniffs the pool) reported configured. That
+        # divergence produced the desktop onboarding "Connected, but Hermes still
+        # cannot resolve a usable provider" error. This mirrors the CLI's
+        # `hermes auth add openai-codex` path and the Nous/MiniMax dashboard
+        # workers, which all use their canonical save helpers.
+        from hermes_cli.auth import _save_codex_tokens
+        _save_codex_tokens({
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        })
         with _oauth_sessions_lock:
             sess["status"] = "approved"
         _log.info("oauth/device: openai-codex login completed (session=%s)", session_id)


### PR DESCRIPTION
## Summary
Picking **OpenAI Codex (ChatGPT)** in the desktop app's first-run provider setup now resolves to a working provider instead of erroring out.

Root cause: the desktop codex device-code worker persisted tokens with a hand-rolled `pool.add_entry()`, writing **only** `credential_pool.openai-codex`. It never set `active_provider`. On a fresh install (no `~/.hermes`, no env keys) the onboarding flow immediately runs `setup.runtime_check` → `resolve_runtime_provider("auto")`, which detects OAuth providers only via `active_provider` — so it fell through and raised `"No inference provider configured"`. Meanwhile `setup.status` (which sniffs the pool) reported configured, producing the disagreement banner: *"Connected, but Hermes still cannot resolve a usable provider."*

## Changes
- `hermes_cli/web_server.py` `_codex_full_login_worker`: persist via the canonical `_save_codex_tokens()` instead of a bare pool write. It writes the `providers.openai-codex` singleton (which sets `active_provider`) **and** syncs the pool — matching the CLI `hermes auth add openai-codex` path and the Nous (`persist_nous_credentials`) / MiniMax (`_minimax_save_auth_state`) dashboard workers, which were already correct.

## Validation
E2E on a fresh empty `HERMES_HOME` with all provider env vars unset:

| | Before | After |
|---|---|---|
| `active_provider` after codex OAuth | `None` | `openai-codex` |
| `setup.runtime_check` | raises "No inference provider configured" | OK → `openai-codex` |
| Onboarding banner | "cannot resolve a usable provider" | proceeds to chat |

## Infographic

![nous-system7](https://v3b.fal.media/files/b/0a9cb3e1/lerW9omxmccucb6iEHtbf_7KXneZPI.png)
