### PR TITLE
fix: preserve gateway user metadata across session splits

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -477,13 +477,34 @@ class AIAgent:
         if self._session_db_created or not self._session_db:
             return
         try:
+            user_id = getattr(self, "_user_id", None)
+            parent_source = None
+            if self._parent_session_id:
+                try:
+                    parent_session = self._session_db.get_session(self._parent_session_id)
+                    if parent_session:
+                        parent_source = parent_session.get("source")
+                        if not user_id:
+                            user_id = parent_session.get("user_id")
+                except Exception:
+                    logger.debug(
+                        "Failed to inherit metadata from parent session %s",
+                        self._parent_session_id,
+                        exc_info=True,
+                    )
+
+            source = (
+                self.platform
+                or parent_source
+                or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+            )
             self._session_db.create_session(
                 session_id=self.session_id,
-                source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                source=source,
                 model=self.model,
                 model_config=self._session_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=user_id,
                 parent_session_id=self._parent_session_id,
             )
             self._session_db_created = True

--- a/tests/agent/test_session_user_id_metadata.py
+++ b/tests/agent/test_session_user_id_metadata.py
@@ -1,0 +1,90 @@
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _agent_for_db_session(*, db, session_id, platform="slack", user_id=None, parent_session_id=None):
+    agent = AIAgent.__new__(AIAgent)
+    agent._session_db_created = False
+    agent._session_db = db
+    agent.session_id = session_id
+    agent.platform = platform
+    agent.model = "test-model"
+    agent._session_init_model_config = {}
+    agent._cached_system_prompt = ""
+    agent._parent_session_id = parent_session_id
+    agent._user_id = user_id
+    return agent
+
+
+def test_gateway_agent_session_creation_persists_user_id(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        agent = _agent_for_db_session(
+            db=db,
+            session_id="gateway_session",
+            platform="slack",
+            user_id="U_KENNY",
+        )
+
+        agent._ensure_db_session()
+
+        session = db.get_session("gateway_session")
+        assert session is not None
+        assert session["source"] == "slack"
+        assert session["user_id"] == "U_KENNY"
+    finally:
+        db.close()
+
+
+def test_compressed_child_session_creation_inherits_parent_user_id(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(
+            "parent_session",
+            source="slack",
+            model="test-model",
+            user_id="U_KENNY",
+        )
+        agent = _agent_for_db_session(
+            db=db,
+            session_id="compressed_child_session",
+            parent_session_id="parent_session",
+            platform="slack",
+        )
+
+        agent._ensure_db_session()
+
+        session = db.get_session("compressed_child_session")
+        assert session is not None
+        assert session["source"] == "slack"
+        assert session["parent_session_id"] == "parent_session"
+        assert session["user_id"] == "U_KENNY"
+    finally:
+        db.close()
+
+
+def test_compressed_child_session_creation_inherits_parent_source_when_platform_missing(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(
+            "parent_session",
+            source="slack",
+            model="test-model",
+            user_id="U_KENNY",
+        )
+        agent = _agent_for_db_session(
+            db=db,
+            session_id="compressed_child_session",
+            parent_session_id="parent_session",
+            platform=None,
+        )
+
+        agent._ensure_db_session()
+
+        session = db.get_session("compressed_child_session")
+        assert session is not None
+        assert session["source"] == "slack"
+        assert session["parent_session_id"] == "parent_session"
+        assert session["user_id"] == "U_KENNY"
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- Persist gateway `user_id` when creating session DB records
- Inherit parent session `user_id` for compressed/child sessions when no live user is present
- Add regression coverage for direct gateway sessions and compressed continuations

## Test Plan
- `scripts/run_tests.sh tests/agent/test_session_user_id_metadata.py tests/test_memory_user_id.py`

## Notes
This keeps user-scoped gateway metadata intact across session creation and context compaction, which helps memory/personalization and other user-aware behavior continue to work after session splits.