### PR TITLE
feat: add grilling skills

### DIFF
--- a/skills/engineering/grill-with-docs/SKILL.md
+++ b/skills/engineering/grill-with-docs/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: grill-with-docs
+description: "Use when the user wants to stress-test a plan against an existing codebase's domain language, docs, code, CONTEXT.md glossary, and ADRs before building."
+version: 1.0.0
+author: Hermes Agent, adapted from Matt Pocock
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [engineering, codebase, documentation, domain-model, adr, ubiquitous-language]
+    homepage: https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md
+    related_skills: [grill-me, writing-plans, systematic-debugging, codebase-inspection]
+---
+
+# Grill With Docs
+
+## Overview
+
+Use this skill to run a grilling session against an existing project. Interview the user relentlessly about their plan, but ground the interview in the codebase, project documentation, domain model, `CONTEXT.md` glossary, and architectural decisions.
+
+This starts with the same one-question-at-a-time pressure testing as `grill-me`, then adds active documentation work: challenge terminology against existing language, sharpen fuzzy terms, cross-reference claims with code, update `CONTEXT.md` when domain terms are resolved, and offer ADRs only when a decision deserves one.
+
+Core principle: align the user, codebase, and documentation before building.
+
+## When to Use
+
+Use when:
+- The user wants to stress-test a plan in an existing codebase.
+- The plan depends on domain language, architecture, business concepts, or historical decisions.
+- The repo may contain `CONTEXT.md`, `CONTEXT-MAP.md`, ADRs, docs, tests, specs, or source code that should constrain the answer.
+- The user mentions `grill-with-docs`, project language, ubiquitous language, domain model, context docs, or ADRs.
+- You need to clarify what terms mean before writing code or an implementation plan.
+
+Don't use when:
+- There is no existing codebase or documentation context; use `grill-me`.
+- The user asks for a quick isolated edit that does not touch domain language or architecture.
+- The task is pure debugging with a known failure and no planning component; use `systematic-debugging`.
+
+## Required Behavior
+
+### Ask One Question at a Time
+
+Interview the user relentlessly, but ask exactly one question at a time and wait for feedback before continuing.
+
+For each question, provide your recommended answer or default direction.
+
+```markdown
+Question: [single focused question]
+
+Recommended answer: [your suggested answer based on docs/code/current constraints]
+```
+
+### Explore Instead of Asking When Possible
+
+If a question can be answered by exploring the codebase or documentation, inspect the codebase instead of asking.
+
+Use Hermes file tools for evidence:
+
+```python
+search_files("CONTEXT.md|CONTEXT-MAP.md|ADR|README|AGENTS.md|CLAUDE.md", path=".")
+search_files("*.md", target="files", path="docs", limit=50)
+read_file("CONTEXT.md")
+search_files("Order|Customer|Invoice", path="src")
+```
+
+When code and user statements conflict, surface the contradiction immediately.
+
+Example:
+
+```markdown
+Your code appears to cancel entire Orders in `src/orders/cancel.ts`, but you just described partial cancellation. Which one should be the domain truth?
+
+Recommended answer: if partial cancellation is a real business capability, we should introduce a separate term for it and update the relevant code/docs rather than overloading "cancellation".
+```
+
+## Domain Documentation Model
+
+### Single-Context Repos
+
+Most repos have one bounded context and can use a root `CONTEXT.md`:
+
+```text
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+### Multi-Context Repos
+
+If `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. Read it to understand where each context lives and how they relate.
+
+```text
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                 # system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/        # context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+When multiple contexts exist, infer which context the current topic belongs to. If unclear, ask one question to choose the context.
+
+### Create Documentation Lazily
+
+Do not create files just because the skill loaded. Create documentation only when there is resolved content to record.
+
+- If no `CONTEXT.md` exists, create it when the first domain term is resolved.
+- If no `docs/adr/` exists, create it when the first ADR is needed.
+- If a `CONTEXT-MAP.md` exists, put glossary updates in the appropriate context's `CONTEXT.md`.
+
+## During the Session
+
+### Challenge Against the Glossary
+
+When the user uses a term that conflicts with existing language in `CONTEXT.md`, call it out immediately.
+
+Example:
+
+```markdown
+Your glossary defines "cancellation" as a full Order cancellation, but you seem to mean removing one item from an Order. Which should this plan use?
+
+Recommended answer: keep "Cancellation" for the full Order operation and introduce "Line Removal" or another precise term for item-level changes.
+```
+
+### Sharpen Fuzzy Language
+
+When the user uses vague or overloaded terms, propose a precise canonical term.
+
+Example:
+
+```markdown
+You're saying "account". In this repo, do you mean Customer, User, Organization, or Billing Account?
+
+Recommended answer: use "Customer" for the buyer relationship and "User" for login identity, unless the codebase already defines different terms.
+```
+
+### Discuss Concrete Scenarios
+
+When domain relationships are unclear, invent specific scenarios that force precision.
+
+Examples:
+- A customer places an order, then removes one item before fulfillment.
+- A manager approves a request, then the requester changes it.
+- A payment succeeds but fulfillment fails.
+- A user belongs to two organizations with different permissions.
+
+Ask which concept owns the scenario and what words should be used.
+
+### Cross-Reference With Code
+
+When the user states how something works, check whether code agrees. Search for the domain terms, read the implementation, and compare.
+
+If you find contradiction, surface it as a decision point. Do not silently let the plan drift away from the implementation.
+
+### Update `CONTEXT.md` Inline
+
+When a term is resolved, update `CONTEXT.md` immediately. Do not batch these updates until the end; capture language while it is fresh.
+
+`CONTEXT.md` is a glossary, not a spec. It should be devoid of implementation details.
+
+Use this format, also available as `references/CONTEXT-FORMAT.md`:
+
+```markdown
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+```
+
+Rules:
+- Be opinionated. Pick one canonical term and list alternatives under `_Avoid_`.
+- Keep definitions tight: one or two sentences max.
+- Define what the term is, not what it does.
+- Only include project/domain-specific terms. Do not add general programming concepts.
+- Group terms under subheadings only when natural clusters emerge.
+
+### Offer ADRs Sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — changing the decision later has meaningful cost.
+2. **Surprising without context** — a future reader will wonder why this path was chosen.
+3. **Real tradeoff** — there were genuine alternatives and a specific reason for choosing one.
+
+If any condition is missing, skip the ADR.
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc. Use the compact format in `references/ADR-FORMAT.md`:
+
+```markdown
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+Optional sections like status, considered options, and consequences are allowed only when they add real value. Most ADRs should be short.
+
+## Grilling Flow
+
+1. Find project instructions and docs: `AGENTS.md`, `README`, docs, existing context docs, ADRs.
+2. Identify whether the repo is single-context or multi-context.
+3. Read the relevant `CONTEXT.md` and existing ADRs.
+4. Ask one plan-grilling question at a time.
+5. For each answer, compare against glossary, docs, and code.
+6. When language is resolved, update `CONTEXT.md`.
+7. When a hard-to-reverse, surprising tradeoff is resolved, offer an ADR.
+8. Continue until the plan and language are aligned enough to write a brief or implementation plan.
+
+## Output Pattern
+
+During the session:
+
+```markdown
+Question: ...
+
+Recommended answer: ...
+
+Why this matters: ...
+```
+
+After the session is sufficiently aligned:
+
+```markdown
+# Alignment Summary
+
+## Plan
+- ...
+
+## Domain Language Updates
+- `CONTEXT.md`: added/changed ...
+
+## Decisions
+- ADR offered/created/skipped: ...
+
+## Remaining Questions
+- ...
+
+## Recommended Next Step
+- ...
+```
+
+If implementation should follow, load/use `writing-plans` and write a bite-sized plan grounded in the resolved language and docs.
+
+## Common Pitfalls
+
+1. **Turning the session into a questionnaire.** Ask one question at a time, with a recommended answer.
+
+2. **Updating `CONTEXT.md` with implementation details.** It is a glossary only. Specs, algorithms, and implementation decisions belong elsewhere.
+
+3. **Creating ADRs too often.** Most decisions do not deserve ADRs. Require all three criteria: hard to reverse, surprising, real tradeoff.
+
+4. **Letting user language override code silently.** If the code says one thing and the user says another, make the conflict explicit.
+
+5. **Ignoring multi-context boundaries.** In a repo with `CONTEXT-MAP.md`, terms may mean different things in different contexts. Update the right context.
+
+6. **Forgetting to write the docs.** This skill is not just a conversation pattern. When language or architectural decisions crystallize, update the files.
+
+7. **Over-documenting generic concepts.** Do not add terms like "timeout", "repository", or "service" unless they are domain-specific concepts in this project.
+
+## Verification Checklist
+
+Before ending a grill-with-docs session:
+
+- [ ] You inspected available docs/code instead of asking answerable questions.
+- [ ] You asked one question at a time.
+- [ ] Each question included a recommended answer.
+- [ ] Existing `CONTEXT.md` / `CONTEXT-MAP.md` / ADRs were considered if present.
+- [ ] Conflicts between user language, docs, and code were surfaced.
+- [ ] Resolved domain terms were written to the appropriate `CONTEXT.md`.
+- [ ] ADRs were offered only for hard-to-reverse, surprising, tradeoff-based decisions.
+- [ ] The final summary names updated docs, remaining questions, and the recommended next step.

--- a/skills/engineering/grill-with-docs/references/ADR-FORMAT.md
+++ b/skills/engineering/grill-with-docs/references/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily, only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording that a decision was made and why, not in filling out sections.
+
+## Optional Sections
+
+Only include these when they add genuine value. Most ADRs will not need them.
+
+- **Status** frontmatter: `proposed`, `accepted`, `deprecated`, or `superseded by ADR-NNNN`.
+- **Considered Options**: only when the rejected alternatives are worth remembering.
+- **Consequences**: only when non-obvious downstream effects need to be called out.
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to Offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful.
+2. **Surprising without context** — a future reader will wonder why it was done this way.
+3. **The result of a real tradeoff** — there were genuine alternatives and one was chosen for specific reasons.
+
+If a decision is easy to reverse, skip it. If it is not surprising, nobody will wonder why. If there was no real alternative, there is nothing to record beyond "we did the obvious thing."
+
+## What Qualifies
+
+- Architectural shape: monorepo, event sourcing, read/write model split.
+- Integration patterns between contexts: domain events vs synchronous HTTP.
+- Technology choices that carry lock-in: database, message bus, auth provider, deployment target.
+- Boundary and scope decisions: which context owns which data.
+- Deliberate deviations from the obvious path: manual SQL instead of ORM, REST instead of GraphQL.
+- Constraints not visible in code: compliance requirements, latency constraints, partner API requirements.
+- Rejected alternatives when the rejection is non-obvious and likely to recur.

--- a/skills/engineering/grill-with-docs/references/CONTEXT-FORMAT.md
+++ b/skills/engineering/grill-with-docs/references/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts do not belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs Multi-Context Repos
+
+Single context, most repos: one `CONTEXT.md` at the repo root.
+
+Multiple contexts: a `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts.
+- If only a root `CONTEXT.md` exists, treat the repo as single-context.
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved.
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/skills/productivity/grill-me/SKILL.md
+++ b/skills/productivity/grill-me/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: grill-me
+description: "Use when the user wants to stress-test a new plan, product, feature, architecture, or design through a relentless one-question-at-a-time interview until shared understanding is reached."
+version: 1.0.0
+author: Hermes Agent, adapted from Matt Pocock
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [planning, product, requirements, discovery, decision-tree, interview]
+    homepage: https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
+    related_skills: [writing-plans, ideation]
+---
+
+# Grill Me
+
+## Overview
+
+Use this skill to interview the user relentlessly about a plan or design until you and the user reach shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one by one.
+
+This skill is for new work: a new app, project, product, feature concept, integration, workflow, automation, or design. If the plan is being evaluated against an existing codebase and project documentation, use `grill-with-docs` instead.
+
+Core principle: ask the next highest-leverage question, not every question at once.
+
+## When to Use
+
+Use when the user:
+- Says "grill me" or asks to be grilled on an idea.
+- Wants to stress-test a plan, product, design, or architecture.
+- Has a new application or project idea that needs requirements discovery.
+- Wants help turning a vague concept into a shared understanding.
+- Needs tradeoffs and assumptions surfaced before implementation planning.
+
+Don't use when:
+- The user has already supplied a complete spec and asks for execution.
+- The task is inside an existing repo and can be answered by inspecting docs/code; use `grill-with-docs`.
+- The user asks for pure brainstorming without interrogation; use `ideation`.
+- The user explicitly says to skip discovery and build.
+
+## Required Behavior
+
+### Ask One Question at a Time
+
+Do not send a giant questionnaire. Ask exactly one focused question, wait for the user's answer, then ask the next question.
+
+Bad:
+
+```markdown
+Here are 20 questions we need to answer...
+```
+
+Good:
+
+```markdown
+First question: who is the first real user of this, and what are they trying to get done?
+
+My recommended answer, if you're building for the fastest useful MVP: pick one concrete initial user group rather than "everyone".
+```
+
+### Provide Your Recommended Answer
+
+For each question, include your recommended answer or default direction. The point is not to make the user do all the thinking; the point is to pressure-test the plan together.
+
+Pattern:
+
+```markdown
+Question: [single focused question]
+
+Recommended answer: [your suggested default, with reasoning]
+```
+
+If the answer depends on facts you do not have, say what assumption your recommendation is based on.
+
+### Resolve Dependencies in Order
+
+Walk the design tree in dependency order:
+
+1. User and problem.
+2. Desired outcome.
+3. MVP workflow.
+4. Data and state.
+5. Roles and permissions.
+6. Integrations and runtime environment.
+7. UX and operational constraints.
+8. Success criteria and failure modes.
+9. Implementation plan.
+
+Do not jump to tech stack before the user, workflow, and constraints are clear.
+
+### Explore Instead of Asking When Possible
+
+If a question can be answered by exploring available artifacts, use tools instead of asking the user.
+
+Examples:
+- If the user says there is a repo, inspect it.
+- If the user links docs, read them.
+- If a config file reveals deployment target, use that evidence.
+- If a design file or screenshot is available, inspect it before asking UX questions.
+
+## Question Strategy
+
+Ask questions that collapse uncertainty. Favor questions that change scope, architecture, or risk.
+
+### Start Here
+
+First question usually:
+
+```markdown
+Who is the first real user for this, and what painful job are they trying to get done?
+
+Recommended answer: choose the narrowest user group that would benefit from the first version. Avoid "everyone" until the workflow is proven.
+```
+
+If the user already gave the user/problem, ask:
+
+```markdown
+What is the smallest end-to-end workflow that would make this useful?
+
+Recommended answer: define one demoable path from input to valuable output, and postpone everything outside that path.
+```
+
+### High-Leverage Questions
+
+Use these as the decision tree unfolds:
+
+- Who is the first user who would be annoyed if this did not exist?
+- What are they doing today instead?
+- What is the first moment where the project creates value?
+- What is the smallest demo that would make you say "yes, that's it"?
+- What must be in v1, and what must definitely not be in v1?
+- What can be manual behind the scenes for the first version?
+- What data does the app need before it can be useful?
+- What data is created, edited, archived, exported, or deleted?
+- Who can view, create, approve, edit, or delete each thing?
+- What should happen when the user makes a mistake?
+- What should be audited or impossible to silently change?
+- What external services must this depend on?
+- What should the first screen show?
+- What does success look like after the first week of use?
+- What would make the project a failure even if the software works?
+
+## Synthesis After Answers
+
+After each answer, briefly update the shared understanding before asking the next question.
+
+Use this compact shape:
+
+```markdown
+Got it. Current understanding:
+- User: ...
+- Problem: ...
+- MVP boundary: ...
+- Open uncertainty: ...
+
+Next question: ...
+
+Recommended answer: ...
+```
+
+Keep the synthesis short. The session should feel like a guided interview, not a report after every answer.
+
+## When Enough Is Known
+
+When the major branches are resolved, stop grilling and produce a short planning artifact:
+
+```markdown
+# Project Brief: [Name]
+
+## One-Sentence Concept
+[Thing] for [user] to [outcome].
+
+## MVP Workflow
+1. ...
+2. ...
+3. ...
+
+## In Scope
+- ...
+
+## Out of Scope
+- ...
+
+## Key Decisions
+- ...
+
+## Open Questions
+- ...
+
+## Recommended Next Step
+...
+```
+
+If the user wants implementation next, switch to `writing-plans` and write a bite-sized implementation plan. If a codebase becomes involved, switch to `grill-with-docs` before implementation planning.
+
+## Common Pitfalls
+
+1. **Asking a wall of questions.** The original point of the skill is one-question-at-a-time pressure testing. Do not turn it into a questionnaire unless the user asks.
+
+2. **Withholding recommendations.** The user asked to be grilled, not abandoned. Every question should include a recommended answer or default direction.
+
+3. **Jumping to implementation.** Do not choose frameworks, schemas, or APIs before the core workflow and constraints are clear.
+
+4. **Treating every idea as MVP.** Aggressively separate first useful version from nice-to-have scope.
+
+5. **Ignoring available evidence.** If files, docs, links, screenshots, or repos can answer a question, inspect them instead of asking.
+
+6. **Letting vague language pass.** Words like "user", "account", "admin", "document", "approval", and "status" often hide multiple concepts. Ask for precision.
+
+## Verification Checklist
+
+Before ending a grill-me session:
+
+- [ ] You asked one question at a time.
+- [ ] Each question included a recommended answer.
+- [ ] Available artifacts were inspected instead of asking answerable questions.
+- [ ] User, problem, outcome, and MVP workflow are clear.
+- [ ] Scope boundaries are explicit.
+- [ ] Key risks, assumptions, and open questions are named.
+- [ ] The next step is clear: more grilling, project brief, prototype, implementation plan, or build.


### PR DESCRIPTION
Adds two Hermes skills adapted from Matt Pocock's skills repo:\n\n- skills/productivity/grill-me/SKILL.md\n- skills/engineering/grill-with-docs/SKILL.md\n\nAlso includes grill-with-docs supporting references for CONTEXT.md and ADR formats.\n\nValidation performed locally:\n- SKILL.md frontmatter starts at byte 0\n- required name/description fields present\n- descriptions under 1024 chars\n- non-empty bodies\n- total content under Hermes skill limits