### PR TITLE
fix(feishu): preserve topic reply targets for send_message

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -308,12 +308,15 @@ def _build_from_sessions_db(platform_name: str) -> List[Dict[str, str]]:
             if not entry_id or entry_id in seen_ids:
                 continue
             seen_ids.add(entry_id)
-            entries.append({
+            entry = {
                 "id": entry_id,
                 "name": _session_entry_name(origin),
                 "type": row.get("chat_type") or "dm",
                 "thread_id": origin.get("thread_id"),
-            })
+            }
+            if origin.get("message_id"):
+                entry["message_id"] = origin.get("message_id")
+            entries.append(entry)
     except Exception as e:
         logger.debug(
             "Channel directory: state.db session read failed for %s: %s",

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -346,12 +346,15 @@ def _build_from_sessions_json(platform_name: str) -> List[Dict[str, str]]:
             if not entry_id or entry_id in seen_ids:
                 continue
             seen_ids.add(entry_id)
-            entries.append({
+            entry = {
                 "id": entry_id,
                 "name": _session_entry_name(origin),
                 "type": session.get("chat_type", "dm"),
                 "thread_id": origin.get("thread_id"),
-            })
+            }
+            if origin.get("message_id"):
+                entry["message_id"] = origin.get("message_id")
+            entries.append(entry)
     except Exception as e:
         logger.debug("Channel directory: failed to read sessions for %s: %s", platform_name, e)
 
@@ -389,6 +392,30 @@ def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:
             return ch.get("type")
     return None
 
+
+
+def lookup_channel_metadata(platform_name: str, target_id: str) -> Dict[str, str]:
+    """Return routing metadata stored for a channel directory entry.
+
+    Session-derived Feishu topic targets need both ``thread_id`` and the
+    triggering/root ``message_id`` so outbound sends can use Feishu's reply API
+    with ``reply_in_thread=True`` instead of attempting an invalid direct
+    ``thread_id`` create.  Other platforms can ignore the extra metadata.
+    """
+    directory = load_directory()
+    for ch in directory.get("platforms", {}).get(platform_name, []):
+        if ch.get("id") != target_id:
+            continue
+
+        metadata: Dict[str, str] = {}
+        thread_id = ch.get("thread_id")
+        if thread_id:
+            metadata["thread_id"] = str(thread_id)
+        reply_to = ch.get("reply_to_message_id") or ch.get("message_id")
+        if reply_to:
+            metadata["reply_to_message_id"] = str(reply_to)
+        return metadata
+    return {}
 
 def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     """

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5390,6 +5390,7 @@ async def _standalone_send(
     message,
     *,
     thread_id=None,
+    metadata=None,
     media_files=None,
     force_document=False,
 ):
@@ -5409,7 +5410,11 @@ async def _standalone_send(
         domain_name = getattr(adapter, "_domain_name", "feishu")
         domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
-        metadata = {"thread_id": thread_id} if thread_id else None
+        metadata = dict(metadata or {})
+        if thread_id and "thread_id" not in metadata:
+            metadata["thread_id"] = thread_id
+        if not metadata:
+            metadata = None
 
         last_result = None
         if message.strip():

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -326,6 +326,42 @@ class TestBuildFromSessions:
             }
         ]
 
+    def test_state_db_origin_message_id_reaches_channel_metadata(self, tmp_path):
+        from hermes_state import SessionDB
+
+        origin = {
+            "platform": "feishu",
+            "chat_id": "oc_chat",
+            "chat_name": "Agent 多线程 Main",
+            "thread_id": "omt_topic",
+            "message_id": "om_root",
+        }
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session("feishu-topic", "feishu", user_id="ou_user")
+        db.record_gateway_session_peer(
+            "feishu-topic",
+            source="feishu",
+            user_id="ou_user",
+            session_key="agent:main:feishu:group:oc_chat:omt_topic",
+            chat_id="oc_chat",
+            chat_type="group",
+            thread_id="omt_topic",
+            display_name="Agent 多线程 Main",
+            origin_json=json.dumps(origin),
+        )
+
+        with patch("hermes_state.SessionDB", return_value=db):
+            entries = _build_from_sessions("feishu")
+
+        cache_file = _write_directory(tmp_path, {"feishu": entries})
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            metadata = lookup_channel_metadata("feishu", "oc_chat:omt_topic")
+
+        assert metadata == {
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_root",
+        }
+
 
 class TestFormatDirectoryForDisplay:
     def test_empty_directory(self, tmp_path):

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from gateway.channel_directory import (
     build_channel_directory,
     lookup_channel_type,
+    lookup_channel_metadata,
     resolve_channel_name,
     format_directory_for_display,
     load_directory,
@@ -158,6 +159,24 @@ class TestResolveChannelName:
         with self._setup(tmp_path, platforms):
             assert resolve_channel_name("telegram", "Coaching Chat / topic 17585") == "-1001:17585"
 
+    def test_lookup_channel_metadata_returns_feishu_thread_reply_target(self, tmp_path):
+        platforms = {
+            "feishu": [
+                {
+                    "id": "oc_chat:omt_topic",
+                    "name": "Agent 多线程 Main / topic omt_topic",
+                    "type": "group",
+                    "thread_id": "omt_topic",
+                    "message_id": "om_root",
+                }
+            ]
+        }
+        with self._setup(tmp_path, platforms):
+            assert lookup_channel_metadata("feishu", "oc_chat:omt_topic") == {
+                "thread_id": "omt_topic",
+                "reply_to_message_id": "om_root",
+            }
+
     def test_id_match_takes_precedence_over_name(self, tmp_path):
         """A raw channel ID resolves to itself, even when a different
         channel happens to be named the same string. Case-sensitive: Slack
@@ -279,6 +298,33 @@ class TestBuildFromSessions:
         assert "Coaching Chat" in names
         assert "Coaching Chat / topic 17585" in names
         assert "Coaching Chat / topic 17587" in names
+
+    def test_build_from_sessions_preserves_feishu_thread_message_id(self, tmp_path):
+        self._write_sessions(tmp_path, {
+            "feishu_topic": {
+                "origin": {
+                    "platform": "feishu",
+                    "chat_id": "oc_chat",
+                    "chat_name": "Agent 多线程 Main",
+                    "thread_id": "omt_topic",
+                    "message_id": "om_root",
+                },
+                "chat_type": "group",
+            },
+        })
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_from_sessions("feishu")
+
+        assert entries == [
+            {
+                "id": "oc_chat:omt_topic",
+                "name": "Agent 多线程 Main / topic omt_topic",
+                "type": "group",
+                "thread_id": "omt_topic",
+                "message_id": "om_root",
+            }
+        ]
 
 
 class TestFormatDirectoryForDisplay:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2038,8 +2038,8 @@ class TestAdapterBehavior(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_message_tool_passes_directory_reply_target_for_feishu_topic(self):
-        from gateway.config import Platform, PlatformConfig
-        from tools.send_message_tool import _send_to_platform
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from tools.send_message_tool import _handle_send
 
         captured = {}
 
@@ -2068,16 +2068,38 @@ class TestAdapterBehavior(unittest.TestCase):
         original_sender = entry.standalone_sender_fn
         entry.standalone_sender_fn = _fake_send_feishu
         try:
-            result = asyncio.run(
-                _send_to_platform(
-                    Platform.FEISHU,
-                    PlatformConfig(enabled=True),
-                    "oc_chat",
-                    "hello topic",
-                    thread_id="omt_topic",
-                    send_metadata={"thread_id": "omt_topic", "reply_to_message_id": "om_root"},
-                )
+            config = GatewayConfig(
+                platforms={Platform.FEISHU: PlatformConfig(enabled=True)}
             )
+            with tempfile.TemporaryDirectory() as tmpdir:
+                directory_path = Path(tmpdir) / "channel_directory.json"
+                directory_path.write_text(json.dumps({
+                    "updated_at": "2026-07-14T00:00:00Z",
+                    "platforms": {
+                        "feishu": [{
+                            "id": "oc_chat:omt_topic",
+                            "name": "Agent 多线程 Main / topic omt_topic",
+                            "type": "group",
+                            "thread_id": "omt_topic",
+                            "message_id": "om_root",
+                        }],
+                    },
+                }))
+                with patch(
+                    "gateway.channel_directory.DIRECTORY_PATH", directory_path
+                ), patch(
+                    "gateway.config.load_gateway_config", return_value=config
+                ), patch(
+                    "tools.interrupt.is_interrupted", return_value=False
+                ), patch(
+                    "model_tools._run_async", side_effect=lambda coro: asyncio.run(coro)
+                ), patch(
+                    "gateway.mirror.mirror_to_session", return_value=True
+                ):
+                    result = json.loads(_handle_send({
+                        "target": "feishu:Agent 多线程 Main / topic omt_topic",
+                        "message": "hello topic",
+                    }))
         finally:
             entry.standalone_sender_fn = original_sender
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2035,6 +2035,57 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
 
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_message_tool_passes_directory_reply_target_for_feishu_topic(self):
+        from gateway.config import Platform, PlatformConfig
+        from tools.send_message_tool import _send_to_platform
+
+        captured = {}
+
+        async def _fake_send_feishu(
+            pconfig,
+            chat_id,
+            message,
+            *,
+            media_files=None,
+            thread_id=None,
+            metadata=None,
+        ):
+            captured.update({
+                "chat_id": chat_id,
+                "message": message,
+                "thread_id": thread_id,
+                "metadata": metadata,
+            })
+            return {"success": True, "platform": "feishu", "chat_id": chat_id, "message_id": "om_sent"}
+
+        from gateway.platform_registry import platform_registry
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+        entry = platform_registry.get("feishu")
+        original_sender = entry.standalone_sender_fn
+        entry.standalone_sender_fn = _fake_send_feishu
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    PlatformConfig(enabled=True),
+                    "oc_chat",
+                    "hello topic",
+                    thread_id="omt_topic",
+                    send_metadata={"thread_id": "omt_topic", "reply_to_message_id": "om_root"},
+                )
+            )
+        finally:
+            entry.standalone_sender_fn = original_sender
+
+        self.assertTrue(result["success"])
+        self.assertEqual(captured["chat_id"], "oc_chat")
+        self.assertEqual(captured["thread_id"], "omt_topic")
+        self.assertEqual(captured["metadata"], {"thread_id": "omt_topic", "reply_to_message_id": "om_root"})
+
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -307,19 +307,28 @@ def _handle_send(args):
     target_ref = parts[1].strip() if len(parts) > 1 else None
     chat_id = None
     thread_id = None
+    send_metadata = None
 
     if target_ref:
         chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+        if is_explicit and chat_id:
+            try:
+                from gateway.channel_directory import lookup_channel_metadata
+                lookup_id = f"{chat_id}:{thread_id}" if thread_id else str(chat_id)
+                send_metadata = lookup_channel_metadata(platform_name, lookup_id) or None
+            except Exception:
+                send_metadata = None
     else:
         is_explicit = False
 
     # Resolve human-friendly channel names to numeric IDs
     if target_ref and not is_explicit:
         try:
-            from gateway.channel_directory import resolve_channel_name
+            from gateway.channel_directory import lookup_channel_metadata, resolve_channel_name
             resolved = resolve_channel_name(platform_name, target_ref)
             if resolved:
                 chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+                send_metadata = lookup_channel_metadata(platform_name, resolved) or None
             else:
                 return json.dumps({
                     "error": f"Could not resolve '{target_ref}' on {platform_name}. "
@@ -441,6 +450,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                send_metadata=send_metadata,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -720,7 +730,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, send_metadata=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -899,6 +909,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chunk,
                 media_files=media_files if is_last else None,
                 thread_id=thread_id,
+                metadata=send_metadata,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -972,7 +983,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _registry_standalone_send("dingtalk", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.FEISHU:
-            result = await _registry_standalone_send("feishu", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send(
+                "feishu", pconfig, chat_id, chunk, thread_id, metadata=send_metadata
+            )
         elif platform == Platform.WECOM:
             result = await _registry_standalone_send("wecom", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.BLUEBUBBLES:
@@ -1260,7 +1273,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(
+    platform_name, pconfig, chat_id, message, thread_id=None, metadata=None
+):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1273,7 +1288,10 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    kwargs = {"thread_id": thread_id}
+    if metadata is not None:
+        kwargs["metadata"] = metadata
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, **kwargs)
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,


### PR DESCRIPTION
## What does this PR do?

Preserves Feishu topic reply metadata for `send_message` targets that come from the channel directory/session history.

When a Feishu topic target is listed as `chat_id:thread_id`, `send_message` previously passed only `thread_id` through to the Feishu adapter. That can route into the invalid direct create path for Feishu thread ids. Session origins already contain the root `message_id`, so this PR carries that value through the channel directory and into `_send_feishu` as `reply_to_message_id`, allowing the existing adapter reply-in-thread path to be used.

## Related Issue

Fixes #37425

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/channel_directory.py`
  - Preserve session-origin `message_id` on session-derived channel entries.
  - Add `lookup_channel_metadata()` to return `thread_id` and `reply_to_message_id` for directory targets.
- `tools/send_message_tool.py`
  - Resolve directory metadata for explicit and human-readable targets.
  - Thread `send_metadata` through `_send_to_platform()` and `_send_feishu()`.
  - Keep existing `thread_id` fallback behavior when no directory metadata is available.
- `tests/gateway/test_channel_directory.py`
  - Cover Feishu topic metadata preservation and lookup.
- `tests/gateway/test_feishu.py`
  - Cover `send_message` passing directory reply metadata into the Feishu send path.

## How to Test

1. `PYTEST_ADDOPTS='' python3 -m pytest -o addopts='' tests/gateway/test_channel_directory.py tests/gateway/test_feishu.py -q`
   - Result: `196 passed, 45 skipped`
2. `python3 -m py_compile gateway/channel_directory.py tools/send_message_tool.py tests/gateway/test_channel_directory.py tests/gateway/test_feishu.py && git diff --check`
   - Result: passed with no output
3. `uv run ruff check gateway/channel_directory.py tools/send_message_tool.py tests/gateway/test_channel_directory.py tests/gateway/test_feishu.py`
   - Result: `All checks passed!`
4. `python3 scripts/check-windows-footguns.py --diff origin/main`
   - Result: `✓ No Windows footguns found (0 file(s) scanned).`

Not tested: full `pytest tests/ -q` suite; live Feishu delivery without app credentials.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
PYTEST_ADDOPTS='' python3 -m pytest -o addopts='' tests/gateway/test_channel_directory.py tests/gateway/test_feishu.py -q
........................................................................ [ 29%]
................................................ssssssssssssssssssssss.. [ 59%]
.....sssssssssssssssssssssss............................................ [ 89%]
.........................                                                [100%]
196 passed, 45 skipped in 2.20s
```
