### PR TITLE
fix(discord): add missing 'message' and 'applied_tags' to _HANDLER_DEFAULTS

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -923,6 +923,7 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "message": "", "applied_tags": None,
 }
 
 


### PR DESCRIPTION
## Bug Description

Creating a forum thread with the `create_thread` tool action always fails with:
```
Forum channels require a 'message' parameter for the initial post content.
```
even when a `message` parameter is explicitly provided in the tool call.

## Root Cause

The `_HANDLER_DEFAULTS` dict in `tools/discord_tool.py` was missing the `message` and `applied_tags` keys. The `_make_handler()` function only extracts keys present in `_HANDLER_DEFAULTS` from the tool call arguments, so any `message` or `applied_tags` values passed by the model were silently discarded before reaching `_create_thread()`.

## Fix

Added `"message": "", "applied_tags": None` to `_HANDLER_DEFAULTS`.

**Before:**
```python
_HANDLER_DEFAULTS = {
    "action": "", "guild_id": "", "channel_id": "", "user_id": "",
    "role_id": "", "message_id": "", "query": "", "name": "",
    "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
}
```
**After:**
```python
_HANDLER_DEFAULTS = {
    "action": "", "guild_id": "", "channel_id": "", "user_id": "",
    "role_id": "", "message_id": "", "query": "", "name": "",
    "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
    "message": "", "applied_tags": None,
}
```

## How the Bug Happened
- Commit `81987f035` introduced `_HANDLER_DEFAULTS` (with `discord` + `discord_admin` split) without `message` or `applied_tags`
- Commit `5cc0cacb6` added forum channel support to `_create_thread()` with proper `message` handling, but forgot to update `_HANDLER_DEFAULTS`
- The two parameters have been silently dropped ever since

## How to Verify

1. In a Discord forum channel, call `create_thread` with a `message` parameter
2. Before this fix: always fails with "Forum channels require a 'message' parameter"
3. After this fix: the thread is created successfully with the initial message

## Test Plan

- Manual verification: create a forum thread with a message parameter
- Existing tests still pass (no functional changes, only parameter plumbing)
- Regression: forum `create_thread` with `applied_tags` now works too

## Risk Assessment

**Low** — This is a one-line addition to a defaults dict. The `_HANDLER_DEFAULTS` is only used by the handler lambda to extract parameters from tool call args; adding new keys simply enables parameter forwarding that was previously blocked. No existing behavior changes — previously missing params were silently ignored, now they're properly forwarded.