### PR TITLE
test(honcho): de-flake prewarm smoke test's thread wait

### DIFF
--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,5 +1,7 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
+import time
+
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -1538,8 +1540,27 @@ class TestDialecticLifecycleSmoke:
             return provider, mock_manager, cfg
 
     def _await_thread(self, provider):
-        if provider._prefetch_thread:
-            provider._prefetch_thread.join(timeout=3.0)
+        """Block until the in-flight prefetch/prewarm thread has fully finished.
+
+        The earlier version did a single ``join(timeout=3.0)`` and then
+        proceeded regardless of whether the thread had actually finished. On a
+        loaded CI runner (6 parallel test slices), the background dialectic
+        thread's completion can slip past that 3s window, so the join times out
+        silently and the test reads ``_prefetch_result`` before the worker wrote
+        it — a flaky ``session-start prewarm must land`` failure. We instead join
+        in a loop up to a generous ceiling and assert the thread is dead, so a
+        genuine hang surfaces as a clear, non-flaky failure instead of a race.
+        """
+        thread = provider._prefetch_thread
+        if thread is None:
+            return
+        deadline = time.monotonic() + 30.0
+        while thread.is_alive() and time.monotonic() < deadline:
+            thread.join(timeout=1.0)
+        assert not thread.is_alive(), (
+            "prefetch/prewarm thread did not finish within 30s — "
+            "this is a real hang, not a timing flake"
+        )
 
     def test_full_multi_turn_session(self):
         """Walks init → turns 1..8 → session end. Asserts at every step that


### PR DESCRIPTION
## Summary
De-flakes `TestDialecticLifecycleSmoke::test_full_multi_turn_session`, the intermittent `session-start prewarm must land in _prefetch_result` CI failure.

Root cause: the test helper `_await_thread` did a single `join(timeout=3.0)` and then proceeded **regardless of whether the background dialectic thread had finished**. On a loaded CI runner (6 parallel test slices) the prewarm thread's completion can slip past that 3s window, so the join times out silently and the test reads `_prefetch_result` before the worker wrote it.

## Changes
- `tests/honcho_plugin/test_session.py`: `_await_thread` now joins in a loop up to a 30s ceiling and asserts the thread is actually dead — a genuine hang surfaces as a clear failure instead of a timing race. Added `import time`.

## Validation
Reproduced the old failure deterministically by delaying the mocked prewarm past the 3s join window, then confirmed the fix:

| | 3.5s prewarm delay | instant |
|---|---|---|
| old single `join(timeout=3.0)` | 5/5 fail | 0/20 |
| new join-loop + assert | 0/8 | 0/20 |

`tests/honcho_plugin/test_session.py` 118/118 passing.

## Infographic

![de-flake-honcho-prewarm-test](https://v3b.fal.media/files/b/0a9cb86b/9Ft5QOI96-0idlIXjL-B1_PlIVbzw1.png)
