### PR TITLE
fix(steer): deliver /steer as a user turn so hardened models stop rejecting it

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2215,38 +2215,40 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
 
 
 
-def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
-    """Append any pending /steer text to the last tool result in this turn.
+_STEER_USER_PREFIX = "[The user sent this mid-task via /steer]\n"
 
-    Called at the end of a tool-call batch, before the next API call.
-    The steer is appended to the last ``role:"tool"`` message's content
-    with a clear marker so the model understands it came from the user
-    and NOT from the tool itself. Role alternation is preserved —
-    nothing new is inserted, we only modify existing content.
 
-    Args:
-        messages: The running messages list.
-        num_tool_msgs: Number of tool results appended in this batch;
-            used to locate the tail slice safely.
+def deliver_pending_steer_as_user_turn(agent, messages: list) -> None:
+    """Deliver any pending /steer text as a new user-role message.
+
+    Called after a tool batch is fully appended (every tool_call_id
+    answered). The steer is appended as a separate ``role:"user"``
+    message so the model attributes it to the user — NOT to the tool.
+
+    Earlier the steer was concatenated into the last tool result's
+    content, but injection-hardened models read tool-result content as
+    untrusted data (the codebase wraps it in <untrusted_tool_result>
+    delimiters by design) and refuse to act on instructions found there.
+    A user-role message carries unambiguous provenance and survives both
+    wire formats: OpenAI sends user-after-tool directly; the Anthropic
+    adapter's _merge_consecutive_roles folds it into the tool-result user
+    turn as a trailing text block.
+
+    Only delivers when the message tail is a tool result — i.e. a batch
+    just completed and a user turn legally follows. If the tail is not a
+    tool result (all tools skipped by an interrupt, or no tools yet),
+    the steer is restashed so the next-turn fallback delivers it. This
+    preserves OpenAI's "answer every tool_call_id before any non-tool
+    message" rule and avoids the orphan-drop in repair_message_sequence.
     """
-    if num_tool_msgs <= 0 or not messages:
+    if not messages:
         return
     steer_text = agent._drain_pending_steer()
     if not steer_text:
         return
-    # Find the last tool-role message in the recent tail. Skipping
-    # non-tool messages defends against future code appending
-    # something else at the boundary.
-    target_idx = None
-    for j in range(len(messages) - 1, max(len(messages) - num_tool_msgs - 1, -1), -1):
-        msg = messages[j]
-        if isinstance(msg, dict) and msg.get("role") == "tool":
-            target_idx = j
-            break
-    if target_idx is None:
-        # No tool result in this batch (e.g. all skipped by interrupt);
-        # put the steer back so the caller's fallback path can deliver
-        # it as a normal next-turn user message.
+    last = messages[-1]
+    if not (isinstance(last, dict) and last.get("role") == "tool"):
+        # Tail isn't a completed tool result — restash for later delivery.
         _lock = getattr(agent, "_pending_steer_lock", None)
         if _lock is not None:
             with _lock:
@@ -2258,22 +2260,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             existing = getattr(agent, "_pending_steer", None)
             agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
         return
-    marker = f"\n\nUser guidance: {steer_text}"
-    existing_content = messages[target_idx].get("content", "")
-    if not isinstance(existing_content, str):
-        # Anthropic multimodal content blocks — preserve them and append
-        # a text block at the end.
-        try:
-            blocks = list(existing_content) if existing_content else []
-            blocks.append({"type": "text", "text": marker.lstrip()})
-            messages[target_idx]["content"] = blocks
-        except Exception:
-            # Fall back to string replacement if content shape is unexpected.
-            messages[target_idx]["content"] = f"{existing_content}{marker}"
-    else:
-        messages[target_idx]["content"] = existing_content + marker
+    messages.append({"role": "user", "content": f"{_STEER_USER_PREFIX}{steer_text}"})
     _ra().logger.info(
-        "Delivered /steer to agent after tool batch (%d chars): %s",
+        "Delivered /steer as user turn after tool batch (%d chars): %s",
         len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
     )
@@ -2355,7 +2344,7 @@ __all__ = [
     "copy_reasoning_content_for_api",
     "cleanup_dead_connections",
     "extract_api_error_context",
-    "apply_pending_steer_to_tool_results",
+    "deliver_pending_steer_as_user_turn",
     "_iter_pool_sockets",
     "force_close_tcp_sockets",
 ]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -856,53 +856,12 @@ def run_conversation(
         
         # ── Pre-API-call /steer drain ──────────────────────────────────
         # If a /steer arrived during the previous API call (while the model
-        # was thinking), drain it now — before we build api_messages — so
-        # the model sees the steer text on THIS iteration.  Without this,
-        # steers sent during an API call only land after the NEXT tool batch,
-        # which may never come if the model returns a final response.
-        #
-        # We scan backwards for the last tool-role message in the messages
-        # list.  If found, the steer is appended there.  If not (first
-        # iteration, no tools yet), the steer stays pending for the next
-        # tool batch — injecting into a user message would break role
-        # alternation, and there's no tool output to piggyback on.
-        _pre_api_steer = agent._drain_pending_steer()
-        if _pre_api_steer:
-            _injected = False
-            for _si in range(len(messages) - 1, -1, -1):
-                _sm = messages[_si]
-                if isinstance(_sm, dict) and _sm.get("role") == "tool":
-                    marker = f"\n\nUser guidance: {_pre_api_steer}"
-                    existing = _sm.get("content", "")
-                    if isinstance(existing, str):
-                        _sm["content"] = existing + marker
-                    else:
-                        # Multimodal content blocks — append text block
-                        try:
-                            blocks = list(existing) if existing else []
-                            blocks.append({"type": "text", "text": marker})
-                            _sm["content"] = blocks
-                        except Exception:
-                            pass
-                    _injected = True
-                    logger.debug(
-                        "Pre-API-call steer drain: injected into tool msg at index %d",
-                        _si,
-                    )
-                    break
-            if not _injected:
-                # No tool message to inject into — put it back so
-                # the post-tool-execution drain picks it up later.
-                _lock = getattr(agent, "_pending_steer_lock", None)
-                if _lock is not None:
-                    with _lock:
-                        if agent._pending_steer:
-                            agent._pending_steer = agent._pending_steer + "\n" + _pre_api_steer
-                        else:
-                            agent._pending_steer = _pre_api_steer
-                else:
-                    existing = getattr(agent, "_pending_steer", None)
-                    agent._pending_steer = (existing + "\n" + _pre_api_steer) if existing else _pre_api_steer
+        # was thinking), deliver it now — before we build api_messages — so
+        # the model sees it on THIS iteration. Delivered as a trailing
+        # user turn when the message tail is a completed tool result;
+        # otherwise it stays pending for the post-tool-batch drain. See
+        # deliver_pending_steer_as_user_turn for the why (provenance).
+        agent._deliver_pending_steer_as_user_turn(messages)
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -519,23 +519,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
         messages.append(make_tool_result_message(name, _tool_content, tc.id))
 
-        # ── Per-tool /steer drain ───────────────────────────────────
-        # Same as the sequential path: drain between each collected
-        # result so the steer lands as early as possible.
-        agent._apply_pending_steer_to_tool_results(messages, 1)
-
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools = len(parsed_calls)
     if num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
         enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id))
 
-    # ── /steer injection ──────────────────────────────────────────────
-    # Append any pending user steer text to the last tool result so the
-    # agent sees it on its next iteration. Runs AFTER budget enforcement
-    # so the steer marker is never truncated. See steer() for details.
+    # ── /steer delivery ───────────────────────────────────────────────
+    # Deliver any pending user steer as a trailing user-role message after
+    # the full tool batch. Runs AFTER budget enforcement so it is never
+    # truncated. See deliver_pending_steer_as_user_turn for why a user turn
+    # (not tool-result content) is required for hardened models.
     if num_tools > 0:
-        agent._apply_pending_steer_to_tool_results(messages, num_tools)
+        agent._deliver_pending_steer_as_user_turn(messages)
 
 
 
@@ -966,12 +962,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
         messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
 
-        # ── Per-tool /steer drain ───────────────────────────────────
-        # Drain pending steer BETWEEN individual tool calls so the
-        # injection lands as soon as a tool finishes — not after the
-        # entire batch.  The model sees it on the next API iteration.
-        agent._apply_pending_steer_to_tool_results(messages, 1)
-
         if not agent.quiet_mode:
             if agent.verbose_logging:
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
@@ -1001,11 +991,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     if num_tools_seq > 0:
         enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id))
 
-    # ── /steer injection ──────────────────────────────────────────────
+    # ── /steer delivery ───────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
     # applied to sequential execution as well.
     if num_tools_seq > 0:
-        agent._apply_pending_steer_to_tool_results(messages, num_tools_seq)
+        agent._deliver_pending_steer_as_user_turn(messages)
 
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2368,10 +2368,10 @@ class AIAgent:
         # which already surfaces its own message) — don't second-guess.
         return ""
 
-    def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
-        """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""
-        from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
-        return apply_pending_steer_to_tool_results(self, messages, num_tool_msgs)
+    def _deliver_pending_steer_as_user_turn(self, messages: list) -> None:
+        """Forwarder — see ``agent.agent_runtime_helpers.deliver_pending_steer_as_user_turn``."""
+        from agent.agent_runtime_helpers import deliver_pending_steer_as_user_turn
+        return deliver_pending_steer_as_user_turn(self, messages)
 
     def _touch_activity(self, desc: str) -> None:
         """Update the last-activity timestamp and description (thread-safe).

--- a/tests/agent/test_steer_anthropic_wire.py
+++ b/tests/agent/test_steer_anthropic_wire.py
@@ -1,0 +1,33 @@
+"""A steer delivered as a user turn after tool results must serialize to a
+valid Anthropic turn: one user message holding the tool_result block(s)
+followed by the steer text block. Guards the _merge_consecutive_roles path."""
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+
+def test_steer_user_turn_merges_into_tool_result_turn():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "tc1", "type": "function",
+             "function": {"name": "terminal", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "content": "tool output", "tool_call_id": "tc1",
+         "name": "terminal", "tool_name": "terminal"},
+        {"role": "user", "content": "[The user sent this mid-task via /steer]\nstop and ask first"},
+    ]
+    _system, result = convert_messages_to_anthropic(messages)
+    # No two consecutive user messages survive.
+    roles = [m["role"] for m in result]
+    for i in range(1, len(roles)):
+        assert not (roles[i] == "user" and roles[i - 1] == "user")
+    # The steer text rides in the same user turn as the tool_result block.
+    user_turns = [m for m in result if m["role"] == "user"]
+    merged = user_turns[-1]
+    assert isinstance(merged["content"], list)
+    types = [b.get("type") for b in merged["content"]]
+    assert "tool_result" in types
+    assert any(
+        b.get("type") == "text" and "stop and ask first" in b.get("text", "")
+        for b in merged["content"]
+    )

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -79,7 +79,7 @@ def _make_agent(monkeypatch):
     # /steer injection (added in PR #12116) fires after every concurrent
     # tool batch. Stub it as a no-op — this test exercises interrupt
     # fanout, not steer injection.
-    stub._apply_pending_steer_to_tool_results = lambda *a, **kw: None
+    stub._deliver_pending_steer_as_user_turn = lambda *a, **kw: None
     stub._invoke_tool = MagicMock(side_effect=lambda *a, **kw: '{"ok": true}')
     return stub
 

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -72,7 +72,7 @@ class TestSteerDrain:
 
 
 class TestSteerInjection:
-    def test_appends_to_last_tool_result(self):
+    def test_appends_user_turn_after_tool_batch(self):
         agent = _bare_agent()
         agent.steer("please also check auth.log")
         messages = [
@@ -81,13 +81,18 @@ class TestSteerInjection:
             {"role": "tool", "content": "ls output A", "tool_call_id": "a"},
             {"role": "tool", "content": "ls output B", "tool_call_id": "b"},
         ]
-        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=2)
-        # The LAST tool result is modified; earlier ones are untouched.
+        agent._deliver_pending_steer_as_user_turn(messages)
+        # Tool results are untouched.
         assert messages[2]["content"] == "ls output A"
-        assert "ls output B" in messages[3]["content"]
-        assert "User guidance:" in messages[3]["content"]
-        assert "please also check auth.log" in messages[3]["content"]
-        # And pending_steer is consumed.
+        assert messages[3]["content"] == "ls output B"
+        # A new user-role message is appended carrying the steer.
+        assert messages[-1]["role"] == "user"
+        assert "please also check auth.log" in messages[-1]["content"]
+        # No tool message contains the steer text (the whole point).
+        assert all(
+            "please also check auth.log" not in (m.get("content") or "")
+            for m in messages if m.get("role") == "tool"
+        )
         assert agent._pending_steer is None
 
     def test_no_op_when_no_steer_pending(self):
@@ -96,65 +101,33 @@ class TestSteerInjection:
             {"role": "assistant", "tool_calls": [{"id": "a"}]},
             {"role": "tool", "content": "output", "tool_call_id": "a"},
         ]
-        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
-        assert messages[-1]["content"] == "output"  # unchanged
+        agent._deliver_pending_steer_as_user_turn(messages)
+        assert len(messages) == 2
+        assert messages[-1]["content"] == "output"
 
-    def test_no_op_when_num_tool_msgs_zero(self):
-        agent = _bare_agent()
-        agent.steer("steer")
-        messages = [{"role": "user", "content": "hi"}]
-        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=0)
-        # Steer should remain pending (nothing to drain into)
-        assert agent._pending_steer == "steer"
-
-    def test_marker_labels_text_as_user_guidance(self):
-        """The injection marker must label the appended text as user
-        guidance so the model attributes it to the user rather than
-        confusing it with tool output.  This is the cache-safe way to
-        signal provenance without violating message-role alternation.
-        """
-        agent = _bare_agent()
-        agent.steer("stop after next step")
-        messages = [{"role": "tool", "content": "x", "tool_call_id": "1"}]
-        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
-        content = messages[-1]["content"]
-        assert "User guidance:" in content
-        assert "stop after next step" in content
-
-    def test_multimodal_content_list_preserved(self):
-        """Anthropic-style list content should be preserved, with the steer
-        appended as a text block."""
-        agent = _bare_agent()
-        agent.steer("extra note")
-        original_blocks = [{"type": "text", "text": "existing output"}]
-        messages = [
-            {"role": "tool", "content": list(original_blocks), "tool_call_id": "1"}
-        ]
-        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
-        new_content = messages[-1]["content"]
-        assert isinstance(new_content, list)
-        assert len(new_content) == 2
-        assert new_content[0] == {"type": "text", "text": "existing output"}
-        assert new_content[1]["type"] == "text"
-        assert "extra note" in new_content[1]["text"]
-
-    def test_restashed_when_no_tool_result_in_batch(self):
-        """If the 'batch' contains no tool-role messages (e.g. all skipped
-        after an interrupt), the steer should be put back into the pending
-        slot so the caller's fallback path can deliver it."""
+    def test_restashed_when_tail_is_not_tool(self):
+        """If the trailing message is not a tool result (e.g. all tools were
+        skipped after an interrupt, or first iteration), inserting a user
+        message would be unsafe/wrong — restash for later delivery."""
         agent = _bare_agent()
         agent.steer("ping")
         messages = [
             {"role": "user", "content": "x"},
             {"role": "assistant", "content": "y"},
         ]
-        # Claim there were N tool msgs, but the tail has none — simulates
-        # the interrupt-cancelled case.
-        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=2)
-        # Messages untouched
+        agent._deliver_pending_steer_as_user_turn(messages)
+        assert len(messages) == 2
         assert messages[-1]["content"] == "y"
-        # And the steer is back in pending so the fallback can grab it
         assert agent._pending_steer == "ping"
+
+    def test_steer_text_carries_provenance_prefix(self):
+        agent = _bare_agent()
+        agent.steer("stop after next step")
+        messages = [{"role": "tool", "content": "x", "tool_call_id": "1"}]
+        agent._deliver_pending_steer_as_user_turn(messages)
+        assert messages[-1]["role"] == "user"
+        assert "/steer" in messages[-1]["content"]
+        assert "stop after next step" in messages[-1]["content"]
 
 
 class TestSteerThreadSafety:

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -174,17 +174,12 @@ class TestSteerClearedOnInterrupt:
 
 
 class TestPreApiCallSteerDrain:
-    """Test that steers arriving during an API call are drained before the
-    next API call — not deferred until the next tool batch.  This is the
-    fix for the scenario where /steer sent during model thinking only lands
-    after the agent is completely done."""
+    """A steer arriving while the model was thinking must land on THIS
+    iteration. With messages ending in a tool result, it is delivered as a
+    trailing user turn; with no completed tool run, it stays pending."""
 
-    def test_pre_api_drain_injects_into_last_tool_result(self):
-        """If a steer is pending when the main loop starts building
-        api_messages, it should be injected into the last tool result
-        in the messages list."""
+    def test_pre_api_drain_appends_user_turn(self):
         agent = _bare_agent()
-        # Simulate messages after a tool batch completed
         messages = [
             {"role": "user", "content": "do something"},
             {"role": "assistant", "content": "ok", "tool_calls": [
@@ -192,61 +187,19 @@ class TestPreApiCallSteerDrain:
             ]},
             {"role": "tool", "content": "output here", "tool_call_id": "tc1"},
         ]
-        # Steer arrives during API call (set after tool execution)
         agent.steer("focus on error handling")
-        # Simulate what the pre-API-call drain does:
-        _pre_api_steer = agent._drain_pending_steer()
-        assert _pre_api_steer == "focus on error handling"
-        # Inject into last tool msg (mirrors the new code in run_conversation)
-        for _si in range(len(messages) - 1, -1, -1):
-            if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += f"\n\nUser guidance: {_pre_api_steer}"
-                break
-        assert "User guidance:" in messages[-1]["content"]
+        agent._deliver_pending_steer_as_user_turn(messages)
+        assert messages[-1]["role"] == "user"
         assert "focus on error handling" in messages[-1]["content"]
         assert agent._pending_steer is None
 
     def test_pre_api_drain_restashes_when_no_tool_message(self):
-        """If there are no tool results yet (first iteration), the steer
-        should be put back into _pending_steer for the post-tool drain."""
         agent = _bare_agent()
-        messages = [
-            {"role": "user", "content": "hello"},
-        ]
+        messages = [{"role": "user", "content": "hello"}]
         agent.steer("early steer")
-        _pre_api_steer = agent._drain_pending_steer()
-        assert _pre_api_steer == "early steer"
-        # No tool message found — put it back
-        found = False
-        for _si in range(len(messages) - 1, -1, -1):
-            if messages[_si].get("role") == "tool":
-                found = True
-                break
-        assert not found
-        # Restash
-        agent._pending_steer = _pre_api_steer
+        agent._deliver_pending_steer_as_user_turn(messages)
+        assert len(messages) == 1
         assert agent._pending_steer == "early steer"
-
-    def test_pre_api_drain_finds_tool_msg_past_assistant(self):
-        """The pre-API drain should scan backwards past a non-tool message
-        (e.g., if an assistant message was somehow appended after tools)
-        and still find the tool result."""
-        agent = _bare_agent()
-        messages = [
-            {"role": "user", "content": "do something"},
-            {"role": "assistant", "content": "let me check", "tool_calls": [
-                {"id": "tc1", "function": {"name": "web_search", "arguments": "{}"}}
-            ]},
-            {"role": "tool", "content": "search results", "tool_call_id": "tc1"},
-        ]
-        agent.steer("change approach")
-        _pre_api_steer = agent._drain_pending_steer()
-        assert _pre_api_steer is not None
-        for _si in range(len(messages) - 1, -1, -1):
-            if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += f"\n\nUser guidance: {_pre_api_steer}"
-                break
-        assert "change approach" in messages[2]["content"]
 
 
 class TestSteerCommandRegistry:

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -274,5 +274,24 @@ class TestSteerCommandRegistry:
         assert should_bypass_active_session("steer") is True
 
 
+class TestSteerCallSites:
+    """Source-level guard: tool_executor delivers the steer only at the
+    batch boundary (one aggregate call per execution path), and the old
+    per-tool drain / old method name are gone. Per-tool insertion is
+    incompatible with safe user-turn delivery (would orphan later tool
+    results in repair_message_sequence)."""
+
+    def test_tool_executor_uses_renamed_aggregate_only(self):
+        import inspect
+
+        import agent.tool_executor as te
+
+        src = inspect.getsource(te)
+        assert "_apply_pending_steer_to_tool_results" not in src
+        # Exactly two delivery calls: parallel-path aggregate + sequential-path
+        # aggregate. No per-tool drains.
+        assert src.count("_deliver_pending_steer_as_user_turn") == 2
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What does this PR do?

Alternative fix for the `/steer` false-positive on injection-resistant models, offered alongside #36938 at the issue author's request to compare both approaches head-to-head.

`/steer` is flagged as a possible prompt-injection attempt by hardened models because the steer text is appended into the last `role:"tool"` message, immediately after the `<untrusted_tool_result>` fence. The model sees an imperative claiming user authority inside the channel it is trained to distrust, so its indirect-injection defense fires on legitimate operator input. Confirmed independently on `minimax-m3` (rejected a steer as a "user-injected instruction in the tool output ... not from you directly"), in addition to the Opus 4.8 report in #36934, so this is model-class behavior rather than one model's quirk.

Where #36938 keeps the steer in the tool channel and relabels the marker (lexical provenance), this PR removes the steer from that channel entirely and delivers it as a real `role:"user"` message after the tool batch (structural provenance). The two are complementary; #36938 remains the minimal-risk option.

**Why it is wire-safe:** delivering after every `tool_call_id` is answered is valid OpenAI alternation. On the Anthropic wire, `_merge_consecutive_roles` folds the trailing user message into the same user turn as the `tool_result` blocks, yielding one valid turn `[tool_result, ..., {type:"text", text: steer}]`. `repair_message_sequence` already treats a user turn as closing a tool-result run. This addresses the role-alternation concern raised in #36934 / #36938 (the issue author has acknowledged it does not hold for post-batch delivery). Prompt-cache impact is symmetric with the relabel approach, since editing the last tool message also invalidates the suffix from that point.

## Related Issue

Refs #36934. Alternative to #36938 (same issue, different approach).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py`: rename `apply_pending_steer_to_tool_results` to `deliver_pending_steer_as_user_turn`. When the message tail is a completed tool result, append `{"role":"user", "content": "[The user sent this mid-task via /steer]\n<text>"}`; otherwise restash the steer for the next-turn fallback.
- `agent/tool_executor.py`: route both aggregate drain sites (parallel + sequential) through the renamed method at the batch boundary; remove the two per-tool drains. Mid-batch delivery would insert a user message before later `tool_call_id`s are answered, which `repair_message_sequence` then drops as orphans. The model only reads at the next API call (after the whole batch), so per-tool vs aggregate delivery is indistinguishable to it.
- `agent/conversation_loop.py`: replace the inline pre-API tool-content append with the same helper call.
- `run_agent.py`: rename the `AIAgent` forwarder method to match.
- `tests/run_agent/test_steer.py`: rewrite `TestSteerInjection` and `TestPreApiCallSteerDrain` to assert user-turn delivery; add `TestSteerCallSites` guarding that the old name is gone and delivery happens only at the two batch boundaries.
- `tests/run_agent/test_concurrent_interrupt.py`: rename the stubbed attribute.
- `tests/agent/test_steer_anthropic_wire.py` (new): integration test that `convert_messages_to_anthropic` merges the steer user turn into the tool-result turn.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_steer.py tests/run_agent/test_concurrent_interrupt.py tests/agent/test_steer_anthropic_wire.py` (22 tests pass).
2. Broader steer/gateway/CLI/ACP surface: `scripts/run_tests.sh tests/gateway/test_steer_command.py tests/gateway/test_busy_session_ack.py tests/cli/test_cli_steer_busy_path.py tests/acp_adapter/test_acp_commands.py` (35 tests pass).
3. Live: on a hardened model, send `/steer <instruction>` mid-tool-batch; the steer is honored instead of being flagged as injection. The new Anthropic-wire test pins the serialization that makes this safe.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found #36938; this is filed as an explicit alternative at the author's request)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the canonical scripts/run_tests.sh on the affected files + the steer/gateway/CLI/ACP surface (57 tests, all green); not the entire tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.17, x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): docstrings on the renamed helper explain the why; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): N/A (pure message-list manipulation, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A (no tool behavior changed)
