### PR TITLE
fix(desktop): honor upward wheel scroll in long threads

### DIFF
--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -415,6 +415,39 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
+  it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      fireEvent.wheel(viewport, { deltaY: -120 })
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
+  })
+
   it('renders reasoning text without a leading token space', () => {
     const { container } = render(<ReasoningHarness />)
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -235,6 +235,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     const disarm = () => {
       armedRef.current = false
+      programmaticScrollPendingRef.current = 0
     }
 
     const onScroll = () => {


### PR DESCRIPTION
## Summary
- Clear stale programmatic bottom-pin scroll bookkeeping when Desktop chat sees explicit user scroll intent.
- Add a regression test for the first upward wheel scroll occurring while a bottom-pin scroll event is still pending.

## Test Plan
- [x] `NODE_ENV=test npm run test:ui -- src/components/assistant-ui/streaming.test.tsx -t "honors the first upward wheel scroll"` (failed before fix: expected 420, received 1200)
- [x] `NODE_ENV=test npm run test:ui -- src/components/assistant-ui/streaming.test.tsx`
- [x] `npm run type-check`
- [x] `npx eslint src/components/assistant-ui/thread-virtualizer.tsx src/components/assistant-ui/streaming.test.tsx` (0 errors; existing warnings in `thread-virtualizer.tsx`)

Closes #37527

## Notes
- `NODE_ENV=test npm run test:ui` for the whole Desktop workspace still reports unrelated pre-existing failures: Vitest treats four Node `electron/*.test.cjs` files as no-suite files, and `src/components/pane-shell/pane-shell.test.tsx` has an unrelated widthOverride assertion failure.