### PR TITLE
feat: add ClawTeam plugin

### DIFF
--- a/plugins/clawteam/PROMPT-TEMPLATE.md
+++ b/plugins/clawteam/PROMPT-TEMPLATE.md
@@ -1,0 +1,100 @@
+# Hermes-driven issue resolution prompt
+
+Template for driving any single GitHub issue end-to-end (read → implement → self-QA → PR) through a `hermes -z --yolo` one-shot, with **dual-team clawteam coordination** for an audit trail.
+
+## Architecture
+
+Two clawteams per run:
+
+| Team | Purpose | Lifetime |
+|---|---|---|
+| `issue-NN-fix` | Implementation audit trail — one milestone message per step | Per-issue (created at start) |
+| `qa-validation` | Cross-issue QA verdicts — one verdict per issue | Long-lived (created once, reused) |
+
+Hermes plays both implementer and reviewer:
+1. **IMPLEMENT** — make the code change, log each step to `issue-NN-fix`
+2. **QA** — re-read the diff, check acceptance criteria, post PASS/FAIL verdict to `qa-validation`
+3. **SHIP** — only on PASS, push branch + open PR
+4. **RETRY** — on FAIL, return to step 2 (max 2 retries) before giving up
+
+The QA verdict gates the PR. No push without an explicit `PASS`.
+
+## Template (fill in the `{{…}}` placeholders)
+
+```text
+You are completing {{REPO}} issue #{{ISSUE_NUMBER}} in {{REPO_DIR}}.
+
+DUAL-TEAM DOGFOODING — process validation is mandatory:
+
+Setup:
+1. Call clawteam_team_discover. If "qa-validation" is NOT in the list,
+   call clawteam_team_spawn name="qa-validation"
+   description="Cross-issue QA verdicts".
+2. Call clawteam_team_spawn name="issue-{{ISSUE_NUMBER}}-fix"
+   description="Hermes-driven fix for #{{ISSUE_NUMBER}} {{ISSUE_TITLE_SHORT}}".
+
+Issue #{{ISSUE_NUMBER}} ({{ISSUE_TITLE}}):
+{{ISSUE_BODY_SUMMARY}}
+
+Environment:
+- Branch: {{BRANCH_NAME}}
+- {{ENV_NOTES}}
+- DO NOT push to main. DO NOT force-push. DO NOT --no-verify.
+
+Process (call clawteam_inbox_send after each step, to the right team):
+
+A. IMPLEMENT phase — to team="issue-{{ISSUE_NUMBER}}-fix" from="hermes":
+   1. Read {{TARGET_FILES}}; identify the exact change locus.
+   2. Apply the fix.
+   3. Run {{TEST_COMMANDS}}.
+   4. Commit on branch {{BRANCH_NAME}} with Closes #{{ISSUE_NUMBER}}.
+
+B. QA phase — VERDICT to team="qa-validation" to="leader" from="hermes":
+   5. Self-review the diff against the acceptance criteria.
+   6. Post a verdict — exact format:
+        "Issue #{{ISSUE_NUMBER}} QA verdict: PASS|FAIL.
+         Checked: <bullets>. Findings: <list or none>.
+         Diff size: +X/-Y lines."
+
+C. SHIP phase — only if verdict=PASS:
+   7. Push branch; open PR with a body that quotes the QA verdict.
+   8. Final clawteam_inbox_send to team="issue-{{ISSUE_NUMBER}}-fix":
+        "Shipped PR <url>".
+
+If verdict=FAIL in step 6: return to step 2 (max 2 retries). After
+2 retries still failing, post final FAIL to qa-validation and stop.
+
+End with exactly one of:
+  ISSUE_{{ISSUE_NUMBER}}_HERMES: PASS  url=<pr-url>
+  ISSUE_{{ISSUE_NUMBER}}_HERMES: FAIL: <one-line reason>
+```
+
+## Why two teams
+
+- **`issue-NN-fix` (per-issue)** lets you peek a single fix's audit trail in isolation. Each `clawteam_inbox_send` here is a build-log entry.
+- **`qa-validation` (shared)** accumulates verdicts across many issues. After a batch run you can `clawteam inbox peek qa-validation --agent leader` and see every PASS/FAIL with findings — one screen.
+
+## Verification
+
+After a run, both should be true:
+
+```bash
+clawteam inbox peek issue-NN-fix --agent leader     # 7+ build-log messages, last one quotes PR URL
+clawteam inbox peek qa-validation --agent leader    # one verdict line per issue this batch
+gh pr view <NN-PR> --json state,mergeable           # OPEN + MERGEABLE if QA passed
+```
+
+## Cleaning up
+
+The dev teams are throwaway:
+
+```bash
+clawteam team cleanup issue-NN-fix --force
+```
+
+Keep `qa-validation` — it's the long-running review history.
+
+## See also
+
+- `scripts/run-hermes-issue.sh` — driver that fills in this template per issue
+- README "Hermes ClawTeam plugin" section for setup/install

--- a/plugins/clawteam/__init__.py
+++ b/plugins/clawteam/__init__.py
@@ -1,0 +1,29 @@
+"""Hermes plugin: ClawTeam.
+
+Two surfaces share the same CLI driver:
+  - dashboard/plugin_api.py — FastAPI router for the UI tab
+  - tools.py + register(ctx) below — agent-facing tools the LLM can call
+
+Shared helper: _clawteam_cli.py (binary discovery, name validation,
+subprocess invocation, JSON parsing, structured errors).
+"""
+
+from __future__ import annotations
+
+from . import tools as _tools
+
+
+def register(ctx) -> None:
+    """Register all ClawTeam tools with the Hermes plugin context.
+
+    Called once by the plugin loader when this plugin is enabled.
+    """
+    for name, schema, handler in _tools.TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="clawteam",
+            schema=schema,
+            handler=handler,
+            check_fn=_tools.check_clawteam_available,
+            emoji="🤝",
+        )

--- a/plugins/clawteam/_clawteam_cli.py
+++ b/plugins/clawteam/_clawteam_cli.py
@@ -1,0 +1,126 @@
+"""Shared helper for running the `clawteam` CLI from this plugin.
+
+Used by both the dashboard FastAPI handlers (plugin_api.py) and the
+agent-facing tools (tools.py). Single source of truth for binary
+discovery, name validation, timeout, and JSON parsing so the two
+surfaces cannot drift.
+
+No FastAPI imports here — handlers/tools wrap CliError into their own
+error shapes (HTTPException for FastAPI, tool_error JSON for tools).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+CLAWTEAM_BIN = os.environ.get("CLAWTEAM_BIN") or shutil.which("clawteam") or "clawteam"
+
+# Matches clawteam's own validate_identifier rules: "only letters, digits,
+# '.', '_' and '-' are allowed". First char cannot be '-' so the CLI never
+# parses a slipped-through name as an option flag. Earlier this regex also
+# allowed '/' and ':' but clawteam rejects those — so they would pass our
+# guard and surface as a 500 from the CLI (Codex PR #18 review finding).
+_NAME_RE = re.compile(r"^[A-Za-z0-9_.][A-Za-z0-9_.\-]*$")
+
+
+class CliError(Exception):
+    """Raised when the clawteam CLI fails or returns unusable output."""
+
+    def __init__(self, message: str, *, status_code: int = 500):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def check_clawteam_available() -> bool:
+    """True iff a clawteam binary is reachable. Cached by Hermes registry."""
+    return bool(shutil.which(CLAWTEAM_BIN) or os.path.isfile(CLAWTEAM_BIN))
+
+
+def require_str(value: Any, *, field: str) -> str:
+    """Require a non-empty string; reject None/non-string/empty/whitespace.
+
+    Use BEFORE validate_name on tool args — `args.get(k)` returns None when
+    the LLM omits the key, and `str(None)` -> "None" passes validate_name
+    (a 4-letter alpha name) but is obviously wrong. This guard short-circuits
+    that class of bug (Codex PR #18 review finding).
+    """
+    if value is None:
+        raise CliError(f"Missing required argument: {field}", status_code=400)
+    if not isinstance(value, str):
+        raise CliError(
+            f"Invalid {field}: expected string, got {type(value).__name__}",
+            status_code=400,
+        )
+    stripped = value.strip()
+    if not stripped:
+        raise CliError(f"Empty {field} not allowed", status_code=400)
+    return stripped
+
+
+def validate_name(name: str, *, field: str = "name") -> str:
+    """Reject names clawteam itself would reject + leading dash for CLI safety."""
+    if not isinstance(name, str) or not _NAME_RE.match(name):
+        raise CliError(
+            f"Invalid {field}: {name!r}. Allowed: letters, digits, '.', '_', '-' "
+            f"(first char must not be '-').",
+            status_code=400,
+        )
+    return name
+
+
+def run_clawteam_json(*args: str, timeout: float = 15.0) -> Any:
+    """Run `clawteam --json <args...>` and return parsed JSON.
+
+    Argv as a list (no shell). Surfaces both stderr AND stdout on
+    non-zero exit (clawteam sometimes emits structured JSON errors
+    on stdout).
+    """
+    cmd = [CLAWTEAM_BIN, "--json", *args]
+    log.debug("clawteam cmd: %s", cmd)
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv list, no shell
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        raise CliError(
+            f"clawteam binary not found at {CLAWTEAM_BIN!r}. "
+            f"Install with apps/molt-factory/scripts/install-clawteam.sh "
+            f"or set CLAWTEAM_BIN.",
+            status_code=503,
+        )
+    except subprocess.TimeoutExpired:
+        raise CliError(
+            f"clawteam {' '.join(args)} timed out after {timeout}s",
+            status_code=504,
+        )
+
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip()
+        out = (proc.stdout or "").strip()
+        joined = " | ".join(s for s in (err, out) if s) or "(no output)"
+        raise CliError(
+            f"clawteam {' '.join(args)} failed (exit {proc.returncode}): {joined}",
+            status_code=500,
+        )
+    text = proc.stdout.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise CliError(
+            f"clawteam {' '.join(args)} returned non-JSON: {exc}",
+            status_code=500,
+        )

--- a/plugins/clawteam/dashboard/dist/index.js
+++ b/plugins/clawteam/dashboard/dist/index.js
@@ -1,0 +1,151 @@
+/**
+ * ClawTeam — Hermes Dashboard Plugin
+ *
+ * Lists teams discovered via `clawteam team discover` and lets the operator
+ * drill into one for member + recent-activity status. Plain IIFE, no build
+ * step. Uses window.__HERMES_PLUGIN_SDK__ for React + DS primitives, and
+ * SDK.fetchJSON for auth-aware, base-path-aware HTTP.
+ */
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const REG = window.__HERMES_PLUGINS__;
+  if (!SDK || !REG) {
+    console.error("[clawteam] Hermes plugin SDK or registry not available on window");
+    return;
+  }
+
+  const { React, fetchJSON } = SDK;
+  const h = React.createElement;
+  const { Card, CardContent, Button, Badge } = SDK.components;
+  const { useState, useEffect, useCallback } = SDK.hooks;
+
+  const API_BASE = "/api/plugins/clawteam";
+
+  function fetchJson(path) {
+    return fetchJSON(API_BASE + path);
+  }
+
+  function TeamRow(props) {
+    const { team, selected, onSelect } = props;
+    const name = (team && (team.name || team.team_name)) || String(team);
+    const leader = team && (team.leader || team.leader_agent);
+    return h(
+      "div",
+      {
+        className: "ct-row" + (selected ? " ct-row-selected" : ""),
+        onClick: function () { onSelect(name); },
+      },
+      h("span", { className: "ct-name" }, name),
+      leader ? h(Badge, { variant: "outline" }, "leader: " + leader) : null
+    );
+  }
+
+  function TeamDetail(props) {
+    const { name } = props;
+    const [data, setData] = useState(null);
+    const [err, setErr] = useState(null);
+
+    useEffect(function () {
+      let cancelled = false;
+      setData(null); setErr(null);
+      fetchJson("/teams/" + encodeURIComponent(name))
+        .then(function (j) { if (!cancelled) setData(j.team); })
+        .catch(function (e) { if (!cancelled) setErr(e.message); });
+      return function () { cancelled = true; };
+    }, [name]);
+
+    if (err) return h("div", { className: "ct-error" }, "Error: " + err);
+    if (!data) return h("div", { className: "ct-muted" }, "Loading…");
+    return h(
+      "pre",
+      { className: "ct-detail" },
+      JSON.stringify(data, null, 2)
+    );
+  }
+
+  function App() {
+    const [teams, setTeams] = useState([]);
+    const [selected, setSelected] = useState(null);
+    const [err, setErr] = useState(null);
+    const [loading, setLoading] = useState(false);
+
+    // useRef + cancel token: a tab-switch mid-fetch must not setState on
+    // unmounted root. Each refresh bumps the token; only the latest one
+    // is allowed to land.
+    const reqRef = React.useRef(0);
+    const mountedRef = React.useRef(true);
+    useEffect(function () {
+      return function () { mountedRef.current = false; };
+    }, []);
+
+    const refresh = useCallback(function () {
+      const token = ++reqRef.current;
+      setLoading(true); setErr(null);
+      fetchJson("/teams")
+        .then(function (j) {
+          if (!mountedRef.current || token !== reqRef.current) return;
+          setTeams(j.teams || []);
+        })
+        .catch(function (e) {
+          if (!mountedRef.current || token !== reqRef.current) return;
+          setErr(e.message);
+        })
+        .finally(function () {
+          if (!mountedRef.current || token !== reqRef.current) return;
+          setLoading(false);
+        });
+    }, []);
+
+    useEffect(function () { refresh(); }, [refresh]);
+
+    return h(
+      "div",
+      { className: "ct-root" },
+      h(
+        "div",
+        { className: "ct-header" },
+        h("h2", null, "ClawTeam"),
+        h(Button, { onClick: refresh, disabled: loading }, loading ? "…" : "Refresh")
+      ),
+      err ? h("div", { className: "ct-error" }, "Error: " + err) : null,
+      h(
+        "div",
+        { className: "ct-cols" },
+        h(
+          Card,
+          { className: "ct-list" },
+          h(
+            CardContent,
+            null,
+            teams.length === 0 && !loading
+              ? h("div", { className: "ct-muted" }, "No teams discovered. Run `clawteam team spawn-team` to create one.")
+              : teams.map(function (t, i) {
+                  const name = (t && (t.name || t.team_name)) || String(t);
+                  return h(TeamRow, {
+                    key: name + ":" + i,
+                    team: t,
+                    selected: name === selected,
+                    onSelect: setSelected,
+                  });
+                })
+          )
+        ),
+        h(
+          Card,
+          { className: "ct-detail-card" },
+          h(
+            CardContent,
+            null,
+            selected
+              ? h(TeamDetail, { name: selected })
+              : h("div", { className: "ct-muted" }, "Select a team to view status.")
+          )
+        )
+      )
+    );
+  }
+
+  REG.register("clawteam", App);
+})();

--- a/plugins/clawteam/dashboard/dist/style.css
+++ b/plugins/clawteam/dashboard/dist/style.css
@@ -1,0 +1,13 @@
+.ct-root { padding: 16px; color: inherit; }
+.ct-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.ct-header h2 { margin: 0; font-size: 18px; font-weight: 600; }
+.ct-cols { display: grid; grid-template-columns: minmax(220px, 320px) 1fr; gap: 12px; }
+.ct-list { min-height: 120px; }
+.ct-row { padding: 8px 10px; border-radius: 6px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.ct-row:hover { background: rgba(255,255,255,0.04); }
+.ct-row-selected { background: rgba(99, 102, 241, 0.18); }
+.ct-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+.ct-detail-card { min-height: 120px; }
+.ct-detail { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; line-height: 1.4; overflow: auto; max-height: 60vh; }
+.ct-error { color: #f87171; margin: 8px 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+.ct-muted { color: rgba(255,255,255,0.5); font-style: italic; font-size: 13px; }

--- a/plugins/clawteam/dashboard/manifest.json
+++ b/plugins/clawteam/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "clawteam",
+  "label": "ClawTeam",
+  "description": "Discover teams, members, and recent mailbox activity from the clawteam CLI.",
+  "icon": "Users",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/clawteam",
+    "position": "after:skills"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/clawteam/dashboard/plugin_api.py
+++ b/plugins/clawteam/dashboard/plugin_api.py
@@ -1,0 +1,60 @@
+"""ClawTeam dashboard plugin — backend API routes.
+
+Mounted at /api/plugins/clawteam/ by the dashboard plugin system.
+
+Thin shell over the `clawteam` CLI. Shared CLI driver lives at
+`..._clawteam_cli` so the agent-facing tools and the dashboard
+endpoints cannot drift on argv handling, name validation, or error
+shape.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+# Hermes' dashboard loader (web_server.py:_mount_plugin_api_routes) loads
+# this file via importlib.util.spec_from_file_location as a standalone
+# module — there is no enclosing package, so `from .._clawteam_cli` would
+# raise ImportError and the route would never mount. Load the sibling
+# helper by file path instead.
+_HELPER_PATH = pathlib.Path(__file__).resolve().parent.parent / "_clawteam_cli.py"
+_spec = importlib.util.spec_from_file_location("_hermes_clawteam_cli", _HELPER_PATH)
+_helper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_helper)
+CliError = _helper.CliError
+run_clawteam_json = _helper.run_clawteam_json
+validate_name = _helper.validate_name
+
+router = APIRouter()
+
+
+def _wrap(exc: CliError) -> HTTPException:
+    return HTTPException(status_code=exc.status_code, detail=str(exc))
+
+
+@router.get("/teams")
+def list_teams() -> dict[str, Any]:
+    """List all discoverable teams."""
+    try:
+        teams = run_clawteam_json("team", "discover")
+    except CliError as exc:
+        raise _wrap(exc)
+    return {"teams": teams or []}
+
+
+@router.get("/teams/{name}")
+def team_status(name: str) -> dict[str, Any]:
+    """Return full status for a single team (members, recent activity)."""
+    try:
+        name = validate_name(name, field="team name")
+        # `--` sentinel: belt-and-braces against future clawteam flag
+        # parsers treating a positional that slips past the regex as
+        # an option.
+        status = run_clawteam_json("team", "status", "--", name)
+    except CliError as exc:
+        raise _wrap(exc)
+    return {"team": status}

--- a/plugins/clawteam/plugin.yaml
+++ b/plugins/clawteam/plugin.yaml
@@ -1,0 +1,11 @@
+name: clawteam
+version: 0.2.0
+description: "ClawTeam integration — discover/spawn teams, send/peek messages; dashboard tab + 5 agent tools."
+author: "molt-labs"
+kind: backend
+provides_tools:
+  - clawteam_team_discover
+  - clawteam_team_status
+  - clawteam_team_spawn
+  - clawteam_inbox_send
+  - clawteam_inbox_peek

--- a/plugins/clawteam/tools.py
+++ b/plugins/clawteam/tools.py
@@ -1,0 +1,167 @@
+"""ClawTeam agent-facing tools.
+
+Five verbs an LLM agent inside Hermes can call to drive a ClawTeam:
+discover, status, spawn, inbox-send, inbox-peek. Each handler shells
+to `clawteam --json …` via the shared driver and wraps the result in
+the standard tool_result / tool_error envelope Hermes' registry uses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.registry import tool_error, tool_result  # type: ignore[import-not-found]
+
+from ._clawteam_cli import (
+    CliError,
+    check_clawteam_available,
+    require_str,
+    run_clawteam_json,
+    validate_name,
+)
+
+
+def _err(exc: Exception) -> str:
+    if isinstance(exc, CliError):
+        return tool_error(str(exc), status_code=exc.status_code)
+    return tool_error(f"clawteam tool failed: {type(exc).__name__}: {exc}")
+
+
+def _handle_team_discover(args: dict, **_kw: Any) -> str:
+    try:
+        teams = run_clawteam_json("team", "discover") or []
+    except Exception as exc:
+        return _err(exc)
+    return tool_result({"teams": teams})
+
+
+def _handle_team_status(args: dict, **_kw: Any) -> str:
+    try:
+        name = validate_name(require_str(args.get("team"), field="team"), field="team")
+        status = run_clawteam_json("team", "status", "--", name)
+    except Exception as exc:
+        return _err(exc)
+    return tool_result({"team": status})
+
+
+def _handle_team_spawn(args: dict, **_kw: Any) -> str:
+    try:
+        name = validate_name(require_str(args.get("name"), field="name"), field="team name")
+        cmd = ["team", "spawn-team", name]
+        description = args.get("description")
+        if isinstance(description, str) and description.strip():
+            cmd += ["-d", description.strip()]
+        leader_name = args.get("leader_name")
+        if isinstance(leader_name, str) and leader_name.strip():
+            leader_name = validate_name(leader_name.strip(), field="leader_name")
+            cmd += ["-n", leader_name]
+        result = run_clawteam_json(*cmd)
+    except Exception as exc:
+        return _err(exc)
+    return tool_result({"spawned": result, "name": name})
+
+
+def _handle_inbox_send(args: dict, **_kw: Any) -> str:
+    try:
+        team = validate_name(require_str(args.get("team"), field="team"), field="team")
+        to = validate_name(require_str(args.get("to"), field="to"), field="to")
+        content = require_str(args.get("content"), field="content")
+        cmd = ["inbox", "send", team, to, content]
+        msg_type = args.get("type")
+        if isinstance(msg_type, str) and msg_type.strip():
+            cmd += ["--type", msg_type.strip()]
+        sender_raw = args.get("from")
+        sender = sender_raw.strip() if isinstance(sender_raw, str) and sender_raw.strip() else "hermes-agent"
+        cmd += ["--from", sender]
+        result = run_clawteam_json(*cmd)
+    except Exception as exc:
+        return _err(exc)
+    return tool_result({"sent": result})
+
+
+def _handle_inbox_peek(args: dict, **_kw: Any) -> str:
+    try:
+        team = validate_name(require_str(args.get("team"), field="team"), field="team")
+        cmd = ["inbox", "peek", team]
+        agent = args.get("agent")
+        if isinstance(agent, str) and agent.strip():
+            agent = validate_name(agent.strip(), field="agent")
+            cmd += ["--agent", agent]
+        result = run_clawteam_json(*cmd)
+    except Exception as exc:
+        return _err(exc)
+    return tool_result(result or {"count": 0, "messages": []})
+
+
+# OpenAI-format schemas. Names use the clawteam_ prefix so Hermes' tool
+# list groups them visibly.
+_TEAM_DISCOVER_SCHEMA = {
+    "name": "clawteam_team_discover",
+    "description": "List all discoverable ClawTeam teams. Returns the team list with name, description, lead agent id, and member count.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+_TEAM_STATUS_SCHEMA = {
+    "name": "clawteam_team_status",
+    "description": "Get full status for one ClawTeam team — members, lead agent, creation time, recent activity.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "team": {"type": "string", "description": "Team name (as returned by clawteam_team_discover)"},
+        },
+        "required": ["team"],
+    },
+}
+
+_TEAM_SPAWN_SCHEMA = {
+    "name": "clawteam_team_spawn",
+    "description": "Spawn a new ClawTeam team and register its leader agent. Returns the spawned team metadata.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Team name (kebab-case recommended)"},
+            "description": {"type": "string", "description": "Optional human-readable team description"},
+            "leader_name": {"type": "string", "description": "Optional leader agent name (default: 'leader')"},
+        },
+        "required": ["name"],
+    },
+}
+
+_INBOX_SEND_SCHEMA = {
+    "name": "clawteam_inbox_send",
+    "description": "Send a point-to-point message to one agent inside a ClawTeam team. The message is written to that agent's inbox; the recipient can read it via clawteam_inbox_peek or its own inbox watcher.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "team": {"type": "string", "description": "Team name"},
+            "to": {"type": "string", "description": "Recipient agent name (use clawteam_team_status to list members)"},
+            "content": {"type": "string", "description": "Message body"},
+            "type": {"type": "string", "description": "Message type (default: 'message')"},
+            "from": {"type": "string", "description": "Sender label shown in the recipient's inbox (default: 'hermes-agent')"},
+        },
+        "required": ["team", "to", "content"],
+    },
+}
+
+_INBOX_PEEK_SCHEMA = {
+    "name": "clawteam_inbox_peek",
+    "description": "Read messages from a team agent's inbox WITHOUT consuming them. Returns {count, messages[]}. Non-destructive — safe to call repeatedly.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "team": {"type": "string", "description": "Team name"},
+            "agent": {"type": "string", "description": "Agent name to peek for (default: from clawteam env identity)"},
+        },
+        "required": ["team"],
+    },
+}
+
+
+# (name, schema, handler) tuples consumed by __init__.py's register(ctx).
+TOOLS = [
+    (_TEAM_DISCOVER_SCHEMA["name"], _TEAM_DISCOVER_SCHEMA, _handle_team_discover),
+    (_TEAM_STATUS_SCHEMA["name"], _TEAM_STATUS_SCHEMA, _handle_team_status),
+    (_TEAM_SPAWN_SCHEMA["name"], _TEAM_SPAWN_SCHEMA, _handle_team_spawn),
+    (_INBOX_SEND_SCHEMA["name"], _INBOX_SEND_SCHEMA, _handle_inbox_send),
+    (_INBOX_PEEK_SCHEMA["name"], _INBOX_PEEK_SCHEMA, _handle_inbox_peek),
+]


### PR DESCRIPTION
## Summary
- Add a ClawTeam Hermes plugin with five agent-facing tools for team discovery, status, spawning, and inbox send/peek workflows.
- Add a shared CLI adapter for invoking `clawteam --json` with name validation, timeout handling, and structured error reporting.
- Add dashboard plugin metadata, API routes, bundled UI assets, and an issue-resolution prompt template for ClawTeam-assisted PR workflows.

## Verification
- `python -m py_compile plugins/clawteam/__init__.py plugins/clawteam/_clawteam_cli.py plugins/clawteam/tools.py plugins/clawteam/dashboard/plugin_api.py`
- Imported `plugins.clawteam`, registered tools with a fake plugin context, and verified all five handlers are exposed.
- Verified invalid ClawTeam identifiers are rejected by the shared validator.

## Risk
- The plugin shells out to the external `clawteam` CLI, so runtime functionality depends on that binary being installed or `CLAWTEAM_BIN` being configured.
