### PR TITLE
fix(desktop): keep onboarding cache sticky across transient runtime failures (fixes #37554)

### DIFF
--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -142,4 +142,52 @@ describe('refreshOnboarding', () => {
 
     expect($desktopOnboarding.get().providers?.map(p => p.id)).toEqual(['shared'])
   })
+
+  // Regression for #37554: a returning user whose runtime probe transiently
+  // fails must NOT have the cached configured=true state downgraded to false.
+  // Otherwise the onboarding overlay re-appears on every restart even though
+  // the user has valid credentials and the durable bootstrap marker is set.
+  it('does not downgrade configured when cache already says true (regression #37554)', async () => {
+    const api = vi.fn(async () => {
+      throw new Error('no api calls expected')
+    })
+
+    installApiMock(api)
+    // Simulate the optimistic cache from a previous successful onboarding.
+    window.localStorage.setItem('hermes-desktop-onboarded-v1', '1')
+    $desktopOnboarding.set(baseState({ configured: true, providers: [provider('cached')] }))
+
+    const ready = await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+
+    expect(ready).toBe(false)
+    // Overlay should stay hidden — the store did NOT flip to configured:false.
+    expect($desktopOnboarding.get().configured).toBe(true)
+    // The optimistic cache is sticky and was not erased.
+    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBe('1')
+    // No API refresh fired (providers were already loaded and onboarding was
+    // not explicitly requested).
+    expect(api).not.toHaveBeenCalled()
+    expect($desktopOnboarding.get().providers?.map(p => p.id)).toEqual(['cached'])
+  })
+
+  it('still flips to configured=false for a brand new install with no prior cache', async () => {
+    const api = vi.fn(async ({ path }: { path: string }) => {
+      if (path === '/api/providers/oauth') {
+        return { providers: [provider('fresh')] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    installApiMock(api)
+    // No cached value, store starts at configured:false — classic first run.
+    $desktopOnboarding.set(baseState({ requested: true }))
+
+    const ready = await refreshOnboarding(onboardingContext(runtimeMismatchGateway()))
+
+    expect(ready).toBe(false)
+    expect($desktopOnboarding.get().configured).toBe(false)
+    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBeNull()
+    expect(api).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -393,9 +393,27 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
 
   const state = $desktopOnboarding.get()
   const reason = runtime.reason || state.reason || DEFAULT_ONBOARDING_REASON
+  // If onboarding was already completed (cache or store says configured ===
+  // true), do NOT downgrade to false. A returning user whose runtime probe
+  // transiently fails — e.g. backend still warming up, gateway momentary
+  // timeout, or a genuine runtime/credentials mismatch — would otherwise
+  // see the onboarding overlay flash on every reload and have to re-add
+  // their provider. The bootstrap marker is the durable source of truth;
+  // localStorage is just the optimistic cache that re-evaluates on
+  // every gateway open. Keep the cache sticky once set, and surface
+  // the runtime failure as a notification so the user knows something
+  // is off without losing access to the app.
+  const wasConfigured = state.configured === true || readCachedConfigured() === true
 
-  writeCachedConfigured(false)
-  patch({ configured: false, reason })
+  if (!wasConfigured) {
+    writeCachedConfigured(false)
+    patch({ configured: false, reason })
+  } else {
+    notifyError(
+      'runtime-not-ready',
+      'Hermes Desktop could not verify the running backend on startup. Some features may be unavailable until the gateway is reachable.'
+    )
+  }
 
   if (state.providers !== null && !state.requested) {
     return false


### PR DESCRIPTION
## What does this PR do?

Stops `refreshOnboarding()` from downgrading the optimistic onboarding cache from `true` to `false` on transient runtime probe failures. A returning user whose runtime check transiently fails (gateway still warming up, momentary timeout, runtime/credentials mismatch) used to see the onboarding overlay flash on every reload and have to re-add their provider, even though the durable bootstrap marker on disk said onboarding was complete.

## Why

`localStorage['hermes-desktop-onboarded-v1']` is only an optimistic cache. Every gateway open triggers `refreshOnboarding()`, which calls `evaluateRuntimeReadiness()` and on failure ran:

```ts
writeCachedConfigured(false)
patch({ configured: false, reason })
```

That overwrite defeated the cache: the next reload would re-evaluate and re-flip. The bootstrap marker (`.hermes-bootstrap-complete`) is the durable source of truth, but the renderer can't see it directly, so the right fix is to keep the cache sticky once it has been set and surface the runtime failure as a notification rather than a full re-onboarding.

## Changes

- `apps/desktop/src/store/onboarding.ts` — in `refreshOnboarding()`, when the runtime probe returns `ready: false`, only downgrade `configured` to `false` if neither the in-memory state nor the localStorage cache already says `configured === true`. If we were already configured, keep the cache and call `notifyError(...)` so the user still sees a heads-up that the gateway isn't reachable.
- `apps/desktop/src/store/onboarding.test.ts` — adds two regression tests:
  - Returning user with cache `configured === true` + transient runtime failure: store stays `configured: true`, cache is preserved, no API refresh fires.
  - Brand new install (no prior cache) with same transient failure: still flips to `configured: false` and refreshes providers.

## How to test

1. `cd apps/desktop && npx vitest run --environment jsdom src/store/onboarding.test.ts` — all 5 tests pass.
2. `npx eslint src/store/onboarding.ts src/store/onboarding.test.ts` — 0 errors (5 pre-existing padding-line warnings on lines unrelated to this change).
3. `npx tsc --noEmit -p tsconfig.json` — 0 errors in changed files. (One pre-existing TS2307 in `src/app/messaging/platform-icon.tsx` is unrelated.)

## Notes

- Behaviour change is intentionally narrow: only affects the path where `runtime.ready === false` AND the user has previously completed onboarding. First-run onboarding still works exactly as before.
- The fix is layered correctly — the bigger "use the durable bootstrap marker" refactor called out in the issue would be a separate, much larger change. This is the smallest, safest fix that resolves the reported regression.

Closes #37554
