### PR TITLE
fix(provider): honor ANTHROPIC_BASE_URL in native anthropic path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,9 +172,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # PR runs only need a test image, so read the shared cache but don't try
-      # to publish cache layers back to ghcr.io from a fork token.
-      - name: Build image (arm64, PR)
+      # PR validation only needs a runnable local image for the docker tests.
+      # Skip cache export on pull_request runs: fork-triggered workflow tokens
+      # can read the shared ghcr cache but may not write organization package
+      # blobs, which turns a successful build into a red CI job during export.
+      - name: Build image (arm64, PR validation)
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -187,8 +189,10 @@ jobs:
             HERMES_GIT_SHA=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
 
-      # Push/release runs still refresh the registry-backed cache so later
-      # arm64 builds start warm and the publish step can reuse the layers.
+      # Push/release builds still read AND write the registry-backed cache so
+      # the publish step reuses layers from this build and the next release
+      # starts warm. The job-lifetime GITHUB_TOKEN avoids the old gha SAS-token
+      # expiry problem on slow cold-cache arm64 runs.
       - name: Build image (arm64, cached publish)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,15 +172,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build once, load into the local daemon for testing, then push
-      # by digest below. Reads AND writes the registry-backed cache so the
-      # push reuses layers from this build and the next build starts warm.
-      #
-      # Registry cache (type=registry on ghcr.io) is used instead of the gha
-      # cache that previously broke here: its credential is the job-lifetime
-      # GITHUB_TOKEN, not a short-lived SAS token, so the cold-build-outlives-
-      # token failure mode cannot recur.
+      # PR runs only need a test image, so read the shared cache but don't try
+      # to publish cache layers back to ghcr.io from a fork token.
+      - name: Build image (arm64, PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:test
+          build-args: |
+            HERMES_GIT_SHA=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
+
+      # Push/release runs still refresh the registry-backed cache so later
+      # arm64 builds start warm and the publish step can reuse the layers.
       - name: Build image (arm64, cached publish)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1660,7 +1660,8 @@ def resolve_runtime_provider(
         cfg_base_url = ""
         if cfg_provider == "anthropic":
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
-        base_url = cfg_base_url or "https://api.anthropic.com"
+        env_base_url = os.getenv("ANTHROPIC_BASE_URL", "").strip().rstrip("/")
+        base_url = cfg_base_url or env_base_url or "https://api.anthropic.com"
 
         # For Microsoft Foundry endpoints, use ANTHROPIC_API_KEY directly —
         # Claude Code OAuth tokens (sk-ant-oat01) are not accepted by Azure.

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2893,3 +2893,104 @@ def test_resolve_runtime_provider_bedrock_nonclaude_target_model_uses_converse(m
     assert resolved["provider"] == "bedrock"
     assert resolved["api_mode"] == "bedrock_converse"
     assert resolved.get("bedrock_anthropic") is not True
+
+
+# ------------------------------------------------------------------
+# fix #31216 - ANTHROPIC_BASE_URL env var in native anthropic path
+# ------------------------------------------------------------------
+
+
+def _stub_anthropic_token(monkeypatch):
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: "test-anthropic-token",
+    )
+
+
+def test_anthropic_base_url_env_used_when_no_config(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp, "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:8317")
+    _stub_anthropic_token(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "http://127.0.0.1:8317"
+
+
+def test_anthropic_config_base_url_wins_over_env(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"provider": "anthropic", "base_url": "http://config-proxy:9090"},
+    )
+    monkeypatch.setattr(
+        rp, "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://env-proxy:8080")
+    _stub_anthropic_token(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "http://config-proxy:9090"
+
+
+def test_anthropic_default_when_neither_config_nor_env(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp, "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    _stub_anthropic_token(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "https://api.anthropic.com"
+
+
+def test_anthropic_base_url_env_stripped_and_slash_removed(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp, "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "  http://127.0.0.1:8317/  ")
+    _stub_anthropic_token(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "http://127.0.0.1:8317"
+
+
+def test_anthropic_env_used_when_cfg_provider_not_anthropic(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    )
+    monkeypatch.setattr(
+        rp, "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:8317")
+    _stub_anthropic_token(monkeypatch)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "http://127.0.0.1:8317"


### PR DESCRIPTION
## Summary
The native anthropic provider path in `resolve_runtime_provider()` reads `model.base_url` from config.yaml but ignores the `ANTHROPIC_BASE_URL` environment variable. Users routing through Anthropic-compatible proxies (e.g. Azure Foundry self-hosted, local reverse proxies) must patch the source or set `model.base_url` in config — the env var that works for every other provider silently does nothing.

PR #14243 added `base_url_env_var="ANTHROPIC_BASE_URL"` to the `ProviderConfig` registry entry, which fixes the `api_key` auth path. But when the provider resolves as `"anthropic"` through auto-detection (the common case for Claude models), the code takes a separate branch at L1469 that never consults the env var.

This adds `ANTHROPIC_BASE_URL` to the native path's fallback chain with config > env > default precedence, matching the contract established by every `api_key` provider.

Fixes #31216

## Changes
- `hermes_cli/runtime_provider.py`: read `ANTHROPIC_BASE_URL` between the config lookup and the `api.anthropic.com` default (+2 lines, -1).
- `tests/hermes_cli/test_runtime_provider_resolution.py`: 4 new tests covering env-only, config-wins-over-env, default fallback, and whitespace/trailing-slash normalization.

## Validation
| Scenario | Before | After |
|---|---|---|
| `ANTHROPIC_BASE_URL` set, no `model.base_url` | ignored, hits `api.anthropic.com` | uses env var |
| Both config and env set | config wins | config wins (unchanged) |
| Neither set | `api.anthropic.com` | `api.anthropic.com` (unchanged) |

## Test plan
- `pytest tests/hermes_cli/test_runtime_provider_resolution.py -v` — 131 passed
- `pytest tests/agent/test_anthropic_adapter.py -v` — 154 passed, 1 skipped
- Manual: `ANTHROPIC_BASE_URL=http://127.0.0.1:8317 hermes -m claude-sonnet-4-6 -z "test"`