### PR TITLE
fix(auth): set active_provider after hermes auth add google-gemini-cli

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2100,6 +2100,25 @@ def get_qwen_auth_status() -> Dict[str, Any]:
 # Actual HTTP traffic goes to https://cloudcode-pa.googleapis.com/v1internal:*.
 # =============================================================================
 
+def _save_google_gemini_cli_tokens(creds: Dict[str, Any]) -> None:
+    """Persist Google Gemini CLI OAuth state to auth.json and set active_provider.
+
+    The actual tokens live in the Google OAuth credential file managed by
+    agent.google_oauth; this call only records the provider-state singleton and
+    sets active_provider so get_active_provider() and _model_section_has_credentials()
+    detect the provider (setup wizard, status checks).
+    """
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, "google-gemini-cli") or {}
+        state["access_token"] = creds.get("access_token", "")
+        state["refresh_token"] = creds.get("refresh_token") or ""
+        if creds.get("email"):
+            state["email"] = creds["email"]
+        _save_provider_state(auth_store, "google-gemini-cli", state)
+        _save_auth_store(auth_store)
+
+
 def resolve_gemini_oauth_runtime_credentials(
     *,
     force_refresh: bool = False,

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -353,6 +353,7 @@ def auth_add_command(args) -> None:
         from agent.google_oauth import run_gemini_oauth_login_pure
 
         creds = run_gemini_oauth_login_pure()
+        auth_mod._save_google_gemini_cli_tokens(creds)
         label = (getattr(args, "label", None) or "").strip() or (
             creds.get("email") or _oauth_default_label(provider, len(pool.entries()) + 1)
         )

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -97,6 +97,42 @@ def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["expires_at_ms"] == 1711234567000
 
 
+def test_auth_add_google_gemini_cli_sets_active_provider(tmp_path, monkeypatch):
+    """hermes auth add google-gemini-cli must set active_provider in auth.json."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    access_token = "ya29.test-google-access-token"
+    monkeypatch.setattr(
+        "agent.google_oauth.run_gemini_oauth_login_pure",
+        lambda: {
+            "access_token": access_token,
+            "refresh_token": "google-refresh-token",
+            "email": "user@example.com",
+            "expires_at_ms": 9999999999000,
+            "project_id": "my-project",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "google-gemini-cli"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["active_provider"] == "google-gemini-cli"
+    assert payload["providers"]["google-gemini-cli"]["access_token"] == access_token
+    assert payload["providers"]["google-gemini-cli"]["email"] == "user@example.com"
+    entries = payload["credential_pool"]["google-gemini-cli"]
+    entry = next(item for item in entries if item["source"] == "manual:google_pkce")
+    assert entry["source"] == "manual:google_pkce"
+    assert entry["refresh_token"] == "google-refresh-token"
+
+
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})


### PR DESCRIPTION
## Problem

`hermes auth add google-gemini-cli` called `pool.add_entry()` but never wrote
to `providers["google-gemini-cli"]` or set `active_provider` in `auth.json`.

`_model_section_has_credentials()` checks `get_active_provider()` first. With
`active_provider` unset and no `api_key_env_vars` configured for an
`oauth_external` provider, the setup wizard reported **"No inference provider
configured"** even after a successful OAuth login.

## Root cause

Same pattern as `openai-codex` (fixed in #37517) and `xai-oauth` (fixed in
#37576): `pool.add_entry()` only writes the credential-pool entry; it doesn't
touch `providers[provider]` or `active_provider` in `auth.json`.

Runtime credential resolution for google-gemini-cli reads tokens directly from
the Google OAuth credential file via `agent.google_oauth.get_valid_access_token()`.
So the agent itself worked fine — only the setup-wizard detection was broken.

## Fix

Add `_save_google_gemini_cli_tokens()` in `hermes_cli/auth.py` that writes a
minimal provider-state singleton and calls `_save_provider_state()`, which sets
`active_provider`. Call it in `auth_commands` before `pool.add_entry()`.

The `pool.add_entry()` call is kept so `hermes auth list` continues to show the
entry. Runtime resolution continues to use `agent.google_oauth` directly; the
`auth.json` singleton is only used for provider detection.

## Test plan

- [x] New test `test_auth_add_google_gemini_cli_sets_active_provider` passes
- [x] All 47 `test_auth_commands` tests pass (46 upstream + 1 new)