### PR TITLE
Clarify desktop install retry guidance

### DIFF
--- a/apps/desktop/src/components/desktop-install-overlay.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.tsx
@@ -348,7 +348,7 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
           </h2>
           <p className="mt-1.5 text-sm text-muted-foreground">
             {failed
-              ? 'One of the install steps failed. Check the details below or the desktop log for the full transcript.'
+              ? 'One of the install steps failed. On Windows, this can happen if another Hermes CLI or desktop instance is running. Stop any running Hermes instances, then retry. Check the details below or the desktop log for the full transcript.'
               : 'This is a one-time setup. The Hermes installer is downloading dependencies and configuring your machine. ' +
                 'Subsequent launches will skip this step.'}
           </p>


### PR DESCRIPTION
## Summary
- Updates the desktop first-launch install failure copy to tell Windows users to stop any running Hermes CLI or desktop instances before retrying.

## Test plan
- `npm run type-check` from `apps/desktop`
- `npm run lint` from `apps/desktop` (fails on existing lint violations across desktop files, including pre-existing rules in the edited overlay)