### PR TITLE
fix(auth): resolve bare "openai" slug to "openai-api" provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1618,6 +1618,7 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
+        "openai": "openai-api",
         "claude": "anthropic", "claude-code": "anthropic",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1226,6 +1226,7 @@ _PROVIDER_ALIASES = {
     "minimax-portal": "minimax-oauth",
     "minimax-global": "minimax-oauth",
     "minimax_oauth": "minimax-oauth",
+    "openai": "openai-api",
     "claude": "anthropic",
     "claude-code": "anthropic",
     "deep-seek": "deepseek",

--- a/tests/hermes_cli/test_openai_provider_alias.py
+++ b/tests/hermes_cli/test_openai_provider_alias.py
@@ -1,0 +1,43 @@
+"""resolve_provider must accept "openai" as an alias for "openai-api".
+
+hermes-agent registers its built-in OpenAI provider as ``openai-api`` in
+``PROVIDER_REGISTRY``.  Consumers (WebUI model picker, config.yaml, CLI
+``--provider`` flag) may reasonably send the bare slug ``openai``.
+Without an alias, ``resolve_provider("openai")`` raises ``AuthError``.
+"""
+
+import pytest
+
+from hermes_cli.auth import resolve_provider, PROVIDER_REGISTRY
+
+
+class TestOpenaiAlias:
+    """The bare slug "openai" must resolve to the "openai-api" registry entry."""
+
+    def test_openai_resolves_to_openai_api(self):
+        assert resolve_provider("openai") == "openai-api"
+
+    def test_case_insensitive(self):
+        assert resolve_provider("OpenAI") == "openai-api"
+        assert resolve_provider("OPENAI") == "openai-api"
+
+    def test_canonical_openai_api_unchanged(self):
+        assert resolve_provider("openai-api") == "openai-api"
+
+    def test_openai_codex_unchanged(self):
+        assert resolve_provider("openai-codex") == "openai-codex"
+
+    def test_openai_api_in_registry(self):
+        assert "openai-api" in PROVIDER_REGISTRY
+
+
+class TestOpenaiModelsAlias:
+    """models.py alias table must also map "openai" -> "openai-api"."""
+
+    def test_models_alias(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("openai") == "openai-api"
+
+    def test_models_normalize_provider(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("openai") == "openai-api"


### PR DESCRIPTION
## Summary

`resolve_provider("openai")` raises `AuthError: Unknown provider 'openai'` even though `openai-api` is a registered provider and `models.py` already groups both slugs under the `"openai"` display key (line 993). Consumers that send the bare slug — WebUI model picker, config.yaml `model.provider`, CLI `--provider` flag — get a confusing error instead of routing to `openai-api`.

The alias tables in `auth.py` and `models.py` had entries for every other provider group (`"claude": "anthropic"`, `"google": "gemini"`, `"grok": "xai"`) but not `"openai"`. This surfaced during nesquena/hermes-webui#3444 where the WebUI picker collapsed `openai-api` to `openai` for display and the send path broke because the agent registry has no `openai` key.

## Changes

- `hermes_cli/auth.py`: add `"openai": "openai-api"` to `_PROVIDER_ALIASES` in `resolve_provider()` (+1)
- `hermes_cli/models.py`: same entry in the models-layer `_PROVIDER_ALIASES` (+1)
- `tests/hermes_cli/test_openai_provider_alias.py`: new file, 7 tests covering resolve, case insensitivity, canonical passthrough, codex independence, registry presence, and the `models.py` alias (+39)

## Validation

| Scenario | Before | After |
|---|---|---|
| `resolve_provider("openai")` | `AuthError: Unknown provider 'openai'` | `"openai-api"` |
| `resolve_provider("OpenAI")` | same error | `"openai-api"` (case-insensitive) |
| `resolve_provider("openai-api")` | `"openai-api"` | `"openai-api"` (unchanged) |
| `resolve_provider("openai-codex")` | `"openai-codex"` | `"openai-codex"` (unchanged) |

## Test plan

- `pytest tests/hermes_cli/test_openai_provider_alias.py -v` — 7 passed
- `pytest tests/hermes_cli/test_api_key_providers.py -v` — 165 passed (regression check)
- Tested on Windows 11, Python 3.11. No platform-specific code.