### PR TITLE
fix: surface insecure local secret file permissions

### DIFF
--- a/docs/specs/nightly-secret-permissions-doctor.md
+++ b/docs/specs/nightly-secret-permissions-doctor.md
@@ -1,0 +1,43 @@
+# Spec: Doctor secret-file permission check
+
+## Problem
+
+Hermes stores sensitive local secrets in files such as `$HERMES_HOME/.env`,
+`$HERMES_HOME/auth.json`, and GitHub CLI `hosts.yml`. Existing writers try to
+create new files with restrictive modes, but users can still end up with old or
+manually-edited files that are group/world-readable. Joe's operating manual calls
+out periodic permission verification as part of the system-layer protection
+model.
+
+## Goal
+
+Add a small `hermes doctor` diagnostic that detects obviously over-permissive
+secret files and gives safe, copy-pasteable remediation guidance without printing
+secret contents.
+
+## Non-goals
+
+- Do not delete, rewrite, or rotate credentials automatically.
+- Do not inspect secret values.
+- Do not enforce POSIX modes on Windows, where mode bits are not reliable.
+- Do not add network calls.
+
+## Behavior
+
+- On POSIX platforms, `hermes doctor` checks:
+  - `$HERMES_HOME/.env`
+  - `$HERMES_HOME/auth.json`
+  - `$HOME/.config/gh/hosts.yml`
+- Missing files are ignored.
+- A checked file is OK when no group/other permission bits are present.
+- A checked file warns when any group/other permission bit is present and adds a
+  manual issue with a `chmod 600 <path>` suggestion.
+- On Windows, the check is skipped with a clear informational line.
+
+## Tests
+
+- Unit-test the pure permission evaluator with secure and insecure files.
+- Unit-test missing files are ignored.
+- Unit-test the doctor rendering helper appends a manual issue for insecure
+  files without printing file contents.
+- Skip POSIX mode tests on Windows.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,9 +5,11 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import stat
 import sys
 import subprocess
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
@@ -52,6 +54,21 @@ _PROVIDER_ENV_HINTS = (
     "XIAOMI_API_KEY",
     "TOKENHUB_API_KEY",
 )
+
+
+@dataclass(frozen=True)
+class SecretFilePermissionCheck:
+    """Result for a local secret-file permission check.
+
+    The doctor output must never read or print file contents; this structure
+    carries only path metadata and POSIX mode bits.
+    """
+
+    label: str
+    path: Path
+    mode: int
+    recommended_mode: int
+    secure: bool
 
 
 from hermes_constants import is_termux as _is_termux
@@ -100,6 +117,92 @@ def _termux_install_all_fallback_notes() -> list[str]:
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
+
+
+def _collect_secret_file_permission_checks(
+    *,
+    hermes_home: Path | None = None,
+    home: Path | None = None,
+) -> list[SecretFilePermissionCheck]:
+    """Return POSIX permission checks for known local secret files.
+
+    Missing files are ignored. A file is considered safe when it has no group
+    or other permission bits. We deliberately do not inspect contents here.
+    """
+
+    hermes_home = Path(hermes_home) if hermes_home is not None else HERMES_HOME
+    home = Path(home) if home is not None else Path.home()
+    candidates = (
+        ("Hermes .env", hermes_home / ".env", 0o600),
+        ("Hermes auth store", hermes_home / "auth.json", 0o600),
+        ("GitHub CLI hosts.yml", home / ".config" / "gh" / "hosts.yml", 0o600),
+    )
+
+    results: list[SecretFilePermissionCheck] = []
+    for label, path, recommended_mode in candidates:
+        try:
+            st = path.stat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            continue
+        if not stat.S_ISREG(st.st_mode):
+            continue
+
+        mode = stat.S_IMODE(st.st_mode)
+        results.append(
+            SecretFilePermissionCheck(
+                label=label,
+                path=path,
+                mode=mode,
+                recommended_mode=recommended_mode,
+                secure=(mode & 0o077) == 0,
+            )
+        )
+    return results
+
+
+def _render_secret_file_permission_checks(
+    manual_issues: list[str],
+    *,
+    hermes_home: Path | None = None,
+    home: Path | None = None,
+    display_home: str | None = None,
+) -> None:
+    """Render doctor diagnostics for local files that may contain secrets."""
+
+    _section("Secret File Permissions")
+    if sys.platform.startswith("win"):
+        check_info("Skipped on Windows — POSIX mode bits are not reliably enforced")
+        return
+
+    hermes_home = Path(hermes_home) if hermes_home is not None else HERMES_HOME
+    display_home = display_home or _DHH
+    results = _collect_secret_file_permission_checks(hermes_home=hermes_home, home=home)
+    if not results:
+        check_info("No known local secret files found yet")
+        return
+
+    for result in results:
+        detail = f"(mode 0o{result.mode:o})"
+        if result.secure:
+            check_ok(result.label, detail)
+            continue
+
+        check_warn(
+            result.label,
+            f"{detail} — restrict to 0o{result.recommended_mode:o}",
+        )
+        if result.path == hermes_home / ".env":
+            display_path = f"{display_home}/.env"
+        elif result.path == hermes_home / "auth.json":
+            display_path = f"{display_home}/auth.json"
+        else:
+            display_path = str(result.path)
+        check_info(f"Run: chmod {result.recommended_mode:o} {display_path}")
+        manual_issues.append(
+            f"Restrict {result.label} permissions: chmod {result.recommended_mode:o} {result.path}"
+        )
 
 
 def _honcho_is_configured_for_doctor() -> bool:
@@ -1004,6 +1107,8 @@ def run_doctor(args):
                 check_info(xai_oauth_status["error"])
     except Exception:
         pass
+
+    _render_secret_file_permission_checks(manual_issues)
 
     _section("Directory Structure")
     hermes_home = HERMES_HOME

--- a/tests/hermes_cli/test_doctor_secret_permissions.py
+++ b/tests/hermes_cli/test_doctor_secret_permissions.py
@@ -1,0 +1,104 @@
+"""Tests for Hermes Doctor secret-file permission diagnostics."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import doctor
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+
+
+def _write_with_mode(path: Path, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("SECRET=value\n", encoding="utf-8")
+    os.chmod(path, mode)
+
+
+def test_secret_permission_check_flags_group_or_other_bits(tmp_path: Path):
+    env_path = tmp_path / ".env"
+    auth_path = tmp_path / "auth.json"
+    _write_with_mode(env_path, 0o600)
+    _write_with_mode(auth_path, 0o644)
+
+    results = doctor._collect_secret_file_permission_checks(
+        hermes_home=tmp_path,
+        home=tmp_path / "home",
+    )
+
+    by_label = {result.label: result for result in results}
+    assert by_label["Hermes .env"].secure is True
+    assert by_label["Hermes auth store"].secure is False
+    assert by_label["Hermes auth store"].mode == 0o644
+    assert by_label["Hermes auth store"].recommended_mode == 0o600
+
+
+def test_secret_permission_check_ignores_missing_files(tmp_path: Path):
+    results = doctor._collect_secret_file_permission_checks(
+        hermes_home=tmp_path,
+        home=tmp_path / "home",
+    )
+
+    assert results == []
+
+
+def test_secret_permission_check_includes_github_hosts(tmp_path: Path):
+    gh_hosts = tmp_path / "home" / ".config" / "gh" / "hosts.yml"
+    _write_with_mode(gh_hosts, 0o660)
+
+    results = doctor._collect_secret_file_permission_checks(
+        hermes_home=tmp_path / ".hermes",
+        home=tmp_path / "home",
+    )
+
+    assert len(results) == 1
+    assert results[0].label == "GitHub CLI hosts.yml"
+    assert results[0].secure is False
+    assert results[0].mode == 0o660
+
+
+def test_render_secret_permission_checks_adds_manual_issue_without_secret_content(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    env_path = tmp_path / ".env"
+    _write_with_mode(env_path, 0o644)
+    manual_issues: list[str] = []
+
+    doctor._render_secret_file_permission_checks(
+        manual_issues,
+        hermes_home=tmp_path,
+        home=tmp_path / "home",
+        display_home="<hermes-home>",
+    )
+
+    output = capsys.readouterr().out
+    assert "Secret File Permissions" in output
+    assert "Hermes .env" in output
+    assert "0o644" in output
+    assert "SECRET=value" not in output
+    assert manual_issues == [f"Restrict Hermes .env permissions: chmod 600 {env_path}"]
+
+
+def test_secret_permission_check_accepts_owner_execute_only_for_directories(tmp_path: Path):
+    # Files should not need execute bits; this test guards against accidentally
+    # treating 0o700 as the target file mode.
+    env_path = tmp_path / ".env"
+    _write_with_mode(env_path, stat.S_IRUSR | stat.S_IWUSR)
+
+    [result] = doctor._collect_secret_file_permission_checks(
+        hermes_home=tmp_path,
+        home=tmp_path / "home",
+    )
+
+    assert result.secure is True
+    assert result.mode == 0o600


### PR DESCRIPTION
## Summary
- Add a small `hermes doctor` section for local secret-file permissions.
- Check `$HERMES_HOME/.env`, `$HERMES_HOME/auth.json`, and GitHub CLI `hosts.yml` without reading or printing secret contents.
- Warn on POSIX group/other permission bits and show a safe `chmod 600 ...` remediation.
- Document the behavior in a short spec.

## Why
Joe's operating manual explicitly calls out periodic verification of sensitive file permissions. Existing writers protect new files, but old or manually edited files can still drift to group/world-readable modes.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_doctor_secret_permissions.py -q -o 'addopts='`
- [x] `python -m pytest tests/hermes_cli/test_doctor_secret_permissions.py tests/hermes_cli/test_auth_toctou_file_modes.py -q -o 'addopts='`
- [x] Smoke: call `_render_secret_file_permission_checks` against a temp `.env`

Note: `scripts/run_tests.sh tests/hermes_cli/test_doctor_secret_permissions.py` currently fails before collection in this local worktree because the dev environment is missing the pytest-timeout plugin (`unrecognized arguments: --timeout=30 --timeout-method=signal`). Focused direct pytest fallback was used per contributor guidance.
