### PR TITLE
feat(memory): per-project Hindsight bank (.hindsight/config.toml walk-up + --hindsight-bank)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -139,6 +139,17 @@ def build_top_level_parser():
         default=None,
         help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
     )
+    _inherited_flag(
+        parser,
+        "--hindsight-bank",
+        default=None,
+        metavar="BANK",
+        help=(
+            "Force the Hindsight long-term-memory bank id for this invocation. "
+            "Overrides any .hindsight/config.toml and the static config.json "
+            "bank id/template. Also settable via HERMES_HINDSIGHT_BANK_OVERRIDE."
+        ),
+    )
     parser.add_argument(
         "--resume",
         "-r",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1862,6 +1862,13 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # --hindsight-bank: force the Hindsight memory bank id for this session.
+    # Exported as an env var so it is read at top precedence by the Hindsight
+    # provider (before any .hindsight/config.toml walk-up or config.json bank
+    # id/template resolution) and survives the TUI relaunch.
+    if getattr(args, "hindsight_bank", None):
+        os.environ["HERMES_HINDSIGHT_BANK_OVERRIDE"] = str(args.hindsight_bank).strip()
+
     _pin_kanban_board_env()
 
     if use_tui:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -511,6 +511,47 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
     return rendered or fallback
 
 
+def _discover_cwd_bank_id(start_dir: str | None = None) -> str | None:
+    """Walk up from *start_dir* (default: cwd) looking for ``.hindsight/config.toml``.
+
+    Mirrors pi's per-project memory behaviour: the closest
+    ``.hindsight/config.toml`` walking up the directory tree wins. Only the
+    ``bank_id`` key is read; any other keys pi writes are ignored. Returns the
+    bank id string, or ``None`` if no readable config with a non-empty
+    ``bank_id`` is found. Never raises — a malformed/unreadable TOML logs a
+    warning and the walk continues (so a broken file does not mask a valid
+    one higher up).
+    """
+    try:
+        import tomllib  # Python 3.11+
+    except Exception:  # pragma: no cover - tomllib always present on 3.11+
+        return None
+
+    from pathlib import Path
+
+    try:
+        current = Path(start_dir).resolve() if start_dir else Path.cwd()
+    except Exception:
+        return None
+
+    for directory in (current, *current.parents):
+        toml_path = directory / ".hindsight" / "config.toml"
+        if not toml_path.is_file():
+            continue
+        try:
+            with toml_path.open("rb") as fh:
+                data = tomllib.load(fh)
+        except Exception as exc:
+            logger.warning(
+                "Ignoring malformed Hindsight config %s: %s", toml_path, exc
+            )
+            continue
+        bank_id = data.get("bank_id")
+        if isinstance(bank_id, str) and bank_id.strip():
+            return bank_id.strip()
+    return None
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
@@ -1149,7 +1190,7 @@ class HindsightMemoryProvider(MemoryProvider):
         banks = cfg_get(self._config, "banks", "hermes", default={})
         static_bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
         self._bank_id_template = self._config.get("bank_id_template", "") or ""
-        self._bank_id = _resolve_bank_id_template(
+        template_bank_id = _resolve_bank_id_template(
             self._bank_id_template,
             fallback=static_bank_id,
             profile=self._agent_identity,
@@ -1158,6 +1199,18 @@ class HindsightMemoryProvider(MemoryProvider):
             user=self._user_id,
             session=self._session_id,
         )
+        # Bank id precedence (highest first), pi-compatible:
+        #   1. --hindsight-bank CLI flag (HERMES_HINDSIGHT_BANK_OVERRIDE env var)
+        #   2. closest .hindsight/config.toml `bank_id` walking up from cwd
+        #   3. config.json bank_id_template -> bank_id -> banks.bankId -> "hermes"
+        cli_bank_override = os.environ.get("HERMES_HINDSIGHT_BANK_OVERRIDE", "").strip()
+        cwd_bank_id = _discover_cwd_bank_id()
+        if cli_bank_override:
+            self._bank_id = cli_bank_override
+        elif cwd_bank_id:
+            self._bank_id = cwd_bank_id
+        else:
+            self._bank_id = template_bank_id
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -510,6 +510,7 @@ AUTHOR_MAP = {
     "101283333+batuhankocyigit@users.noreply.github.com": "batuhankocyigit",
     "255305877+ismell0992-afk@users.noreply.github.com": "ismell0992-afk",
     "cyprian@ironin.pl": "iRonin",
+    "cyprian@ironin.it": "iRonin",
     "valdi.jorge@gmail.com": "jvcl",
     "q19dcp@gmail.com": "aj-nt",
     "ebukau84@gmail.com": "UgwujaGeorge",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -25,6 +25,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _discover_cwd_bank_id,
 )
 
 
@@ -34,7 +35,7 @@ from plugins.memory.hindsight import (
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
+def _clean_env(monkeypatch, tmp_path):
     """Ensure no stale env vars leak between tests."""
     for key in (
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
@@ -42,8 +43,13 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HERMES_HINDSIGHT_BANK_OVERRIDE",
     ):
         monkeypatch.delenv(key, raising=False)
+    # Run from an isolated, empty cwd so per-project .hindsight/config.toml
+    # walk-up discovery (added for pi-style per-project banks) cannot pick up
+    # an ambient config from the developer's checkout and perturb assertions.
+    monkeypatch.chdir(tmp_path)
 
 
 def _make_mock_client():
@@ -1582,3 +1588,133 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# Per-project bank discovery (pi-style .hindsight/config.toml walk-up)
+# ---------------------------------------------------------------------------
+
+
+def _write_toml(path, body):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+class TestDiscoverCwdBankId:
+    """Unit tests for the closest-.hindsight/config.toml walk-up helper."""
+
+    def test_finds_bank_id_in_parent_dir(self, tmp_path, monkeypatch):
+        _write_toml(tmp_path / ".hindsight" / "config.toml", 'bank_id = "project-foo"\n')
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True, exist_ok=True)
+        monkeypatch.chdir(nested)
+        assert _discover_cwd_bank_id() == "project-foo"
+
+    def test_closest_config_wins(self, tmp_path, monkeypatch):
+        _write_toml(tmp_path / ".hindsight" / "config.toml", 'bank_id = "outer"\n')
+        inner = tmp_path / "sub"
+        _write_toml(inner / ".hindsight" / "config.toml", 'bank_id = "inner"\n')
+        monkeypatch.chdir(inner)
+        assert _discover_cwd_bank_id() == "inner"
+
+    def test_ignores_other_keys(self, tmp_path, monkeypatch):
+        _write_toml(
+            tmp_path / ".hindsight" / "config.toml",
+            'bank_id = "project-bar"\nbudget = "high"\n[server]\nurl = "http://x"\n',
+        )
+        monkeypatch.chdir(tmp_path)
+        assert _discover_cwd_bank_id() == "project-bar"
+
+    def test_absent_toml_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert _discover_cwd_bank_id() is None
+
+    def test_malformed_toml_returns_none(self, tmp_path, monkeypatch):
+        _write_toml(tmp_path / ".hindsight" / "config.toml", 'bank_id = "unterminated\n')
+        monkeypatch.chdir(tmp_path)
+        assert _discover_cwd_bank_id() is None
+
+    def test_empty_bank_id_returns_none(self, tmp_path, monkeypatch):
+        _write_toml(tmp_path / ".hindsight" / "config.toml", 'bank_id = ""\n')
+        monkeypatch.chdir(tmp_path)
+        assert _discover_cwd_bank_id() is None
+
+    def test_missing_bank_id_key_returns_none(self, tmp_path, monkeypatch):
+        _write_toml(tmp_path / ".hindsight" / "config.toml", 'budget = "mid"\n')
+        monkeypatch.chdir(tmp_path)
+        assert _discover_cwd_bank_id() is None
+
+    def test_explicit_start_dir(self, tmp_path):
+        _write_toml(tmp_path / ".hindsight" / "config.toml", 'bank_id = "explicit"\n')
+        nested = tmp_path / "x" / "y"
+        nested.mkdir(parents=True, exist_ok=True)
+        assert _discover_cwd_bank_id(str(nested)) == "explicit"
+
+
+class TestBankIdPrecedence:
+    """End-to-end bank id resolution precedence through provider.initialize()."""
+
+    def _init(self, tmp_path, monkeypatch, config):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="s1", hermes_home=str(tmp_path), platform="cli")
+        return p
+
+    def test_toml_beats_static_config_bank_id(self, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        _write_toml(project / ".hindsight" / "config.toml", 'bank_id = "project-toml"\n')
+        monkeypatch.chdir(project)
+        p = self._init(tmp_path, monkeypatch, {
+            "mode": "cloud", "apiKey": "k", "api_url": "http://x",
+            "bank_id": "static-json",
+        })
+        assert p._bank_id == "project-toml"
+
+    def test_toml_beats_template(self, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        _write_toml(project / ".hindsight" / "config.toml", 'bank_id = "project-toml"\n')
+        monkeypatch.chdir(project)
+        p = self._init(tmp_path, monkeypatch, {
+            "mode": "cloud", "apiKey": "k", "api_url": "http://x",
+            "bank_id": "fallback", "bank_id_template": "hermes-{platform}",
+        })
+        assert p._bank_id == "project-toml"
+
+    def test_cli_override_beats_toml(self, tmp_path, monkeypatch):
+        project = tmp_path / "proj"
+        _write_toml(project / ".hindsight" / "config.toml", 'bank_id = "project-toml"\n')
+        monkeypatch.chdir(project)
+        monkeypatch.setenv("HERMES_HINDSIGHT_BANK_OVERRIDE", "cli-bank")
+        p = self._init(tmp_path, monkeypatch, {
+            "mode": "cloud", "apiKey": "k", "api_url": "http://x",
+            "bank_id": "static-json",
+        })
+        assert p._bank_id == "cli-bank"
+
+    def test_cli_override_beats_template_without_toml(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HERMES_HINDSIGHT_BANK_OVERRIDE", "cli-bank")
+        p = self._init(tmp_path, monkeypatch, {
+            "mode": "cloud", "apiKey": "k", "api_url": "http://x",
+            "bank_id": "fallback", "bank_id_template": "hermes-{platform}",
+        })
+        assert p._bank_id == "cli-bank"
+
+    def test_template_used_when_no_toml_or_flag(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        p = self._init(tmp_path, monkeypatch, {
+            "mode": "cloud", "apiKey": "k", "api_url": "http://x",
+            "bank_id": "fallback", "bank_id_template": "hermes-{platform}",
+        })
+        assert p._bank_id == "hermes-cli"
+
+    def test_static_bank_id_used_when_no_toml_flag_or_template(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        p = self._init(tmp_path, monkeypatch, {
+            "mode": "cloud", "apiKey": "k", "api_url": "http://x",
+            "bank_id": "static-json",
+        })
+        assert p._bank_id == "static-json"


### PR DESCRIPTION
## Motivation

Hindsight long-term memory currently resolves a single bank id from the
static `config.json` (`bank_id` / `banks.bankId` / `bank_id_template`),
with the `{workspace}` placeholder hardcoded to `"hermes"`. There is no
way to give each project (or each legal claim / working directory) its
own memory bank.

This brings **pi-parity per-project memory isolation**: pi reads the
closest `.hindsight/config.toml` walking up from cwd and uses its
`bank_id`. Hermes can now reuse the very same files, so a checkout that
already has a pi-style `.hindsight/config.toml` gets the right bank with
no extra config.

## Mechanisms

1. **`--hindsight-bank <name>`** — new root-level CLI flag (alongside
   `-m/--model`). Exported as `HERMES_HINDSIGHT_BANK_OVERRIDE` before the
   provider initializes (survives the TUI relaunch). Forces the bank id
   for the session; overrides everything.
2. **Closest `.hindsight/config.toml`** — `_discover_cwd_bank_id()` walks
   up from `os.getcwd()` to the filesystem root, stops at the first hit,
   parses it with stdlib `tomllib` (3.11+), and reads only `bank_id`
   (other pi-written keys are ignored). Never raises: a malformed or
   unreadable TOML logs a warning and the walk continues so a broken file
   cannot mask a valid one higher up.

## Precedence (highest first)

1. `--hindsight-bank` flag (`HERMES_HINDSIGHT_BANK_OVERRIDE`)
2. closest `.hindsight/config.toml` `bank_id`
3. existing `config.json`: `bank_id_template` → `bank_id` → `banks.bankId` → `"hermes"`

## Backward compatibility

With no flag and no `.hindsight/config.toml`, the existing
template/static resolution is **unchanged**. All existing provider tests
pass; the autouse test fixture now runs from an isolated cwd so ambient
`.hindsight/config.toml` files in a developer checkout cannot perturb
assertions.

## Tests

`tests/plugins/memory/test_hindsight_provider.py` — 14 new tests covering
walk-up discovery (parent dir, closest-wins, ignores other keys, explicit
start dir), graceful fallback (absent/malformed/empty/missing key), and
full provider precedence (toml > static, toml > template, flag > toml,
flag > template, template/static fallback). 115 passed.