### PR TITLE
fix(anthropic): strip trailing /v1 from base_url in build_anthropic_client (#24833)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,9 +172,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # PR runs only need a test image, so read the shared cache but don't try
-      # to publish cache layers back to ghcr.io from a fork token.
-      - name: Build image (arm64, PR)
+      # PR validation only needs a runnable local image for the docker tests.
+      # Skip cache export on pull_request runs: fork-triggered workflow tokens
+      # can read the shared ghcr cache but may not write organization package
+      # blobs, which turns a successful build into a red CI job during export.
+      - name: Build image (arm64, PR validation)
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -187,8 +189,10 @@ jobs:
             HERMES_GIT_SHA=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
 
-      # Push/release runs still refresh the registry-backed cache so later
-      # arm64 builds start warm and the publish step can reuse the layers.
+      # Push/release builds still read AND write the registry-backed cache so
+      # the publish step reuses layers from this build and the next release
+      # starts warm. The job-lifetime GITHUB_TOKEN avoids the old gha SAS-token
+      # expiry problem on slow cold-cache arm64 runs.
       - name: Build image (arm64, cached publish)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -172,15 +172,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build once, load into the local daemon for testing, then push
-      # by digest below. Reads AND writes the registry-backed cache so the
-      # push reuses layers from this build and the next build starts warm.
-      #
-      # Registry cache (type=registry on ghcr.io) is used instead of the gha
-      # cache that previously broke here: its credential is the job-lifetime
-      # GITHUB_TOKEN, not a short-lived SAS token, so the cold-build-outlives-
-      # token failure mode cannot recur.
+      # PR runs only need a test image, so read the shared cache but don't try
+      # to publish cache layers back to ghcr.io from a fork token.
+      - name: Build image (arm64, PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:test
+          build-args: |
+            HERMES_GIT_SHA=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/nousresearch/hermes-agent:buildcache-arm64
+
+      # Push/release runs still refresh the registry-backed cache so later
+      # arm64 builds start warm and the publish step can reuse the layers.
       - name: Build image (arm64, cached publish)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -122,6 +122,19 @@ class TestBuildAnthropicClient:
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://proxy.example.com/anthropic"
 
+    def test_strips_trailing_v1_from_base_url(self):
+        """SDK appends its own /v1, so a configured /v1 suffix must not double up."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-x", base_url="https://api.anthropic.com/v1")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://api.anthropic.com"
+
+    def test_strips_trailing_v1_with_slash_from_base_url(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-x", base_url="https://proxy.example.com/anthropic/v1/")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://proxy.example.com/anthropic"
+
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(


### PR DESCRIPTION
## Summary

The Anthropic SDK appends `/v1` to `base_url` when constructing request URLs. When a user configures `model.base_url` or `ANTHROPIC_BASE_URL` with a trailing `/v1` (the value the older setup guidance suggested), the SDK produces `/v1/v1/messages` and every request 404s.

The bearer-hook constructor `_build_anthropic_client_with_bearer_hook` already strips a trailing `/v1` at line 612, but its sibling `build_anthropic_client` — the path used for OAuth, x-api-key, and plain Bearer auth (the common case) — forwarded the value verbatim. This applies the same strip in the main constructor, aligning the two paths.

Fixes #24833

## Changes

- `agent/anthropic_adapter.py`: strip trailing `/v1` or `/v1/` from `normalized_base_url` in `build_anthropic_client()`, immediately after `_normalize_base_url_text()`, mirroring the existing idiom in the bearer-hook constructor (+4 lines)
- `tests/agent/test_anthropic_adapter.py`: two new tests covering `/v1` and `/v1/` suffix stripping (+13 lines)

## Validation

| Scenario | Before | After |
|---|---|---|
| `base_url: https://api.anthropic.com/v1` | SDK builds `/v1/v1/messages` → 404 | stripped to `https://api.anthropic.com` → correct |
| `base_url: https://proxy.example.com/anthropic/v1/` | `/v1/v1/messages` → 404 | stripped to `https://proxy.example.com/anthropic` → correct |
| `base_url: https://custom.api.com` (no /v1) | unchanged | unchanged |
| Azure endpoint (`*.azure.com/models/anthropic`) | unchanged (uses api-version query) | unchanged |
| Azure Foundry endpoint | unchanged (bearer-hook path) | unchanged |
| No base_url set | default Anthropic endpoint | unchanged |

## Test plan

- `pytest tests/agent/test_anthropic_adapter.py -v --timeout=0` — 156 passed, 1 skipped
- `test_custom_base_url` passes (non-`/v1` URLs untouched)
- `test_azure_anthropic_endpoint_keeps_context_1m_beta` passes (Azure unaffected)
- `test_azure_foundry_anthropic_endpoint_uses_bearer_auth` passes (Foundry unaffected)
- Manual: `model.base_url: https://api.anthropic.com/v1` no longer 404s