### PR TITLE
fix: guard os.getcwd() against deleted CWD (FileNotFoundError)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1042,7 +1042,12 @@ def _get_env_config() -> Dict[str, Any]:
     # remote home, and everything else starts in the backend's default
     # root-like cwd.
     if env_type == "local":
-        default_cwd = os.getcwd()
+        try:
+            default_cwd = os.getcwd()
+        except FileNotFoundError:
+            # CWD was deleted (scratch workspace cleanup). Fall back to
+            # TERMINAL_CWD, home, or the workspace root.
+            default_cwd = os.getenv("TERMINAL_CWD", os.path.expanduser("~"))
     elif env_type == "ssh":
         default_cwd = "~"
     else:


### PR DESCRIPTION
When a scratch workspace is cleaned up while a terminal session is active, `os.getcwd()` raises `FileNotFoundError` and the tool crashes. Wrap it in try/except and fall back to `TERMINAL_CWD` env var or the user's home directory.

This is a common edge case in CI, ephemeral containers, and workspace-tooling environments where directories may be deleted out from under a running process.