### PR TITLE
fix(web): return effective enabled state from toolset toggle endpoint

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5881,7 +5881,9 @@ async def toggle_toolset(name: str, body: ToolsetToggle):
     else:
         enabled.discard(name)
     _save_platform_tools(config, "cli", enabled)
-    return {"ok": True, "name": name, "enabled": body.enabled}
+    config_after = load_config()
+    effective = set(_get_platform_tools(config_after, "cli", include_default_mcp_servers=False))
+    return {"ok": True, "name": name, "enabled": name in effective}
 
 
 @app.get("/api/tools/toolsets/{name}/config")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1748,6 +1748,24 @@ class TestNewEndpoints:
         )
         assert resp.status_code == 400
 
+    def test_toggle_toolset_platform_restricted_returns_actual_state(self):
+        """PUT for a platform-restricted toolset must return enabled=false.
+
+        discord_admin is restricted to the 'discord' platform.
+        _save_platform_tools silently drops it for the 'cli' platform, so the
+        response must reflect what was actually persisted — not the requested state.
+        Closes #37609.
+        """
+        resp = self.client.put("/api/tools/toolsets/discord_admin", json={"enabled": True})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["name"] == "discord_admin"
+        assert body["enabled"] is False
+
+        listing = {t["name"]: t for t in self.client.get("/api/tools/toolsets").json()}
+        assert listing["discord_admin"]["enabled"] is False
+
     def test_config_raw_get(self):
         resp = self.client.get("/api/config/raw")
         assert resp.status_code == 200


### PR DESCRIPTION
## Problem

`PUT /api/tools/toolsets/{name}` always responds with `enabled: body.enabled`
regardless of whether the write was actually applied. `_save_platform_tools()`
silently drops toolsets restricted to other platforms (e.g. `discord_admin` is
restricted to `platform='discord'`; the endpoint hardcodes `platform='cli'`).
Result: the desktop Skills & Tools toggle flashes `on` and then reverts to `off`
on the next navigation — with no error surfaced to the user.

Reported in #37609.

### Root cause trace

```
PUT /api/tools/toolsets/discord_admin  {"enabled": true}

_save_platform_tools(config, "cli", {…, "discord_admin"})
  └─ _toolset_allowed_for_platform("discord_admin", "cli")
       └─ _TOOLSET_PLATFORM_RESTRICTIONS["discord_admin"] = {"discord"}
       └─ "cli" ∉ {"discord"}  →  write silently dropped

return {"ok": True, "enabled": True}   ← false success
```

## Fix

After saving, re-read the config and return whether the toolset is actually
present in the effective set — so the API response always reflects reality:

```python
_save_platform_tools(config, "cli", enabled)
config_after = load_config()
effective = set(_get_platform_tools(config_after, "cli", include_default_mcp_servers=False))
return {"ok": True, "name": name, "enabled": name in effective}
```

`_get_platform_tools` is already imported in the same block.

## Test plan

- [x] `test_toggle_toolset_platform_restricted_returns_actual_state` — toggling `discord_admin` on returns `enabled: false`; GET listing confirms it stayed off
- [x] `test_toggle_toolset_enable_disable` — normal (unrestricted) toggles still work and return the correct state
- [x] `test_toggle_toolset_unknown_returns_400` — regression guard