### PR TITLE
fix(gateway): stabilize macOS launchd restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4072,6 +4072,24 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Failed to launch systemd planned-restart helper: %s", e)
 
+    @staticmethod
+    def _running_under_launchd() -> bool:
+        """Return True when this gateway process appears to be launchd-managed.
+
+        systemd exposes INVOCATION_ID, but macOS launchd does not set an
+        equivalent environment marker.  A LaunchAgent-launched process is
+        reparented to launchd (PID 1), while an interactive ``hermes gateway
+        run`` keeps the user's shell/terminal as its parent.  Use that as the
+        lightweight service-manager signal so in-chat ``/restart`` can take the
+        service restart path instead of spawning a detached helper.
+        """
+        if sys.platform != "darwin":
+            return False
+        try:
+            return os.getppid() == 1
+        except Exception:
+            return False
+
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:
             return False
@@ -10642,11 +10660,14 @@ class GatewayRunner:
         active_agents = self._running_agent_count()
         # When running under a service manager (systemd/launchd) or inside a
         # Docker/Podman container, use the service restart path: exit with
-        # code 75 so the service manager / container restart policy restarts
-        # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # the planned-restart code so the supervisor/container policy restarts
+        # us.  The detached subprocess approach is brittle under supervisors:
+        # systemd may kill the helper's cgroup, Docker/tini exits with the
+        # gateway, and macOS launchd can throttle/delay the detached
+        # `hermes gateway restart` helper.  Foreground `hermes gateway run`
+        # still uses the detached helper so a user-launched process can come
+        # back without an installed service.
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or self._running_under_launchd()
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3488,17 +3488,20 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         except (OSError, AttributeError):
             pass
 
-    # Refresh the systemd unit definition on every boot so that restart
-    # settings (RestartSec, StartLimitIntervalSec, etc.) stay current even
-    # when the process was respawned via exit-code-75 (stale-code or
-    # /restart) rather than through `hermes gateway restart` which already
-    # calls refresh_systemd_unit_if_needed().  Without this, a code update
-    # that ships new unit settings won't take effect until the next manual
-    # `hermes gateway start/restart` — leaving the gateway vulnerable to
-    # the exact failure mode the new settings were meant to prevent.
+    # Refresh the service definition on every boot so restart settings stay
+    # current even when the process was respawned by the service manager
+    # (exit-code-75 / /restart) rather than through the manual
+    # `hermes gateway start/restart` commands.  Without this, a code update
+    # that ships new service settings won't take effect until the next manual
+    # CLI restart — leaving /restart on stale launchd/systemd definitions.
     if supports_systemd_services():
         try:
             refresh_systemd_unit_if_needed(system=False)
+        except Exception:
+            pass  # best-effort; don't block gateway startup
+    elif sys.platform == "darwin":
+        try:
+            refresh_launchd_plist_if_needed()
         except Exception:
             pass  # best-effort; don't block gateway startup
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -17,8 +17,10 @@ from tests.gateway.restart_test_helpers import make_restart_runner, make_restart
 @pytest.mark.asyncio
 async def test_restart_command_while_busy_requests_drain_without_interrupt(monkeypatch):
     # Ensure INVOCATION_ID is NOT set — systemd sets this in service mode,
-    # which changes the restart call signature.
+    # which changes the restart call signature. Also force non-launchd mode so
+    # this test covers foreground/bare-process behaviour on every OS.
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run.GatewayRunner, "_running_under_launchd", staticmethod(lambda: False))
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     event = MessageEvent(
@@ -45,6 +47,39 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
     assert "Draining" in expected and "1" in expected
     running_agent.interrupt.assert_not_called()
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_service_path_under_launchd(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run.GatewayRunner, "_running_under_launchd", staticmethod(lambda: True))
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is not None
+    assert "Restarting" in result
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+def test_running_under_launchd_detects_macos_launchagent(monkeypatch):
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setattr(gateway_run.os, "getppid", lambda: 1)
+    assert gateway_run.GatewayRunner._running_under_launchd() is True
+
+    monkeypatch.setattr(gateway_run.os, "getppid", lambda: 12345)
+    assert gateway_run.GatewayRunner._running_under_launchd() is False
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
+    monkeypatch.setattr(gateway_run.os, "getppid", lambda: 1)
+    assert gateway_run.GatewayRunner._running_under_launchd() is False
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -27,6 +27,7 @@ def _install_fake_gateway_run(monkeypatch, start_gateway):
     monkeypatch.setattr(
         gateway, "refresh_systemd_unit_if_needed", lambda system=False: False
     )
+    monkeypatch.setattr(gateway, "refresh_launchd_plist_if_needed", lambda: False)
 
 
 def test_run_gateway_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):
@@ -162,6 +163,49 @@ def test_run_gateway_windows_detached_absorbs_console_controls(monkeypatch):
 
     assert calls == [(False, 0)]
     assert (gateway.signal.SIGINT, gateway.signal.SIG_IGN) in signal_calls
+
+
+def test_run_gateway_refreshes_launchd_plist_on_macos_service_boot(monkeypatch):
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    refreshed = []
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    monkeypatch.setattr(gateway.sys, "platform", "darwin")
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "refresh_launchd_plist_if_needed", lambda: refreshed.append(True) or True)
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: True)
+
+    gateway.run_gateway()
+
+    assert refreshed == [True]
+    assert calls == [(False, 0)]
+
+
+def test_run_gateway_prefers_systemd_refresh_when_available(monkeypatch):
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    systemd_refreshed = []
+    launchd_refreshed = []
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    monkeypatch.setattr(gateway.sys, "platform", "darwin")
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "refresh_systemd_unit_if_needed", lambda system=False: systemd_refreshed.append(system) or True)
+    monkeypatch.setattr(gateway, "refresh_launchd_plist_if_needed", lambda: launchd_refreshed.append(True) or True)
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: True)
+
+    gateway.run_gateway()
+
+    assert systemd_refreshed == [False]
+    assert launchd_refreshed == []
+    assert calls == [(False, 0)]
 
 
 class TestSystemdLingerStatus:


### PR DESCRIPTION
## Summary
- Detect macOS LaunchAgent-managed gateway processes and route in-chat `/restart` through the service restart path instead of the detached helper.
- Refresh installed launchd plist definitions on gateway boot, matching the existing systemd self-heal behaviour for service-manager respawns.
- Add regression tests for launchd detection, restart routing, and boot-time launchd plist refresh.

## Why
On macOS, launchd does not set systemd's `INVOCATION_ID`, so a LaunchAgent-managed gateway could incorrectly treat `/restart` as a foreground process restart and spawn the detached `hermes gateway restart` helper. That path is less reliable under launchd and can leave `/restart` dependent on a stale service definition until a manual CLI `hermes gateway start/restart` refreshes the plist.

Recent gateway logs showed `/restart` shutting the gateway down cleanly but taking minutes to become reachable again, while manual `hermes gateway restart` recovered cleanly. `hermes gateway status` also reported a stale launchd service definition.

## Test Plan
- `python -m pytest tests/gateway/test_restart_drain.py tests/hermes_cli/test_gateway.py -q -o 'addopts='`

Result: `55 passed`
