### PR TITLE
chore: ignore local embedded python runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ mini-swe-agent/
 .direnv/
 .nix-stamps/
 result
+
+# Local embedded Python runtimes created by tooling
+/python/
 website/static/api/skills-index.json
 # skills.json + skills-meta.json are build artifacts emitted by
 # website/scripts/extract-skills.py during prebuild — keep them out of


### PR DESCRIPTION
## Summary
- Ignore local /python/ embedded runtime trees created by tooling
- Prevent generated CPython binaries/bytecode from dirtying checkouts

## Verification
- git diff --check
- compared root-owned checkout: no tracked edits, only untracked python/ runtime tree