### PR TITLE
fix(gateway): guard Telegram picker model switches mid-turn

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3144,7 +3144,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception:
                     pass
-            await query.answer(text="Model switched!")
+            result_preview = str(result_text or "").strip()
+            result_lower = result_preview.lower()
+            if result_lower.startswith(("error", "❌")):
+                answer_text = "Model switch failed."
+            elif "agent is running" in result_lower:
+                answer_text = "Wait for the current response."
+            else:
+                answer_text = "Model switched!"
+            await query.answer(text=answer_text)
 
             # Clean up state
             self._model_picker_state.pop(chat_id, None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10888,6 +10888,10 @@ class GatewayRunner:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
+                        running_agent = getattr(_self, "_running_agents", {}).get(_session_key)
+                        if running_agent is not None:
+                            return "Agent is running — wait or /stop first, then switch models."
+
                         result = _switch_model(
                             raw_input=model_id,
                             current_provider=_cur_provider,

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.session import SessionEntry, SessionSource, build_session_key
@@ -242,3 +243,56 @@ class TestIsIntentionalModelSwitch:
         }
 
         assert runner._is_intentional_model_switch(sk, "gpt-5.4") is False
+
+
+@pytest.mark.asyncio
+async def test_model_picker_refuses_switch_while_agent_running(monkeypatch):
+    """Interactive gateway pickers must match typed /model's mid-turn guard."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+
+    captured = {}
+
+    class _PickerAdapter:
+        async def send_model_picker(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(success=True)
+
+    runner.adapters = {Platform.TELEGRAM: _PickerAdapter()}
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"model": {"default": "old-model", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_picker_providers",
+        lambda **_kwargs: [
+            {
+                "slug": "openrouter",
+                "name": "OpenRouter",
+                "models": ["new-model"],
+                "total_models": 1,
+                "is_current": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_kwargs: pytest.fail("switch_model must not run mid-turn"),
+    )
+
+    event = SimpleNamespace(source=source, get_command_args=lambda: "")
+
+    result = await runner._handle_model_command(event)
+
+    assert result is None
+    callback = captured["on_model_selected"]
+    callback_result = await callback(source.chat_id, "new-model", "openrouter")
+
+    assert callback_result == "Agent is running — wait or /stop first, then switch models."
+    assert session_key not in runner._session_model_overrides

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -147,6 +147,41 @@ class TestTelegramModelPicker:
         assert "12345" not in adapter._model_picker_state
 
     @pytest.mark.asyncio
+    async def test_model_selected_reports_running_agent_wait_state(self):
+        adapter = _make_adapter()
+        callback = AsyncMock(
+            return_value="Agent is running — wait or /stop first, then switch models."
+        )
+        adapter._model_picker_state["12345"] = {
+            "providers": [
+                {
+                    "slug": "openai",
+                    "name": "OpenAI",
+                    "total_models": 1,
+                    "is_current": True,
+                }
+            ],
+            "current_model": "model_1",
+            "current_provider": "openai",
+            "session_key": "s",
+            "on_model_selected": callback,
+            "selected_provider": "openai",
+            "model_list": ["gpt-5"],
+            "msg_id": 42,
+        }
+
+        query = AsyncMock()
+        query.data = "mm:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        await adapter._handle_model_picker_callback(query, "mm:0", "12345")
+
+        query.answer.assert_awaited_once_with(text="Wait for the current response.")
+
+    @pytest.mark.asyncio
     async def test_provider_group_folds_and_drills_down(self, monkeypatch):
         """A provider family (e.g. MiniMax) collapses to one mpg: button at
         the top level; tapping it expands to its authenticated members as


### PR DESCRIPTION
## What does this PR do?

Prevents Telegram interactive `/model` picker callbacks from confirming a model switch while that session's agent is still running. This matches the existing typed `/model` mid-turn guard and avoids a false "Model switched" confirmation while in-flight API calls can still use the previous model.

## Related Issue

Fixes #37621

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: rejects Telegram/Discord-style picker model selections when `_running_agents` already has an active entry for the session, before calling `switch_model()` or writing session overrides.
- `gateway/platforms/telegram.py`: changes the inline button toast to report wait/failure states instead of always saying "Model switched!".
- `tests/gateway/test_model_switch_persistence.py`: adds a regression proving picker callbacks do not switch or persist overrides mid-turn.
- `tests/gateway/test_telegram_model_picker.py`: adds a regression for the Telegram picker wait-state toast.

## How to Test

1. `pytest tests/gateway/test_model_switch_persistence.py tests/gateway/test_telegram_model_picker.py -q` — passed, 16 tests.
2. `ruff check gateway/run.py gateway/platforms/telegram.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_telegram_model_picker.py` — passed.
3. `python scripts/check-windows-footguns.py gateway/run.py gateway/platforms/telegram.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_telegram_model_picker.py` — passed.
4. `git diff --check` — passed.
5. `$VIRTUAL_ENV/bin/python -m pytest tests/ -q -x --timeout=60` — stopped on pre-existing/out-of-scope `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`; this PR does not touch ACP or `tools/approval.py`. A system-Python run also failed earlier during collection because `fastapi` was missing outside the shared venv.
6. `ruff format --check ...` was not used as a readiness gate because the touched files have large pre-existing formatter drift; applying it would reformat unrelated code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS/Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-fceb7217 kind=pr-open -->