### PR TITLE
feat(cli): add 'hermes prompt-dump' to print the full assembled system prompt

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11427,6 +11427,13 @@ def cmd_prompt_size(args):
     _impl(args)
 
 
+def cmd_prompt_dump(args):
+    """Print the full assembled system prompt (pi --dump-prompt parity)."""
+    from hermes_cli.prompt_size import cmd_prompt_dump as _impl
+
+    _impl(args)
+
+
 def cmd_logs(args):
     """View and filter Hermes log files."""
     from hermes_cli.logs import tail_log, list_logs
@@ -14855,6 +14862,31 @@ Examples:
         help="Emit the breakdown as JSON",
     )
     prompt_size_parser.set_defaults(func=cmd_prompt_size)
+
+    # =========================================================================
+    # prompt-dump command
+    # =========================================================================
+    prompt_dump_parser = subparsers.add_parser(
+        "prompt-dump",
+        help="Print the full assembled system prompt text (offline)",
+        description=(
+            "Dump the full assembled system prompt for a fresh session to "
+            "stdout \u2014 identity, guidance, skills index, memory, profile, and "
+            "context tiers, joined as sent to the model. Runs offline (no API "
+            "call). pi --dump-prompt parity."
+        ),
+    )
+    prompt_dump_parser.add_argument(
+        "--platform",
+        default="cli",
+        help="Platform to simulate (cli, telegram, discord, ...). Default: cli",
+    )
+    prompt_dump_parser.add_argument(
+        "--json",
+        action="store_true",
+        help='Emit as JSON: {"prompt": "..."}',
+    )
+    prompt_dump_parser.set_defaults(func=cmd_prompt_dump)
 
     # =========================================================================
     # Parse and execute

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -109,6 +109,41 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     }
 
 
+def build_full_prompt_text(platform: str = "cli") -> str:
+    """Return the full assembled system prompt string for a fresh session.
+
+    Builds the exact same prompt the size report measures (same platform /
+    model / HERMES_HOME basis, joined tiers) but returns the text instead of
+    a byte breakdown. Used by ``hermes prompt-dump`` (pi ``--dump-prompt``
+    parity). Runs offline — no network call.
+    """
+    from agent.system_prompt import build_system_prompt
+
+    agent = _build_inspection_agent(platform)
+    return build_system_prompt(agent)
+
+
+def cmd_prompt_dump(args: Any) -> None:
+    """Entry point for ``hermes prompt-dump``.
+
+    Dumps the full assembled system prompt to stdout (pi ``--dump-prompt``
+    parity). With ``--json`` emits ``{"prompt": "..."}`` so the output stays
+    machine-readable; otherwise prints the raw prompt (no banner/table) so it
+    can be piped or redirected. Runs offline — no network call.
+    """
+    platform = getattr(args, "platform", "cli") or "cli"
+    as_json = getattr(args, "json", False)
+    try:
+        prompt = build_full_prompt_text(platform)
+    except Exception as e:
+        print(f"Could not build system prompt: {e}")
+        return
+    if as_json:
+        print(json.dumps({"prompt": prompt}, ensure_ascii=False, indent=2))
+    else:
+        print(prompt)
+
+
 def _fmt_kb(n: int) -> str:
     return f"{n / 1024:.1f} KB"
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -510,6 +510,7 @@ AUTHOR_MAP = {
     "101283333+batuhankocyigit@users.noreply.github.com": "batuhankocyigit",
     "255305877+ismell0992-afk@users.noreply.github.com": "ismell0992-afk",
     "cyprian@ironin.pl": "iRonin",
+    "cyprian@ironin.it": "iRonin",
     "valdi.jorge@gmail.com": "jvcl",
     "q19dcp@gmail.com": "aj-nt",
     "ebukau84@gmail.com": "UgwujaGeorge",

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -6,9 +6,28 @@ import pytest
 
 from hermes_cli.prompt_size import (
     _SKILLS_BLOCK_RE,
+    build_full_prompt_text,
+    cmd_prompt_dump,
+    cmd_prompt_size,
     compute_prompt_breakdown,
     render_breakdown,
 )
+
+
+class _Args:
+    """Minimal argparse-like namespace for driving cmd_prompt_size."""
+
+    def __init__(self, platform="cli", json=False):
+        self.platform = platform
+        self.json = json
+
+
+class _DumpArgs:
+    """Minimal argparse-like namespace for driving cmd_prompt_dump."""
+
+    def __init__(self, platform="cli", json=False):
+        self.platform = platform
+        self.json = json
 
 
 def _seed_memory(hermes_home, memory_text="", user_text=""):
@@ -116,3 +135,38 @@ def test_json_serializable(isolated_home):
     data = compute_prompt_breakdown("cli")
     # Round-trips cleanly for ``--json`` output.
     assert json.loads(json.dumps(data)) == json.loads(json.dumps(data))
+
+
+def test_build_full_prompt_text_non_empty_with_marker(isolated_home):
+    """prompt-dump builds the full assembled prompt with a stable-tier marker."""
+    prompt = build_full_prompt_text("cli")
+    assert prompt.strip()
+    # Stable identity tier always opens with the Hermes Agent identity line.
+    assert "You are Hermes Agent" in prompt
+
+
+def test_cmd_dump_prints_full_prompt(isolated_home, capsys):
+    """`prompt-dump` prints the raw prompt (no size table/banner)."""
+    cmd_prompt_dump(_DumpArgs())
+    out = capsys.readouterr().out
+    assert "You are Hermes Agent" in out
+    # Size-report labels must NOT appear in dump mode.
+    assert "System prompt total" not in out
+    assert "Tool schemas" not in out
+
+
+def test_cmd_dump_json_emits_prompt_key(isolated_home, capsys):
+    """`prompt-dump --json` wraps the prompt in a {"prompt": ...} object."""
+    cmd_prompt_dump(_DumpArgs(json=True))
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert "prompt" in payload
+    assert "You are Hermes Agent" in payload["prompt"]
+
+
+def test_cmd_prompt_size_unchanged_prints_size_report(isolated_home, capsys):
+    """prompt-size still prints the size breakdown, never the raw prompt."""
+    cmd_prompt_size(_Args())
+    out = capsys.readouterr().out
+    assert "System prompt total" in out
+    assert "You are Hermes Agent" not in out


### PR DESCRIPTION
Adds a dedicated offline `hermes prompt-dump` command (pi `--dump-prompt` parity) that prints the full assembled system prompt to stdout.

- `hermes prompt-dump` — full prompt text (identity, guidance, skills index, memory, profile, context tiers, joined as sent to the model)
- `hermes prompt-dump --json` — emits `{"prompt": "..."}`
- `--platform` — simulate cli/telegram/discord/...
- Runs offline (no API call). `prompt-size` is unchanged (size breakdown only).

Replaces the earlier `prompt-size --text` approach with a standalone command for clearer semantics.