### PR TITLE
fix: select Codex runtime after desktop OAuth

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3729,12 +3729,20 @@ def _codex_full_login_worker(session_id: str) -> None:
         if not access_token:
             raise RuntimeError("token exchange did not return access_token")
 
-        from hermes_cli.auth import _save_codex_tokens
+        from hermes_cli.auth import _save_codex_tokens, _update_config_for_provider
 
         _save_codex_tokens({
             "access_token": access_token,
             "refresh_token": refresh_token,
         })
+
+        # Saving tokens makes OAuth look connected, but chat still needs a
+        # selected runtime provider.
+        base_url = (
+            os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+            or DEFAULT_CODEX_BASE_URL
+        )
+        _update_config_for_provider("openai-codex", base_url)
         with _oauth_sessions_lock:
             sess["status"] = "approved"
         _log.info("oauth/device: openai-codex login completed (session=%s)", session_id)

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -20,6 +20,7 @@ The fix:
 These tests pin the corrected behavior.
 """
 import asyncio
+import json
 import time
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -302,6 +303,84 @@ def test_minimax_dashboard_poller_accepts_absolute_ms_expired_in():
     assert captured_state["access_token"] == "access"
     assert 1790 <= captured_state["expires_in"] <= 1810
     assert datetime.fromisoformat(captured_state["expires_at"]).year < 9999
+
+
+def test_codex_dashboard_login_persists_active_runtime_provider(tmp_path, monkeypatch):
+    """Desktop Codex OAuth should leave runtime resolution ready, not just logged in."""
+    from hermes_cli import web_server as ws
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n  default: gpt-5.3-codex\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+
+    session_id = "codex-dashboard-runtime-test"
+    ws._oauth_sessions[session_id] = {
+        "session_id": session_id,
+        "provider": "openai-codex",
+        "flow": "device_code",
+        "created_at": time.time(),
+        "status": "pending",
+        "error_message": None,
+    }
+
+    class _FakeResponse:
+        def __init__(self, payload):
+            self.status_code = 200
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/api/accounts/deviceauth/usercode"):
+                return _FakeResponse({
+                    "user_code": "CODE-1234",
+                    "device_auth_id": "device-auth-id",
+                    "interval": "3",
+                })
+            if url.endswith("/api/accounts/deviceauth/token"):
+                return _FakeResponse({
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "code-verifier",
+                })
+            if url.endswith("/oauth/token"):
+                return _FakeResponse({
+                    "access_token": "codex-access-token",
+                    "refresh_token": "codex-refresh-token",
+                })
+            raise AssertionError(f"unexpected POST {url}")
+
+    monkeypatch.setattr(httpx, "Client", _FakeClient)
+    monkeypatch.setattr(ws.time, "sleep", lambda seconds: None)
+
+    try:
+        ws._codex_full_login_worker(session_id)
+
+        assert ws._oauth_sessions[session_id]["status"] == "approved"
+        auth_store = json.loads((hermes_home / "auth.json").read_text(encoding="utf-8"))
+        assert auth_store["active_provider"] == "openai-codex"
+
+        runtime = resolve_runtime_provider(requested=None)
+        assert runtime["provider"] == "openai-codex"
+        assert runtime["api_key"] == "codex-access-token"
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
 
 
 def test_anthropic_pkce_branch_still_works():


### PR DESCRIPTION
## Summary
- select `openai-codex` as the active runtime provider after successful Desktop Codex device-code OAuth
- keep the existing token persistence path intact, then call the same provider/config updater used by CLI auth/model setup
- add a focused regression test proving Desktop OAuth leaves `resolve_runtime_provider(requested=None)` ready

## Why
Desktop onboarding could show OpenAI Codex as connected because the device-code worker saved auth tokens, but runtime resolution still failed with “No inference provider configured” because no provider configuration was activated. Running `hermes model` in the CLI fixed affected installs by doing the missing provider selection. This PR makes the Desktop OAuth success path do that provider activation automatically.

Fixes #37515.

## Validation
- RED: `uv run --extra dev python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_codex_dashboard_login_persists_active_runtime_provider -q -o 'addopts='` failed before the implementation because no active Codex runtime provider was selected
- `uv run --extra dev python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py::test_codex_dashboard_login_persists_active_runtime_provider -q -o 'addopts='` → 1 passed
- `uv run --extra dev python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='` → 33 passed
- `./scripts/run_tests.sh tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_auth_codex_provider.py` → 33 passed
- `uv run --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_oauth_dispatch.py` → passed
- `git diff --check` → passed

## Review notes
- Kept the production diff to the existing `_codex_full_login_worker()` success path: after `_save_codex_tokens(...)`, call `_update_config_for_provider("openai-codex", base_url)`.
- Trimmed the regression to the issue symptom: OAuth completes, `auth.json.active_provider` is set, and `resolve_runtime_provider(requested=None)` resolves Codex with the new token.
