### PR TITLE
fix: recreate SessionDB after persistent VACUUM-stale connection failures

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -473,7 +473,7 @@ class AIAgent:
             return None
 
     def _ensure_db_session(self) -> None:
-        """Create session DB row on first use. Disables _session_db on failure."""
+        """Create session DB row on first use. Recreates SessionDB on persistent failure."""
         if self._session_db_created or not self._session_db:
             return
         try:
@@ -487,12 +487,34 @@ class AIAgent:
                 parent_session_id=self._parent_session_id,
             )
             self._session_db_created = True
+            self._session_db_create_failures = 0
         except Exception as e:
-            # Transient failure (e.g. SQLite lock). Keep _session_db alive —
-            # _session_db_created stays False so next run_conversation() retries.
-            logger.warning(
-                "Session DB creation failed (will retry next turn): %s", e
-            )
+            self._session_db_create_failures = getattr(self, '_session_db_create_failures', 0) + 1
+            # After 3 consecutive failures, the connection may be stale
+            # (e.g. VACUUM replaced the database file on disk).  Tear it
+            # down and create a fresh SessionDB for the next attempt.
+            if self._session_db_create_failures >= 3:
+                logger.warning(
+                    "Session DB creation failed %d times — recreating connection. "
+                    "Last error: %s",
+                    self._session_db_create_failures, e,
+                )
+                try:
+                    self._session_db.close()
+                except Exception:
+                    pass
+                try:
+                    from hermes_state import SessionDB
+                    self._session_db = SessionDB()
+                    self._session_db_create_failures = 0
+                except Exception as recreate_err:
+                    logger.warning(
+                        "Session DB recreation also failed: %s", recreate_err
+                    )
+            else:
+                logger.warning(
+                    "Session DB creation failed (will retry next turn): %s", e
+                )
 
     def _transition_context_engine_session(
         self,


### PR DESCRIPTION
When the SQLite database file is replaced by VACUUM, stale SessionDB connections persist as dead references. The existing retry logic loops indefinitely on 'file is not a database' errors without ever recovering, because the connection itself is broken.

After 3 consecutive session-creation failures, tear down the old SessionDB and create a fresh one. If the fresh connection also fails, log it and continue — the next run_conversation() will retry from scratch.