### PR TITLE
fix(provider): warn when model config dict omits provider instead of silently routing to auto (#29285)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -29,7 +29,7 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import get_compatible_custom_providers, load_config, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname
 
@@ -439,6 +439,20 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
     if env_provider:
         return env_provider
 
+    # Warn when the raw config is a dict with a model but no provider.
+    # _get_model_config() normalizes string configs into dicts too, so we
+    # must inspect the raw shape to avoid false positives on `model: "x"`.
+    raw_model = read_raw_config().get("model")
+    if (
+        isinstance(raw_model, dict)
+        and (raw_model.get("default") or raw_model.get("model"))
+        and not (isinstance(raw_model.get("provider"), str) and raw_model.get("provider").strip())
+    ):
+        logger.warning(
+            "model config sets a default but no 'provider'; falling back to "
+            "auto-detection, which may route to auth.json active_provider "
+            "instead of the model you configured. Set model.provider explicitly."
+        )
     return "auto"
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1023,6 +1023,57 @@ def test_resolve_requested_provider_precedence(monkeypatch):
     assert rp.resolve_requested_provider() == "auto"
 
 
+# ── warn on dict model config missing provider (#29285) ───────────────
+
+
+def test_resolve_requested_provider_warns_dict_no_provider(monkeypatch, caplog):
+    """model: {default: "abab6.5"} (dict, no provider) should warn."""
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "abab6.5"})
+    monkeypatch.setattr(
+        rp, "read_raw_config", lambda: {"model": {"default": "abab6.5"}}
+    )
+    import logging
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.runtime_provider"):
+        result = rp.resolve_requested_provider()
+    assert result == "auto"
+    assert "model config sets a default but no 'provider'" in caplog.text
+
+
+def test_resolve_requested_provider_no_warn_string_model(monkeypatch, caplog):
+    """model: "claude-sonnet-4-6" (string) should NOT warn."""
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        rp, "_get_model_config", lambda: {"default": "claude-sonnet-4-6"}
+    )
+    monkeypatch.setattr(
+        rp, "read_raw_config", lambda: {"model": "claude-sonnet-4-6"}
+    )
+    import logging
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.runtime_provider"):
+        result = rp.resolve_requested_provider()
+    assert result == "auto"
+    assert "model config sets a default but no 'provider'" not in caplog.text
+
+
+def test_resolve_requested_provider_no_warn_dict_with_provider(monkeypatch, caplog):
+    """model: {default: "x", provider: "anthropic"} should return provider, no warn."""
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        rp, "_get_model_config",
+        lambda: {"default": "x", "provider": "anthropic"},
+    )
+    monkeypatch.setattr(
+        rp, "read_raw_config",
+        lambda: {"model": {"default": "x", "provider": "anthropic"}},
+    )
+    import logging
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.runtime_provider"):
+        result = rp.resolve_requested_provider()
+    assert result == "anthropic"
+    assert "model config sets a default but no 'provider'" not in caplog.text
+
+
 # ── api_mode config override tests ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

When `config.yaml` has `model:` as a dict with a `default` (or `model`) key but no `provider`, `resolve_requested_provider()` silently returns `"auto"`. Downstream, `"auto"` routes to `auth.json`'s `active_provider`, so the user's model config gets silently overridden by whatever OAuth provider happened to authenticate last.

This adds a `logger.warning()` on the final `return "auto"` path that fires only when the raw config is a dict missing `provider`. It doesn't raise or change control flow, so legitimate auto setups keep working.

## Changes

**`hermes_cli/runtime_provider.py`** (14 lines added)
- Before `return "auto"` in `resolve_requested_provider()`, inspect the raw config via `read_raw_config().get("model")` (not the normalized dict from `_get_model_config()`, which erases the string-vs-dict distinction, and not `load_config()`, which can normalize strings into dicts when legacy root-level keys are present).
- Warn only when the raw config is a `dict` that has `default`/`model` but no non-empty string `provider`.

**`tests/hermes_cli/test_runtime_provider_resolution.py`** (51 lines added)
- 3 new tests covering the warning behavior.

## Validation

| Config shape | Expected result | Warning? | Test |
|---|---|---|---|
| `model: {default: "abab6.5"}` | returns `"auto"` | YES | `test_resolve_requested_provider_warns_dict_no_provider` |
| `model: "claude-sonnet-4-6"` | returns `"auto"` | NO | `test_resolve_requested_provider_no_warn_string_model` |
| `model: {default: "x", provider: "anthropic"}` | returns `"anthropic"` | NO | `test_resolve_requested_provider_no_warn_dict_with_provider` |

## Test plan

- [x] 3 new tests pass (`pytest tests/hermes_cli/test_runtime_provider_resolution.py -v --timeout=0`)
- [x] Existing `test_resolve_requested_provider_precedence` still passes (no regression)
- [ ] Full test suite on CI (to be verified after push)

## Competing PRs

| PR | Approach | Gap this PR fills |
|---|---|---|
| #29615 | Reorders env-key priority inside `auth.py` | Downstream of the fallthrough; no-op for the dict-no-provider shape |
| #29809 | Same as #29615, different priority ordering | Same gap |
| #33332 | Fixes string-model + dropped root provider variant | Different variant; does not cover dict-without-provider |

This targets the specific case where a user writes `model:` as an explicit dict that carries a model name but omits `provider`. None of the three competing PRs detect or warn about this shape. The approach is intentionally minimal: warn-only, no control flow change, nothing that could break existing setups.

## Upstream

Closes #29285.
Reported by @slideshow-dingo.
