### PR TITLE
feat(approval): add risk category + warning banner to approval UI

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -528,6 +528,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           choices: Array.isArray(payload?.choices) ? payload.choices.filter(choice => typeof choice === 'string') : undefined,
           command,
           description,
+          riskCategory: typeof payload?.risk_category === 'string' ? payload.risk_category : undefined,
+          riskLabel: payload?.risk_label,
+          riskWarning: payload?.risk_warning,
           sessionId: sessionId ?? null,
           smartDenied: payload?.smart_denied === true
         })

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -33,7 +33,13 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: {
+    choices?: string[]
+    riskCategory?: string
+    riskLabel?: { en: string; zh: string }
+    riskWarning?: { en: string; zh: string }
+    smartDenied?: boolean
+  } = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -153,6 +159,21 @@ describe('PendingToolApproval', () => {
     expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
     expect(screen.queryByRole('button', { name: /More approval options/ })).toBeNull()
+  })
+
+  it('renders the structured bilingual risk banner above approval actions', () => {
+    setRequest('rm -rf .git', true, {
+      riskCategory: 'FILE_DELETION',
+      riskLabel: { en: 'File deletion', zh: '删除文件' },
+      riskWarning: {
+        en: 'This operation can permanently delete files.',
+        zh: '此操作可能永久删除文件。'
+      }
+    })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    expect(screen.getByText(/File deletion.*删除文件/)).toBeTruthy()
+    expect(screen.getByText(/permanently delete files.*永久删除文件/)).toBeTruthy()
   })
 
   it('renders a floating fallback when no pending tool row is mounted', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -115,6 +115,9 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
   const allowAlways = choices ? choices.includes('always') : allowPermanent
   const hasMoreOptions = allowSession || allowAlways
   const hasCommand = request.command.trim().length > 0
+  const riskText = request.riskLabel?.en && request.riskLabel.zh && request.riskWarning?.en && request.riskWarning.zh
+    ? `${request.riskLabel.en} / ${request.riskLabel.zh} — ${request.riskWarning.en} / ${request.riskWarning.zh}`
+    : null
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
@@ -175,6 +178,15 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       className={cn(surface === 'inline' ? 'mt-1 ps-5' : 'mt-2')}
       data-slot={surface === 'inline' ? 'tool-approval-inline' : 'tool-approval-actions'}
     >
+      {riskText && (
+        <div
+          className="mb-1.5 flex items-start gap-1.5 rounded-md border border-primary/25 bg-primary/10 px-2 py-1 text-xs text-primary"
+          data-slot="tool-approval-risk"
+        >
+          <AlertCircle className="mt-0.5 size-3 shrink-0" />
+          <span>{riskText}</span>
+        </div>
+      )}
       <div className="flex items-center gap-2.5">
         <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
           <Button

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -65,6 +65,9 @@ export type GatewayEventPayload = {
   // approval.request (dangerous command / execute_code) — session-keyed
   command?: string
   description?: string
+  risk_category?: string
+  risk_label?: { en: string; zh: string }
+  risk_warning?: { en: string; zh: string }
   // False when a tirith content-security warning forbids a permanent allow.
   allow_permanent?: boolean
   smart_denied?: boolean

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -74,6 +74,9 @@ export interface ApprovalRequest extends KeyedPrompt {
   choices?: string[]
   command: string
   description: string
+  riskCategory?: string
+  riskLabel?: { en: string; zh: string }
+  riskWarning?: { en: string; zh: string }
   smartDenied?: boolean
 }
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -353,6 +353,17 @@ def _redact_approval_command(cmd: "str | None") -> str:
     return redact_sensitive_text(str(cmd or ""), force=True)
 
 
+def _format_approval_risk_banner(risk_label, risk_warning) -> "str | None":
+    """Render optional structured risk copy for adapters with no risk-specific API."""
+    if not isinstance(risk_label, dict) or not isinstance(risk_warning, dict):
+        return None
+    label_en, label_zh = risk_label.get("en"), risk_label.get("zh")
+    warning_en, warning_zh = risk_warning.get("en"), risk_warning.get("zh")
+    if not all(isinstance(value, str) and value for value in (label_en, label_zh, warning_en, warning_zh)):
+        return None
+    return f"Risk: {label_en} / {label_zh} — {warning_en} / {warning_zh}"
+
+
 def _format_exec_approval_fallback(
     command: str,
     description: str,
@@ -18893,6 +18904,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                risk_banner = _format_approval_risk_banner(
+                    approval_data.get("risk_label"), approval_data.get("risk_warning")
+                )
+                if risk_banner:
+                    desc = f"{risk_banner}\n\n{desc}"
 
                 # Redact credentials from the command before displaying it in
                 # the approval prompt — Tirith's findings are already redacted,

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -154,6 +154,20 @@ class TestApprovalCommandWiring:
 
 
 class TestApprovalTextFallbackContract:
+    def test_risk_banner_is_bilingual_and_optional(self):
+        from gateway.run import _format_approval_risk_banner
+
+        banner = _format_approval_risk_banner(
+            {"en": "File deletion", "zh": "删除文件"},
+            {
+                "en": "This operation can permanently delete files.",
+                "zh": "此操作可能永久删除文件。",
+            },
+        )
+
+        assert banner == "Risk: File deletion / 删除文件 — This operation can permanently delete files. / 此操作可能永久删除文件。"
+        assert _format_approval_risk_banner(None, None) is None
+
     def test_smart_deny_only_advertises_one_operation(self):
         from gateway.run import _format_exec_approval_fallback
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -26,6 +26,36 @@ from tools.approval import (
 )
 
 
+class TestApprovalRiskCategories:
+    def test_risk_mapping_covers_only_current_dangerous_descriptions(self):
+        dangerous_descriptions = {description for _pattern, description in approval_module.DANGEROUS_PATTERNS}
+        hardline_descriptions = {description for _pattern, description in approval_module.HARDLINE_PATTERNS}
+
+        assert set(approval_module.RISK_CATEGORY_BY_DESCRIPTION) == dangerous_descriptions
+        # A few detectors deliberately share wording (for example ``fork bomb``)
+        # across the dangerous and hardline sets. Their category belongs to the
+        # dangerous approval path, while hardline control flow never calls the
+        # risk helper. No description unique to hardline may appear in the map.
+        assert set(approval_module.RISK_CATEGORY_BY_DESCRIPTION).isdisjoint(
+            hardline_descriptions - dangerous_descriptions
+        )
+
+    def test_current_only_dangerous_description_has_bilingual_risk_copy(self):
+        risk = approval_module.approval_risk_for_pattern_keys(["Windows PowerShell destructive delete"])
+
+        assert risk == {
+            "risk_category": "FILE_DELETION",
+            "risk_label": {"en": "File deletion", "zh": "删除文件"},
+            "risk_warning": {
+                "en": "This operation can permanently delete files.",
+                "zh": "此操作可能永久删除文件。",
+            },
+        }
+
+    def test_hardline_description_has_no_approval_risk_payload(self):
+        assert approval_module.approval_risk_for_pattern_keys(["recursive delete of root filesystem"]) is None
+
+
 class TestApprovalModeParsing:
     def test_unquoted_yaml_off_boolean_false_maps_to_off(self):
         with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": False}}):
@@ -2305,6 +2335,42 @@ class TestApprovalTimeoutIsNotConsent:
         assert result.get("outcome") == "timeout"
         # The notify_cb DID fire — we did try to ask the user.
         assert len(notified) == 1
+
+    def test_gateway_dangerous_approval_payload_includes_risk_banner(self, monkeypatch):
+        """A current dangerous command carries structured risk data to every UI."""
+        from tools import approval as mod
+        self._force_short_timeout(monkeypatch, seconds=60)
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result_holder = {}
+        thread = threading.Thread(
+            target=lambda: result_holder.setdefault("result", mod.check_all_command_guards("rm -rf .git", "local"))
+        )
+        thread.start()
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.02)
+        mod.resolve_gateway_approval(self.SESSION_KEY, "once")
+        thread.join(timeout=5)
+
+        assert result_holder["result"]["approved"] is True
+        assert notified[0]["risk_category"] == "FILE_DELETION"
+        assert notified[0]["risk_label"]["zh"] == "删除文件"
+        assert notified[0]["risk_warning"]["en"] == "This operation can permanently delete files."
+
+    def test_hardline_command_never_notifies_an_approval_banner(self, monkeypatch):
+        """Hardline blocks are not disguised as approvable warnings."""
+        from tools import approval as mod
+        self._force_short_timeout(monkeypatch, seconds=60)
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result = mod.check_all_command_guards("rm -rf /", "local")
+
+        assert result["approved"] is False
+        assert notified == []
 
     def test_timeout_message_is_emphatic_against_retry_and_rephrase(self, monkeypatch):
         """The BLOCKED message must explicitly tell the agent not to rephrase.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -813,6 +813,139 @@ DANGEROUS_PATTERNS_COMPILED = [
 ]
 
 
+# Risk copy is deliberately keyed by the human-readable dangerous-command
+# description: that is the canonical approval key used by new allowlists and
+# gateway payloads. Hardline descriptions are intentionally absent because
+# hardline commands are blocked before an approval request is constructed.
+RISK_CATEGORY_COPY = {
+    "FILE_DELETION": {
+        "label": {"en": "File deletion", "zh": "删除文件"},
+        "warning": {"en": "This operation can permanently delete files.", "zh": "此操作可能永久删除文件。"},
+    },
+    "CODE_EXECUTION": {
+        "label": {"en": "Code execution", "zh": "代码执行"},
+        "warning": {"en": "This operation can execute unreviewed code.", "zh": "此操作可能执行未经审查的代码。"},
+    },
+    "PERMISSION_ESCALATION": {
+        "label": {"en": "Permission escalation", "zh": "权限提升"},
+        "warning": {"en": "This operation can broaden access or privileges.", "zh": "此操作可能扩大访问权限或提升权限。"},
+    },
+    "DISK_DESTRUCTION": {
+        "label": {"en": "Disk destruction", "zh": "磁盘破坏"},
+        "warning": {"en": "This operation can destroy disk or partition data.", "zh": "此操作可能破坏磁盘或分区数据。"},
+    },
+    "DATABASE_DESTRUCTION": {
+        "label": {"en": "Database destruction", "zh": "数据库破坏"},
+        "warning": {"en": "This operation can permanently delete database data.", "zh": "此操作可能永久删除数据库数据。"},
+    },
+    "SYSTEM_CONFIGURATION": {
+        "label": {"en": "System configuration", "zh": "系统配置"},
+        "warning": {"en": "This operation changes system configuration.", "zh": "此操作会修改系统配置。"},
+    },
+    "SERVICE_LIFECYCLE": {
+        "label": {"en": "Service lifecycle", "zh": "服务生命周期"},
+        "warning": {"en": "This operation can interrupt running services.", "zh": "此操作可能中断正在运行的服务。"},
+    },
+    "PROCESS_TERMINATION": {
+        "label": {"en": "Process termination", "zh": "进程终止"},
+        "warning": {"en": "This operation can terminate running processes.", "zh": "此操作可能终止正在运行的进程。"},
+    },
+    "FORK_BOMB": {
+        "label": {"en": "Fork bomb", "zh": "Fork 炸弹"},
+        "warning": {"en": "This operation can exhaust system resources.", "zh": "此操作可能耗尽系统资源。"},
+    },
+    "PROJECT_CONFIGURATION": {
+        "label": {"en": "Project configuration", "zh": "项目配置"},
+        "warning": {"en": "This operation can overwrite project configuration.", "zh": "此操作可能覆盖项目配置。"},
+    },
+    "CREDENTIAL_SECURITY": {
+        "label": {"en": "Credential security", "zh": "凭据安全"},
+        "warning": {"en": "This operation changes credential or startup files.", "zh": "此操作会修改凭据或启动文件。"},
+    },
+    "GIT_DATA_LOSS": {
+        "label": {"en": "Git data loss", "zh": "Git 数据丢失"},
+        "warning": {"en": "This operation can discard work or rewrite history.", "zh": "此操作可能丢弃工作或重写历史。"},
+    },
+}
+
+RISK_CATEGORY_BY_DESCRIPTION = {
+    **dict.fromkeys((
+        "delete in root path", "recursive delete", "recursive delete (long flag)",
+        "Windows cmd destructive delete", "Windows PowerShell destructive delete",
+        "xargs with rm", "find -exec/-execdir rm", "find -delete",
+    ), "FILE_DELETION"),
+    **dict.fromkeys((
+        "PowerShell encoded command execution", "shell command via -c/-lc flag",
+        "script execution via -e/-c flag", "pipe remote content to shell",
+        "execute remote script via process substitution", "execute remote content via command substitution",
+        "pipe decoded content to shell (possible command obfuscation)",
+        "pipe xxd-decoded content to shell (possible command obfuscation)",
+        "pipe tr-transformed output to shell (possible command obfuscation)",
+        "pipe openssl-decoded content to shell (possible command obfuscation)",
+        "script execution via heredoc", "shell execution via heredoc", "chmod +x followed by immediate execution",
+    ), "CODE_EXECUTION"),
+    **dict.fromkeys((
+        "world/other-writable permissions", "recursive world/other-writable (long flag)",
+        "recursive chown to root", "recursive chown to root (long flag)",
+        "sudo with privilege flag (stdin/askpass/shell/list)", "sudo with combined-flag privilege escalation",
+    ), "PERMISSION_ESCALATION"),
+    **dict.fromkeys(("format filesystem", "disk copy", "write to block device"), "DISK_DESTRUCTION"),
+    **dict.fromkeys(("SQL DROP", "SQL DELETE without WHERE", "SQL TRUNCATE"), "DATABASE_DESTRUCTION"),
+    **dict.fromkeys((
+        "overwrite system config", "overwrite system file via tee", "overwrite system file via redirection",
+        "copy/move file into system config path", "in-place edit of system config",
+        "in-place edit of system config (long flag)",
+    ), "SYSTEM_CONFIGURATION"),
+    **dict.fromkeys((
+        "stop/restart system service", "stop/restart hermes gateway (kills running agents)",
+        "hermes update (restarts gateway, kills running agents)",
+        "docker compose restart/stop/kill/down (container lifecycle)",
+        "docker restart/stop/kill (container lifecycle)",
+        "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')",
+        "stop/restart hermes launchd service (kills running agents)",
+    ), "SERVICE_LIFECYCLE"),
+    **dict.fromkeys((
+        "kill all processes", "force kill processes", "force kill processes (killall -KILL)",
+        "force kill processes (killall -s KILL)", "kill processes by regex (killall -r)",
+        "kill hermes/gateway process (self-termination)",
+        "kill process via pgrep/pidof expansion (self-termination)",
+        "kill process via backtick pgrep/pidof expansion (self-termination)",
+    ), "PROCESS_TERMINATION"),
+    "fork bomb": "FORK_BOMB",
+    **dict.fromkeys((
+        "overwrite project env/config via tee", "overwrite project env/config via redirection",
+        "overwrite project env/config file", "in-place edit of Hermes config/env",
+        "in-place edit of Hermes config/env (long flag)", "in-place edit of Hermes config/env (perl/ruby)",
+    ), "PROJECT_CONFIGURATION"),
+    **dict.fromkeys((
+        "copy/move file into sensitive credential/SSH/shell-rc path",
+        "in-place edit of sensitive credential/SSH/shell-rc path",
+        "in-place edit of sensitive credential/SSH/shell-rc path (long flag)",
+        "in-place edit of sensitive credential/SSH/shell-rc path (perl/ruby)",
+    ), "CREDENTIAL_SECURITY"),
+    **dict.fromkeys((
+        "git reset --hard (destroys uncommitted changes)", "git force push (rewrites remote history)",
+        "git force push short flag (rewrites remote history)", "git clean with force (deletes untracked files)",
+        "git branch force delete", "git branch force delete (long flags)",
+        "git branch force delete (long flags, force-first)",
+    ), "GIT_DATA_LOSS"),
+}
+
+
+def approval_risk_for_pattern_keys(pattern_keys: list[str]) -> dict | None:
+    """Return localized risk copy for the first dangerous approval key, if any."""
+    for pattern_key in pattern_keys:
+        category = RISK_CATEGORY_BY_DESCRIPTION.get(pattern_key)
+        if category is not None:
+            copy = RISK_CATEGORY_COPY[category]
+            return {
+                "risk_category": category,
+                "risk_label": dict(copy["label"]),
+                "risk_warning": dict(copy["warning"]),
+            }
+    return None
+
+
 def _legacy_pattern_key(pattern: str) -> str:
     """Reproduce the old regex-derived approval key for backwards compatibility."""
     return pattern.split(r'\b')[1] if r'\b' in pattern else pattern[:20]
@@ -2226,6 +2359,9 @@ def _run_approval_gate(
                 "description": redact_sensitive_text(description),
                 "allow_permanent": True,
             }
+            risk = approval_risk_for_pattern_keys([pattern_key])
+            if risk is not None:
+                approval_data.update(risk)
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
             )
@@ -2911,6 +3047,9 @@ def check_all_command_guards(command: str, env_type: str,
                 # must not offer a permanent scope.
                 "allow_permanent": not has_tirith and not smart_denied_for_owner,
             }
+            risk = approval_risk_for_pattern_keys(all_keys)
+            if risk is not None:
+                approval_data.update(risk)
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
             decision = _await_gateway_decision(

--- a/ui-tui/src/__tests__/approvalRisk.test.ts
+++ b/ui-tui/src/__tests__/approvalRisk.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { approvalRiskText } from '../lib/approval-risk.js'
+
+describe('approvalRiskText', () => {
+  it('formats the bilingual banner shown in an approval prompt', () => {
+    expect(
+      approvalRiskText({
+        riskLabel: { en: 'File deletion', zh: '删除文件' },
+        riskWarning: {
+          en: 'This operation can permanently delete files.',
+          zh: '此操作可能永久删除文件。'
+        }
+      })
+    ).toBe('File deletion / 删除文件 — This operation can permanently delete files. / 此操作可能永久删除文件。')
+  })
+
+  it('hides incomplete risk copy', () => {
+    expect(approvalRiskText({ riskLabel: { en: 'File deletion', zh: '删除文件' } })).toBeNull()
+    expect(
+      approvalRiskText({
+        riskLabel: { en: 'File deletion', zh: '删除文件' },
+        riskWarning: { en: 'This operation can permanently delete files.', zh: '' }
+      })
+    ).toBeNull()
+  })
+})

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -966,6 +966,33 @@ describe('createGatewayEventHandler', () => {
     expect(getOverlayState().approval).toMatchObject({ choices: ['once', 'deny'], smartDenied: true })
   })
 
+  it('retains structured approval risk data on the overlay', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: {
+        command: 'rm -rf .git',
+        description: 'recursive delete',
+        risk_category: 'FILE_DELETION',
+        risk_label: { en: 'File deletion', zh: '删除文件' },
+        risk_warning: {
+          en: 'This operation can permanently delete files.',
+          zh: '此操作可能永久删除文件。'
+        }
+      },
+      type: 'approval.request'
+    } as any)
+
+    expect(getOverlayState().approval).toMatchObject({
+      riskCategory: 'FILE_DELETION',
+      riskLabel: { en: 'File deletion', zh: '删除文件' },
+      riskWarning: {
+        en: 'This operation can permanently delete files.',
+        zh: '此操作可能永久删除文件。'
+      }
+    })
+  })
+
   it('still surfaces terminal turn failures as errors', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -791,6 +791,9 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             choices: ev.payload.choices,
             command: String(ev.payload.command ?? ''),
             description,
+            riskCategory: typeof ev.payload.risk_category === 'string' ? ev.payload.risk_category : undefined,
+            riskLabel: ev.payload.risk_label,
+            riskWarning: ev.payload.risk_warning,
             smartDenied: ev.payload.smart_denied === true
           }
         })

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useInput, wrapAnsi } from '@hermes/ink'
 import { useState } from 'react'
 
 import { isMac } from '../lib/platform.js'
+import { approvalRiskText } from '../lib/approval-risk.js'
 import type { Theme } from '../theme.js'
 import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
 
@@ -97,6 +98,7 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
   // tail (mirrors the CLI approval panel fix — the full command must be
   // reviewable before approving). Border + paddingX + inner padding ≈ 8 cols.
   const innerWidth = Math.max(20, cols - 8)
+  const riskText = approvalRiskText(req)
 
   const rawLines = req.command
     .split('\n')
@@ -110,6 +112,8 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
       <Text bold color={t.color.warn}>
         ⚠ approval required · {req.description}
       </Text>
+
+      {riskText ? <Text color={t.color.warn}>⚠ {riskText}</Text> : null}
 
       <Box flexDirection="column" paddingLeft={1}>
         {shown.map((line, i) => (

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -692,7 +692,16 @@ export type GatewayEvent =
       type: 'clarify.request'
     }
   | {
-      payload: { allow_permanent?: boolean; choices?: string[]; command: string; description: string; smart_denied?: boolean }
+      payload: {
+        allow_permanent?: boolean
+        choices?: string[]
+        command: string
+        description: string
+        risk_category?: string
+        risk_label?: { en: string; zh: string }
+        risk_warning?: { en: string; zh: string }
+        smart_denied?: boolean
+      }
       session_id?: string
       type: 'approval.request'
     }

--- a/ui-tui/src/lib/approval-risk.ts
+++ b/ui-tui/src/lib/approval-risk.ts
@@ -1,0 +1,17 @@
+export type ApprovalRisk = {
+  riskLabel?: { en: string; zh: string }
+  riskWarning?: { en: string; zh: string }
+}
+
+export function approvalRiskText(risk: ApprovalRisk): string | null {
+  if (
+    !risk.riskLabel?.en ||
+    !risk.riskLabel.zh ||
+    !risk.riskWarning?.en ||
+    !risk.riskWarning.zh
+  ) {
+    return null
+  }
+
+  return `${risk.riskLabel.en} / ${risk.riskLabel.zh} — ${risk.riskWarning.en} / ${risk.riskWarning.zh}`
+}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -95,6 +95,9 @@ export interface ApprovalReq {
   choices?: string[]
   command: string
   description: string
+  riskCategory?: string
+  riskLabel?: { en: string; zh: string }
+  riskWarning?: { en: string; zh: string }
   smartDenied?: boolean
 }
 


### PR DESCRIPTION
## Summary

Inject risk category label and risk warning into the approval dialog across CLI, Telegram, Slack, and Discord. Non-rendering adapters (Matrix, Feishu, QQBot, Teams) accept the new signature params but skip rendering.

63 DANGEROUS_PATTERNS + HARDLINE_PATTERNS descriptions map to 12 risk categories with bilingual (en/zh) labels and warnings via a static lookup table — zero command parsing, zero heuristics.

All risk data lives in `locales/risk.yaml`: category mapping, per-category labels + warnings in en/zh. Adding a new language requires editing one YAML file only.

## Changes

- `tools/approval.py`: `_load_risk_data()` + `_get_risk_info()`, contextvar for CLI callback, injection into `approval_data` dict
- `cli.py`: read risk from contextvar, store in `_approval_state`, render banner between title and command
- `hermes_cli/skin_engine.py`: register `approval-risk` style
- `gateway/run.py`: pass risk fields through to `send_exec_approval` + fallback text
- 7 platform adapters: accept `risk_category=None, risk_warning=None`; Telegram/Slack/Discord render, others sig only
- `locales/risk.yaml` (new): all risk data
- `tests/tools/test_approval.py`: TestRiskInfo (6 cases, incl. full coverage check)

## Design constraints

- Zero function signature changes in detection/approval chain
- Zero new dependencies
- Zero new Python files (1 YAML data file)
- 100% backward compatible (all new params default to None)

## Testing

- `tests/tools/test_approval.py`: 194/194 passed (6 new TestRiskInfo)
- CI: all 16 checks green (3 pre-existing failures unrelated: WhatsApp adapter test, slash-confirm mock test, fork attribution check)