### PR TITLE
fix(oneshot): join memory daemon threads before process exit (#37632)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -364,7 +364,19 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    response = agent.chat(prompt) or ""
+
+    # Join memory-provider daemon threads (e.g. Honcho's honcho-sync,
+    # honcho-prewarm-dialectic, honcho-context-prefetch) before the process
+    # exits.  Without this, CPython's Py_FinalizeEx force-terminates the
+    # still-running daemon threads via pthread_exit(), and glibc converts
+    # that forced unwind into abort() → SIGABRT → exit 134.  (#37632)
+    try:
+        agent.shutdown_memory_provider()
+    except Exception:
+        pass  # memory providers are strictly best-effort
+
+    return response
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/tests/cli/test_oneshot_memory_shutdown.py
+++ b/tests/cli/test_oneshot_memory_shutdown.py
@@ -1,0 +1,75 @@
+"""Regression test for #37632: oneshot mode must call shutdown_memory_provider.
+
+Without this, Honcho memory daemon threads (honcho-sync, honcho-prewarm-dialectic,
+honcho-context-prefetch) remain blocked in httpx I/O when the process exits.
+CPython's Py_FinalizeEx force-terminates them via pthread_exit(), and glibc
+converts that into abort() → SIGABRT → exit 134.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestOneshotMemoryShutdown:
+    """shutdown_memory_provider() must be called after agent.chat() in oneshot mode."""
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.config.load_config")
+    @patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None)
+    @patch("hermes_cli.oneshot.get_fallback_chain", return_value=None)
+    @patch("run_agent.AIAgent")
+    def test_run_agent_calls_shutdown_after_chat(
+        self, MockAIAgent, mock_fb, mock_sdb, mock_load_config, mock_resolve
+    ):
+        """_run_agent must call agent.shutdown_memory_provider() after chat()."""
+        mock_load_config.return_value = {"model": {"default": "test-model", "provider": "test"}}
+        mock_resolve.return_value = {
+            "api_key": "test-key",
+            "base_url": "http://test",
+            "provider": "test",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.chat.return_value = "test response"
+        MockAIAgent.return_value = mock_agent
+
+        from hermes_cli.oneshot import _run_agent
+
+        result = _run_agent("test prompt")
+
+        assert result == "test response"
+        mock_agent.chat.assert_called_once_with("test prompt")
+        mock_agent.shutdown_memory_provider.assert_called_once()
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.config.load_config")
+    @patch("hermes_cli.oneshot._create_session_db_for_oneshot", return_value=None)
+    @patch("hermes_cli.oneshot.get_fallback_chain", return_value=None)
+    @patch("run_agent.AIAgent")
+    def test_run_agent_shutdown_does_not_crash_on_error(
+        self, MockAIAgent, mock_fb, mock_sdb, mock_load_config, mock_resolve
+    ):
+        """shutdown_memory_provider raising must not crash _run_agent."""
+        mock_load_config.return_value = {"model": {"default": "test-model", "provider": "test"}}
+        mock_resolve.return_value = {
+            "api_key": "test-key",
+            "base_url": "http://test",
+            "provider": "test",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.chat.return_value = "test response"
+        mock_agent.shutdown_memory_provider.side_effect = RuntimeError("boom")
+        MockAIAgent.return_value = mock_agent
+
+        from hermes_cli.oneshot import _run_agent
+
+        # Must not raise despite shutdown_memory_provider failing
+        result = _run_agent("test prompt")
+        assert result == "test response"
+        mock_agent.shutdown_memory_provider.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Calls `shutdown_memory_provider()` after `agent.chat()` in the `hermes -z` one-shot path, joining Honcho memory daemon threads before process exit to prevent SIGABRT (exit 134) during Python interpreter finalization.

## Related Issue

Fixes #37632

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py`: Added `agent.shutdown_memory_provider()` call after `agent.chat()` in `_run_agent()`, wrapped in try/except since memory providers are best-effort. This joins daemon threads (honcho-sync, honcho-prewarm-dialectic, honcho-context-prefetch) with bounded timeouts before the process exits.
- `tests/cli/test_oneshot_memory_shutdown.py`: Added regression tests verifying (1) `shutdown_memory_provider()` is called after chat, and (2) a raising `shutdown_memory_provider` does not crash `_run_agent`.

## How to Test

1. Enable Honcho memory provider in config.yaml
2. Run `hermes -z "reply with exactly: ok" --yolo > /dev/null 2>&1; echo "exit=$?"`
3. Before fix: `exit=134` (SIGABRT). After fix: `exit=0`.
4. Run `pytest tests/cli/test_oneshot_memory_shutdown.py -v` — both tests should pass.
5. Run `pytest tests/cli/test_cli_shutdown_memory_messages.py -v` — existing tests still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/oneshot.py:_run_agent` (callers: 2 — `run_oneshot` and Termux fast path)
- Blast radius: LOW — change is isolated to the one-shot exit path, no behavioral change for interactive CLI or gateway
- Related patterns: `cli.py:959-970` calls `shutdown_memory_provider` on interactive CLI exit; `gateway/run.py:3640-3655` calls it on gateway session expiry. This PR fills the missing one-shot gap.
