### PR TITLE
fix(gateway): drop stale generation final responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18010,6 +18010,26 @@ class GatewayRunner:
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
 
+            if not _run_still_current():
+                logger.info(
+                    "Dropping stale agent result for %s — generation %s is no longer current",
+                    session_key or "?",
+                    run_generation,
+                )
+                if _stream_consumer is not None:
+                    _stream_consumer.finish()
+                return {
+                    "final_response": "",
+                    "messages": agent_history,
+                    "api_calls": result.get("api_calls", 0),
+                    "completed": result.get("completed"),
+                    "interrupted": True,
+                    "interrupt_message": None,
+                    "tools": tools_holder[0] or [],
+                    "history_offset": len(agent_history),
+                    "stale_generation": True,
+                }
+
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
                 _stream_consumer.finish()

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1133,7 +1133,9 @@ async def test_run_agent_drops_tool_progress_after_generation_invalidation(monke
 
     all_progress_text = " ".join(call["content"] for call in adapter.sent)
     all_progress_text += " ".join(call["content"] for call in adapter.edits)
-    assert result["final_response"] == "done"
+    assert result["final_response"] == ""
+    assert result["interrupted"] is True
+    assert result["stale_generation"] is True
     assert 'first command' in all_progress_text
     assert 'second command' not in all_progress_text
 
@@ -1193,7 +1195,9 @@ async def test_run_agent_drops_interim_commentary_after_generation_invalidation(
     )
 
     sent_texts = [call["content"] for call in adapter.sent]
-    assert result["final_response"] == "done"
+    assert result["final_response"] == ""
+    assert result["interrupted"] is True
+    assert result["stale_generation"] is True
     assert "first interim" in sent_texts
     assert "second interim" not in sent_texts
 


### PR DESCRIPTION
## What does this PR do?

Prevents gateway runs from returning stale final responses after their session generation has been invalidated. This closes a race where callbacks were already guarded, but the completed `run_conversation()` result could still flow through `_run_agent` and later be delivered or persisted as an out-of-context Telegram reply.

## Related Issue

Fixes #37555

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: Drop `_run_agent` results when the session generation is no longer current, returning an interrupted empty response before final-response delivery, media append, session sync, or title generation can use stale data.
- `tests/gateway/test_run_progress_topics.py`: Strengthen generation-invalidation tests so stale tool-progress and interim-commentary runs also assert no final response is returned.

## How to Test

1. Run `pytest tests/gateway/test_run_progress_topics.py -q -x --timeout=60` and confirm the gateway invalidation regressions pass.
2. Run `pytest tests/ -q -x --timeout=60` for the broad suite. In this worktree it failed once at `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`, outside the gateway diff; an isolated rerun of that same test passed.
3. Run `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_run_progress_topics.py`, `git diff --check`, and `ruff check .`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4 arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest tests/gateway/test_run_progress_topics.py -q -x --timeout=60`: 28 passed.
- `pytest tests/ -q -x --timeout=60`: failed once at `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`; isolated rerun passed (`1 passed`).
- `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_run_progress_topics.py`: passed.
- `git diff --check`: passed.
- `ruff check .`: passed with a pre-existing warning about an invalid `# noqa` directive in `run_agent.py:68`.
- `ruff format --check .`: not clean due pre-existing formatting drift across unrelated files; changed files are also in files with broader pre-existing format drift, so this PR does not run auto-format to avoid scope creep.

<!-- autocontrib:worker-id=issue-new-d66efc66 kind=pr-open -->