### PR TITLE
fix(update): prefer managed uv over PATH

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7480,7 +7480,7 @@ def _update_via_zip(args):
     print("→ Updating Python dependencies...")
 
     pip_cmd = [sys.executable, "-m", "pip"]
-    uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)
+    uv_bin = _resolve_uv_binary() or _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
         uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
         if _is_termux_env(uv_env):
@@ -7507,6 +7507,7 @@ def _update_via_zip(args):
             )
         _install_python_dependencies_with_optional_fallback(pip_cmd)
 
+    _validate_python_update_environment()
     _update_node_dependencies()
     _build_web_ui(PROJECT_ROOT / "web")
 
@@ -8535,6 +8536,67 @@ def _install_python_dependencies_with_optional_fallback(
         )
 
 
+def _python_update_validation_code() -> str:
+    """Return a target-interpreter validation script for post-update installs."""
+    return r'''
+import pathlib
+import re
+import sys
+import sysconfig
+
+from frozenlist import FrozenList
+from multidict import CIMultiDict, MultiDict
+import aiohttp
+import uvicorn.protocols.websockets.websockets_impl
+
+if FrozenList is None or CIMultiDict is None or MultiDict is None:
+    raise RuntimeError("compiled container symbols did not import")
+if not hasattr(aiohttp, "ClientSession"):
+    raise RuntimeError("aiohttp.ClientSession is missing")
+
+current_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+site_paths = {
+    pathlib.Path(value)
+    for key, value in sysconfig.get_paths().items()
+    if key in {"purelib", "platlib"} and value
+}
+bad = []
+compiled_re = re.compile(r"^Tag:\s+(cp\d+)-cp\d+-", re.MULTILINE)
+for site_path in site_paths:
+    if not site_path.exists():
+        continue
+    for wheel in site_path.glob("*.dist-info/WHEEL"):
+        text = wheel.read_text(encoding="utf-8", errors="replace")
+        compiled_tags = {match.group(1) for match in compiled_re.finditer(text)}
+        if compiled_tags and current_tag not in compiled_tags:
+            bad.append(f"{wheel.parent.name}: {', '.join(sorted(compiled_tags))}")
+
+if bad:
+    raise RuntimeError(
+        "binary wheel tag mismatch for this Python "
+        f"({current_tag} expected): " + "; ".join(bad)
+    )
+'''
+
+
+def _validate_python_update_environment() -> None:
+    """Fail update if dependency metadata, wheel tags, or compiled imports are broken."""
+    print("→ Validating Python dependencies...")
+    checks = (
+        ("dependency metadata", [sys.executable, "-m", "pip", "check"]),
+        (
+            "compiled dependency imports and wheel tags",
+            [sys.executable, "-c", _python_update_validation_code()],
+        ),
+    )
+    for label, cmd in checks:
+        result = subprocess.run(cmd, cwd=PROJECT_ROOT)
+        if result.returncode != 0:
+            print(f"✗ Python {label} validation failed")
+            sys.exit(result.returncode)
+    print("  ✓ Python dependency validation passed")
+
+
 def _is_termux_env(env: dict[str, str] | None = None) -> bool:
     return _is_termux_startup_environment(env)
 
@@ -8579,9 +8641,46 @@ def _install_psutil_android_compat(
         )
 
 
+def _uv_executable_names() -> tuple[str, ...]:
+    if os.name == "nt":
+        return ("uv.exe", "uv")
+    return ("uv",)
+
+
+def _existing_uv_binary(path: Path) -> str | None:
+    if path.is_file() and (os.name == "nt" or os.access(path, os.X_OK)):
+        return str(path)
+    return None
+
+
+def _resolve_uv_binary() -> str | None:
+    """Prefer Hermes-managed uv locations before falling back to PATH."""
+    candidates: list[Path] = []
+    for env_dir in (Path(sys.prefix), PROJECT_ROOT / "venv"):
+        bindir = env_dir / ("Scripts" if os.name == "nt" else "bin")
+        for name in _uv_executable_names():
+            candidates.append(bindir / name)
+
+    home = Path(os.environ.get("USERPROFILE") or str(Path.home()))
+    for name in _uv_executable_names():
+        candidates.append(home / ".local" / "bin" / name)
+        candidates.append(home / ".cargo" / "bin" / name)
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = os.path.normcase(os.path.abspath(candidate))
+        if key in seen:
+            continue
+        seen.add(key)
+        if uv_bin := _existing_uv_binary(candidate):
+            return uv_bin
+
+    return shutil.which("uv")
+
+
 def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
     """Best-effort uv bootstrap on Termux for faster update installs."""
-    uv_bin = shutil.which("uv")
+    uv_bin = _resolve_uv_binary()
     if uv_bin or not _is_termux_env():
         return uv_bin
     try:
@@ -8589,7 +8688,7 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         subprocess.run(pip_cmd + ["install", "uv"], cwd=PROJECT_ROOT, check=False)
     except Exception:
         pass
-    return shutil.which("uv")
+    return _resolve_uv_binary()
 
 
 def _update_node_dependencies() -> None:
@@ -9237,7 +9336,7 @@ def _cmd_update_pip(args):
     print(f"→ Current version: {__version__}")
     print("→ Checking PyPI for updates...")
 
-    uv = shutil.which("uv")
+    uv = _resolve_uv_binary()
     in_venv = sys.prefix != sys.base_prefix
     # pipx-managed installs live under .../pipx/venvs/<name>/...
     pipx_managed = "pipx" in sys.prefix.split(os.sep)
@@ -9649,7 +9748,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # individually so update does not silently strip working capabilities.
         print("→ Updating Python dependencies...")
         pip_cmd = [sys.executable, "-m", "pip"]
-        uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)
+        uv_bin = _resolve_uv_binary() or _ensure_uv_for_termux(pip_cmd)
         install_group = "all"
 
         if uv_bin:
@@ -9692,6 +9791,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _install_psutil_android_compat(pip_cmd)
             _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
+        _validate_python_update_environment()
         _refresh_active_lazy_features()
 
         _update_node_dependencies()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -288,31 +288,36 @@ function Install-AgentBrowser {
 # Dependency checks
 # ============================================================================
 
+function Get-KnownUvPath {
+    foreach ($uvPath in @("$env:USERPROFILE\.local\bin\uv.exe", "$env:USERPROFILE\.cargo\bin\uv.exe")) {
+        if (Test-Path $uvPath) {
+            return $uvPath
+        }
+    }
+    return $null
+}
+
 function Install-Uv {
     Write-Info "Checking for uv package manager..."
-    
-    # Check if uv is already available
+
+    # Prefer the uv location installed by the Astral installer before PATH.
+    # PATH can contain unrelated package-manager shims, such as Anaconda's uv.
+    $knownUvPath = Get-KnownUvPath
+    if ($knownUvPath) {
+        $script:UvCmd = $knownUvPath
+        $version = & $knownUvPath --version
+        Write-Success "uv found at $knownUvPath ($version)"
+        return $true
+    }
+
+    # Fall back to PATH for winget/manual installs.
     if (Get-Command uv -ErrorAction SilentlyContinue) {
         $version = uv --version
         $script:UvCmd = "uv"
         Write-Success "uv found ($version)"
         return $true
     }
-    
-    # Check common install locations
-    $uvPaths = @(
-        "$env:USERPROFILE\.local\bin\uv.exe",
-        "$env:USERPROFILE\.cargo\bin\uv.exe"
-    )
-    foreach ($uvPath in $uvPaths) {
-        if (Test-Path $uvPath) {
-            $script:UvCmd = $uvPath
-            $version = & $uvPath --version
-            Write-Success "uv found at $uvPath ($version)"
-            return $true
-        }
-    }
-    
+
     # Install uv
     Write-Info "Installing uv (fast Python package manager)..."
     # Capture EAP outside the try block so the catch's restore call always
@@ -395,6 +400,13 @@ function Resolve-UvCmd {
     # in the same process and set $script:UvCmd).
     if ($script:UvCmd) {
         if ($script:UvCmd -eq "uv") {
+            # Upgrade a PATH-only uv to the known Astral location when it
+            # exists. PATH can prefer unrelated shims such as Anaconda's uv.
+            $knownUvPath = Get-KnownUvPath
+            if ($knownUvPath) {
+                $script:UvCmd = $knownUvPath
+                return
+            }
             # "uv" on PATH -- verify it's still resolvable (PATH could have
             # changed mid-session; cheap to recheck).
             if (Get-Command uv -ErrorAction SilentlyContinue) { return }
@@ -404,29 +416,27 @@ function Resolve-UvCmd {
         # Stale; fall through to re-discover.
     }
 
-    # Try PATH first (covers `winget install astral.uv`, manual installs,
-    # and the post-Install-Uv state where uv.exe lives in
-    # %USERPROFILE%\.local\bin which the installer added to PATH).
-    if (Get-Command uv -ErrorAction SilentlyContinue) {
-        $script:UvCmd = "uv"
+    # Prefer the well-known install locations the Astral installer drops uv
+    # into before PATH, which may contain unrelated package-manager shims.
+    $knownUvPath = Get-KnownUvPath
+    if ($knownUvPath) {
+        $script:UvCmd = $knownUvPath
         return
     }
 
     # Refresh PATH from registry in case the current process started before
     # Install-Uv updated User PATH.
     $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
-    if (Get-Command uv -ErrorAction SilentlyContinue) {
-        $script:UvCmd = "uv"
+    $knownUvPath = Get-KnownUvPath
+    if ($knownUvPath) {
+        $script:UvCmd = $knownUvPath
         return
     }
 
-    # Check the well-known install locations the astral.sh installer drops
-    # uv into.  Mirrors the probe order Install-Uv uses.
-    foreach ($uvPath in @("$env:USERPROFILE\.local\bin\uv.exe", "$env:USERPROFILE\.cargo\bin\uv.exe")) {
-        if (Test-Path $uvPath) {
-            $script:UvCmd = $uvPath
-            return
-        }
+    # Fall back to PATH for winget/manual installs.
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $script:UvCmd = "uv"
+        return
     }
 
     throw "uv is not installed or not on PATH. Run install.ps1 -Stage uv first."

--- a/tests/hermes_cli/test_update_uv_resolution.py
+++ b/tests/hermes_cli/test_update_uv_resolution.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+    path.chmod(0o755)
+    return path
+
+
+def test_resolve_uv_binary_prefers_venv_uv_over_path(tmp_path, monkeypatch):
+    from hermes_cli import main as main_mod
+
+    project_root = tmp_path / "repo"
+    venv_uv = _touch(project_root / "venv" / "bin" / "uv")
+    path_uv = _touch(tmp_path / "anaconda3" / "bin" / "uv")
+
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(main_mod.sys, "prefix", str(tmp_path / "python"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: str(path_uv))
+
+    assert main_mod._resolve_uv_binary() == str(venv_uv)
+
+
+def test_resolve_uv_binary_prefers_astral_user_uv_over_path(tmp_path, monkeypatch):
+    from hermes_cli import main as main_mod
+
+    project_root = tmp_path / "repo"
+    managed_uv = _touch(tmp_path / "home" / ".local" / "bin" / "uv")
+    path_uv = _touch(tmp_path / "anaconda3" / "bin" / "uv")
+
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(main_mod.sys, "prefix", str(tmp_path / "python"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: str(path_uv))
+
+    assert main_mod._resolve_uv_binary() == str(managed_uv)
+
+
+def test_python_update_validation_checks_known_compiled_imports_and_wheel_tags():
+    from hermes_cli import main as main_mod
+
+    code = main_mod._python_update_validation_code()
+
+    assert "from frozenlist import FrozenList" in code
+    assert "from multidict import CIMultiDict, MultiDict" in code
+    assert 'hasattr(aiohttp, "ClientSession")' in code
+    assert "uvicorn.protocols.websockets.websockets_impl" in code
+    assert "*.dist-info/WHEEL" in code
+    assert "binary wheel tag mismatch" in code


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows update/install path where Hermes can pick an unrelated `uv.exe` from PATH before the uv installed for the current user or venv. In the reproduced failure, PATH resolved to Anaconda's `uv.exe`, which then mutated the Hermes Python 3.11 environment with incompatible compiled wheels and left the desktop gateway unable to import packages such as `frozenlist`, `aiohttp`, and `uvicorn` websocket support.

This keeps the existing PATH fallback for manual/winget installs, but prefers Hermes-managed and Astral-managed uv locations first. It also validates the Python environment after update dependency installation so a broken dependency state fails the update instead of being reported as successful.

## Related Issue

Fixes #

No issue number yet; this came from a Windows desktop install/update support repro.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — adds `_resolve_uv_binary()` and routes update dependency installs through it so the updater prefers the current venv uv, repo venv uv, `%USERPROFILE%/.local/bin/uv`, and `%USERPROFILE%/.cargo/bin/uv` before PATH.
- `hermes_cli/main.py` — adds post-update Python validation with `pip check`, compiled dependency import probes, and a `*.dist-info/WHEEL` tag scan to catch wrong-ABI wheels such as cp310 wheels in a cp311 venv.
- `scripts/install.ps1` — updates Windows installer uv discovery so the known Astral uv locations win over PATH, while preserving PATH fallback for winget/manual installs.
- `tests/hermes_cli/test_update_uv_resolution.py` — adds focused coverage for resolver precedence and the validation script's import/wheel-tag probes.

## How to Test

1. Put an unrelated `uv` earlier on PATH than the user-managed Astral uv location, then run the Windows installer/update path. Hermes should use the known user uv path instead of the PATH shim.
2. Break the target venv with wrong-ABI compiled wheels. The update should fail during Python dependency validation rather than reporting success.
3. Focused local checks run for this PR:
   - `/home/gille/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_uv_resolution.py`
   - `git diff --check origin/main...HEAD`
   - direct resolver smoke test proving `%USERPROFILE%/.local/bin/uv` beats a fake Anaconda PATH uv.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2/Linux with Windows-path failure mode modeled in focused resolver smoke; Windows desktop repro described above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing command/config change.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — resolver keeps PATH fallback and only prefers existing managed uv locations first.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## For New Skills

N/A.

## Screenshots / Logs

Observed Windows failure mode before this fix:

- Update selected `C:\Users\btgil\anaconda3\Scripts\uv.exe` before `C:\Users\btgil\.local\bin\uv.exe`.
- Hermes Python 3.11 venv then contained incompatible compiled wheel metadata such as `Tag: cp310-cp310-win_amd64`.
- Gateway imports failed after update with errors around `FrozenList`, `aiohttp.ClientSession`, and `uvicorn.protocols.websockets.websockets_impl`.

Local validation run:

- `/home/gille/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_uv_resolution.py` passed.
- `git diff --check origin/main...HEAD` passed.
- Direct resolver smoke passed: managed user uv resolved before fake Anaconda PATH uv.

Full local pytest was not run on this workstation; GitHub CI should own full-suite coverage for this branch.
