### PR TITLE
fix(discord): forward message and applied_tags to create_thread

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -472,6 +472,58 @@ class TestCreateThread:
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
 
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_with_message_for_forum(self, mock_req, monkeypatch):
+        """Forum channel threads must forward the message param to the API."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "802", "name": "Forum Post"}
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="Forum Post",
+            message="Hello forum!",
+        ))
+        assert result["success"] is True
+        assert result["thread_id"] == "802"
+        mock_req.assert_called_once_with(
+            "POST", "/channels/11/threads", "test-token",
+            body={
+                "name": "Forum Post",
+                "auto_archive_duration": 1440,
+                "type": 11,
+                "message": {"content": "Hello forum!"},
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_with_applied_tags(self, mock_req, monkeypatch):
+        """Forum channel threads must forward applied_tags to the API."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "803", "name": "Tagged Post"}
+        result = json.loads(discord_core(
+            action="create_thread", channel_id="11", name="Tagged Post",
+            message="Tagged content", applied_tags=["tag1", "tag2"],
+        ))
+        assert result["success"] is True
+        mock_req.assert_called_once_with(
+            "POST", "/channels/11/threads", "test-token",
+            body={
+                "name": "Tagged Post",
+                "auto_archive_duration": 1440,
+                "type": 11,
+                "message": {"content": "Tagged content"},
+                "applied_tags": ["tag1", "tag2"],
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_thread_without_message_no_message_key(self, mock_req, monkeypatch):
+        """Standalone threads without message should NOT include message key."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "804", "name": "Plain Thread"}
+        discord_core(action="create_thread", channel_id="11", name="Plain Thread")
+        body = mock_req.call_args[1]["body"]
+        assert "message" not in body
+        assert "applied_tags" not in body
+
 
 # ---------------------------------------------------------------------------
 # Actions: add_role / remove_role

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -428,6 +428,8 @@ def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
     auto_archive_duration: int = 1440,
+    message: str = "",
+    applied_tags: Any = None,
     **_kwargs: Any,
 ) -> str:
     """Create a thread in a channel."""
@@ -439,13 +441,17 @@ def _create_thread(
             "auto_archive_duration": auto_archive_duration,
         }
     else:
-        # Create a standalone thread
+        # Create a standalone thread (or forum post if message is provided)
         path = f"/channels/{channel_id}/threads"
         body = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
             "type": 11,  # PUBLIC_THREAD
         }
+        if message:
+            body["message"] = {"content": message}
+        if applied_tags is not None:
+            body["applied_tags"] = applied_tags
     thread = _discord_request("POST", path, token, body=body)
     return json.dumps({
         "success": True,
@@ -712,6 +718,15 @@ def _build_schema(
             "enum": [60, 1440, 4320, 10080],
             "description": "Thread archive duration in minutes (create_thread, default 1440).",
         },
+        "message": {
+            "type": "string",
+            "description": "Initial post content for forum channel threads (create_thread).",
+        },
+        "applied_tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Forum tag IDs to apply to the new thread (create_thread).",
+        },
     }
 
     return {
@@ -839,6 +854,8 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    message: str = "",
+    applied_tags: Any = None,
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -872,6 +889,8 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "message": message,
+        "applied_tags": applied_tags,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -894,6 +913,8 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            message=message,
+            applied_tags=applied_tags,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -923,6 +944,7 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "message": "", "applied_tags": None,
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `create_thread` Discord tool action silently dropping the `message` and `applied_tags` parameters. When creating a forum channel thread, the model passes `message` for the initial post content, but `_HANDLER_DEFAULTS` didn't include these keys, so `_make_handler()` discarded them before they reached `_create_thread()`.

## Related Issue

Fixes #37658

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/discord_tool.py`: Added `message` and `applied_tags` to `_HANDLER_DEFAULTS`, `_run_discord_action()` signature, `local_vars` dict, and `action_fn()` call chain. Updated `_create_thread()` to accept and forward `message` (as `{"content": ...}`) and `applied_tags` in the Discord API request body. Added `message` and `applied_tags` to the tool schema properties in `_build_schema()`.
- `tests/tools/test_discord_tool.py`: Added 3 regression tests — forum thread with message, forum thread with applied_tags, and standalone thread without message (verifying no extra keys leak).

## How to Test

1. Run `pytest tests/tools/test_discord_tool.py -x -q` — all 93 tests pass (including 3 new ones)
2. The new tests verify:
   - `create_thread` with `message="Hello forum!"` includes `{"content": "Hello forum!"}` in the API body
   - `create_thread` with `applied_tags=["tag1", "tag2"]` includes them in the API body
   - `create_thread` without `message` does NOT include `message` or `applied_tags` keys (backward compatible)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/discord_tool.py` → `_HANDLER_DEFAULTS` (line 944), `_make_handler` (line 951), `_run_discord_action` (line 829), `_create_thread` (line 427), `_build_schema` (line 609)
- Call chain: `_make_handler` → `discord_core` → `_run_discord_action` → `_create_thread` → `_discord_request`
- Blast radius: LOW — changes are additive (new optional parameters with defaults), existing behavior unchanged when `message`/`applied_tags` not provided
- Related patterns: `_HANDLER_DEFAULTS` acts as a whitelist for parameter forwarding; any key not in it is silently discarded by `_make_handler()`
