### PR TITLE
fix(desktop): dedupe pasted clipboard images

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractClipboardImageBlobs } from './text-utils'
+
+function fileList(files: File[]): FileList {
+  return {
+    length: files.length,
+    item: (index: number) => files[index] ?? null,
+    ...Object.fromEntries(files.map((file, index) => [index, file]))
+  } as unknown as FileList
+}
+
+function clipboard(overrides: Partial<DataTransfer>): DataTransfer {
+  return {
+    files: fileList([]),
+    getData: () => '',
+    items: [] as unknown as DataTransferItemList,
+    ...overrides
+  } as DataTransfer
+}
+
+describe('extractClipboardImageBlobs', () => {
+  it('dedupes the same pasted image exposed through items and files', () => {
+    const itemImage = new File(['same-image'], 'clipboard.png', { type: 'image/png' })
+    const fileImage = new File(['same-image'], 'screenshot.png', { type: 'image/png' })
+
+    const data = clipboard({
+      files: fileList([fileImage]),
+      items: [
+        {
+          getAsFile: () => itemImage,
+          kind: 'file',
+          type: 'image/png'
+        }
+      ] as unknown as DataTransferItemList
+    })
+
+    expect(extractClipboardImageBlobs(data)).toEqual([itemImage])
+  })
+
+  it('keeps image files that were not already exposed as clipboard items', () => {
+    const itemImage = new File(['first'], 'first.png', { type: 'image/png' })
+    const secondImage = new File(['second-image'], 'second.png', { type: 'image/png' })
+
+    const data = clipboard({
+      files: fileList([secondImage]),
+      items: [
+        {
+          getAsFile: () => itemImage,
+          kind: 'file',
+          type: 'image/png'
+        }
+      ] as unknown as DataTransferItemList
+    })
+
+    expect(extractClipboardImageBlobs(data)).toEqual([itemImage, secondImage])
+  })
+})

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -10,21 +10,35 @@ const TRIGGER_RE = /(?:^|[\s])([@/])([^\s@/]*)$/
 
 export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   const blobs: Blob[] = []
-  const seen = new Set<Blob>()
+  const seenByReference = new Set<Blob>()
+  const itemImageKeys = new Set<string>()
 
-  const push = (blob: Blob | null) => {
-    if (!blob || blob.size === 0 || seen.has(blob)) {
+  const imageKey = (blob: Blob) => `${blob.type}:${blob.size}`
+
+  const push = (blob: Blob | null, source: 'derived' | 'file' | 'item') => {
+    if (!blob || blob.size === 0 || seenByReference.has(blob)) {
       return
     }
 
-    seen.add(blob)
+    const key = imageKey(blob)
+
+    if (source === 'file' && itemImageKeys.has(key)) {
+      return
+    }
+
+    seenByReference.add(blob)
+
+    if (source === 'item') {
+      itemImageKeys.add(key)
+    }
+
     blobs.push(blob)
   }
 
   if (clipboard.items?.length) {
     for (const item of clipboard.items) {
       if (item.kind === 'file' && item.type.startsWith('image/')) {
-        push(item.getAsFile())
+        push(item.getAsFile(), 'item')
       }
     }
   }
@@ -34,7 +48,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
       const file = clipboard.files.item(i)
 
       if (file && file.type.startsWith('image/')) {
-        push(file)
+        push(file, 'file')
       }
     }
   }
@@ -46,7 +60,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   const text = clipboard.getData('text/plain').trim()
 
   if (DATA_IMAGE_URL_RE.test(text)) {
-    push(dataUrlToBlob(text))
+    push(dataUrlToBlob(text), 'derived')
   }
 
   if (blobs.length === 0) {
@@ -56,7 +70,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
       const matches = html.matchAll(/<img\b[^>]*?\bsrc\s*=\s*["'](data:image\/[^"']+)["']/gi)
 
       for (const match of matches) {
-        push(dataUrlToBlob(match[1]))
+        push(dataUrlToBlob(match[1]), 'derived')
       }
     }
   }


### PR DESCRIPTION
## Summary
- Dedupes Windows screenshot paste when Electron exposes the same image through clipboard.items and clipboard.files.
- Keeps distinct file images when they were not already exposed as clipboard items.
- Adds regression tests for both paths.

## Test plan
- npm run lint -- src/app/chat/composer/text-utils.ts src/app/chat/composer/text-utils.test.ts
- npm run test:ui -- src/app/chat/composer/text-utils.test.ts
- npm run type-check

Closes #37575
