### PR TITLE
fix(tools): avoid redundant overlapping file reads

### DIFF
--- a/tests/tools/test_accretion_caps.py
+++ b/tests/tools/test_accretion_caps.py
@@ -7,6 +7,7 @@ unbounded in long-running CLI / gateway sessions:
   file_tools._read_tracker[task_id]
     ├─ read_history (set)      — one entry per unique (path, offset, limit)
     ├─ dedup (dict)            — one entry per unique (path, offset, limit)
+    ├─ path_coverage (dict)    — one entry per unique resolved path
     └─ read_timestamps (dict)  — one entry per unique resolved path
   process_registry._completion_consumed (set) — one entry per session_id
     ever polled / waited / logged
@@ -78,26 +79,66 @@ class TestReadTrackerCaps:
         assert "/path/7" in task_data["read_timestamps"]
         assert "/path/0" not in task_data["read_timestamps"]
 
+    def test_path_coverage_capped_oldest_first(self, monkeypatch):
+        """path_coverage dict is bounded; oldest path entries are evicted first."""
+        from tools import file_tools as ft
+
+        monkeypatch.setattr(ft, "_PATH_COVERAGE_CAP", 4)
+        task_data = {
+            "read_history": set(),
+            "dedup": {},
+            "path_coverage": {
+                f"/path/{i}": {"mtime": float(i), "intervals": [(1, 10)]}
+                for i in range(10)
+            },
+            "read_timestamps": {},
+        }
+        ft._cap_read_tracker_data(task_data)
+        assert len(task_data["path_coverage"]) == 4
+        assert "/path/9" in task_data["path_coverage"]
+        assert "/path/6" in task_data["path_coverage"]
+        assert "/path/0" not in task_data["path_coverage"]
+
+    def test_path_coverage_interval_cap_bounds_one_file(self, monkeypatch):
+        """One highly fragmented file cannot grow coverage intervals forever."""
+        from tools import file_tools as ft
+        from tools.read_coverage import record_path_coverage
+
+        monkeypatch.setattr(ft, "_PATH_COVERAGE_INTERVAL_CAP", 3)
+        task_data = {"path_coverage": {}}
+        for line in range(1, 101, 10):
+            record_path_coverage(
+                task_data, "/big", 1.0, line, 1,
+                ft._PATH_COVERAGE_INTERVAL_CAP,
+            )
+
+        intervals = task_data["path_coverage"]["/big"]["intervals"]
+        assert len(intervals) <= 3
+
     def test_cap_is_idempotent_under_cap(self, monkeypatch):
         """When containers are under cap, _cap_read_tracker_data is a no-op."""
         from tools import file_tools as ft
 
         monkeypatch.setattr(ft, "_READ_HISTORY_CAP", 100)
         monkeypatch.setattr(ft, "_DEDUP_CAP", 100)
+        monkeypatch.setattr(ft, "_PATH_COVERAGE_CAP", 100)
         monkeypatch.setattr(ft, "_READ_TIMESTAMPS_CAP", 100)
         task_data = {
             "read_history": {("/a", 0, 500), ("/b", 0, 500)},
             "dedup": {("/a", 0, 500): 1.0},
+            "path_coverage": {"/a": {"mtime": 1.0, "intervals": [(1, 500)]}},
             "read_timestamps": {"/a": 1.0},
         }
         rh_before = set(task_data["read_history"])
         dedup_before = dict(task_data["dedup"])
+        coverage_before = dict(task_data["path_coverage"])
         ts_before = dict(task_data["read_timestamps"])
 
         ft._cap_read_tracker_data(task_data)
 
         assert task_data["read_history"] == rh_before
         assert task_data["dedup"] == dedup_before
+        assert task_data["path_coverage"] == coverage_before
         assert task_data["read_timestamps"] == ts_before
 
     def test_cap_handles_missing_containers(self):
@@ -114,6 +155,7 @@ class TestReadTrackerCaps:
 
         monkeypatch.setattr(ft, "_READ_HISTORY_CAP", 3)
         monkeypatch.setattr(ft, "_DEDUP_CAP", 3)
+        monkeypatch.setattr(ft, "_PATH_COVERAGE_CAP", 3)
         monkeypatch.setattr(ft, "_READ_TIMESTAMPS_CAP", 3)
 
         # Create 10 distinct files and read each once.
@@ -126,6 +168,7 @@ class TestReadTrackerCaps:
             td = ft._read_tracker["long-session"]
             assert len(td["read_history"]) <= 3
             assert len(td["dedup"]) <= 3
+            assert len(td.get("path_coverage", {})) <= 3
             # read_timestamps is populated lazily (via setdefault) only
             # when os.path.getmtime() succeeds. On some CI filesystems
             # that stat can race with file creation — skip rather than

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -21,6 +21,7 @@ from tools.file_tools import (
     _is_blocked_device,
     _invalidate_dedup_for_path,
     _READ_DEDUP_STATUS_MESSAGE,
+    _READ_ALREADY_LOADED_STATUS_MESSAGE,
     _DEFAULT_MAX_READ_CHARS,
     _read_tracker,
     notify_other_tool_call,
@@ -264,6 +265,23 @@ class TestFileDedup(unittest.TestCase):
         fake.write_file.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_already_loaded_status_text(self, mock_ops):
+        """write_file rejects the path-coverage read_file status too."""
+        fake = MagicMock()
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            _READ_ALREADY_LOADED_STATUS_MESSAGE,
+            task_id="guard",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("internal read_file status text", result["error"])
+        fake.write_file.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
     def test_write_rejects_status_text_with_small_framing(self, mock_ops):
         """write_file rejects small wrappers around the status text too.
 
@@ -358,6 +376,154 @@ class TestFileDedup(unittest.TestCase):
 
         r2 = json.loads(read_file_tool(self._tmpfile, task_id="task_b"))
         self.assertNotEqual(r2.get("dedup"), True)
+
+
+# ---------------------------------------------------------------------------
+# Path-level read coverage guard
+# ---------------------------------------------------------------------------
+
+class TestPathReadCoverageGuard(unittest.TestCase):
+    """Overlapping read windows should not resend unchanged lines."""
+
+    def setUp(self):
+        _read_tracker.clear()
+        self._tmpdir = _make_safe_tempdir("hermes-read-coverage-")
+        self._tmpfile = os.path.join(self._tmpdir, "coverage.txt")
+        with open(self._tmpfile, "w") as f:
+            f.write("\n".join(f"line {i}" for i in range(1, 1001)))
+
+    def tearDown(self):
+        _read_tracker.clear()
+        try:
+            os.unlink(self._tmpfile)
+            os.rmdir(self._tmpdir)
+        except OSError:
+            pass
+
+    def _range_fake_ops(self):
+        fake = MagicMock()
+
+        def read_file(path, offset=1, limit=500):
+            end = offset + limit - 1
+            return _FakeReadResult(
+                content=f"lines {offset}-{end}\n",
+                total_lines=1000,
+                file_size=9000,
+            )
+
+        fake.read_file.side_effect = read_file
+        return fake
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_overlapping_superset_returns_only_new_lines(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, offset=10, limit=10, task_id="coverage")
+        result = json.loads(read_file_tool(
+            self._tmpfile, offset=10, limit=12, task_id="coverage",
+        ))
+
+        self.assertEqual(fake.read_file.call_args_list[-1].args, (self._tmpfile, 20, 2))
+        self.assertEqual(result["content"], "lines 20-21\n")
+        self.assertIn("returning only new lines 20-21", result["_hint"])
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_fully_covered_different_window_returns_already_loaded(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, offset=1, limit=100, task_id="coverage")
+        result = json.loads(read_file_tool(
+            self._tmpfile, offset=20, limit=10, task_id="coverage",
+        ))
+
+        self.assertEqual(result["status"], "already_loaded")
+        self.assertFalse(result["content_returned"])
+        self.assertEqual(fake.read_file.call_count, 1)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_repeated_already_loaded_escalates_to_block(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, offset=1, limit=100, task_id="coverage")
+        first_stub = json.loads(read_file_tool(
+            self._tmpfile, offset=20, limit=10, task_id="coverage",
+        ))
+        second_stub = json.loads(read_file_tool(
+            self._tmpfile, offset=30, limit=10, task_id="coverage",
+        ))
+
+        self.assertEqual(first_stub["status"], "already_loaded")
+        self.assertIn("error", second_stub)
+        self.assertIn("BLOCKED", second_stub["error"])
+        self.assertEqual(fake.read_file.call_count, 1)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_coverage_resets_after_mtime_change(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, offset=1, limit=100, task_id="coverage")
+        covered = json.loads(read_file_tool(
+            self._tmpfile, offset=20, limit=10, task_id="coverage",
+        ))
+        self.assertEqual(covered["status"], "already_loaded")
+
+        new_mtime = os.path.getmtime(self._tmpfile) + 10
+        os.utime(self._tmpfile, (new_mtime, new_mtime))
+
+        fresh = json.loads(read_file_tool(
+            self._tmpfile, offset=20, limit=10, task_id="coverage",
+        ))
+        self.assertNotEqual(fresh.get("status"), "already_loaded")
+        self.assertIn("content", fresh)
+        self.assertEqual(fake.read_file.call_count, 2)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_other_tool_does_not_reset_path_coverage(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, offset=1, limit=100, task_id="coverage")
+        notify_other_tool_call("coverage")
+        result = json.loads(read_file_tool(
+            self._tmpfile, offset=20, limit=10, task_id="coverage",
+        ))
+
+        self.assertEqual(result["status"], "already_loaded")
+        self.assertEqual(fake.read_file.call_count, 1)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_legitimate_paginated_walk_still_succeeds(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        for offset in (1, 101, 201, 301, 401):
+            result = json.loads(read_file_tool(
+                self._tmpfile, offset=offset, limit=100, task_id="coverage",
+            ))
+            self.assertNotEqual(result.get("status"), "already_loaded")
+            self.assertNotIn("error", result)
+            self.assertIn("content", result)
+
+        self.assertEqual(fake.read_file.call_count, 5)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_reset_file_dedup_clears_path_coverage(self, mock_ops):
+        fake = self._range_fake_ops()
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, offset=1, limit=100, task_id="coverage")
+        reset_file_dedup("coverage")
+        result = json.loads(read_file_tool(
+            self._tmpfile, offset=20, limit=10, task_id="coverage",
+        ))
+
+        self.assertNotEqual(result.get("status"), "already_loaded")
+        self.assertIn("content", result)
+        self.assertEqual(fake.read_file.call_count, 2)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -15,6 +15,12 @@ from tools.file_operations import (
     normalize_read_pagination,
     normalize_search_pagination,
 )
+from tools.read_coverage import (
+    cap_path_coverage,
+    first_uncovered_interval,
+    get_path_coverage,
+    record_path_coverage,
+)
 from tools import file_state
 from agent.redact import redact_sensitive_text
 
@@ -404,6 +410,9 @@ _file_ops_cache: dict = {}
 #                   Used to skip re-reads of unchanged files.  Reset on
 #                   context compression (the original content is summarised
 #                   away so the model needs the full content again).
+#   "path_coverage": dict mapping resolved_path → {mtime, intervals}.
+#                    Used to skip or narrow re-reads of unchanged line ranges
+#                    even when the model changes offset/limit.
 #   "read_timestamps": dict mapping resolved_path → modification-time float
 #                      recorded when the file was last read (or written) by
 #                      this task.  Used by write_file and patch to detect
@@ -458,12 +467,37 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
 # accretion to a few hundred KB regardless of session length.
 _READ_HISTORY_CAP = 500       # set; used only by get_read_files_summary
 _DEDUP_CAP = 1000             # dict; skip-identical-reread guard
+_PATH_COVERAGE_CAP = 1000     # dict; skip/narrow overlapping re-read guard
+_PATH_COVERAGE_INTERVAL_CAP = 128  # intervals retained for any one path
 _READ_TIMESTAMPS_CAP = 1000   # dict; external-edit detection for write/patch
 _READ_DEDUP_STATUS_MESSAGE = (
     "File unchanged since last read. The content from "
     "the earlier read_file result in this conversation is "
     "still current — refer to that instead of re-reading."
 )
+_READ_ALREADY_LOADED_STATUS_MESSAGE = (
+    "Requested lines were already returned by an earlier read_file result for "
+    "this unchanged file. Use that prior output instead of re-reading; use "
+    "search_files to locate a specific string or request only uncovered lines."
+)
+_READ_STATUS_MESSAGES = (
+    _READ_DEDUP_STATUS_MESSAGE,
+    _READ_ALREADY_LOADED_STATUS_MESSAGE,
+)
+
+
+def _ensure_read_tracker_fields(task_data: dict) -> None:
+    """Backfill per-task read tracker keys after live upgrades.
+
+    Must be called with ``_read_tracker_lock`` held.
+    """
+    task_data.setdefault("last_key", None)
+    task_data.setdefault("consecutive", 0)
+    task_data.setdefault("read_history", set())
+    task_data.setdefault("dedup", {})
+    task_data.setdefault("dedup_hits", {})
+    task_data.setdefault("path_coverage", {})
+    task_data.setdefault("read_timestamps", {})
 
 
 def _cap_read_tracker_data(task_data: dict) -> None:
@@ -474,11 +508,12 @@ def _cap_read_tracker_data(task_data: dict) -> None:
       * ``read_history`` (set): pop arbitrary entries on overflow.  This
         is fine because the set only feeds diagnostic summaries; losing
         old entries just trims the summary's tail.
-      * ``dedup`` / ``read_timestamps`` (dict): pop oldest by insertion
-        order (Python 3.7+ dicts).  Evicted entries lose their dedup
-        skip on a future re-read (the file gets re-sent once) and
-        external-edit mtime comparison (the write/patch falls back to
-        a non-mtime check).  Both are graceful degradations, not bugs.
+      * ``dedup`` / ``path_coverage`` / ``read_timestamps`` (dict): pop
+        oldest path/key by insertion order (Python 3.7+ dicts). Evicted
+        entries lose their dedup/coverage skip on a future re-read (the
+        file gets re-sent once) and external-edit mtime comparison (the
+        write/patch falls back to a non-mtime check). These are graceful
+        degradations, not bugs.
     """
     rh = task_data.get("read_history")
     if rh is not None and len(rh) > _READ_HISTORY_CAP:
@@ -506,6 +541,8 @@ def _cap_read_tracker_data(task_data: dict) -> None:
                 dedup_hits.pop(next(iter(dedup_hits)))
             except (StopIteration, KeyError):
                 break
+
+    cap_path_coverage(task_data, _PATH_COVERAGE_CAP)
 
     ts = task_data.get("read_timestamps")
     if ts is not None and len(ts) > _READ_TIMESTAMPS_CAP:
@@ -540,11 +577,11 @@ def _is_internal_file_status_text(content: str) -> bool:
     stripped = content.strip()
     if not stripped:
         return False
-    if stripped == _READ_DEDUP_STATUS_MESSAGE:
-        return True
-    if _READ_DEDUP_STATUS_MESSAGE in stripped and \
-            len(stripped) <= 2 * len(_READ_DEDUP_STATUS_MESSAGE):
-        return True
+    for message in _READ_STATUS_MESSAGES:
+        if stripped == message:
+            return True
+        if message in stripped and len(stripped) <= 2 * len(message):
+            return True
     return False
 
 
@@ -729,31 +766,45 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         if block_error:
             return json.dumps({"error": block_error})
 
-        # ── Dedup check ───────────────────────────────────────────────
-        # If we already read this exact (path, offset, limit) and the
-        # file hasn't been modified since, return a lightweight stub
-        # instead of re-sending the same content.  Saves context tokens.
+        # ── Dedup / coverage check ────────────────────────────────────
+        # Exact-window dedup preserves the existing lightweight stub for
+        # identical (path, offset, limit) reads. Path-level interval coverage
+        # supplements it by skipping or narrowing overlapping re-reads where
+        # the model changes offset/limit to bypass the exact key.
         resolved_str = str(_resolved)
+        requested_offset, requested_limit = offset, limit
+        requested_start, requested_end = offset, offset + limit - 1
+        current_mtime = None
+        try:
+            current_mtime = os.path.getmtime(resolved_str)
+        except OSError:
+            pass
+
         dedup_key = (resolved_str, offset, limit)
+        uncovered_interval = None
+        coverage_hint = None
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
                 "read_history": set(), "dedup": {},
-                "dedup_hits": {}, "read_timestamps": {},
+                "dedup_hits": {}, "path_coverage": {},
+                "read_timestamps": {},
             })
-            # Backward-compat for pre-existing tracker entries that predate
-            # dedup_hits/read_timestamps (long-lived task or crossed an
-            # upgrade boundary).
-            if "dedup_hits" not in task_data:
-                task_data["dedup_hits"] = {}
-            if "read_timestamps" not in task_data:
-                task_data["read_timestamps"] = {}
+            _ensure_read_tracker_fields(task_data)
+            if current_mtime is not None:
+                coverage = get_path_coverage(task_data, resolved_str, current_mtime)
+                uncovered_interval = first_uncovered_interval(
+                    coverage.get("intervals", []), requested_start, requested_end,
+                )
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
+            _cap_read_tracker_data(task_data)
 
         if cached_mtime is not None:
             try:
-                current_mtime = os.path.getmtime(resolved_str)
-                if current_mtime == cached_mtime:
+                mtime_for_dedup = current_mtime
+                if mtime_for_dedup is None:
+                    mtime_for_dedup = os.path.getmtime(resolved_str)
+                if mtime_for_dedup == cached_mtime:
                     # Count repeated stub returns so weak tool-followers that
                     # ignore the "refer to earlier result" hint don't burn
                     # their iteration budget in an infinite read loop.  After
@@ -788,6 +839,47 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                     }, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
+
+        if current_mtime is not None:
+            if uncovered_interval is None:
+                coverage_hit_key = (resolved_str, "coverage")
+                with _read_tracker_lock:
+                    hits = task_data["dedup_hits"].get(coverage_hit_key, 0) + 1
+                    task_data["dedup_hits"][coverage_hit_key] = hits
+                    _cap_read_tracker_data(task_data)
+
+                if hits >= 2:
+                    return json.dumps({
+                        "error": (
+                            f"BLOCKED: You have re-read lines that were "
+                            f"already returned for '{path}' {hits + 1} times. "
+                            "STOP calling read_file for this path and use the "
+                            "content already in context."
+                        ),
+                        "path": path,
+                        "already_read": hits + 1,
+                    }, ensure_ascii=False)
+
+                return json.dumps({
+                    "status": "already_loaded",
+                    "message": _READ_ALREADY_LOADED_STATUS_MESSAGE,
+                    "path": path,
+                    "offset": requested_offset,
+                    "limit": requested_limit,
+                    "dedup": True,
+                    "content_returned": False,
+                }, ensure_ascii=False)
+
+            first_missing_start, first_missing_end = uncovered_interval
+            if uncovered_interval != (requested_start, requested_end):
+                offset = first_missing_start
+                limit = first_missing_end - first_missing_start + 1
+                dedup_key = (resolved_str, offset, limit)
+                coverage_hint = (
+                    f"Requested lines {requested_start}-{requested_end} partly "
+                    f"overlapped prior read_file output for this unchanged file; "
+                    f"returning only new lines {first_missing_start}-{first_missing_end}."
+                )
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
@@ -834,19 +926,18 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "to keep context usage efficient."
             ))
 
+        if coverage_hint is not None:
+            result_dict.setdefault("_hint", coverage_hint)
+
         # ── Track for consecutive-loop detection ──────────────────────
         read_key = ("read", path, offset, limit)
         with _read_tracker_lock:
-            # Ensure "dedup" / "dedup_hits" keys exist (backward compat with
-            # old tracker state from pre-dedup-guard sessions).
-            if "dedup" not in task_data:
-                task_data["dedup"] = {}
-            if "dedup_hits" not in task_data:
-                task_data["dedup_hits"] = {}
+            _ensure_read_tracker_fields(task_data)
             # Real read succeeded — this key is no longer in a stub-loop, so
             # reset its hit counter.  (File either changed or stat failed
             # earlier and we fell through.)
             task_data["dedup_hits"].pop(dedup_key, None)
+            task_data["dedup_hits"].pop((resolved_str, "coverage"), None)
             task_data["read_history"].add((path, offset, limit))
             if task_data["last_key"] == read_key:
                 task_data["consecutive"] += 1
@@ -855,14 +946,20 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 task_data["consecutive"] = 1
             count = task_data["consecutive"]
 
-            # Store mtime at read time for two purposes:
+            # Store mtime at read time for three purposes:
             # 1. Dedup: skip identical re-reads of unchanged files.
-            # 2. Staleness: warn on write/patch if the file changed since
+            # 2. Coverage: skip/narrow overlapping reads of unchanged files.
+            # 3. Staleness: warn on write/patch if the file changed since
             #    the agent last read it (external edit, concurrent agent, etc.).
             try:
                 _mtime_now = os.path.getmtime(resolved_str)
                 task_data["dedup"][dedup_key] = _mtime_now
-                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
+                task_data["read_timestamps"][resolved_str] = _mtime_now
+                if not result_dict.get("error"):
+                    record_path_coverage(
+                        task_data, resolved_str, _mtime_now, offset, limit,
+                        _PATH_COVERAGE_INTERVAL_CAP,
+                    )
             except OSError:
                 pass  # Can't stat — skip tracking for this entry
 
@@ -914,8 +1011,8 @@ def reset_file_dedup(task_id: str = None):
     Called after context compression — the original read content has been
     summarised away, so the model needs the full content if it reads the
     same file again.  Without this, reads after compression would return
-    a "file unchanged" stub pointing at content that no longer exists in
-    context.
+    a "file unchanged" / "already_loaded" stub pointing at content that no
+    longer exists in context.
 
     Call with a task_id to clear just that task, or without to clear all.
     """
@@ -927,12 +1024,16 @@ def reset_file_dedup(task_id: str = None):
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
                     task_data["dedup_hits"].clear()
+                if "path_coverage" in task_data:
+                    task_data["path_coverage"].clear()
         else:
             for task_data in _read_tracker.values():
                 if "dedup" in task_data:
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
                     task_data["dedup_hits"].clear()
+                if "path_coverage" in task_data:
+                    task_data["path_coverage"].clear()
 
 
 def notify_other_tool_call(task_id: str = "default"):
@@ -956,20 +1057,20 @@ def notify_other_tool_call(task_id: str = "default"):
 
 
 def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
-    """Remove all dedup cache entries whose resolved path matches *filepath*.
+    """Remove cached read state whose resolved path matches *filepath*.
 
     Called after write_file and patch so that a subsequent read_file on
     the same path always returns fresh content instead of a stale
-    "File unchanged" stub.  The dedup cache keys are tuples of
-    ``(resolved_path, offset, limit)``; we must evict **all** offset/limit
-    combinations for the written path because any cached range could now
-    be stale.
+    "File unchanged" / "already_loaded" stub. The dedup cache keys are
+    tuples of ``(resolved_path, offset, limit)`` and coverage is keyed by
+    ``resolved_path``; we must evict all entries for the written path
+    because any cached range could now be stale.
 
     Must be called with ``_read_tracker_lock`` **not** held — acquires it
     internally.
     """
     try:
-        resolved = str(_resolve_path(filepath))
+        resolved = str(_resolve_path_for_task(filepath, task_id))
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
@@ -977,12 +1078,14 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
         if task_data is None:
             return
         dedup = task_data.get("dedup")
-        if not dedup:
-            return
-        # Collect keys to remove (can't mutate dict during iteration).
-        stale_keys = [k for k in dedup if k[0] == resolved]
-        for k in stale_keys:
-            del dedup[k]
+        if dedup:
+            # Collect keys to remove (can't mutate dict during iteration).
+            stale_keys = [k for k in dedup if k[0] == resolved]
+            for k in stale_keys:
+                del dedup[k]
+        path_coverage = task_data.get("path_coverage")
+        if path_coverage:
+            path_coverage.pop(resolved, None)
 
 
 def _update_read_timestamp(filepath: str, task_id: str) -> None:

--- a/tools/read_coverage.py
+++ b/tools/read_coverage.py
@@ -1,0 +1,77 @@
+"""Line-interval coverage helpers for read_file context deduplication."""
+
+from __future__ import annotations
+
+
+def merge_intervals(
+    intervals: list[tuple[int, int]],
+    start: int,
+    end: int,
+) -> list[tuple[int, int]]:
+    """Merge an inclusive interval into sorted inclusive intervals."""
+    merged: list[tuple[int, int]] = []
+    for s, e in sorted([*intervals, (start, end)]):
+        if merged and s <= merged[-1][1] + 1:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+        else:
+            merged.append((s, e))
+    return merged
+
+
+def first_uncovered_interval(
+    intervals: list[tuple[int, int]],
+    start: int,
+    end: int,
+) -> tuple[int, int] | None:
+    """Return the first inclusive sub-interval not covered, or None."""
+    cursor = start
+    for s, e in intervals:
+        if e < cursor:
+            continue
+        if s > cursor:
+            return cursor, min(end, s - 1)
+        cursor = max(cursor, e + 1)
+        if cursor > end:
+            return None
+    return (cursor, end) if cursor <= end else None
+
+
+def get_path_coverage(task_data: dict, resolved_path: str, mtime: float) -> dict:
+    """Return path coverage state, resetting intervals when mtime changes."""
+    coverage_by_path = task_data.setdefault("path_coverage", {})
+    coverage = coverage_by_path.get(resolved_path)
+    if coverage is None or coverage.get("mtime") != mtime:
+        coverage = {"mtime": mtime, "intervals": []}
+        coverage_by_path[resolved_path] = coverage
+    else:
+        coverage.setdefault("intervals", [])
+    return coverage
+
+
+def record_path_coverage(
+    task_data: dict,
+    resolved_path: str,
+    mtime: float,
+    offset: int,
+    limit: int,
+    max_intervals: int,
+) -> None:
+    """Record the returned read_file line interval for an unchanged path."""
+    start, end = offset, offset + limit - 1
+    coverage = get_path_coverage(task_data, resolved_path, mtime)
+    merged = merge_intervals(coverage.get("intervals", []), start, end)
+    # If a file is too fragmented, forget old coverage rather than growing
+    # task-local state forever. The safe degradation is one future resend.
+    coverage["intervals"] = [(start, end)] if len(merged) > max_intervals else merged
+
+
+def cap_path_coverage(task_data: dict, max_paths: int) -> None:
+    """Bound the number of paths that retain interval coverage."""
+    coverage_by_path = task_data.get("path_coverage")
+    if coverage_by_path is None or len(coverage_by_path) <= max_paths:
+        return
+    for _ in range(len(coverage_by_path) - max_paths):
+        try:
+            coverage_by_path.pop(next(iter(coverage_by_path)))
+        except (StopIteration, KeyError):
+            break


### PR DESCRIPTION
## Summary

Fixes redundant `read_file` context inflation when agents re-read unchanged files with slightly different `offset`/`limit` windows.

## Changes

- Add path+mtime line-interval coverage tracking alongside the existing exact `(path, offset, limit)` dedup cache.
- Return `status: "already_loaded"` when a different read window is already fully covered by prior output for the unchanged file.
- Narrow partially overlapping reads to the first uncovered line range instead of re-sending already loaded lines.
- Keep legitimate pagination working: non-overlapping sequential windows still return content.
- Clear coverage on context-compression dedup reset and after writes/patches invalidate cached read state.
- Move interval bookkeeping into `tools/read_coverage.py` so `tools/file_tools.py` only contains the read-path integration.
- Bound both number of covered paths and fragmented intervals per path.
- Guard the new `already_loaded` status text against accidental `write_file` persistence.

## Similar open PRs checked

- #33066 (`fix(file-tools): guard read_file against no-progress re-read loops`) is related, but it warns/blocks only after repeated no-progress reads. This PR avoids duplicate context immediately by returning `already_loaded` or narrowing to uncovered intervals, and keeps path+mtime coverage across intervening non-read tool calls until compression/mtime/write invalidation.
- #37385 (`test(macos): resolve /tmp symlink in file_tools path assertions`) exactly covers the macOS `/tmp` -> `/private/tmp` test issue I hit locally. I removed that unrelated test-only fix from this PR to avoid duplicating it.
- #20517 (`fix(tools): make read_file dedup task-aware`) overlaps one invalidation concern. This PR keeps task-aware invalidation because the new path coverage state must be invalidated with the same resolver used for reads; it does not include the broader cached-cwd changes from #20517.

## Design review follow-up

A review pass flagged the first version as too noisy inside `file_tools.py` and too diagnostic-heavy. This revision trims the `already_loaded` payload, removes verbose interval lists from tool responses, adds stub-loop escalation for repeated `already_loaded` stubs, and extracts interval helpers into `tools/read_coverage.py`.

`tools/file_tools.py` now has 150 insertions / 47 deletions in this PR; the interval helper module is 77 lines.

## Validation

- `scripts/run_tests.sh tests/tools/test_file_read_guards.py tests/tools/test_accretion_caps.py tests/tools/test_read_loop_detection.py` — 83 passed
- `git diff --check`
