### PR TITLE
fix: extract svg MEDIA attachments

### DIFF
--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -271,6 +271,14 @@ class TestExtractMedia:
         assert media[0][0] == "/path/to/audio.ogg"
         assert media[0][1] is False  # no voice tag
 
+    def test_svg_media_tag(self):
+        content = "MEDIA:/path/to/chart.svg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/path/to/chart.svg"
+        assert media[0][1] is False
+        assert "MEDIA:" not in cleaned
+
     def test_media_with_voice_directive(self):
         content = "[[audio_as_voice]]\nMEDIA:/path/to/voice.ogg"
         media, cleaned = BasePlatformAdapter.extract_media(content)


### PR DESCRIPTION
## Summary
- Recognize `.svg` paths in `MEDIA:` tags so SVG charts are delivered like other media attachments.
- Add regression coverage for SVG extraction.
- Preserve the existing media safety and allowlist checks.

## Verification
- `python3 -m pytest tests/gateway/test_platform_base.py tests/gateway/test_send_image_file.py -q`
- 127 passed