### PR TITLE
fix(agent): respect model.context_length config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1485,7 +1485,14 @@ def init_agent(
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
     _ctx = getattr(agent.context_compressor, "context_length", 0)
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+    if _config_context_length is not None and _ctx and _ctx < _config_context_length:
+        raise ValueError(
+            f"Model {agent.model} has a context window of {_ctx:,} tokens, "
+            f"which is below the user-configured override of "
+            f"{_config_context_length:,} tokens.  Adjust or remove the "
+            f"model.context_length setting in config.yaml to proceed."
+        )
+    if _config_context_length is None and _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "

--- a/tests/agent/test_agent_init.py
+++ b/tests/agent/test_agent_init.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import pytest
+
+import agent.agent_init as agent_init
+import agent.auxiliary_client as auxiliary_client
+from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+import hermes_cli.config as config_module
+
+
+class DummyCompressor:
+    def __init__(self, *args, **kwargs):
+        self.context_length = self._context_length
+
+
+def make_agent():
+    agent = SimpleNamespace()
+    agent._base_url_hostname = ""
+    agent._base_url_lower = ""
+    agent._transport_cache = {}
+    agent._get_transport = lambda *args, **kwargs: None
+    agent._is_openrouter_url = lambda *args, **kwargs: False
+    agent._is_azure_openai_url = lambda *args, **kwargs: False
+    agent._is_direct_openai_url = lambda *args, **kwargs: False
+    agent._provider_model_requires_responses_api = lambda *args, **kwargs: False
+    agent._anthropic_prompt_cache_policy = lambda *args, **kwargs: (False, False)
+    agent._create_openai_client = lambda *args, **kwargs: SimpleNamespace()
+    agent._ensure_lmstudio_runtime_loaded = lambda _config_context_length: None
+    return agent
+
+
+def test_init_agent_rejects_model_below_user_config_override(monkeypatch):
+    config = {"model": {"context_length": 60000}}
+    monkeypatch.setattr(config_module, "load_config", lambda: config)
+    monkeypatch.setattr(agent_init, "_install_safe_stdio", lambda: None)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda *args, **kwargs: (SimpleNamespace(api_key="test-key", base_url="https://example.invalid/v1"), "test/model"),
+    )
+
+    context_length = 50000
+
+    class Compressor(DummyCompressor):
+        _context_length = context_length
+
+    monkeypatch.setattr(agent_init, "ContextCompressor", Compressor)
+
+    agent = make_agent()
+
+    with pytest.raises(ValueError, match="user-configured override"):
+        agent_init.init_agent(agent, model="test/model")
+
+
+def test_init_agent_rejects_model_below_minimum_without_override(monkeypatch):
+    monkeypatch.setattr(config_module, "load_config", lambda: {})
+    monkeypatch.setattr(agent_init, "_install_safe_stdio", lambda: None)
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda *args, **kwargs: (SimpleNamespace(api_key="test-key", base_url="https://example.invalid/v1"), "test/model"),
+    )
+
+    context_length = 50000
+
+    class Compressor(DummyCompressor):
+        _context_length = context_length
+
+    monkeypatch.setattr(agent_init, "ContextCompressor", Compressor)
+
+    agent = make_agent()
+
+    with pytest.raises(ValueError, match=f"below the minimum {MINIMUM_CONTEXT_LENGTH:,}"):
+        agent_init.init_agent(agent, model="test/model")


### PR DESCRIPTION

## What does this PR do?

This PR fixes #8430 in a exhaustive way, introducing proper context length checking in case the user has provided a model.context_length config.

## Related Issue

#8430 

Fixes #8430 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

1. Show the existing error message only when context_length is None
2. Show a new actionable error message if the model's context is less than the context_length value set in the config.
- 

## How to Test

1.  Run hermes agent with any model with context < 64000
2.  Set `model.context_length` in config to be less than 64000
3.  Send a 'hi' to hermes and see if you get a response

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate  -- The existing PRs are not as exhaustive (adding a new error message and check) as this
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A




