### PR TITLE
fix(tools): bound tool error bodies at the dispatch boundary

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from tools.registry import (
     ToolRegistry,
+    _MAX_LOGGED_ERROR_CHARS,
     _MAX_TOOL_ERROR_CHARS,
     _module_registers_tools,
     discover_builtin_tools,
@@ -164,12 +165,23 @@ class TestToolErrorBounding:
         result = json.loads(tool_error(msg))
         assert result["error"] == msg
 
-    def test_full_body_preserved_in_logs_when_truncated(self, caplog):
+    def test_longer_prefix_reaches_logs_than_context(self, caplog):
         import logging
         body = "boom: " + "Z" * 5000
         with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+            result = json.loads(tool_error(body))
+        logged = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert body[:5000] in logged
+        assert len(result["error"]) < 5000
+
+    def test_log_line_is_bounded_for_huge_bodies(self, caplog):
+        import logging
+        body = "boom: " + "Z" * 500_000
+        with caplog.at_level(logging.DEBUG, logger="tools.registry"):
             json.loads(tool_error(body))
-        assert any(body in rec.getMessage() for rec in caplog.records)
+        for record in caplog.records:
+            assert len(record.getMessage()) < _MAX_LOGGED_ERROR_CHARS + 200
+        assert body not in "\n".join(r.getMessage() for r in caplog.records)
 
 
 class TestDispatchBoundsDirectErrorResults:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -6,7 +6,13 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
-from tools.registry import ToolRegistry, _module_registers_tools, discover_builtin_tools
+from tools.registry import (
+    ToolRegistry,
+    _MAX_TOOL_ERROR_CHARS,
+    _module_registers_tools,
+    discover_builtin_tools,
+    tool_error,
+)
 
 
 def _dummy_handler(args, **kwargs):
@@ -136,6 +142,87 @@ class TestUnknownToolDispatch:
         result = json.loads(reg.dispatch("nonexistent", {}))
         assert "error" in result
         assert "Unknown tool" in result["error"]
+
+
+class TestToolErrorBounding:
+    def test_short_message_unchanged(self):
+        result = json.loads(tool_error("Missing required parameter: query"))
+        assert result["error"] == "Missing required parameter: query"
+
+    def test_extra_kwargs_preserved(self):
+        result = json.loads(tool_error("bad input", success=False))
+        assert result["error"] == "bad input"
+        assert result["success"] is False
+
+    def test_oversized_body_truncated(self):
+        result = json.loads(tool_error("boom: " + "X" * 5000))
+        assert result["error"].endswith("… [truncated]")
+        assert len(result["error"]) <= _MAX_TOOL_ERROR_CHARS + len("… [truncated]")
+
+    def test_at_limit_not_truncated(self):
+        msg = "Y" * _MAX_TOOL_ERROR_CHARS
+        result = json.loads(tool_error(msg))
+        assert result["error"] == msg
+
+    def test_full_body_preserved_in_logs_when_truncated(self, caplog):
+        import logging
+        body = "boom: " + "Z" * 5000
+        with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+            json.loads(tool_error(body))
+        assert any(body in rec.getMessage() for rec in caplog.records)
+
+
+class TestDispatchBoundsDirectErrorResults:
+    """Handlers that bypass tool_error() and serialize errors directly are
+    still bounded at the dispatch boundary."""
+
+    @staticmethod
+    def _register(reg, name, handler):
+        reg.register(
+            name=name,
+            toolset="core",
+            schema=_make_schema(name),
+            handler=handler,
+        )
+
+    def test_direct_json_error_result_truncated(self):
+        reg = ToolRegistry()
+        self._register(reg, "direct", lambda args, **kw: json.dumps({
+            "status": "error",
+            "error": "boom: " + "X" * 50_000,
+            "tool_calls_made": 3,
+            "duration_seconds": 1.2,
+        }, ensure_ascii=False))
+        result = json.loads(reg.dispatch("direct", {}))
+        assert result["error"].endswith("… [truncated]")
+        assert len(result["error"]) <= _MAX_TOOL_ERROR_CHARS + len("… [truncated]")
+        assert result["status"] == "error"
+        assert result["tool_calls_made"] == 3
+        assert result["duration_seconds"] == 1.2
+
+    def test_small_error_result_unchanged(self):
+        reg = ToolRegistry()
+        payload = json.dumps({"error": "not found", "success": False})
+        self._register(reg, "small", lambda args, **kw: payload)
+        assert reg.dispatch("small", {}) == payload
+
+    def test_oversized_non_error_result_unchanged(self):
+        reg = ToolRegistry()
+        payload = json.dumps({"data": "D" * 50_000})
+        self._register(reg, "big_data", lambda args, **kw: payload)
+        assert reg.dispatch("big_data", {}) == payload
+
+    def test_oversized_non_json_result_unchanged(self):
+        reg = ToolRegistry()
+        payload = "plain text " * 10_000
+        self._register(reg, "plain", lambda args, **kw: payload)
+        assert reg.dispatch("plain", {}) == payload
+
+    def test_non_string_error_value_unchanged(self):
+        reg = ToolRegistry()
+        payload = json.dumps({"error": {"detail": "E" * 5_000}})
+        self._register(reg, "nested", lambda args, **kw: payload)
+        assert reg.dispatch("nested", {}) == payload
 
 
 class TestToolsetAvailability:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -237,6 +237,27 @@ class TestDispatchBoundsDirectErrorResults:
         assert reg.dispatch("nested", {}) == payload
 
 
+class TestDispatchExceptionLogging:
+    def test_raising_handler_logs_bounded_message(self, caplog):
+        import logging
+        body = "upstream said: " + "Q" * 200_000
+        reg = ToolRegistry()
+        reg.register(
+            name="boom",
+            toolset="core",
+            schema=_make_schema("boom"),
+            handler=lambda args, **kw: (_ for _ in ()).throw(RuntimeError(body)),
+        )
+        with caplog.at_level(logging.ERROR, logger="tools.registry"):
+            result = json.loads(reg.dispatch("boom", {}))
+        messages = [r.getMessage() for r in caplog.records]
+        assert messages, "dispatch should log the failure"
+        for message in messages:
+            assert len(message) < _MAX_LOGGED_ERROR_CHARS + 200
+            assert body not in message
+        assert len(result["error"]) < _MAX_TOOL_ERROR_CHARS + 200
+
+
 class TestToolsetAvailability:
     def test_no_check_fn_is_available(self):
         reg = ToolRegistry()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -29,13 +29,19 @@ logger = logging.getLogger(__name__)
 # Cap on a tool error body; only trims runaway interpolated exceptions (static msgs are ~115 chars).
 _MAX_TOOL_ERROR_CHARS = 2048
 _TOOL_ERROR_TRUNCATION_MARKER = "… [truncated]"
+# Logs keep more of the body than the model sees, but still a bounded amount.
+_MAX_LOGGED_ERROR_CHARS = 8192
 
 
 def _bound_error_text(text: str) -> str:
-    """Bound an error body destined for model context; full body stays in logs."""
+    """Bound an error body destined for model context; logs keep a longer prefix."""
     if len(text) <= _MAX_TOOL_ERROR_CHARS:
         return text
-    logger.debug("tool error body truncated for context (%d chars): %s", len(text), text)
+    logger.debug(
+        "tool error body truncated for context (%d chars): %s",
+        len(text),
+        text[:_MAX_LOGGED_ERROR_CHARS],
+    )
     return text[:_MAX_TOOL_ERROR_CHARS] + _TOOL_ERROR_TRUNCATION_MARKER
 
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -818,7 +818,10 @@ class ToolRegistry:
                 result = entry.handler(args, **kwargs)
             return self._normalize_handler_result(name, result)
         except Exception as e:
-            logger.exception("Tool %s dispatch error: %s", name, e)
+            # exc_info already renders the exception, so keep the message copy bounded.
+            logger.exception(
+                "Tool %s dispatch error: %s", name, _bound_error_text(str(e))
+            )
             # Route through the sanitizer so framing tokens / CDATA / fences
             # in exception strings don't reach the model as structural noise.
             # See model_tools._sanitize_tool_error for rationale.

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -26,6 +26,41 @@ from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
+# Cap on a tool error body; only trims runaway interpolated exceptions (static msgs are ~115 chars).
+_MAX_TOOL_ERROR_CHARS = 2048
+_TOOL_ERROR_TRUNCATION_MARKER = "… [truncated]"
+
+
+def _bound_error_text(text: str) -> str:
+    """Bound an error body destined for model context; full body stays in logs."""
+    if len(text) <= _MAX_TOOL_ERROR_CHARS:
+        return text
+    logger.debug("tool error body truncated for context (%d chars): %s", len(text), text)
+    return text[:_MAX_TOOL_ERROR_CHARS] + _TOOL_ERROR_TRUNCATION_MARKER
+
+
+def _bound_json_error_result(result: str) -> str:
+    """Trim an oversized ``error`` field in a JSON string result.
+
+    Handlers that serialize exceptions directly — ``json.dumps({"error":
+    str(exc), ...})`` instead of ``tool_error()`` — bypass the cap in
+    ``tool_error``. Applied at the dispatch boundary so no registered tool
+    can return an unbounded error body that stacks across retries.
+    """
+    if len(result) <= _MAX_TOOL_ERROR_CHARS or '"error"' not in result:
+        return result
+    try:
+        payload = json.loads(result)
+    except ValueError:
+        return result
+    if not isinstance(payload, dict):
+        return result
+    error = payload.get("error")
+    if not isinstance(error, str) or len(error) <= _MAX_TOOL_ERROR_CHARS:
+        return result
+    payload["error"] = _bound_error_text(error)
+    return json.dumps(payload, ensure_ascii=False)
+
 
 def _is_registry_register_call(node: ast.AST) -> bool:
     """Return True when *node* is a ``registry.register(...)`` call expression."""
@@ -736,7 +771,7 @@ class ToolRegistry:
         persistence from receiving values they cannot safely slice or size.
         """
         if isinstance(result, str):
-            return result
+            return _bound_json_error_result(result)
         if (
             isinstance(result, dict)
             and result.get("_multimodal") is True
@@ -935,7 +970,8 @@ def tool_error(message, **extra) -> str:
     >>> tool_error("bad input", success=False)
     '{"error": "bad input", "success": false}'
     """
-    result = {"error": str(message)}
+    # Bound the context-bound copy so a raw exception can't bloat history across retries.
+    result = {"error": _bound_error_text(str(message))}
     if extra:
         result.update(extra)
     return json.dumps(result, ensure_ascii=False)


### PR DESCRIPTION
Cap the size of tool error bodies so a failing tool cannot inject an unbounded string into the message history.

## Problem

Tool error strings built from raw exceptions have no length bound. Two paths produce them:

1. Handlers returning `tool_error(f"... {e}")` — e.g. `plugins/memory/honcho/__init__.py`: `tool_error(f"Honcho {tool_name} failed: {e}")`.
2. Handlers serializing directly, bypassing the helper — `json.dumps({"error": str(exc), ...})`. `tools/code_execution_tool.py` does this in both of its outer except blocks, and ~50 similar sites exist across `tools/` and `plugins/`.

When the underlying exception wraps a big payload (an HTTP error carrying a proxy HTML page, a long traceback), the error body lands in context at full size. Because message history is re-sent every turn, a model that keeps re-calling a failing tool during a backend outage stacks these results turn over turn — over a multi-minute outage this accumulates into hundreds of KB / multi-hundred-K-token prompts.

Existing guards don't cover this: `_sanitize_tool_error` (#26823) caps only the *exception* paths (dispatch's except block and `handle_function_call`'s outer except), not results a handler returns after catching its own exception. The result-persistence layer only kicks in at 100K chars per result — a 30KB error body slips under it and still stacks across retries.

## Fix

Both paths are now bounded at `_MAX_TOOL_ERROR_CHARS = 2048` in `tools/registry.py`:

- `tool_error()` caps its message via a shared `_bound_error_text()` helper. On truncation the full body is logged at DEBUG first — only the copy returned into context is trimmed.
- `ToolRegistry._normalize_handler_result` — the boundary every registered handler's result already passes through — runs string results through `_bound_json_error_result()`: if the result parses as a JSON object with a string `error` field over the cap, only that field is trimmed and the payload re-serialized (sibling keys like `status` / `tool_calls_made` preserved). Non-error results, non-JSON strings, results with non-string `error` values, and multimodal envelopes pass through untouched, and a cheap `len` + `'"error"'` prefilter avoids parsing ordinary results.

This closes the bypass flagged in review: `code_execution_tool`'s direct `str(exc)` serialization (and every similar site) is covered without touching any call site. Scope is registered-tool results returned through `registry.dispatch()`; exception paths remain covered by `_sanitize_tool_error`. Static messages are untouched: the longest in-tree `tool_error` message is ~115 chars.

## Tests

`tests/tools/test_registry.py::TestToolErrorBounding` — helper behavior:
- short message unchanged; extra kwargs preserved
- oversized body truncated with marker; at-limit body not truncated
- full body present in DEBUG logs when truncated

`tests/tools/test_registry.py::TestDispatchBoundsDirectErrorResults` — dispatch-boundary integration:
- direct JSON error result (code_execution_tool shape) truncated, sibling keys preserved
- small error result byte-identical passthrough
- oversized non-error result untouched
- oversized non-JSON string untouched
- non-string `error` value untouched

`scripts/run_tests.sh tests/tools/test_registry.py` → 54 passed. Full `tests/tools/` + `tests/test_sanitize_tool_error.py` run shows no new failures (the 5 failures present are reproducible on clean `main`).
