### PR TITLE
docs(mcp): add registry metadata for Hermes server

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nousresearch/hermes-agent",
+  "description": "Hermes Agent MCP bridge for reading conversations, polling events, and sending platform messages.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "version": "0.15.1",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp#running-hermes-as-an-mcp-server",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent",
+      "version": "0.15.1",
+      "runtimeHint": "uvx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "hermes-agent[mcp]"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -658,6 +658,17 @@ hermes mcp serve
 
 This starts a stdio MCP server. The MCP client (not you) manages the process lifecycle.
 
+### Registry metadata
+
+Hermes ships a root-level [`server.json`](https://github.com/NousResearch/hermes-agent/blob/main/server.json) for MCP registries and clients that can import a server from package metadata. The entry launches Hermes through the PyPI package and fixes the command arguments to `mcp serve`, so clients do not accidentally run plain `hermes`.
+
+The MCP server uses the optional Python MCP dependency. If your client does not understand PyPI extras in registry metadata, install or point it at the MCP extra explicitly:
+
+```bash
+pip install "hermes-agent[mcp]"
+uvx --from "hermes-agent[mcp]" hermes mcp serve
+```
+
 ### MCP client configuration
 
 Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:


### PR DESCRIPTION
## Summary
- Add root-level `server.json` metadata so Hermes Agent can be submitted/imported as an MCP registry server
- Encode the PyPI/uvx launch path with fixed `mcp serve` package arguments so clients do not invoke plain `hermes`
- Document the `hermes-agent[mcp]` fallback for MCP clients that do not understand registry metadata extras

## Validation
- `mcp-publisher validate server.json`
- JSON Schema validation against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- `hermes mcp serve --help`
- `git diff --check`
- Independent review subagent approved the final diff

## Notes
- No publishing/submission was performed by this PR; it prepares the metadata required for registry submissions.
