### PR TITLE
fix(tui): intercept /usage in slash.exec to return live session stats

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5459,3 +5459,115 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         assert requeued["session_id"] == "proc_busy_test"
     finally:
         server._sessions.pop("sid_busy", None)
+
+
+# ---------------------------------------------------------------------------
+# /usage slash command — server-side interception (issue #37637)
+# ---------------------------------------------------------------------------
+
+
+def _make_usage_agent(calls: int = 3):
+    """Minimal agent namespace with usage counters set to non-zero values."""
+    import types
+    agent = types.SimpleNamespace(
+        model="claude-sonnet-4.6",
+        provider="anthropic",
+        base_url=None,
+        api_key="sk-test",
+        session_api_calls=calls,
+        session_input_tokens=1000,
+        session_output_tokens=500,
+        session_cache_read_tokens=200,
+        session_cache_write_tokens=100,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=1000,
+        session_completion_tokens=500,
+        session_total_tokens=1500,
+        context_compressor=types.SimpleNamespace(
+            last_prompt_tokens=800,
+            context_length=200000,
+            compression_count=0,
+        ),
+    )
+    return agent
+
+
+def test_slash_usage_no_agent_returns_no_calls_message():
+    """When the session has no agent yet, /usage returns the 'no calls' message
+    instead of routing to the slash worker (which would return 'No active agent').
+    The session agent is None — no worker should be started."""
+    import types
+    sid = "usage-no-agent"
+    server._sessions[sid] = _session(agent=None)
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "slash.exec",
+             "params": {"session_id": sid, "command": "/usage"}}
+        )
+        result = resp.get("result", {})
+        output = result.get("output", "")
+        assert "No API calls" in output
+        # Verify the slash worker was never spawned (it would fail anyway since
+        # there is no real slash_worker binary in the test environment).
+        assert server._sessions[sid].get("slash_worker") is None
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_slash_usage_with_active_agent_returns_formatted_stats():
+    """When the session has an agent with API calls, /usage returns formatted
+    token stats directly from the live session — not from the slash worker
+    subprocess (which has no agent and always reports 'No active agent')."""
+    import types
+    agent = _make_usage_agent(calls=3)
+    sid = "usage-with-agent"
+    server._sessions[sid] = _session(agent=agent)
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "slash.exec",
+             "params": {"session_id": sid, "command": "/usage"}}
+        )
+        result = resp.get("result", {})
+        output = result.get("output", "")
+        # Must contain the model name and token counts — not an error message.
+        assert "claude-sonnet-4.6" in output
+        assert "1,500" in output or "1500" in output   # total tokens
+        assert "API calls" in output
+        # Must NOT contain the slash-worker fallback error messages.
+        assert "No active agent" not in output
+        assert "No API calls made yet" not in output
+        # Slash worker must still be None (was never started for /usage).
+        assert server._sessions[sid].get("slash_worker") is None
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_format_usage_text_contains_required_fields():
+    """_format_usage_text() must include model, token counts, and context info."""
+    from tui_gateway.server import _format_usage_text
+
+    usage = {
+        "model": "gpt-5",
+        "input": 1000,
+        "output": 500,
+        "cache_read": 200,
+        "cache_write": 100,
+        "reasoning": 0,
+        "prompt": 1000,
+        "completion": 500,
+        "total": 1500,
+        "calls": 5,
+        "cost_status": "estimated",
+        "cost_usd": 0.0025,
+        "context_used": 800,
+        "context_max": 128000,
+        "context_percent": 1,
+        "compressions": 2,
+    }
+    text = _format_usage_text(usage)
+    assert "gpt-5" in text
+    assert "1,500" in text or "1500" in text
+    assert "5" in text
+    assert "128,000" in text or "128000" in text
+    assert "Compressions" in text
+    assert "$" in text

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1504,6 +1504,47 @@ def _get_usage(agent) -> dict:
     return usage
 
 
+def _format_usage_text(usage: dict) -> str:
+    """Format a _get_usage() dict as a human-readable text block.
+
+    Mirrors the layout of cli.py's _show_usage() so TUI users see the same
+    information they would get in the interactive CLI.  Called by the
+    slash.exec handler when /usage is intercepted to avoid routing through the
+    slash worker subprocess, whose HermesCLI instance has no active agent and
+    would return 'No active agent — send a message first.'
+    """
+    lines = ["  \U0001f4ca Session Token Usage", f"  {'─' * 40}"]
+    lines.append(f"  Model:                     {usage.get('model', '')}")
+    lines.append(f"  Input tokens:              {usage.get('input', 0):>10,}")
+    lines.append(f"  Cache read tokens:         {usage.get('cache_read', 0):>10,}")
+    lines.append(f"  Cache write tokens:        {usage.get('cache_write', 0):>10,}")
+    lines.append(f"  Output tokens:             {usage.get('output', 0):>10,}")
+    if usage.get("reasoning"):
+        lines.append(f"  ⤷ Reasoning (subset):      {usage['reasoning']:>10,}")
+    lines.append(f"  Prompt tokens (total):     {usage.get('prompt', 0):>10,}")
+    lines.append(f"  Completion tokens:         {usage.get('completion', 0):>10,}")
+    lines.append(f"  Total tokens:              {usage.get('total', 0):>10,}")
+    lines.append(f"  API calls:                 {usage.get('calls', 0):>10,}")
+    cost_status = usage.get("cost_status", "unknown")
+    lines.append(f"  Cost status:              {cost_status:>10}")
+    if "cost_usd" in usage:
+        prefix = "~" if cost_status == "estimated" else ""
+        lines.append(f"  Total cost:              {prefix}${float(usage['cost_usd']):>10.4f}")
+    elif cost_status == "included":
+        lines.append(f"  Total cost:              {'included':>10}")
+    else:
+        lines.append(f"  Total cost:              {'n/a':>10}")
+    lines.append(f"  {'─' * 40}")
+    if "context_used" in usage and "context_max" in usage:
+        ctx_pct = usage.get("context_percent", 0)
+        lines.append(
+            f"  Current context:  {usage['context_used']:,} / {usage['context_max']:,} ({ctx_pct:.0f}%)"
+        )
+    if "compressions" in usage:
+        lines.append(f"  Compressions:     {usage['compressions']}")
+    return "\n".join(lines)
+
+
 def _probe_credentials(agent) -> str:
     """Light credential check at session creation — returns warning or ''."""
     try:
@@ -6915,6 +6956,18 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"output": str(result or "(no output)")})
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
+
+    # /usage is intercepted here so it reads from the live session agent instead
+    # of routing to the slash worker subprocess.  The slash worker's HermesCLI
+    # has no active agent (it is a subprocess that never runs conversation turns),
+    # so _show_usage() would always return "No active agent — send a message
+    # first." regardless of actual session activity (issue #37637).
+    if _cmd_base == "usage":
+        agent = session.get("agent")
+        if agent is None or not getattr(agent, "session_api_calls", 0):
+            return _ok(rid, {"output": "(._.) No API calls made yet in this session."})
+        usage = _get_usage(agent)
+        return _ok(rid, {"output": _format_usage_text(usage)})
 
     worker = session.get("slash_worker")
     if not worker:


### PR DESCRIPTION
## Summary

The `/usage` slash command was silently broken in the TUI: it was routed to the slash worker subprocess, whose `HermesCLI` instance has no active agent (the subprocess never runs conversation turns). `_show_usage()` in that subprocess always returned `"No active agent -- send a message first."` regardless of actual session activity. Closes #37637.

## Root cause

`slash.exec` routes every command through the slash worker. The worker's `HermesCLI` is initialized with `resume=session_key` to load history, but `self.agent` is `None` until a conversation turn runs inside that subprocess — which never happens. So `/usage` always hit the early-return path and the TUI showed an error instead of real stats.

## Fix

Intercept `/usage` in the `slash.exec` handler **before** the slash worker path, matching the pattern used for plugin commands. When `_cmd_base == "usage"`, read the live session agent via `session.get("agent")` and call the existing `_get_usage()` helper (already used for the status bar) to build a formatted text response. Add `_format_usage_text()` alongside `_get_usage()` to produce a text block matching `cli.py`'s `_show_usage()` layout.

This mirrors the gateway's `_handle_usage_command()` which also bypasses the CLI path and reads the live agent directly.

## Changes

- `tui_gateway/server.py`:
  - Add `_format_usage_text(usage: dict) -> str` — formats a `_get_usage()` dict as a human-readable text block (model, token counts, cost, context window, compressions).
  - In `slash.exec`, intercept `_cmd_base == "usage"` before the worker path: return `_format_usage_text(_get_usage(agent))` when the agent has calls, or a clear "no calls yet" message otherwise.
- `tests/test_tui_gateway_server.py`: 3 regression tests.

## Test plan

- [ ] `pytest tests/test_tui_gateway_server.py::test_slash_usage_no_agent_returns_no_calls_message tests/test_tui_gateway_server.py::test_slash_usage_with_active_agent_returns_formatted_stats tests/test_tui_gateway_server.py::test_format_usage_text_contains_required_fields -x -q` — 3 tests pass