### PR TITLE
fix(desktop): remove session search aux model

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -29,7 +29,6 @@ const AUX_TASKS: readonly AuxTaskMeta[] = [
   { key: 'vision', label: 'Vision', hint: 'Image analysis' },
   { key: 'web_extract', label: 'Web extract', hint: 'Page summarization' },
   { key: 'compression', label: 'Compression', hint: 'Context compaction' },
-  { key: 'session_search', label: 'Session search', hint: 'Recall queries' },
   { key: 'skills_hub', label: 'Skills hub', hint: 'Skill search' },
   { key: 'approval', label: 'Approval', hint: 'Smart auto-approve' },
   { key: 'mcp', label: 'MCP', hint: 'MCP tool routing' },


### PR DESCRIPTION
## Summary
- remove `session_search` from the desktop app auxiliary model settings list
- keep the desktop settings list aligned with `_AUX_TASK_SLOTS` in `hermes_cli/web_server.py`
- avoids the desktop UI sending `task: session_search` to `/api/model/set`, which returns `400: unknown auxiliary task: session_search` because session search no longer uses an auxiliary LLM

## Findings
- Backend `_AUX_TASK_SLOTS` does not include `session_search`.
- Web models page already excludes `session_search`.
- Desktop model settings still exposed `session_search`, causing the Electron settings flow to hit the backend validation error.

## Verification
- `npm ci --ignore-scripts`
- `npm run type-check -w hermes`
- `npx eslint src/app/settings/model-settings.tsx`
- confirmed no `session_search` remains in `apps/desktop/src/app/settings`
