### PR TITLE
fix(desktop): hide dead "Use local gateway" recovery under env-forced remote mode

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DesktopConnectionConfig } from '@/global'
+import { $desktopBoot, failDesktopBoot } from '@/store/boot'
+import { $desktopOnboarding } from '@/store/onboarding'
+
+import { BootFailureOverlay } from './boot-failure-overlay'
+
+// Unique to the env-override guidance — the boot error box also echoes the env
+// var names, so match on this sentence to avoid colliding with it.
+const ENV_GUIDANCE = /switching to the local gateway from here won't help/i
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+function connectionConfig(partial: Partial<DesktopConnectionConfig> = {}): DesktopConnectionConfig {
+  return {
+    envOverride: false,
+    mode: 'local',
+    remoteTokenPreview: null,
+    remoteTokenSet: false,
+    remoteUrl: '',
+    ...partial
+  }
+}
+
+function installDesktopBridge(config: DesktopConnectionConfig) {
+  desktopWindow.hermesDesktop = {
+    applyConnectionConfig: vi.fn().mockResolvedValue(config),
+    getConnectionConfig: vi.fn().mockResolvedValue(config),
+    getRecentLogs: vi.fn().mockResolvedValue({ path: '', lines: [] }),
+    repairBootstrap: vi.fn().mockResolvedValue({ ok: true }),
+    resetBootstrap: vi.fn().mockResolvedValue({ ok: true }),
+    revealLogs: vi.fn().mockResolvedValue({ ok: true, path: '' })
+  } as unknown as Window['hermesDesktop']
+}
+
+beforeEach(() => {
+  $desktopOnboarding.set({
+    configured: true,
+    flow: { status: 'idle' },
+    mode: 'oauth',
+    providers: null,
+    reason: null,
+    requested: false,
+    manual: false
+  })
+  failDesktopBoot('HERMES_DESKTOP_REMOTE_URL is set but HERMES_DESKTOP_REMOTE_TOKEN is not.')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+  $desktopBoot.set({
+    error: null,
+    fakeMode: false,
+    message: '',
+    phase: 'renderer.ready',
+    progress: 100,
+    running: false,
+    timestamp: 0,
+    visible: false
+  })
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('BootFailureOverlay', () => {
+  it('offers the local-gateway recovery when no env override is forcing remote mode', async () => {
+    installDesktopBridge(connectionConfig({ envOverride: false }))
+
+    render(<BootFailureOverlay />)
+
+    expect(await screen.findByRole('button', { name: 'Use local gateway' })).toBeTruthy()
+    expect(screen.queryByText(ENV_GUIDANCE)).toBeNull()
+  })
+
+  it('hides the dead local-gateway button and explains the env override when remote is forced', async () => {
+    installDesktopBridge(connectionConfig({ envOverride: true, mode: 'remote', remoteUrl: 'https://gw.example.com' }))
+
+    render(<BootFailureOverlay />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Use local gateway' })).toBeNull()
+    })
+    expect(screen.getByText(ENV_GUIDANCE)).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -18,6 +18,12 @@ export function BootFailureOverlay() {
   const [busy, setBusy] = useState<BusyAction>(null)
   const [logs, setLogs] = useState<string[]>([])
   const [showLogs, setShowLogs] = useState(false)
+  // When the remote backend is forced via HERMES_DESKTOP_REMOTE_URL, the main
+  // process ignores the saved connection config (resolveRemoteBackend reads the
+  // env var first), so "Use local gateway" can't recover — switching to local
+  // just reloads back into the same failure. Surface the env-var instructions
+  // instead, mirroring how the Gateway settings screen handles envOverride.
+  const [envOverride, setEnvOverride] = useState(false)
 
   const visible = Boolean(boot.error) && !boot.running
   // While first-run onboarding owns the picker/flow we let it surface its own
@@ -33,6 +39,11 @@ export function BootFailureOverlay() {
     void window.hermesDesktop
       ?.getRecentLogs()
       .then(res => setLogs(res.lines ?? []))
+      .catch(() => undefined)
+
+    void window.hermesDesktop
+      ?.getConnectionConfig()
+      .then(config => setEnvOverride(Boolean(config?.envOverride)))
       .catch(() => undefined)
   }, [visible])
 
@@ -92,10 +103,12 @@ export function BootFailureOverlay() {
                 {busy === 'repair' ? <Loader2 className="size-4 animate-spin" /> : <Wrench className="size-4" />}
                 Repair install
               </Button>
-              <Button disabled={Boolean(busy)} onClick={() => void switchToLocalGateway()} variant="outline">
-                {busy === 'local' ? <Loader2 className="size-4 animate-spin" /> : null}
-                Use local gateway
-              </Button>
+              {envOverride ? null : (
+                <Button disabled={Boolean(busy)} onClick={() => void switchToLocalGateway()} variant="outline">
+                  {busy === 'local' ? <Loader2 className="size-4 animate-spin" /> : null}
+                  Use local gateway
+                </Button>
+              )}
               <Button onClick={openLogs} variant="ghost">
                 <FileText className="size-4" />
                 Open logs
@@ -104,6 +117,13 @@ export function BootFailureOverlay() {
             <p className="text-xs text-muted-foreground">
               Repair re-runs the installer and can take a few minutes on a fresh machine.
             </p>
+            {envOverride ? (
+              <p className="text-xs text-muted-foreground">
+                A remote gateway is forced by environment variables, so switching to the local gateway from here won't
+                help. Unset <code>HERMES_DESKTOP_REMOTE_URL</code> and <code>HERMES_DESKTOP_REMOTE_TOKEN</code>, then
+                restart Hermes to fall back to the local gateway.
+              </p>
+            ) : null}
           </div>
 
           {logs.length > 0 ? (


### PR DESCRIPTION
## Summary

The boot failure overlay advertises a recovery path that cannot work when the
desktop is forced into remote mode by environment variables. The **"Use local
gateway"** button is a dead end: clicking it reloads the app straight back into
the same failure. This PR hides that button when an env override is active and
shows the correct recovery instructions instead.

## The bug

When `HERMES_DESKTOP_REMOTE_URL` is set but `HERMES_DESKTOP_REMOTE_TOKEN` is
missing/invalid, the app fails to boot and the recovery overlay appears. The
overlay offers "Use local gateway", which calls
`applyConnectionConfig({ mode: 'local' })` — the main process persists the new
config and reloads the window.

However, `resolveRemoteBackend()` reads the env var **first** and ignores the
saved connection config entirely, so on reload it throws the same error and the
overlay returns. The user cannot recover from inside the app; they must know to
clear the environment variable externally.

## Root cause

- `resolveRemoteBackend()` short-circuits on `process.env.HERMES_DESKTOP_REMOTE_URL`
  before consulting the saved config — `apps/desktop/electron/main.cjs`.
- The "Use local gateway" handler reloads via `applyConnectionConfig` —
  `apps/desktop/src/components/boot-failure-overlay.tsx`.
- The backend already exposes this state as `envOverride`
  (`sanitizeDesktopConnectionConfig`), and the Gateway settings screen already
  honors it by disabling its controls and telling the user to unset the env vars
  — `apps/desktop/src/app/settings/gateway-settings.tsx`. Only the boot overlay
  ignored `envOverride`.

## The fix

`BootFailureOverlay` now reads `envOverride` via `getConnectionConfig()` when it
becomes visible. When the env override is active it:

- hides the non-functional "Use local gateway" button, and
- shows explicit recovery guidance: unset `HERMES_DESKTOP_REMOTE_URL` /
  `HERMES_DESKTOP_REMOTE_TOKEN` and restart.

When no env override is present, behavior is unchanged (backward compatible).
This mirrors the existing `envOverride` contract already used by the Gateway
settings screen.

## How to reproduce

1. Set `HERMES_DESKTOP_REMOTE_URL` to any URL and leave
   `HERMES_DESKTOP_REMOTE_TOKEN` unset.
2. Launch Hermes Desktop — boot fails and the recovery overlay appears.
3. **Before:** clicking "Use local gateway" reloads into the same failure (dead end).
4. **After:** the button is hidden; the overlay instructs the user to unset the
   env vars and restart.

## Tests

- Added `apps/desktop/src/components/boot-failure-overlay.test.tsx` covering both
  states (button present without an env override; button hidden + guidance shown
  with an env override).
- `npm run test:ui -- boot-failure-overlay` → passing.
- `npm run type-check` (`tsc -b`) → clean.
- `eslint` on the changed files → clean.

This is a renderer-only React change with no OS-specific code; it was verified
through the platform-agnostic jsdom unit test suite.

## Scope & risk

Low. The change is limited to the boot recovery overlay and config-state wiring.
No backend or connection-resolution logic is modified.

