### PR TITLE
Fix/cli bugs batch 37501 37472

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3346,6 +3346,7 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "created-desc": "created_at DESC, id DESC",
     "priority": "priority DESC, created_at ASC",
     "priority-desc": "priority ASC, created_at ASC",
+    "priority-recent": "priority DESC, created_at DESC, rowid DESC",
     "status": "status ASC, created_at ASC",
     "assignee": "assignee ASC, created_at ASC",
     "title": "title ASC, id ASC",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1452,6 +1452,7 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "created-desc": "created_at DESC, id DESC",
     "priority": "priority DESC, created_at ASC",
     "priority-desc": "priority ASC, created_at ASC",
+    "priority-recent": "priority DESC, created_at DESC, rowid DESC",
     "status": "status ASC, created_at ASC",
     "assignee": "assignee ASC, created_at ASC",
     "title": "title ASC, id ASC",

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -67,9 +67,12 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     )
     mcp_add_p.add_argument(
         "--env",
-        nargs="*",
+        action="append",
         default=[],
-        help="Environment variables for stdio servers (KEY=VALUE)",
+        help=(
+            "Environment variable for stdio servers (KEY=VALUE). "
+            "Repeat to set multiple."
+        ),
     )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -39,7 +39,14 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "--connect-timeout", type=float,
         help="Timeout in seconds for initial connection and tool discovery")
     mcp_add_p.add_argument(
-        "--env", nargs="*", default=[], help="Environment variables for stdio servers (KEY=VALUE)")
+        "--env",
+        action="append",
+        default=[],
+        help=(
+            "Environment variable for stdio servers (KEY=VALUE). "
+            "Repeat to set multiple."
+        ),
+    )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -405,6 +405,7 @@ def get_board(
             include_archived=include_archived,
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
+            order_by="priority-recent",
         )
         # Pre-fetch link counts per task (cheap: one query).
         link_counts: dict[str, dict[str, int]] = {}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -275,7 +275,8 @@ def get_board(
     with _board_conn(board) as (board, conn):
         tasks = kanban_db.list_tasks(
             conn, tenant=tenant, include_archived=include_archived,
-            workflow_template_id=workflow_template_id, current_step_key=current_step_key)
+            workflow_template_id=workflow_template_id, current_step_key=current_step_key,
+            order_by="priority-recent")
         # Link / comment / progress rollups are each one aggregate query rather than N per-task lookups.
         link_counts: dict[str, dict[str, int]] = {}
         for row in conn.execute("SELECT parent_id, child_id FROM task_links").fetchall():

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -465,6 +465,61 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
         assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
 
 
+def test_delete_archived_task_rejects_non_archived_rows(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="live")
+        assert kb.delete_archived_task(conn, tid) is False
+        assert kb.get_task(conn, tid) is not None
+
+
+def test_list_tasks_order_by(kanban_home):
+    with kb.connect() as conn:
+        # Create tasks with different titles and priorities
+        t_a = kb.create_task(conn, title="alpha", priority=1)
+        t_b = kb.create_task(conn, title="beta", priority=2)
+        t_c = kb.create_task(conn, title="gamma", priority=1)
+
+        # Default sort: priority DESC, created ASC
+        default = kb.list_tasks(conn)
+        assert [t.id for t in default] == [t_b, t_a, t_c]
+
+        # Sort by title ASC
+        by_title = kb.list_tasks(conn, order_by="title")
+        assert [t.id for t in by_title] == [t_a, t_b, t_c]
+
+        # Sort by assignee
+        kb.assign_task(conn, t_a, "alice")
+        kb.assign_task(conn, t_b, "bob")
+        kb.assign_task(conn, t_c, "alice")
+        by_assignee = kb.list_tasks(conn, order_by="assignee")
+        # alice's tasks first (alphabetically), then bob's
+        assignees = [t.assignee for t in by_assignee]
+        assert assignees[:2] == ["alice", "alice"]
+        assert assignees[2] == "bob"
+
+        # Invalid sort order raises ValueError
+        try:
+            kb.list_tasks(conn, order_by="bogus")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "order_by must be one of" in str(e)
+
+
+def test_list_tasks_priority_recent_order(kanban_home):
+    # Used by the dashboard so newest cards float to the top of each lane
+    # while higher-priority cards still sort above lower-priority ones.
+    with kb.connect() as conn:
+        t_a = kb.create_task(conn, title="alpha", priority=1)
+        t_b = kb.create_task(conn, title="beta", priority=2)
+        t_c = kb.create_task(conn, title="gamma", priority=1)
+        t_d = kb.create_task(conn, title="delta", priority=2)
+
+        ordered = kb.list_tasks(conn, order_by="priority-recent")
+        # priority=2 group: newest first (t_d before t_b),
+        # then priority=1 group: newest first (t_c before t_a).
+        assert [t.id for t in ordered] == [t_d, t_b, t_c, t_a]
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -478,6 +478,61 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
         assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
 
 
+def test_delete_archived_task_rejects_non_archived_rows(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="live")
+        assert kb.delete_archived_task(conn, tid) is False
+        assert kb.get_task(conn, tid) is not None
+
+
+def test_list_tasks_order_by(kanban_home):
+    with kb.connect() as conn:
+        # Create tasks with different titles and priorities
+        t_a = kb.create_task(conn, title="alpha", priority=1)
+        t_b = kb.create_task(conn, title="beta", priority=2)
+        t_c = kb.create_task(conn, title="gamma", priority=1)
+
+        # Default sort: priority DESC, created ASC
+        default = kb.list_tasks(conn)
+        assert [t.id for t in default] == [t_b, t_a, t_c]
+
+        # Sort by title ASC
+        by_title = kb.list_tasks(conn, order_by="title")
+        assert [t.id for t in by_title] == [t_a, t_b, t_c]
+
+        # Sort by assignee
+        kb.assign_task(conn, t_a, "alice")
+        kb.assign_task(conn, t_b, "bob")
+        kb.assign_task(conn, t_c, "alice")
+        by_assignee = kb.list_tasks(conn, order_by="assignee")
+        # alice's tasks first (alphabetically), then bob's
+        assignees = [t.assignee for t in by_assignee]
+        assert assignees[:2] == ["alice", "alice"]
+        assert assignees[2] == "bob"
+
+        # Invalid sort order raises ValueError
+        try:
+            kb.list_tasks(conn, order_by="bogus")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "order_by must be one of" in str(e)
+
+
+def test_list_tasks_priority_recent_order(kanban_home):
+    # Used by the dashboard so newest cards float to the top of each lane
+    # while higher-priority cards still sort above lower-priority ones.
+    with kb.connect() as conn:
+        t_a = kb.create_task(conn, title="alpha", priority=1)
+        t_b = kb.create_task(conn, title="beta", priority=2)
+        t_c = kb.create_task(conn, title="gamma", priority=1)
+        t_d = kb.create_task(conn, title="delta", priority=2)
+
+        ordered = kb.list_tasks(conn, order_by="priority-recent")
+        # priority=2 group: newest first (t_d before t_b),
+        # then priority=1 group: newest first (t_c before t_a).
+        assert [t.id for t in ordered] == [t_d, t_b, t_c, t_a]
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kbc.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")

--- a/tests/hermes_cli/test_mcp_add_env_repeat.py
+++ b/tests/hermes_cli/test_mcp_add_env_repeat.py
@@ -1,0 +1,64 @@
+"""Regression test: ``hermes mcp add --env KEY=VALUE`` must accumulate
+across repeated flags rather than keeping only the final one.
+
+Before the fix the ``--env`` argument used ``nargs="*"`` which made a
+second ``--env`` flag overwrite the previous value, so
+
+    hermes mcp add foo --command bar \
+        --env A=1 \
+        --env B=2
+
+silently dropped ``A=1`` and persisted only ``B=2`` to ``config.yaml``.
+
+Fix: switch to ``action="append"`` so repeated flags accumulate.  We
+replicate the relevant parser shape here rather than importing the real
+builder, mirroring ``test_mcp_add_command_dest.py``.
+"""
+
+import argparse
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+
+    mcp_p = subparsers.add_parser("mcp")
+    mcp_sub = mcp_p.add_subparsers(dest="mcp_action")
+
+    mcp_add = mcp_sub.add_parser("add")
+    mcp_add.add_argument("name")
+    mcp_add.add_argument("--command", dest="mcp_command")
+    mcp_add.add_argument("--env", action="append", default=[])
+
+    return parser
+
+
+class TestMcpAddEnvRepeat:
+    def test_repeated_env_flags_accumulate(self):
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "mcp",
+                "add",
+                "alpaca",
+                "--command",
+                "uvx",
+                "--env",
+                "ALPACA_API_KEY=xxx",
+                "--env",
+                "ALPACA_SECRET_KEY=yyy",
+            ]
+        )
+        assert args.env == ["ALPACA_API_KEY=xxx", "ALPACA_SECRET_KEY=yyy"]
+
+    def test_no_env_flag_is_empty_list(self):
+        parser = _build_parser()
+        args = parser.parse_args(["mcp", "add", "foo", "--command", "npx"])
+        assert args.env == []
+
+    def test_single_env_flag(self):
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["mcp", "add", "foo", "--command", "npx", "--env", "X=1"]
+        )
+        assert args.env == ["X=1"]


### PR DESCRIPTION
## What does this PR do?

Fixes two unrelated CLI/UX bugs reported in the issue tracker, batched into a single PR because both are small, isolated, and well-scoped:

1. **`hermes mcp add` silently drops every `--env` flag except the last** — repeated `--env KEY=VALUE` arguments overwrote each other, so MCP stdio servers requiring multiple secrets were misconfigured at install time with no error.
2. **Kanban dashboard shows the oldest cards at the top of each lane** — users had to scroll past stale tasks to see recent activity.

Each fix is its own commit so they can be reviewed/cherry-picked independently.

## Related Issues

Fixes #37501
Fixes #37472

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### #37501 — `hermes mcp add` accumulates repeated `--env` flags

- `hermes_cli/main.py` (mcp_add_p `--env`): switched the argument from `nargs="*"` to `action="append"`. With `nargs="*"`, each repeated `--env` flag overwrote the previous value; with `action="append"` the downstream `_parse_env_assignments()` receives every entry.
- `tests/hermes_cli/test_mcp_add_env_repeat.py` (new): regression test mirroring the minimal-parser-replica pattern used in `test_mcp_add_command_dest.py`. Covers repeated `--env`, single `--env`, and absent `--env`.

### #37472 — Kanban dashboard sorts lanes newest-first

Took a **scoped** fix rather than flipping the global default — the default ordering is load-bearing for the dispatcher's FIFO claim semantics and for `hermes kanban list` output, so changing it globally would have unintended side effects.

- `hermes_cli/kanban_db.py` (`VALID_SORT_ORDERS`): added a new `"priority-recent"` order: `priority DESC, created_at DESC, rowid DESC`. The `rowid DESC` tiebreaker is necessary because `created_at` is integer seconds and tasks created in the same second otherwise sort by string-compared UUID `id` (non-deterministic).
- `plugins/kanban/dashboard/plugin_api.py`: dashboard now passes `order_by="priority-recent"` explicitly to `list_tasks()`.
- `tests/hermes_cli/test_kanban_db.py`: new `test_list_tasks_priority_recent_order` covering same-second creation with mixed priorities.

## How to Test

### #37501

```bash
hermes mcp remove alpaca || true
hermes mcp add alpaca \
  --command /usr/local/bin/uvx \
  --args alpaca-mcp-server \
  --env ALPACA_API_KEY=xxx \
  --env ALPACA_SECRET_KEY=yyy

grep -A3 'alpaca:' ~/.hermes/config.yaml
# Expect: BOTH ALPACA_API_KEY and ALPACA_SECRET_KEY present under env:
