### PR TITLE
fix(gateway): delete all overflow preview messages after fallback final

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1669,8 +1669,13 @@ _RETRYABLE_ERROR_PATTERNS = (
 
 # Type for message handlers.  Handlers may return a plain string (normal
 # reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
+# a ``DeliveryCleanupReply`` to delete stale intermediate messages only after
+# the final reply has landed successfully, or
 # ``None`` when the response was already delivered (e.g. via streaming).
-MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+MessageHandler = Callable[
+    [MessageEvent],
+    Awaitable[Optional[Union[str, "EphemeralReply", "DeliveryCleanupReply"]]],
+]
 
 
 def resolve_channel_prompt(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1572,6 +1572,19 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+class DeliveryCleanupReply(str):
+    """Reply text with stale message ids to delete after successful delivery."""
+
+    cleanup_message_ids: tuple[str, ...]
+
+    def __new__(cls, text: str, cleanup_message_ids=()):
+        instance = super().__new__(cls, text)
+        instance.cleanup_message_ids = tuple(
+            str(message_id) for message_id in cleanup_message_ids if message_id
+        )
+        return instance
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -3266,6 +3279,38 @@ class BasePlatformAdapter(ABC):
             return response.text, int(ttl or 0)
         return response, 0
 
+    @staticmethod
+    def _send_result_message_ids(result: Any) -> list[str]:
+        raw_response = getattr(result, "raw_response", None)
+        raw_ids = (
+            raw_response.get("message_ids")
+            if isinstance(raw_response, dict)
+            else None
+        )
+        if isinstance(raw_ids, (list, tuple)):
+            message_ids = [str(message_id) for message_id in raw_ids if message_id]
+            if message_ids:
+                return message_ids
+        message_id = getattr(result, "message_id", None)
+        return [str(message_id)] if message_id else []
+
+    async def _cleanup_messages_after_delivery(
+        self,
+        chat_id: str,
+        message_ids: tuple[str, ...],
+        *,
+        current_message_ids: set[str],
+    ) -> None:
+        if not message_ids:
+            return
+        for message_id in message_ids:
+            if message_id in current_message_ids:
+                continue
+            try:
+                await self.delete_message(chat_id, message_id)
+            except Exception:
+                pass
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -4049,6 +4094,9 @@ class BasePlatformAdapter(ABC):
             # string, and remember the TTL + platform capability so the
             # post-send block can schedule the deletion.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
+            _delivery_cleanup_ids = tuple(
+                getattr(response, "cleanup_message_ids", ()) or ()
+            )
 
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or
@@ -4198,6 +4246,14 @@ class BasePlatformAdapter(ABC):
                         metadata=_thread_metadata,
                     )
                     _record_delivery(result)
+                    if result.success and _delivery_cleanup_ids:
+                        await self._cleanup_messages_after_delivery(
+                            event.source.chat_id,
+                            _delivery_cleanup_ids,
+                            current_message_ids=set(
+                                self._send_result_message_ids(result)
+                            ),
+                        )
 
                     # Schedule auto-deletion of system-notice replies.
                     # Detached so the handler returns immediately; errors

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2470,11 +2470,82 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return True
         except Exception as e:
+            wait = self._retry_after_seconds(e)
+            if wait is not None:
+                self._schedule_delete_message_retry(chat_id, message_id, wait)
+                logger.warning(
+                    "[%s] Telegram delete flood-controlled for message %s; "
+                    "retrying cleanup in %.1fs",
+                    self.name, message_id, wait,
+                )
+                return False
             logger.debug(
                 "[%s] Failed to delete Telegram message %s: %s",
                 self.name, message_id, e,
             )
             return False
+
+    @staticmethod
+    def _retry_after_seconds(error: Exception) -> Optional[float]:
+        retry_after = getattr(error, "retry_after", None)
+        if retry_after is None:
+            match = re.search(r"retry\s+after\s+([0-9]+(?:\.[0-9]+)?)", str(error), re.I)
+            if match:
+                retry_after = match.group(1)
+        if retry_after is None:
+            return None
+        try:
+            wait = float(retry_after)
+        except (TypeError, ValueError):
+            wait = 1.0
+        return max(wait, 0.0)
+
+    def _schedule_delete_message_retry(
+        self,
+        chat_id: str,
+        message_id: str,
+        wait_seconds: float,
+        *,
+        attempt: int = 1,
+    ) -> None:
+        async def _retry_delete() -> None:
+            try:
+                await asyncio.sleep(wait_seconds)
+                if not self._bot:
+                    return
+                await self._bot.delete_message(
+                    chat_id=int(chat_id),
+                    message_id=int(message_id),
+                )
+                logger.info(
+                    "[%s] Deferred Telegram cleanup deleted message %s",
+                    self.name, message_id,
+                )
+            except Exception as retry_err:
+                next_wait = self._retry_after_seconds(retry_err)
+                if next_wait is not None and attempt < 3:
+                    logger.warning(
+                        "[%s] Deferred Telegram cleanup still flood-controlled "
+                        "for message %s; retrying in %.1fs",
+                        self.name, message_id, next_wait,
+                    )
+                    self._schedule_delete_message_retry(
+                        chat_id,
+                        message_id,
+                        next_wait,
+                        attempt=attempt + 1,
+                    )
+                    return
+                logger.debug(
+                    "[%s] Deferred Telegram cleanup failed for message %s: %s",
+                    self.name, message_id, retry_err,
+                )
+
+        task = asyncio.create_task(_retry_delete())
+        background_tasks = getattr(self, "_background_tasks", None)
+        if isinstance(background_tasks, set):
+            background_tasks.add(task)
+            task.add_done_callback(background_tasks.discard)
 
     def supports_draft_streaming(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -86,6 +86,14 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+
+def _wrap_stream_preview_cleanup_reply(response: Any, agent_result: Dict[str, Any]) -> Any:
+    """Attach stale stream-preview cleanup ids to a pending final reply."""
+    cleanup_ids = tuple(agent_result.get("stream_preview_cleanup_ids") or ())
+    if response and cleanup_ids and not agent_result.get("already_sent"):
+        return DeliveryCleanupReply(response, cleanup_message_ids=cleanup_ids)
+    return response
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -9423,14 +9431,7 @@ class GatewayRunner:
             if _footer_line and response and not agent_result.get("already_sent"):
                 response = f"{response}\n\n{_footer_line}"
 
-            _stream_cleanup_ids = tuple(
-                agent_result.get("stream_preview_cleanup_ids") or ()
-            )
-            if response and _stream_cleanup_ids and not agent_result.get("already_sent"):
-                response = DeliveryCleanupReply(
-                    response,
-                    cleanup_message_ids=_stream_cleanup_ids,
-                )
+            response = _wrap_stream_preview_cleanup_reply(response, agent_result)
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1133,6 +1133,7 @@ from gateway.session import (
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    DeliveryCleanupReply,
     EphemeralReply,
     MessageEvent,
     MessageType,
@@ -9421,6 +9422,15 @@ class GatewayRunner:
                 _footer_line = ""
             if _footer_line and response and not agent_result.get("already_sent"):
                 response = f"{response}\n\n{_footer_line}"
+
+            _stream_cleanup_ids = tuple(
+                agent_result.get("stream_preview_cleanup_ids") or ()
+            )
+            if response and _stream_cleanup_ids and not agent_result.get("already_sent"):
+                response = DeliveryCleanupReply(
+                    response,
+                    cleanup_message_ids=_stream_cleanup_ids,
+                )
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -18924,6 +18934,15 @@ class GatewayRunner:
                             "Failed to edit streamed message for session %s: %s",
                             session_key or "?", _edit_err,
                         )
+            elif not _is_empty_sentinel and _sc is not None:
+                cleanup_ids_fn = getattr(_sc, "preview_cleanup_ids_for_final", None)
+                if callable(cleanup_ids_fn):
+                    try:
+                        cleanup_ids = cleanup_ids_fn(_final)
+                    except Exception:
+                        cleanup_ids = ()
+                    if cleanup_ids:
+                        response["stream_preview_cleanup_ids"] = tuple(cleanup_ids)
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -143,6 +143,11 @@ class GatewayStreamConsumer:
         # timestamps would be stale by completion time.  Ported from
         # openclaw/openclaw#72038.
         self._message_created_ts: Optional[float] = None
+        # Message ids that currently make up the visible streaming preview.
+        # Usually this is a single id, but Telegram can split an oversized
+        # edit into the original message plus continuation messages.  Fallback
+        # cleanup must delete the whole stale preview, not just the latest id.
+        self._preview_message_ids: list[str] = []
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
@@ -257,6 +262,7 @@ class GatewayStreamConsumer:
             return
         self._message_id = None
         self._message_created_ts = None
+        self._preview_message_ids = []
         self._accumulated = ""
         self._last_sent_text = ""
         self._fallback_final_send = False
@@ -512,6 +518,7 @@ class GatewayStreamConsumer:
                             return
                         if got_segment_break:
                             self._message_id = None
+                            self._preview_message_ids = []
                             self._fallback_final_send = False
                             self._fallback_prefix = ""
                         continue
@@ -701,6 +708,7 @@ class GatewayStreamConsumer:
             )
             if result.success and result.message_id:
                 self._message_id = str(result.message_id)
+                self._remember_preview_message_ids(result.message_id)
                 self._already_sent = True
                 self._last_sent_text = text
                 # Fresh content bubble — close off any stale tool bubble
@@ -748,6 +756,25 @@ class GatewayStreamConsumer:
         if remaining:
             chunks.append(remaining)
         return chunks
+
+    def _remember_preview_message_ids(self, *message_ids: Optional[str]) -> None:
+        """Track platform messages that belong to the current stream preview."""
+        for message_id in message_ids:
+            if not message_id:
+                continue
+            message_id = str(message_id)
+            if message_id == "__no_edit__" or message_id in self._preview_message_ids:
+                continue
+            self._preview_message_ids.append(message_id)
+
+    def _stale_preview_cleanup_ids(self, current_message_id: Optional[str]) -> list[str]:
+        """Return stale preview ids to delete after a replacement final send."""
+        ids = list(self._preview_message_ids)
+        if current_message_id and current_message_id != "__no_edit__":
+            current_message_id = str(current_message_id)
+            if current_message_id not in ids:
+                ids.append(current_message_id)
+        return ids
 
     async def _send_fallback_final(self, text: str) -> None:
         """Send the final continuation after streaming edits stop working.
@@ -804,7 +831,8 @@ class GatewayStreamConsumer:
         safe_limit = max(500, raw_limit - 100)
         chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
 
-        stale_message_id = self._message_id  # partial message to clean up
+        stale_message_id = self._message_id  # partial message(s) to clean up
+        stale_message_ids = self._stale_preview_cleanup_ids(stale_message_id)
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
@@ -859,18 +887,22 @@ class GatewayStreamConsumer:
         # implement ``delete_message``, the delete fails (flood control still
         # active, bot lacks permission, message too old to delete), the
         # partial remains but at least the full answer was delivered.
-        if stale_message_id and stale_message_id != last_message_id:
+        if stale_message_ids:
             delete_fn = getattr(self.adapter, "delete_message", None)
             if delete_fn is not None:
-                try:
-                    await delete_fn(self.chat_id, stale_message_id)
-                except Exception as e:
-                    logger.debug(
-                        "Fallback partial cleanup failed (%s): %s",
-                        stale_message_id, e,
-                    )
+                for stale_id in stale_message_ids:
+                    if stale_id == last_message_id:
+                        continue
+                    try:
+                        await delete_fn(self.chat_id, stale_id)
+                    except Exception as e:
+                        logger.debug(
+                            "Fallback partial cleanup failed (%s): %s",
+                            stale_id, e,
+                        )
 
         self._message_id = last_message_id
+        self._preview_message_ids = []
         self._already_sent = True
         self._final_response_sent = True
         self._final_content_delivered = True
@@ -1081,6 +1113,7 @@ class GatewayStreamConsumer:
         Ported from openclaw/openclaw#72038.
         """
         old_message_id = self._message_id
+        old_message_ids = self._stale_preview_cleanup_ids(old_message_id)
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
@@ -1097,16 +1130,17 @@ class GatewayStreamConsumer:
         # is best-effort; platforms that don't implement ``delete_message``
         # just leave the preview behind (still an acceptable outcome —
         # the visible final timestamp is the important part).
-        if old_message_id and old_message_id != "__no_edit__":
+        if old_message_ids:
             delete_fn = getattr(self.adapter, "delete_message", None)
             if delete_fn is not None:
-                try:
-                    await delete_fn(self.chat_id, old_message_id)
-                except Exception as e:
-                    logger.debug(
-                        "Fresh-final preview cleanup failed (%s): %s",
-                        old_message_id, e,
-                    )
+                for old_id in old_message_ids:
+                    try:
+                        await delete_fn(self.chat_id, old_id)
+                    except Exception as e:
+                        logger.debug(
+                            "Fresh-final preview cleanup failed (%s): %s",
+                            old_id, e,
+                        )
         # Adopt the new message id as the current message so subsequent
         # callers (e.g. overflow split loops, finalize retries) see a
         # consistent state.
@@ -1120,6 +1154,7 @@ class GatewayStreamConsumer:
             # don't try to edit something we can't address.
             self._message_id = "__no_edit__"
             self._message_created_ts = None
+        self._preview_message_ids = []
         self._already_sent = True
         self._last_sent_text = text
         if is_turn_final:
@@ -1252,6 +1287,10 @@ class GatewayStreamConsumer:
                             and result.message_id
                             and result.message_id != self._message_id
                         ):
+                            self._remember_preview_message_ids(
+                                self._message_id,
+                                *[str(mid) for mid in _continuation_ids],
+                            )
                             self._message_id = str(result.message_id)
                             self._message_created_ts = time.monotonic()
                             self._last_sent_text = ""
@@ -1316,6 +1355,7 @@ class GatewayStreamConsumer:
                 if result.success:
                     if result.message_id:
                         self._message_id = result.message_id
+                        self._remember_preview_message_ids(result.message_id)
                         # Track when the preview first became visible to
                         # the user so fresh-final logic can detect stale
                         # preview timestamps on long-running responses.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -149,6 +149,8 @@ class GatewayStreamConsumer:
         # cleanup must delete the whole stale preview, not just the latest id.
         self._preview_message_ids: list[str] = []
         self._preview_message_text = ""
+        self._pending_preview_cleanup_candidates: list[tuple[list[str], str]] = []
+        # Back-compat mirrors used by older tests/debug probes.
         self._pending_preview_cleanup_ids: list[str] = []
         self._pending_preview_cleanup_text = ""
         self._already_sent = False
@@ -224,7 +226,7 @@ class GatewayStreamConsumer:
             return ()
 
         cleanup_ids: list[str] = []
-        candidates = [(self._pending_preview_cleanup_ids, self._pending_preview_cleanup_text)]
+        candidates = list(self._pending_preview_cleanup_candidates)
         if include_current:
             candidates.append((self._preview_message_ids, self._preview_message_text))
         for ids, preview_text in candidates:
@@ -847,15 +849,56 @@ class GatewayStreamConsumer:
                 continue
             self._preview_message_ids.append(message_id)
 
+    def _sync_pending_preview_cleanup_mirror(self) -> None:
+        """Keep legacy pending-cleanup fields aligned with all candidates."""
+        ids: list[str] = []
+        text = ""
+        for candidate_ids, candidate_text in self._pending_preview_cleanup_candidates:
+            if not text and candidate_text:
+                text = candidate_text
+            for message_id in candidate_ids:
+                if message_id not in ids:
+                    ids.append(message_id)
+        self._pending_preview_cleanup_ids = ids
+        self._pending_preview_cleanup_text = text
+
+    def _add_pending_preview_cleanup_candidate(
+        self,
+        message_ids: list[str],
+        preview_text: str,
+    ) -> None:
+        ids: list[str] = []
+        for message_id in message_ids:
+            if not message_id:
+                continue
+            message_id = str(message_id)
+            if message_id == "__no_edit__" or message_id in ids:
+                continue
+            ids.append(message_id)
+        preview_text = self._preview_text_for_cleanup(preview_text)
+        if not ids or not preview_text:
+            return
+
+        for index, (existing_ids, existing_text) in enumerate(
+            self._pending_preview_cleanup_candidates
+        ):
+            if existing_ids == ids:
+                if len(preview_text) > len(existing_text):
+                    self._pending_preview_cleanup_candidates[index] = (
+                        ids, preview_text,
+                    )
+                    self._sync_pending_preview_cleanup_mirror()
+                return
+
+        self._pending_preview_cleanup_candidates.append((ids, preview_text))
+        self._sync_pending_preview_cleanup_mirror()
+
     def _stage_current_preview_for_replay_cleanup(self) -> None:
         """Preserve the visible preview group across a tool-boundary reset."""
-        if (
-            self._preview_message_ids
-            and self._preview_message_text
-            and not self._pending_preview_cleanup_ids
-        ):
-            self._pending_preview_cleanup_ids = list(self._preview_message_ids)
-            self._pending_preview_cleanup_text = self._preview_message_text
+        self._add_pending_preview_cleanup_candidate(
+            list(self._preview_message_ids),
+            self._preview_message_text,
+        )
 
     def _stale_preview_cleanup_ids(self, current_message_id: Optional[str]) -> list[str]:
         """Return stale preview ids to delete after a replacement final send."""
@@ -873,14 +916,20 @@ class GatewayStreamConsumer:
         current_message_id: Optional[str],
     ) -> None:
         """Delete a prior overflow preview only after a matching replay lands."""
-        ids = list(self.preview_cleanup_ids_for_final(
-            final_text,
-            include_current=False,
-        ))
+        final_text = self._preview_text_for_cleanup(final_text)
+        ids: list[str] = []
+        remaining_candidates: list[tuple[list[str], str]] = []
+        for candidate_ids, preview_text in self._pending_preview_cleanup_candidates:
+            if preview_text and final_text.startswith(preview_text):
+                for message_id in candidate_ids:
+                    if message_id not in ids:
+                        ids.append(message_id)
+            else:
+                remaining_candidates.append((candidate_ids, preview_text))
         if not ids:
             return
-        self._pending_preview_cleanup_ids = []
-        self._pending_preview_cleanup_text = ""
+        self._pending_preview_cleanup_candidates = remaining_candidates
+        self._sync_pending_preview_cleanup_mirror()
         delete_fn = getattr(self.adapter, "delete_message", None)
         if delete_fn is None:
             return
@@ -1018,6 +1067,10 @@ class GatewayStreamConsumer:
                             stale_id, e,
                         )
 
+        await self._cleanup_pending_preview_after_replay(
+            final_text,
+            current_message_id=last_message_id,
+        )
         self._message_id = last_message_id
         self._preview_message_ids = []
         self._already_sent = True
@@ -1279,6 +1332,10 @@ class GatewayStreamConsumer:
             # don't try to edit something we can't address.
             self._message_id = "__no_edit__"
             self._message_created_ts = None
+        await self._cleanup_pending_preview_after_replay(
+            text,
+            current_message_id=self._message_id,
+        )
         self._preview_message_ids = []
         self._already_sent = True
         self._last_sent_text = text

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -288,13 +288,7 @@ class GatewayStreamConsumer:
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
             return
-        if (
-            len(self._preview_message_ids) > 1
-            and self._preview_message_text
-            and not self._pending_preview_cleanup_ids
-        ):
-            self._pending_preview_cleanup_ids = list(self._preview_message_ids)
-            self._pending_preview_cleanup_text = self._preview_message_text
+        self._stage_current_preview_for_replay_cleanup()
         self._message_id = None
         self._message_created_ts = None
         self._preview_message_ids = []
@@ -852,6 +846,16 @@ class GatewayStreamConsumer:
             if message_id == "__no_edit__" or message_id in self._preview_message_ids:
                 continue
             self._preview_message_ids.append(message_id)
+
+    def _stage_current_preview_for_replay_cleanup(self) -> None:
+        """Preserve the visible preview group across a tool-boundary reset."""
+        if (
+            self._preview_message_ids
+            and self._preview_message_text
+            and not self._pending_preview_cleanup_ids
+        ):
+            self._pending_preview_cleanup_ids = list(self._preview_message_ids)
+            self._pending_preview_cleanup_text = self._preview_message_text
 
     def _stale_preview_cleanup_ids(self, current_message_id: Optional[str]) -> list[str]:
         """Return stale preview ids to delete after a replacement final send."""

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -148,6 +148,9 @@ class GatewayStreamConsumer:
         # edit into the original message plus continuation messages.  Fallback
         # cleanup must delete the whole stale preview, not just the latest id.
         self._preview_message_ids: list[str] = []
+        self._preview_message_text = ""
+        self._pending_preview_cleanup_ids: list[str] = []
+        self._pending_preview_cleanup_text = ""
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
@@ -209,6 +212,31 @@ class GatewayStreamConsumer:
         the subsequent cosmetic edit (cursor removal) failed."""
         return self._final_content_delivered
 
+    def preview_cleanup_ids_for_final(
+        self,
+        final_text: str,
+        *,
+        include_current: bool = True,
+    ) -> tuple[str, ...]:
+        """Stale preview ids safe to delete after an external final send."""
+        final_text = self._preview_text_for_cleanup(final_text)
+        if not final_text:
+            return ()
+
+        cleanup_ids: list[str] = []
+        candidates = [(self._pending_preview_cleanup_ids, self._pending_preview_cleanup_text)]
+        if include_current:
+            candidates.append((self._preview_message_ids, self._preview_message_text))
+        for ids, preview_text in candidates:
+            if not ids or not preview_text:
+                continue
+            if not final_text.startswith(preview_text):
+                continue
+            for message_id in ids:
+                if message_id not in cleanup_ids:
+                    cleanup_ids.append(message_id)
+        return tuple(cleanup_ids)
+
     async def _edit_message(
         self,
         *,
@@ -260,9 +288,17 @@ class GatewayStreamConsumer:
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
             return
+        if (
+            len(self._preview_message_ids) > 1
+            and self._preview_message_text
+            and not self._pending_preview_cleanup_ids
+        ):
+            self._pending_preview_cleanup_ids = list(self._preview_message_ids)
+            self._pending_preview_cleanup_text = self._preview_message_text
         self._message_id = None
         self._message_created_ts = None
         self._preview_message_ids = []
+        self._preview_message_text = ""
         self._accumulated = ""
         self._last_sent_text = ""
         self._fallback_final_send = False
@@ -483,7 +519,10 @@ class GatewayStreamConsumer:
                     )
 
                 current_update_visible = False
+                replay_cleanup_text = None
                 if should_edit and self._accumulated:
+                    if got_done:
+                        replay_cleanup_text = self._accumulated
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (
@@ -495,19 +534,37 @@ class GatewayStreamConsumer:
                         # helper the non-streaming path uses — to split with
                         # proper word/code-fence boundaries and chunk
                         # indicators like "(1/2)".
+                        preview_text = self._accumulated
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit, len_fn=_len_fn,
                         )
                         chunks_delivered = False
+                        delivered_chunk_ids: list[str] = []
+                        expected_chunks = [
+                            chunk for chunk in chunks
+                            if self._clean_for_display(chunk).strip()
+                        ]
                         reply_to = self._message_id or self._initial_reply_to_id
                         for chunk in chunks:
                             new_id = await self._send_new_chunk(chunk, reply_to)
                             if new_id is not None and new_id != reply_to:
                                 chunks_delivered = True
+                                delivered_chunk_ids.append(str(new_id))
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
+                        if chunks_delivered:
+                            self._remember_preview_text_for_cleanup(preview_text)
                         if got_done:
+                            final_chunks_delivered = (
+                                chunks_delivered
+                                and len(delivered_chunk_ids) == len(expected_chunks)
+                            )
+                            if final_chunks_delivered:
+                                await self._cleanup_pending_preview_after_replay(
+                                    preview_text,
+                                    current_message_id=delivered_chunk_ids[-1],
+                                )
                             # Only claim final delivery if THESE chunks actually
                             # landed.  ``_already_sent`` may be True from prior
                             # tool-progress edits or fallback-mode promotion (#10748)
@@ -517,19 +574,18 @@ class GatewayStreamConsumer:
                                 self._final_content_delivered = True
                             return
                         if got_segment_break:
-                            self._message_id = None
-                            self._preview_message_ids = []
-                            self._fallback_final_send = False
-                            self._fallback_prefix = ""
+                            self._reset_segment_state()
                         continue
 
                     # Existing message: edit it with the first chunk, then
                     # start a new message for the overflow remainder.
+                    split_preview_text = ""
                     while (
                         _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is not None
                         and self._edit_supported
                     ):
+                        preview_text = self._accumulated
                         _cp_budget = _custom_unit_to_cp(
                             self._accumulated, _safe_limit, _len_fn,
                         )
@@ -545,6 +601,7 @@ class GatewayStreamConsumer:
                             # fallback final-send path can deliver the remaining
                             # continuation without dropping content.
                             break
+                        split_preview_text = preview_text
                         self._accumulated = self._accumulated[split_at:].lstrip("\n")
                         self._message_id = None
                         self._last_sent_text = ""
@@ -567,6 +624,12 @@ class GatewayStreamConsumer:
                         is_turn_final=got_done,
                     )
                     self._last_edit_time = time.monotonic()
+                    if (
+                        split_preview_text
+                        and current_update_visible
+                        and len(self._preview_message_ids) > 1
+                    ):
+                        self._remember_preview_text_for_cleanup(split_preview_text)
 
                 if got_done:
                     # Final edit without cursor. If progressive editing failed
@@ -574,6 +637,7 @@ class GatewayStreamConsumer:
                     # here instead of letting the base gateway path send the
                     # full response again.
                     if self._accumulated:
+                        cleanup_pending_preview = False
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
                         elif (
@@ -586,6 +650,7 @@ class GatewayStreamConsumer:
                             # need an explicit finalize signal.
                             self._final_response_sent = True
                             self._final_content_delivered = True
+                            cleanup_pending_preview = True
                         elif self._message_id:
                             # Either the mid-stream edit didn't run (no
                             # visible update this tick) OR the adapter needs
@@ -595,10 +660,17 @@ class GatewayStreamConsumer:
                             )
                             if self._final_response_sent:
                                 self._final_content_delivered = True
+                                cleanup_pending_preview = True
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                             if self._final_response_sent:
                                 self._final_content_delivered = True
+                                cleanup_pending_preview = True
+                        if cleanup_pending_preview:
+                            await self._cleanup_pending_preview_after_replay(
+                                replay_cleanup_text or self._accumulated,
+                                current_message_id=self._message_id,
+                            )
                     return
 
                 if commentary_text is not None:
@@ -690,6 +762,19 @@ class GatewayStreamConsumer:
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
 
+    def _preview_text_for_cleanup(self, text: str) -> str:
+        text = self._clean_for_display(text)
+        if self.cfg.cursor and text.endswith(self.cfg.cursor):
+            text = text[:-len(self.cfg.cursor)]
+        return text.rstrip()
+
+    def _remember_preview_text_for_cleanup(self, text: str) -> None:
+        text = self._preview_text_for_cleanup(text)
+        if not text:
+            return
+        if not self._preview_message_text or len(text) > len(self._preview_message_text):
+            self._preview_message_text = text
+
     async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
         """Send a new message chunk, optionally threaded to a previous message.
 
@@ -709,6 +794,7 @@ class GatewayStreamConsumer:
             if result.success and result.message_id:
                 self._message_id = str(result.message_id)
                 self._remember_preview_message_ids(result.message_id)
+                self._remember_preview_text_for_cleanup(text)
                 self._already_sent = True
                 self._last_sent_text = text
                 # Fresh content bubble — close off any stale tool bubble
@@ -775,6 +861,33 @@ class GatewayStreamConsumer:
             if current_message_id not in ids:
                 ids.append(current_message_id)
         return ids
+
+    async def _cleanup_pending_preview_after_replay(
+        self,
+        final_text: str,
+        *,
+        current_message_id: Optional[str],
+    ) -> None:
+        """Delete a prior overflow preview only after a matching replay lands."""
+        ids = list(self.preview_cleanup_ids_for_final(
+            final_text,
+            include_current=False,
+        ))
+        if not ids:
+            return
+        self._pending_preview_cleanup_ids = []
+        self._pending_preview_cleanup_text = ""
+        delete_fn = getattr(self.adapter, "delete_message", None)
+        if delete_fn is None:
+            return
+        current_id = str(current_message_id) if current_message_id else None
+        for message_id in ids:
+            if message_id == current_id:
+                continue
+            try:
+                await delete_fn(self.chat_id, message_id)
+            except Exception:
+                pass
 
     async def _send_fallback_final(self, text: str) -> None:
         """Send the final continuation after streaming edits stop working.
@@ -1021,13 +1134,21 @@ class GatewayStreamConsumer:
         if not tail.strip():
             return
         try:
-            result = await self.adapter.send(
-                chat_id=self.chat_id,
-                content=tail,
-                metadata=self.metadata,
+            raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+            _len_fn: "Callable[[str], int]" = (
+                self.adapter.message_len_fn
+                if isinstance(self.adapter, _BasePlatformAdapter)
+                else len
             )
-            if result.success:
-                self._already_sent = True
+            safe_limit = max(500, raw_limit - 100)
+            for chunk in self._split_text_chunks(tail, safe_limit, len_fn=_len_fn):
+                new_id = await self._send_new_chunk(chunk, None)
+                if not new_id:
+                    break
+                # If a later tail chunk hits flood-control and the stream task is
+                # cancelled, the ids already sent must still be eligible for the
+                # base final replay cleanup.
+                self._remember_preview_text_for_cleanup(self._accumulated)
         except Exception as e:
             logger.error("Segment-break tail flush error: %s", e)
 
@@ -1297,6 +1418,7 @@ class GatewayStreamConsumer:
                             self._notify_new_message()
                         else:
                             self._last_sent_text = text
+                        self._remember_preview_text_for_cleanup(text)
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0
                         return True
@@ -1356,6 +1478,7 @@ class GatewayStreamConsumer:
                     if result.message_id:
                         self._message_id = result.message_id
                         self._remember_preview_message_ids(result.message_id)
+                        self._remember_preview_text_for_cleanup(text)
                         # Track when the preview first became visible to
                         # the user so fresh-final logic can detect stale
                         # preview timestamps on long-running responses.

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -403,6 +403,73 @@ async def test_delivery_cleanup_reply_deletes_after_successful_final_send():
     ]
 
 
+def test_stream_preview_cleanup_ids_wrap_final_response():
+    gateway_run = importlib.import_module("gateway.run")
+
+    wrapped = gateway_run._wrap_stream_preview_cleanup_reply(
+        "complete final answer",
+        {
+            "stream_preview_cleanup_ids": ("old_preview_1", "old_preview_2"),
+            "already_sent": False,
+        },
+    )
+
+    assert isinstance(wrapped, DeliveryCleanupReply)
+    assert str(wrapped) == "complete final answer"
+    assert wrapped.cleanup_message_ids == ("old_preview_1", "old_preview_2")
+
+
+def test_stream_preview_cleanup_ids_do_not_wrap_already_sent_response():
+    gateway_run = importlib.import_module("gateway.run")
+
+    wrapped = gateway_run._wrap_stream_preview_cleanup_reply(
+        "complete final answer",
+        {
+            "stream_preview_cleanup_ids": ("old_preview_1",),
+            "already_sent": True,
+        },
+    )
+
+    assert wrapped == "complete final answer"
+    assert not isinstance(wrapped, DeliveryCleanupReply)
+
+
+@pytest.mark.asyncio
+async def test_delivery_cleanup_reply_continues_after_delete_failure():
+    adapter = CleanupCaptureAdapter()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    event = MessageEvent(
+        text="prompt",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="user_msg",
+    )
+    session_key = "agent:main:telegram:group:-1001"
+    delete_attempts = []
+
+    async def flaky_delete(chat_id, message_id):
+        delete_attempts.append({"chat_id": chat_id, "message_id": str(message_id)})
+        if message_id == "old_preview_1":
+            raise RuntimeError("delete flood-control")
+        return True
+
+    async def handler(_event):
+        return DeliveryCleanupReply(
+            "complete final answer",
+            cleanup_message_ids=("old_preview_1", "old_preview_2"),
+        )
+
+    adapter.delete_message = flaky_delete
+    adapter.set_message_handler(handler)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert [entry["message_id"] for entry in delete_attempts] == [
+        "old_preview_1",
+        "old_preview_2",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_delivery_cleanup_reply_keeps_preview_when_final_send_fails():
     adapter = CleanupCaptureAdapter()

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -20,7 +20,13 @@ from types import SimpleNamespace
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    DeliveryCleanupReply,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
 from gateway.session import SessionSource
 
 
@@ -365,3 +371,62 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     # deletes at least one progress bubble.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1
+
+
+@pytest.mark.asyncio
+async def test_delivery_cleanup_reply_deletes_after_successful_final_send():
+    """Stale stream previews are deleted only after the fallback final lands."""
+    adapter = CleanupCaptureAdapter()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    event = MessageEvent(
+        text="prompt",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="user_msg",
+    )
+    session_key = "agent:main:telegram:group:-1001"
+
+    async def handler(_event):
+        return DeliveryCleanupReply(
+            "complete final answer",
+            cleanup_message_ids=("old_preview_1", "old_preview_2"),
+        )
+
+    adapter.set_message_handler(handler)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert [entry["content"] for entry in adapter.sent] == ["complete final answer"]
+    assert [entry["message_id"] for entry in adapter.deleted] == [
+        "old_preview_1",
+        "old_preview_2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delivery_cleanup_reply_keeps_preview_when_final_send_fails():
+    adapter = CleanupCaptureAdapter()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    event = MessageEvent(
+        text="prompt",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="user_msg",
+    )
+    session_key = "agent:main:telegram:group:-1001"
+
+    async def handler(_event):
+        return DeliveryCleanupReply(
+            "complete final answer",
+            cleanup_message_ids=("old_preview_1",),
+        )
+
+    async def failed_send(**_kwargs):
+        return SendResult(success=False, error="network down")
+
+    adapter.set_message_handler(handler)
+    adapter._send_with_retry = failed_send
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.deleted == []

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -821,6 +821,77 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer._final_response_sent is True
 
     @pytest.mark.asyncio
+    async def test_fallback_final_deletes_all_overflow_preview_messages(self):
+        """Telegram overflow edits can turn one preview into several messages.
+
+        When a later flood-control fallback sends the complete final answer as
+        a fresh message, every stale preview message must be cleaned up — not
+        just the last continuation id (#16668 / #23416 follow-up).
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_final"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.delete_message = AsyncMock(return_value=None)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Seed the consumer as if TelegramAdapter.edit_message split an
+        # oversized streaming edit across the original message and two
+        # continuation messages, then the stream got stuck on the last id.
+        consumer._message_id = "msg_continuation_2"
+        consumer._preview_message_ids = [
+            "msg_initial",
+            "msg_continuation_1",
+            "msg_continuation_2",
+        ]
+        consumer._last_sent_text = ""
+
+        await consumer._send_fallback_final("Complete final answer")
+
+        assert [
+            call.args for call in adapter.delete_message.await_args_list
+        ] == [
+            ("chat_123", "msg_initial"),
+            ("chat_123", "msg_continuation_1"),
+            ("chat_123", "msg_continuation_2"),
+        ]
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_segment_break_after_first_message_overflow_clears_preview_ids(self):
+        """Overflow ids from a finalized pre-tool segment must not leak into
+        the next segment's cleanup set."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_pre_1"),
+            SimpleNamespace(success=True, message_id="msg_pre_2"),
+            SimpleNamespace(success=True, message_id="msg_final"),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.truncate_message = MagicMock(
+            return_value=["pre tool chunk 1", "pre tool chunk 2"],
+        )
+        adapter.MAX_MESSAGE_LENGTH = 610
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("x" * 620)
+        consumer.on_delta(None)
+        consumer.on_delta("Final answer")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert consumer._preview_message_ids == ["msg_final"]
+
+    @pytest.mark.asyncio
     async def test_fallback_final_does_not_delete_when_no_chunks_reach_user(self):
         """If every fallback send fails, the partial is the only thing the
         user has — must NOT be deleted."""
@@ -1109,6 +1180,11 @@ class TestEditOverflowSplitAndDeliver:
         assert ok is True
         # Consumer advanced to the latest continuation id.
         assert consumer._message_id == "msg_continuation_2"
+        assert consumer._preview_message_ids == [
+            "msg_initial",
+            "msg_continuation_1",
+            "msg_continuation_2",
+        ]
         # Skip-if-same cache reset so the next edit doesn't false-positive.
         assert consumer._last_sent_text == ""
         # on_new_message fired so the tool-progress bubble breaks below
@@ -1907,4 +1983,3 @@ class TestUtf16OverflowDetection:
         # auto-attr mock. Verified indirectly by all the other tests in
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
-

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1005,6 +1005,35 @@ class TestSegmentBreakOnToolBoundary:
             pass
 
     @pytest.mark.asyncio
+    async def test_multiple_pending_previews_survive_for_base_final_replay(self):
+        """Several tool-boundary previews can all be stale after final replay."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_new"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        first_preview = "Answer start\n"
+        second_preview = "Answer start\nMore streamed rows\n"
+        final_replay = second_preview + "Final status: tool boundary reached"
+
+        consumer._preview_message_ids = ["msg_first"]
+        consumer._preview_message_text = first_preview
+        consumer._reset_segment_state()
+
+        consumer._preview_message_ids = ["msg_second_1", "msg_second_2"]
+        consumer._preview_message_text = second_preview
+        consumer._reset_segment_state()
+
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == (
+            "msg_first",
+            "msg_second_1",
+            "msg_second_2",
+        )
+
+    @pytest.mark.asyncio
     async def test_segment_tail_flush_ids_survive_for_base_final_replay(self):
         send_count = 0
 

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -892,6 +892,157 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer._preview_message_ids == ["msg_final"]
 
     @pytest.mark.asyncio
+    async def test_overflow_preview_cleanup_ids_survive_for_base_final_replay(self):
+        """Base final send can clean previews if stream finalization times out."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_pre_1"),
+            SimpleNamespace(success=True, message_id="msg_pre_2"),
+            SimpleNamespace(success=True, message_id="msg_final_partial"),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit, **kw: [text[:limit], text[limit:]],
+        )
+        adapter.MAX_MESSAGE_LENGTH = 610
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        pre_tool_preview = "".join(
+            f"Preview row {idx:02d} - status: _streaming_\n"
+            for idx in range(1, 19)
+        )
+        final_replay = pre_tool_preview + "\nFinal answer tail"
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(pre_tool_preview)
+        consumer.on_delta(None)
+        for _ in range(20):
+            if consumer._pending_preview_cleanup_ids:
+                break
+            await asyncio.sleep(0.02)
+
+        consumer.on_delta(final_replay[:80])
+        for _ in range(20):
+            if consumer._preview_message_ids == ["msg_final_partial"]:
+                break
+            await asyncio.sleep(0.02)
+
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == (
+            "msg_pre_1",
+            "msg_pre_2",
+            "msg_final_partial",
+        )
+        assert consumer.preview_cleanup_ids_for_final("Different final") == ()
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == (
+            "msg_pre_1",
+            "msg_pre_2",
+            "msg_final_partial",
+        )
+
+    @pytest.mark.asyncio
+    async def test_segment_tail_flush_ids_survive_for_base_final_replay(self):
+        send_count = 0
+
+        async def send_tail_chunk(**_kwargs):
+            nonlocal send_count
+            send_count += 1
+            return SimpleNamespace(success=True, message_id=f"msg_tail_{send_count}")
+
+        adapter = MagicMock()
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.send = AsyncMock(side_effect=send_tail_chunk)
+        adapter.MAX_MESSAGE_LENGTH = 610
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        visible_prefix = "\n".join(
+            f"{idx}. Preview row {idx} - status: streaming"
+            for idx in range(1, 47)
+        )
+        unsent_tail = "\n".join(
+            f"{idx}. Preview row {idx} - status: streaming"
+            for idx in range(47, 91)
+        )
+        preview_text = f"{visible_prefix}\n{unsent_tail}"
+        final_replay = preview_text + "\nFinal status: tool boundary reached"
+
+        consumer._message_id = "msg_prefix"
+        consumer._preview_message_ids = ["msg_prefix"]
+        consumer._last_sent_text = visible_prefix + config.cursor
+        consumer._preview_message_text = visible_prefix
+        consumer._accumulated = preview_text
+
+        await consumer._flush_segment_tail_on_edit_failure()
+        consumer._reset_segment_state()
+
+        expected_ids = ("msg_prefix",) + tuple(
+            f"msg_tail_{idx}" for idx in range(1, send_count + 1)
+        )
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == expected_ids
+        assert consumer.preview_cleanup_ids_for_final("Different final") == ()
+
+    @pytest.mark.asyncio
+    async def test_segment_tail_flush_keeps_landed_ids_when_cancelled_mid_flush(self):
+        send_count = 0
+
+        async def send_tail_chunk(**_kwargs):
+            nonlocal send_count
+            send_count += 1
+            if send_count == 1:
+                return SimpleNamespace(success=True, message_id="msg_tail_1")
+            await asyncio.sleep(60)
+
+        adapter = MagicMock()
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.send = AsyncMock(side_effect=send_tail_chunk)
+        adapter.MAX_MESSAGE_LENGTH = 610
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        visible_prefix = "Preview row 1 - status: streaming"
+        unsent_tail = "\n".join(
+            f"Preview row {idx} - status: streaming"
+            for idx in range(2, 40)
+        )
+        preview_text = f"{visible_prefix}\n{unsent_tail}"
+        final_replay = preview_text + "\nFinal status: tool boundary reached"
+
+        consumer._message_id = "msg_prefix"
+        consumer._preview_message_ids = ["msg_prefix"]
+        consumer._last_sent_text = visible_prefix + config.cursor
+        consumer._preview_message_text = visible_prefix
+        consumer._accumulated = preview_text
+
+        task = asyncio.create_task(consumer._flush_segment_tail_on_edit_failure())
+        for _ in range(20):
+            if "msg_tail_1" in consumer._preview_message_ids:
+                break
+            await asyncio.sleep(0.02)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        consumer._reset_segment_state()
+
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == (
+            "msg_prefix",
+            "msg_tail_1",
+        )
+
+    @pytest.mark.asyncio
     async def test_fallback_final_does_not_delete_when_no_chunks_reach_user(self):
         """If every fallback send fails, the partial is the only thing the
         user has — must NOT be deleted."""
@@ -1190,6 +1341,44 @@ class TestEditOverflowSplitAndDeliver:
         # on_new_message fired so the tool-progress bubble breaks below
         # the new continuation (per the openclaw #32535 lesson).
         assert new_msg_count[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_split_and_deliver_cleanup_ids_survive_segment_boundary(self):
+        adapter = MagicMock()
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True,
+            message_id="msg_continuation_2",
+            continuation_message_ids=("msg_continuation_1", "msg_continuation_2"),
+        ))
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_initial"),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_999", config)
+        consumer._message_id = "msg_initial"
+        consumer._already_sent = True
+
+        preview_text = (
+            "## Telegram duplicate cleanup check\n\n"
+            "1. Preview row 1 - status: streaming\n"
+            "2. Preview row 2 - status: streaming\n"
+        )
+        final_replay = preview_text + "\nFinal status: tool boundary reached"
+
+        assert await consumer._send_or_edit(preview_text) is True
+
+        consumer._reset_segment_state()
+
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == (
+            "msg_initial",
+            "msg_continuation_1",
+            "msg_continuation_2",
+        )
+        assert consumer.preview_cleanup_ids_for_final("Different final") == ()
 
 
 class TestInterimCommentaryMessages:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -949,6 +949,62 @@ class TestSegmentBreakOnToolBoundary:
         )
 
     @pytest.mark.asyncio
+    async def test_single_preview_cleanup_id_survives_for_base_final_replay(self):
+        """A one-message preview before a tool boundary can still be stale.
+
+        Live Telegram can show one long edited preview, hit a tool boundary,
+        then have the model replay that same final answer from the beginning.
+        If the stream task is later cancelled or flood-controlled, the base
+        final-send path must still know the old preview id to delete after the
+        replacement final lands.
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_old_preview"),
+            SimpleNamespace(success=True, message_id="msg_new_partial"),
+        ])
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        preview_text = (
+            "## Telegram duplicate cleanup check\n\n"
+            + "".join(
+                f"{idx}. Preview row {idx} - status: streaming\n"
+                for idx in range(1, 12)
+            )
+        )
+        final_replay = preview_text + "\nFinal status: tool boundary reached"
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(preview_text)
+        consumer.on_delta(None)
+        for _ in range(20):
+            if consumer._pending_preview_cleanup_ids:
+                break
+            await asyncio.sleep(0.02)
+
+        consumer.on_delta(final_replay[:120])
+        for _ in range(20):
+            if consumer._preview_message_ids == ["msg_new_partial"]:
+                break
+            await asyncio.sleep(0.02)
+
+        assert consumer.preview_cleanup_ids_for_final(final_replay) == (
+            "msg_old_preview",
+            "msg_new_partial",
+        )
+        assert consumer.preview_cleanup_ids_for_final("Different final") == ()
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
     async def test_segment_tail_flush_ids_survive_for_base_final_replay(self):
         send_count = 0
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -10,6 +10,7 @@ avoid retrying with a partial topic route that can render outside the lane.
 
 import sys
 import types
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -1412,3 +1413,37 @@ async def test_send_retries_retry_after_errors():
     assert result.success is True
     assert result.message_id == "300"
     assert attempt[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_message_retries_retry_after_as_background_cleanup(monkeypatch):
+    """Stale preview cleanup must survive Telegram delete flood-control."""
+    adapter = _make_adapter()
+    adapter._background_tasks = set()
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("gateway.platforms.telegram.asyncio.sleep", fake_sleep)
+
+    attempts = []
+
+    async def mock_delete_message(**kwargs):
+        attempts.append(kwargs["message_id"])
+        if len(attempts) == 1:
+            raise FakeRetryAfter(0.25)
+        return True
+
+    adapter._bot = SimpleNamespace(delete_message=mock_delete_message)
+
+    deleted_now = await adapter.delete_message("123", "456")
+
+    assert deleted_now is False
+    assert len(adapter._background_tasks) == 1
+
+    await asyncio.gather(*list(adapter._background_tasks))
+
+    assert sleeps == [0.25]
+    assert attempts == [456, 456]


### PR DESCRIPTION
## Summary

Impact: user-visible stale Telegram streaming partials can remain above the final answer after overflow-edit fallback.

Telegram streaming previews can become more than one visible message when an oversized `edit_message` is split across the original message plus continuation messages. If a later edit/flood-control failure makes the stream consumer fall back to sending the complete final answer as a fresh message, the cleanup added in #23416 only deletes the latest `_message_id`. Earlier overflow preview chunks remain visible as stale partials above the final answer.

This tracks every platform message id that belongs to the current streaming preview and uses that full set for fallback/fresh-final cleanup.

## Root cause

`TelegramAdapter.edit_message()` returns `continuation_message_ids` when it split-delivers an oversized edit. The stream consumer correctly advances `_message_id` to the last continuation, but it loses the earlier ids. `_send_fallback_final()` therefore only best-effort deletes the last continuation, leaving the original large partial message behind.

## Changes

- Track all message ids that make up the current streaming preview.
- Clear that tracking when a stream segment resets, including first-message overflow at a tool boundary.
- Clear that tracking when a replacement final succeeds.
- Delete every stale preview id during fallback-final and fresh-final cleanup.
- Add regression coverage for the overflow-preview case and the segment-boundary reset edge case.
- Assert the existing overflow path records the ids automatically.

## Validation

- First reproduced the bug with the new regression test: current code only deleted `msg_continuation_2`, leaving `msg_initial` and `msg_continuation_1`.
- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py -- -q -k 'fallback_final_deletes_all_overflow_preview_messages or segment_break_after_first_message_overflow_clears_preview_ids or consumer_advances_message_id_on_split_and_deliver'`
- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_progress_edit_transient.py -- -q`
- `uv run ruff check gateway/stream_consumer.py tests/gateway/test_stream_consumer.py`
- `git diff --check`

Follow-up to #23416.
