### PR TITLE
feat: add /system_prompt command and last-turn /usage breakdown

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1550,6 +1550,9 @@ def init_agent(
     agent.session_cache_read_tokens = 0
     agent.session_cache_write_tokens = 0
     agent.session_reasoning_tokens = 0
+    # Per-call snapshot for the most recent successful provider response.
+    # Cumulative session_* counters are still the source of truth for totals.
+    agent.last_turn_usage = None
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1877,6 +1877,20 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+                    # Keep the final successful provider-call usage available for
+                    # `/context` / `/usage` style surfaces. The session_* counters
+                    # above are cumulative; this snapshot preserves the last turn's
+                    # cache split without provider-specific payload parsing later.
+                    agent.last_turn_usage = {
+                        "input_tokens": canonical_usage.input_tokens,
+                        "output_tokens": canonical_usage.output_tokens,
+                        "cache_read_tokens": canonical_usage.cache_read_tokens,
+                        "cache_write_tokens": canonical_usage.cache_write_tokens,
+                        "reasoning_tokens": canonical_usage.reasoning_tokens,
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": total_tokens,
+                    }
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""

--- a/cli.py
+++ b/cli.py
@@ -8811,6 +8811,8 @@ class HermesCLI:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "system_prompt":
+            self._show_system_prompt()
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "copy":
@@ -10334,6 +10336,15 @@ class HermesCLI:
         self._pending_relaunch = ["update"]
         return True
 
+    def _show_system_prompt(self):
+        """Show read-only system-prompt construction sizes without raw prompt text."""
+        try:
+            from hermes_cli.prompt_size import compute_system_prompt_breakdown, render_system_prompt_breakdown
+            data = compute_system_prompt_breakdown(agent=self.agent, platform="cli") if self.agent else compute_system_prompt_breakdown(platform="cli")
+            print(render_system_prompt_breakdown(data, markdown=False))
+        except Exception as e:
+            print(f"(._.) Could not compute system prompt breakdown: {e}")
+
     def _show_usage(self):
         """Show rate limits (if available) and session token usage."""
         if not self.agent:
@@ -10370,6 +10381,7 @@ class HermesCLI:
         ctx_len = compressor.context_length
         pct = min(100, (last_prompt / ctx_len * 100)) if ctx_len else 0
         compressions = compressor.compression_count
+        last_turn_usage = getattr(agent, "last_turn_usage", None)
 
         msg_count = len(self.conversation_history)
         cost_result = estimate_usage_cost(
@@ -10409,9 +10421,31 @@ class HermesCLI:
         else:
             print(f"  Total cost:              {'n/a':>10}")
         print(f"  {'─' * 40}")
-        print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
-        print(f"  Messages:         {msg_count}")
-        print(f"  Compressions:     {compressions}")
+        print(f"  Context window:           {ctx_len:>10,}")
+        print(f"  Current prompt:           {last_prompt:>10,} ({pct:.1f}%)")
+        print(f"  Messages:                 {msg_count:>10,}")
+        print(f"  Compressions:             {compressions:>10,}")
+        if last_turn_usage:
+            lt_input = last_turn_usage.get("input_tokens", 0) or 0
+            lt_cache_read = last_turn_usage.get("cache_read_tokens", 0) or 0
+            lt_cache_write = last_turn_usage.get("cache_write_tokens", 0) or 0
+            lt_output = last_turn_usage.get("output_tokens", 0) or 0
+            lt_reasoning = last_turn_usage.get("reasoning_tokens", 0) or 0
+            lt_prompt = last_turn_usage.get("prompt_tokens")
+            if lt_prompt is None:
+                lt_prompt = lt_input + lt_cache_read + lt_cache_write
+            lt_uncached = max(0, lt_prompt - lt_cache_read)
+            hit_pct = (100 * lt_cache_read / lt_prompt) if lt_prompt else 0
+            print(f"  {'─' * 40}")
+            print("  Last turn")
+            print(f"    In (prompt):            {lt_prompt:>10,}")
+            print(f"      Cached:               {lt_cache_read:>10,} ({hit_pct:.0f}% hit)")
+            print(f"      Uncached:             {lt_uncached:>10,}")
+            if lt_cache_write:
+                print(f"      Cache write:          {lt_cache_write:>10,}")
+            print(f"    Out:                    {lt_output:>10,}")
+            if lt_reasoning:
+                print(f"    Reasoning:              {lt_reasoning:>10,}")
         if cost_result.status == "unknown":
             print(f"  Note:             Pricing unknown for {agent.model}")
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8075,6 +8075,9 @@ class GatewayRunner:
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "system_prompt":
+            return await self._handle_system_prompt_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
@@ -13797,6 +13800,36 @@ class GatewayRunner:
         key = "gateway.branch.branched_one" if msg_count == 1 else "gateway.branch.branched_many"
         return t(key, title=branch_title, count=msg_count, parent=parent_session_id, new=new_session_id)
 
+    async def _handle_system_prompt_command(self, event: MessageEvent) -> str:
+        """Handle /system_prompt -- read-only prompt/tool schema size report."""
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        agent = self._running_agents.get(session_key)
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached = _cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+        if agent is _AGENT_PENDING_SENTINEL:
+            agent = None
+
+        platform = getattr(getattr(source, "platform", None), "value", None) or str(getattr(source, "platform", "gateway") or "gateway")
+        try:
+            from hermes_cli.prompt_size import compute_system_prompt_breakdown, render_system_prompt_breakdown
+            data = await asyncio.to_thread(
+                compute_system_prompt_breakdown,
+                agent=agent,
+                platform=platform,
+                resident=bool(agent),
+            )
+            return render_system_prompt_breakdown(data, markdown=True)
+        except Exception as e:
+            logger.debug("system_prompt breakdown failed: %s", e, exc_info=True)
+            return f"Could not compute system prompt breakdown: {e}"
+
     async def _handle_usage_command(self, event: MessageEvent) -> str:
         """Handle /usage command -- show token usage for the current session.
 
@@ -13865,6 +13898,8 @@ class GatewayRunner:
             output_tokens = getattr(agent, "session_output_tokens", 0) or 0
             cache_read = getattr(agent, "session_cache_read_tokens", 0) or 0
             cache_write = getattr(agent, "session_cache_write_tokens", 0) or 0
+            reasoning_tokens = getattr(agent, "session_reasoning_tokens", 0) or 0
+            last_turn_usage = getattr(agent, "last_turn_usage", None)
 
             lines.append(t("gateway.usage.header_session"))
             lines.append(t("gateway.usage.label_model", model=agent.model))
@@ -13906,6 +13941,31 @@ class GatewayRunner:
                 lines.append(t("gateway.usage.label_context", used=f"{ctx.last_prompt_tokens:,}", total=f"{ctx.context_length:,}", pct=f"{pct:.0f}"))
             if ctx.compression_count:
                 lines.append(t("gateway.usage.label_compressions", count=ctx.compression_count))
+
+            # Last-turn cached/uncached breakdown (no new locale keys; literal
+            # labels keep this change self-contained). Only shown when the most
+            # recent API turn recorded usage.
+            if last_turn_usage:
+                lt_input = last_turn_usage.get("input_tokens", 0) or 0
+                lt_cache_read = last_turn_usage.get("cache_read_tokens", 0) or 0
+                lt_cache_write = last_turn_usage.get("cache_write_tokens", 0) or 0
+                lt_output = last_turn_usage.get("output_tokens", 0) or 0
+                lt_reasoning = last_turn_usage.get("reasoning_tokens", 0) or 0
+                lt_prompt = last_turn_usage.get("prompt_tokens")
+                if lt_prompt is None:
+                    lt_prompt = lt_input + lt_cache_read + lt_cache_write
+                lt_uncached = max(0, lt_prompt - lt_cache_read)
+                hit_pct = (100 * lt_cache_read / lt_prompt) if lt_prompt else 0
+                lines.append("")
+                lines.append("**Last turn**")
+                lines.append(f"In (prompt): {lt_prompt:,}")
+                lines.append(f"  Cached: {lt_cache_read:,} ({hit_pct:.0f}% hit)")
+                lines.append(f"  Uncached: {lt_uncached:,}")
+                if lt_cache_write:
+                    lines.append(f"  Cache write: {lt_cache_write:,}")
+                lines.append(f"Out: {lt_output:,}")
+                if lt_reasoning:
+                    lines.append(f"Reasoning: {lt_reasoning:,}")
 
             if account_lines:
                 lines.append("")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -202,7 +202,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("help", "Show available commands", "Info"),
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
-    CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("usage", "Show token usage, context window, and rate limits for the current session", "Info"),
+    CommandDef("system_prompt", "Show system prompt and tool-schema size breakdown (no raw prompt text)", "Info",
+               aliases=("system-prompt", "prompt")),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",
@@ -1017,6 +1019,16 @@ _SLACK_RESERVED_COMMANDS = frozenset({
     "topic", "mute", "pro", "shortcuts",
 })
 
+# High-value aliases that must survive the 50-slash cap regardless of how
+# many canonical commands exist. Without an explicit reservation, adding a
+# new canonical command can silently evict these in the alias pass (they are
+# appended after every canonical name). Reserving them up front keeps the
+# documented short forms (/bg, /btw, /reset, /q) first-class on Slack —
+# the parity guarantee that test_includes_aliases_as_first_class_slashes
+# protects.
+_SLACK_ESSENTIAL_ALIASES = ("bg", "btw", "reset", "q")
+
+
 
 def _sanitize_slack_name(raw: str) -> str:
     """Convert a command name to a valid Slack slash command name.
@@ -1070,6 +1082,15 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
         # Slack description cap is 2000 chars; keep it short.
         entries.append((slack_name, desc[:140], hint[:100]))
         seen.add(slack_name)
+
+    # Reserve high-value short-form aliases up front so the 50-slash cap can
+    # never silently evict them when canonical commands are added (#parity).
+    for alias in _SLACK_ESSENTIAL_ALIASES:
+        cmd = _COMMAND_LOOKUP.get(alias)
+        if cmd is None or not _is_gateway_available(cmd, overrides):
+            continue
+        _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
+
 
     # First pass: canonical names (so they win slots if we hit the cap).
     for cmd in COMMAND_REGISTRY:

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -1,21 +1,17 @@
-"""Prompt-size diagnostic: ``hermes prompt-size``.
+"""Prompt/system-prompt size diagnostics.
 
-Reports a byte/char breakdown of the system prompt the agent would build for
-a fresh session — system prompt total, the ``<available_skills>`` index,
-memory + user profile, and tool-schema JSON. Lets users see where their fixed
-prompt budget goes (issue #34667) without parsing a saved session JSON by hand.
-
-The diagnostic builds a real inspection agent (so the numbers match what
-actually ships on the wire) but never makes a network call: it passes dummy
-credentials so ``AIAgent.__init__`` takes the direct-construction path, then
-calls ``build_system_prompt_parts`` / inspects ``agent.tools`` offline.
+Provides the existing ``hermes prompt-size`` CLI subcommand plus the shared
+rendering used by the in-session ``/system_prompt`` slash command.  Diagnostics
+measure prompt construction and tool schemas locally; they never make model API
+calls and never print raw prompt content.
 """
 
 from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict, List, Tuple
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Tuple
 
 # The skills index is wrapped in this tag pair inside the stable tier.
 _SKILLS_BLOCK_RE = re.compile(r"<available_skills>.*?</available_skills>", re.DOTALL)
@@ -25,12 +21,28 @@ def _bytes(s: str) -> int:
     return len(s.encode("utf-8"))
 
 
+def _approx_tokens_from_chars(chars: int) -> int:
+    """Cheap display-only estimate.  Provider truth is shown without ``~``."""
+    return max(0, (chars + 3) // 4)
+
+
+def _tool_name(schema: Any) -> str:
+    if not isinstance(schema, dict):
+        return "unknown"
+    fn = schema.get("function")
+    if isinstance(fn, dict) and fn.get("name"):
+        return str(fn.get("name"))
+    if schema.get("name"):
+        return str(schema.get("name"))
+    return "unknown"
+
+
 def _build_inspection_agent(platform: str) -> Any:
     """Construct an offline AIAgent for prompt inspection.
 
     Dummy ``api_key`` + ``base_url`` force the direct-construction path in
     ``run_agent.py`` (no provider auto-detection, no network). Toolsets and
-    platform come from the caller so the breakdown matches a real session.
+    platform come from config so the breakdown matches a real fresh session.
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
@@ -49,32 +61,86 @@ def _build_inspection_agent(platform: str) -> Any:
     )
 
 
+def _prompt_parts_for_agent(agent: Any) -> Tuple[Dict[str, str], str]:
+    from agent.system_prompt import build_system_prompt, build_system_prompt_parts
+
+    parts = build_system_prompt_parts(agent)
+    cached = getattr(agent, "_cached_system_prompt", None)
+    # If a resident agent already has a cached prompt, read it.  Do not assign or
+    # invalidate anything: /system_prompt is strictly observational.
+    full = cached if isinstance(cached, str) and cached else build_system_prompt(agent)
+    return parts, full
+
+
+def _toolset_breakdown(agent: Any) -> List[Dict[str, Any]]:
+    try:
+        from run_agent import get_toolset_for_tool
+    except Exception:  # pragma: no cover - defensive for unusual embeddings
+        get_toolset_for_tool = lambda _name: None  # noqa: E731
+
+    buckets: dict[str, dict[str, Any]] = defaultdict(lambda: {"tools": 0, "chars": 0, "bytes": 0})
+    for schema in getattr(agent, "tools", None) or []:
+        name = _tool_name(schema)
+        toolset = get_toolset_for_tool(name) or "unknown"
+        blob = json.dumps(schema, ensure_ascii=False)
+        buckets[toolset]["tools"] += 1
+        buckets[toolset]["chars"] += len(blob)
+        buckets[toolset]["bytes"] += _bytes(blob)
+
+    rows = [
+        {"toolset": toolset, **vals}
+        for toolset, vals in buckets.items()
+    ]
+    rows.sort(key=lambda r: (-int(r["chars"]), str(r["toolset"])))
+    return rows
+
+
 def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     """Return a dict of prompt-size measurements for a fresh session.
 
-    Keys: ``system_prompt`` (chars/bytes), ``skills_index``, ``memory``,
-    ``user_profile``, ``tools`` (count + json bytes), and ``sections`` (a list
-    of (label, chars, bytes) for the three prompt tiers).
+    Backwards-compatible data shape used by ``hermes prompt-size``.
     """
-    from agent.system_prompt import build_system_prompt, build_system_prompt_parts
-
     agent = _build_inspection_agent(platform)
+    data = compute_system_prompt_breakdown(agent=agent, platform=platform, resident=False)
+    return {
+        "platform": platform,
+        "model": data["model"],
+        "system_prompt": {"chars": data["system_prompt"]["chars"], "bytes": data["system_prompt"]["bytes"]},
+        "skills_index": {"chars": data["major_blocks"]["skills_catalog"]["chars"], "bytes": data["major_blocks"]["skills_catalog"]["bytes"]},
+        "memory": {"chars": data["major_blocks"]["memory"]["chars"], "bytes": data["major_blocks"]["memory"]["bytes"]},
+        "user_profile": {"chars": data["major_blocks"]["user_profile"]["chars"], "bytes": data["major_blocks"]["user_profile"]["bytes"]},
+        "tools": {"count": data["tools"]["count"], "json_bytes": data["tools"]["bytes"]},
+        "sections": [(r["label"], r["chars"], r["bytes"]) for r in data["tiers"]],
+    }
 
-    parts = build_system_prompt_parts(agent)
-    full = build_system_prompt(agent)
 
+def compute_system_prompt_breakdown(
+    *,
+    agent: Optional[Any] = None,
+    platform: str = "cli",
+    resident: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Measure system prompt + tool schemas without exposing raw content.
+
+    Passing a resident ``agent`` reads its current cached prompt when available;
+    passing no agent constructs an offline inspection agent.  Neither path makes
+    model API calls or mutates session counters/cache state.
+    """
+    if agent is None:
+        agent = _build_inspection_agent(platform)
+        if resident is None:
+            resident = False
+    elif resident is None:
+        resident = True
+
+    parts, full = _prompt_parts_for_agent(agent)
     stable = parts.get("stable", "")
     context = parts.get("context", "")
     volatile = parts.get("volatile", "")
 
-    # Skills index — the <available_skills> block (the largest single block
-    # when many skills are installed). Measured inside the stable tier.
     skills_match = _SKILLS_BLOCK_RE.search(stable)
-    skills_index = skills_match.group(0) if skills_match else ""
+    skills_catalog = skills_match.group(0) if skills_match else ""
 
-    # Memory + user profile live in the volatile tier. We re-derive their
-    # blocks directly from the memory store so the numbers are attributable
-    # even though they're joined into ``volatile``.
     memory_block = ""
     user_block = ""
     store = getattr(agent, "_memory_store", None)
@@ -87,25 +153,33 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
         except Exception:
             pass
 
-    # Tool-schema JSON — the other half of the fixed per-call payload.
-    tools = getattr(agent, "tools", None) or []
-    tools_json = json.dumps(tools, ensure_ascii=False)
+    tool_rows = _toolset_breakdown(agent)
+    tools_chars = sum(int(r["chars"]) for r in tool_rows)
+    tools_bytes = sum(int(r["bytes"]) for r in tool_rows)
+    tools_count = sum(int(r["tools"]) for r in tool_rows)
 
-    sections: List[Tuple[str, int, int]] = [
-        ("stable (identity/guidance/skills)", len(stable), _bytes(stable)),
-        ("context (AGENTS.md/cwd files)", len(context), _bytes(context)),
-        ("volatile (memory/profile/timestamp)", len(volatile), _bytes(volatile)),
+    tiers = [
+        {"label": "stable", "description": "identity / guidance / skills catalog", "chars": len(stable), "bytes": _bytes(stable)},
+        {"label": "context", "description": "cwd context files / caller system message", "chars": len(context), "bytes": _bytes(context)},
+        {"label": "volatile", "description": "memory / user profile / timestamp", "chars": len(volatile), "bytes": _bytes(volatile)},
     ]
+
+    major = {
+        "skills_catalog": {"label": "skills catalog (<available_skills>)", "chars": len(skills_catalog), "bytes": _bytes(skills_catalog)},
+        "memory": {"label": "MEMORY.md snapshot", "chars": len(memory_block), "bytes": _bytes(memory_block)},
+        "user_profile": {"label": "USER.md profile", "chars": len(user_block), "bytes": _bytes(user_block)},
+    }
 
     return {
         "platform": platform,
-        "model": getattr(agent, "model", "") or "",
+        "resident": bool(resident),
+        "model": getattr(agent, "model", "") or "unset",
+        "provider": getattr(agent, "provider", "") or "unset",
         "system_prompt": {"chars": len(full), "bytes": _bytes(full)},
-        "skills_index": {"chars": len(skills_index), "bytes": _bytes(skills_index)},
-        "memory": {"chars": len(memory_block), "bytes": _bytes(memory_block)},
-        "user_profile": {"chars": len(user_block), "bytes": _bytes(user_block)},
-        "tools": {"count": len(tools), "json_bytes": _bytes(tools_json)},
-        "sections": sections,
+        "tiers": tiers,
+        "major_blocks": major,
+        "tools": {"count": tools_count, "chars": tools_chars, "bytes": tools_bytes, "toolsets": tool_rows},
+        "cache_note": "Hermes caches the whole system prompt as one provider prefix block; tiers are measurement labels, not separate cache controls.",
     }
 
 
@@ -113,8 +187,51 @@ def _fmt_kb(n: int) -> str:
     return f"{n / 1024:.1f} KB"
 
 
+def _fmt_measure(chars: int, byts: int) -> str:
+    return f"~{_approx_tokens_from_chars(chars):,} tok · {chars:,} chars · {_fmt_kb(byts)}"
+
+
+def render_system_prompt_breakdown(data: Dict[str, Any], *, markdown: bool = False, max_toolsets: int = 12) -> str:
+    """Render /system_prompt output for CLI/gateway without raw prompt text."""
+    bold_l = "**" if markdown else ""
+    bold_r = "**" if markdown else ""
+    lines: List[str] = []
+    sp = data["system_prompt"]
+    tools = data["tools"]
+    fixed_chars = int(sp["chars"]) + int(tools["chars"])
+    fixed_bytes = int(sp["bytes"]) + int(tools["bytes"])
+
+    lines.append(f"🧠 {bold_l}System prompt breakdown{bold_r}")
+    lines.append(f"Model: {data.get('provider', 'unset')}/{data.get('model', 'unset')}")
+    lines.append(f"Source: {'resident agent (read-only)' if data.get('resident') else 'offline inspection agent'}")
+    lines.append("")
+    lines.append(f"System prompt: {_fmt_measure(sp['chars'], sp['bytes'])}")
+    lines.append(f"Tool schemas: ~{_approx_tokens_from_chars(tools['chars']):,} tok · {tools['count']} tools · {_fmt_kb(tools['bytes'])}")
+    lines.append(f"Fixed overhead: {_fmt_measure(fixed_chars, fixed_bytes)}")
+    lines.append("")
+    lines.append(f"{bold_l}System prompt tiers{bold_r}")
+    for row in data["tiers"]:
+        lines.append(f"- {row['label']}: {_fmt_measure(row['chars'], row['bytes'])} — {row['description']}")
+    lines.append("")
+    lines.append(f"{bold_l}Major blocks{bold_r}")
+    for key in ("skills_catalog", "memory", "user_profile"):
+        row = data["major_blocks"][key]
+        lines.append(f"- {row['label']}: {_fmt_measure(row['chars'], row['bytes'])}")
+    lines.append("- skill tools: counted under Tool schemas (skills_list / skill_view / skill_manage), not the skills catalog")
+    lines.append("")
+    lines.append(f"{bold_l}Tool schemas by toolset{bold_r}")
+    for row in tools["toolsets"][:max_toolsets]:
+        lines.append(f"- {row['toolset']}: ~{_approx_tokens_from_chars(row['chars']):,} tok · {row['tools']} tool(s)")
+    if len(tools["toolsets"]) > max_toolsets:
+        lines.append(f"- … {len(tools['toolsets']) - max_toolsets} more toolset(s)")
+    lines.append("")
+    lines.append(f"Cache: {data['cache_note']}")
+    lines.append("Privacy: raw SOUL/MEMORY/USER/system-prompt text is never printed by this command.")
+    return "\n".join(lines)
+
+
 def render_breakdown(data: Dict[str, Any]) -> str:
-    """Render the breakdown as plain text suitable for a terminal."""
+    """Render the legacy prompt-size breakdown as plain terminal text."""
     lines: List[str] = []
     sp = data["system_prompt"]
     lines.append(f"Prompt-size breakdown (platform={data['platform']}, model={data['model'] or 'unset'})")

--- a/run_agent.py
+++ b/run_agent.py
@@ -599,6 +599,11 @@ class AIAgent:
         self.session_cache_write_tokens = 0
         self.session_reasoning_tokens = 0
         self.session_api_calls = 0
+        # Snapshot of the most recent successful provider call, normalized into
+        # Hermes' canonical usage shape. Session counters above are cumulative;
+        # this per-call record lets status/usage surfaces show the last turn's
+        # cached-vs-uncached split without re-parsing logs or provider payloads.
+        self.last_turn_usage: Optional[Dict[str, int]] = None
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"

--- a/tests/gateway/test_system_prompt_command.py
+++ b/tests/gateway/test_system_prompt_command.py
@@ -8,7 +8,7 @@ Covers:
 """
 
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -248,3 +248,90 @@ class TestGatewayUsageLastTurn:
             result = await runner._handle_usage_command(event)
 
         assert "Last turn" not in result
+
+
+# ---------------------------------------------------------------------------
+# True end-to-end: drive the real _handle_message router (not just handlers)
+# ---------------------------------------------------------------------------
+
+def _make_routing_event(command, args=""):
+    """MessageEvent-shaped mock that flows through GatewayRunner._handle_message."""
+    event = MagicMock()
+    event.get_command.return_value = command
+    event.get_command_args.return_value = args
+    event.text = f"/{command} {args}".strip()
+    event.message_type = None
+    event.source = MagicMock()
+    event.source.user_id = "571820863"
+    event.source.user_name = "Ace"
+    event.source.platform = MagicMock()
+    event.source.platform.value = "telegram"
+    event.source.chat_type = "dm"
+    event.source.chat_id = "571820863"
+    return event
+
+
+def _make_routing_runner():
+    """Bare GatewayRunner wired with just enough state to reach slash dispatch."""
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.config = {}
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner.session_store = MagicMock()
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._session_key_for_source = MagicMock(return_value=SK)
+    # No per-command access gate, no hook interception.
+    runner._check_slash_access = MagicMock(return_value=None)
+    runner.hooks = MagicMock()
+    runner.hooks.emit_collect = AsyncMock(return_value=[])
+    return runner
+
+
+class TestSlashCommandEndToEndRouting:
+    """Exercise the full _handle_message dispatch path, including alias
+    resolution and the known-command gate — not just the leaf handlers."""
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_routes_through_handle_message(self):
+        runner = _make_routing_runner()
+        event = _make_routing_event("system_prompt")
+        fake = _fake_breakdown()
+        with patch("hermes_cli.prompt_size.compute_system_prompt_breakdown", return_value=fake):
+            result = await runner._handle_message(event)
+        assert result is not None
+        assert "System prompt breakdown" in result
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_alias_routes_through_handle_message(self):
+        """The `/prompt` alias must resolve to the same handler end-to-end."""
+        runner = _make_routing_runner()
+        event = _make_routing_event("prompt")
+        fake = _fake_breakdown()
+        with patch("hermes_cli.prompt_size.compute_system_prompt_breakdown", return_value=fake):
+            result = await runner._handle_message(event)
+        assert result is not None
+        assert "System prompt breakdown" in result
+
+    @pytest.mark.asyncio
+    async def test_usage_routes_through_handle_message(self):
+        from agent.usage_pricing import CanonicalUsage
+        runner = _make_routing_runner()
+        agent = _make_usage_agent(
+            last_turn=CanonicalUsage(input_tokens=2_000, output_tokens=800, cache_read_tokens=28_000)
+        )
+        runner._agent_cache[SK] = (agent, "sig")
+        event = _make_routing_event("usage")
+        with patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+            mock_cost.return_value = MagicMock(amount_usd=None, status="included")
+            result = await runner._handle_message(event)
+        assert result is not None
+        assert "Last turn" in result
+        assert "Cached: 28,000" in result
+

--- a/tests/gateway/test_system_prompt_command.py
+++ b/tests/gateway/test_system_prompt_command.py
@@ -1,0 +1,250 @@
+"""Tests for the /system_prompt command, prompt-size renderer, and last-turn /usage.
+
+Covers:
+  * Command registry: /system_prompt + aliases, gateway-visible.
+  * Renderer: no raw SOUL/MEMORY/USER/system-prompt text leaks into output.
+  * Gateway /system_prompt: resolves a cached agent without a network call.
+  * Gateway /usage: last-turn cached/uncached breakdown.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Command registration
+# ---------------------------------------------------------------------------
+
+class TestSystemPromptCommandRegistration:
+    def test_command_registered(self):
+        from hermes_cli.commands import resolve_command
+        cmd = resolve_command("system_prompt")
+        assert cmd is not None
+        assert cmd.name == "system_prompt"
+        assert cmd.category == "Info"
+
+    def test_aliases_resolve(self):
+        from hermes_cli.commands import resolve_command
+        for alias in ("system-prompt", "prompt"):
+            cmd = resolve_command(alias)
+            assert cmd is not None
+            assert cmd.name == "system_prompt"
+
+    def test_gateway_visible(self):
+        """Unlike CLI-only commands, /system_prompt should be reachable from the gateway."""
+        from hermes_cli.commands import resolve_command, GATEWAY_KNOWN_COMMANDS
+        cmd = resolve_command("system_prompt")
+        assert cmd is not None
+        assert cmd.cli_only is False
+        assert "system_prompt" in GATEWAY_KNOWN_COMMANDS
+
+
+# ---------------------------------------------------------------------------
+# Renderer — privacy + structure
+# ---------------------------------------------------------------------------
+
+def _fake_breakdown():
+    return {
+        "platform": "telegram",
+        "resident": True,
+        "model": "claude-opus-4-8",
+        "provider": "claude-api-proxy",
+        "system_prompt": {"chars": 40_000, "bytes": 41_000},
+        "tiers": [
+            {"label": "stable", "description": "identity / guidance / skills catalog", "chars": 30_000, "bytes": 30_500},
+            {"label": "context", "description": "cwd context files / caller system message", "chars": 2_000, "bytes": 2_050},
+            {"label": "volatile", "description": "memory / user profile / timestamp", "chars": 8_000, "bytes": 8_450},
+        ],
+        "major_blocks": {
+            "skills_catalog": {"label": "skills catalog (<available_skills>)", "chars": 20_000, "bytes": 20_100},
+            "memory": {"label": "MEMORY.md snapshot", "chars": 2_800, "bytes": 2_847},
+            "user_profile": {"label": "USER.md profile", "chars": 1_360, "bytes": 1_360},
+        },
+        "tools": {
+            "count": 3,
+            "chars": 12_000,
+            "bytes": 12_010,
+            "toolsets": [
+                {"toolset": "web", "tools": 2, "chars": 8_000, "bytes": 8_010},
+                {"toolset": "file", "tools": 1, "chars": 4_000, "bytes": 4_000},
+            ],
+        },
+        "cache_note": "Hermes caches the whole system prompt as one provider prefix block.",
+    }
+
+
+class TestRendererPrivacyAndStructure:
+    def test_render_contains_sizes_not_raw_content(self):
+        from hermes_cli.prompt_size import render_system_prompt_breakdown
+        out = render_system_prompt_breakdown(_fake_breakdown(), markdown=True)
+        # Structural labels present
+        assert "System prompt breakdown" in out
+        assert "skills catalog" in out
+        assert "MEMORY.md snapshot" in out
+        assert "USER.md profile" in out
+        assert "Tool schemas by toolset" in out
+        assert "web" in out and "file" in out
+        # Privacy note present
+        assert "raw" in out.lower()
+
+    def test_render_never_emits_known_secret_markers(self):
+        """Renderer only receives sizes, never raw text — guard against regressions
+        that might start passing raw blocks through."""
+        from hermes_cli.prompt_size import render_system_prompt_breakdown
+        out = render_system_prompt_breakdown(_fake_breakdown(), markdown=False)
+        # These would only appear if raw SOUL/MEMORY content were threaded in.
+        assert "OP_SERVICE_ACCOUNT_TOKEN" not in out
+        assert "Universal Homelab Password" not in out
+
+    def test_legacy_breakdown_shape_preserved(self):
+        """compute_prompt_breakdown keeps its historical keys for `hermes prompt-size`."""
+        from hermes_cli import prompt_size
+
+        fake = {
+            "platform": "cli",
+            "resident": False,
+            "model": "m",
+            "provider": "p",
+            "system_prompt": {"chars": 10, "bytes": 11},
+            "tiers": [
+                {"label": "stable", "description": "d", "chars": 5, "bytes": 5},
+                {"label": "context", "description": "d", "chars": 2, "bytes": 2},
+                {"label": "volatile", "description": "d", "chars": 3, "bytes": 4},
+            ],
+            "major_blocks": {
+                "skills_catalog": {"label": "s", "chars": 4, "bytes": 4},
+                "memory": {"label": "m", "chars": 2, "bytes": 2},
+                "user_profile": {"label": "u", "chars": 1, "bytes": 1},
+            },
+            "tools": {"count": 1, "chars": 6, "bytes": 6, "toolsets": []},
+            "cache_note": "n",
+        }
+        with patch.object(prompt_size, "compute_system_prompt_breakdown", return_value=fake), \
+             patch.object(prompt_size, "_build_inspection_agent", return_value=MagicMock()):
+            data = prompt_size.compute_prompt_breakdown("cli")
+        assert set(data) >= {"platform", "model", "system_prompt", "skills_index", "memory", "user_profile", "tools", "sections"}
+        assert data["skills_index"]["chars"] == 4
+        assert data["tools"]["json_bytes"] == 6
+        assert data["tools"]["count"] == 1
+        assert len(data["sections"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Gateway /system_prompt — agent lookup, offline
+# ---------------------------------------------------------------------------
+
+def _make_runner(session_key, agent=None, cached_agent=None):
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner.session_store = MagicMock()
+    if agent is not None:
+        runner._running_agents[session_key] = agent
+    if cached_agent is not None:
+        runner._agent_cache[session_key] = (cached_agent, "sig")
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+    return runner
+
+
+SK = "agent:aegis:telegram:private:571820863"
+
+
+class TestGatewaySystemPromptCommand:
+    @pytest.mark.asyncio
+    async def test_uses_cached_agent_and_renders(self):
+        agent = MagicMock()
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+        event.source = MagicMock()
+
+        fake = _fake_breakdown()
+        with patch("hermes_cli.prompt_size.compute_system_prompt_breakdown", return_value=fake) as mock_compute:
+            result = await runner._handle_system_prompt_command(event)
+
+        # Resident agent passed through (read-only inspection)
+        assert mock_compute.call_count == 1
+        _, kwargs = mock_compute.call_args
+        assert kwargs.get("agent") is agent
+        assert kwargs.get("resident") is True
+        assert "System prompt breakdown" in result
+
+    @pytest.mark.asyncio
+    async def test_no_agent_falls_back_to_offline_inspection(self):
+        runner = _make_runner(SK)  # no running, no cached
+        event = MagicMock()
+        event.source = MagicMock()
+
+        fake = _fake_breakdown()
+        fake["resident"] = False
+        with patch("hermes_cli.prompt_size.compute_system_prompt_breakdown", return_value=fake) as mock_compute:
+            result = await runner._handle_system_prompt_command(event)
+
+        _, kwargs = mock_compute.call_args
+        assert kwargs.get("agent") is None
+        assert kwargs.get("resident") is False
+        assert "System prompt breakdown" in result
+
+
+# ---------------------------------------------------------------------------
+# Gateway /usage — last-turn breakdown
+# ---------------------------------------------------------------------------
+
+def _make_usage_agent(last_turn=None):
+    agent = MagicMock()
+    agent.model = "claude-opus-4-8"
+    agent.provider = "claude-api-proxy"
+    agent.base_url = None
+    agent.session_total_tokens = 50_000
+    agent.session_api_calls = 3
+    agent.session_input_tokens = 35_000
+    agent.session_output_tokens = 10_000
+    agent.session_cache_read_tokens = 5_000
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.last_turn_usage = last_turn
+    rl = MagicMock()
+    rl.has_data = False
+    agent.get_rate_limit_state.return_value = rl
+    ctx = MagicMock()
+    ctx.last_prompt_tokens = 30_000
+    ctx.context_length = 200_000
+    ctx.compression_count = 0
+    agent.context_compressor = ctx
+    return agent
+
+
+class TestGatewayUsageLastTurn:
+    @pytest.mark.asyncio
+    async def test_last_turn_section_shown(self):
+        from agent.usage_pricing import CanonicalUsage
+        last = CanonicalUsage(input_tokens=2_000, output_tokens=800, cache_read_tokens=28_000, cache_write_tokens=0)
+        agent = _make_usage_agent(last_turn=last)
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+        event.source = MagicMock()
+
+        with patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+            mock_cost.return_value = MagicMock(amount_usd=None, status="included")
+            result = await runner._handle_usage_command(event)
+
+        assert "Last turn" in result
+        assert "Cached: 28,000" in result
+        # prompt = 2000 + 28000 = 30000; uncached = 30000 - 28000 = 2000
+        assert "Uncached: 2,000" in result
+
+    @pytest.mark.asyncio
+    async def test_last_turn_section_absent_when_no_usage(self):
+        agent = _make_usage_agent(last_turn=None)
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+        event.source = MagicMock()
+
+        with patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+            mock_cost.return_value = MagicMock(amount_usd=None, status="included")
+            result = await runner._handle_usage_command(event)
+
+        assert "Last turn" not in result

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -21,6 +21,7 @@ def _make_mock_agent(**overrides):
         "session_output_tokens": 10_000,
         "session_cache_read_tokens": 5_000,
         "session_cache_write_tokens": 2_000,
+        "last_turn_usage": None,
     }
     defaults.update(overrides)
     for k, v in defaults.items():

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -45,8 +45,9 @@ def _make_minimal_agent() -> AIAgent:
     agent.session_estimated_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
+    agent.last_turn_usage = None
 
-    # The two fields under test
+    # The fields under test
     agent._user_turn_count = 0
     agent.context_compressor = None  # will be set per-test as needed
 
@@ -88,6 +89,24 @@ class TestResetSessionState:
         assert agent._user_turn_count == 0, (
             f"_user_turn_count must be 0 after reset; got: {agent._user_turn_count}"
         )
+
+    def test_last_turn_usage_cleared_on_reset(self):
+        """Last-call usage snapshot must not leak across sessions."""
+        agent = _make_minimal_agent()
+        agent.last_turn_usage = {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_tokens": 80,
+            "cache_write_tokens": 10,
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+        }
+        agent.context_compressor = None
+
+        agent.reset_session_state()
+
+        assert agent.last_turn_usage is None
 
     def test_both_fields_cleared_together(self):
         """Both stale fields are cleared in a single reset_session_state() call."""


### PR DESCRIPTION
## Summary
Adds context observability without exposing raw prompt content.

- **/system_prompt** (aliases `system-prompt`, `prompt`) — read-only breakdown of system-prompt tiers (stable/context/volatile), major blocks (skills catalog, MEMORY.md, USER.md), and tool schemas by toolset. Never prints raw SOUL/MEMORY/USER/system-prompt text. Works in CLI and gateway; uses the resident agent when present, otherwise an offline inspection agent (no network call).
- Shared renderer/data model lives in `hermes_cli/prompt_size.py`; the legacy `hermes prompt-size` data shape is preserved.
- **/usage** (CLI + gateway) gains a last-turn cached/uncached breakdown via a new `agent.last_turn_usage` field, plus clearer context-window display.
- Reserves high-value Slack short-form aliases (`/bg` `/btw` `/reset` `/q`) before the 50-slash cap so adding canonical commands can't silently evict them.

## Test Plan
- `tests/gateway/test_system_prompt_command.py` (new): registry + aliases + gateway visibility; renderer privacy (no raw content / secret markers); legacy breakdown shape; gateway command cached-agent + offline fallback; gateway /usage last-turn section shown/hidden.
- `tests/gateway/test_usage_command.py`: updated mock default for `last_turn_usage`; all pass.
- `tests/hermes_cli/test_prompt_size.py`: legacy `hermes prompt-size` still passes.
- `tests/hermes_cli/test_commands.py` + CLI command/prefix/status tests: pass (Slack alias parity restored).
- No model API calls in any new code path; no raw prompt text emitted.
