### PR TITLE
fix(gateway): honor WECOM_GROUP_ALLOWED_USERS in env-only WeCom group allowlist

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -172,7 +172,15 @@ class WeComAdapter(BasePlatformAdapter):
         )
 
         self._group_policy = str(extra.get("group_policy") or os.getenv("WECOM_GROUP_POLICY", "open")).strip().lower()
-        self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
+        # group_policy already honors WECOM_GROUP_POLICY, so the allowlist must honor
+        # WECOM_GROUP_ALLOWED_USERS too. Without the env fallback an env-only setup
+        # (group_policy=allowlist via env, no config extra) runs with an empty
+        # allowlist and drops every group message at intake.
+        self._group_allow_from = _coerce_list(
+            extra.get("group_allow_from")
+            or extra.get("groupAllowFrom")
+            or os.getenv("WECOM_GROUP_ALLOWED_USERS", "")
+        )
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 
         self._session: Optional["aiohttp.ClientSession"] = None

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -336,6 +336,43 @@ class TestPolicyHelpers:
         assert adapter._is_group_allowed("group-1", "user-2") is False
         assert adapter._is_group_allowed("group-2", "user-1") is False
 
+    def test_group_allowlist_honors_env_only_allowed_groups(self, monkeypatch):
+        """Env-only setup (WECOM_GROUP_POLICY + WECOM_GROUP_ALLOWED_USERS, no config
+        ``extra``) must populate the group allowlist. Otherwise ``group_policy:
+        allowlist`` runs with an empty allowlist and drops every group message
+        at intake — the documented env vars become no-ops."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setenv("WECOM_GROUP_POLICY", "allowlist")
+        monkeypatch.setenv("WECOM_GROUP_ALLOWED_USERS", "group-1, group-2")
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        assert adapter._group_policy == "allowlist"
+        assert adapter._group_allow_from == ["group-1", "group-2"]
+        assert adapter._is_group_allowed("group-1", "any-user") is True
+        assert adapter._is_group_allowed("group-2", "any-user") is True
+        assert adapter._is_group_allowed("group-x", "any-user") is False
+
+    def test_group_allowlist_extra_takes_precedence_over_env(self, monkeypatch):
+        """Config ``extra`` wins over the env fallback, so an explicit
+        group allowlist is never silently widened by a stray
+        WECOM_GROUP_ALLOWED_USERS."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setenv("WECOM_GROUP_ALLOWED_USERS", "env-group")
+
+        adapter = WeComAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"group_policy": "allowlist", "group_allow_from": ["cfg-group"]},
+            )
+        )
+
+        assert adapter._group_allow_from == ["cfg-group"]
+        assert adapter._is_group_allowed("cfg-group", "any-user") is True
+        assert adapter._is_group_allowed("env-group", "any-user") is False
+
 
 class TestMediaHelpers:
     def test_detect_wecom_media_type(self):


### PR DESCRIPTION
## Summary

`group_policy` already honors `WECOM_GROUP_POLICY`, so the group allowlist must honor `WECOM_GROUP_ALLOWED_USERS` too. Without the env fallback, an env-only setup (`group_policy=allowlist` via env, no config `extra`) runs with an empty `_group_allow_from` and drops every authorized group message at intake — the same bug that was just fixed for the DM allowlist (`WECOM_ALLOWED_USERS`) in the preceding PR.

`weixin.py` already follows this pattern (reads `WEIXIN_GROUP_ALLOWED_USERS` at line 1182); this aligns WeCom with the sibling implementation.

## Changes

- `gateway/platforms/wecom.py`: add `or os.getenv("WECOM_GROUP_ALLOWED_USERS", "")` fallback to `_group_allow_from` construction, mirroring the `WECOM_ALLOWED_USERS` DM fix pattern.
- `tests/gateway/test_wecom.py`: add two regression tests mirroring the DM allowlist test pair:
  - `test_group_allowlist_honors_env_only_allowed_groups` — env-only setup populates `_group_allow_from` from `WECOM_GROUP_ALLOWED_USERS`
  - `test_group_allowlist_extra_takes_precedence_over_env` — config `extra` wins over the env fallback (no accidental list widening)

## Test plan

- [ ] `pytest tests/gateway/test_wecom.py::TestPolicyHelpers -x -q` — all 6 tests pass