### PR TITLE
[codex] docs: add Tool Search to sidebar

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
           label: 'Core',
           items: [
             'user-guide/features/tools',
+            'user-guide/features/tool-search',
             'user-guide/features/skills',
             'user-guide/features/lsp',
             'user-guide/features/curator',


### PR DESCRIPTION
## Summary

- Adds the existing Tool Search docs page to the manually curated Docusaurus sidebar under Features > Core.
- Keeps the change scoped to sidebar navigation only.

## Why

Tool Search was introduced in #34493 with `website/docs/user-guide/features/tool-search.md`, but that PR did not include `website/sidebars.ts`. The page is routable and indexed by search, but absent from the sidebar because the sidebar is manually enumerated.

I checked #34493 and the superseded #31163 discussion/files for any indication that the omission was intentional. I found none; both PRs list the docs page as part of the feature and neither mentions intentionally hiding it from navigation.

## Validation

- `git diff --check`
- `npm run build --prefix website`

The docs build exits successfully. It still reports existing unrelated broken-link/anchor warnings, including zh-Hans docs warnings and an existing `/docs/integrations/mcp` link from `web-dashboard`; this sidebar entry resolves correctly.
