### PR TITLE
feat(skills): expose native skill search tool

### DIFF
--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -70,8 +71,11 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
     """
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     try:
+        bash_exe = shutil.which("bash")
+        if not bash_exe:
+            return "[inline-shell error: bash not found]"
         completed = subprocess.run(
-            ["bash", "-c", command],
+            [bash_exe, "-c", command],
             cwd=str(cwd) if cwd else None,
             capture_output=True,
             text=True,

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -291,3 +291,45 @@ class TestResolveToolsetIncludeRegistry:
 
     def test_registry_only_toolset_static_view_is_empty(self):
         assert resolve_toolset("__definitely_not_a_real_toolset__", include_registry=False) == []
+
+
+class TestSkillSearchToolsetCoverage:
+    """``skill_search`` must resolve into every platform bundle that ships the
+    skill-discovery tools, so normal agents receive its schema by default.
+
+    See the sibling ``get_tool_definitions(enabled_toolsets=["hermes-cli"])``
+    regression in ``tests/tools/test_skills_tool.py`` for the end-to-end
+    (schema-resolution + check_fn) proof on the default session path.
+    """
+
+    def test_hermes_cli_toolset_includes_skill_search(self):
+        assert "skill_search" in resolve_toolset("hermes-cli")
+
+    def test_messaging_platforms_include_skill_search(self):
+        for platform in (
+            "hermes-cron",
+            "hermes-telegram",
+            "hermes-discord",
+            "hermes-whatsapp",
+            "hermes-slack",
+            "hermes-signal",
+            "hermes-api-server",
+            "hermes-acp",
+        ):
+            assert "skill_search" in resolve_toolset(platform), (
+                f"{platform} exposes skill discovery but is missing skill_search"
+            )
+
+    def test_standalone_skills_toolset_includes_skill_search(self):
+        assert "skill_search" in resolve_toolset("skills")
+
+    def test_skill_search_travels_with_skills_list_across_all_toolsets(self):
+        """Parity invariant: no toolset may expose ``skills_list`` without also
+        exposing ``skill_search``. Guards against a future toolset (or a new
+        platform bundle) enumerating skills while leaving search unreachable."""
+        for name in TOOLSETS:
+            resolved = set(resolve_toolset(name))
+            if "skills_list" in resolved:
+                assert "skill_search" in resolved, (
+                    f"toolset '{name}' exposes skills_list without skill_search"
+                )

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -15,6 +15,7 @@ from tools.skills_tool import (
     _get_category_from_path,
     _find_all_skills,
     skill_matches_platform,
+    skill_search,
     skills_list,
     skill_view,
     MAX_DESCRIPTION_LENGTH,
@@ -1370,3 +1371,96 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is True
         assert "LOCAL BODY" in result["content"]
+
+
+class TestSkillSearch:
+    def test_search_installed_skills_returns_compact_matches(self, tmp_path):
+        _make_skill(
+            tmp_path,
+            "flutter-ui-development",
+            category="software-development",
+            body="FULL BODY SHOULD NOT LEAK INTO SEARCH RESULTS",
+        )
+        _make_skill(tmp_path, "spotify", category="media")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            raw = skill_search("flutter", source="installed", limit=10)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["query"] == "flutter"
+        assert result["count"] == 1
+        assert result["results"] == [
+            {
+                "name": "flutter-ui-development",
+                "identifier": "software-development/flutter-ui-development",
+                "source": "installed",
+                "description": "Description for flutter-ui-development.",
+                "installed": True,
+                "category": "software-development",
+                "tags": [],
+            }
+        ]
+        assert "FULL BODY SHOULD NOT LEAK" not in raw
+
+    def test_search_validates_empty_query(self):
+        result = json.loads(skill_search("   "))
+
+        assert result["success"] is False
+        assert "query" in result["error"]
+
+    def test_search_installed_nested_skill_identifier_loads_with_skill_view(self, tmp_path):
+        _make_skill(
+            tmp_path,
+            "deep-skill",
+            category="foundations/runtime",
+            body="Nested skill body.",
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            search_result = json.loads(skill_search("deep", source="installed"))
+            identifier = search_result["results"][0]["identifier"]
+            view_result = json.loads(skill_view(identifier))
+
+        assert identifier == "foundations/runtime/deep-skill"
+        assert view_result["success"] is True
+        assert "Nested skill body." in view_result["content"]
+
+    def test_search_caps_limit_and_preserves_installed_first(self, tmp_path):
+        _make_skill(tmp_path, "alpha-local", body="No body in search")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool.unified_search") as unified, \
+             patch("tools.skills_tool.create_source_router", return_value=[]):
+            from tools.skills_hub import SkillMeta
+
+            unified.return_value = [
+                SkillMeta(
+                    name="alpha-remote",
+                    description="Remote alpha skill.",
+                    source="hermes-index",
+                    identifier="owner/repo/alpha-remote",
+                    trust_level="community",
+                    tags=["alpha"],
+                )
+            ]
+            raw = skill_search("alpha", source="all", limit=99)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["limit"] == 50
+        assert [item["source"] for item in result["results"]] == [
+            "installed",
+            "hermes-index",
+        ]
+        assert result["results"][0]["identifier"] == "alpha-local"
+        assert result["results"][1]["installed"] is False
+        assert "trust_level" in result["results"][1]
+
+    def test_tool_is_registered_under_skills_toolset(self):
+        entry = skills_tool_module.registry.get_entry("skill_search")
+
+        assert entry is not None
+        assert entry.toolset == "skills"
+        assert entry.schema["name"] == "skill_search"
+        assert "query" in entry.schema["parameters"]["required"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1464,3 +1464,40 @@ class TestSkillSearch:
         assert entry.toolset == "skills"
         assert entry.schema["name"] == "skill_search"
         assert "query" in entry.schema["parameters"]["required"]
+
+    def test_skill_search_exposed_on_default_hermes_cli_session(self):
+        """Regression: registering ``skill_search`` under the ``skills`` toolset
+        is not enough — the default interactive session resolves its schema
+        footprint from the ``hermes-cli`` platform bundle. If ``skill_search``
+        isn't wired into that composition, ``get_tool_definitions`` never sends
+        the schema to the model and the tool is silently unreachable by default.
+        """
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        _clear_tool_defs_cache()
+        tools = get_tool_definitions(enabled_toolsets=["hermes-cli"], quiet_mode=True)
+        names = {t.get("function", {}).get("name") for t in tools}
+
+        assert "skill_search" in names, (
+            "skill_search must be exposed on the default hermes-cli session path "
+            "(wire it into _HERMES_CORE_TOOLS in toolsets.py)"
+        )
+        # The exposed schema must be the real one the model can call.
+        schema = next(
+            t["function"] for t in tools
+            if t.get("function", {}).get("name") == "skill_search"
+        )
+        assert "query" in schema["parameters"]["required"]
+
+    def test_skill_search_travels_with_skills_list_on_default_path(self):
+        """Discovery-tool parity guard: any default session that can enumerate
+        skills (``skills_list``) must also be able to search them
+        (``skill_search``). This fails loudly if a future edit exposes one
+        without the other."""
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        _clear_tool_defs_cache()
+        tools = get_tool_definitions(enabled_toolsets=["hermes-cli"], quiet_mode=True)
+        names = {t.get("function", {}).get("name") for t in tools}
+
+        assert {"skills_list", "skill_view", "skill_search"} <= names

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -84,6 +84,7 @@ from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
     is_skill_support_path as _is_skill_support_path,
 )
+from tools.skills_hub import create_source_router, unified_search
 
 logger = logging.getLogger(__name__)
 
@@ -752,12 +753,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
 
                 category = _get_category_from_path(skill_md)
+                try:
+                    identifier = skill_md.parent.relative_to(scan_dir).as_posix()
+                except ValueError:
+                    identifier = name
 
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "identifier": identifier,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -780,6 +786,215 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Keep every skill listing path ordered the same way."""
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
+
+
+
+def _skill_identifier(skill: Dict[str, Any]) -> str:
+    """Return the stable identifier a model can pass to ``skill_view``."""
+    identifier = str(skill.get("identifier") or "").strip().strip("/")
+    if identifier:
+        return identifier
+    name = str(skill.get("name") or "").strip()
+    category = str(skill.get("category") or "").strip().strip("/")
+    return f"{category}/{name}" if category else name
+
+
+def _installed_skill_matches(skill: Dict[str, Any], query: str) -> bool:
+    haystack = " ".join(
+        str(value or "")
+        for value in (
+            skill.get("name"),
+            skill.get("description"),
+            skill.get("category"),
+            " ".join(skill.get("tags") or []),
+        )
+    ).lower()
+    return query.lower() in haystack
+
+
+def _compact_text(value: Any, limit: int) -> str:
+    text = str(value or "")
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def _compact_tags(value: Any, *, max_tags: int = 20, max_len: int = 64) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [_compact_text(tag, max_len) for tag in value[:max_tags]]
+
+
+def _compact_installed_skill_result(skill: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": _compact_text(skill.get("name", ""), MAX_NAME_LENGTH),
+        "identifier": _compact_text(_skill_identifier(skill), 256),
+        "source": "installed",
+        "description": _compact_text(skill.get("description", ""), MAX_DESCRIPTION_LENGTH),
+        "installed": True,
+        "category": skill.get("category"),
+        "tags": _compact_tags(skill.get("tags") or []),
+    }
+
+
+def _compact_remote_skill_result(meta: Any) -> Dict[str, Any]:
+    result = {
+        "name": _compact_text(getattr(meta, "name", ""), MAX_NAME_LENGTH),
+        "identifier": _compact_text(getattr(meta, "identifier", ""), 256),
+        "source": _compact_text(getattr(meta, "source", ""), 64),
+        "description": _compact_text(getattr(meta, "description", ""), MAX_DESCRIPTION_LENGTH),
+        "installed": False,
+        "trust_level": _compact_text(getattr(meta, "trust_level", "community"), 64),
+        "tags": _compact_tags(getattr(meta, "tags", []) or []),
+    }
+    repo = getattr(meta, "repo", None)
+    path = getattr(meta, "path", None)
+    if repo:
+        result["repo"] = _compact_text(repo, 256)
+    if path:
+        result["path"] = _compact_text(path, 256)
+    return result
+
+
+def skill_search(
+    query: str,
+    source: str = "all",
+    limit: int = 10,
+    include_installed: bool = True,
+    task_id: str = None,
+) -> str:
+    """Search installed skills and the Hermes Skills Hub without loading bodies.
+
+    ``skill_search`` is a model-facing wrapper around the same installed-skill
+    index used by ``skills_list`` plus the native Skills Hub search stack used by
+    ``hermes skills search``. Results are intentionally compact: identifiers,
+    descriptions, provenance, and tags only. Installation and full skill bodies
+    remain explicit follow-up actions via the existing hub CLI / ``skill_view``.
+    """
+    try:
+        normalized_query = str(query or "").strip()
+        if not normalized_query:
+            return tool_error("skill_search requires a non-empty query", success=False)
+
+        normalized_source = str(source or "all").strip() or "all"
+        allowed_sources = {
+            "all",
+            "installed",
+            "official",
+            "hermes-index",
+            "skills-sh",
+            "skills.sh",
+            "well-known",
+            "github",
+            "clawhub",
+            "claude-marketplace",
+            "lobehub",
+            "browse-sh",
+        }
+        if normalized_source not in allowed_sources:
+            return tool_error(
+                f"Unsupported skill search source '{normalized_source}'. "
+                f"Use one of: {', '.join(sorted(allowed_sources))}",
+                success=False,
+            )
+
+        capped_limit = max(1, min(int(limit or 10), 50))
+        results: List[Dict[str, Any]] = []
+        seen: Set[str] = set()
+
+        if include_installed or normalized_source == "installed":
+            installed = [
+                skill for skill in _find_all_skills()
+                if _installed_skill_matches(skill, normalized_query)
+            ]
+            for skill in _sort_skills(installed):
+                compact = _compact_installed_skill_result(skill)
+                identifier = str(compact.get("identifier") or compact.get("name") or "")
+                if identifier in seen:
+                    continue
+                seen.add(identifier)
+                results.append(compact)
+                if len(results) >= capped_limit:
+                    break
+
+        if normalized_source != "installed" and len(results) < capped_limit:
+            hub_source = "all" if normalized_source in {"all", "installed"} else normalized_source
+            if hub_source == "skills.sh":
+                hub_source = "skills-sh"
+            remote_limit = capped_limit - len(results)
+            remote_results = unified_search(
+                normalized_query,
+                create_source_router(),
+                source_filter=hub_source,
+                limit=remote_limit,
+            )
+            for meta in remote_results:
+                compact = _compact_remote_skill_result(meta)
+                identifier = str(compact.get("identifier") or compact.get("name") or "")
+                if not identifier or identifier in seen:
+                    continue
+                seen.add(identifier)
+                results.append(compact)
+                if len(results) >= capped_limit:
+                    break
+
+        return json.dumps(
+            {
+                "success": True,
+                "query": normalized_query,
+                "source": normalized_source,
+                "include_installed": include_installed,
+                "limit": capped_limit,
+                "results": results,
+                "count": len(results),
+                "hint": "Use skill_view(name=<identifier>) for installed results; use hermes skills install <identifier> for external hub results.",
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        return tool_error(str(e), success=False)
+
+
+def _load_category_description(category_dir: Path) -> Optional[str]:
+    """
+    Load category description from DESCRIPTION.md if it exists.
+
+    Args:
+        category_dir: Path to the category directory
+
+    Returns:
+        Description string or None if not found
+    """
+    desc_file = category_dir / "DESCRIPTION.md"
+    if not desc_file.exists():
+        return None
+
+    try:
+        content = desc_file.read_text(encoding="utf-8")
+        # Parse frontmatter if present
+        frontmatter, body = _parse_frontmatter(content)
+
+        # Prefer frontmatter description, fall back to first non-header line
+        description = frontmatter.get("description", "")
+        if not description:
+            for line in body.strip().split("\n"):
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    description = line
+                    break
+
+        # Truncate to reasonable length
+        if len(description) > MAX_DESCRIPTION_LENGTH:
+            description = description[: MAX_DESCRIPTION_LENGTH - 3] + "..."
+
+        return description if description else None
+    except (UnicodeDecodeError, PermissionError) as e:
+        logger.debug("Failed to read category description %s: %s", desc_file, e)
+        return None
+    except Exception as e:
+        logger.warning(
+            "Error parsing category description %s: %s", desc_file, e, exc_info=True
+        )
+        return None
+
 
 
 def skills_list(category: str = None, task_id: str = None) -> str:
@@ -1180,7 +1395,7 @@ def skill_view(
                     _record(None, found_md)
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+            paths = [smd.as_posix() for _, smd in candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1683,7 +1898,7 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": "List available skills (name + description). Use skill_search(query) to find matching skills or skill_view(name) to load full content.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1693,6 +1908,46 @@ SKILLS_LIST_SCHEMA = {
             }
         },
         "required": [],
+    },
+}
+
+SKILL_SEARCH_SCHEMA = {
+    "name": "skill_search",
+    "description": "Search installed skills and the Hermes Skills Hub by query without loading full SKILL.md bodies. Returns compact identifiers/descriptions only; use skill_view for installed matches or hermes skills install for external matches.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query, e.g. 'flutter qa', 'github review', or 'kubernetes'.",
+            },
+            "source": {
+                "type": "string",
+                "enum": [
+                    "all",
+                    "installed",
+                    "official",
+                    "hermes-index",
+                    "skills-sh",
+                    "well-known",
+                    "github",
+                    "clawhub",
+                    "claude-marketplace",
+                    "lobehub",
+                    "browse-sh",
+                ],
+                "description": "Optional source filter. Default 'all'. Use 'installed' to avoid remote hub search.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results to return; capped at 50.",
+            },
+            "include_installed": {
+                "type": "boolean",
+                "description": "When true, include installed local/profile skills before hub results. Default true.",
+            },
+        },
+        "required": ["query"],
     },
 }
 
@@ -1725,6 +1980,22 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
+
+registry.register(
+    name="skill_search",
+    toolset="skills",
+    schema=SKILL_SEARCH_SCHEMA,
+    handler=lambda args, **kw: skill_search(
+        query=args.get("query", ""),
+        source=args.get("source", "all"),
+        limit=args.get("limit", 10),
+        include_installed=args.get("include_installed", True),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_skills_requirements,
+    emoji="🔎",
+)
+
 def _skill_view_with_bump(args, **kw):
     """Invoke skill_view, then bump view_count on success. Best-effort: a
     telemetry failure never breaks the tool call."""

--- a/toolsets.py
+++ b/toolsets.py
@@ -42,7 +42,7 @@ _HERMES_CORE_TOOLS = [
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills
-    "skills_list", "skill_view", "skill_manage",
+    "skills_list", "skill_search", "skill_view", "skill_manage",
     # Browser automation
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
@@ -165,7 +165,7 @@ TOOLSETS = {
     
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
-        "tools": ["skills_list", "skill_view", "skill_manage"],
+        "tools": ["skills_list", "skill_search", "skill_view", "skill_manage"],
         "includes": []
     },
     
@@ -350,7 +350,7 @@ TOOLSETS = {
             "terminal", "process", "read_terminal", "close_terminal",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list", "skill_search", "skill_view", "skill_manage",
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
@@ -382,7 +382,7 @@ TOOLSETS = {
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list", "skill_search", "skill_view", "skill_manage",
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
@@ -406,7 +406,7 @@ TOOLSETS = {
             # Vision + image generation
             "vision_analyze", "image_generate",
             # Skills
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list", "skill_search", "skill_view", "skill_manage",
             # Browser automation
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",


### PR DESCRIPTION
## Summary
- expose native Hermes Skills Hub search as a model-facing `skill_search` tool in the `skills` toolset
- include installed/profile skills first, then existing hub search results, without loading full `SKILL.md` bodies
- add regression coverage for compact output, nested installed identifiers, limit validation, and registration

## Test Plan
- `./venv/Scripts/python.exe -m pytest tests/tools/test_skills_tool.py -q --timeout-method=thread`
- `git diff --check upstream/main..HEAD`
- focused added-line privacy scan against `upstream/main..HEAD`
