### PR TITLE
feat(dashboard): show model and provider on cron job cards

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1293,6 +1293,8 @@ export interface CronJob {
   name?: string | null;
   prompt?: string | null;
   script?: string | null;
+  model?: string | null;
+  provider?: string | null;
   schedule?: { kind?: string; expr?: string; display?: string };
   schedule_display?: string | null;
   enabled: boolean;

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -630,6 +630,13 @@ export default function CronPage() {
           const deliver = asText(job.deliver);
           const profile = getJobProfile(job);
           const jobKey = getJobKey(job);
+          const model = asText(job.model);
+          const provider = asText(job.provider);
+          const modelLabel = model
+            ? provider
+              ? `${model} · ${provider}`
+              : model
+            : "";
 
           return (
             <Card key={jobKey}>
@@ -645,6 +652,11 @@ export default function CronPage() {
                     <Badge tone="outline">{profileLabel(profile)}</Badge>
                     {deliver && deliver !== "local" && (
                       <Badge tone="outline">{deliver}</Badge>
+                    )}
+                    {modelLabel && (
+                      <Badge tone="outline" title={modelLabel}>
+                        {modelLabel}
+                      </Badge>
                     )}
                   </div>
                   {hasName && promptText && (


### PR DESCRIPTION
## Summary

Cron jobs can pin a specific model and provider — e.g. routing a job to `openai-codex/gpt-5.5` via the OpenAI Codex provider, or `gemini-2.5-flash` via a local LiteLLM. But the dashboard never showed *which* model a job runs on. To answer "what model is this cron using?" you had to crack open `cron/jobs.json`.

This surfaces it as an outline badge on each job card: `model · provider` (or just `model` when no provider is pinned), shown only when a model override exists.

## Changes

- **`web/src/lib/api.ts`:** add `model` / `provider` to the `CronJob` type. The API already serializes these on cron job records (raw job dict passed through `_annotate_cron_job`); the type just didn't declare them.
- **`web/src/pages/CronPage.tsx`:** render a `model · provider` badge in the job list, gated on a model being present.

Display-only and frontend-only. Jobs with no pinned model, and `no_agent` script jobs (which don't use a model), render unchanged.

## Relationship to #24382

There's an older open PR (#24382) that adds full model/provider **editing** controls plus backend create/update plumbing and tests. It's a broader feature but is currently ~2,180 commits behind `main` and unmergeable, and its `api.ts` baseline predates the current profile-aware cron signatures. This PR is intentionally narrower — read-only display only — so it's mergeable today against current `main`. If a maintainer prefers the fuller editing flow, #24382 can supersede this; they're not mutually exclusive (this is the display half, cleanly rebased).

## Testing

- `npx tsc -b` — clean (web/)
- Manual: jobs with a pinned model show the badge; jobs without one are visually unchanged.
