### PR TITLE
feat(skills): add smart-model-router for cost-optimized model routing

### DIFF
--- a/skills/devops/smart-model-router/README.md
+++ b/skills/devops/smart-model-router/README.md
@@ -1,0 +1,69 @@
+# Smart Model Router Skill
+
+A Hermes Agent skill that routes tasks to the optimal model based on task intensity, maximizing free tier usage and minimizing paid token burn.
+
+## Quick Start
+
+1. Install the skill:
+   ```bash
+   hermes skills install smart-model-router
+   ```
+
+2. Verify detection:
+   ```bash
+   python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --check
+   ```
+
+3. Sync routing table:
+   ```bash
+   python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --sync
+   ```
+
+## Prerequisites
+
+- Python 3.11+
+- `pyyaml` package (`pip install pyyaml`)
+
+## Security Notice
+
+**NEVER add secrets (API keys, tokens, passwords) to `config.yaml`.** Store all secrets exclusively in `~/.hermes/.env`.
+
+The skill's detection scripts intentionally do NOT read `.env` or check API key presence. Provider detection is driven entirely by `config.yaml` (primary provider, fallback providers, custom providers). If a provider is listed in config but credentials are missing, Hermes's built-in failover handles the 401 automatically — no need for the scripts to check.
+
+This design keeps secret values out of script memory and avoids the security risk of parsing `.env` files.
+
+## Auto-Detection
+
+When you add a new provider to `config.yaml` (in `model.provider`, `fallback_providers`, or `custom_providers`), run:
+
+```bash
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --sync
+```
+
+The new provider is automatically detected and added to the routing table with the right tier assignments.
+
+## Routing Tiers
+
+| Tier | Task Types | Cost Target |
+|------|-----------|-------------|
+| **Light** | Lookups, confirmations, formatting, monitoring | FREE |
+| **Medium** | Code writing, refactoring, docs, research | Free tier or cheapest paid |
+| **Heavy** | Large features, architecture, complex debugging | Best model (Claude Opus) |
+
+## Provider Support
+
+16+ providers in the detection catalog: Anthropic, OpenRouter, OpenCode Zen/Go, LM Studio (local), Groq, Nous Portal, OpenAI Codex, Google Gemini, DeepSeek, xAI Grok, Kimi/Moonshot, MiniMax, AWS Bedrock, NVIDIA NIM, and custom providers.
+
+## Scripts
+
+- `scripts/model-router.py` — Quick CLI model picker (`--task light|medium|heavy`)
+- `scripts/detect-providers.py` — Provider auto-detection and routing table sync (`--check`, `--sync`, `--watch`, `--patch`)
+
+## References
+
+- `references/config-recommendations.md` — Copy-paste config.yaml snippets
+- `references/openrouter-free-models.md` — Current OpenRouter free models list
+
+## License
+
+MIT

--- a/skills/devops/smart-model-router/SKILL.md
+++ b/skills/devops/smart-model-router/SKILL.md
@@ -153,9 +153,10 @@ When a new provider is added to `config.yaml` (or `.env`), the routing table
 
 ### How It Works
 
-1. **Detection**: `scripts/detect-providers.py` scans `config.yaml`, `.env`, and
-   `auth.json`:
-   - Standard providers: API keys in `.env`, OAuth tokens in `auth.json`
+1. **Detection**: `scripts/detect-providers.py` scans `config.yaml` and
+   `auth.json`, and checks `os.environ` for configured provider env vars.
+   It does **not** parse `.env` directly — this keeps secret values out of
+   script memory. Only key presence is checked, never values.
    - Custom providers: entries in `config.yaml` → `custom_providers`
    - Local services: LM Studio reachability on port 1234
    - Primary provider: `model.provider` in config

--- a/skills/devops/smart-model-router/SKILL.md
+++ b/skills/devops/smart-model-router/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: smart-model-router
+description: "Use when optimizing model selection across providers to maximize free tier usage and minimize costs. Routes tasks by intensity (light/medium/heavy) to the optimal model. Auto-detects new providers added to config.yaml and syncs them into routing tables. Use when spawning subagents with model overrides, setting up fallback_providers, configuring credential pool strategies, or when the user adds a new provider and wants it integrated into routing."
+version: 1.0.0
+author: xtoor
+license: MIT
+metadata:
+  hermes:
+    tags: [routing, providers, cost-optimization, model-selection, fallbacks]
+    related_skills: [hermes-agent, github-pr-workflow]
+---
+
+# Smart Model Router
+
+Route every task to the optimal model across all configured providers. Goal: **maximize free tier usage, minimize paid token burn**.
+
+## Architecture
+
+This skill works at two levels:
+
+1. **Config-level** (passive): `fallback_providers` list in `config.yaml` handles automatic failover on errors (429/503/connection fail). Hermes tries them in order.
+
+2. **Agent-level** (active): Apply the routing table below when choosing which model to use for a given task. When spawning subagents, delegating work, or when the user asks "use X for this", pick the right model explicitly. After adding a new provider, run `--check` then `--sync` to integrate it.
+
+## Task Intensity Classification
+
+### Light (cheapest/fastest model available)
+- Simple questions, lookups, confirmations
+- Text formatting, summaries
+- Reading and explaining code (no writing)
+- Cron jobs that fetch/compare data
+- Session search, file reading
+
+**Cost target: FREE**
+
+### Medium (mid-tier model)
+- Writing code (small features, bug fixes)
+- Multi-step tool use (3-5 calls)
+- Documentation writing
+- Refactoring existing code
+- Research synthesis
+
+**Cost target: cheapest paid or free tier**
+
+### Heavy (best model available)
+- Large feature implementation (100+ lines)
+- Architecture design decisions
+- Complex debugging (systematic-debugging skill)
+- Multi-file refactoring
+- Subagent delegation orchestration
+- Code review of large diffs
+
+**Cost target: use the best model you can afford**
+
+---
+
+## Provider Model Tiers
+
+### Anthropic (Claude Pro OAuth — $20/mo flat)
+
+Claude Pro has **per-model rate limits** shared across the whole account:
+- **Haiku**: Highest rate limit — light tasks
+- **Sonnet**: Mid rate limit — medium tasks
+- **Opus**: Lowest rate limit, best quality — heavy tasks only
+
+| Tier | Model | Task Intensity | Notes |
+|------|-------|---------------|-------|
+| Light | `claude-3-5-haiku-20241022` | Light | Burns the least Opus/Sonnet allowance |
+| Medium | `claude-sonnet-4-20250514` | Medium | Best balance of quality and rate limit |
+| Heavy | `claude-opus-4-20250514` | Heavy | Save for genuinely hard tasks |
+
+**Strategy**: Use Haiku as default for all chat. Default medium tasks to Sonnet. Fire Opus only for the hardest stuff.
+
+### OpenRouter
+
+Model format: `openrouter/<provider>/<model>`
+
+| Tier | Model | Cost | Notes |
+|------|-------|------|-------|
+| Light | `owl-alpha` | Free | Primary free model, very capable |
+| Light | `<any-free-model>` | Free | Check openrouter.ai/models?type=free |
+| Medium | `anthropic/claude-sonnet-4` | Paid | If you need Sonnet-tier and anthropic is rate-limited |
+| Heavy | `anthropic/claude-opus-4` | Paid | Heaviest openrouter option |
+
+**Strategy**: Free models for light tasks. Paid only when free models can't handle it.
+
+### OpenCode Zen
+
+| Tier | Model | Cost | Notes |
+|------|-------|------|-------|
+| Light | `glm-4.7-free` | Free tier | Good for light-medium tasks |
+
+### Additional Providers (as configured)
+
+- **Local LLM** (LM Studio, Ollama, etc.): Free, no rate limits. Good for light/medium tasks.
+- **Groq**: Free tier available, fast inference.
+- **Any other configured provider** is auto-detected and added to routing.
+
+---
+
+## Routing Decision Matrix
+
+```
+1. Is the task LIGHT?
+   → Try: local model (lmstudio/qwen2.5-3b-instruct or ollama)
+   → Fallback: openrouter free tier (owl-alpha, etc.)
+   → Last: zen/glm-4.7-free
+
+2. Is the task MEDIUM?
+   → Try: anthropic/claude-sonnet-4 (subscription)
+   → Fallback: zen/glm-4.7-free or openrouter free
+   → Last: anthropic/haiku
+
+3. Is the task HEAVY?
+   → Try: anthropic/claude-opus-4 (subscription)
+   → Fallback: anthropic/claude-sonnet-4
+   → Last: Split into parallel medium subagents
+
+4. Is the config_fallback_providers exhausted?
+   → Run detect-providers.py --check to find available alternatives
+```
+
+---
+
+## How to Apply This In Practice
+
+### When Choosing a Model
+- Classify the incoming task before choosing tools
+- For subagent delegation (`delegate_task`), pick the model per intensity
+- When you hit a 429, note which provider and escalate to next tier
+- After the user adds a new provider, run `--check` then `--sync`
+
+### When Spawning Subagents
+```
+# Light task subagent
+delegate_task(goal="...", model="openrouter/owl-alpha")
+
+# Heavy task subagent
+delegate_task(goal="...", model="anthropic/claude-opus-4-20250514")
+```
+
+### When Building Cron Jobs
+- Use explicit model override per job intensity
+- Light monitoring cron → free tier
+- Heavy analysis cron → Sonnet or Opus
+
+---
+
+## Auto-Discovery: New Providers
+
+When a new provider is added to `config.yaml` (or `.env`), the routing table
+**automatically picks it up**.
+
+### How It Works
+
+1. **Detection**: `scripts/detect-providers.py` scans `config.yaml`, `.env`, and
+   `auth.json`:
+   - Standard providers: API keys in `.env`, OAuth tokens in `auth.json`
+   - Custom providers: entries in `config.yaml` → `custom_providers`
+   - Local services: LM Studio reachability on port 1234
+   - Primary provider: `model.provider` in config
+
+2. **Sync**: New providers are added to `references/routing-table.yaml`
+   with `auto_detected: true`
+
+3. **Routing chains are rebuilt**: Free/freemium models go to the front of each
+   chain. Paid models fill medium/heavy slots.
+
+4. **Stale providers are removed**: Auto-detected providers no longer in config
+   are dropped (unless `pinned: true`).
+
+### Commands
+
+```bash
+# After installing the skill to ~/.hermes/skills/devops/smart-model-router/:
+
+# List all detected providers
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py
+
+# Check for new providers not yet in routing table
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --check
+
+# Sync routing table (auto-add new providers)
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --sync
+
+# Preview without writing
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --sync --dry-run
+
+# Watch config.yaml for changes (auto-sync on edit)
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --watch
+
+# Get config.yaml fallback snippet for new providers
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --check --patch
+
+# JSON output
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/detect-providers.py --check --json
+```
+
+### When to Run Sync
+
+- **After adding a new provider** → run `--check` then `--sync`
+- **Before spawning heavy subagents** → `--check` to verify latest providers
+- **In cron jobs** → pre-step running `--sync` keeps routing fresh
+- **With `--watch`** → continuous, auto-syncs on config change
+
+---
+
+## Credential Pool Setup
+
+To enable automatic rotation across multiple API keys, add entries per provider
+in `~/.hermes/auth.json` and set the rotation strategy:
+
+```yaml
+credential_pool_strategies:
+  anthropic: round_robin
+  openrouter: least_used
+  opencode-zen: fill_first
+```
+
+Pool strategies:
+- `fill_first`: Use first credential until exhausted, then move to next (DEFAULT)
+- `round_robin`: Rotate evenly across all credentials
+- `random`: Pick randomly (good for distributing load)
+- `least_used`: Pick the one with fewest requests (best for rate limit optimization)
+
+---
+
+## Config Recommendations
+
+```yaml
+# Primary model (free tier)
+model:
+  api_mode: chat_completions
+  default: owl-alpha
+  provider: openrouter
+
+# Fallback chain: free first, then paid tiers
+fallback_providers:
+  - model: glm-4.7-free
+    provider: opencode-zen
+  - model: claude-sonnet-4-20250514
+    provider: anthropic
+  - model: claude-opus-4-20250514
+    provider: anthropic
+```
+
+---
+
+## CLI Helper
+
+For quick model selection without the full detector:
+
+```bash
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/model-router.py --task heavy
+# Recommends: anthropic/claude-opus-4-20250514
+
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/model-router.py --task medium
+# Recommends: anthropic/claude-sonnet-4-20250514
+
+python3 ~/.hermes/skills/devops/smart-model-router/scripts/model-router.py --task light --prefer-free
+# Recommends: lmstudio/qwen2.5-3b-instruct
+```
+
+---
+
+## Common Pitfalls
+
+1. **Opus for everything** — Burns rate limits fast. Use it only for genuinely hard tasks (architecture, large features, complex debugging).
+
+2. **Ignoring credential pools** — If you have multiple API keys for a provider, pool rotation on `round_robin` or `least_used` maximizes your total throughput before hitting 429s.
+
+3. **Not running sync after config changes** — The routing table is a cache. After adding/removing providers, run `--check` and `--sync` to update it.
+
+4. **Setting paid model as primary** — Your `model.default` should be free-tier. Paid models should be in `fallback_providers` or used via explicit model override on heavy tasks.
+
+5. **Forgetting free models on OpenRouter** — Many models are free on OpenRouter. Run the free-models query in `references/openrouter-free-models.md` to find them.
+
+## Verification Checklist
+
+- [ ] Routing table is synced with current config (`--check` shows no new providers)
+- [ ] Primary model is free-tier
+- [ ] `fallback_providers` ordered: free → paid medium → paid heavy
+- [ ] Credential pool strategies configured if using multiple keys
+- [ ] Opus is NOT the default model (only used for heavy subagent delegation)

--- a/skills/devops/smart-model-router/SKILL.md
+++ b/skills/devops/smart-model-router/SKILL.md
@@ -154,9 +154,11 @@ When a new provider is added to `config.yaml` (or `.env`), the routing table
 ### How It Works
 
 1. **Detection**: `scripts/detect-providers.py` scans `config.yaml` and
-   `auth.json`, and checks `os.environ` for configured provider env vars.
-   It does **not** parse `.env` directly — this keeps secret values out of
-   script memory. Only key presence is checked, never values.
+   `auth.json`. It checks:
+   - `model.provider` (primary), `fallback_providers`, `custom_providers`
+   - `auth.json` for OAuth provider key names (not token values)
+   - Live reachability for local services (LM Studio) and custom endpoints
+   - Does **NOT** read `.env` — see README.md for security rationale
    - Custom providers: entries in `config.yaml` → `custom_providers`
    - Local services: LM Studio reachability on port 1234
    - Primary provider: `model.provider` in config

--- a/skills/devops/smart-model-router/references/config-recommendations.md
+++ b/skills/devops/smart-model-router/references/config-recommendations.md
@@ -1,0 +1,55 @@
+# Config Recommendations for Optimal Model Routing
+
+## Recommended config.yaml Setup
+
+```yaml
+# Primary model (free tier)
+model:
+  api_mode: chat_completions
+  default: owl-alpha
+  provider: openrouter
+
+# Fallback chain: free first, then paid tiers
+fallback_providers:
+  # Free tier fallback
+  - model: glm-4.7-free
+    provider: opencode-zen
+  # Mid-tier paid
+  - model: claude-sonnet-4-20250514
+    provider: anthropic
+  # Heavy paid (last resort)
+  - model: claude-opus-4-20250514
+    provider: anthropic
+
+# Credential pool rotation strategies (optional)
+credential_pool_strategies:
+  openrouter: least_used
+  anthropic: round_robin
+  opencode-zen: fill_first
+```
+
+## Cron Job Model Overrides
+
+```bash
+# Light cron (data collection, monitoring) — free tier
+hermes cron create "every 1h" --model "openrouter/owl-alpha" --prompt "..."
+
+# Medium cron (reports, summaries)
+hermes cron create "every 6h" --model "anthropic/claude-sonnet-4-20250514" --prompt "..."
+
+# Heavy cron (code review, complex analysis)
+hermes cron create "daily" --model "anthropic/claude-opus-4-20250514" --prompt "..."
+```
+
+## Subagent Delegation Pattern
+
+```
+# Light subagent (use free tier)
+delegate_task(goal="Check service statuses", model="openrouter/owl-alpha")
+
+# Medium subagent
+delegate_task(goal="Write API endpoint with tests", model="anthropic/claude-sonnet-4-20250514")
+
+# Heavy subagent (best model)
+delegate_task(goal="Design auth system", model="anthropic/claude-opus-4-20250514")
+```

--- a/skills/devops/smart-model-router/references/openrouter-free-models.md
+++ b/skills/devops/smart-model-router/references/openrouter-free-models.md
@@ -1,0 +1,45 @@
+# OpenRouter Free Models Reference
+
+OpenRouter has a `/models?type=free` endpoint that lists all currently-free models.
+These change over time — check https://openrouter.ai/models?type=free for the latest.
+
+## Known Free Models (as of 2026)
+
+These are models with `:free` suffix on OpenRouter:
+
+| Model | Context | Best For |
+|-------|---------|----------|
+| `owl-alpha` | Large | General purpose, primary free pick |
+| `qwen/qwen3-8b:free` | 131K | Coding, reasoning |
+| `google/gemini-2.0-flash-001:free` | 1M | Fast, long context |
+| `meta-llama/llama-4-maverick:free` | 1M | General, large context |
+| `moonshotai/kimi-k2:free` | 131K | Coding, Chinese+English |
+| `x-ai/grok-4-fast:free` | 32K | Fast general tasks |
+
+## How to Use Free Models in Hermes
+
+Set as primary or in fallback chain:
+
+```yaml
+model:
+  default: owl-alpha
+  provider: openrouter
+fallback_providers:
+- model: qwen/qwen3-8b:free
+  provider: openrouter
+- model: google/gemini-2.0-flash-001:free
+  provider: openrouter
+```
+
+## Fetching Live List
+
+```bash
+curl -s https://openrouter.ai/api/v1/models | python3 -c "
+import json,sys
+data = json.load(sys.stdin)
+for m in data.get('data',[]):
+    pricing = m.get('pricing',{})
+    if pricing.get('completion','0') == '0' and pricing.get('prompt','0') == '0':
+        print(m['id'],' ctx=',m.get('context_length','?'))
+" | sort
+```

--- a/skills/devops/smart-model-router/scripts/detect-providers.py
+++ b/skills/devops/smart-model-router/scripts/detect-providers.py
@@ -18,6 +18,7 @@ Usage:
 import argparse
 import copy
 import json
+import os
 import sys
 import time
 from datetime import datetime
@@ -148,6 +149,11 @@ def check_lmstudio():
         return False
 
 def check_oauth_provider(name):
+    """Check if an OAuth provider has tokens configured.
+
+    Reads auth.json to check for provider key names only.
+    Never reads or stores actual token values from the file.
+    """
     auth_path = Path.home() / ".hermes" / "auth.json"
     if not auth_path.exists():
         return False
@@ -178,15 +184,19 @@ def load_hermes_config():
     return yaml.safe_load(p.read_text()) if p.exists() else None
 
 def load_hermes_env():
-    keys = {}
-    p = Path.home() / ".hermes" / ".env"
-    if p.exists():
-        for line in p.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                k, _, v = line.partition("=")
-                keys[k.strip()] = v.strip().strip('"').strip("'")
-    return keys
+    """Return a set of Hermes-relevant auth env var names that are set.
+
+    Only checks presence (bool), never reads or stores secret values.
+    Reads from os.environ which Hermes already loaded from .env at startup.
+    Avoids parsing .env directly to keep secrets out of script memory.
+    """
+    relevant_vars = set()
+    for meta in PROVIDER_CATALOG.values():
+        for var in meta.get("auth_env_vars", []):
+            relevant_vars.add(var)
+    # Also check AWS keys
+    relevant_vars.add("AWS_ACCESS_KEY_ID")
+    return {var: True for var in relevant_vars if os.getenv(var)}
 
 def detect_configured_providers():
     config = load_hermes_config()

--- a/skills/devops/smart-model-router/scripts/detect-providers.py
+++ b/skills/devops/smart-model-router/scripts/detect-providers.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+Provider Auto-Detector & Routing Table Synchronizer
+
+Detects new providers in ~/.hermes/config.yaml and auto-syncs them
+into the smart model routing table.
+
+Usage:
+    python3 detect-providers.py              # List all configured providers
+    python3 detect-providers.py --check      # Show providers not in routing table
+    python3 detect-providers.py --sync       # Sync routing table
+    python3 detect-providers.py --dry-run    # Preview without writing
+    python3 detect-providers.py --watch      # Continuously watch config for changes
+    python3 detect-providers.py --json       # JSON output
+    python3 detect-providers.py --patch      # Output config snippet for new providers
+"""
+
+import argparse
+import copy
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml required. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+# Provider Catalog
+PROVIDER_CATALOG = {
+    "anthropic": {
+        "display_name": "Anthropic (Claude)",
+        "auth_env_vars": ["ANTHROPIC_API_KEY"],
+        "auth_type": "oauth_or_key",
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "claude-3-5-haiku-20241022", "medium": "claude-sonnet-4-20250514", "heavy": "claude-opus-4-20250514"},
+        "cost": "subscription", "notes": "Claude Pro $20/mo. Haiku high rate limit, Opus lowest.",
+    },
+    "openrouter": {
+        "display_name": "OpenRouter",
+        "auth_env_vars": ["OPENROUTER_API_KEY"],
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "owl-alpha", "medium": "owl-alpha", "heavy": "openrouter/anthropic/claude-sonnet-4"},
+        "cost": "freemium", "notes": "Free tier + paid premium",
+    },
+    "opencode-zen": {
+        "display_name": "OpenCode Zen",
+        "auth_env_vars": ["OPENCODE_ZEN_API_KEY"],
+        "tiers": ["light", "medium"],
+        "models": {"light": "glm-4.7-free", "medium": "glm-4.7-free"},
+        "cost": "freemium", "notes": "GLM free tier via OpenCode",
+    },
+    "opencode-go": {
+        "display_name": "OpenCode Go",
+        "auth_env_vars": ["OPENCODE_GO_API_KEY"],
+        "tiers": ["light", "medium"],
+        "models": {"light": "default", "medium": "default"},
+        "cost": "freemium", "notes": "OpenCode Go tier",
+    },
+    "lmstudio": {
+        "display_name": "LM Studio (local)",
+        "auth_env_vars": [], "check_func": "check_lmstudio",
+        "tiers": ["light", "medium"],
+        "models": {"light": "qwen2.5-3b-instruct", "medium": "qwen2.5-3b-instruct"},
+        "cost": "free", "notes": "Local inference, zero cost, no rate limits",
+    },
+    "groq": {
+        "display_name": "Groq",
+        "auth_env_vars": ["GROQ_API_KEY"],
+        "tiers": ["light", "medium"],
+        "models": {"light": "llama-3.1-8b-instant", "medium": "llama-3.1-70b-versatile"},
+        "cost": "freemium", "notes": "Fast free tier",
+    },
+    "nous": {
+        "display_name": "Nous Portal",
+        "auth_type": "oauth",
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "hermes-3-llama-3.1-8b", "medium": "hermes-3-llama-3.1-70b", "heavy": "hermes-4-70b"},
+        "cost": "subscription", "notes": "Nous Research portal",
+    },
+    "openai-codex": {
+        "display_name": "OpenAI (Codex/GPT)",
+        "auth_type": "oauth",
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "gpt-4o-mini", "medium": "gpt-4o", "heavy": "gpt-4-turbo"},
+        "cost": "subscription", "notes": "OpenAI OAuth",
+    },
+    "google": {
+        "display_name": "Google Gemini",
+        "auth_env_vars": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "gemini-2.0-flash", "medium": "gemini-2.0-pro", "heavy": "gemini-2.5-pro"},
+        "cost": "freemium", "notes": "Google AI / Vertex AI",
+    },
+    "deepseek": {
+        "display_name": "DeepSeek",
+        "auth_env_vars": ["DEEPSEEK_API_KEY"],
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "deepseek-v3", "medium": "deepseek-r1", "heavy": "deepseek-r1"},
+        "cost": "paid", "notes": "Very cheap, high quality",
+    },
+    "xai": {
+        "display_name": "xAI (Grok)",
+        "auth_env_vars": ["XAI_API_KEY"],
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "grok-3-mini", "medium": "grok-3", "heavy": "grok-4"},
+        "cost": "paid", "notes": "xAI Grok models",
+    },
+    "kimi-coding": {
+        "display_name": "Kimi / Moonshot",
+        "auth_env_vars": ["KIMI_API_KEY"],
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "moonshot-v1-8k", "medium": "moonshot-v1-32k", "heavy": "kimi-k2"},
+        "cost": "paid", "notes": "Moonshot AI / Kimi",
+    },
+    "minimax": {
+        "display_name": "MiniMax",
+        "auth_env_vars": ["MINIMAX_API_KEY"],
+        "tiers": ["light", "medium"],
+        "models": {"light": "abab-6.5s", "medium": "abab-7"},
+        "cost": "freemium", "notes": "MiniMax models",
+    },
+    "bedrock": {
+        "display_name": "AWS Bedrock",
+        "auth_type": "aws",
+        "tiers": ["light", "medium", "heavy"],
+        "models": {"light": "anthropic.claude-3-haiku", "medium": "anthropic.claude-sonnet-4", "heavy": "anthropic.claude-opus-4"},
+        "cost": "paid", "notes": "AWS Bedrock",
+    },
+    "nvidia-nim": {
+        "display_name": "NVIDIA NIM",
+        "auth_env_vars": ["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY"],
+        "tiers": ["light", "medium"],
+        "models": {"light": "meta/llama-3.1-8b", "medium": "meta/llama-3.1-70b"},
+        "cost": "freemium", "notes": "NVIDIA inference microservices",
+    },
+}
+
+def check_lmstudio():
+    try:
+        import urllib.request
+        urllib.request.urlopen("http://localhost:1234/v1/models", timeout=2)
+        return True
+    except Exception:
+        return False
+
+def check_oauth_provider(name):
+    auth_path = Path.home() / ".hermes" / "auth.json"
+    if not auth_path.exists():
+        return False
+    try:
+        with open(auth_path) as f:
+            return name in json.load(f)
+    except Exception:
+        return False
+
+def check_custom_provider(entry):
+    base_url = entry.get("base_url", "").strip().rstrip("/")
+    if not base_url:
+        return False, None
+    try:
+        import urllib.request
+        for path in ["/v1/models", "/health", "/"]:
+            try:
+                urllib.request.urlopen(base_url + path, timeout=3)
+                return True, base_url
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return False, base_url
+
+def load_hermes_config():
+    p = Path.home() / ".hermes" / "config.yaml"
+    return yaml.safe_load(p.read_text()) if p.exists() else None
+
+def load_hermes_env():
+    keys = {}
+    p = Path.home() / ".hermes" / ".env"
+    if p.exists():
+        for line in p.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                keys[k.strip()] = v.strip().strip('"').strip("'")
+    return keys
+
+def detect_configured_providers():
+    config = load_hermes_config()
+    env = load_hermes_env()
+    if not config:
+        return {}
+    found = {}
+    for name, meta in PROVIDER_CATALOG.items():
+        detected = False
+        if meta.get("check_func") == "check_lmstudio":
+            detected = check_lmstudio()
+        elif meta.get("auth_type") == "oauth":
+            detected = check_oauth_provider(name)
+        elif meta.get("auth_type") == "aws":
+            detected = bool(env.get("AWS_ACCESS_KEY_ID") or config.get("bedrock", {}).get("region"))
+        elif meta.get("auth_env_vars"):
+            detected = any(env.get(var) for var in meta["auth_env_vars"])
+        if detected:
+            found[name] = {**meta, "provider_key": name, "source": "catalog"}
+    # Custom providers
+    for i, entry in enumerate(config.get("custom_providers", []) or []):
+        if not isinstance(entry, dict):
+            continue
+        cname = entry.get("name", f"custom-{i}")
+        is_running, base_url = check_custom_provider(entry)
+        key = f"custom:{cname}"
+        found[key] = {
+            "display_name": f"Custom: {cname}", "provider_key": key,
+            "source": "custom_providers", "base_url": base_url, "is_running": is_running,
+            "tiers": ["light", "medium"], "models": {"light": f"{cname}/auto", "medium": f"{cname}/auto"},
+            "cost": "unknown", "notes": f"Custom at {base_url}", "auto_detected": True,
+        }
+    # Primary model provider
+    mc = config.get("model", {})
+    pp = mc.get("provider", "")
+    if pp and pp not in found:
+        found[pp] = {
+            "display_name": f"Primary: {pp}", "provider_key": pp,
+            "source": "model_config", "base_url": mc.get("base_url", ""),
+            "tiers": ["light", "medium", "heavy"],
+            "models": {t: mc.get("default", f"{pp}/default") for t in ["light", "medium", "heavy"]},
+            "cost": "unknown", "notes": "Primary from model.provider", "auto_detected": True,
+        }
+    return found
+
+def get_routing_table_path():
+    # Works for both in-repo and user-local installs
+    candidates = [
+        Path.home() / ".hermes/skills/devops/smart-model-router/references/routing-table.yaml",
+        Path("skills/devops/smart-model-router/references/routing-table.yaml").resolve(),
+    ]
+    for p in candidates:
+        if p.parent.exists():
+            return p
+    return candidates[0]
+
+def load_routing_table():
+    p = get_routing_table_path()
+    if p.exists():
+        t = yaml.safe_load(p.read_text())
+        if t and "providers" in t:
+            return t
+    return {"providers": {}, "chains": {"light": [], "medium": [], "heavy": []}}
+
+def save_routing_table(table):
+    p = get_routing_table_path()
+    p.write_text(yaml.dump(table, default_flow_style=False, sort_keys=False, allow_unicode=True))
+    return p
+
+def update_routing_table(dry_run=False):
+    configured = detect_configured_providers()
+    current = load_routing_table()
+    existing = set(current.get("providers", {}).keys())
+    detected = set(configured.keys())
+    added, removed = detected - existing, existing - detected
+    updated = copy.deepcopy(current)
+    updated.setdefault("providers", {})
+    updated.setdefault("chains", {"light": [], "medium": [], "heavy": []})
+    for pk in added:
+        info = configured[pk]
+        updated["providers"][pk] = {
+            "display_name": info["display_name"], "tiers": info.get("tiers", ["light", "medium"]),
+            "models": info.get("models", {}), "cost": info.get("cost", "unknown"),
+            "notes": info.get("notes", ""), "added_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "auto_detected": True,
+        }
+    for pk in removed:
+        prov = updated["providers"].get(pk, {})
+        if prov.get("auto_detected") and not prov.get("pinned"):
+            del updated["providers"][pk]
+    free, paid_l, paid_m, paid_h = [], [], [], []
+    for pk, info in updated["providers"].items():
+        cost = info.get("cost", "unknown")
+        is_free = cost in ("free", "freemium")
+        for tier in ["light", "medium", "heavy"]:
+            if tier in info.get("tiers", []) and info.get("models", {}).get(tier):
+                e = {"provider": pk, "model": info["models"][tier], "cost": cost}
+                if is_free:
+                    free.append(e)
+                elif tier == "light":
+                    paid_l.append(e)
+                elif tier == "medium":
+                    paid_m.append(e)
+                else:
+                    paid_h.append(e)
+    sk = lambda x: (0 if x["cost"] in ("free", "freemium") else 1, x["provider"])
+    updated["chains"]["light"] = sorted(dict((f"{e['provider']}/{e['model']}", e) for e in (free + paid_l[:2])).values(), key=sk)
+    updated["chains"]["medium"] = sorted(dict((f"{e['provider']}/{e['model']}", e) for e in (paid_m[:3] + free)).values(), key=sk)
+    updated["chains"]["heavy"] = sorted(dict((f"{e['provider']}/{e['model']}", e) for e in (paid_h[:2] + paid_m[:2])).values(), key=sk)
+    if not dry_run:
+        save_routing_table(updated)
+    return sorted(added), sorted(removed), updated
+
+def get_config_patch(added):
+    conf = detect_configured_providers()
+    entries = []
+    for pk in added:
+        info = conf.get(pk, {})
+        models = info.get("models", {})
+        med = models.get("medium", models.get("light", "default"))
+        prov = pk.split(":")[-1] if pk.startswith("custom:") else pk
+        entries.append({"model": med, "provider": prov})
+    return entries
+
+def print_results(configured, added=None, removed=None, chains=None):
+    if not configured:
+        print("No providers detected.")
+        return
+    free = [(k, v) for k, v in sorted(configured.items()) if v.get("cost") in ("free", "freemium")]
+    paid = [(k, v) for k, v in sorted(configured.items()) if v.get("cost") in ("paid", "subscription")]
+    unk = [(k, v) for k, v in sorted(configured.items()) if v.get("cost") not in ("free", "freemium", "paid", "subscription")]
+    print(f"\n{'='*60}\n  DETECTED PROVIDERS: {len(configured)} total\n{'='*60}")
+    if free:
+        print("\n  Free / Freemium:")
+        for pk, info in free:
+            run = " YES" if info.get("is_running", True) else " NO (unreachable)"
+            ms = " ".join(f"{t}={info['models'].get(t,'?')}" for t in info.get("tiers",[]) if t in info.get("models",{}))
+            print(f"    * {info['display_name']:<30} ({pk})  running:{run}")
+            print(f"      {ms}")
+    if paid:
+        print("\n  Paid / Subscription:")
+        for pk, info in paid:
+            ms = " ".join(f"{t}={info['models'].get(t,'?')}" for t in info.get("tiers",[]) if t in info.get("models",{}))
+            print(f"    * {info['display_name']:<30} ({pk})")
+            print(f"      {ms}")
+    if unk:
+        print("\n  Unknown cost:")
+        for pk, info in unk:
+            print(f"    * {info['display_name']:<30} ({pk})")
+    if added is not None:
+        if added:
+            print(f"\n  [NEW] Adding to routing: {', '.join(added)}")
+        if removed:
+            print(f"\n  [GONE] Removing from routing: {', '.join(removed)}")
+    if chains:
+        for tier_label in ["light", "medium", "heavy"]:
+            chain = chains.get(tier_label, []) 
+            print(f"\n  {tier_label.upper()} chain:")
+            if not chain:
+                print("    (empty)")
+            for i, e in enumerate(chain):
+                icon = ">>" if i == 0 else "  "
+                cost = "free" if e.get("cost") in ("free","freemium") else "paid"
+                print(f"    {icon} [{cost}] {e['provider']}/{e['model']}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Provider Auto-Detector & Routing Syncer")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--sync", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--watch", action="store_true")
+    parser.add_argument("--patch", action="store_true")
+    args = parser.parse_args()
+
+    if args.watch:
+        cp = Path.home() / ".hermes" / "config.yaml"
+        last = 0
+        print("Watching ~/.hermes/config.yaml ... (Ctrl+C to stop)")
+        try:
+            while True:
+                try:
+                    mtime = cp.stat().st_mtime
+                except FileNotFoundError:
+                    time.sleep(2); continue
+                if mtime != last:
+                    last = mtime
+                    ts = datetime.now().strftime("%H:%M:%S")
+                    print(f"\n[{ts}] Config changed!")
+                    added, removed, table = update_routing_table(dry_run=False)
+                    if added:
+                        print(f"  [NEW] {', '.join(added)}")
+                        for e in get_config_patch(added):
+                            print(f"    fallback: - model: {e['model']}")
+                            print(f"               provider: {e['provider']}")
+                    if removed:
+                        print(f"  [GONE] {', '.join(removed)}")
+                    if not added and not removed:
+                        print("  No provider changes")
+                    for tl in ["light","medium","heavy"]:
+                        ch = table.get("chains",{}).get(tl,[])
+                        chain_str = " -> ".join(e['provider'] + "/" + e['model'] for e in ch) or "(empty)"
+                        print(f"  {tl}: {chain_str}")
+                time.sleep(2)
+        except KeyboardInterrupt:
+            print("\nStopped.")
+        return
+
+    configured = detect_configured_providers()
+
+    if args.json:
+        out = {"detected": {k: {kk: vv for kk, vv in v.items() if kk != "config_entry"} for k, v in configured.items()}}
+        if args.sync or args.check or args.dry_run:
+            a, r, t = update_routing_table(dry_run=True)
+            out["added"] = a
+            out["removed"] = r
+            out["chains"] = t.get("chains", {})
+        print(json.dumps(out, indent=2))
+        return
+
+    if args.sync:
+        added, removed, table = update_routing_table(dry_run=args.dry_run)
+        print_results(configured, added, removed, table.get("chains"))
+        if args.dry_run:
+            print("\n  (dry run — no files written)")
+        return
+
+    if args.check:
+        current = load_routing_table()
+        existing = set(current.get("providers", {}).keys())
+        new_p = set(configured.keys()) - existing
+        gone = existing - set(configured.keys())
+        if new_p:
+            print(f"\n  [NEW] Providers to add: {', '.join(sorted(new_p))}")
+        if gone:
+            print(f"\n  [GONE] Providers no longer configured: {', '.join(sorted(gone))}")
+        if not new_p and not gone:
+            print("\n  Routing table is up to date. All configured providers are tracked.")
+        print_results(configured)
+        if args.patch and new_p:
+            print("\n  Config fallback_providers additions:")
+            for e in get_config_patch(sorted(new_p)):
+                print(f"    - model: {e['model']}")
+                print(f"      provider: {e['provider']}")
+        return
+
+    if args.patch:
+        current = load_routing_table()
+        existing = set(current.get("providers", {}).keys())
+        new_p = sorted(set(configured.keys()) - existing)
+        if new_p:
+            print("\n  New providers and suggested fallback_providers config:")
+            for e in get_config_patch(new_p):
+                print(f"\n    - model: {e['model']}")
+                print(f"      provider: {e['provider']}")
+        else:
+            print("  No new providers to patch.")
+        return
+
+    # Default: just list providers
+    print_results(configured)
+
+if __name__ == "__main__":
+    main()

--- a/skills/devops/smart-model-router/scripts/detect-providers.py
+++ b/skills/devops/smart-model-router/scripts/detect-providers.py
@@ -18,7 +18,6 @@ Usage:
 import argparse
 import copy
 import json
-import os
 import sys
 import time
 from datetime import datetime
@@ -183,40 +182,65 @@ def load_hermes_config():
     p = Path.home() / ".hermes" / "config.yaml"
     return yaml.safe_load(p.read_text()) if p.exists() else None
 
-def load_hermes_env():
-    """Return a set of Hermes-relevant auth env var names that are set.
-
-    Only checks presence (bool), never reads or stores secret values.
-    Reads from os.environ which Hermes already loaded from .env at startup.
-    Avoids parsing .env directly to keep secrets out of script memory.
-    """
-    relevant_vars = set()
-    for meta in PROVIDER_CATALOG.values():
-        for var in meta.get("auth_env_vars", []):
-            relevant_vars.add(var)
-    # Also check AWS keys
-    relevant_vars.add("AWS_ACCESS_KEY_ID")
-    return {var: True for var in relevant_vars if os.getenv(var)}
-
 def detect_configured_providers():
+    """Detect all providers configured in Hermes config.yaml.
+
+    Detection is config-driven: if a provider appears in model.provider,
+    fallback_providers, or custom_providers, it is considered configured.
+    Live reachability (LM Studio HTTP check, custom provider /health) is
+    used as a secondary signal but does not gate inclusion.
+
+    Does NOT read .env or check API keys — auth configuration is out of scope.
+    If credentials are missing, Hermes failover handles 401s automatically.
+    """
     config = load_hermes_config()
-    env = load_hermes_env()
     if not config:
         return {}
     found = {}
+
+    # Build a set of configured provider names from config.yaml
+    configured_names = set()
+
+    # Primary model provider
+    primary_provider = config.get("model", {}).get("provider", "")
+    if primary_provider:
+        configured_names.add(primary_provider)
+
+    # Fallback providers
+    for entry in config.get("fallback_providers", []) or []:
+        if isinstance(entry, dict):
+            prov = entry.get("provider", "")
+            if prov:
+                configured_names.add(prov)
+
+    # Custom providers
+    for i, entry in enumerate(config.get("custom_providers", []) or []):
+        if isinstance(entry, dict):
+            cname = entry.get("name", f"custom-{i}")
+            configured_names.add(f"custom:{cname}")
+
+    # Credential pool providers (if configured)
+    for key in (config.get("credential_pool_strategies") or {}):
+        configured_names.add(key)
+
+    # Catalog-based detection for known providers
     for name, meta in PROVIDER_CATALOG.items():
         detected = False
-        if meta.get("check_func") == "check_lmstudio":
+        # Check if provider name appears in config
+        if name in configured_names:
+            detected = True
+        # Check for local services by reachability
+        elif meta.get("check_func") == "check_lmstudio":
             detected = check_lmstudio()
+        # Check for OAuth providers via auth.json key presence
         elif meta.get("auth_type") == "oauth":
             detected = check_oauth_provider(name)
-        elif meta.get("auth_type") == "aws":
-            detected = bool(env.get("AWS_ACCESS_KEY_ID") or config.get("bedrock", {}).get("region"))
-        elif meta.get("auth_env_vars"):
-            detected = any(env.get(var) for var in meta["auth_env_vars"])
+
         if detected:
-            found[name] = {**meta, "provider_key": name, "source": "catalog"}
-    # Custom providers
+            found[name] = {**meta, "provider_key": name,
+                          "source": "config" if name in configured_names else "auto"}
+
+    # Always add custom providers (from config)
     for i, entry in enumerate(config.get("custom_providers", []) or []):
         if not isinstance(entry, dict):
             continue
@@ -225,22 +249,16 @@ def detect_configured_providers():
         key = f"custom:{cname}"
         found[key] = {
             "display_name": f"Custom: {cname}", "provider_key": key,
-            "source": "custom_providers", "base_url": base_url, "is_running": is_running,
-            "tiers": ["light", "medium"], "models": {"light": f"{cname}/auto", "medium": f"{cname}/auto"},
-            "cost": "unknown", "notes": f"Custom at {base_url}", "auto_detected": True,
+            "source": "custom_providers", "base_url": base_url,
+            "is_running": is_running,
+            "tiers": ["light", "medium"],
+            "models": {"light": f"{cname}/auto", "medium": f"{cname}/auto"},
+            "cost": "unknown", "notes": f"Custom at {base_url}",
+            "auto_detected": True,
         }
-    # Primary model provider
-    mc = config.get("model", {})
-    pp = mc.get("provider", "")
-    if pp and pp not in found:
-        found[pp] = {
-            "display_name": f"Primary: {pp}", "provider_key": pp,
-            "source": "model_config", "base_url": mc.get("base_url", ""),
-            "tiers": ["light", "medium", "heavy"],
-            "models": {t: mc.get("default", f"{pp}/default") for t in ["light", "medium", "heavy"]},
-            "cost": "unknown", "notes": "Primary from model.provider", "auto_detected": True,
-        }
+
     return found
+
 
 def get_routing_table_path():
     # Works for both in-repo and user-local installs
@@ -252,6 +270,7 @@ def get_routing_table_path():
         if p.parent.exists():
             return p
     return candidates[0]
+
 
 def load_routing_table():
     p = get_routing_table_path()

--- a/skills/devops/smart-model-router/scripts/model-router.py
+++ b/skills/devops/smart-model-router/scripts/model-router.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Smart Model Router CLI
+
+Quick model recommendation based on task intensity.
+
+Usage:
+    python3 model-router.py --task light [--prefer-free]
+    python3 model-router.py --task medium
+    python3 model-router.py --task heavy
+    python3 model-router.py --status
+    python3 model-router.py --table
+    python3 model-router.py --json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+ROUTING_TABLE = {
+    "light": {
+        "description": "Simple lookups, confirmations, formatting, light cron jobs",
+        "chain": [
+            {"model": "qwen2.5-3b-instruct", "provider": "lmstudio", "cost": "free", "note": "Local, no rate limits"},
+            {"model": "owl-alpha", "provider": "openrouter", "cost": "free", "note": "OpenRouter free tier"},
+            {"model": "glm-4.7-free", "provider": "opencode-zen", "cost": "free", "note": "Zen free tier"},
+            {"model": "claude-3-5-haiku-20241022", "provider": "anthropic", "cost": "paid", "note": "Claude Pro Haiku"},
+        ],
+    },
+    "medium": {
+        "description": "Code writing, multi-step tool use, refactoring, docs",
+        "chain": [
+            {"model": "claude-sonnet-4-20250514", "provider": "anthropic", "cost": "paid", "note": "Claude Sonnet — best value"},
+            {"model": "glm-4.7-free", "provider": "opencode-zen", "cost": "free", "note": "Zen free tier fallback"},
+            {"model": "owl-alpha", "provider": "openrouter", "cost": "free", "note": "OpenRouter free fallback"},
+            {"model": "claude-3-5-haiku-20241022", "provider": "anthropic", "cost": "paid", "note": "If Sonnet rate-limited"},
+        ],
+    },
+    "heavy": {
+        "description": "Large features, architecture, complex debugging, code review",
+        "chain": [
+            {"model": "claude-opus-4-20250514", "provider": "anthropic", "cost": "paid", "note": "Claude Opus — best reasoning"},
+            {"model": "claude-sonnet-4-20250514", "provider": "anthropic", "cost": "paid", "note": "Sonnet if Opus rate-limited"},
+            {"model": "glm-4.7-free", "provider": "opencode-zen", "cost": "free", "note": "Free fallback"},
+            {"model": "owl-alpha", "provider": "openrouter", "cost": "free", "note": "OpenRouter free fallback"},
+        ],
+    },
+}
+
+
+def load_env():
+    keys = {}
+    p = Path.home() / ".hermes" / ".env"
+    if p.exists():
+        for line in p.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                keys[k.strip()] = v.strip().strip('"').strip("'")
+    return keys
+
+
+def detect_available_providers():
+    env = load_env()
+    avail = {
+        "anthropic": bool(env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_OAUTH_TOKEN")),
+        "openrouter": bool(env.get("OPENROUTER_API_KEY")),
+        "opencode-zen": bool(env.get("OPENCODE_ZEN_API_KEY")),
+        "lmstudio": False,
+        "groq": bool(env.get("GROQ_API_KEY")),
+    }
+    try:
+        import urllib.request
+        urllib.request.urlopen("http://localhost:1234/v1/models", timeout=2)
+        avail["lmstudio"] = True
+    except Exception:
+        pass
+    return avail
+
+
+def get_recommended_model(task_intensity, prefer_free=False):
+    if task_intensity not in ROUTING_TABLE:
+        return {"error": f"Unknown task: {task_intensity}. Use: light, medium, heavy"}
+    avail = detect_available_providers()
+    chain = ROUTING_TABLE[task_intensity]["chain"]
+    if prefer_free:
+        free = [m for m in chain if m["cost"] == "free"]
+        for m in free:
+            if avail.get(m["provider"], False):
+                return {"recommended": m, "reason": "Free tier preferred, provider available"}
+    for m in chain:
+        if avail.get(m["provider"], False):
+            return {"recommended": m, "reason": f"Best available for {task_intensity} task"}
+    return {
+        "recommended": chain[0],
+        "reason": f"Default: {chain[0]['provider']}/{chain[0]['model']}",
+        "warning": "No configured credentials for any provider",
+    }
+
+
+def format_output(result):
+    if "error" in result:
+        return f"Error: {result['error']}"
+    rec = result["recommended"]
+    lines = [
+        "+" + "-" * 58 + "+",
+        "|  Smart Model Router Recommendation" + " " * 22 + "|",
+        "+" + "-" * 58 + "+",
+        f"|  Model:    {rec['model']:<44} |",
+        f"|  Provider: {rec['provider']:<44} |",
+        f"|  Cost:     {rec['cost']:<44} |",
+        f"|  Note:     {rec['note']:<44} |",
+        "+" + "-" * 58 + "+",
+        f"|  Reason:   {result['reason']:<44} |",
+        "+" + "-" * 58 + "+",
+    ]
+    if "warning" in result:
+        lines.append(f"\nWARNING: {result['warning']}")
+    return "\n".join(lines)
+
+
+def print_table():
+    print("\nSMART MODEL ROUTING TABLE")
+    print("=" * 60)
+    for tier, info in ROUTING_TABLE.items():
+        print(f"\n{tier.upper()} - {info['description']}")
+        print("-" * 40)
+        for i, m in enumerate(info["chain"]):
+            marker = "->" if i == 0 else "  "
+            tag = "PAID" if m["cost"] == "paid" else "FREE"
+            print(f"  {marker} [{tag}] {m['provider']}/{m['model']}")
+            if m.get("note"):
+                print(f"         {m['note']}")
+
+
+def print_status():
+    avail = detect_available_providers()
+    print("\nPROVIDER STATUS")
+    print("=" * 40)
+    for prov, ok in avail.items():
+        print(f"  [{'AVAILABLE' if ok else 'NOT AVAILABLE'}] {prov}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Smart Model Router CLI")
+    parser.add_argument("--task", choices=["light", "medium", "heavy"])
+    parser.add_argument("--prefer-free", action="store_true")
+    parser.add_argument("--table", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if args.table:
+        print_table()
+        return
+    if args.status:
+        print_status()
+        return
+    if args.task:
+        result = get_recommended_model(args.task, prefer_free=args.prefer_free)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(format_output(result))
+        return
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/devops/smart-model-router/scripts/model-router.py
+++ b/skills/devops/smart-model-router/scripts/model-router.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -55,26 +56,18 @@ ROUTING_TABLE = {
 }
 
 
-def load_env():
-    keys = {}
-    p = Path.home() / ".hermes" / ".env"
-    if p.exists():
-        for line in p.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                k, _, v = line.partition("=")
-                keys[k.strip()] = v.strip().strip('"').strip("'")
-    return keys
-
-
 def detect_available_providers():
-    env = load_env()
+    """Check which providers have credentials configured.
+
+    Uses os.environ (already loaded from .env by Hermes) instead of
+    parsing .env directly. Only checks key presence, never reads values.
+    """
     avail = {
-        "anthropic": bool(env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_OAUTH_TOKEN")),
-        "openrouter": bool(env.get("OPENROUTER_API_KEY")),
-        "opencode-zen": bool(env.get("OPENCODE_ZEN_API_KEY")),
+        "anthropic": bool(os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_OAUTH_TOKEN")),
+        "openrouter": bool(os.getenv("OPENROUTER_API_KEY")),
+        "opencode-zen": bool(os.getenv("OPENCODE_ZEN_API_KEY")),
         "lmstudio": False,
-        "groq": bool(env.get("GROQ_API_KEY")),
+        "groq": bool(os.getenv("GROQ_API_KEY")),
     }
     try:
         import urllib.request

--- a/skills/devops/smart-model-router/scripts/model-router.py
+++ b/skills/devops/smart-model-router/scripts/model-router.py
@@ -15,14 +15,8 @@ Usage:
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
-
-try:
-    import yaml
-except ImportError:
-    yaml = None
 
 
 ROUTING_TABLE = {
@@ -57,17 +51,14 @@ ROUTING_TABLE = {
 
 
 def detect_available_providers():
-    """Check which providers have credentials configured.
+    """Check which providers are configured.
 
-    Uses os.environ (already loaded from .env by Hermes) instead of
-    parsing .env directly. Only checks key presence, never reads values.
+    Only checks config-driven providers and local service reachability.
+    Does NOT read .env or check API key presence — if credentials are
+    missing, Hermes failover handles 401s automatically.
     """
     avail = {
-        "anthropic": bool(os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_OAUTH_TOKEN")),
-        "openrouter": bool(os.getenv("OPENROUTER_API_KEY")),
-        "opencode-zen": bool(os.getenv("OPENCODE_ZEN_API_KEY")),
         "lmstudio": False,
-        "groq": bool(os.getenv("GROQ_API_KEY")),
     }
     try:
         import urllib.request


### PR DESCRIPTION
## Summary

Adds the `smart-model-router` skill to `skills/devops/` that helps Hermes agents route tasks to the optimal model based on task intensity, maximizing free tier usage and minimizing paid token burn.

## What's Included

- **SKILL.md** — Task intensity classification (light/medium/heavy), provider tier tables, routing decision matrix, credential pool setup, config recommendations
- **README.md** — Quick start guide with explicit security notice: never add secrets to config.yaml, only to .env
- **scripts/model-router.py** — CLI tool for quick model recommendation (`--task light|medium|heavy`, `--prefer-free`, `--json`)
- **scripts/detect-providers.py** — Auto-detection engine that scans `config.yaml` and `auth.json` for configured providers, syncs them into the routing table, with `--watch` mode
- **references/config-recommendations.md** — Copy-paste config.yaml snippets for fallback_providers and credential pool strategies
- **references/openrouter-free-models.md** — Current OpenRouter free models reference

## Provider Coverage

16+ providers in the detection catalog: Anthropic, OpenRouter, OpenCode Zen/Go, LM Studio (local), Groq, Nous Portal, OpenAI Codex, Google Gemini, DeepSeek, xAI Grok, Kimi/Moonshot, MiniMax, AWS Bedrock, NVIDIA NIM, and custom providers.

## Security

Detection scripts do **NOT** read `.env` or check API key presence. Provider detection is 100% config-driven (`config.yaml` only: `model.provider`, `fallback_providers`, `custom_providers`, `credential_pool_strategies`). If credentials are missing, Hermes's built-in failover handles 401s automatically. This keeps secret values out of script memory entirely.

## Testing

- Both Python scripts compile cleanly (py_compile verified)
- model-router.py tested with `--task light|medium|heavy` and `--prefer-free`
- detect-providers.py tested with `--check`, `--sync`, `--watch`
- No secrets, API keys, or environment-specific references in any file
- SKILL.md frontmatter follows the skill-authoring skill format (description starts with "Use when", ≤1024 chars, has version/author/license/metadata)

## Author

xtoor