### PR TITLE
fix(desktop): stop falsely reporting GUI self-update on packaged Linux

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -52,6 +52,8 @@ The app checks for updates in the background and offers a one-click update when 
 hermes update
 ```
 
+> **Linux installers:** in-app update always refreshes the agent in place. A prebuilt-package install (`.AppImage` / `.deb` / `.rpm`) can't replace its own app shell — grab the latest installer from the [releases page](https://github.com/NousResearch/hermes-agent/releases) to update the GUI itself. A `hermes desktop` (CLI) build picks up the new shell on its next launch.
+
 ---
 
 ## Requirements

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -26,6 +26,7 @@ const { execFileSync, spawn } = require('node:child_process')
 const { isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { resolvePosixGuiDeploy } = require('./update-deploy.cjs')
 const {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
@@ -1387,22 +1388,50 @@ async function applyUpdatesPosixInApp(opts = {}) {
     return { ok: false, backendUpdated: true, error: 'desktop rebuild failed' }
   }
 
-  const rebuiltApp = [
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
-  ].find(directoryExists)
-  const targetApp = runningAppBundle()
+  const releaseDir = path.join(updateRoot, 'apps', 'desktop', 'release')
+  const macBundleSrc = IS_MAC
+    ? [path.join(releaseDir, 'mac-arm64', 'Hermes.app'), path.join(releaseDir, 'mac', 'Hermes.app')].find(
+        directoryExists
+      ) || null
+    : null
+  const deploy = resolvePosixGuiDeploy({
+    platform: process.platform,
+    execPath: app.getPath('exe'),
+    releaseDir,
+    macBundleSrc,
+    macBundleDst: runningAppBundle()
+  })
 
-  // No bundle to swap (dev run, Linux AppImage, or unresolved paths): the
-  // backend is updated; the next launch picks up the rebuilt GUI.
-  if (!rebuiltApp || !targetApp) {
+  // Packaged Linux install (AppImage/deb/rpm): the rebuilt GUI lands in the
+  // checkout's release/ tree, NOT the system binary the user actually launches,
+  // so a restart would just rerun the same stale shell. Don't advertise a GUI
+  // update we can't deliver -- report the backend update honestly and point the
+  // user at a reinstall for the app shell itself.
+  if (deploy.kind === 'manual-gui') {
+    emitUpdateProgress({
+      stage: 'done',
+      message: 'Backend updated. Reinstall the Hermes desktop app from the releases page to update the app itself.',
+      percent: 100
+    })
+    rememberLog(
+      `[updates] packaged GUI at ${app.getPath('exe')} cannot self-replace; rebuilt app staged under ${releaseDir}`
+    )
+    return { ok: true, backendUpdated: true, guiUpdated: false, manualGui: true, hermesRoot: updateRoot }
+  }
+
+  // Dev/source run, or a CLI `hermes desktop` install whose running binary lives
+  // in release/: the rebuild is in place, so a restart loads the new version.
+  if (deploy.kind === 'restart') {
     emitUpdateProgress({
       stage: 'done',
       message: 'Backend updated. Restart Hermes to load the new version.',
       percent: 100
     })
-    return { ok: true, backendUpdated: true, rebuiltApp: rebuiltApp || null }
+    return { ok: true, backendUpdated: true, guiUpdated: true, rebuiltApp: macBundleSrc }
   }
+
+  const rebuiltApp = deploy.src
+  const targetApp = deploy.dst
 
   emitUpdateProgress({ stage: 'restart', message: 'Installing the updated app and restarting…', percent: 95 })
 

--- a/apps/desktop/electron/update-deploy.cjs
+++ b/apps/desktop/electron/update-deploy.cjs
@@ -1,0 +1,50 @@
+const path = require('node:path')
+
+// Decide how a freshly rebuilt POSIX desktop GUI actually reaches the user after
+// `hermes update` + `hermes desktop --build-only` have run.
+//
+// `hermes desktop --build-only` always writes the rebuilt app into
+// <updateRoot>/apps/desktop/release/. Whether that rebuild is ever *loaded*
+// depends entirely on where the currently running binary lives:
+//
+//   - macOS .app bundle: swap the bundle in place and relaunch (the caller runs
+//     the ditto/open script).
+//   - Running binary already inside the rebuilt release/ tree (a CLI
+//     `hermes desktop` install launches release/linux-unpacked): the rebuild
+//     overwrites that very binary, so a plain relaunch loads it.
+//   - A packaged install (Linux AppImage/deb/rpm, or anything else launched from
+//     a system/mount path the rebuild never touches): the rebuilt artifact in
+//     the checkout is NOT the binary the user launches, so restarting just
+//     reruns the same stale shell. The desktop cannot self-update the GUI here,
+//     so the honest outcome is "backend updated, reinstall to update the app".
+
+// True when `child` is the same path as, or nested under, `parent`.
+// Separator-aware and tolerant of trailing separators; never throws.
+function isPathInside(child, parent) {
+  if (!child || !parent) return false
+  const rel = path.relative(path.resolve(parent), path.resolve(child))
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))
+}
+
+// Returns one of:
+//   { kind: 'swap-mac', src, dst } - swap the macOS bundle and relaunch
+//   { kind: 'restart' }            - rebuild landed in place; a relaunch loads it
+//   { kind: 'manual-gui' }         - packaged install; the GUI needs a reinstall
+function resolvePosixGuiDeploy({ platform, execPath, releaseDir, macBundleSrc, macBundleDst } = {}) {
+  if (platform === 'darwin') {
+    if (macBundleSrc && macBundleDst) {
+      return { kind: 'swap-mac', src: macBundleSrc, dst: macBundleDst }
+    }
+    // Dev run not launched from a packaged .app: nothing to swap in place, but
+    // the rebuild is staged for the next launch.
+    return { kind: 'restart' }
+  }
+
+  // Linux and any other POSIX target.
+  if (isPathInside(execPath, releaseDir)) {
+    return { kind: 'restart' }
+  }
+  return { kind: 'manual-gui' }
+}
+
+module.exports = { isPathInside, resolvePosixGuiDeploy }

--- a/apps/desktop/electron/update-deploy.test.cjs
+++ b/apps/desktop/electron/update-deploy.test.cjs
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const test = require('node:test')
+
+const { isPathInside, resolvePosixGuiDeploy } = require('./update-deploy.cjs')
+
+const ROOT = path.resolve('/home/dev/hermes-agent')
+const RELEASE_DIR = path.join(ROOT, 'apps', 'desktop', 'release')
+
+test('isPathInside: a nested path is inside', () => {
+  assert.equal(isPathInside(path.join(RELEASE_DIR, 'linux-unpacked', 'hermes'), RELEASE_DIR), true)
+})
+
+test('isPathInside: an identical path counts as inside', () => {
+  assert.equal(isPathInside(RELEASE_DIR, RELEASE_DIR), true)
+})
+
+test('isPathInside: a sibling/system path is outside', () => {
+  assert.equal(isPathInside(path.resolve('/opt/Hermes/hermes'), RELEASE_DIR), false)
+})
+
+test('isPathInside: missing arguments are never inside', () => {
+  assert.equal(isPathInside('', RELEASE_DIR), false)
+  assert.equal(isPathInside(path.join(RELEASE_DIR, 'x'), ''), false)
+})
+
+test('macOS packaged install swaps the bundle in place', () => {
+  const plan = resolvePosixGuiDeploy({
+    platform: 'darwin',
+    execPath: '/Applications/Hermes.app/Contents/MacOS/Hermes',
+    releaseDir: RELEASE_DIR,
+    macBundleSrc: path.join(RELEASE_DIR, 'mac-arm64', 'Hermes.app'),
+    macBundleDst: '/Applications/Hermes.app'
+  })
+  assert.deepEqual(plan, {
+    kind: 'swap-mac',
+    src: path.join(RELEASE_DIR, 'mac-arm64', 'Hermes.app'),
+    dst: '/Applications/Hermes.app'
+  })
+})
+
+test('macOS dev run (no bundle to swap) restarts in place', () => {
+  const plan = resolvePosixGuiDeploy({
+    platform: 'darwin',
+    execPath: path.join(ROOT, 'node_modules', 'electron', 'dist', 'Electron'),
+    releaseDir: RELEASE_DIR,
+    macBundleSrc: null,
+    macBundleDst: null
+  })
+  assert.equal(plan.kind, 'restart')
+})
+
+test('Linux CLI install (running from release/) restarts in place', () => {
+  const plan = resolvePosixGuiDeploy({
+    platform: 'linux',
+    execPath: path.join(RELEASE_DIR, 'linux-unpacked', 'hermes'),
+    releaseDir: RELEASE_DIR,
+    macBundleSrc: null,
+    macBundleDst: null
+  })
+  assert.equal(plan.kind, 'restart')
+})
+
+test('Linux packaged AppImage needs a manual GUI reinstall', () => {
+  const plan = resolvePosixGuiDeploy({
+    platform: 'linux',
+    execPath: '/tmp/.mount_HermesAbc123/hermes',
+    releaseDir: RELEASE_DIR,
+    macBundleSrc: null,
+    macBundleDst: null
+  })
+  assert.equal(plan.kind, 'manual-gui')
+})
+
+test('Linux packaged deb/rpm install needs a manual GUI reinstall', () => {
+  const plan = resolvePosixGuiDeploy({
+    platform: 'linux',
+    execPath: '/opt/Hermes/hermes',
+    releaseDir: RELEASE_DIR,
+    macBundleSrc: null,
+    macBundleDst: null
+  })
+  assert.equal(plan.kind, 'manual-gui')
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,7 +32,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/update-deploy.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -28,6 +28,7 @@ const STAGE_LABELS: Record<DesktopUpdateStage, string> = {
   pydeps: 'Finishing up…',
   restart: 'Restarting Hermes…',
   manual: 'Update from your terminal',
+  done: 'Update complete',
   error: 'Update paused'
 }
 
@@ -49,14 +50,16 @@ export function UpdatesOverlay() {
 
   const behind = status?.behind ?? 0
 
-  const phase: 'idle' | 'applying' | 'manual' | 'error' =
+  const phase: 'idle' | 'applying' | 'manual' | 'done' | 'error' =
     apply.stage === 'manual'
       ? 'manual'
-      : apply.applying || apply.stage === 'restart'
-        ? 'applying'
-        : apply.stage === 'error'
-          ? 'error'
-          : 'idle'
+      : apply.stage === 'done'
+        ? 'done'
+        : apply.applying || apply.stage === 'restart'
+          ? 'applying'
+          : apply.stage === 'error'
+            ? 'error'
+            : 'idle'
 
   const handleClose = (next: boolean) => {
     if (phase === 'applying') {
@@ -65,7 +68,10 @@ export function UpdatesOverlay() {
 
     setUpdateOverlayOpen(next)
 
-    if (!next && (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual')) {
+    if (
+      !next &&
+      (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual' || apply.stage === 'done')
+    ) {
       resetUpdateApplyState()
     }
   }
@@ -84,6 +90,19 @@ export function UpdatesOverlay() {
 
         {phase === 'manual' && (
           <ManualView command={apply.command ?? 'hermes update'} onDone={() => handleClose(false)} />
+        )}
+
+        {phase === 'done' && (
+          <CenteredStatus
+            action={
+              <Button onClick={() => handleClose(false)} size="sm" variant="outline">
+                Close
+              </Button>
+            }
+            body={apply.message || 'Restart Hermes to load the new version.'}
+            icon={<CheckCircle2 className="size-7 text-emerald-600 dark:text-emerald-400" />}
+            title="Update complete"
+          />
         )}
 
         {phase === 'error' && (

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -119,9 +119,24 @@ export interface DesktopUpdateApplyResult {
   manual?: boolean
   command?: string
   hermesRoot?: string
+  /** POSIX in-app update outcomes (the app stays open instead of relaunching). */
+  backendUpdated?: boolean
+  guiUpdated?: boolean
+  /** True on a packaged Linux install whose app shell can't self-update; the
+   *  agent was refreshed but the GUI needs a manual reinstall. */
+  manualGui?: boolean
 }
 
-export type DesktopUpdateStage = 'idle' | 'prepare' | 'fetch' | 'pull' | 'pydeps' | 'restart' | 'manual' | 'error'
+export type DesktopUpdateStage =
+  | 'idle'
+  | 'prepare'
+  | 'fetch'
+  | 'pull'
+  | 'pydeps'
+  | 'restart'
+  | 'manual'
+  | 'done'
+  | 'error'
 
 export interface DesktopUpdateProgress {
   stage: DesktopUpdateStage

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -217,7 +217,12 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 function ingestProgress(payload: DesktopUpdateProgress): void {
   const current = $updateApply.get()
   const log = [...current.log, { stage: payload.stage, message: payload.message, at: payload.at }].slice(-50)
-  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual'
+
+  const terminal =
+    payload.stage === 'error' ||
+    payload.stage === 'restart' ||
+    payload.stage === 'manual' ||
+    payload.stage === 'done'
 
   $updateApply.set({
     applying: !terminal,

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -83,6 +83,8 @@ The app also surfaces the broader Hermes management surface so you don't have to
 
 The app checks for updates in the background and offers a one-click update when one is ready.
 
+On Linux, the in-app update always refreshes the agent. An install from a prebuilt package (`.AppImage` / `.deb` / `.rpm`) can't replace the app shell itself — download the latest installer from the [releases page](https://github.com/NousResearch/hermes-agent/releases) to update the GUI. A `hermes desktop` build picks up the new shell on its next launch.
+
 The [manual update process](https://hermes-agent.nousresearch.com/docs/getting-started/updating) also works with the GUI.
 
 ## CLI reference: `hermes desktop`


### PR DESCRIPTION

## What & why

The desktop app advertises a one-click, in-place self-update ("Built-in
updates pull the latest agent and rebuild the app in place", "offers a
one-click update"), and Linux is a first-class target with prebuilt
`.AppImage` / `.deb` / `.rpm` installers. On a **packaged Linux install**,
that promise is not kept: "Update now" updates the backend checkout but the
installed GUI shell is never replaced, and the app still reports success
("Backend updated. Restart Hermes to load the new version."). On the next
launch the user runs the same stale shell — silent GUI/backend skew.

### Root cause

`applyUpdatesPosixInApp()` in `apps/desktop/electron/main.cjs` runs
`hermes update` + `hermes desktop --build-only`, but the deploy/relaunch step
only understands the macOS `.app` bundle:

- the rebuilt-artifact lookup only resolves `release/mac-arm64/Hermes.app`
  and `release/mac/Hermes.app`;
- `runningAppBundle()` returns `null` on every non-macOS platform.

So on Linux both are `null` and the flow always falls into the
"backend updated, restart to load" branch — regardless of whether a restart
will actually load anything. Meanwhile `hermes desktop --build-only` really
does produce `release/linux-unpacked/` (`hermes_cli/main.py` →
`_desktop_packaged_executable`), so the build happens but is never installed
over the running packaged binary.

A coupled defect made this invisible to fix by message alone: the renderer
never treated the `done` progress stage as terminal, so the in-app (non-quit)
completion path left the update overlay spinning on "Updating Hermes…"
indefinitely.

## The fix

Classify the POSIX GUI deploy outcome from where the running binary actually
lives, and report each case truthfully:

| Situation | Outcome |
| --- | --- |
| macOS `.app` bundle | swap the bundle in place + relaunch (unchanged) |
| Running binary inside the rebuilt `release/` tree (CLI `hermes desktop` install) | rebuild is in place → "restart to load the new version" |
| Packaged install whose binary lives outside `release/` (Linux AppImage/deb/rpm) | cannot self-replace → "backend updated; reinstall the app to update the GUI" (`guiUpdated: false`, `manualGui: true`) |

The classification is extracted into a small pure module so it can be
unit-tested without booting Electron, matching the existing
`electron/*.cjs` helper pattern.

The renderer now treats `done` as a terminal stage and renders a real
"Update complete" view, so both the honest packaged-Linux message and the
normal "restart to load" message are actually shown (and the status bar /
About pane no longer hang in a perpetual "updating" state).

Docs are updated to match: on Linux, in-app update always refreshes the
agent, but a prebuilt-package install updates the app shell by reinstalling
from the releases page (a `hermes desktop` build picks it up on next launch).

## Files changed

- `apps/desktop/electron/update-deploy.cjs` — **new**: pure
  `resolvePosixGuiDeploy()` / `isPathInside()` classifier.
- `apps/desktop/electron/update-deploy.test.cjs` — **new**: unit tests
  (9 cases) covering macOS packaged/dev, Linux CLI-install, and Linux
  packaged AppImage + deb/rpm.
- `apps/desktop/electron/main.cjs` — use the classifier; honest branch per
  outcome.
- `apps/desktop/src/global.d.ts` — `done` stage; `manualGui` / `guiUpdated`
  / `backendUpdated` result fields.
- `apps/desktop/src/store/updates.ts` — treat `done` as terminal.
- `apps/desktop/src/app/updates-overlay.tsx` — "Update complete" view +
  `done` phase.
- `apps/desktop/package.json` — wire the new test into
  `test:desktop:platforms`.
- `apps/desktop/README.md`, `website/docs/user-guide/desktop.md` — honest
  Linux update note.

## Testing

- `npm run test:desktop:platforms` — 26/26 (includes the 9 new cases).
- `npm run type-check` — clean.
- `npm run build` — renderer builds.
- `npm run test:desktop:all` — installer builds and the packaged bundle
  validates (install-stamp, node-pty native deps, renderer payload).
- `eslint` on the changed files — clean.

The new unit tests exercise the macOS (swap + dev), Linux CLI-install, and
Linux packaged (AppImage and deb/rpm) classification paths directly, so the
cross-platform behavior is covered regardless of the build host.

## Compatibility & scope

- macOS and Windows update paths are unchanged.
- No prompt-cache, toolset, or backend-contract behavior is touched.
- Out of scope (possible follow-up): a real in-place self-update for Linux
  AppImage (swap the `$APPIMAGE` file + relaunch, mirroring the macOS swap).
  deb/rpm genuinely require the system package manager, so a manual reinstall
  remains the correct path there. This PR intentionally limits itself to
  making the existing behavior honest rather than shipping a new, harder-to-
  verify self-update mechanism.