### PR TITLE
fix(launchd): extend kickstart fallback to cover exit codes 5 and 125

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3220,7 +3220,7 @@ def launchd_start():
             timeout=30,
         )
     except subprocess.CalledProcessError as e:
-        if e.returncode not in {3, 113}:
+        if e.returncode not in {3, 113, 5, 125}:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
         subprocess.run(
@@ -3339,7 +3339,7 @@ def launchd_restart():
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
-        if e.returncode not in {3, 113}:
+        if e.returncode not in {3, 113, 5, 125}:
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")


### PR DESCRIPTION
## Problem

On macOS, when the Hermes gateway launchd service is unloaded (e.g. after a botched `--all` restart, incomplete update, or manual `launchctl bootout`), `launchctl kickstart` returns exit code **5** (Input/output error) or **125** (service not found in domain) instead of the previously handled **3** and **113**.

The current error-code check in both `launchd_start()` and `launchd_restart()` only catches `{3, 113}`, so exit 5 and 125 are re-raised as `subprocess.CalledProcessError` — the self-healing bootstrap fallback never runs, and the gateway stays permanently unloaded until the user manually runs `hermes gateway start`.

## Changes

Two lines changed in `hermes_cli/gateway.py`:

| Function | Before | After |
|----------|--------|-------|
| `launchd_start()` (line 3226) | `if e.returncode not in {3, 113}` | `if e.returncode not in {3, 113, 5, 125}` |
| `launchd_restart()` (line 3345) | `if e.returncode not in {3, 113}` | `if e.returncode not in {3, 113, 5, 125}` |

When kickstart returns 5 or 125, the existing bootstrap fallback path runs — exactly the same recovery that already works for exit codes 3 and 113.

## Related PRs (all addressing the same launchd-unloaded problem)

This fix is intentionally minimal. The following PRs take deeper approaches to the same root cause:

| PR | Author | Approach | Relation |
|----|--------|----------|----------|
| #35288 (OPEN) | @gweber | Recover unloaded launchd after update | Broader scope — this PR fixes the error-code gap that would also block that recovery |
| #34230 (OPEN) | @chrometh | Restart through launchd supervision | Architectural change; this PR is a bugfix that complements it |
| #34366 (OPEN) | @Jadoking | kickstart after graceful restart | Describes the same `state=not running` after exit 75; this PR adds the bootstrap safety net |
| #31218 (OPEN) | @dev-jin | Self-heal missing plist in launchd_restart | Overlapping: also handles exit 5; this PR is a superset (exit 5 + 125) with the same bootstrap pattern |
| #27691 (OPEN) | @gbondy2 | Verify launchd restart relaunches | Adds verification + fallback kickstart; this PR ensures bootstrap works when kickstart itself fails |
| #13172 (OPEN) | @tangyuanjc | Recover unloaded launchd gateways | update-path specific; this PR applies to all launchd restart paths |
| #28632 (OPEN) | @JiehoonKwak | Bug report: `--all` leaves service unloaded | Documents the `bootout`→`bootstrap` atomicity gap; this PR ensures the bootstrap fallback catches all exit codes |

None of these PRs have been merged. This change is the smallest common denominator — it fixes the error-code gap that blocks recovery regardless of which deeper approach is eventually chosen.

## Testing

- `pytest tests/hermes_cli/test_gateway_service.py -v -q -k launchd`: **14/14 passed**
- Total: **129/135 passed** (6 pre-existing failures: `UserSystemdUnavailableError` on macOS — unrelated)
- Syntax: `python -m py_compile hermes_cli/gateway.py` — OK

## Verification (macOS)

```bash
# Reproduce: unload the service and try kickstart
launchctl bootout gui/501/ai.hermes.gateway
launchctl kickstart gui/501/ai.hermes.gateway
# Before fix: subprocess.CalledProcessError (exit 5) raised
# After fix: "↻ launchd job was unloaded; reloading" → bootstrap → ✓ Service restarted
```