### PR TITLE
fix: tighten gateway runtime status controls

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -154,14 +154,19 @@ def cron_tick():
 def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
-    from hermes_cli.gateway import find_gateway_pids
+    from hermes_cli.gateway import _format_gateway_pids, get_gateway_runtime_snapshot
 
     print()
 
-    pids = find_gateway_pids()
-    if pids:
+    snapshot = get_gateway_runtime_snapshot()
+    pids = snapshot.gateway_pids
+    if snapshot.running:
         print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
-        print(f"  PID: {', '.join(map(str, pids))}")
+        print(f"  Manager: {snapshot.manager}")
+        if pids:
+            print(f"  PID: {_format_gateway_pids(pids, limit=None)}")
+        elif snapshot.service_running:
+            print("  Service: running")
     else:
         print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
         print()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -135,16 +135,14 @@ def _get_service_pids() -> set:
                 timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                pid = _parse_launchd_pid(result.stdout or "", label)
+                if pid:
+                    pids.add(pid)
+            else:
+                state = _launchd_service_state()
+                pid = state.get("pid")
+                if isinstance(pid, int) and pid > 0:
+                    pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -1026,16 +1024,7 @@ def _recover_pending_systemd_restart(
 def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    return result.returncode == 0
+    return bool(_launchd_service_state().get("running"))
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -3004,6 +2993,113 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _parse_launchd_pid(output: str, label: str) -> int | None:
+    """Extract a live PID from either `launchctl list` or `launchctl print`.
+
+    macOS has at least three shapes in the wild:
+    - tabular `launchctl list <label>` output: `PID\tStatus\tLabel`
+    - `launchctl print gui/<uid>/<label>` output: `pid = 123`
+    - dictionary `launchctl list <label>` output: `\"PID\" = 123;`
+    """
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == label:
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            if pid > 0:
+                return pid
+
+        stripped = line.strip()
+        if stripped.startswith("pid = "):
+            raw_pid = stripped.split("=", 1)[1]
+        elif stripped.startswith('"PID" = '):
+            raw_pid = stripped.split("=", 1)[1]
+        else:
+            continue
+
+        try:
+            pid = int(raw_pid.strip().rstrip(";"))
+        except ValueError:
+            continue
+        if pid > 0:
+            return pid
+    return None
+
+
+def _launchd_service_state() -> dict:
+    """Return launchd load/running state for the current profile service.
+
+    macOS has two useful views here. `launchctl list <label>` is concise but
+    can return a false negative in some GUI domains; `launchctl print
+    gui/<uid>/<label>` is more explicit and has proven more reliable for the
+    LaunchAgent status path.
+    """
+    label = get_launchd_label()
+    state: dict = {
+        "loaded": False,
+        "running": False,
+        "pid": None,
+        "output": "",
+        "source": "",
+    }
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        result = None
+
+    if result is not None and result.returncode == 0:
+        output = result.stdout or ""
+        pid = _parse_launchd_pid(output, label)
+        state.update(
+            {
+                "loaded": True,
+                "running": bool(pid),
+                "pid": pid,
+                "output": output,
+                "source": "launchctl list",
+            }
+        )
+        return state
+
+    target = f"{_launchd_domain()}/{label}"
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", target],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return state
+
+    if result.returncode != 0:
+        state["output"] = result.stderr or result.stdout or ""
+        state["source"] = "launchctl print"
+        return state
+
+    output = result.stdout or ""
+    pid = _parse_launchd_pid(output, label)
+    running = "state = running" in output or bool(pid)
+    state.update(
+        {
+            "loaded": True,
+            "running": running,
+            "pid": pid,
+            "output": output,
+            "source": "launchctl print",
+        }
+    )
+    return state
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
@@ -3355,19 +3451,11 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
-    except subprocess.TimeoutExpired:
-        loaded = False
-        loaded_output = ""
+    state = _launchd_service_state()
+    loaded = bool(state.get("loaded"))
+    running = bool(state.get("running"))
+    pid = state.get("pid")
+    loaded_output = str(state.get("output") or "")
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -3378,7 +3466,13 @@ def launchd_status(deep: bool = False):
 
     if loaded:
         print("✓ Gateway service is loaded")
-        print(loaded_output)
+        if running:
+            detail = f"PID {pid}" if isinstance(pid, int) and pid > 0 else "running"
+            print(f"✓ Gateway service is running ({detail})")
+        else:
+            print("⚠ Gateway service is loaded but not running")
+        if loaded_output:
+            print(loaded_output)
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -627,8 +627,8 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
             return False
 
-        # Load opus codec for voice channel support
-        if not discord.opus.is_loaded():
+        # Load opus codec only when Discord voice-channel playback is enabled.
+        if os.getenv("DISCORD_VOICE_CHANNEL_PLAYBACK", "true").strip().lower() not in {"0", "false", "no", "off"} and not discord.opus.is_loaded():
             import ctypes.util
             opus_candidates = []
             bundled_opus = _find_discord_windows_bundled_opus(discord)
@@ -6139,6 +6139,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+    if "voice_channel_playback" in discord_cfg and not os.getenv("DISCORD_VOICE_CHANNEL_PLAYBACK"):
+        os.environ["DISCORD_VOICE_CHANNEL_PLAYBACK"] = str(discord_cfg["voice_channel_playback"]).lower()
     # ignored_channels: channels where bot never responds (even when mentioned)
     ic = discord_cfg.get("ignored_channels")
     if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -346,6 +346,42 @@ class TestLoadGatewayConfig:
         # Env value preserved, not clobbered by yaml.
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
+    def test_bridges_discord_voice_channel_playback_from_config_yaml(self, tmp_path, monkeypatch):
+        """discord.voice_channel_playback should reach the runtime env var."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  voice_channel_playback: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_VOICE_CHANNEL_PLAYBACK", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_VOICE_CHANNEL_PLAYBACK") == "false"
+
+    def test_discord_voice_channel_playback_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        """Explicit env var should win over config.yaml for voice playback."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  voice_channel_playback: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_VOICE_CHANNEL_PLAYBACK", "true")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_VOICE_CHANNEL_PLAYBACK") == "true"
+
     def test_bridges_discord_allow_from_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.allow_from should populate DISCORD_ALLOWED_USERS for auth."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_opus.py
+++ b/tests/gateway/test_discord_opus.py
@@ -30,6 +30,13 @@ class TestOpusFindLibrary:
         assert "sys.platform" in source or "darwin" in source, \
             "Homebrew fallback must be guarded by macOS platform check"
 
+    def test_opus_loading_can_be_disabled_by_env(self):
+        """Voice-channel playback off should skip eager Opus loading."""
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        source = inspect.getsource(DiscordAdapter.connect)
+        assert "DISCORD_VOICE_CHANNEL_PLAYBACK" in source
+        assert "discord.opus.is_loaded" in source
+
     def test_windows_bundled_discord_opus_dll_is_discovered(self, monkeypatch, tmp_path):
         """Native Windows installs should try discord.py's bundled opus DLL."""
         import plugins.platforms.discord.adapter as adapter

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -5,7 +5,8 @@ from argparse import Namespace
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
-from hermes_cli.cron import cron_command
+from hermes_cli.cron import cron_command, cron_status
+from hermes_cli.gateway import GatewayRuntimeSnapshot
 
 
 @pytest.fixture()
@@ -111,3 +112,40 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+
+class TestCronStatus:
+    def test_cron_status_uses_runtime_snapshot_service_only(self, tmp_cron_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "hermes_cli.gateway.get_gateway_runtime_snapshot",
+            lambda: GatewayRuntimeSnapshot(
+                manager="launchd (macOS)",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=(),
+            ),
+        )
+
+        cron_status()
+
+        out = capsys.readouterr().out
+        assert "Gateway is running" in out
+        assert "Manager: launchd (macOS)" in out
+        assert "Service: running" in out
+        assert "Gateway is not running" not in out
+
+    def test_cron_status_prints_normalized_gateway_pids(self, tmp_cron_dir, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "hermes_cli.gateway.get_gateway_runtime_snapshot",
+            lambda: GatewayRuntimeSnapshot(
+                manager="manual process",
+                gateway_pids=(123, 456),
+            ),
+        )
+
+        cron_status()
+
+        out = capsys.readouterr().out
+        assert "Gateway is running" in out
+        assert "Manager: manual process" in out
+        assert "PID: 123, 456" in out

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -38,6 +38,10 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -678,6 +682,92 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_parses_dictionary_pid_from_list(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f'{{\n\t"Label" = "{label}";\n\t"PID" = 4242;\n}}\n',
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+        output = capsys.readouterr().out
+        assert "Gateway service is loaded" in output
+        assert "Gateway service is running (PID 4242)" in output
+
+    def test_get_service_pids_parses_dictionary_pid_from_launchd_list(self, monkeypatch):
+        label = gateway_cli.get_launchd_label()
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "list", label]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f'{{\n\t"Label" = "{label}";\n\t"PID" = 5151;\n}}\n',
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._get_service_pids() == {5151}
+
+    def test_launchd_status_falls_back_to_print_when_list_misses_loaded_job(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f"gui/501/{label} = {{\n\tstate = running\n\tpid = 4242\n}}\n",
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "Gateway service is loaded" in output
+        assert "Gateway service is running (PID 4242)" in output
+
+    def test_probe_launchd_service_running_falls_back_to_print(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("current", encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=f"gui/501/{label} = {{\n\tstate = running\n\tpid = 4242\n}}\n",
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
@@ -737,6 +827,10 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 


### PR DESCRIPTION
## Summary
- Normalize macOS launchd gateway status so loaded/running/PID details are reported consistently.
- Tighten cron runtime status reporting from unified runtime snapshots.
- Make Discord Opus eager loading configurable so runtime status/control surfaces behave more predictably.

## Verification
- Static added-line scan: no obvious hardcoded secret/injection patterns.
- Independent review: passed; no security concerns or logic errors found.
- Targeted tests:

```text
python -m pytest \
  tests/hermes_cli/test_gateway_service.py \
  tests/hermes_cli/test_cron.py \
  tests/gateway/test_config.py \
  tests/gateway/test_discord_opus.py \
  -q -o 'addopts='

203 passed in 3.48s
```

- Broader gateway/Discord slice:

```text
718 passed, 2 failed, 2 warnings in 14.24s
```

The 2 failures are pre-existing baseline failures in `tests/hermes_cli/test_gateway_wsl.py` and reproduce on `origin/main`.
