### PR TITLE
feat(kanban): first-class task artifact registry

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1052,6 +1052,29 @@ CREATE TABLE IF NOT EXISTS task_attachments (
     created_at   INTEGER NOT NULL
 );
 
+-- First-class registry of artifacts a task produced (commit SHAs, files,
+-- URLs, deploy links, message ids). Promoted from the per-run
+-- ``metadata["artifacts"]`` string-list into a typed, queryable form so a
+-- board can answer "what did this task produce, and is it real?".
+-- ``verified`` is a best-effort trust signal stamped out-of-band (a later
+-- ``kanban verify-artifacts`` pass); rows land 'unchecked' at completion.
+CREATE TABLE IF NOT EXISTS task_artifacts (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id       TEXT NOT NULL,
+    run_id        INTEGER,
+    kind          TEXT NOT NULL,
+    -- kind: file | commit | url | deploy | doc | message | pr
+    ref           TEXT NOT NULL,
+    label         TEXT,
+    verified      TEXT NOT NULL DEFAULT 'unchecked',
+    -- verified: unchecked | verified | unverified | missing
+    verified_at   INTEGER,
+    verify_detail TEXT,
+    created_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_artifacts_task ON task_artifacts(task_id, id);
+CREATE INDEX IF NOT EXISTS idx_artifacts_verified ON task_artifacts(verified);
+
 -- Subscription from a gateway source (platform + chat + thread) to a
 -- task. The gateway's kanban-notifier watcher tails task_events and
 -- pushes ``completed`` / ``blocked`` / ``spawn_auto_blocked`` events to
@@ -3502,6 +3525,76 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+_VALID_ARTIFACT_KINDS = {"file", "commit", "url", "deploy", "doc", "message", "pr"}
+_MAX_ARTIFACTS_PER_RUN = 50
+_MAX_REF_LEN = 2048
+_MAX_LABEL_LEN = 256
+_COMMIT_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def _infer_artifact_kind(ref: str) -> str:
+    """Conservative kind inference for a bare ref. Biased toward file over
+    commit so a misclassified filename degrades to 'missing', never error."""
+    r = ref.strip()
+    low = r.lower()
+    if low.startswith(("http://", "https://")):
+        return "url"
+    if "/" in r or "." in r:
+        return "file"
+    if _COMMIT_RE.match(low):
+        return "commit"
+    return "message"
+
+
+def _normalize_artifacts(raw, metadata):
+    """Parse artifacts (typed {kind,ref,label} or bare strings) from the kwarg
+    AND metadata['artifacts'] into a deduped, validated, capped list of
+    (kind, ref, label). All untrusted input is bounded here."""
+    items = []
+    if isinstance(metadata, dict):
+        md = metadata.get("artifacts")
+        if isinstance(md, (list, tuple)):
+            items.extend(md)
+    if raw is not None:
+        items.extend(raw if isinstance(raw, (list, tuple)) else [raw])
+    out, seen = [], set()
+    for it in items:
+        if isinstance(it, dict):
+            ref = str(it.get("ref", "")).strip()
+            kind = str(it.get("kind", "")).strip().lower() or _infer_artifact_kind(ref)
+            label = it.get("label")
+        else:
+            ref = str(it).strip()
+            kind = _infer_artifact_kind(ref)
+            label = None
+        if not ref or len(ref) > _MAX_REF_LEN:
+            continue
+        ref = "".join(ch for ch in ref if ch == " " or ch.isprintable())
+        if kind not in _VALID_ARTIFACT_KINDS:
+            kind = "message"
+        if label is not None:
+            label = "".join(ch for ch in str(label) if ch == " " or ch.isprintable())[:_MAX_LABEL_LEN] or None
+        key = (kind, ref)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((kind, ref, label))
+        if len(out) >= _MAX_ARTIFACTS_PER_RUN:
+            break
+    return out
+
+
+def _persist_artifacts(conn, task_id, run_id, artifacts, now):
+    """Insert normalized (kind, ref, label) rows into task_artifacts as
+    'unchecked' (verification is a separate out-of-band pass)."""
+    for kind, ref, label in artifacts:
+        conn.execute(
+            "INSERT INTO task_artifacts (task_id, run_id, kind, ref, label, "
+            "verified, created_at) VALUES (?, ?, ?, ?, ?, 'unchecked', ?)",
+            (task_id, run_id, kind, ref, label, now),
+        )
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3510,6 +3603,7 @@ def complete_task(
     summary: Optional[str] = None,
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
+    artifacts: Optional[Iterable] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
@@ -3651,6 +3745,11 @@ def complete_task(
             completed_payload,
             run_id=run_id,
         )
+        # Promote artifacts (from the kwarg and/or metadata["artifacts"]) into
+        # the first-class task_artifacts registry — typed, queryable, 'unchecked'.
+        _norm_artifacts = _normalize_artifacts(artifacts, metadata)
+        if _norm_artifacts:
+            _persist_artifacts(conn, task_id, run_id, _norm_artifacts, now)
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
     # its own txn so the completion itself is already durable by the

--- a/tests/hermes_cli/test_kanban_artifacts.py
+++ b/tests/hermes_cli/test_kanban_artifacts.py
@@ -1,0 +1,119 @@
+"""Tests for the first-class task_artifacts registry.
+
+Artifacts a task produced (file paths, commit SHAs, URLs, deploy links) are
+promoted from the per-run ``metadata["artifacts"]`` string-list into a typed,
+queryable ``task_artifacts`` table at completion. All rows land ``unchecked``
+(verification is a separate out-of-band pass). The legacy bare-string
+``metadata["artifacts"]`` path (which the gateway notifier consumes) is
+preserved unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def _artifacts(conn, tid):
+    return conn.execute(
+        "SELECT kind, ref, label, verified FROM task_artifacts "
+        "WHERE task_id=? ORDER BY id",
+        (tid,),
+    ).fetchall()
+
+
+def test_artifacts_captured_typed_and_inferred(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship", created_by="hive")
+        kb.complete_task(
+            conn, tid, result="done",
+            metadata={"artifacts": ["src/foo.py"]},
+            artifacts=[
+                "a1b2c3d4e5f6",                       # → commit (inferred)
+                "https://edgelesslab.com/blog/x",     # → url (inferred)
+                {"kind": "deploy", "ref": "https://app.edgeless.dev", "label": "prod"},
+            ],
+        )
+        rows = _artifacts(conn, tid)
+        kinds = {r["kind"]: r["ref"] for r in rows}
+        assert kinds["file"] == "src/foo.py"
+        assert kinds["commit"] == "a1b2c3d4e5f6"
+        assert kinds["url"] == "https://edgelesslab.com/blog/x"
+        assert kinds["deploy"] == "https://app.edgeless.dev"
+        assert all(r["verified"] == "unchecked" for r in rows)
+        # typed label preserved
+        assert next(r for r in rows if r["kind"] == "deploy")["label"] == "prod"
+
+
+def test_artifact_dedup(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", created_by="hive")
+        kb.complete_task(
+            conn, tid, result="done",
+            metadata={"artifacts": ["src/foo.py"]},
+            artifacts=["src/foo.py"],  # same ref via both paths
+        )
+        rows = _artifacts(conn, tid)
+        assert len([r for r in rows if r["ref"] == "src/foo.py"]) == 1
+
+
+def test_artifact_validation_rejects_oversized(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", created_by="hive")
+        kb.complete_task(conn, tid, result="done",
+                         artifacts=["x" * 5000, "ok/path.txt"])
+        rows = _artifacts(conn, tid)
+        assert len(rows) == 1 and rows[0]["ref"] == "ok/path.txt"
+
+
+def test_artifacts_per_run_capped(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", created_by="hive")
+        kb.complete_task(conn, tid, result="done",
+                         artifacts=[f"f{i}/x.txt" for i in range(200)])
+        assert len(_artifacts(conn, tid)) <= kb._MAX_ARTIFACTS_PER_RUN
+
+
+def test_notifier_backcompat_metadata_stays_bare_strings(kanban_home):
+    """The gateway notifier only delivers str items off the completed event —
+    typed artifacts must NOT poison that path."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", created_by="hive")
+        kb.complete_task(conn, tid, result="done",
+                         metadata={"artifacts": ["src/foo.py"]})
+        ev = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='completed'",
+            (tid,)).fetchone()
+        payload = json.loads(ev["payload"])
+        assert payload.get("artifacts") == ["src/foo.py"]
+        assert all(isinstance(a, str) for a in payload["artifacts"])
+
+
+def test_no_artifact_completion_unchanged(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", created_by="hive")
+        assert kb.complete_task(conn, tid, result="done") is True
+        assert kb.get_task(conn, tid).status == "done"
+        assert _artifacts(conn, tid) == []
+
+
+def test_kind_inference():
+    assert kb._infer_artifact_kind("https://x.com/y") == "url"
+    assert kb._infer_artifact_kind("src/main.py") == "file"
+    assert kb._infer_artifact_kind("README.md") == "file"
+    assert kb._infer_artifact_kind("a1b2c3d4") == "commit"
+    assert kb._infer_artifact_kind("deadbeefcafe1234") == "commit"
+    assert kb._infer_artifact_kind("hello world") == "message"


### PR DESCRIPTION
Promote the artifacts a task produces from a buried `metadata["artifacts"]` string-list into a typed, queryable `task_artifacts` table, so a board can answer "what did this task actually produce?".

At completion, artifacts (from a new `complete_task(artifacts=...)` kwarg and/or the existing `metadata["artifacts"]`) are normalized — typed `{kind, ref, label}` objects or bare strings with conservative kind inference (file / commit / url / deploy / doc / message / pr) — deduped, validated, capped, and persisted as `unchecked` rows. Verification is a deliberate out-of-band pass (separate PR); nothing here does file I/O, subprocess, or network.

Backward compatible: `metadata["artifacts"]` is still written as a bare string list, so the gateway notifier (which only delivers str items off the completed event) is unchanged. Ungated/no-artifact completions are unaffected.

- schema: additive `task_artifacts` table + indexes in SCHEMA_SQL (self-contained — no dependency on additively-migrated columns)
- `complete_task` persists inside the existing completion write-txn
- input is bounded at the trust boundary (ref/label length+charset caps, per-run cap, kind allowlist) — the security control for untrusted worker-supplied refs
- tests: typed+inferred capture, dedup, oversize-reject, per-run cap, notifier back-compat (metadata stays bare strings), no-artifact regression, kind-inference unit

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

