### PR TITLE
perf(model-metadata): resolve localhost to IPv4 in detect_local_server_type

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -631,16 +631,17 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     import httpx
 
     normalized = _normalize_base_url(base_url)
+
+    # Resolve localhost to IPv4 to avoid 2s IPv6 timeout on Windows dual-stack.
+    normalized = normalized.replace("://localhost:", "://127.0.0.1:")
+    normalized = normalized.replace("://localhost/", "://127.0.0.1/")
+    if normalized.endswith("://localhost"):
+        normalized = normalized[:-len("localhost")] + "127.0.0.1"
+
     server_url = normalized
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
-    lmstudio_url = _lmstudio_server_root(base_url)
-
-    # Resolve localhost to IPv4 to avoid 2s IPv6 timeout on Windows dual-stack.
-    server_url = server_url.replace("://localhost:", "://127.0.0.1:")
-    server_url = server_url.replace("://localhost/", "://127.0.0.1/")
-    if server_url.endswith("://localhost"):
-        server_url = server_url[:-len("localhost")] + "127.0.0.1"
+    lmstudio_url = _lmstudio_server_root(normalized)
 
     headers = _auth_headers(api_key)
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -636,6 +636,12 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
         server_url = server_url[:-3]
     lmstudio_url = _lmstudio_server_root(base_url)
 
+    # Resolve localhost to IPv4 to avoid 2s IPv6 timeout on Windows dual-stack.
+    server_url = server_url.replace("://localhost:", "://127.0.0.1:")
+    server_url = server_url.replace("://localhost/", "://127.0.0.1/")
+    if server_url.endswith("://localhost"):
+        server_url = server_url[:-len("localhost")] + "127.0.0.1"
+
     headers = _auth_headers(api_key)
 
     try:

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -507,6 +507,66 @@ class TestDetectLocalServerTypeAuth:
         assert client_mock.get.call_args_list[0].args[0] == "http://localhost:1234/api/v1/models"
 
 
+class TestDetectLocalServerTypeLocalhostIPv4:
+    """detect_local_server_type should resolve localhost to 127.0.0.1."""
+
+    def test_localhost_resolved_to_ipv4(self):
+        """Probes should use 127.0.0.1, not localhost, to avoid IPv6 timeout."""
+        from agent.model_metadata import detect_local_server_type
+
+        resp = MagicMock()
+        resp.status_code = 200
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = resp
+
+        with patch("httpx.Client", return_value=client_mock):
+            detect_local_server_type("http://localhost:8317/v1")
+
+        for call in client_mock.get.call_args_list:
+            url = call[0][0]
+            assert "localhost" not in url, f"Probe URL still uses localhost: {url}"
+            assert "127.0.0.1" in url
+
+    def test_non_localhost_urls_unchanged(self):
+        """Non-localhost URLs should not be modified."""
+        from agent.model_metadata import detect_local_server_type
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        resp = MagicMock()
+        resp.status_code = 404
+        client_mock.get.return_value = resp
+
+        with patch("httpx.Client", return_value=client_mock):
+            detect_local_server_type("http://192.168.1.100:8080")
+
+        for call in client_mock.get.call_args_list:
+            url = call[0][0]
+            assert "192.168.1.100" in url
+
+    def test_127_0_0_1_urls_unchanged(self):
+        """URLs already using 127.0.0.1 should pass through unchanged."""
+        from agent.model_metadata import detect_local_server_type
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        resp = MagicMock()
+        resp.status_code = 404
+        client_mock.get.return_value = resp
+
+        with patch("httpx.Client", return_value=client_mock):
+            detect_local_server_type("http://127.0.0.1:8317")
+
+        for call in client_mock.get.call_args_list:
+            url = call[0][0]
+            assert "127.0.0.1" in url
+
+
 class TestFetchEndpointModelMetadataLmStudio:
     """fetch_endpoint_model_metadata should use LM Studio's native models endpoint."""
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -504,7 +504,7 @@ class TestDetectLocalServerTypeAuth:
             result = detect_local_server_type("http://localhost:1234/api/v1")
 
         assert result == "lm-studio"
-        assert client_mock.get.call_args_list[0].args[0] == "http://localhost:1234/api/v1/models"
+        assert client_mock.get.call_args_list[0].args[0] == "http://127.0.0.1:1234/api/v1/models"
 
 
 class TestDetectLocalServerTypeLocalhostIPv4:


### PR DESCRIPTION
## Summary

On Windows, `localhost` resolves to both `::1` (IPv6) and `127.0.0.1` (IPv4). Python httpx tries IPv6 first; when the local server only binds IPv4, each connection attempt hangs for the full 2 sec connect timeout before falling back. `detect_local_server_type()` is called 3+ times during agent init (from `fetch_endpoint_model_metadata`, `get_ollama_num_ctx`, and `_query_local_context_length`), each creating a fresh `httpx.Client`, so the IPv6 timeout compounds to ~6-14s of dead time.

The fix replaces `localhost` with `127.0.0.1` inside `detect_local_server_type()` before connecting. The function is only called for local endpoints (all callers guard with `is_local_endpoint()`), so IPv6 loopback adds no diagnostic value and the replacement is safe.

## Changes

- `agent/model_metadata.py`: resolve `localhost` to `127.0.0.1` in `detect_local_server_type()` after `_normalize_base_url` and `/v1` stripping, before probe requests (+6 lines)
- `tests/agent/test_model_metadata_local_ctx.py`: add `TestDetectLocalServerTypeLocalhostIPv4` with 3 tests verifying localhost resolution, LAN IP passthrough, and 127.0.0.1 passthrough (+60 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| `localhost:8317` (IPv4-only server, Windows) | 2 sec per probe (~14s total) | <0.1s per probe (~4s total) |
| `127.0.0.1:8317` | fast | fast (unchanged) |
| `192.168.1.100:8080` (LAN IP) | fast | fast (unchanged) |
| Linux/macOS (localhost = IPv4 only) | fast | fast (unchanged) |

## Test plan

- `pytest tests/agent/test_model_metadata_local_ctx.py -v --timeout=0` — 25 passed
- Manual: `hermes -m claude-sonnet-4-6 -z "test"` on Windows with `localhost` base_url — 4.0s vs 19.9s before

Fixes #37594