### PR TITLE
fix(gateway): wire agent.load_soul_identity config to gateway AIAgent construction (#37480)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1794,6 +1794,7 @@ class GatewayRunner:
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
+        self._load_soul_identity = self._load_soul_identity()
         self._busy_input_mode = self._load_busy_input_mode()
         self._busy_text_mode = self._load_busy_text_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
@@ -3113,6 +3114,21 @@ class GatewayRunner:
             return "priority"
         logger.warning("Unknown service_tier '%s', ignoring", raw)
         return None
+
+    @staticmethod
+    def _load_soul_identity() -> bool:
+        """Load SOUL identity toggle from config.yaml.
+
+        Reads agent.load_soul_identity from config.yaml. When True, the
+        gateway will load ``~/.hermes/SOUL.md`` as the primary agent
+        identity even when context files are otherwise skipped.  This
+        matches the CLI behaviour controlled by the same config key.
+        """
+        cfg = _load_gateway_runtime_config()
+        return is_truthy_value(
+            cfg_get(cfg, "agent", "load_soul_identity"),
+            default=False,
+        )
 
     @staticmethod
     def _load_show_reasoning() -> bool:
@@ -12440,6 +12456,7 @@ class GatewayRunner:
                     disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
+                    load_soul_identity=self._load_soul_identity,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
@@ -15844,6 +15861,7 @@ class GatewayRunner:
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
+        ("agent", "load_soul_identity"),
         ("memory", "provider"),
     )
 
@@ -17567,6 +17585,7 @@ class GatewayRunner:
                     prefill_messages=self._prefill_messages or None,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
+                    load_soul_identity=self._load_soul_identity,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),

--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -95,3 +95,36 @@ def test_gateway_runtime_loaders_expand_env_var_templates(
     loader = getattr(gateway_run.GatewayRunner, loader_name)
 
     assert loader() == expected
+
+
+def test_load_soul_identity_true(monkeypatch, gateway_home):
+    """agent.load_soul_identity: true → True."""
+    _write_config(gateway_home, "agent:\n  load_soul_identity: true\n")
+    assert gateway_run.GatewayRunner._load_soul_identity() is True
+
+
+def test_load_soul_identity_false(monkeypatch, gateway_home):
+    """agent.load_soul_identity: false → False."""
+    _write_config(gateway_home, "agent:\n  load_soul_identity: false\n")
+    assert gateway_run.GatewayRunner._load_soul_identity() is False
+
+
+def test_load_soul_identity_absent(monkeypatch, gateway_home):
+    """Missing key defaults to False."""
+    _write_config(gateway_home, "agent: {}\n")
+    assert gateway_run.GatewayRunner._load_soul_identity() is False
+
+
+def test_load_soul_identity_cache_busting_key_present():
+    """Agent config change busts the agent cache."""
+    from gateway.run import GatewayRunner
+    from unittest.mock import patch
+
+    out = GatewayRunner._extract_cache_busting_config({})
+    assert "agent.load_soul_identity" in out
+    assert out["agent.load_soul_identity"] is None  # absent → None
+
+    out = GatewayRunner._extract_cache_busting_config(
+        {"agent": {"load_soul_identity": True}}
+    )
+    assert out["agent.load_soul_identity"] is True


### PR DESCRIPTION
## What does this PR do?

Wires the `agent.load_soul_identity` config key from `~/.hermes/config.yaml` into gateway AIAgent construction. Previously, the gateway `GatewayRunner` never read this config, so agents always used `DEFAULT_AGENT_IDENTITY` regardless of SOUL.md/AGENTS.md files on disk.

## Related Issue

Fixes #37480

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `tests/gateway/test_runtime_config_env_expansion.py` — 7 existing + 4 new tests
- [x] `tests/gateway/test_agent_cache.py` — 63 existing tests
- [x] Fail-without-fix verified: new tests confirm load_soul_identity passes through to agent cache key

## Root Cause

`GatewayRunner.__init__` in `gateway/run.py` had no code to read `agent.load_soul_identity` from the loaded config. The `AIAgent` constructor supports `load_soul_identity`, but the gateway never passed it — so SOUL.md / AGENTS.md files were silently ignored for gateway-spawned agents.

## Fix

Adds `_load_soul_identity()` static method to `GatewayRunner` (following the same pattern as `_load_service_tier`), reads `agent.load_soul_identity` from config, stores in `__init__`, and passes it to agent cache key so cached agents with different soul settings are not confused.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] No new dependencies added
- [x] No AI attribution in commits