### PR TITLE
fix(tui): render markdown fences as code

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -245,6 +245,25 @@ describe('Md wrapping', () => {
     expect(rendered).toContain('if __name__ == "__main__":')
     expect(rendered).toContain('obj.__init__()')
   })
+
+  it('renders markdown-labeled fences as literal code blocks', () => {
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { width: 80 },
+        React.createElement(Md, {
+          t: DEFAULT_THEME,
+          text: ['```markdown', '# Title', '', '```python', 'print("hi")', '```', '```'].join('\n')
+        })
+      )
+    )
+
+    const rendered = lines.join('\n')
+
+    expect(rendered).toContain('# Title')
+    expect(rendered).toContain('```python')
+    expect(rendered).toContain('print("hi")')
+  })
 })
 
 describe('Md link labels', () => {

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -738,13 +738,6 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
           i++
         }
 
-        if (['md', 'markdown'].includes(lang)) {
-          start('paragraph')
-          nodes.push(<Md cols={cols} compact={compact} key={key} t={t} text={block.join('\n')} />)
-
-          continue
-        }
-
         start('code')
 
         const isDiff = lang === 'diff'


### PR DESCRIPTION
## Summary
- Render ```markdown``` / ```md``` fences as literal code blocks instead of recursively rendering their contents as markdown
- Preserve nested code fences inside markdown examples
- Add a regression test for markdown-labeled code fences

## Test Plan
- npm run build --prefix packages/hermes-ink
- npm test -- src/__tests__/markdown.test.ts
- npm run build