### PR TITLE
fix(auth): clear active_provider when removing the active OAuth provider

### DIFF
--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -232,6 +232,8 @@ def _clear_auth_store_provider(provider: str) -> bool:
         providers_dict = auth_store.get("providers")
         if isinstance(providers_dict, dict) and provider in providers_dict:
             del providers_dict[provider]
+            if auth_store.get("active_provider") == provider:
+                auth_store["active_provider"] = None
             _save_auth_store(auth_store)
             return True
     return False

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1688,3 +1688,48 @@ def test_auth_remove_codex_manual_device_code_suppresses_canonical(tmp_path, mon
 
     auth_remove_command(SimpleNamespace(provider="openai-codex", target="1"))
     assert is_source_suppressed("openai-codex", "device_code")
+
+
+def test_clear_auth_store_provider_clears_active_provider(tmp_path, monkeypatch):
+    """_clear_auth_store_provider must also clear active_provider when the
+    removed provider is the active one — parity with clear_provider_auth()."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "active_provider": "xai-oauth",
+        "providers": {
+            "xai-oauth": {"access_token": "tok", "refresh_token": "ref"},
+        },
+    })
+
+    from agent.credential_sources import _clear_auth_store_provider
+
+    result = _clear_auth_store_provider("xai-oauth")
+    assert result is True
+
+    auth_file = tmp_path / "hermes" / "auth.json"
+    store = json.loads(auth_file.read_text())
+    assert "xai-oauth" not in store.get("providers", {})
+    assert store.get("active_provider") is None
+
+
+def test_clear_auth_store_provider_preserves_active_provider_for_other(tmp_path, monkeypatch):
+    """When a non-active provider is removed, active_provider must be untouched."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "active_provider": "nous",
+        "providers": {
+            "nous": {"access_token": "nous-tok"},
+            "xai-oauth": {"access_token": "xai-tok"},
+        },
+    })
+
+    from agent.credential_sources import _clear_auth_store_provider
+
+    result = _clear_auth_store_provider("xai-oauth")
+    assert result is True
+
+    store = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert "xai-oauth" not in store.get("providers", {})
+    assert store.get("active_provider") == "nous"


### PR DESCRIPTION
## Problem

`_clear_auth_store_provider()` deletes `providers[provider]` from auth.json but does not
update `active_provider`. After removal, `get_active_provider()` still returns the stale
provider name. On the next launch `is_provider_explicitly_configured()` returns `True` for
it, credential-pool resolution finds an empty pool, and raises **"No inference provider
configured"** — even when other providers are still available.

### Affected providers

All providers whose removal dispatches through `_clear_auth_store_provider`:
`nous`, `openai-codex`, `xai-oauth`, `minimax-oauth`
(and any future provider that calls it).

### Failure path

```
hermes auth add xai-oauth      # active_provider = "xai-oauth"
hermes auth remove xai-oauth   # providers["xai-oauth"] deleted
                                # active_provider = "xai-oauth"  ← stale
hermes                         # get_active_provider() → "xai-oauth"
                                # load_pool("xai-oauth") → empty
                                # → "No inference provider configured"
```

## Fix

`clear_provider_auth()` (used by `hermes logout`) already nulls `active_provider` when it
matches the removed provider ([auth.py:1412-1413](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/auth.py#L1412-L1413)). Apply the same guard inside `_clear_auth_store_provider()`:

```python
del providers_dict[provider]
if auth_store.get("active_provider") == provider:
    auth_store["active_provider"] = None
_save_auth_store(auth_store)
```

Both changes happen inside the same `_auth_store_lock()` context, so the write is atomic.

## Test plan

- [x] `test_clear_auth_store_provider_clears_active_provider` — removes the active provider, verifies `active_provider` is `None`
- [x] `test_clear_auth_store_provider_preserves_active_provider_for_other` — removes a non-active provider, verifies `active_provider` is unchanged
- [x] All existing `credential_sources` tests pass