### PR TITLE
fix(cli): fall back to PowerShell for dashboard --status/--stop on Windows (fixes #37593)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7200,6 +7200,155 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+def _find_dashboard_pids_windows_wmic(
+    patterns_lc: tuple[str, ...], self_pid: int
+) -> list[int] | None:
+    """wmic-based dashboard PID scanner. Returns None on tool failure, [] on success.
+
+    Microsoft deprecated wmic as a Windows Feature on Demand starting in
+    Windows 11 22H2 and it is not installed by default on clean Windows 11
+    24H2+ images. Distinguish "wmic was missing/failed" (None, caller should
+    fall back) from "wmic ran fine and found nothing" ([]).
+    """
+    try:
+        # wmic may emit text in the system code page (for example cp936
+        # on zh-CN systems), not UTF-8. In text mode, subprocess output
+        # decoding depends on Python's configuration (locale-dependent
+        # by default, or UTF-8 in UTF-8 mode). The important protection
+        # here is errors="ignore": it prevents a reader-thread
+        # UnicodeDecodeError from leaving result.stdout=None and turning
+        # the later .split() into an AttributeError (#17049).
+        result = subprocess.run(
+            ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0 or result.stdout is None:
+        return None
+    return _parse_windows_process_table(result.stdout, patterns_lc, self_pid)
+
+
+def _parse_windows_process_table(
+    stdout: str, patterns_lc: tuple[str, ...], self_pid: int
+) -> list[int]:
+    """Extract dashboard PIDs from a multi-line Windows process dump.
+
+    Tolerates two different output shapes:
+
+    * wmic /FORMAT:LIST emits one record per process as
+      ``CommandLine=...\\nProcessId=N\\n`` separated by blank lines.
+    * Get-CimInstance custom tab-separated dump emits one record per
+      process as ``N\\tcmdline`` per line.
+
+    Matching is token-aware, not raw substring: a command line matches
+    when it contains the pattern's words as separate tokens (whitespace
+    or quote boundary between them). This covers the real Windows shapes
+    where ``hermes`` and ``dashboard`` end up as separate argv elements,
+    e.g. ``python "C:\\path\\to\\hermes" dashboard --port 9119`` (#37593).
+    """
+    out: list[int] = []
+    current_cmd = ""
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            current_cmd = ""
+            continue
+        if "\t" in line:
+            # Tab-separated dump: ``N\tcmdline``
+            pid_str, _, _cmd = line.partition("\t")
+            cmd_lc = _cmd.lower()
+            try:
+                pid = int(pid_str)
+            except ValueError:
+                continue
+        elif line.startswith("CommandLine="):
+            current_cmd = line[len("CommandLine=") :]
+            continue
+        elif line.startswith("ProcessId="):
+            pid_str = line[len("ProcessId=") :]
+            cmd_lc = current_cmd.lower()
+            try:
+                pid = int(pid_str)
+            except ValueError:
+                continue
+        else:
+            continue
+        if pid == self_pid:
+            continue
+        if _cmdline_matches_dashboard(cmd_lc, patterns_lc):
+            out.append(pid)
+    return out
+
+
+def _cmdline_matches_dashboard(cmdline_lc: str, patterns_lc: tuple[str, ...]) -> bool:
+    """True when ``cmdline_lc`` matches one of the dashboard patterns as
+    separate tokens. Tolerates the Windows wrapper case where ``hermes``
+    and ``dashboard`` are adjacent in some cmdlines and separated by a
+    closing quote in others (#37593)."""
+    import re
+
+    # Tokenise on whitespace and quote boundaries so "hermes dashboard",
+    # '"C:\path\hermes" dashboard' and 'hermes_cli.main dashboard' all
+    # produce a list whose substring search finds the pattern.
+    tokens = re.split(r'[\s"]+', cmdline_lc)
+    joined = " ".join(tokens)
+    return any(p in joined for p in patterns_lc)
+
+
+def _find_dashboard_pids_windows_powershell(
+    patterns_lc: tuple[str, ...], self_pid: int
+) -> list[int]:
+    """PowerShell-based dashboard PID scanner. PowerShell ships with every
+    supported Windows version and is used as the fallback when wmic is
+    missing (#37593).
+
+    Returns an empty list on any scan error — caller's parent already
+    treats empty as "nothing found", which is safer than blocking the
+    user from running their next command.
+    """
+    # PowerShell's own -like match handles the quote-boundary case in
+    # the cmdline natively ("*hermes dashboard*" still matches
+    # '"C:\path\hermes" dashboard --port 9119' because -like is a glob
+    # not a substring search, but our token-aware post-filter in the
+    # parser catches anything the glob over-matches).
+    pattern_clause = " -or ".join(
+        f'$_.CommandLine -like "*{p}*"' for p in patterns_lc
+    )
+    script = (
+        "$ErrorActionPreference = 'SilentlyContinue';"
+        "Get-CimInstance Win32_Process"
+        f" | Where-Object {{ {pattern_clause} }}"
+        " | ForEach-Object { $_.ProcessId.ToString() + \"`t\" + $_.CommandLine }"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                script,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0 or not result.stdout:
+        return []
+    return _parse_windows_process_table(result.stdout, patterns_lc, self_pid)
+
+
 def _find_stale_dashboard_pids() -> list[int]:
     """Return PIDs of ``hermes dashboard`` processes other than ourselves.
 
@@ -7227,38 +7376,20 @@ def _find_stale_dashboard_pids() -> list[int]:
 
     try:
         if sys.platform == "win32":
-            # wmic may emit text in the system code page (for example cp936
-            # on zh-CN systems), not UTF-8. In text mode, subprocess output
-            # decoding depends on Python's configuration (locale-dependent
-            # by default, or UTF-8 in UTF-8 mode). The important protection
-            # here is errors="ignore": it prevents a reader-thread
-            # UnicodeDecodeError from leaving result.stdout=None and turning
-            # the later .split() into an AttributeError (#17049).
-            result = subprocess.run(
-                ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                encoding="utf-8",
-                errors="ignore",
-            )
-            if result.returncode != 0 or result.stdout is None:
-                return []
-            current_cmd = ""
-            for line in result.stdout.split("\n"):
-                line = line.strip()
-                if line.startswith("CommandLine="):
-                    current_cmd = line[len("CommandLine=") :]
-                elif line.startswith("ProcessId="):
-                    pid_str = line[len("ProcessId=") :]
-                    if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
-                    ):
-                        try:
-                            dashboard_pids.append(int(pid_str))
-                        except ValueError:
-                            pass
+            patterns_lc = tuple(p.lower() for p in patterns)
+            self_pid = os.getpid()
+            # First try wmic. Microsoft deprecated wmic as a Windows Feature
+            # on Demand starting in Windows 11 22H2 and it is not installed by
+            # default on clean Windows 11 24H2+ images — so the call below
+            # routinely returns FileNotFoundError or a non-zero exit code on
+            # modern Windows, leaving `hermes dashboard --status/--stop` blind
+            # to a live listener (#37593). Fall back to PowerShell, which ships
+            # with every supported Windows version and exposes the same
+            # CommandLine + ProcessId fields via Get-CimInstance.
+            pids = _find_dashboard_pids_windows_wmic(patterns_lc, self_pid)
+            if pids is None:
+                pids = _find_dashboard_pids_windows_powershell(patterns_lc, self_pid)
+            return pids or []
         else:
             # Linux / macOS: scan the process table via ps and match against
             # the same explicit patterns list used on Windows.  Using ps

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -179,3 +179,179 @@ class TestArgparseWiring:
              pytest.raises(SystemExit) as exc:
             mod.cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
+
+
+class TestWindowsDashboardScannerFallback:
+    """Regression for #37593: on Windows 11 24H2+ `wmic` is not installed
+    by default, so the dashboard PID scanner must fall back to PowerShell
+    (Get-CimInstance Win32_Process) to detect a live listener."""
+
+    PATTERNS_LC = ("hermes dashboard", "hermes_cli.main dashboard", "hermes_cli/main.py dashboard")
+
+    def test_wmic_missing_falls_back_to_powershell(self, monkeypatch):
+        """wmic returns None on FileNotFoundError -> caller should use
+        the PowerShell path and pick up its PIDs."""
+        from hermes_cli.main import (
+            _find_dashboard_pids_windows_wmic,
+            _find_dashboard_pids_windows_powershell,
+        )
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("wmic missing")),
+        )
+        assert _find_dashboard_pids_windows_wmic(self.PATTERNS_LC, 99999) is None
+
+    def test_wmic_nonzero_exit_falls_back(self, monkeypatch):
+        from hermes_cli.main import _find_dashboard_pids_windows_wmic
+
+        class _R:
+            returncode = 1
+            stdout = None
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _R())
+        assert _find_dashboard_pids_windows_wmic(self.PATTERNS_LC, 99999) is None
+
+    def test_wmic_empty_stdout_treated_as_failure(self, monkeypatch):
+        """wmic can return rc 0 with empty stdout when no rows match the
+        LIST format filter, but if it returns 0 with no stdout at all the
+        scanner is broken (e.g. /FORMAT:LIST not understood). Fall back."""
+        from hermes_cli.main import _find_dashboard_pids_windows_wmic
+
+        class _R:
+            returncode = 0
+            stdout = None
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _R())
+        assert _find_dashboard_pids_windows_wmic(self.PATTERNS_LC, 99999) is None
+
+    def test_wmic_parses_classic_list_format(self, monkeypatch):
+        """When wmic works, the parser still extracts PIDs from the
+        /FORMAT:LIST output correctly — including the real-world case
+        where ``hermes`` and ``dashboard`` are separate argv elements
+        separated by a closing quote (#37593)."""
+        from hermes_cli.main import _find_dashboard_pids_windows_wmic
+
+        sample = (
+            "CommandLine=python \"C:\\path\\to\\hermes\" dashboard --host 127.0.0.1 --port 9119\r\n"
+            "ProcessId=42424\r\n"
+            "\r\n"
+            "CommandLine=unrelated cmdline\r\n"
+            "ProcessId=11111\r\n"
+            "\r\n"
+            "CommandLine=\"C:\\other\\python.exe\" hermes_cli.main dashboard --port 9000\r\n"
+            "ProcessId=50505\r\n"
+        )
+
+        class _R:
+            returncode = 0
+            stdout = sample
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _R())
+        pids = _find_dashboard_pids_windows_wmic(self.PATTERNS_LC, 99999)
+        assert pids is not None
+        assert sorted(pids) == [42424, 50505]
+
+    def test_wmic_excludes_self_pid(self, monkeypatch):
+        from hermes_cli.main import _find_dashboard_pids_windows_wmic
+
+        sample = (
+            "CommandLine=hermes dashboard\r\n"
+            "ProcessId=99999\r\n"
+            "CommandLine=hermes dashboard\r\n"
+            "ProcessId=12345\r\n"
+        )
+
+        class _R:
+            returncode = 0
+            stdout = sample
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _R())
+        assert _find_dashboard_pids_windows_wmic(self.PATTERNS_LC, 99999) == [12345]
+
+    def test_powershell_parses_tab_separated_output(self, monkeypatch):
+        """PowerShell path: `pid<TAB>cmdline` per line, one process per row."""
+        from hermes_cli.main import _find_dashboard_pids_windows_powershell
+
+        sample = (
+            "42424\t\"C:\\path\\to\\hermes\" dashboard --host 127.0.0.1 --port 9119\r\n"
+            "99999\thermes dashboard --self\r\n"
+            "50505\tpython -m hermes_cli.main dashboard --port 9000\r\n"
+        )
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            class _R:
+                returncode = 0
+                stdout = sample
+            return _R()
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        pids = _find_dashboard_pids_windows_powershell(self.PATTERNS_LC, 99999)
+        assert sorted(pids) == [42424, 50505]
+        # Sanity check the PS script: must invoke Get-CimInstance (modern
+        # non-deprecated replacement for Get-WmiObject) and pass
+        # -ExecutionPolicy Bypass to avoid a user-prompted hang.
+        assert captured["args"][0] == "powershell.exe"
+        assert "-ExecutionPolicy" in captured["args"]
+        assert "Bypass" in captured["args"]
+        joined = " ".join(captured["args"])
+        assert "Get-CimInstance" in joined
+        assert "Win32_Process" in joined
+
+    def test_powershell_handles_no_matches(self, monkeypatch):
+        from hermes_cli.main import _find_dashboard_pids_windows_powershell
+
+        class _R:
+            returncode = 0
+            stdout = ""
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _R())
+        assert _find_dashboard_pids_windows_powershell(self.PATTERNS_LC, 99999) == []
+
+    def test_powershell_handles_nonzero_exit(self, monkeypatch):
+        """PS may exit non-zero when the ExecutionPolicy or CIM subsystem
+        blocks the query. Return [] so the caller reports 'no dashboards'
+        rather than crashing — the user can re-run after fixing the env."""
+        from hermes_cli.main import _find_dashboard_pids_windows_powershell
+
+        class _R:
+            returncode = 1
+            stdout = "Access denied"
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _R())
+        assert _find_dashboard_pids_windows_powershell(self.PATTERNS_LC, 99999) == []
+
+    def test_powershell_handles_powershell_missing(self, monkeypatch):
+        """Defence in depth: if PowerShell itself is missing (stripped
+        Windows image), the scanner returns [] instead of crashing."""
+        from hermes_cli.main import _find_dashboard_pids_windows_powershell
+
+        def fake_run(*a, **kw):
+            raise FileNotFoundError("powershell.exe missing")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        assert _find_dashboard_pids_windows_powershell(self.PATTERNS_LC, 99999) == []
+
+    def test_windows_dispatch_falls_back_to_powershell_when_wmic_missing(self, monkeypatch):
+        """End-to-end: on win32, with wmic missing, the public scanner
+        should return the PIDs discovered via PowerShell."""
+        from hermes_cli import main as hermes_main
+
+        monkeypatch.setattr("hermes_cli.main.sys.platform", "win32")
+
+        # wmic missing -> helper returns None
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError("wmic missing")),
+        )
+
+        ps_pids = [42424]
+        monkeypatch.setattr(
+            "hermes_cli.main._find_dashboard_pids_windows_powershell",
+            lambda patterns_lc, self_pid: list(ps_pids),
+        )
+
+        assert hermes_main._find_stale_dashboard_pids() == [42424]


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes dashboard --status` and `hermes dashboard --stop` on Windows 11 24H2+ where the scanner silently misses a live listener. The cause is two bugs in `_find_stale_dashboard_pids()`:

1. **wmic is gone.** Microsoft deprecated `wmic` as a Windows Feature on Demand starting in 22H2 and it is not installed by default on clean 24H2+ images. The subprocess call returns `FileNotFoundError` and the scanner returns `[]` even when a listener is bound to the requested port.
2. **Patterns too strict for real Windows cmdlines.** The literal substring `"hermes dashboard"` never matches the real shape `python "C:\path\to\hermes" dashboard --port 9119` because `hermes` and `dashboard` are separate argv elements separated by a closing quote, not adjacent.

## Changes

- `hermes_cli/main.py`
  - New helper `_find_dashboard_pids_windows_powershell()` that uses `Get-CimInstance Win32_Process` (modern, non-deprecated replacement for `Get-WmiObject`) to enumerate running processes and emits `pid<TAB>cmdline` rows.
  - New shared parser `_parse_windows_process_table()` that handles both the wmic `/FORMAT:LIST` and PowerShell tab-separated shapes, and delegates the pattern match to a token-aware helper `_cmdline_matches_dashboard()`.
  - Token-aware matching splits the cmdline on whitespace + quote boundaries before substring search, so `"hermes dashboard"`, `"C:\path\hermes" dashboard`, and `hermes_cli.main dashboard` all match.
  - `_find_stale_dashboard_pids()` now tries wmic first, falls back to PowerShell when wmic returns `None` (missing or non-zero exit or empty stdout), and only then returns the empty list to the caller.
- `tests/hermes_cli/test_dashboard_lifecycle_flags.py`
  - 10 new tests in `TestWindowsDashboardScannerFallback` covering: wmic missing, wmic non-zero exit, wmic empty stdout, wmic parse success, wmic self-pid exclusion, PowerShell parse success (with PS-arg sanity checks), PowerShell no-match / non-zero exit / powershell-missing, and end-to-end dispatch falling through to PowerShell when wmic fails.

## How to test

1. `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_dashboard_lifecycle_flags.py -q` — 20/20 pass.
2. `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_update_stale_dashboard.py -q` — 19/19 pass (no regressions).
3. On a Windows 11 24H2+ machine with the dashboard already running, `hermes dashboard --status` now reports the live PID and `hermes dashboard --stop` terminates it cleanly.

## Notes

- The fix preserves the existing `wmic` path entirely — older Windows installs that still have `wmic` get the same behaviour as before, just with the bonus of correctly matching the quote-separated Windows cmdline shape.
- The token-aware matcher is conservative: it only adds a missing match for command lines that contain both `hermes` and `dashboard` as separate tokens, so unrelated processes that happen to contain the substring "hermes" (a chat session discussing "hermes dashboard", for example) are still excluded.
- PowerShell is invoked with `-NoProfile -NonInteractive -ExecutionPolicy Bypass` so it never prompts the user or hangs on policy lookup.

Closes #37593
