### PR TITLE
fix(honcho): use _host_block helper for dot-form legacy host key fallback (fixes #37436)

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -833,8 +833,8 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         # that would break a no-auth local server, so we substitute the SDK's
         # required-non-empty placeholder unless the host block opts in.
         _raw = config.raw or {}
-        _host_block = (_raw.get("hosts") or {}).get(config.host, {})
-        _host_has_key = bool(_host_block.get("apiKey"))
+        _host_block_local = _host_block(_raw, config.host)  # uses dot-form legacy fallback (#37436)
+        _host_has_key = bool(_host_block_local.get("apiKey"))
         effective_api_key = config.api_key if _host_has_key else "local"
     else:
         effective_api_key = config.api_key


### PR DESCRIPTION
## What does this PR do?

Fixes a silent auth failure in the Honcho runtime client path. `_resolve_or_create_client()` reimplemented the host-block lookup as a plain `dict.get(config.host)` instead of calling the existing `_host_block()` helper that handles the legacy dot-form-to-underscore-form fallback. When `config.host` is `hermes_profile_a` (underscore — the format returned by `profile_host_key()`) but the JSON config stores it as `hermes.profile_a` (dot — the old format the helper is designed to bridge), the direct lookup misses and `effective_api_key` is set to `"local"` — every Honcho API call returns 401, silently dropping cross-peer queries and message sync.

## Changes

- `plugins/memory/honcho/client.py`: 2-line change — replace the bare `(_raw.get("hosts") or {}).get(config.host, {})` with `_host_block(_raw, config.host)`. Renamed the local from `_host_block` to `_host_block_local` to avoid shadowing the function.

## How to test

1. `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/honcho_plugin/ -q --timeout=120` — 316/316 pass, 17 skipped (unchanged).

## Notes

- The repro case: a `~/.hermes/honcho.json` with host keys in dot form (`"hermes.profile_a"`) and `baseUrl: "http://localhost:8000"` (the `_is_local` branch). Before the fix, `_host_has_key` is False and `effective_api_key = "local"` → 401 Invalid JWT on every write/read.
- After the fix, `_host_block()` tries dot-form first, then falls back to underscore-form, so both formats work.
- This bug was the third most operationally damaging entry in #36098's Honcho plugin trap-path catalogue.

Closes #37436
