### PR TITLE
fix(models): restore gemini-3-flash-preview to Gemini OAuth picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -241,6 +241,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "google-gemini-cli": [
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
+        # Code Assist serves two flash slugs with different access gates
+        # (gemini-cli models.ts): gemini-3-flash-preview is the preview flash
+        # that subscription/free-tier OAuth users actually reach, while
+        # gemini-3.5-flash is GA-channel-gated. Offer both so non-GA users
+        # aren't stuck with a slug cloudcode-pa 404s for them.
+        "gemini-3-flash-preview",
         "gemini-3.5-flash",
     ],
     "zai": [


### PR DESCRIPTION
## Summary
Restores `gemini-3-flash-preview` to the Google OAuth (`google-gemini-cli` / Code Assist) model picker so subscription/free-tier OAuth users have a working flash model again.

Root cause: #37046 swapped `gemini-3-flash-preview` → `gemini-3.5-flash` in the OAuth picker on the premise that the slug was simply renamed. It wasn't. Per gemini-cli's own `models.ts`, Code Assist serves **two distinct flash slugs with different access gates**:

- `gemini-3-flash-preview` (`PREVIEW_GEMINI_FLASH_MODEL`) — the flash that subscription/free-tier OAuth users actually reach
- `gemini-3.5-flash` (`DEFAULT_GEMINI_3_5_FLASH_MODEL`) — GA-channel-gated (`useGemini3_5Flash`)

The picked model string is passed verbatim into the `{project, model, ...}` envelope sent to `cloudcode-pa.googleapis.com/v1internal:generateContent`, so non-GA users got a hard error on every prompt — `gemini-3.5-flash` 404s for them.

## Changes
- `hermes_cli/models.py`: `google-gemini-cli` picker now offers **both** `gemini-3-flash-preview` and `gemini-3.5-flash`, matching gemini-cli's own `/model` list. Non-GA users pick the preview slug; GA-channel users can pick either.

## Scope
Only the OAuth picker. The `gemini` (API-key), OpenRouter, and Nous lists are **untouched** — `google/gemini-3.5-flash` is a real live model on those surfaces (OpenRouter released it May 19), so #34581 and the API-key half of #37046 were correct.

## Validation
| | Before | After |
|---|---|---|
| OAuth flash slugs offered | `gemini-3.5-flash` only | `gemini-3-flash-preview` + `gemini-3.5-flash` |
| Non-GA subscription user | error every prompt | working preview flash selectable |

Targeted tests: `tests/hermes_cli/test_models.py`, `test_model_catalog.py`, `test_model_validation.py` — 181 passed.

Reported by J.A.R.V.I.S in Discord.

## Infographic

![n64-questworld](https://v3b.fal.media/files/b/0a9cb820/-QLLuXKLsNBdokayFLBeQ_TromutlD.png)
