### PR TITLE
perf(cli): fast-path global version startup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -65,6 +65,22 @@ import os
 import sys
 
 
+def _project_root_str_fast() -> str:
+    return os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+
+def _ensure_project_root_on_path_fast() -> None:
+    project_root = _project_root_str_fast()
+    normalized_root = os.path.normcase(os.path.realpath(project_root))
+    sys.path[:] = [
+        entry
+        for entry in sys.path
+        if not entry
+        or os.path.normcase(os.path.realpath(entry)) != normalized_root
+    ]
+    sys.path.insert(0, project_root)
+
+
 def _set_process_title() -> None:
     """Set the process title to 'hermes' so tools like 'ps', 'top', and
     'htop' show the app name instead of 'python3.xx'.
@@ -204,6 +220,55 @@ def _is_termux_fast_version_argv(argv: list[str]) -> bool:
     return argv in (["--version"], ["-V"], ["version"])
 
 
+def _is_global_fast_version_argv(argv: list[str]) -> bool:
+    return argv in (["--version"], ["-V"])
+
+
+def _is_container_startup_environment_fast() -> bool:
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+        return True
+    try:
+        with open("/proc/1/cgroup", encoding="utf-8") as handle:
+            cgroup = handle.read()
+    except OSError:
+        return False
+    return "docker" in cgroup or "podman" in cgroup or "/lxc/" in cgroup
+
+
+def _active_profile_may_override_home_fast(hermes_root: str) -> bool:
+    active_profile = os.path.join(hermes_root, "active_profile")
+    try:
+        if os.path.exists(active_profile):
+            with open(active_profile, encoding="utf-8") as handle:
+                active = handle.read().strip()
+            return bool(active and active != "default")
+    except (OSError, UnicodeDecodeError):
+        pass
+    return False
+
+
+def _container_mode_may_be_active_fast() -> bool:
+    if os.environ.get("HERMES_DEV") == "1":
+        return False
+    if _is_container_startup_environment_fast():
+        return False
+
+    hermes_home = os.environ.get("HERMES_HOME", "").strip()
+    if hermes_home:
+        if os.path.exists(os.path.join(hermes_home, ".container-mode")):
+            return True
+        parent_name = os.path.basename(os.path.dirname(os.path.normpath(hermes_home)))
+        return (
+            parent_name != "profiles"
+            and _active_profile_may_override_home_fast(hermes_home)
+        )
+
+    default_home = os.path.join(os.path.expanduser("~"), ".hermes")
+    if _active_profile_may_override_home_fast(default_home):
+        return True
+    return os.path.exists(os.path.join(default_home, ".container-mode"))
+
+
 def _read_openai_version_fast() -> str | None:
     """Read OpenAI SDK version without importing ``importlib.metadata``."""
     for base in sys.path:
@@ -236,20 +301,36 @@ def _print_fast_version_info() -> None:
     print(f"OpenAI SDK: {openai_version}" if openai_version else "OpenAI SDK: Not installed")
 
 
-def _try_termux_ultrafast_version() -> bool:
-    """Handle ``hermes --version`` before config/logging imports on Termux."""
-    if os.environ.get("HERMES_TERMUX_DISABLE_FAST_CLI") == "1":
+def _try_ultrafast_version() -> bool:
+    """Handle ``hermes --version`` before config/logging imports."""
+    is_termux = _is_termux_startup_environment_fast()
+    if (
+        is_termux
+        and os.environ.get("HERMES_TERMUX_DISABLE_FAST_CLI") == "1"
+    ):
         return False
-    if not _is_termux_startup_environment_fast():
+    if is_termux:
+        if not _is_termux_fast_version_argv(sys.argv[1:]):
+            return False
+    elif not _is_global_fast_version_argv(sys.argv[1:]):
         return False
-    if not _is_termux_fast_version_argv(sys.argv[1:]):
+    elif _container_mode_may_be_active_fast():
         return False
 
     _print_fast_version_info()
     return True
 
 
-if _try_termux_ultrafast_version():
+def _try_termux_ultrafast_version() -> bool:
+    """Backward-compatible test hook for the Termux startup fast path."""
+    if not _is_termux_startup_environment_fast():
+        return False
+    return _try_ultrafast_version()
+
+
+_ensure_project_root_on_path_fast()
+
+if _try_ultrafast_version():
     raise SystemExit(0)
 
 import argparse
@@ -294,8 +375,8 @@ def _require_tty(command_name: str) -> None:
 
 
 # Add project root to path
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
-sys.path.insert(0, str(PROJECT_ROOT))
+PROJECT_ROOT = Path(_project_root_str_fast())
+_ensure_project_root_on_path_fast()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 import os
 from pathlib import Path
+import subprocess
 import sys
 import types
 
@@ -410,6 +411,102 @@ def test_termux_ultrafast_version_runs_before_heavy_startup(
     assert "Project:" in out
     assert "Python:" in out
     assert "OpenAI SDK:" in out
+
+
+def test_ultrafast_version_runs_off_termux(monkeypatch, capsys, main_mod):
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.delenv("HERMES_TERMUX_DISABLE_FAST_CLI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_ultrafast_version() is True
+
+    out = capsys.readouterr().out
+    assert "Hermes Agent v" in out
+    assert "Project:" in out
+    assert "Python:" in out
+    assert "OpenAI SDK:" in out
+
+
+def test_project_root_fast_path_reprioritizes_existing_entry(monkeypatch, main_mod):
+    project_root = main_mod._project_root_str_fast()
+    monkeypatch.setattr(sys, "path", ["", "shadow", project_root, "later"])
+
+    main_mod._ensure_project_root_on_path_fast()
+
+    assert sys.path == [project_root, "", "shadow", "later"]
+
+
+def test_ultrafast_version_skips_container_mode_marker(
+    monkeypatch, tmp_path, capsys, main_mod
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".container-mode").write_text("backend=podman\n", encoding="utf-8")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.delenv("HERMES_DEV", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(main_mod, "_is_container_startup_environment_fast", lambda: False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_ultrafast_version() is False
+    assert capsys.readouterr().out == ""
+
+
+def test_ultrafast_version_skips_root_hermes_home_with_active_profile(
+    monkeypatch, tmp_path, capsys, main_mod
+):
+    hermes_home = tmp_path / ".hermes"
+    (hermes_home / "profiles" / "coder").mkdir(parents=True)
+    (hermes_home / "active_profile").write_text("coder\n", encoding="utf-8")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.delenv("HERMES_DEV", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(main_mod, "_is_container_startup_environment_fast", lambda: False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_ultrafast_version() is False
+    assert capsys.readouterr().out == ""
+
+
+def test_ultrafast_version_direct_script_invocation_works():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "hermes_cli" / "main.py"), "--version"],
+        cwd=repo_root.parent,
+        env={**os.environ, "PYTHONPATH": ""},
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Hermes Agent v" in result.stdout
+    assert "Project:" in result.stdout
+
+
+def test_ultrafast_version_preserves_non_termux_version_command(
+    monkeypatch, capsys, main_mod
+):
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.delenv("HERMES_TERMUX_DISABLE_FAST_CLI", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+
+    assert main_mod._try_ultrafast_version() is False
+    assert capsys.readouterr().out == ""
+
+
+def test_termux_ultrafast_version_disable_stays_termux_scoped(
+    monkeypatch, capsys, main_mod
+):
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("HERMES_TERMUX_DISABLE_FAST_CLI", "1")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+
+    assert main_mod._try_ultrafast_version() is True
+
+    assert "Hermes Agent v" in capsys.readouterr().out
 
 
 def test_read_openai_version_fast(monkeypatch, tmp_path, main_mod):


### PR DESCRIPTION
## What does this PR do?

Speeds up global `hermes --version` and `hermes -V` by answering them before the heavier CLI parser/config/logging imports run.

The fast path keeps normal startup semantics for cases that may need routing or profile setup: `hermes version` still uses the regular command path, Termux keeps its existing `version` behavior and disable flag, and host-side container/profile mode skips the fast path.

## Related Issue

N/A - small CLI startup performance improvement found while comparing agent startup speed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: adds an early global version fast path for exact `--version` / `-V`
- `hermes_cli/main.py`: keeps project-root path precedence for direct source-checkout invocation
- `hermes_cli/main.py`: skips the fast path when container mode or non-default active-profile routing may apply
- `tests/hermes_cli/test_tui_resume_flow.py`: covers the fast path, direct script invocation, container/profile guards, preserved `hermes version`, and Termux disable scoping

## How to Test

1. Run the focused startup/version test file:
   ```bash
   python scripts/run_tests_parallel.py tests/hermes_cli/test_tui_resume_flow.py
   ```
2. Run the focused startup/plugin regression file:
   ```bash
   python -m pytest tests/hermes_cli/test_startup_plugin_gating.py -q
   ```
3. Run syntax/lint checks for the touched files:
   ```bash
   python -m py_compile hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py
   python -m ruff check hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py
   python scripts/check-windows-footguns.py --diff origin/main
   ```
4. Smoke-test the version fast path from a source checkout:
   ```bash
   python -m hermes_cli.main --version
   python hermes_cli/main.py --version
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run locally; focused tests below passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, plus focused pytest through WSL/Linux venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## For New Skills

N/A - this PR does not add a skill.

## Screenshots / Logs

Focused startup/version test run:
```text
python scripts/run_tests_parallel.py tests/hermes_cli/test_tui_resume_flow.py -> 52/52 passed in 62.7s
```

Focused startup/plugin regression run:
```text
python -m pytest tests/hermes_cli/test_startup_plugin_gating.py -q -> 37 passed in 3.77s
```

Lint/compile/diff checks:
```text
python -m py_compile hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py -> passed
python -m ruff check hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py -> All checks passed!
python scripts/check-windows-footguns.py --diff origin/main -> No Windows footguns found (2 files scanned)
git diff --check && git diff --cached --check -> clean
```

Local timing samples:
```text
Baseline on main, WSL venv:
python -m hermes_cli.main --version -> avg 1750.9 ms, p50 1752.2 ms
python hermes_cli/main.py --version -> avg 1827.5 ms, p50 1772.7 ms

After this patch, WSL venv:
python -m hermes_cli.main --version -> avg 486.4 ms, p50 519.6 ms
python hermes_cli/main.py --version -> avg 555.3 ms, p50 560.8 ms

After this patch, Windows:
python -m hermes_cli.main --version -> avg 135.8 ms, p50 104.9 ms
python hermes_cli/main.py --version -> avg 198.7 ms, p50 199.5 ms
```

Local review:
```text
codex review --disable plugins --disable memories --disable tool_search --disable apps --uncommitted -> No discrete correctness issues identified in the staged changes.
```