### PR TITLE
fix(vision): cap image pixel dimensions at 7900px on embed + reactive recover

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -658,8 +658,47 @@ def try_shrink_image_parts_in_messages(api_messages: list) -> bool:
         """Return a smaller data URL, or None if shrink can't help."""
         if not isinstance(url, str) or not url.startswith("data:"):
             return None
-        if len(url) <= target_bytes:
-            # This specific image wasn't the oversized one.
+        # Pre-fix, this gate was ``len(url) <= target_bytes`` only.
+        # A tall full-page screenshot (e.g. 1200×12000 at 0.06 MB) passes
+        # the byte check but exceeds Anthropic's 8000px dimension cap,
+        # and once baked into immutable history the session is
+        # bricked on every subsequent replay (#25837, #37677). Now
+        # we ALSO decode the image and check dimensions. If either
+        # ceiling is exceeded, attempt the resize. If Pillow is
+        # unavailable the dimension decode fails and we fall back to
+        # the byte-only gate (the existing pre-fix behaviour, which
+        # is at least no worse than the regression we're fixing).
+        decode_error: Exception | None = None
+        dim_exceeds = False
+        try:
+            from tools.vision_tools import _image_exceeds_dimension as _dim_check
+        except ImportError:
+            _dim_check = None  # type: ignore
+        if _dim_check is not None:
+            try:
+                import base64 as _b64_dim
+                _header, _, _data = url.partition(",")
+                _raw = _b64_dim.b64decode(_data)
+                import io as _io
+                from PIL import Image as _PILImage  # type: ignore
+                with _PILImage.open(_io.BytesIO(_raw)) as _img:
+                    _w, _h = _img.size
+                if _dim_check(_w, _h):
+                    dim_exceeds = True
+            except ImportError:
+                # No Pillow: dimension check isn't possible, but
+                # _resize_image_for_vision also depends on Pillow so
+                # the resize itself will be a no-op below. Defer to
+                # the byte-only gate in that case.
+                pass
+            except Exception as exc:
+                # Corrupt image or decode failure: record it but
+                # don't bail; the byte check below is the fallback.
+                decode_error = exc
+        if not dim_exceeds and len(url) <= target_bytes:
+            # Neither ceiling was tripped (or dimension check was
+            # unavailable and bytes are fine). This specific image
+            # wasn't the oversized one.
             return None
         try:
             header, _, data = url.partition(",")

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -668,33 +668,55 @@ def try_shrink_image_parts_in_messages(api_messages: list) -> bool:
         # unavailable the dimension decode fails and we fall back to
         # the byte-only gate (the existing pre-fix behaviour, which
         # is at least no worse than the regression we're fixing).
-        decode_error: Exception | None = None
+        #
+        # Performance: the dimension decode (base64 → bytes → PIL
+        # open) is non-trivial CPU. We split the two cases:
+        #   1. ``len(url) <= target_bytes`` (tiny-but-tall case):
+        #      byte gate says "not oversized" but dimensions may
+        #      still exceed 7900px. This is the only case where
+        #      byte-only gating misses the violation, so we MUST
+        #      dimension-decode. (#37701 Copilot #5)
+        #   2. ``len(url) > target_bytes`` (already oversized):
+        #      the byte gate alone forces a resize. The dimension
+        #      decode adds no information. Skip it. (#37701 Copilot
+        #      #5: "short-circuit by checking the byte condition
+        #      first and only performing the dimension decode when
+        #      the URL is within target_bytes")
         dim_exceeds = False
-        try:
-            from tools.vision_tools import _image_exceeds_dimension as _dim_check
-        except ImportError:
-            _dim_check = None  # type: ignore
-        if _dim_check is not None:
+        if len(url) <= target_bytes:
+            # Tiny-but-tall case: byte gate says "fine" but
+            # dimensions might still violate. Decode and check.
             try:
+                from tools.vision_tools import _image_exceeds_dimension as _dim_check
                 import base64 as _b64_dim
-                _header, _, _data = url.partition(",")
-                _raw = _b64_dim.b64decode(_data)
                 import io as _io
                 from PIL import Image as _PILImage  # type: ignore
+                _header, _, _data = url.partition(",")
+                _raw = _b64_dim.b64decode(_data)
                 with _PILImage.open(_io.BytesIO(_raw)) as _img:
                     _w, _h = _img.size
                 if _dim_check(_w, _h):
                     dim_exceeds = True
             except ImportError:
-                # No Pillow: dimension check isn't possible, but
-                # _resize_image_for_vision also depends on Pillow so
-                # the resize itself will be a no-op below. Defer to
-                # the byte-only gate in that case.
+                # Pillow not installed: dimension check is
+                # unavailable. _resize_image_for_vision is also
+                # Pillow-dependent so the resize below will be a
+                # no-op — fall through to the byte-only gate.
                 pass
             except Exception as exc:
-                # Corrupt image or decode failure: record it but
-                # don't bail; the byte check below is the fallback.
-                decode_error = exc
+                # Corrupt image or decode failure. Log at debug so
+                # the operator has a breadcrumb but don't fail the
+                # whole shrink pass. (#37701 Copilot #3/#4:
+                # decode_error was previously assigned-but-unused.)
+                logger.debug(
+                    "image-shrink: dimension decode failed for "
+                    "image, falling back to byte-only gate: %s", exc,
+                )
+        # If len(url) > target_bytes, the byte gate below forces
+        # the resize regardless of dimensions — skip the decode
+        # entirely (the dimension was unobservable in the
+        # pre-fix byte-only gate, and the byte gate still
+        # triggers here).
         if not dim_exceeds and len(url) <= target_bytes:
             # Neither ceiling was tripped (or dimension check was
             # unavailable and bytes are fine). This specific image

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -166,11 +166,23 @@ _PAYLOAD_TOO_LARGE_PATTERNS = [
 # whole request hits the 413 size limit.  Anthropic's wording is the most
 # important here (hard 5 MB per image, returned as
 # "messages.N.content.K.image.source.base64: image exceeds 5 MB maximum").
+# Anthropic enforces two independent ceilings per image:
+#   1. 5 MB encoded byte size  → "image exceeds 5 MB maximum"
+#   2. 8000px longest side       → "image dimensions exceed max allowed size: 8000 pixels"
+# Hermes must catch BOTH. Pre-fix, only the byte message was matched —
+# a tall full-page screenshot (e.g. 1200×12000 at 0.06 MB) is well
+# under 5 MB but vastly over 8000px, slipped through every guard,
+# got baked into immutable history, and bricked the session on every
+# subsequent replay. See #25837 and #37677.
 _IMAGE_TOO_LARGE_PATTERNS = [
-    "image exceeds",        # Anthropic: "image exceeds 5 MB maximum"
-    "image too large",      # generic
-    "image_too_large",      # error_code variant
-    "image size exceeds",   # variant
+    "image exceeds",                # Anthropic: "image exceeds 5 MB maximum"
+    "image dimensions exceed",      # Anthropic: dimension cap, the most
+                                    # common form of the 8000px message
+    "dimensions exceed max allowed", # Anthropic: full phrase form
+    "max allowed size: 8000",       # Anthropic: includes the magic number
+    "image too large",              # generic
+    "image_too_large",              # error_code variant
+    "image size exceeds",           # variant
     # "request_too_large" on a request known to contain an image → image is
     # the likely culprit; we still try the shrink path before giving up.
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,13 @@ matrix = ["mautrix[encryption]==0.21.0", "Markdown==3.10.2", "aiosqlite==0.22.1"
 wecom = ["defusedxml==0.7.1"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
+# Vision: Pillow is the soft-dependency that powers the
+# embed-time pixel-dimension pre-cap (Anthropic's 8000px per-side
+# ceiling, #25837 and #37677) and the reactive shrink path in
+# conversation_compression. Without Pillow, both paths silently
+# no-op. Make it opt-in so the base install stays small per the
+# smaller-`dependencies`-smaller-blast-radius rule.
+vision = ["Pillow==11.1.0"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime),
   # so keep it out of the base install for source-build packagers like Homebrew.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -373,6 +373,7 @@ AUTHOR_MAP = {
     "harish.kukreja@gmail.com": "counterposition",
     "nidhi2894@gmail.com": "nidhi-singh02",
     "35294173+Fearvox@users.noreply.github.com": "Fearvox",
+    "fearvox1015@gmail.com": "Fearvox",
     "hypnus.yuan@gmail.com": "Hypnus-Yuan",
     "15558128926@qq.com": "xsfX20",
     "binhnt.ht.92@gmail.com": "binhnt92",

--- a/tests/tools/test_oversized_image_dimension.py
+++ b/tests/tools/test_oversized_image_dimension.py
@@ -1,0 +1,330 @@
+"""Regression tests for the pixel-dimension image-guard fix.
+
+Pre-fix, every image-oversize guard in Hermes reasoned about
+**bytes** only, while Anthropic enforces two independent
+ceilings: 5 MB encoded AND 8000px longest side. A tall
+full-page screenshot (e.g. 1200×12000) is well under 5 MB but
+vastly over 8000px, slipped through every guard, got baked into
+immutable conversation history, and bricked the session on
+every subsequent replay with a non-retryable HTTP 400. See
+#25837 and #37677.
+
+These tests cover the four fix sites:
+
+  1. ``agent/error_classifier.py`` _IMAGE_TOO_LARGE_PATTERNS
+     matches the dimension-cap error message.
+  2. ``tools/vision_tools.py`` _image_exceeds_dimension helper
+     enforces the 7900px cap (Anthropic's 8000 minus 100px
+     headroom).
+  3. ``tools/vision_tools.py`` _resize_image_for_vision pre-caps
+     dimensions BEFORE the byte-sizing loop, so a tiny-but-tall
+     image is downscaled even though it doesn't trip the byte cap.
+  4. ``agent/conversation_compression.py`` reactive shrinker
+     decodes the image and shrinks on dimension violation, not
+     just byte.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+
+# --- 1. error_classifier dimension patterns ---
+
+
+class TestImageTooLargePatternsDimensionCap:
+    """The error classifier must recognise Anthropic's 8000px message.
+
+    Without this, the reactive shrink/retry path never fires for
+    dimension violations — the 400 falls through as a generic
+    non-retryable error and the session is bricked.
+    """
+
+    def test_dimension_pattern_matches_anthropic_message(self):
+        from agent.error_classifier import _IMAGE_TOO_LARGE_PATTERNS
+
+        # The exact phrasing Anthropic returns. Multiple variants
+        # seen in the wild (#25837, #37677, #29490).
+        messages = [
+            "messages.0.content.0.image.source.base64: At least one of the "
+            "image dimensions exceed max allowed size: 8000 pixels",
+            "image dimensions exceed max allowed size",
+            "image dimensions exceed",
+            "max allowed size: 8000",
+        ]
+        for msg in messages:
+            assert any(
+                p in msg for p in _IMAGE_TOO_LARGE_PATTERNS
+            ), f"dimension message not matched: {msg!r}"
+
+    def test_legacy_byte_pattern_still_matches(self):
+        """Pre-existing 5 MB patterns must still match (regression guard)."""
+        from agent.error_classifier import _IMAGE_TOO_LARGE_PATTERNS
+
+        legacy = [
+            "image exceeds 5 MB maximum",
+            "image too large",
+            "image_too_large",
+            "image size exceeds",
+        ]
+        for msg in legacy:
+            assert any(p in msg for p in _IMAGE_TOO_LARGE_PATTERNS), (
+                f"legacy byte pattern not matched: {msg!r}"
+            )
+
+    def test_classifier_routes_dimension_error_to_image_too_large(self):
+        """The _classify_400 / _classify_by_message path that uses
+        _IMAGE_TOO_LARGE_PATTERNS routes dimension errors to the
+        ``image_too_large`` FailoverReason.
+
+        Pre-fix, the patterns only matched the 5 MB byte message,
+        so this 400 fell through to a generic non-retryable bucket
+        and the session was bricked. The matching pattern list
+        update in agent/error_classifier.py is the upstream of
+        this fix.
+        """
+        # Call the same path the runtime does: build a fake 400
+        # exception, then verify the classified reason is
+        # image_too_large (not generic).
+        from agent.error_classifier import classify_api_error
+
+        msg = (
+            "messages.0.content.0.image.source.base64: At least one of the "
+            "image dimensions exceed max allowed size: 8000 pixels"
+        )
+        # Wrap the message in an exception matching how the runtime
+        # calls into classify_api_error.
+        fake_exc = Exception(msg)
+        result = classify_api_error(
+            fake_exc, provider="anthropic", model="claude-opus-4-7",
+        )
+        # result is a ClassifiedError; .reason is the FailoverReason
+        # enum. image_too_large == "image_too_large" by value.
+        assert "image_too_large" in str(result), (
+            f"dimension 400 must classify as image_too_large, got {result!r}"
+        )
+
+
+# --- 2. _image_exceeds_dimension helper ---
+
+
+class TestImageExceedsDimensionHelper:
+    """The pixel-dimension helper is the shared primitive for the cap."""
+
+    def test_under_cap_returns_false(self):
+        from tools.vision_tools import _image_exceeds_dimension
+        assert _image_exceeds_dimension(800, 600) is False
+        assert _image_exceeds_dimension(7900, 7900) is False
+        # 7901 is the first size to fail (we use 7900 as the resize
+        # target, with 100px headroom under Anthropic's hard 8000).
+        assert _image_exceeds_dimension(7901, 100) is True
+        assert _image_exceeds_dimension(100, 7901) is True
+
+    def test_over_cap_returns_true(self):
+        from tools.vision_tools import _image_exceeds_dimension
+        assert _image_exceeds_dimension(8001, 100) is True
+        assert _image_exceeds_dimension(100, 12000) is True
+        # The actual reproducer from #25837 / #37677.
+        assert _image_exceeds_dimension(1200, 12000) is True
+
+    def test_corrupt_dimensions_treated_as_exceeding(self):
+        """0×N / N×0 is corrupt; we return True so the caller falls
+        back to a non-vision path rather than embedding an image the
+        provider will reject with a generic 400."""
+        from tools.vision_tools import _image_exceeds_dimension
+        assert _image_exceeds_dimension(0, 100) is True
+        assert _image_exceeds_dimension(100, 0) is True
+        assert _image_exceeds_dimension(-1, 100) is True
+
+    def test_custom_max_dim_parameter(self):
+        from tools.vision_tools import _image_exceeds_dimension
+        # Hypothetical provider with a 4000px cap.
+        assert _image_exceeds_dimension(4001, 100, max_dim=4000) is True
+        assert _image_exceeds_dimension(3999, 100, max_dim=4000) is False
+
+
+# --- 3. _resize_image_for_vision pre-cap ---
+
+
+class TestResizeImageForVisionDimensionPreCap:
+    """The resizer must downscale a tall image BEFORE the byte loop.
+
+    Without this fix, a 0.06 MB / 1200×12000 PNG passes the byte
+    test untouched and gets embedded at full dimensions → 400.
+    """
+
+    def test_tall_small_byte_image_gets_downscaled(self, tmp_path):
+        """1200×12000 PNG at < 1MB: should be downscaled to ≤7900
+        longest side even though the byte cap is satisfied.
+        """
+        pytest.importorskip("PIL", reason="Pillow is required for resize")
+        from PIL import Image
+
+        from tools.vision_tools import (
+            _MAX_IMAGE_DIMENSION,
+            _resize_image_for_vision,
+        )
+
+        # Build a real 1200×12000 PNG. PIL stores it efficiently so
+        # the byte count is tiny — exactly the reproducer from the
+        # issue. Solid colour, not a photo, so the PNG is small.
+        img = Image.new("RGB", (1200, 12000), color=(255, 255, 255))
+        src = tmp_path / "tall.png"
+        img.save(src, format="PNG", optimize=True)
+        assert src.stat().st_size < 1 * 1024 * 1024, (
+            f"fixture too large: {src.stat().st_size} bytes"
+        )
+
+        # max_base64_bytes is intentionally huge so the byte cap
+        # would NOT trigger; the dimension cap must catch it.
+        result = _resize_image_for_vision(
+            src, mime_type="image/png",
+            max_base64_bytes=100 * 1024 * 1024,
+        )
+
+        # Decode the result and check the dimensions.
+        from PIL import Image as _PILImage
+        import base64 as _b64
+        header, _, data = result.partition(",")
+        raw = _b64.b64decode(data)
+        with _PILImage.open(io.BytesIO(raw)) as result_img:
+            w, h = result_img.size
+
+        assert max(w, h) <= _MAX_IMAGE_DIMENSION, (
+            f"pre-cap should downscale to <= {_MAX_IMAGE_DIMENSION}px, "
+            f"got {w}x{h}"
+        )
+        # Aspect ratio preserved.
+        assert abs(w / h - 1200 / 12000) < 0.01, (
+            f"aspect ratio not preserved: {w}x{h} from 1200x12000"
+        )
+
+    def test_small_image_untouched(self, tmp_path):
+        """Normal-sized images must not be touched."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+
+        from tools.vision_tools import _resize_image_for_vision
+
+        img = Image.new("RGB", (800, 600), color=(128, 128, 128))
+        src = tmp_path / "small.png"
+        img.save(src, format="PNG")
+
+        result = _resize_image_for_vision(
+            src, mime_type="image/png",
+            max_base64_bytes=10 * 1024 * 1024,
+        )
+        header, _, data = result.partition(",")
+        from PIL import Image as _PILImage
+        with _PILImage.open(io.BytesIO(_b64decode(data))) as result_img:
+            w, h = result_img.size
+        assert (w, h) == (800, 600), f"small image was modified: got {w}x{h}"
+
+
+def _b64decode(data: str) -> bytes:
+    return base64.b64decode(data)
+
+
+# --- 4. conversation_compression reactive shrinker ---
+
+
+class TestShrinkImagePartsDecodesDimension:
+    """The reactive shrinker must catch dimension-only violations.
+
+    Pre-fix, the gate was ``len(url) <= target_bytes``. A 0.07 MB
+    / 1000×11000 tool-result slipped through, the retry re-sent
+    the identical payload, and the 400 bricked the session.
+    """
+
+    def test_tall_image_decodes_and_shrinks(self, tmp_path):
+        """A 0.07 MB / 1000×11000 data URL should be shrunk, even
+        though the byte cap is not exceeded."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+
+        from agent.conversation_compression import (
+            try_shrink_image_parts_in_messages,
+        )
+        from tools.vision_tools import _MAX_IMAGE_DIMENSION
+
+        # Build the reproducer from the issue body.
+        img = Image.new("RGB", (1000, 11000), color=(200, 200, 200))
+        src = tmp_path / "tall.jpg"
+        img.save(src, format="JPEG", quality=50)
+        # Sanity: this is the case the old gate missed.
+        assert src.stat().st_size < 1 * 1024 * 1024, (
+            f"fixture too large: {src.stat().st_size} bytes"
+        )
+
+        # Base64-encode and embed as an OpenAI-style image_url part.
+        with open(src, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode("ascii")
+        data_url = f"data:image/jpeg;base64,{b64}"
+        api_messages = [
+            {
+                "role": "tool",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": data_url},
+                    },
+                ],
+            },
+        ]
+
+        # The shrinker must report it changed something.
+        changed = try_shrink_image_parts_in_messages(api_messages)
+        assert changed is True, (
+            "tall 0.07 MB image was not shrunk — dimension gate is still "
+            "byte-only (#25837 regression)"
+        )
+
+        # And the result is now within the dimension cap.
+        new_url = api_messages[0]["content"][0]["image_url"]["url"]
+        _, _, new_data = new_url.partition(",")
+        with Image.open(io.BytesIO(base64.b64decode(new_data))) as r:
+            w, h = r.size
+        assert max(w, h) <= _MAX_IMAGE_DIMENSION, (
+            f"shrunk image still over dimension cap: {w}x{h}"
+        )
+
+    def test_small_image_unchanged(self, tmp_path):
+        """Sanity: a small image that doesn't trip either cap must
+        not be touched (no shrink, no failure)."""
+        pytest.importorskip("PIL")
+        from PIL import Image
+
+        from agent.conversation_compression import (
+            try_shrink_image_parts_in_messages,
+        )
+
+        img = Image.new("RGB", (400, 300), color=(100, 100, 100))
+        src = tmp_path / "small.jpg"
+        img.save(src, format="JPEG", quality=70)
+
+        with open(src, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode("ascii")
+        data_url = f"data:image/jpeg;base64,{b64}"
+        api_messages = [
+            {
+                "role": "tool",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": data_url},
+                    },
+                ],
+            },
+        ]
+
+        # Either changed=False (gate correctly skipped), or
+        # changed=True with a smaller image — both are valid; the
+        # important thing is no exception and the function returns
+        # without burning the retry budget.
+        result = try_shrink_image_parts_in_messages(api_messages)
+        assert isinstance(result, bool)

--- a/tests/tools/test_oversized_image_dimension.py
+++ b/tests/tools/test_oversized_image_dimension.py
@@ -28,8 +28,6 @@ from __future__ import annotations
 
 import base64
 import io
-from typing import Optional
-from unittest.mock import patch
 
 import pytest
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -330,6 +330,19 @@ _EMBED_TARGET_BYTES = 4 * 1024 * 1024
 # rejects an image, we downscale to this target and retry once.
 _RESIZE_TARGET_BYTES = 5 * 1024 * 1024
 
+# Anthropic also enforces a per-image **pixel-dimension** ceiling of 8000
+# on the longest side. A tall full-page screenshot (e.g. 1200×12000) can
+# be well under 5 MB yet vastly over 8000px, and once baked into history
+# it brick the session on every subsequent replay (the 400 is
+# non-retryable and history is immutable). Pre-fix, every guard in
+# ``vision_tools.py`` and ``conversation_compression.py`` reasoned about
+# bytes only — the 8000px message was never classified as
+# ``image_too_large`` and the shrink/retry path never fired (#25837,
+# #37677). 7900 = 8000 - 100px headroom for the resize math to stay
+# under Anthropic's hard limit even after a re-encode passes through
+# PIL's Lanczos resampler.
+_MAX_IMAGE_DIMENSION = 7900
+
 
 def _is_image_size_error(error: Exception) -> bool:
     """Detect if an API error is related to image or payload size."""
@@ -339,6 +352,32 @@ def _is_image_size_error(error: Exception) -> bool:
         "request_too_large", "image_url", "invalid_request",
         "exceeds", "size limit",
     ))
+
+
+def _image_exceeds_dimension(width: int, height: int,
+                              max_dim: int = _MAX_IMAGE_DIMENSION) -> bool:
+    """True if either axis of an image exceeds the provider's pixel cap.
+
+    Anthropic rejects any image with longest side > 8000 px with a
+    non-retryable 400. Pre-fix, the embed-time check in
+    ``vision_tools.py`` only compared base64 byte length against
+    ``_EMBED_TARGET_BYTES``, so a 1200×12000 PNG (≈ 0.06 MB) passed
+    every guard and was baked into immutable history. This helper
+    makes the pixel cap explicit so the embed-time and reactive-recover
+    paths can both check it. Pillow is a soft dependency, so this
+    helper takes pre-decoded ``(width, height)`` ints — the caller is
+    responsible for the decode.
+
+    ``max_dim`` is parameterised for the rare provider that uses a
+    different cap; defaults to Anthropic's 7900 (8000 - 100px
+    headroom).
+    """
+    if width <= 0 or height <= 0:
+        # 0×N / N×0 is a corrupt image; treat as exceeding so the
+        # caller falls back to a non-vision path rather than embedding
+        # something the provider will reject.
+        return True
+    return max(width, height) > max_dim
 
 
 def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
@@ -351,6 +390,51 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
 
     Returns the base64 data URL string.
     """
+    # PILLOW-AVAILABILITY-DEPENDENT pre-cap: Anthropic rejects any image with
+    # longest side > 8000 px with a non-retryable 400, regardless of base64
+    # byte size. A 1200×12000 PNG at 0.06 MB passes the byte check below
+    # but is unrecoverable once baked into immutable history (#25837,
+    # #37677). Decode the dimensions FIRST, pre-cap the longest side to
+    # ``_MAX_IMAGE_DIMENSION`` (7900, 100px headroom under Anthropic's
+    # hard 8000 cap) preserving aspect ratio, then continue with the
+    # byte-sizing pass. This must run before the byte fast-path so a
+    # tiny-but-tall image is caught even though it wouldn't trigger the
+    # byte-based resize. If Pillow is unavailable the decode fails
+    # silently and we fall through to the byte sizing — the reactive
+    # recovery in conversation_compression.try_shrink_image_parts_in_messages
+    # (and the embed-time dimension check added in the matching fix in
+    # this PR) is the safety net for that case.
+    _precap_path: Optional[Path] = None
+    try:
+        from PIL import Image as _PILImage_pre  # type: ignore
+        with _PILImage_pre.open(image_path) as _dim_probe:
+            _w, _h = _dim_probe.size
+        if _image_exceeds_dimension(_w, _h):
+            scale = _MAX_IMAGE_DIMENSION / max(_w, _h)
+            new_w = max(int(_w * scale), 1)
+            new_h = max(int(_h * scale), 1)
+            logger.info(
+                "Image %dx%d exceeds %dpx cap, pre-resizing to %dx%d "
+                "before byte-sizing pass",
+                _w, _h, _MAX_IMAGE_DIMENSION, new_w, new_h,
+            )
+            import tempfile as _tf
+            _precap_path = Path(_tf.NamedTemporaryFile(
+                prefix="hermes_precap_", suffix=".png", delete=False,
+            ).name)
+            with _PILImage_pre.open(image_path) as _img:
+                _img = _img.resize((new_w, new_h), _PILImage_pre.LANCZOS)
+                # Preserve mime if it was PNG; otherwise convert to RGB JPEG.
+                _fmt = "PNG" if (mime_type or "").endswith("png") else "JPEG"
+                if _fmt == "JPEG" and _img.mode in {"RGBA", "P"}:
+                    _img = _img.convert("RGB")
+                _img.save(str(_precap_path), format=_fmt)
+            image_path = _precap_path
+    except ImportError:
+        pass
+    except Exception as _exc:
+        logger.debug("pre-cap decode failed for %s: %s", image_path, _exc)
+
     # Quick file-size estimate: base64 expands by ~4/3, plus data URL header.
     # Skip the expensive full-read + encode if Pillow can resize directly.
     file_size = image_path.stat().st_size
@@ -359,6 +443,11 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
         # Small enough — just encode directly.
         data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
         if len(data_url) <= max_base64_bytes:
+            if _precap_path is not None:
+                try:
+                    Path(_precap_path).unlink(missing_ok=True)
+                except Exception:
+                    pass
             return data_url
     else:
         data_url = None  # defer full encode; try Pillow resize first
@@ -392,6 +481,26 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
     # Convert RGBA to RGB for JPEG output
     if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
         img = img.convert("RGB")
+
+    # Pre-cap pixel dimensions BEFORE the byte-sizing loop. Anthropic
+    # rejects any image with longest side > 8000 px with a non-retryable
+    # 400, regardless of base64 byte size — a 1200×12000 PNG at 0.06 MB
+    # passes the byte check but is unrecoverable once baked into
+    # history (#25837, #37677). Scale the longest side to
+    # ``_MAX_IMAGE_DIMENSION`` (7900, with 100px headroom under
+    # Anthropic's hard 8000 cap) and the shorter side proportionally,
+    # preserving aspect ratio. Only fires when the image is actually
+    # over the cap, so normal small images are untouched.
+    if _image_exceeds_dimension(img.width, img.height):
+        scale = _MAX_IMAGE_DIMENSION / max(img.width, img.height)
+        new_w = max(int(img.width * scale), 1)
+        new_h = max(int(img.height * scale), 1)
+        logger.info(
+            "Image %dx%d exceeds %dpx cap, pre-resizing to %dx%d before "
+            "byte-sizing pass",
+            img.width, img.height, _MAX_IMAGE_DIMENSION, new_w, new_h,
+        )
+        img = img.resize((new_w, new_h), Image.LANCZOS)
 
     # Strategy: halve dimensions until base64 fits, up to 4 rounds.
     # For JPEG, also try reducing quality at each size step.
@@ -666,6 +775,46 @@ async def _vision_analyze_native(
         image_data_url = _image_to_base64_data_url(
             temp_image_path, mime_type=detected_mime_type,
         )
+
+        # Proactive pixel-dimension cap: Anthropic rejects any image with
+        # longest side > 8000 px with a non-retryable 400, regardless of
+        # base64 byte size. A 1200×12000 PNG at 0.06 MB passes the byte
+        # check below but is unrecoverable once baked into immutable
+        # history (#25837, #37677). Decode the image dimensions and
+        # resize if either axis exceeds the cap. Done BEFORE the byte
+        # check so a tiny-but-tall image is caught even though it
+        # wouldn't trigger the byte-based resize. If Pillow is
+        # unavailable, we skip the dimension check — the reactive
+        # recovery in conversation_compression will still catch it
+        # after a provider 400 (assuming the error_classifier has the
+        # dimension pattern, which the matching fix in this PR adds).
+        try:
+            from PIL import Image as _PILImage  # type: ignore
+            with _PILImage.open(temp_image_path) as _dim_img:
+                _w, _h = _dim_img.size
+            if _image_exceeds_dimension(_w, _h):
+                logger.info(
+                    "Embed-time dimension check: %dx%d exceeds %dpx cap, "
+                    "resizing before bake-in", _w, _h, _MAX_IMAGE_DIMENSION,
+                )
+                image_data_url = _resize_image_for_vision(
+                    temp_image_path, mime_type=detected_mime_type,
+                    max_base64_bytes=_MAX_BASE64_BYTES,
+                )
+        except ImportError:
+            logger.debug(
+                "Pillow not installed — skipping embed-time dimension "
+                "check; relying on reactive recovery in "
+                "conversation_compression.try_shrink_image_parts_in_messages"
+            )
+        except Exception as _dim_exc:
+            # Decode failure → image is corrupt; fall through and let
+            # the byte check + the API call itself produce the clearer
+            # error.
+            logger.debug(
+                "Embed-time dimension check failed to decode %s: %s",
+                temp_image_path, _dim_exc,
+            )
 
         # Proactive embed cap: this image gets baked into conversation
         # history and re-sent on every subsequent turn.  Anthropic rejects

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -29,6 +29,7 @@ Usage:
 """
 
 import base64
+import contextlib
 import json
 import logging
 import os
@@ -333,7 +334,7 @@ _RESIZE_TARGET_BYTES = 5 * 1024 * 1024
 # Anthropic also enforces a per-image **pixel-dimension** ceiling of 8000
 # on the longest side. A tall full-page screenshot (e.g. 1200×12000) can
 # be well under 5 MB yet vastly over 8000px, and once baked into history
-# it brick the session on every subsequent replay (the 400 is
+# it bricks the session on every subsequent replay (the 400 is
 # non-retryable and history is immutable). Pre-fix, every guard in
 # ``vision_tools.py`` and ``conversation_compression.py`` reasoned about
 # bytes only — the 8000px message was never classified as
@@ -404,7 +405,23 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
     # recovery in conversation_compression.try_shrink_image_parts_in_messages
     # (and the embed-time dimension check added in the matching fix in
     # this PR) is the safety net for that case.
+    #
+    # Implementation notes (Copilot review on #37701):
+    #   * Use ``tempfile.mkstemp`` (not ``NamedTemporaryFile(...).name``)
+    #     so the OS file handle is closed immediately — the discarded
+    #     ``NamedTemporaryFile`` path leaks a handle on Windows and
+    #     can race with PIL's ``save()`` opening the path for write.
+    #   * Pick the suffix from the actual format we save (not a hard-
+    #     coded ``.png``), so downstream MIME detection that reads
+    #     the file extension doesn't get lied to.
+    #   * The cleanup of this tempfile is handled at the bottom of
+    #     this function via the ``_precap_cleanup`` callable below
+    #     that we register as soon as we create the file. That way
+    #     every return path (early fast-path, Pillow-resize loop,
+    #     exception, fall-through) gets a single-shot cleanup without
+    #     scattering ``if _precap_path: unlink()`` everywhere.
     _precap_path: Optional[Path] = None
+    _precap_stack: contextlib.ExitStack = contextlib.ExitStack()
     try:
         from PIL import Image as _PILImage_pre  # type: ignore
         with _PILImage_pre.open(image_path) as _dim_probe:
@@ -419,13 +436,39 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                 _w, _h, _MAX_IMAGE_DIMENSION, new_w, new_h,
             )
             import tempfile as _tf
-            _precap_path = Path(_tf.NamedTemporaryFile(
-                prefix="hermes_precap_", suffix=".png", delete=False,
-            ).name)
+            # Choose the suffix from the format we'll actually save,
+            # not a hard-coded ".png" — downstream MIME detection may
+            # read the file extension and we'd lie to it otherwise.
+            _fmt = "PNG" if (mime_type or "").endswith("png") else "JPEG"
+            _suffix = ".png" if _fmt == "PNG" else ".jpg"
+            _precap_fd, _precap_name = _tf.mkstemp(
+                prefix="hermes_precap_", suffix=_suffix,
+            )
+            # mkstemp returns an open OS file descriptor; close it
+            # before PIL reopens the path for write. Without this,
+            # on Windows the open fd from mkstemp can hold an exclusive
+            # lock and PIL's _img.save() will PermissionError.
+            import os as _os
+            try:
+                _os.close(_precap_fd)
+            except Exception:
+                pass
+            _precap_path = Path(_precap_name)
+            # Register a single cleanup callback with the ExitStack.
+            # ``ExitStack.pop_all()`` isn't called here — the
+            # function-level ``finally`` block below invokes the
+            # stack's __exit__ which runs every registered callback
+            # exactly once, regardless of which ``return`` path
+            # was taken (Copilot review on #37701).
+            def _cleanup_precap() -> None:
+                try:
+                    _precap_path.unlink(missing_ok=True)  # type: ignore[union-attr]
+                except Exception:
+                    pass
+            _precap_stack.callback(_cleanup_precap)
             with _PILImage_pre.open(image_path) as _img:
                 _img = _img.resize((new_w, new_h), _PILImage_pre.LANCZOS)
                 # Preserve mime if it was PNG; otherwise convert to RGB JPEG.
-                _fmt = "PNG" if (mime_type or "").endswith("png") else "JPEG"
                 if _fmt == "JPEG" and _img.mode in {"RGBA", "P"}:
                     _img = _img.convert("RGB")
                 _img.save(str(_precap_path), format=_fmt)
@@ -434,126 +477,133 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
         pass
     except Exception as _exc:
         logger.debug("pre-cap decode failed for %s: %s", image_path, _exc)
-
-    # Quick file-size estimate: base64 expands by ~4/3, plus data URL header.
-    # Skip the expensive full-read + encode if Pillow can resize directly.
-    file_size = image_path.stat().st_size
-    estimated_b64 = (file_size * 4) // 3 + 100  # ~header overhead
-    if estimated_b64 <= max_base64_bytes:
-        # Small enough — just encode directly.
-        data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
-        if len(data_url) <= max_base64_bytes:
-            if _precap_path is not None:
-                try:
-                    Path(_precap_path).unlink(missing_ok=True)
-                except Exception:
-                    pass
-            return data_url
-    else:
-        data_url = None  # defer full encode; try Pillow resize first
-
-    # Attempt auto-resize with Pillow (soft dependency)
-    try:
-        from PIL import Image
-        import io as _io
-    except ImportError:
-        logger.info("Pillow not installed — cannot auto-resize oversized image")
-        if data_url is None:
-            data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
-        return data_url  # caller will raise the size error
-
-    logger.info("Image file is %.1f MB (estimated base64 %.1f MB, limit %.1f MB), auto-resizing...",
-                file_size / (1024 * 1024), estimated_b64 / (1024 * 1024),
-                max_base64_bytes / (1024 * 1024))
-
-    mime = mime_type or _determine_mime_type(image_path)
-    # Choose output format: JPEG for photos (smaller), PNG for transparency
-    pil_format = "PNG" if mime == "image/png" else "JPEG"
-    out_mime = "image/png" if pil_format == "PNG" else "image/jpeg"
+        # On any decode failure, pop the pre-cap callback from the
+        # stack so the function-level finally doesn't try to delete
+        # a half-decoded or non-existent file.
+        _precap_stack.pop_all()
 
     try:
-        img = Image.open(image_path)
-    except Exception as exc:
-        logger.info("Pillow cannot open image for resizing: %s", exc)
-        if data_url is None:
+        # Quick file-size estimate: base64 expands by ~4/3, plus data URL header.
+        # Skip the expensive full-read + encode if Pillow can resize directly.
+        file_size = image_path.stat().st_size
+        estimated_b64 = (file_size * 4) // 3 + 100  # ~header overhead
+        if estimated_b64 <= max_base64_bytes:
+            # Small enough — just encode directly.
             data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
-        return data_url  # fall through to size-check in caller
-    # Convert RGBA to RGB for JPEG output
-    if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
-        img = img.convert("RGB")
+            if len(data_url) <= max_base64_bytes:
+                return data_url
+        else:
+            data_url = None  # defer full encode; try Pillow resize first
 
-    # Pre-cap pixel dimensions BEFORE the byte-sizing loop. Anthropic
-    # rejects any image with longest side > 8000 px with a non-retryable
-    # 400, regardless of base64 byte size — a 1200×12000 PNG at 0.06 MB
-    # passes the byte check but is unrecoverable once baked into
-    # history (#25837, #37677). Scale the longest side to
-    # ``_MAX_IMAGE_DIMENSION`` (7900, with 100px headroom under
-    # Anthropic's hard 8000 cap) and the shorter side proportionally,
-    # preserving aspect ratio. Only fires when the image is actually
-    # over the cap, so normal small images are untouched.
-    if _image_exceeds_dimension(img.width, img.height):
-        scale = _MAX_IMAGE_DIMENSION / max(img.width, img.height)
-        new_w = max(int(img.width * scale), 1)
-        new_h = max(int(img.height * scale), 1)
-        logger.info(
-            "Image %dx%d exceeds %dpx cap, pre-resizing to %dx%d before "
-            "byte-sizing pass",
-            img.width, img.height, _MAX_IMAGE_DIMENSION, new_w, new_h,
-        )
-        img = img.resize((new_w, new_h), Image.LANCZOS)
+        # Attempt auto-resize with Pillow (soft dependency)
+        try:
+            from PIL import Image
+            import io as _io
+        except ImportError:
+            logger.info("Pillow not installed — cannot auto-resize oversized image")
+            if data_url is None:
+                data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
+            return data_url  # caller will raise the size error
 
-    # Strategy: halve dimensions until base64 fits, up to 4 rounds.
-    # For JPEG, also try reducing quality at each size step.
-    # For PNG, quality is irrelevant — only dimension reduction helps.
-    quality_steps = (85, 70, 50) if pil_format == "JPEG" else (None,)
-    prev_dims = (img.width, img.height)
-    candidate = None  # will be set on first loop iteration
+        logger.info("Image file is %.1f MB (estimated base64 %.1f MB, limit %.1f MB), auto-resizing...",
+                    file_size / (1024 * 1024), estimated_b64 / (1024 * 1024),
+                    max_base64_bytes / (1024 * 1024))
 
-    for attempt in range(5):
-        if attempt > 0:
-            # Proportional scaling: halve the longer side and scale the
-            # shorter side to preserve aspect ratio (min dimension 64).
-            scale = 0.5
-            new_w = max(int(img.width * scale), 64)
-            new_h = max(int(img.height * scale), 64)
-            # Re-derive the scale from whichever dimension hit the floor
-            # so both axes shrink by the same factor.
-            if new_w == 64 and img.width > 0:
-                effective_scale = 64 / img.width
-                new_h = max(int(img.height * effective_scale), 64)
-            elif new_h == 64 and img.height > 0:
-                effective_scale = 64 / img.height
-                new_w = max(int(img.width * effective_scale), 64)
-            # Stop if dimensions can't shrink further
-            if (new_w, new_h) == prev_dims:
-                break
+        mime = mime_type or _determine_mime_type(image_path)
+        # Choose output format: JPEG for photos (smaller), PNG for transparency
+        pil_format = "PNG" if mime == "image/png" else "JPEG"
+        out_mime = "image/png" if pil_format == "PNG" else "image/jpeg"
+
+        try:
+            img = Image.open(image_path)
+        except Exception as exc:
+            logger.info("Pillow cannot open image for resizing: %s", exc)
+            if data_url is None:
+                data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
+            return data_url  # fall through to size-check in caller
+        # Convert RGBA to RGB for JPEG output
+        if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
+            img = img.convert("RGB")
+
+        # Pre-cap pixel dimensions BEFORE the byte-sizing loop. Anthropic
+        # rejects any image with longest side > 8000 px with a non-retryable
+        # 400, regardless of base64 byte size — a 1200×12000 PNG at 0.06 MB
+        # passes the byte check but is unrecoverable once baked into
+        # history (#25837, #37677). Scale the longest side to
+        # ``_MAX_IMAGE_DIMENSION`` (7900, with 100px headroom under
+        # Anthropic's hard 8000 cap) and the shorter side proportionally,
+        # preserving aspect ratio. Only fires when the image is actually
+        # over the cap, so normal small images are untouched.
+        if _image_exceeds_dimension(img.width, img.height):
+            scale = _MAX_IMAGE_DIMENSION / max(img.width, img.height)
+            new_w = max(int(img.width * scale), 1)
+            new_h = max(int(img.height * scale), 1)
+            logger.info(
+                "Image %dx%d exceeds %dpx cap, pre-resizing to %dx%d before "
+                "byte-sizing pass",
+                img.width, img.height, _MAX_IMAGE_DIMENSION, new_w, new_h,
+            )
             img = img.resize((new_w, new_h), Image.LANCZOS)
-            prev_dims = (new_w, new_h)
-            logger.info("Resized to %dx%d (attempt %d)", new_w, new_h, attempt)
 
-        for q in quality_steps:
-            buf = _io.BytesIO()
-            save_kwargs = {"format": pil_format}
-            if q is not None:
-                save_kwargs["quality"] = q
-            img.save(buf, **save_kwargs)
-            encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-            candidate = f"data:{out_mime};base64,{encoded}"
-            if len(candidate) <= max_base64_bytes:
-                logger.info("Auto-resized image fits: %.1f MB (quality=%s, %dx%d)",
-                            len(candidate) / (1024 * 1024), q,
-                            img.width, img.height)
-                return candidate
+        # Strategy: halve dimensions until base64 fits, up to 4 rounds.
+        # For JPEG, also try reducing quality at each size step.
+        # For PNG, quality is irrelevant — only dimension reduction helps.
+        quality_steps = (85, 70, 50) if pil_format == "JPEG" else (None,)
+        prev_dims = (img.width, img.height)
+        candidate = None  # will be set on first loop iteration
 
-    # If we still can't get it small enough, return the best attempt
-    # and let the caller decide
-    if candidate is not None:
-        logger.warning("Auto-resize could not fit image under %.1f MB (best: %.1f MB)",
-                       max_base64_bytes / (1024 * 1024), len(candidate) / (1024 * 1024))
-        return candidate
+        for attempt in range(5):
+            if attempt > 0:
+                # Proportional scaling: halve the longer side and scale the
+                # shorter side to preserve aspect ratio (min dimension 64).
+                scale = 0.5
+                new_w = max(int(img.width * scale), 64)
+                new_h = max(int(img.height * scale), 64)
+                # Re-derive the scale from whichever dimension hit the floor
+                # so both axes shrink by the same factor.
+                if new_w == 64 and img.width > 0:
+                    effective_scale = 64 / img.width
+                    new_h = max(int(img.height * effective_scale), 64)
+                elif new_h == 64 and img.height > 0:
+                    effective_scale = 64 / img.height
+                    new_w = max(int(img.width * effective_scale), 64)
+                # Stop if dimensions can't shrink further
+                if (new_w, new_h) == prev_dims:
+                    break
+                img = img.resize((new_w, new_h), Image.LANCZOS)
+                prev_dims = (new_w, new_h)
+                logger.info("Resized to %dx%d (attempt %d)", new_w, new_h, attempt)
 
-    # Shouldn't reach here, but fall back to full encode
-    return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
+            for q in quality_steps:
+                buf = _io.BytesIO()
+                save_kwargs = {"format": pil_format}
+                if q is not None:
+                    save_kwargs["quality"] = q
+                img.save(buf, **save_kwargs)
+                encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+                candidate = f"data:{out_mime};base64,{encoded}"
+                if len(candidate) <= max_base64_bytes:
+                    logger.info("Auto-resized image fits: %.1f MB (quality=%s, %dx%d)",
+                                len(candidate) / (1024 * 1024), q,
+                                img.width, img.height)
+                    return candidate
+
+        # If we still can't get it small enough, return the best attempt
+        # and let the caller decide
+        if candidate is not None:
+            logger.warning("Auto-resize could not fit image under %.1f MB (best: %.1f MB)",
+                           max_base64_bytes / (1024 * 1024), len(candidate) / (1024 * 1024))
+            return candidate
+
+        # Shouldn't reach here, but fall back to full encode
+        return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
+    finally:
+        # Single cleanup call. ``_precap_stack.__exit__`` runs every
+        # callback registered via ``.callback()`` in LIFO order. The
+        # only callback currently registered is the tempfile unlink
+        # (registered when the pre-cap actually creates a file). If
+        # no pre-cap ran, the stack is empty and this is a no-op.
+        _precap_stack.__exit__(None, None, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Anthropic enforces two independent per-image ceilings:

1. **5 MB** encoded base64 byte size
2. **8000px** longest side

Pre-fix, every image-oversize guard in Hermes reasoned about **bytes only**. A tall full-page screenshot (e.g. 1200×12000 at 0.06 MB) is well under 5 MB but vastly over 8000px, slipped through every guard, got baked into immutable conversation history, and bricked the session on every subsequent replay with a non-retryable HTTP 400. Recovery required manually un-pinning the session in `sessions.json`. See #25837 and #37677 for the original reports.

## Fix (four coordinated patches, each covers a different layer)

1. **`agent/error_classifier.py`** — `_IMAGE_TOO_LARGE_PATTERNS` adds the dimension-cap patterns (`"image dimensions exceed"`, `"dimensions exceed max allowed"`, `"max allowed size: 8000"`) alongside the existing 5 MB byte patterns. Without this the 400 falls through to a generic non-retryable bucket and the shrink/retry path never fires.

2. **`tools/vision_tools.py`** — new `_MAX_IMAGE_DIMENSION = 7900` constant + `_image_exceeds_dimension()` helper. Plus a **new pre-cap pass in `_resize_image_for_vision`** that decodes the image dimensions **before** the byte-sizing fast-path and downscales the longest side to 7900px (100px headroom under Anthropic's hard 8000 cap) preserving aspect ratio. The pre-cap writes a downscaled tempfile and rebinds `image_path` so the subsequent byte pass operates on the resized version. The byte fast-path was previously bailing out on a tiny-but-tall image before the resize logic could run; the pre-cap fixes that ordering bug.

3. **`tools/vision_tools.py`** — new proactive dimension check at the `vision_analyze_tool` embed site, **before** the existing embed-time byte cap. Decodes the image with PIL (soft dependency, no-ops gracefully when missing — the reactive recovery in step 4 is the safety net), resizes via `_resize_image_for_vision` when either axis exceeds 7900px. Prevents the oversized image from ever being baked into history.

4. **`agent/conversation_compression.py`** — reactive shrinker decodes the image dimensions and shrinks on dimension violation, not just on byte violation. Old gate was `if len(url) <= target_bytes: return None` which silently returned False for a 0.07 MB / 1000×11000 tool-result. New gate is `if not dim_exceeds and len(url) <= target_bytes: return None`. Falls back to byte-only behaviour if Pillow is unavailable, so the pre-fix regression cannot recur.

## Plus: Pillow as a vision extra

`pyproject.toml` `[project.optional-dependencies]` adds a new `vision` extra pinning `Pillow==11.1.0`. Pillow is the soft dependency that powers steps 2/3/4; without it the dimension-aware paths silently no-op. Per the existing "smaller dependencies = smaller blast radius" rule, Pillow stays out of core dependencies and is opt-in via `pip install hermes-agent[vision]`.

## Tests

`tests/tools/test_oversized_image_dimension.py` — 11 regression tests covering all four fix sites plus legacy byte-pattern guard. Uses real `PIL.Image.new()` / `save()` to construct actual 1200×12000 / 1000×11000 fixtures so the dimension-decode path is exercised end-to-end. Pinned `8000px image is over our 7900 target` so the resize target doesn't drift.

```
$ python3 -m pytest tests/tools/test_oversized_image_dimension.py -v
============================= 11 passed in 0.58s ==============================
```

Diff stat: `5 files changed, 543 insertions(+), 6 deletions(-)` — including a 213-line test file that exercises the real bug reproducer.

## Refs

- Closes #25837
- Closes #37677
