### PR TITLE
fix(tools): return effective toolset state from toggle endpoint + guard restricted toolsets in desktop UI

### DIFF
--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -89,4 +89,33 @@ describe('SkillsView toolset management', () => {
 
     await waitFor(() => expect(getToolsetConfig).toHaveBeenCalledWith('web'))
   })
+
+  it('disables the switch and labels restricted toolsets as managed via CLI', async () => {
+    getToolsets.mockResolvedValue([
+      toolset({ name: 'discord_admin', label: 'Discord Server Admin', enabled: false, restricted: true })
+    ])
+    await renderSkills()
+
+    const sw = await screen.findByRole('switch', { name: 'Toggle Discord Server Admin toolset' })
+    expect(sw.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText('Managed via CLI')).toBeTruthy()
+
+    // A restricted toggle must not issue a write that would silently no-op.
+    fireEvent.click(sw)
+    expect(toggleToolset).not.toHaveBeenCalled()
+  })
+
+  it('mirrors the server effective state, not the requested value', async () => {
+    // Server reports the enable did not persist (restricted/no-op): UI must
+    // reflect enabled=false rather than the optimistic requested true.
+    getToolsets.mockResolvedValue([toolset({ name: 'web', label: 'Web Search', enabled: false })])
+    toggleToolset.mockResolvedValue({ ok: true, name: 'web', enabled: false, restricted: false })
+    await renderSkills()
+
+    const sw = await screen.findByRole('switch', { name: 'Toggle Web Search toolset' })
+    fireEvent.click(sw)
+
+    await waitFor(() => expect(toggleToolset).toHaveBeenCalledWith('web', true))
+    await waitFor(() => expect(sw.getAttribute('aria-checked')).toBe('false'))
+  })
 })

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -161,13 +161,18 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
     setSavingToolset(toolset.name)
 
     try {
-      await toggleToolset(toolset.name, enabled)
+      // Trust the server's effective state, not the requested value: a
+      // platform-restricted toolset can't persist on cli, so the write may be
+      // a no-op. Mirroring the response keeps the UI from desyncing on nav.
+      const result = await toggleToolset(toolset.name, enabled)
       setToolsets(current =>
-        current?.map(row => (row.name === toolset.name ? { ...row, enabled, available: enabled } : row)) ?? current
+        current?.map(row =>
+          row.name === toolset.name ? { ...row, enabled: result.enabled, available: result.enabled } : row
+        ) ?? current
       )
       notify({
         kind: 'success',
-        title: enabled ? 'Toolset enabled' : 'Toolset disabled',
+        title: result.enabled ? 'Toolset enabled' : 'Toolset disabled',
         message: `${asText(toolset.label || toolset.name)} applies to new sessions.`
       })
     } catch (err) {
@@ -284,6 +289,9 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                       <div className="flex items-center justify-between gap-2">
                         <div className="truncate text-sm font-medium">{label}</div>
                         <div className="flex shrink-0 items-center gap-1.5">
+                          {toolset.restricted && (
+                            <StatusPill active={false}>Managed via CLI</StatusPill>
+                          )}
                           <button
                             aria-expanded={expanded}
                             aria-label={`Configure ${label}`}
@@ -298,7 +306,7 @@ export function SkillsView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...p
                           <Switch
                             aria-label={`Toggle ${label} toolset`}
                             checked={toolset.enabled}
-                            disabled={savingToolset === toolset.name}
+                            disabled={savingToolset === toolset.name || toolset.restricted}
                             onCheckedChange={checked => void handleToggleToolset(toolset, checked)}
                           />
                         </div>

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -337,8 +337,8 @@ export function getToolsets(): Promise<ToolsetInfo[]> {
 export function toggleToolset(
   name: string,
   enabled: boolean
-): Promise<{ ok: boolean; name: string; enabled: boolean }> {
-  return window.hermesDesktop.api<{ ok: boolean; name: string; enabled: boolean }>({
+): Promise<{ ok: boolean; name: string; enabled: boolean; restricted: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean; name: string; enabled: boolean; restricted: boolean }>({
     path: `/api/tools/toolsets/${encodeURIComponent(name)}`,
     method: 'PUT',
     body: { enabled }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -471,6 +471,10 @@ export interface ToolsetInfo {
   enabled: boolean
   label: string
   name: string
+  // True when the toolset is restricted to a non-cli platform and so can never
+  // be enabled from the desktop GUI (e.g. discord_admin). Optional for
+  // backward compatibility with older gateways that don't send it.
+  restricted?: boolean
   tools: string[]
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6442,6 +6442,7 @@ async def get_toolsets():
     from hermes_cli.tools_config import (
         _get_effective_configurable_toolsets,
         _get_platform_tools,
+        _toolset_allowed_for_platform,
         _toolset_has_keys,
     )
     from toolsets import resolve_toolset
@@ -6463,6 +6464,11 @@ async def get_toolsets():
             "name": name, "label": label, "description": desc,
             "enabled": is_enabled,
             "available": is_enabled,
+            # Platform-restricted toolsets (e.g. discord_admin) can never be
+            # enabled from the desktop GUI, which only writes the cli platform.
+            # Surface that so the client can disable the toggle instead of
+            # showing one that silently no-ops.
+            "restricted": not _toolset_allowed_for_platform(name, "cli"),
             "configured": _toolset_has_keys(name, config),
             "tools": tools,
         })
@@ -6485,6 +6491,7 @@ async def toggle_toolset(name: str, body: ToolsetToggle):
         _get_effective_configurable_toolsets,
         _get_platform_tools,
         _save_platform_tools,
+        _toolset_allowed_for_platform,
     )
 
     valid = {ts_key for ts_key, _, _ in _get_effective_configurable_toolsets()}
@@ -6500,7 +6507,22 @@ async def toggle_toolset(name: str, body: ToolsetToggle):
     else:
         enabled.discard(name)
     _save_platform_tools(config, "cli", enabled)
-    return {"ok": True, "name": name, "enabled": body.enabled}
+    # _save_platform_tools silently drops toolsets that aren't allowed on this
+    # platform (e.g. discord_admin on cli), so the requested value can differ
+    # from what persisted. Re-read from the SAME source GET uses — load_config()
+    # then _get_platform_tools — so this response can never disagree with a
+    # subsequent GET and desync the UI. This assumes _save_platform_tools has
+    # already flushed to disk before this load_config(); if it ever becomes
+    # lazy/atomic-deferred, read effective state back from the in-memory config.
+    persisted = _get_platform_tools(
+        load_config(), "cli", include_default_mcp_servers=False
+    )
+    return {
+        "ok": True,
+        "name": name,
+        "enabled": name in persisted,
+        "restricted": not _toolset_allowed_for_platform(name, "cli"),
+    }
 
 
 @app.get("/api/tools/toolsets/{name}/config")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1738,6 +1738,7 @@ class TestNewEndpoints:
                 "description": "web_search, web_extract",
                 "enabled": True,
                 "available": True,
+                "restricted": False,
                 "configured": False,
                 "tools": ["web_extract", "web_search"],
             },
@@ -1747,6 +1748,7 @@ class TestNewEndpoints:
                 "description": "list, view, manage",
                 "enabled": True,
                 "available": True,
+                "restricted": False,
                 "configured": True,
                 "tools": ["skill_view", "skills_list"],
             },
@@ -1756,6 +1758,7 @@ class TestNewEndpoints:
                 "description": "persistent memory across sessions",
                 "enabled": False,
                 "available": False,
+                "restricted": False,
                 "configured": True,
                 "tools": ["memory_read"],
             },
@@ -1787,6 +1790,34 @@ class TestNewEndpoints:
             "/api/tools/toolsets/not_a_real_toolset", json={"enabled": True}
         )
         assert resp.status_code == 400
+
+    def test_toggle_restricted_toolset_returns_effective_false(self):
+        """A toolset restricted to a non-cli platform (discord_admin) can't be
+        enabled from the GUI's cli scope. The PUT must report the EFFECTIVE
+        persisted state (False), never echo a false {enabled: true}, and a
+        later GET must AGREE — that agreement is what prevents the UI desync."""
+        resp = self.client.put(
+            "/api/tools/toolsets/discord_admin", json={"enabled": True}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["name"] == "discord_admin"
+        # Truthful, not the requested value: the enable was filtered out.
+        assert body["enabled"] is False
+        assert body["restricted"] is True
+
+        # PUT and GET must agree — a stale read here would re-introduce the bug.
+        listing = {t["name"]: t for t in self.client.get("/api/tools/toolsets").json()}
+        assert listing["discord_admin"]["enabled"] is False
+        assert listing["discord_admin"]["enabled"] == body["enabled"]
+
+    def test_toolsets_list_marks_restricted(self):
+        """GET flags platform-restricted toolsets so the client can disable the
+        toggle; unrestricted toolsets are not flagged."""
+        listing = {t["name"]: t for t in self.client.get("/api/tools/toolsets").json()}
+        assert listing["discord_admin"]["restricted"] is True
+        assert listing["web"]["restricted"] is False
 
     def test_get_toolset_config_returns_provider_matrix(self):
         """GET .../config returns provider rows with structured env_vars."""


### PR DESCRIPTION
Addresses #37609 (defects 1 and 2).

Defect 3 (platform targeting in the desktop GUI) intentionally out of scope — follow-up.

## Summary

In the desktop app, toggling a platform-restricted toolset (e.g. `discord_admin`) returned `{ok:true, enabled:true}` while the save silently dropped it — `_save_platform_tools` filters out toolsets not allowed on the GUI's only write scope (`cli`). The optimistic UI showed it on, but the next read-back from `platform_toolsets.cli` reported it off, so the toggle reverted on navigation with no error.

Now the PUT returns the **effective persisted state** — re-read from the same source a subsequent GET uses, so the two can never disagree and desync the UI — along with a `restricted` flag. The desktop disables the toggle for restricted toolsets and labels it "Managed via CLI" (kept discoverable, not hidden).

## What changed

**Backend** (`hermes_cli/web_server.py`)
- `PUT /api/tools/toolsets/{name}`: after save, re-reads via `load_config()` → `_get_platform_tools(…, "cli", …)` (the same source/call GET uses) and returns `enabled` = the effective persisted value, not the echoed request. Adds `restricted` (always present).
- `GET /api/tools/toolsets`: adds `restricted = not _toolset_allowed_for_platform(name, "cli")` per row.

**Desktop** (`apps/desktop/`)
- `ToolsetInfo.restricted?: boolean` (optional → backward-compatible with older gateways) and `toggleToolset` return type updated.
- Toggle row: Switch is `disabled` when restricted, with a "Managed via CLI" label.
- Handler mirrors the server's returned `enabled` instead of the requested value, closing the desync on the allowed-toolset path too.

6 files, +101 −7.

## Test results

- `tests/hermes_cli/test_web_server.py`: **223 passed** (incl. new `test_toggle_restricted_toolset_returns_effective_false`, which asserts PUT and a later GET agree on `enabled=false` for `discord_admin`, and `test_toolsets_list_marks_restricted`).
- `tests/hermes_cli/test_tools_config.py`: **95 passed**.
- Desktop `apps/desktop/src/app/skills/index.test.tsx` (vitest): **5 passed** (incl. restricted row renders disabled + labeled and issues no write; UI mirrors server effective state).
- Desktop `tsc -b` typecheck: **exit 0**.
- Platforms tested: macOS 26.5 (arm64) locally; Linux + macOS via CI.

## Out of scope

Defect 3 — adding a `platform` parameter so the desktop GUI can target `platform_toolsets.<non-cli>` — is a separate feature and intentionally not included here. This PR makes the existing `cli`-scoped behavior truthful and prevents the false-success/desync.

