### PR TITLE
fix(gateway): avoid message shadowing in run_sync

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17359,14 +17359,6 @@ class GatewayRunner:
                 _fut.add_done_callback(_track_status_id)
 
         def run_sync():
-            # The conditional re-assignment of `message` further below
-            # (prepending model-switch notes) makes Python treat it as a
-            # local variable in the entire function.  `nonlocal` lets us
-            # read *and* reassign the outer `_run_agent` parameter without
-            # triggering an UnboundLocalError on the earlier read at
-            # `_resolve_turn_agent_config(message, …)`.
-            nonlocal message
-
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
@@ -17863,10 +17855,11 @@ class GatewayRunner:
                     logger.error("Failed to send approval request: %s", _e)
 
             # Prepend pending model switch note so the model knows about the switch
+            run_message_text = message
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                run_message_text = _msn + "\n\n" + run_message_text
 
             # Auto-continue: if the loaded history ends with a tool result,
             # the previous agent turn was interrupted mid-work (gateway
@@ -17922,22 +17915,22 @@ class GatewayRunner:
                     if _reason == "shutdown_timeout"
                     else "a gateway interruption"
                 )
-                message = (
+                run_message_text = (
                     f"[System note: Your previous turn in this session was interrupted "
                     f"by {_reason_phrase}. The conversation history below is intact. "
                     f"If it contains unfinished tool result(s), process them first and "
                     f"summarize what was accomplished, then address the user's new "
                     f"message below.]\n\n"
-                    + message
+                    + run_message_text
                 )
             elif _has_fresh_tool_tail:
-                message = (
+                run_message_text = (
                     "[System note: Your previous turn was interrupted before you could "
                     "process the last tool result(s). The conversation history contains "
                     "tool outputs you haven't responded to yet. Please finish processing "
                     "those results and summarize what was accomplished, then address the "
                     "user's new message below.]\n\n"
-                    + message
+                    + run_message_text
                 )
 
             # Consume one-shot /reload-skills note (if the user ran
@@ -17949,7 +17942,7 @@ class GatewayRunner:
             if _pending_notes and session_key and session_key in _pending_notes:
                 _srn = _pending_notes.pop(session_key, None)
                 if _srn:
-                    message = _srn + "\n\n" + message
+                    run_message_text = _srn + "\n\n" + run_message_text
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
@@ -17964,7 +17957,7 @@ class GatewayRunner:
                     try:
                         from agent.image_routing import build_native_content_parts
                         _parts, _skipped = build_native_content_parts(
-                            message,
+                            run_message_text,
                             _native_imgs,
                         )
                         if _skipped:
@@ -17976,15 +17969,15 @@ class GatewayRunner:
                             _run_message: Any = _parts
                         else:
                             # All images failed to read — fall back to plain text.
-                            _run_message = message
+                            _run_message = run_message_text
                     except Exception as _img_exc:
                         logger.warning(
                             "Native image attachment failed, falling back to text: %s",
                             _img_exc,
                         )
-                        _run_message = message
+                        _run_message = run_message_text
                 else:
-                    _run_message = message
+                    _run_message = run_message_text
 
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,
@@ -17995,7 +17988,7 @@ class GatewayRunner:
                     "task_id": session_id,
                 }
                 if observed_group_context:
-                    _conversation_kwargs["persist_user_message"] = message
+                    _conversation_kwargs["persist_user_message"] = run_message_text
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -185,3 +185,54 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+    assert _CapturingAgent.last_run["user_message"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_prepends_pending_model_note_without_shadowing_message(
+    monkeypatch, tmp_path
+):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openai",
+            "api_mode": "chat_completions",
+            "base_url": "",
+            "api_key": "***",
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-4o"
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(
+        tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"}
+    )
+
+    session_key = "agent:main:telegram:dm:12345"
+    runner._pending_model_notes[session_key] = "[Note: switched to gpt-4o.]"
+
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "ok"
+    assert (
+        _CapturingAgent.last_run["user_message"] == "[Note: switched to gpt-4o.]\n\nhi"
+    )
+    assert session_key not in runner._pending_model_notes


### PR DESCRIPTION
## What does this PR do?

Avoids mutating the outer `_run_agent(message=...)` parameter inside the gateway `run_sync()` closure. The per-turn message now uses a local `run_message_text` while preserving pending model-switch notes, restart/tool-tail notes, reload-skill notes, native image wrapping, and observed-context persistence.

## Related Issue

Fixes #5387

## Addressing maintainer feedback

- #5390: closed, unmerged PR that proposed the same root-cause fix.
- #5290: open issue reporting the same gateway `UnboundLocalError` root cause.
- #5326: open issue reporting the same gateway `UnboundLocalError` root cause.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: replaces `nonlocal message` and in-place message rewrites with a local `run_message_text` used for all user-turn note prepending and final agent input construction.
- `tests/gateway/test_fast_command.py`: asserts the normal gateway `_run_agent()` path keeps the original user message and adds regression coverage for pending model-note prepending.

## How to Test

1. `$VIRTUAL_ENV/bin/python -m pytest tests/gateway/test_fast_command.py -q` → `5 passed`.
2. `$VIRTUAL_ENV/bin/python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_fast_command.py` → no footguns found.
3. `git diff --check` → passed.
4. `$VIRTUAL_ENV/bin/python -m ruff check gateway/run.py tests/gateway/test_fast_command.py` → passed.
5. `$VIRTUAL_ENV/bin/python -m pytest tests/ -q -x --timeout=60` was run twice and stopped before gateway tests in unrelated `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`. That ACP test passes in isolation in both this working tree and a clean `HEAD` export (`1 passed` each), so the broad-suite failure appears order-dependent and outside this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 arm64 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Relevant command results are listed in `How to Test`.

<!-- autocontrib:worker-id=issue-new-2e1e73d7 kind=pr-open -->