### PR TITLE
fix: thread update alert highlights

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1597,6 +1597,158 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     return None
 
 
+def _load_update_summary(summary_path: Path) -> dict | None:
+    """Load a structured update-summary marker written by ``hermes update``."""
+    try:
+        if not summary_path.exists():
+            return None
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and data.get("schema") == 1:
+            return data
+    except Exception as exc:
+        logger.debug("Could not read update summary marker: %s", exc)
+    return None
+
+
+def _short_sha(value: Any) -> str:
+    text = str(value or "").strip()
+    return text[:10] if text else "unknown"
+
+
+def _format_update_highlight_reply(summary: dict | None, output: str = "") -> str | None:
+    """Render the detailed update-info reply from structured summary data.
+
+    This intentionally avoids dumping raw commit subjects.  The updater groups
+    incoming commits by touched product area and stores representative cleaned
+    phrases, so the alert reads like release highlights instead of git log.
+    """
+    if not summary:
+        return None
+
+    commit_count = int(summary.get("commit_count") or 0)
+    if commit_count <= 0:
+        return None
+
+    current_version = summary.get("current_version") or "current"
+    target_version = summary.get("target_version") or "latest"
+    branch = summary.get("branch") or "main"
+    file_count = int(summary.get("files_changed_count") or 0)
+    from_sha = _short_sha(summary.get("from_sha"))
+    to_sha = _short_sha(summary.get("to_sha"))
+
+    lines = [
+        f"*Update info — Hermes v{current_version} → v{target_version}*",
+        f"Pulled {commit_count} commit{'s' if commit_count != 1 else ''} on `{branch}` ({from_sha} → {to_sha}), touching {file_count} file{'s' if file_count != 1 else ''}.",
+        "",
+        "*Highlights*",
+    ]
+
+    categories = summary.get("categories") if isinstance(summary.get("categories"), list) else []
+    if categories:
+        for category in categories[:8]:
+            if not isinstance(category, dict):
+                continue
+            name = category.get("name") or "Updated area"
+            commits = int(category.get("commit_count") or 0)
+            files = int(category.get("file_count") or 0)
+            area_summary = category.get("summary") or "related improvements"
+            highlights = [
+                str(item).strip().rstrip(".")
+                for item in (category.get("highlights") or [])
+                if str(item).strip()
+            ]
+            detail = area_summary
+            if highlights:
+                detail = "; ".join(highlights[:3])
+            lines.append(
+                f"• *{name}* — {commits} commit{'s' if commits != 1 else ''}, {files} file{'s' if files != 1 else ''}: {detail}."
+            )
+    else:
+        lines.append("• Version updated successfully; no per-area highlight data was available.")
+
+    lines.extend([
+        "",
+        "_Generated from changed source areas and cleaned commit subjects; raw update logs are kept out of the alert unless the update fails._",
+    ])
+    return "\n".join(lines)
+
+
+def _metadata_for_update_detail_reply(
+    platform: Platform,
+    base_metadata: dict | None,
+    success_message_id: str | None,
+    chat_type: str | None = None,
+) -> dict | None:
+    """Route detailed update info as a reply to the success alert when possible."""
+    if not success_message_id:
+        return base_metadata
+    metadata = dict(base_metadata or {})
+    if platform == Platform.SLACK:
+        # Slack threads are keyed by thread_ts.  Prefer the success alert's ts
+        # so the main visible alert can say "check the reply" and the detailed
+        # information hangs off that alert instead of the triggering command.
+        return {"thread_id": success_message_id}
+    if platform == Platform.TELEGRAM:
+        if chat_type == "dm" and metadata.get("thread_id"):
+            metadata["telegram_dm_topic_reply_fallback"] = True
+            metadata["telegram_reply_to_message_id"] = success_message_id
+            return metadata
+        return metadata
+    return metadata or None
+
+
+async def _send_update_completion_messages(
+    *,
+    adapter: Any,
+    chat_id: str,
+    platform: Platform,
+    chat_type: str | None,
+    exit_code: int,
+    metadata: dict | None,
+    output: str,
+    summary: dict | None,
+) -> None:
+    """Send final update status, with success details in a follow-up reply."""
+    if exit_code != 0:
+        await adapter.send(
+            chat_id,
+            "❌ Hermes update failed (exit code {}).".format(exit_code),
+            metadata=metadata,
+        )
+        return
+
+    detail = _format_update_highlight_reply(summary, output)
+    if not detail:
+        await adapter.send(chat_id, "✅ Hermes update finished successfully.", metadata=metadata)
+        return
+
+    main_result = await adapter.send(
+        chat_id,
+        "✅ Hermes update finished successfully. Check the reply for update info.",
+        metadata=metadata,
+    )
+    success_message_id = getattr(main_result, "message_id", None)
+    reply_metadata = _metadata_for_update_detail_reply(
+        platform,
+        metadata,
+        success_message_id,
+        chat_type=chat_type,
+    )
+    try:
+        await adapter.send(
+            chat_id,
+            detail,
+            reply_to=success_message_id,
+            metadata=reply_metadata,
+        )
+    except TypeError:
+        # Some plugin adapters expose send(chat_id, content, metadata=...) only.
+        await adapter.send(chat_id, detail, metadata=reply_metadata)
+    except Exception as exc:
+        logger.debug("Update detail reply failed; retrying in original thread: %s", exc)
+        await adapter.send(chat_id, detail, metadata=metadata)
+
+
 def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
@@ -14753,6 +14905,7 @@ class GatewayRunner:
         pending_path = _hermes_home / ".update_pending.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+        summary_path = _hermes_home / ".update_summary.json"
         session_key = self._session_key_for_source(event.source)
         pending = {
             "platform": event.source.platform.value,
@@ -14770,6 +14923,7 @@ class GatewayRunner:
         _tmp_pending.write_text(json.dumps(pending))
         _tmp_pending.replace(pending_path)
         exit_code_path.unlink(missing_ok=True)
+        summary_path.unlink(missing_ok=True)
 
         # Spawn `hermes update --gateway` detached so it survives gateway restart.
         # --gateway enables file-based IPC for interactive prompts (stash
@@ -14894,6 +15048,7 @@ class GatewayRunner:
         claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+        summary_path = _hermes_home / ".update_summary.json"
         prompt_path = _hermes_home / ".update_prompt.json"
 
         loop = asyncio.get_running_loop()
@@ -14902,6 +15057,8 @@ class GatewayRunner:
         # Resolve the adapter and chat_id for sending messages
         adapter = None
         chat_id = None
+        chat_type = None
+        platform = None
         session_key = None
         metadata = None
         for path in (claimed_path, pending_path):
@@ -14991,21 +15148,32 @@ class GatewayRunner:
                 try:
                     exit_code_raw = exit_code_path.read_text().strip() or "1"
                     exit_code = int(exit_code_raw)
-                    if exit_code == 0:
-                        await adapter.send(chat_id, "✅ Hermes update finished.", metadata=metadata)
-                    else:
-                        await adapter.send(
-                            chat_id,
-                            "❌ Hermes update failed (exit code {}).".format(exit_code),
-                            metadata=metadata,
-                        )
+                    summary = _load_update_summary(summary_path)
+                    full_output = ""
+                    if output_path.exists():
+                        try:
+                            full_output = _strip_ansi(output_path.read_text()).strip()
+                        except OSError:
+                            full_output = ""
+                    if platform is None:
+                        raise RuntimeError("update watcher resolved adapter without platform")
+                    await _send_update_completion_messages(
+                        adapter=adapter,
+                        chat_id=chat_id,
+                        platform=platform,
+                        chat_type=chat_type,
+                        exit_code=exit_code,
+                        metadata=metadata,
+                        output=full_output,
+                        summary=summary,
+                    )
                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
                 except Exception as e:
                     logger.warning("Update final notification failed: %s", e)
 
                 # Cleanup
                 for p in (pending_path, claimed_path, output_path,
-                          exit_code_path, prompt_path):
+                          exit_code_path, summary_path, prompt_path):
                     p.unlink(missing_ok=True)
                 (_hermes_home / ".update_response").unlink(missing_ok=True)
                 self._update_prompt_pending.pop(session_key, None)
@@ -15090,7 +15258,7 @@ class GatewayRunner:
             except Exception:
                 pass
             for p in (pending_path, claimed_path, output_path,
-                      exit_code_path, prompt_path):
+                      exit_code_path, summary_path, prompt_path):
                 p.unlink(missing_ok=True)
             (_hermes_home / ".update_response").unlink(missing_ok=True)
             self._update_prompt_pending.pop(session_key, None)
@@ -15109,6 +15277,7 @@ class GatewayRunner:
         claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+        summary_path = _hermes_home / ".update_summary.json"
 
         if not pending_path.exists() and not claimed_path.exists():
             return False
@@ -15162,18 +15331,31 @@ class GatewayRunner:
                 )
                 # Strip ANSI escape codes for clean display
                 output = re.sub(r'\x1b\[[0-9;]*m', '', output).strip()
-                if output:
-                    if len(output) > 3500:
-                        output = "…" + output[-3500:]
-                    if exit_code == 0:
-                        msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
-                    else:
-                        msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
-                elif exit_code == 0:
-                    msg = "✅ Hermes update finished successfully."
+                summary = _load_update_summary(summary_path)
+                if summary and exit_code == 0:
+                    await _send_update_completion_messages(
+                        adapter=adapter,
+                        chat_id=chat_id,
+                        platform=platform,
+                        chat_type=chat_type,
+                        exit_code=exit_code,
+                        metadata=metadata,
+                        output=output,
+                        summary=summary,
+                    )
                 else:
-                    msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
-                await adapter.send(chat_id, msg, metadata=metadata)
+                    if output:
+                        if len(output) > 3500:
+                            output = "…" + output[-3500:]
+                        if exit_code == 0:
+                            msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
+                        else:
+                            msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
+                    elif exit_code == 0:
+                        msg = "✅ Hermes update finished successfully."
+                    else:
+                        msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
+                    await adapter.send(chat_id, msg, metadata=metadata)
                 logger.info(
                     "Sent post-update notification to %s:%s (exit=%s)",
                     platform_str,
@@ -15188,6 +15370,7 @@ class GatewayRunner:
                 claimed_path.unlink(missing_ok=True)
                 output_path.unlink(missing_ok=True)
                 exit_code_path.unlink(missing_ok=True)
+                summary_path.unlink(missing_ok=True)
 
         return True
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -203,6 +203,7 @@ if _try_termux_ultrafast_version():
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -9336,6 +9337,233 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         pass
 
 
+_UPDATE_HIGHLIGHT_CATEGORIES = (
+    {
+        "key": "gateway",
+        "name": "Messaging gateway and alert delivery",
+        "summary": "updates to Slack/Telegram/Discord routing, threaded replies, gateway commands, or status delivery",
+        "paths": ("gateway/",),
+        "keywords": ("gateway", "slack", "telegram", "discord", "thread", "reply", "alert", "update notification", "message"),
+    },
+    {
+        "key": "agent",
+        "name": "Agent runtime and model behavior",
+        "summary": "agent loop, providers, context handling, memory, reasoning, or model-routing improvements",
+        "paths": ("agent/", "run_agent.py", "model_tools.py", "toolsets.py"),
+        "keywords": ("agent", "model", "provider", "context", "memory", "reasoning", "compression", "tool"),
+    },
+    {
+        "key": "cli_config",
+        "name": "CLI, setup, and configuration",
+        "summary": "command-line workflows, setup/config migration, install/update, auth, profile, or environment fixes",
+        "paths": ("hermes_cli/", "scripts/", "hermes_constants.py", "hermes_logging.py"),
+        "keywords": ("cli", "config", "setup", "install", "update", "profile", "auth", "env", "migration"),
+    },
+    {
+        "key": "tools_integrations",
+        "name": "Tools and integrations",
+        "summary": "tool implementations, MCP/plugins, browser/media/web access, cron, or external service integrations",
+        "paths": ("tools/", "plugins/", "cron/", "mcp/"),
+        "keywords": ("tool", "mcp", "plugin", "cron", "browser", "web", "image", "tts", "search"),
+    },
+    {
+        "key": "ui",
+        "name": "Dashboard, desktop, and TUI",
+        "summary": "dashboard, desktop app, website, terminal UI, and user-interface polish",
+        "paths": ("apps/", "ui-tui/", "website/", "web/"),
+        "keywords": ("dashboard", "desktop", "tui", "ui", "website", "frontend", "display"),
+    },
+    {
+        "key": "skills_docs",
+        "name": "Skills and documentation",
+        "summary": "bundled skills, documentation, examples, and user-facing guidance",
+        "paths": ("skills/", "optional-skills/", "docs/", "README", "AGENTS.md"),
+        "keywords": ("skill", "docs", "documentation", "guide", "readme", "example"),
+    },
+    {
+        "key": "quality",
+        "name": "Quality, tests, and reliability",
+        "summary": "tests, regression coverage, safety guards, and reliability hardening",
+        "paths": ("tests/",),
+        "keywords": ("test", "regression", "reliability", "guard", "fix", "race", "crash", "timeout"),
+    },
+)
+
+
+def _clean_update_subject(subject: str) -> str:
+    """Normalize a commit subject into a human-readable detail phrase."""
+    text = (subject or "").strip()
+    text = re.sub(r"^\w+(?:\([^)]*\))?!?:\s*", "", text)
+    text = re.sub(r"\s*\(#\d+\)\s*$", "", text)
+    text = text.strip(" .")
+    if not text:
+        return "maintenance and reliability fixes"
+    return text[:1].upper() + text[1:]
+
+
+def _category_for_update_commit(subject: str, files: list[str]) -> dict:
+    """Choose the best highlight category for one incoming update commit."""
+    path_scores = {cat["key"]: 0 for cat in _UPDATE_HIGHLIGHT_CATEGORIES}
+    for file_path in files:
+        for cat in _UPDATE_HIGHLIGHT_CATEGORIES:
+            if any(file_path == prefix or file_path.startswith(prefix) for prefix in cat["paths"]):
+                path_scores[cat["key"]] += 2
+    subject_lc = subject.lower()
+    for cat in _UPDATE_HIGHLIGHT_CATEGORIES:
+        if any(keyword in subject_lc for keyword in cat["keywords"]):
+            path_scores[cat["key"]] += 1
+    best_key = max(path_scores, key=lambda key: path_scores[key])
+    if path_scores[best_key] <= 0:
+        return _UPDATE_HIGHLIGHT_CATEGORIES[-1]
+    return next(cat for cat in _UPDATE_HIGHLIGHT_CATEGORIES if cat["key"] == best_key)
+
+
+def _parse_update_git_log(raw_log: str) -> list[dict]:
+    """Parse ``git log --name-only`` output used for gateway update summaries."""
+    commits: list[dict] = []
+    for record in raw_log.split("\x1e"):
+        record = record.strip("\n")
+        if not record.strip():
+            continue
+        lines = [line.strip() for line in record.splitlines() if line.strip()]
+        if not lines:
+            continue
+        header = lines[0]
+        parts = header.split("\x1f", 1)
+        if len(parts) != 2:
+            continue
+        sha, subject = parts
+        files = [line for line in lines[1:] if "\x1f" not in line]
+        commits.append({"sha": sha, "subject": subject, "files": files})
+    return commits
+
+
+def _target_version_from_ref(git_cmd, repo_root: Path, ref: str) -> str | None:
+    """Read hermes_cli.__version__ from a remote ref without checking it out."""
+    try:
+        result = subprocess.run(
+            git_cmd + ["show", f"{ref}:hermes_cli/__init__.py"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        match = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", result.stdout, re.MULTILINE)
+        return match.group(1) if match else None
+    except Exception:
+        return None
+
+
+def _build_gateway_update_summary(
+    *,
+    git_cmd,
+    repo_root: Path,
+    compare_range: str,
+    branch: str,
+    target_ref: str,
+    from_sha: str | None,
+    commit_count: int,
+) -> dict | None:
+    """Create a structured, non-raw-commit update summary for gateway alerts.
+
+    The gateway completion notification reads this JSON and posts the detailed
+    highlight list as a reply to the success alert.  Keep this deterministic and
+    local-only: update runs before the new code is trusted, so it should not
+    depend on an LLM or network services.
+    """
+    try:
+        log_result = subprocess.run(
+            git_cmd + [
+                "log",
+                "--reverse",
+                "--name-only",
+                "--pretty=format:%x1e%H%x1f%s",
+                compare_range,
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        if log_result.returncode != 0:
+            return None
+        commits = _parse_update_git_log(log_result.stdout)
+        if not commits:
+            return None
+
+        diff_result = subprocess.run(
+            git_cmd + ["diff", "--name-only", compare_range],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        changed_files = [
+            line.strip()
+            for line in (diff_result.stdout if diff_result.returncode == 0 else "").splitlines()
+            if line.strip()
+        ]
+
+        buckets: dict[str, dict] = {}
+        for commit in commits:
+            category = _category_for_update_commit(commit["subject"], commit["files"])
+            bucket = buckets.setdefault(
+                category["key"],
+                {
+                    "key": category["key"],
+                    "name": category["name"],
+                    "summary": category["summary"],
+                    "commit_count": 0,
+                    "file_count": 0,
+                    "highlights": [],
+                    "_files": set(),
+                },
+            )
+            bucket["commit_count"] += 1
+            bucket["_files"].update(commit["files"])
+            phrase = _clean_update_subject(commit["subject"])
+            if phrase not in bucket["highlights"] and len(bucket["highlights"]) < 4:
+                bucket["highlights"].append(phrase)
+
+        categories = []
+        for bucket in buckets.values():
+            bucket["file_count"] = len(bucket.pop("_files"))
+            categories.append(bucket)
+        categories.sort(key=lambda item: (-item["commit_count"], item["name"]))
+
+        return {
+            "schema": 1,
+            "branch": branch,
+            "target_ref": target_ref,
+            "from_sha": from_sha,
+            "to_sha": commits[-1]["sha"],
+            "current_version": __version__,
+            "target_version": _target_version_from_ref(git_cmd, repo_root, target_ref),
+            "commit_count": commit_count,
+            "files_changed_count": len(changed_files),
+            "categories": categories,
+            "generated_from": "git log subjects plus touched source paths",
+        }
+    except Exception as exc:
+        logger.debug("Could not build gateway update summary: %s", exc)
+        return None
+
+
+def _write_gateway_update_summary(summary: dict | None) -> None:
+    """Persist the update summary for the gateway completion notifier."""
+    if not summary:
+        return
+    try:
+        summary_path = get_hermes_home() / ".update_summary.json"
+        tmp_path = summary_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(summary, ensure_ascii=False), encoding="utf-8")
+        tmp_path.replace(summary_path)
+    except Exception as exc:
+        logger.debug("Could not write gateway update summary: %s", exc)
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -9697,6 +9925,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # every user who ran ``hermes update`` for the 7 minutes between
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
+        if gateway_mode:
+            _write_gateway_update_summary(
+                _build_gateway_update_summary(
+                    git_cmd=git_cmd,
+                    repo_root=PROJECT_ROOT,
+                    compare_range=f"HEAD..origin/{branch}",
+                    branch=branch,
+                    target_ref=f"origin/{branch}",
+                    from_sha=pre_pull_sha,
+                    commit_count=commit_count,
+                )
+            )
         try:
             pull_result = subprocess.run(
                 git_cmd + ["pull", "--ff-only", "origin", branch],

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -16,7 +16,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -286,6 +286,78 @@ class TestWatchUpdateProgress:
         assert mock_adapter.send.call_count >= 1
         all_sent = " ".join(str(c) for c in mock_adapter.send.call_args_list)
         assert "update finished" in all_sent.lower()
+
+    @pytest.mark.asyncio
+    async def test_success_with_summary_posts_main_alert_then_detail_reply(self, tmp_path):
+        """A successful version update posts compact main alert + detailed reply."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending = {
+            "platform": "slack",
+            "chat_id": "C111",
+            "user_id": "U222",
+            "session_key": "agent:main:slack:dm:C111",
+        }
+        summary = {
+            "schema": 1,
+            "branch": "main",
+            "from_sha": "abc123456789",
+            "to_sha": "def987654321",
+            "current_version": "0.15.1",
+            "target_version": "0.15.2",
+            "commit_count": 4,
+            "files_changed_count": 12,
+            "categories": [
+                {
+                    "name": "Messaging gateway and alert delivery",
+                    "summary": "threaded alerts and delivery polish",
+                    "commit_count": 2,
+                    "file_count": 5,
+                    "highlights": [
+                        "Thread update summaries under the success alert",
+                        "Preserve Slack reply metadata",
+                    ],
+                },
+                {
+                    "name": "Tools and integrations",
+                    "summary": "tooling updates",
+                    "commit_count": 2,
+                    "file_count": 7,
+                    "highlights": ["Improve browser and cron integration summaries"],
+                },
+            ],
+        }
+        (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
+        (hermes_home / ".update_output.txt").write_text("")
+        (hermes_home / ".update_summary.json").write_text(json.dumps(summary))
+        (hermes_home / ".update_exit_code").write_text("0")
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(side_effect=[
+            SendResult(success=True, message_id="1710000000.000100"),
+            SendResult(success=True, message_id="1710000000.000200"),
+        ])
+        runner.adapters = {Platform.SLACK: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(
+                poll_interval=0.1,
+                stream_interval=0.2,
+                timeout=5.0,
+            )
+
+        assert mock_adapter.send.call_count == 2
+        main_call = mock_adapter.send.call_args_list[0]
+        reply_call = mock_adapter.send.call_args_list[1]
+        assert "Check the reply for update info" in main_call.args[1]
+        assert "Hermes v0.15.1 → v0.15.2" in reply_call.args[1]
+        assert "Messaging gateway and alert delivery" in reply_call.args[1]
+        assert "Pulled 4 commits" in reply_call.args[1]
+        assert reply_call.kwargs["reply_to"] == "1710000000.000100"
+        assert reply_call.kwargs["metadata"] == {"thread_id": "1710000000.000100"}
+        assert not (hermes_home / ".update_summary.json").exists()
 
     @pytest.mark.asyncio
     async def test_detects_and_forwards_prompt(self, tmp_path):


### PR DESCRIPTION
## Summary
- Add a structured update-summary marker during `hermes update --gateway` before pulling new code.
- Change successful gateway update alerts to post a compact main message that says to check the reply for update info.
- Send a follow-up reply with grouped, comprehensive highlights by changed product area instead of raw update logs / commit comments.

## Test Plan
- `python -m pytest tests/gateway/test_update_streaming.py tests/gateway/test_update_command.py tests/hermes_cli/test_cmd_update.py -q -o 'addopts='`\n- `python -m py_compile gateway/run.py hermes_cli/main.py`