### PR TITLE
feat: support package-managed installs (Snap/Homebrew)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4330,10 +4330,12 @@ class GatewayRunner:
             for v in _builtin_allow_all_vars + _plugin_allow_all_vars
         )
         if not _any_allowlist and not _allow_all:
+            from hermes_cli.config import get_env_path
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
-                "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "
-                "or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id)."
+                "Set GATEWAY_ALLOW_ALL_USERS=true in %s to allow open access, "
+                "or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id).",
+                get_env_path(),
             )
         
         # Discover Python plugins before shell hooks so plugin block

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -239,6 +239,8 @@ _MANAGED_SYSTEM_NAMES = {
     "homebrew": "Homebrew",
     "nix": "NixOS",
     "nixos": "NixOS",
+    "snap": "Snap",
+    "snapcraft": "Snap",
 }
 
 
@@ -267,6 +269,17 @@ def is_managed() -> bool:
     return get_managed_system() is not None
 
 
+def is_config_managed() -> bool:
+    """Return True when user configuration is managed declaratively.
+
+    NixOS owns both the package and generated config, so interactive config
+    writers must refuse mutations. Package managers like Homebrew and Snap own
+    the install tree only; users still configure Hermes in their writable
+    HERMES_HOME.
+    """
+    return get_managed_system() == "NixOS"
+
+
 _NIX_UPDATE_MSG = "Update your Nix flake input and rebuild (e.g. nix flake update, nixos-rebuild, or home-manager switch)"
 
 
@@ -275,6 +288,8 @@ def get_managed_update_command() -> Optional[str]:
     managed_system = get_managed_system()
     if managed_system == "Homebrew":
         return "brew upgrade hermes-agent"
+    if managed_system == "Snap":
+        return "snap refresh hermes-agent"
     if managed_system == "NixOS":
         return _NIX_UPDATE_MSG
     return None
@@ -364,6 +379,8 @@ def recommended_update_command_for_method(method: str) -> str:
         return _NIX_UPDATE_MSG
     if method == "homebrew":
         return "brew upgrade hermes-agent"
+    if method == "snap":
+        return "snap refresh hermes-agent"
     if method == "docker":
         return "docker pull nousresearch/hermes-agent:latest"
     if method == "pip":
@@ -458,6 +475,15 @@ def format_managed_message(action: str = "modify this Hermes installation") -> s
             f"(HERMES_MANAGED={env_hint}).\n"
             "Use:\n"
             "  brew upgrade hermes-agent"
+        )
+
+    if managed_system == "Snap":
+        env_hint = raw or "snap"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by Snap "
+            f"(HERMES_MANAGED={env_hint}).\n"
+            "Use:\n"
+            "  snap refresh hermes-agent"
         )
 
     return (
@@ -616,7 +642,7 @@ def _secure_dir(path):
     created at runtime by kanban workers don't land as root:root and block
     subsequent uid-mapped workers).
     """
-    if is_managed():
+    if is_config_managed():
         return
     try:
         mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
@@ -664,7 +690,7 @@ def _secure_file(path):
     Skipped in containers — Docker/Podman volume mounts often need broader
     permissions.  Set HERMES_SKIP_CHMOD=1 to force-skip on other systems.
     """
-    if is_managed() or _is_container():
+    if is_config_managed() or _is_container():
         return
     try:
         if os.path.exists(str(path)):
@@ -685,12 +711,12 @@ def _ensure_default_soul_md(home: Path) -> None:
 def ensure_hermes_home():
     """Ensure ~/.hermes directory structure exists with secure permissions.
 
-    In managed mode (NixOS), dirs are created by the activation script with
+    In config-managed mode (NixOS), dirs are created by the activation script with
     setgid + group-writable (2770). We skip mkdir and set umask(0o007) so
     any files created (e.g. SOUL.md) are group-writable (0660).
     """
     home = get_hermes_home()
-    if is_managed():
+    if is_config_managed():
         old_umask = os.umask(0o007)
         try:
             _ensure_hermes_home_managed(home)
@@ -5014,7 +5040,7 @@ _COMMENTED_SECTIONS = """
 def save_config(config: Dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
     with _CONFIG_LOCK:
-        if is_managed():
+        if is_config_managed():
             managed_error("save configuration")
             return
         from utils import atomic_yaml_write
@@ -5280,7 +5306,7 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
 
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
-    if is_managed():
+    if is_config_managed():
         managed_error(f"set {key}")
         return
     if not _ENV_VAR_NAME_RE.match(key):
@@ -5355,7 +5381,7 @@ def remove_env_value(key: str) -> bool:
 
     Returns True if the key was found and removed, False otherwise.
     """
-    if is_managed():
+    if is_config_managed():
         managed_error(f"remove {key}")
         return False
     if not _ENV_VAR_NAME_RE.match(key):
@@ -5654,7 +5680,7 @@ def show_config():
 
 def edit_config():
     """Open config file in user's editor."""
-    if is_managed():
+    if is_config_managed():
         managed_error("edit configuration")
         return
     config_path = get_config_path()
@@ -5694,7 +5720,7 @@ def edit_config():
 
 def set_config_value(key: str, value: str):
     """Set a configuration value."""
-    if is_managed():
+    if is_config_managed():
         managed_error("set configuration values")
         return
     # Check if it's an API key (goes to .env)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1118,7 +1118,16 @@ def run_doctor(args):
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
 
-    if sys.platform != "win32":
+    from hermes_cli.config import get_managed_system as _get_managed_system
+    _managed_system = _get_managed_system()
+    if sys.platform != "win32" and _managed_system:
+        # Package-managed installs (Snap, Homebrew, NixOS) own the `hermes`
+        # command and the install tree. There is no pip venv entry point or
+        # ~/.local/bin symlink to verify, and `pip install -e` cannot run
+        # against a read-only install — so the checks below don't apply.
+        _section("Command Installation")
+        check_ok(f"Managed by {_managed_system} (command provided by the {_managed_system} package)")
+    elif sys.platform != "win32":
         _section("Command Installation")
         # Determine the venv entry point location
         _venv_bin = None

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -26,6 +26,7 @@ from gateway.restart import (
 from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
+    is_config_managed,
     is_managed,
     managed_error,
     read_raw_config,
@@ -5433,7 +5434,7 @@ def _configure_platform(platform: dict) -> None:
 
 def gateway_setup():
     """Interactive setup for messaging platforms + gateway service."""
-    if is_managed():
+    if is_config_managed():
         managed_error("run gateway setup")
         return
 
@@ -5891,6 +5892,24 @@ def _maybe_redirect_run_to_s6_supervision(args) -> bool:
 def _gateway_command_inner(args):
     subcmd = getattr(args, "gateway_command", None)
 
+    from hermes_cli.config import get_managed_system
+
+    if get_managed_system() == "Snap" and subcmd in {"install", "uninstall", "start", "stop", "restart"}:
+        if subcmd == "install":
+            print("The gateway service is declared by the Hermes Snap package.")
+            print("Use: snap start hermes-agent.gateway")
+            print("Use: snap services hermes-agent.gateway")
+            return
+        if subcmd == "uninstall":
+            print("The gateway service is declared by the Hermes Snap package.")
+            print("Use: snap stop hermes-agent.gateway")
+            print("To remove Hermes entirely, use: snap remove hermes-agent")
+            return
+        action = {"start": "start", "stop": "stop", "restart": "restart"}[subcmd]
+        print(f"This Hermes installation is managed by Snap.")
+        print(f"Use: snap {action} hermes-agent.gateway")
+        return
+
     # Default to run if no subcommand
     if subcmd is None or subcmd == "run":
         if _maybe_redirect_run_to_s6_supervision(args):
@@ -5908,7 +5927,7 @@ def _gateway_command_inner(args):
     # Service management commands
     if subcmd == "install":
         if is_managed():
-            managed_error("install gateway service (managed by NixOS)")
+            managed_error("install gateway service")
             return
         force = getattr(args, "force", False)
         system = getattr(args, "system", False)
@@ -6002,7 +6021,7 @@ def _gateway_command_inner(args):
 
     elif subcmd == "uninstall":
         if is_managed():
-            managed_error("uninstall gateway service (managed by NixOS)")
+            managed_error("uninstall gateway service")
             return
         system = getattr(args, "system", False)
         if is_termux():
@@ -6360,6 +6379,11 @@ def _gateway_command_inner(args):
             run_gateway(verbose=0)
 
     elif subcmd == "status":
+        if get_managed_system() == "Snap":
+            print("This Hermes installation is managed by Snap.")
+            print("Use: snap services hermes-agent.gateway")
+            return
+
         deep = getattr(args, "deep", False)
         full = getattr(args, "full", False)
         system = getattr(args, "system", False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2166,8 +2166,15 @@ def cmd_setup(args):
 
 def cmd_postinstall(args):
     """One-shot bootstrap for pip users: install non-Python deps + run setup."""
-    from hermes_cli.config import stamp_install_method
+    from hermes_cli.config import get_managed_system, stamp_install_method
     from hermes_cli.dep_ensure import ensure_dependency
+
+    managed_system = get_managed_system()
+    if managed_system == "Snap":
+        print("Hermes is installed as a Snap; postinstall is not needed.")
+        print("Use `hermes setup` to configure providers and tools.")
+        print("Use `snap refresh hermes-agent` to update the package.")
+        return
 
     stamp_install_method("pip")
 
@@ -6418,6 +6425,14 @@ def cmd_version(args):
 def cmd_uninstall(args):
     """Uninstall Hermes Agent."""
     _require_tty("uninstall")
+    from hermes_cli.config import get_managed_system
+
+    if get_managed_system() == "Snap":
+        print("Hermes is installed as a Snap.")
+        print("Use: snap remove hermes-agent")
+        print("To remove saved user data too, use: snap remove --purge hermes-agent")
+        return
+
     from hermes_cli.uninstall import run_uninstall
 
     run_uninstall(args)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2844,8 +2844,8 @@ def run_setup_wizard(args):
       hermes setup tools     — just tool configuration
       hermes setup agent     — just agent settings
     """
-    from hermes_cli.config import is_managed, managed_error
-    if is_managed():
+    from hermes_cli.config import is_config_managed, managed_error
+    if is_config_managed():
         managed_error("run setup wizard")
         return
     ensure_hermes_home()

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -190,6 +190,47 @@ class TestDoctorCommandInstallation:
         assert "Venv entry point not found" in out
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_managed_install_skips_venv_entry_point_check(self, monkeypatch, tmp_path):
+        """Package-managed installs (e.g. Snap) own the command and a read-only
+        tree, so doctor must not emit the pip/venv reinstall warning."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+        # No venv entry point — on an unmanaged install this would warn.
+
+        monkeypatch.setenv("HERMES_MANAGED", "snap")
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+        try:
+            import httpx
+            monkeypatch.setattr(httpx, "get", lambda *a, **kw: types.SimpleNamespace(status_code=200))
+        except Exception:
+            pass
+
+        out = _run_doctor(fix=False)
+        assert "Command Installation" in out
+        assert "Managed by Snap" in out
+        assert "Venv entry point not found" not in out
+        assert "pip install -e" not in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
     def test_dot_venv_dir_is_found(self, monkeypatch, tmp_path):
         """The check finds entry points in .venv/ as well as venv/."""
         home, project, _ = _setup_doctor_env(monkeypatch, tmp_path, venv_name=".venv")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1780,6 +1780,63 @@ class TestDockerAwareGateway:
         out = capsys.readouterr().out
         assert "docker" in out.lower()
 
+    def test_managed_snap_gateway_install_prints_snap_guidance(self, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+        args = SimpleNamespace(gateway_command="install", force=False, system=False, run_as_user=None)
+        gateway_cli.gateway_command(args)
+
+        captured = capsys.readouterr()
+        assert "declared by the Hermes Snap package" in captured.out
+        assert "snap start hermes-agent.gateway" in captured.out
+        assert "snap services hermes-agent.gateway" in captured.out
+
+    def test_managed_snap_gateway_uninstall_prints_snap_guidance(self, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+        args = SimpleNamespace(gateway_command="uninstall", system=False)
+        gateway_cli.gateway_command(args)
+
+        captured = capsys.readouterr()
+        assert "declared by the Hermes Snap package" in captured.out
+        assert "snap stop hermes-agent.gateway" in captured.out
+        assert "snap remove hermes-agent" in captured.out
+
+    def test_managed_snap_gateway_start_prints_snap_service_guidance(self, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+        args = SimpleNamespace(gateway_command="start", system=False)
+        gateway_cli.gateway_command(args)
+
+        captured = capsys.readouterr()
+        assert "managed by Snap" in captured.out
+        assert "snap start hermes-agent.gateway" in captured.out
+
+    def test_managed_snap_gateway_status_prints_snap_service_guidance(self, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+        args = SimpleNamespace(gateway_command="status", deep=False, system=False, full=False)
+        gateway_cli.gateway_command(args)
+
+        captured = capsys.readouterr()
+        assert "managed by Snap" in captured.out
+        assert "snap services hermes-agent.gateway" in captured.out
+
+    def test_managed_snap_gateway_setup_is_not_blocked(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MANAGED", "snap")
+        called = False
+
+        def fake_setup():
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(gateway_cli, "gateway_setup", fake_setup)
+
+        args = SimpleNamespace(gateway_command="setup")
+        gateway_cli.gateway_command(args)
+
+        assert called is True
+
     def test_start_in_container_prints_docker_guidance(self, monkeypatch, capsys):
         """'hermes gateway start' inside Docker exits 0 with container guidance."""
         import pytest

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -3,10 +3,11 @@ from unittest.mock import patch
 
 from hermes_cli.config import (
     format_managed_message,
+    is_config_managed,
     get_managed_system,
     recommended_update_command,
 )
-from hermes_cli.main import cmd_update
+from hermes_cli.main import cmd_postinstall, cmd_uninstall, cmd_update
 from tools.skills_hub import OptionalSkillSource
 
 
@@ -14,7 +15,23 @@ def test_get_managed_system_homebrew(monkeypatch):
     monkeypatch.setenv("HERMES_MANAGED", "homebrew")
 
     assert get_managed_system() == "Homebrew"
+    assert is_config_managed() is False
     assert recommended_update_command() == "brew upgrade hermes-agent"
+
+
+def test_get_managed_system_nixos_is_config_managed(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+
+    assert get_managed_system() == "NixOS"
+    assert is_config_managed() is True
+
+
+def test_get_managed_system_snap(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+    assert get_managed_system() == "Snap"
+    assert is_config_managed() is False
+    assert recommended_update_command() == "snap refresh hermes-agent"
 
 
 def test_format_managed_message_homebrew(monkeypatch):
@@ -24,6 +41,15 @@ def test_format_managed_message_homebrew(monkeypatch):
 
     assert "managed by Homebrew" in message
     assert "brew upgrade hermes-agent" in message
+
+
+def test_format_managed_message_snap(monkeypatch):
+    monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+    message = format_managed_message("update Hermes Agent")
+
+    assert "managed by Snap" in message
+    assert "snap refresh hermes-agent" in message
 
 
 def test_recommended_update_command_defaults_to_hermes_update(monkeypatch):
@@ -49,6 +75,44 @@ def test_cmd_update_blocks_managed_homebrew(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "managed by Homebrew" in captured.err
     assert "brew upgrade hermes-agent" in captured.err
+
+
+def test_cmd_update_blocks_managed_snap(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+    with patch("hermes_cli.main.subprocess.run") as mock_run:
+        cmd_update(SimpleNamespace())
+
+    assert not mock_run.called
+    captured = capsys.readouterr()
+    assert "managed by Snap" in captured.err
+    assert "snap refresh hermes-agent" in captured.err
+
+
+def test_cmd_postinstall_snap_prints_guidance(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+    with patch("hermes_cli.main.cmd_setup") as mock_setup:
+        cmd_postinstall(SimpleNamespace())
+
+    assert not mock_setup.called
+    captured = capsys.readouterr()
+    assert "installed as a Snap" in captured.out
+    assert "hermes setup" in captured.out
+    assert "snap refresh hermes-agent" in captured.out
+
+
+def test_cmd_uninstall_snap_prints_guidance(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_MANAGED", "snap")
+
+    with patch("hermes_cli.main._require_tty"), \
+         patch("hermes_cli.uninstall.run_uninstall") as mock_uninstall:
+        cmd_uninstall(SimpleNamespace())
+
+    assert not mock_uninstall.called
+    captured = capsys.readouterr()
+    assert "installed as a Snap" in captured.out
+    assert "snap remove hermes-agent" in captured.out
 
 
 def test_optional_skill_source_honors_env_override(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6557,7 +6557,7 @@ def _(rid, params: dict) -> dict:
     """
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY
-        from hermes_cli.config import is_managed, save_env_value
+        from hermes_cli.config import is_config_managed, save_env_value
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
         slug = (params.get("slug") or "").strip()
@@ -6565,7 +6565,7 @@ def _(rid, params: dict) -> dict:
         if not slug or not api_key:
             return _err(rid, 4001, "slug and api_key are required")
 
-        if is_managed():
+        if is_config_managed():
             return _err(rid, 4006, "managed install — credentials are read-only")
 
         pconfig = PROVIDER_REGISTRY.get(slug)


### PR DESCRIPTION
## What does this PR do?

Distinguishes **config-managed** installs (NixOS — declarative, read-only config) from **package-managed** installs (Snap/Homebrew — the package owns the install tree, but the user still configures Hermes in a writable `HERMES_HOME`).

Previously a single `is_managed()` gate blocked **all** interactive config/credential writes for any managed install. That is correct for NixOS, but wrong for Snap/Homebrew, where the user must still be able to save settings. This is the prerequisite for snap packaging (#37709), and it independently fixes spurious managed-install guidance on Homebrew/NixOS.

## Related Issue

Part of #37709

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

(Also folds in two small, same-theme fixes: a `doctor` false warning and a misleading gateway log path under relocated `HERMES_HOME`.)

## Changes Made

- `hermes_cli/config.py`: add `is_config_managed()` (true only for NixOS); recognize `snap`/`snapcraft` → "Snap"; Snap update/message helpers; swap `is_managed()` → `is_config_managed()` in the file-permission and config-write paths so package-managed installs can write to `HERMES_HOME`.
- `hermes_cli/gateway.py`, `hermes_cli/setup.py`, `tui_gateway/server.py`: allow config writes on package-managed installs, and route `gateway install/uninstall/start/stop/status` to snapd-native commands.
- `hermes_cli/main.py`: `postinstall` is a no-op with guidance under Snap; `uninstall` points at `snap remove hermes-agent`.
- `hermes_cli/doctor.py`: skip the pip/venv "Command Installation" checks on managed installs (the `pip install -e` advice can't apply to a read-only package).
- `gateway/run.py`: the allowlist warning now references the resolved `HERMES_HOME/.env` path via `get_env_path()` instead of a hardcoded `~/.hermes/.env`.
- Tests: `tests/hermes_cli/test_managed_installs.py`, `test_gateway_service.py`, `test_doctor_command_install.py`.

## How to Test

```bash
pytest tests/hermes_cli/test_managed_installs.py \
       tests/hermes_cli/test_gateway_service.py \
       tests/hermes_cli/test_doctor_command_install.py -q
```

Manual:
```bash
HERMES_MANAGED=snap hermes doctor    # "Managed by Snap"; no pip/venv advice
HERMES_MANAGED=snap hermes update    # prints: snap refresh hermes-agent
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(config):`, `fix(doctor):`, …)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (managed-install behavior)
- [x] All touched-area tests pass. (The full `scripts/run_tests.sh` has unrelated pre-existing env failures on my machine — optional backends needing API keys/network: web/voice/browser/image/wecom/acp — none in files this PR touches.)
- [x] I've added tests for my changes
- [x] Tested on: Ubuntu 24.04 (amd64)

### Documentation & Housekeeping

- [x] Docs — N/A (internal behavior; no user-facing config keys)
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — platform-neutral Python; the `doctor` change sits inside the existing `sys.platform != "win32"` guard
- [x] Tool descriptions/schemas — N/A
