### PR TITLE
fix(install): skip submodule init when none declared

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1251,13 +1251,20 @@ function Install-Repository {
         }
     }
 
-    # Ensure submodules are initialized and updated
-    Write-Info "Initializing submodules..."
-    git -c windows.appendAtomically=false submodule update --init --recursive 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warn "Submodule init failed (terminal/RL tools may need manual setup)"
+    # Ensure submodules are initialized and updated when the repository
+    # actually declares them.  Current Hermes has no .gitmodules; running
+    # `git submodule` anyway forces Git-for-Windows through shell helper
+    # scripts and can fail on machines where that optional path is broken.
+    if (Test-Path ".gitmodules") {
+        Write-Info "Initializing submodules..."
+        git -c windows.appendAtomically=false submodule update --init --recursive 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "Submodule init failed (terminal/RL tools may need manual setup)"
+        } else {
+            Write-Success "Submodules ready"
+        }
     } else {
-        Write-Success "Submodules ready"
+        Write-Info "No submodules declared; skipping submodule init"
     }
     Pop-Location
 


### PR DESCRIPTION
## What does this PR do?

Skips the Windows installer's post-clone `git submodule update --init --recursive` step when the checked-out repository does not declare any submodules.

The current Hermes repository has no `.gitmodules`, but `scripts/install.ps1` still always invokes `git submodule` after clone or ZIP fallback. On Windows machines where Git-for-Windows' shell helper path is broken, that unnecessary command can fail with errors such as:

`/mingw64/libexec/git-core/git-sh-setup: line 46: /git-sh-i18n: No such file or directory`

Because there is no submodule work to do in this case, the installer can safely skip the command and continue.

## Related Issue

Fixes #

No GitHub issue yet. Reported from Discord support thread `1511490038045741308`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1`: checks for `.gitmodules` before running `git submodule update --init --recursive`.
- `scripts/install.ps1`: prints `No submodules declared; skipping submodule init` when no submodules are declared.

## How to Test

1. On a checkout without `.gitmodules`, run the Windows installer repository stage or full installer path.
2. Confirm the installer does not invoke `git submodule update --init --recursive`.
3. Confirm the repository stage continues after printing `No submodules declared; skipping submodule init`.

Local validation performed:

1. `git diff --check`
2. Windows PowerShell parser check for `scripts/install.ps1`: `PowerShell parse OK`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu with Windows PowerShell parser check against `scripts/install.ps1`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Reported failing Windows installer log excerpt:

`/mingw64/libexec/git-core/git-sh-setup: line 46: /git-sh-i18n: No such file or directory`

The failure occurred after ZIP fallback completed and immediately after:

`-> Initializing submodules...`
