### PR TITLE
fix desktop macOS microphone permission guidance

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -34,6 +34,7 @@ const {
   resolveReadableFileForIpc,
   resolveTimeoutMs
 } = require('./hardening.cjs')
+const { requestMicrophoneAccess } = require('./microphone-permissions.cjs')
 
 let nodePty = null
 
@@ -3465,11 +3466,7 @@ ipcMain.on('hermes:previewShortcutActive', (_event, active) => {
 })
 
 ipcMain.handle('hermes:requestMicrophoneAccess', async () => {
-  if (!IS_MAC || typeof systemPreferences.askForMediaAccess !== 'function') {
-    return true
-  }
-
-  return systemPreferences.askForMediaAccess('microphone')
+  return requestMicrophoneAccess({ isMac: IS_MAC, rememberLog, shell, systemPreferences })
 })
 
 ipcMain.handle('hermes:api', async (_event, request) => {

--- a/apps/desktop/electron/microphone-permissions.cjs
+++ b/apps/desktop/electron/microphone-permissions.cjs
@@ -1,0 +1,74 @@
+const MICROPHONE_PRIVACY_SETTINGS_URL = 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone'
+
+const KNOWN_MICROPHONE_STATUSES = new Set(['granted', 'denied', 'restricted', 'not-determined', 'unknown'])
+
+function normalizeMicrophoneStatus(status) {
+  const value = String(status || 'unknown')
+
+  return KNOWN_MICROPHONE_STATUSES.has(value) ? value : 'unknown'
+}
+
+function readMicrophoneStatus(systemPreferences) {
+  if (typeof systemPreferences?.getMediaAccessStatus !== 'function') {
+    return 'unknown'
+  }
+
+  try {
+    return normalizeMicrophoneStatus(systemPreferences.getMediaAccessStatus('microphone'))
+  } catch {
+    return 'unknown'
+  }
+}
+
+function openMicrophonePrivacySettings({ isMac, rememberLog = () => {}, shell } = {}) {
+  if (!isMac || typeof shell?.openExternal !== 'function') {
+    return false
+  }
+
+  shell
+    .openExternal(MICROPHONE_PRIVACY_SETTINGS_URL)
+    .catch(error => rememberLog(`[permissions] failed to open microphone privacy settings: ${error.message}`))
+
+  return true
+}
+
+async function requestMicrophoneAccess({ isMac, rememberLog = () => {}, shell, systemPreferences } = {}) {
+  if (!isMac) {
+    return { granted: true, settingsOpened: false, status: 'granted' }
+  }
+
+  let status = readMicrophoneStatus(systemPreferences)
+
+  if (status === 'granted') {
+    return { granted: true, settingsOpened: false, status }
+  }
+
+  if (
+    (status === 'not-determined' || status === 'unknown') &&
+    typeof systemPreferences?.askForMediaAccess === 'function'
+  ) {
+    let granted = false
+
+    try {
+      granted = await systemPreferences.askForMediaAccess('microphone')
+    } catch (error) {
+      rememberLog(`[permissions] microphone access prompt failed: ${error.message}`)
+    }
+
+    status = readMicrophoneStatus(systemPreferences)
+
+    if (granted || status === 'granted') {
+      return { granted: true, settingsOpened: false, status: status === 'granted' ? status : 'granted' }
+    }
+  }
+
+  const settingsOpened = openMicrophonePrivacySettings({ isMac, rememberLog, shell })
+
+  return { granted: false, settingsOpened, status }
+}
+
+module.exports = {
+  MICROPHONE_PRIVACY_SETTINGS_URL,
+  openMicrophonePrivacySettings,
+  requestMicrophoneAccess
+}

--- a/apps/desktop/electron/microphone-permissions.test.cjs
+++ b/apps/desktop/electron/microphone-permissions.test.cjs
@@ -1,0 +1,90 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  MICROPHONE_PRIVACY_SETTINGS_URL,
+  openMicrophonePrivacySettings,
+  requestMicrophoneAccess
+} = require('./microphone-permissions.cjs')
+
+function shellMock() {
+  const calls = []
+
+  return {
+    calls,
+    shell: {
+      openExternal: async url => {
+        calls.push(url)
+      }
+    }
+  }
+}
+
+test('non-mac platforms do not request microphone media access', async () => {
+  const { calls, shell } = shellMock()
+  const systemPreferences = {
+    askForMediaAccess: async () => {
+      throw new Error('unexpected prompt')
+    }
+  }
+
+  const result = await requestMicrophoneAccess({ isMac: false, shell, systemPreferences })
+
+  assert.deepEqual(result, { granted: true, settingsOpened: false, status: 'granted' })
+  assert.deepEqual(calls, [])
+})
+
+test('macOS not-determined status prompts for microphone access first', async () => {
+  const { calls, shell } = shellMock()
+  const systemPreferences = {
+    askForMediaAccess: async mediaType => {
+      assert.equal(mediaType, 'microphone')
+
+      return true
+    },
+    getMediaAccessStatus: () => 'not-determined'
+  }
+
+  const result = await requestMicrophoneAccess({ isMac: true, shell, systemPreferences })
+
+  assert.deepEqual(result, { granted: true, settingsOpened: false, status: 'granted' })
+  assert.deepEqual(calls, [])
+})
+
+test('macOS denied status opens microphone privacy settings', async () => {
+  const { calls, shell } = shellMock()
+  const systemPreferences = {
+    askForMediaAccess: async () => true,
+    getMediaAccessStatus: () => 'denied'
+  }
+
+  const result = await requestMicrophoneAccess({ isMac: true, shell, systemPreferences })
+
+  assert.deepEqual(result, { granted: false, settingsOpened: true, status: 'denied' })
+  assert.deepEqual(calls, [MICROPHONE_PRIVACY_SETTINGS_URL])
+})
+
+test('macOS prompt denial opens microphone privacy settings', async () => {
+  const { calls, shell } = shellMock()
+  let status = 'not-determined'
+  const systemPreferences = {
+    askForMediaAccess: async () => {
+      status = 'denied'
+
+      return false
+    },
+    getMediaAccessStatus: () => status
+  }
+
+  const result = await requestMicrophoneAccess({ isMac: true, shell, systemPreferences })
+
+  assert.deepEqual(result, { granted: false, settingsOpened: true, status: 'denied' })
+  assert.deepEqual(calls, [MICROPHONE_PRIVACY_SETTINGS_URL])
+})
+
+test('openMicrophonePrivacySettings is macOS-only', () => {
+  const { calls, shell } = shellMock()
+
+  assert.equal(openMicrophonePrivacySettings({ isMac: false, shell }), false)
+  assert.deepEqual(calls, [])
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,7 +32,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/microphone-permissions.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
@@ -1,0 +1,67 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useMicRecorder } from './use-mic-recorder'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+const initialMediaDevices = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices')
+
+function installDesktopBridge(result: Awaited<ReturnType<Window['hermesDesktop']['requestMicrophoneAccess']>> | boolean) {
+  desktopWindow.hermesDesktop = {
+    requestMicrophoneAccess: vi.fn().mockResolvedValue(result)
+  } as unknown as Window['hermesDesktop']
+}
+
+function installMediaDevices(getUserMedia = vi.fn()) {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia }
+  })
+
+  return getUserMedia
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+
+  if (initialMediaDevices) {
+    Object.defineProperty(navigator, 'mediaDevices', initialMediaDevices)
+  } else {
+    Reflect.deleteProperty(navigator, 'mediaDevices')
+  }
+})
+
+describe('useMicRecorder', () => {
+  it('shows macOS settings guidance when microphone permission is denied', async () => {
+    const getUserMedia = installMediaDevices()
+    installDesktopBridge({ granted: false, settingsOpened: true, status: 'denied' })
+    vi.stubGlobal('MediaRecorder', class TestMediaRecorder {})
+
+    const { result } = renderHook(() => useMicRecorder())
+
+    await expect(result.current.handle.start()).rejects.toThrow(
+      'System Settings was opened at Privacy & Security > Microphone'
+    )
+    expect(getUserMedia).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy denial message for boolean bridge results', async () => {
+    const getUserMedia = installMediaDevices()
+    installDesktopBridge(false)
+    vi.stubGlobal('MediaRecorder', class TestMediaRecorder {})
+
+    const { result } = renderHook(() => useMicRecorder())
+
+    await expect(result.current.handle.start()).rejects.toThrow('Microphone permission was denied.')
+    expect(getUserMedia).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -23,6 +23,33 @@ interface MicRecorderHandle {
   cancel: () => void
 }
 
+type MicrophoneAccessResult =
+  | Awaited<ReturnType<Window['hermesDesktop']['requestMicrophoneAccess']>>
+  | boolean
+  | undefined
+
+function microphoneAccessGranted(result: MicrophoneAccessResult) {
+  if (result === undefined) {
+    return true
+  }
+
+  if (typeof result === 'boolean') {
+    return result
+  }
+
+  return result.granted
+}
+
+function microphoneAccessDeniedError(result: MicrophoneAccessResult): Error {
+  if (typeof result === 'object' && result?.settingsOpened) {
+    return new Error(
+      'Microphone permission was denied. System Settings was opened at Privacy & Security > Microphone. Enable Hermes, then try again.'
+    )
+  }
+
+  return new Error('Microphone permission was denied.')
+}
+
 function micError(error: unknown): Error {
   const name = error instanceof DOMException ? error.name : ''
 
@@ -161,10 +188,10 @@ export function useMicRecorder(): { handle: MicRecorderHandle; level: number; re
       throw new Error('This runtime does not support microphone recording.')
     }
 
-    const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+    const access = await window.hermesDesktop?.requestMicrophoneAccess?.()
 
-    if (permitted === false) {
-      throw new Error('Microphone access denied.')
+    if (!microphoneAccessGranted(access)) {
+      throw microphoneAccessDeniedError(access)
     }
 
     let stream: MediaStream

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -11,7 +11,7 @@ declare global {
       testConnectionConfig: (payload: DesktopConnectionConfigInput) => Promise<DesktopConnectionTestResult>
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
-      requestMicrophoneAccess: () => Promise<boolean>
+      requestMicrophoneAccess: () => Promise<HermesMicrophoneAccessResult>
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
@@ -71,6 +71,14 @@ export interface HermesTerminalSession {
   cwd: string
   id: string
   shell: string
+}
+
+export type HermesMicrophoneAccessStatus = 'denied' | 'granted' | 'not-determined' | 'restricted' | 'unknown'
+
+export interface HermesMicrophoneAccessResult {
+  granted: boolean
+  settingsOpened: boolean
+  status: HermesMicrophoneAccessStatus
 }
 
 export interface HermesTerminalExit {

--- a/apps/desktop/src/store/notifications.test.ts
+++ b/apps/desktop/src/store/notifications.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $notifications, clearNotifications, notifyError } from './notifications'
+
+afterEach(() => {
+  clearNotifications()
+})
+
+describe('notifyError', () => {
+  it('keeps microphone settings guidance visible', () => {
+    notifyError(
+      new Error(
+        'Microphone permission was denied. System Settings was opened at Privacy & Security > Microphone. Enable Hermes, then try again.'
+      ),
+      'Voice recording failed'
+    )
+
+    expect($notifications.get()[0]?.message).toBe(
+      'Microphone permission was denied. System Settings was opened so you can allow Hermes, then try again.'
+    )
+  })
+})

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -72,6 +72,11 @@ const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string
       'The desktop backend rejected that request (405 Method Not Allowed). Try restarting Hermes Desktop.'
   },
   {
+    test: msg => /microphone permission/i.test(msg) && /system settings/i.test(msg),
+    summarize: () =>
+      'Microphone permission was denied. System Settings was opened so you can allow Hermes, then try again.'
+  },
+  {
     test: msg => /microphone permission/i.test(msg),
     summarize: () => 'Microphone permission was denied.'
   }


### PR DESCRIPTION
## What changed

- Added a small Electron microphone permission helper for macOS desktop builds.
- When microphone access is `not-determined`, Hermes now asks macOS for microphone access before calling `getUserMedia`.
- When access is already denied or restricted, Hermes opens System Settings at Privacy & Security > Microphone and returns a structured permission result to the renderer.
- Updated the shared recorder hook so both voice dictation and voice conversation show an actionable permission message instead of a generic recording failure.
- Kept notification summaries from collapsing the new System Settings guidance.

## Why

On first macOS desktop use, clicking the composer microphone or Start voice conversation could fail with a plain "Microphone access denied" notification. Users were not taken to the macOS permission surface or told how to recover after denial.

## Duplicate PR check

Searched open PRs for `microphone permission`, `Microphone access denied`, `voice recording failed`, `macOS microphone`, `requestMicrophoneAccess`, `askForMediaAccess`, `getUserMedia desktop`, and `desktop microphone permission`. The only broad matches were Termux/CLI voice PRs, not this desktop macOS permission flow.

## Validation

- `npm run test:desktop:platforms`
- `npm run test:ui -- src/app/chat/composer/hooks/use-mic-recorder.test.ts src/store/notifications.test.ts`
- `npm run type-check`
- `npx eslint electron/microphone-permissions.cjs electron/microphone-permissions.test.cjs src/app/chat/composer/hooks/use-mic-recorder.ts src/app/chat/composer/hooks/use-mic-recorder.test.ts src/global.d.ts src/store/notifications.ts src/store/notifications.test.ts`

Note: full `npm run lint` still fails on pre-existing desktop lint issues in unrelated files, plus existing issues in `electron/main.cjs` that predate this patch.