### PR TITLE
feat(kanban): add native worker lane dispatch hooks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5864,6 +5864,12 @@ class GatewayRunner:
                 disabled_corrupt_boards.pop(slug, None)
             try:
                 conn = _kb.connect(board=slug)
+                try:
+                    from hermes_cli.plugins import build_worker_lane_dispatch
+
+                    worker_lane_spawn, worker_lane_exists = build_worker_lane_dispatch()
+                except Exception:
+                    worker_lane_spawn, worker_lane_exists = None, None
                 # `connect()` runs the schema + idempotent migration on
                 # first open per process; the previous explicit
                 # `init_db()` call here busted the per-process cache and
@@ -5872,6 +5878,8 @@ class GatewayRunner:
                 # `_kanban_notifier_watcher` and issue #21378.
                 return _kb.dispatch_once(
                     conn,
+                    spawn_fn=worker_lane_spawn,
+                    spawnable_assignee_fn=worker_lane_exists,
                     board=slug,
                     max_spawn=max_spawn,
                     max_in_progress=max_in_progress,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2150,9 +2150,17 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
+    try:
+        from hermes_cli.plugins import build_worker_lane_dispatch
+
+        worker_lane_spawn, worker_lane_exists = build_worker_lane_dispatch()
+    except Exception:
+        worker_lane_spawn, worker_lane_exists = None, None
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
             conn,
+            spawn_fn=worker_lane_spawn,
+            spawnable_assignee_fn=worker_lane_exists,
             dry_run=args.dry_run,
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5784,6 +5784,7 @@ def dispatch_once(
     conn: sqlite3.Connection,
     *,
     spawn_fn=None,
+    spawnable_assignee_fn=None,
     ttl_seconds: Optional[int] = None,
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
@@ -5975,7 +5976,13 @@ def dispatch_once(
             from hermes_cli.profiles import profile_exists  # local import: avoids cycle
         except Exception:
             profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row_assignee):
+        external_spawnable = False
+        if spawnable_assignee_fn is not None:
+            try:
+                external_spawnable = bool(spawnable_assignee_fn(row_assignee))
+            except Exception:
+                external_spawnable = False
+        if profile_exists is not None and not profile_exists(row_assignee) and not external_spawnable:
             # Bucket separately from skipped_unassigned: the operator
             # cannot fix this by assigning a profile (the assignee IS the
             # intended owner — a terminal lane). Health telemetry uses
@@ -6109,7 +6116,13 @@ def dispatch_once(
             from hermes_cli.profiles import profile_exists
         except Exception:
             profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        external_spawnable = False
+        if spawnable_assignee_fn is not None:
+            try:
+                external_spawnable = bool(spawnable_assignee_fn(row["assignee"]))
+            except Exception:
+                external_spawnable = False
+        if profile_exists is not None and not profile_exists(row["assignee"]) and not external_spawnable:
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,7 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import importlib.metadata
 import importlib.util
 import inspect
@@ -461,6 +462,46 @@ class PluginContext:
             "args_hint": (args_hint or "").strip(),
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
+
+    # -- kanban worker lane registration ------------------------------------
+
+    def register_worker_lane(
+        self,
+        *,
+        match: str,
+        spawn_fn: Callable,
+        profile_exists: bool = True,
+    ) -> None:
+        """Register an external Kanban worker lane.
+
+        ``match`` is an assignee string or glob pattern, for example
+        ``agentplane-*``. The dispatcher treats matching assignees as spawnable
+        without requiring a Hermes profile and delegates process creation to
+        ``spawn_fn(task, workspace, board=...)``.
+        """
+        pattern = str(match or "").strip()
+        if not pattern:
+            logger.warning(
+                "Plugin '%s' tried to register a worker lane with an empty match.",
+                self.manifest.name,
+            )
+            return
+        if not callable(spawn_fn):
+            logger.warning(
+                "Plugin '%s' tried to register worker lane %r with a non-callable spawn_fn.",
+                self.manifest.name,
+                pattern,
+            )
+            return
+        self._manager._worker_lanes.append(
+            {
+                "match": pattern,
+                "spawn_fn": spawn_fn,
+                "profile_exists": bool(profile_exists),
+                "plugin": self.manifest.name,
+            }
+        )
+        logger.debug("Plugin %s registered worker lane: %s", self.manifest.name, pattern)
 
     # -- tool dispatch -------------------------------------------------------
 
@@ -1012,6 +1053,7 @@ class PluginManager:
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._worker_lanes: List[Dict[str, Any]] = []
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
@@ -1039,6 +1081,7 @@ class PluginManager:
             self._plugin_tool_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
+            self._worker_lanes.clear()
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._context_engine = None
@@ -1799,6 +1842,47 @@ def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
     """
     manager = _ensure_plugins_discovered()
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
+
+
+def _worker_lane_matches(pattern: str, assignee: str) -> bool:
+    return fnmatch.fnmatchcase(assignee, pattern)
+
+
+def _matching_worker_lane(manager: PluginManager, assignee: object) -> Optional[Dict[str, Any]]:
+    name = str(assignee or "").strip()
+    if not name:
+        return None
+    for lane in manager._worker_lanes:
+        pattern = str(lane.get("match") or "").strip()
+        if pattern and _worker_lane_matches(pattern, name):
+            return lane
+    return None
+
+
+def build_worker_lane_dispatch() -> tuple[Optional[Callable], Optional[Callable[[object], bool]]]:
+    """Return dispatcher helpers for plugin-registered Kanban worker lanes.
+
+    The first callable is a composite ``spawn_fn``: it delegates matching
+    assignees to plugin lanes and falls back to the built-in Hermes profile
+    spawner for normal assignees. The second callable lets ``dispatch_once``
+    treat matching non-profile assignees as spawnable.
+    """
+    manager = _ensure_plugins_discovered()
+    if not manager._worker_lanes:
+        return None, None
+
+    def is_spawnable(assignee: object) -> bool:
+        return _matching_worker_lane(manager, assignee) is not None
+
+    def spawn(task, workspace, *, board=None):
+        lane = _matching_worker_lane(manager, getattr(task, "assignee", None))
+        if lane is not None:
+            return lane["spawn_fn"](task, workspace, board=board)
+        from hermes_cli import kanban_db
+
+        return kanban_db._default_spawn(task, workspace, board=board)
+
+    return spawn, is_spawnable
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1954,8 +1954,19 @@ def dispatch(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        try:
+            from hermes_cli.plugins import build_worker_lane_dispatch
+
+            worker_lane_spawn, worker_lane_exists = build_worker_lane_dispatch()
+        except Exception:
+            worker_lane_spawn, worker_lane_exists = None, None
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            spawn_fn=worker_lane_spawn,
+            spawnable_assignee_fn=worker_lane_exists,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            board=board,
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1293,6 +1293,32 @@ def test_dispatch_skips_nonspawnable_into_separate_bucket(kanban_home, monkeypat
     assert not res.spawned
 
 
+def test_dispatch_spawns_registered_external_lane(kanban_home, monkeypatch):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append((task.id, task.assignee, workspace))
+        return 4242
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="agentplane", assignee="agentplane-coder")
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            spawnable_assignee_fn=lambda assignee: str(assignee).startswith("agentplane-"),
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task_id not in res.skipped_nonspawnable
+    assert len(spawns) == 1
+    assert spawns[0][1] == "agentplane-coder"
+    assert task.status == "running"
+    assert task.worker_pid == 4242
+
+
 def test_has_spawnable_ready_false_when_only_terminal_lanes(kanban_home, monkeypatch):
     """``has_spawnable_ready`` returns False when every ready task is
     assigned to a control-plane lane — used by gateway/CLI dispatchers

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -15,6 +15,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    build_worker_lane_dispatch,
     get_plugin_command_handler,
     get_plugin_commands,
     get_pre_tool_call_block_message,
@@ -653,6 +654,29 @@ class TestPluginContext:
         mgr.discover_and_load()
 
         assert "plugin_echo" in mgr._plugin_tool_names
+
+    def test_register_worker_lane_builds_dispatch_helpers(self, monkeypatch):
+        manifest = PluginManifest(name="lane_plugin")
+        mgr = PluginManager()
+        ctx = PluginContext(manifest, mgr)
+        calls = []
+
+        def spawn_fn(task, workspace, *, board=None):
+            calls.append((task.assignee, workspace, board))
+            return 4242
+
+        ctx.register_worker_lane(match="agentplane-*", spawn_fn=spawn_fn, profile_exists=True)
+
+        monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: mgr)
+        spawn, is_spawnable = build_worker_lane_dispatch()
+
+        class Task:
+            assignee = "agentplane-coder"
+
+        assert is_spawnable("agentplane-coder") is True
+        assert is_spawnable("daily") is False
+        assert spawn(Task(), "/workspace/project", board="repo-board") == 4242
+        assert calls == [("agentplane-coder", "/workspace/project", "repo-board")]
 
         from tools.registry import registry
         assert "plugin_echo" in registry._tools

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -44,7 +44,10 @@ For Hermes profile lanes, the dispatcher's `_default_spawn` runs `hermes -p <ass
 | `HERMES_PROFILE` | the worker's own profile name (for `kanban_comment` author attribution) |
 | `HERMES_TENANT` | tenant namespace, if the task has one |
 
-For non-Hermes lanes (registered via a plugin), the plugin supplies its own `spawn_fn` callable that gets `task`, `workspace`, and `board` and returns an optional pid for crash detection.
+For non-Hermes lanes (registered via a plugin), the plugin calls
+`ctx.register_worker_lane(match=..., spawn_fn=..., profile_exists=True)`. The dispatcher treats
+matching assignees as spawnable without requiring a Hermes profile. The `spawn_fn` callable gets
+`task`, `workspace`, and `board` and returns an optional pid for crash detection.
 
 ### 3. A lifecycle terminator
 
@@ -90,7 +93,22 @@ A specialisation of the profile lane: an orchestrator is a Hermes profile whose 
 
 ## Adding an external CLI worker lane
 
-Wiring a non-Hermes CLI tool (Codex CLI, Claude Code CLI, OpenCode CLI, a local coding-model runner, etc.) as a kanban worker lane is *not yet a paved path*. The dispatcher's spawn function is pluggable (`spawn_fn` is a parameter on `dispatch_once`), and a plugin could register its own `spawn_fn` for a non-Hermes assignee, but the surrounding integration work — wrapping the CLI's exit code into `kanban_complete` / `kanban_block` calls, mapping the CLI's workspace/sandbox conventions onto the dispatcher's `HERMES_KANBAN_WORKSPACE` env, handling auth and per-CLI policy — is still per-integration design work.
+Wiring a non-Hermes CLI tool (Codex CLI, Claude Code CLI, OpenCode CLI, a local coding-model runner, etc.) as a kanban worker lane is done through a plugin-owned worker-lane registration:
+
+```python
+def register(ctx):
+    ctx.register_worker_lane(
+        match="my-runner-*",
+        spawn_fn=spawn_my_runner,
+        profile_exists=True,
+    )
+```
+
+The dispatcher still owns claim, retry, crash detection, timeout, and run history. The plugin owns
+only process spawning for matching assignees. The surrounding integration work — wrapping the CLI's
+exit code into `kanban_complete` / `kanban_block` calls, mapping the CLI's workspace/sandbox
+conventions onto the dispatcher's `HERMES_KANBAN_WORKSPACE` env, handling auth and per-CLI policy —
+remains per-integration design work.
 
 If you're considering adding a CLI lane, open an issue describing the specific CLI and the workflow you're trying to enable. The contract above is the constraints any such lane must satisfy; the implementation shape (one plugin per CLI vs a generic CLI-runner plugin parameterised by config) is open.
 


### PR DESCRIPTION
## Summary
- add a native plugin worker-lane registration API for external assignees such as `agentplane-*`
- route CLI, dashboard, and gateway dispatch through registered lane spawn/profile checks
- document `ctx.register_worker_lane(...)` for non-Hermes worker lanes

## Verification
- `python3 -m py_compile hermes_cli/plugins.py hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py gateway/run.py`
- `git diff --check`
- `uv run --extra dev python -m pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_plugins.py` (279 passed, 1 existing SyntaxWarning in `cli.py`)
- `uv run --extra dev ruff check hermes_cli/plugins.py hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py gateway/run.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_plugins.py`
