### PR TITLE
fix: allow spaces in model names and pass custom_providers for context display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6991,13 +6991,16 @@ class HermesCLI:
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
         try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
             from hermes_cli.model_switch import resolve_display_context_length
+            _cp = get_compatible_custom_providers(load_config())
             ctx = resolve_display_context_length(
                 result.new_model,
                 result.target_provider,
                 base_url=result.base_url or self.base_url or "",
                 api_key=result.api_key or self.api_key or "",
                 model_info=mi,
+                custom_providers=_cp,
                 config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
             )
             if ctx:
@@ -7225,13 +7228,16 @@ class HermesCLI:
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
+        from hermes_cli.config import get_compatible_custom_providers, load_config
         from hermes_cli.model_switch import resolve_display_context_length
+        _cp = get_compatible_custom_providers(load_config())
         ctx = resolve_display_context_length(
             result.new_model,
             result.target_provider,
             base_url=result.base_url or self.base_url or "",
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
+            custom_providers=_cp,
             config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
         )
         if ctx:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3344,21 +3344,19 @@ def validate_requested_model(
             api_key=api_key,
         ) or requested
 
-    if not requested:
+    # Allow spaces in model names — some providers (litellm, custom endpoints)
+    # use descriptive labels like "gemini-2.5-flash (balanced)" to help users
+    # pick the right model. Strip outer whitespace but keep internal spaces.
+    stripped = requested.strip()
+    if not stripped:
         return {
             "accepted": False,
             "persist": False,
             "recognized": False,
             "message": "Model name cannot be empty.",
         }
-
-    if any(ch.isspace() for ch in requested):
-        return {
-            "accepted": False,
-            "persist": False,
-            "recognized": False,
-            "message": "Model names cannot contain spaces.",
-        }
+    if stripped != requested:
+        requested = stripped
 
     if normalized == "lmstudio":
         from hermes_cli.auth import AuthError


### PR DESCRIPTION
Two fixes for model name handling with litellm/custom providers:

**1. Allow spaces in model names**

Removes the blanket rejection of spaces in `validated_model_string()`. Providers like litellm use descriptive labels such as `gemini-2.5-flash (balanced)` in their model lists. The existing check rejected any model name containing a space, making these names unusable via `/model`.

Instead of rejecting, we now strip outer whitespace and keep internal spaces — the model name is passed through to the provider as-is.

**2. Honor per-model context_length in CLI display**

The CLI `/model` switch output showed `Context: 256,000 tokens` for models that have a `context_length` set in `config.yaml`'s `providers.<slug>.models.<model>`. The gateway (TUI) already passed `custom_providers` to `resolve_display_context_length`, but the two CLI display paths did not.

Adding `custom_providers` to the two CLI `resolve_display_context_length` calls lets step 0b in `get_model_context_length` find the per-model context_length override from config.yaml, so the displayed context matches what's actually configured.