### PR TITLE
fix(gateway): require all overflow chunks before final delivery

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -492,23 +492,35 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit, len_fn=_len_fn,
                         )
-                        chunks_delivered = False
+                        any_chunks_delivered = False
+                        all_chunks_delivered = True
                         reply_to = self._message_id or self._initial_reply_to_id
                         for chunk in chunks:
-                            new_id = await self._send_new_chunk(chunk, reply_to)
-                            if new_id is not None and new_id != reply_to:
-                                chunks_delivered = True
+                            previous_reply_to = reply_to
+                            new_id = await self._send_new_chunk(chunk, previous_reply_to)
+                            chunk_delivered = (
+                                new_id is not None and new_id != previous_reply_to
+                            )
+                            if chunk_delivered:
+                                any_chunks_delivered = True
+                                reply_to = new_id
+                            else:
+                                all_chunks_delivered = False
+                                break
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            # Only claim final delivery if THESE chunks actually
-                            # landed.  ``_already_sent`` may be True from prior
-                            # tool-progress edits or fallback-mode promotion (#10748)
-                            # — that doesn't mean the final answer reached the user.
-                            self._final_response_sent = chunks_delivered
-                            if chunks_delivered:
+                            # Only claim final delivery if EVERY split chunk
+                            # landed. A single successful chunk is partial
+                            # content, not final delivery; otherwise run.py
+                            # suppresses the normal final-send fallback and the
+                            # user can lose later chunks of the answer.
+                            self._final_response_sent = all_chunks_delivered
+                            if all_chunks_delivered:
                                 self._final_content_delivered = True
+                            elif not any_chunks_delivered:
+                                self._already_sent = False
                             return
                         if got_segment_break:
                             self._message_id = None

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -897,12 +897,10 @@ class TestFinalResponseDeliveryGuard:
         consumer._already_sent = True
 
         # Long text > MAX_MESSAGE_LENGTH, no existing message id (fresh send path)
-        long_text = "x" * 200
+        long_text = "x" * 1000
         consumer.on_delta(long_text)
-        task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.05)
         consumer.finish()
-        await task
+        await consumer.run()
 
         assert consumer._final_response_sent is False, (
             "_already_sent leaked into _final_response_sent — gateway will "
@@ -910,9 +908,9 @@ class TestFinalResponseDeliveryGuard:
         )
 
     @pytest.mark.asyncio
-    async def test_split_overflow_partial_send_marks_final_sent(self):
-        """Split-overflow path: if at least one chunk lands on done frame,
-        we did deliver the final answer — _final_response_sent must be True."""
+    async def test_split_overflow_all_chunks_sent_marks_final_sent(self):
+        """Split-overflow path may claim final delivery only when every
+        chunk lands. A partial split send must leave the gateway fallback live."""
         adapter = MagicMock()
         adapter.send = AsyncMock(side_effect=[
             SimpleNamespace(success=True, message_id="msg_1"),
@@ -923,20 +921,48 @@ class TestFinalResponseDeliveryGuard:
         )
         adapter.MAX_MESSAGE_LENGTH = 100
         adapter.truncate_message = MagicMock(
-            side_effect=lambda text, limit: [text[:limit], text[limit:]],
+            side_effect=lambda text, limit, **kwargs: [text[:limit], text[limit:]],
         )
 
         config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
         consumer = GatewayStreamConsumer(adapter, "chat_123", config)
 
-        long_text = "x" * 200
+        long_text = "x" * 1000
         consumer.on_delta(long_text)
-        task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.05)
         consumer.finish()
-        await task
+        await consumer.run()
 
         assert consumer._final_response_sent is True
+        assert consumer._final_content_delivered is True
+
+    @pytest.mark.asyncio
+    async def test_split_overflow_partial_chunk_failure_does_not_mark_final_delivered(self):
+        """If only chunk 1 of an overflow split lands, do not suppress the
+        normal final-send fallback; chunk 2 still needs delivery."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=False, error="flood_control:13.0"),
+        ])
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 100
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit, **kwargs: [text[:limit], text[limit:]],
+        )
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        long_text = "x" * 1000
+        consumer.on_delta(long_text)
+        consumer.finish()
+        await consumer.run()
+
+        assert consumer._already_sent is True
+        assert consumer._final_response_sent is False
+        assert consumer._final_content_delivered is False
 
 
 class TestFinalContentDeliveredGuard:

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -181,6 +181,41 @@ class TestDraftStreamingHappyPath:
         adapter.send.assert_awaited()
 
 
+class TestDraftOverflowSplitDelivery:
+    """Draft previews are not final delivery; overflow split chunks still
+    need all real sendMessage chunks to land before suppressing fallback."""
+
+    @pytest.mark.asyncio
+    async def test_partial_overflow_split_after_draft_does_not_mark_final_delivered(self):
+        adapter = _make_draft_capable_adapter()
+        adapter.MAX_MESSAGE_LENGTH = 100
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit, **kwargs: [text[:limit], text[limit:]],
+        )
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=False, error="flood_control:13.0"),
+        ])
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("preview")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("x" * 1000)
+        consumer.finish()
+        await task
+
+        assert len(adapter.draft_calls) >= 1
+        assert adapter.send.await_count == 2
+        assert consumer._already_sent is True
+        assert consumer._final_response_sent is False
+        assert consumer._final_content_delivered is False
+
+
 class TestDraftFallbackOnFailure:
     """When a draft frame fails, the consumer disables drafts for the rest
     of the response and continues via the edit-based path."""


### PR DESCRIPTION
## Summary
- require every overflow-split stream chunk to send before marking final delivery confirmed
- leave the gateway fallback path available when a later chunk fails after an earlier chunk landed
- chain successfully delivered continuation chunks to the previous chunk, and stop on first failed chunk to avoid out-of-order partial delivery

## Root cause
`GatewayStreamConsumer` currently treats `chunks_delivered` as "any split chunk landed". For long Telegram/draft-streamed replies, that means chunk 1 can succeed, chunk 2 can fail, and the consumer still sets `final_response_sent` / `final_content_delivered`. `gateway/run.py` then suppresses the normal final-send fallback, so the user can be left with only the first `(1/N)` chunk.

This closes the partial-success gap left after #23420, which covered the all-chunks-fail case but still treated one successful chunk as complete final delivery.

## Tests
- `python -m pytest tests/gateway/test_stream_consumer.py::TestFinalResponseDeliveryGuard::test_split_overflow_partial_chunk_failure_does_not_mark_final_delivered tests/gateway/test_stream_consumer_draft.py::TestDraftOverflowSplitDelivery::test_partial_overflow_split_after_draft_does_not_mark_final_delivered -q -o 'addopts='`
- `python -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_runtime_footer.py -q -o 'addopts='`
- `python -m py_compile gateway/stream_consumer.py gateway/run.py gateway/runtime_footer.py gateway/platforms/telegram.py`

## Duplicate check
Searched existing issues/PRs for `chunks_delivered`, `split-overflow`, `final_response_sent`, `final_content_delivered`, and partial chunk delivery. Found related historical PRs #23420/#25923/#33724 and open issue #27942, but no open PR fixing this partial split-chunk failure mode.