### PR TITLE
feat(signal): add outbound quote/reply-to support

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -623,6 +623,7 @@ class SignalAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             timestamp=timestamp,
+            message_id=str(ts_ms) if ts_ms else None,
             raw_message={"sender": sender, "timestamp_ms": ts_ms},
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
@@ -978,6 +979,13 @@ class SignalAdapter(BasePlatformAdapter):
                 params["textStyle"] = text_styles[0]
             else:
                 params["textStyles"] = text_styles
+
+        if reply_to is not None:
+            try:
+                params["quoteTimestamp"] = int(reply_to)
+                params["quoteAuthor"] = chat_id
+            except (ValueError, TypeError):
+                pass
 
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]


### PR DESCRIPTION
## Summary

Adds support for quoting or replying to a specific message when sending outbound Signal messages. When the gateway processes a message with a quote field in the envelope metadata, it includes the quoted message in the outbound send so the recipient sees the reply in context.

## Changes
- **gateway/platforms/signal.py**: Pass quote data through to signal-cli send endpoint when available

## Testing
- Existing Signal adapter tests cover the send path.
- Manually verified with paired Signal devices that quoted replies appear correctly.