### PR TITLE
fix(config): resolve provider-level context_length on /model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1544,6 +1544,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             provider=agent.provider,
             api_mode=agent.api_mode,
         )
+        # Persist the resolved context length so the /model display path
+        # (cli.py) can read it via getattr(agent, "_config_context_length").
+        # Without this, the display always sees None (cleared at the top of
+        # switch_model) and falls through to the 256K default for custom
+        # providers that don't match any probe path.
+        if new_context_length and new_context_length > 0:
+            agent._config_context_length = new_context_length
 
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3717,10 +3717,13 @@ def get_compatible_custom_providers(
 
     custom_providers = config.get("custom_providers")
     if custom_providers is not None:
-        if not isinstance(custom_providers, list):
-            return []
-        for entry in custom_providers:
-            _append_if_new(_normalize_custom_provider_entry(entry))
+        if isinstance(custom_providers, list):
+            for entry in custom_providers:
+                _append_if_new(_normalize_custom_provider_entry(entry))
+        elif isinstance(custom_providers, dict) and custom_providers:
+            # Handle dict-shaped custom_providers (same as providers:)
+            for entry in providers_dict_to_custom_providers(custom_providers):
+                _append_if_new(entry)
 
     for entry in providers_dict_to_custom_providers(config.get("providers")):
         _append_if_new(entry)
@@ -3775,21 +3778,35 @@ def get_custom_provider_context_length(
         entry_url = (entry.get("base_url") or "").rstrip("/")
         if not entry_url or entry_url != target_url:
             continue
+        # 1. Per-model override: models.<model_name>.context_length
         models = entry.get("models")
-        if not isinstance(models, dict):
-            continue
-        model_cfg = models.get(model)
-        if not isinstance(model_cfg, dict):
-            continue
-        raw_ctx = model_cfg.get("context_length")
-        if raw_ctx is None:
-            continue
-        try:
-            ctx = int(raw_ctx)
-        except (TypeError, ValueError):
-            continue
-        if ctx > 0:
-            return ctx
+        if isinstance(models, dict):
+            model_cfg = models.get(model)
+            if isinstance(model_cfg, dict):
+                raw_ctx = model_cfg.get("context_length")
+                if raw_ctx is not None:
+                    try:
+                        ctx = int(raw_ctx)
+                    except (TypeError, ValueError):
+                        pass
+                    else:
+                        if ctx > 0:
+                            return ctx
+        # 2. Provider-level fallback: when the entry's default model
+        #    matches the requested model, use the top-level context_length.
+        #    This covers the common config shape where providers.<name>
+        #    has model + context_length as siblings (no nested models dict).
+        entry_model = (entry.get("model") or "").strip()
+        if entry_model == model:
+            raw_ctx = entry.get("context_length")
+            if raw_ctx is not None:
+                try:
+                    ctx = int(raw_ctx)
+                except (TypeError, ValueError):
+                    pass
+                else:
+                    if ctx > 0:
+                        return ctx
     return None
 
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -585,6 +585,16 @@ def resolve_display_context_length(
     """
     try:
         from agent.model_metadata import get_model_context_length
+        # Load custom_providers from config if not passed by the caller.
+        # Both cli.py call sites (picker and /model <name>) omit this arg,
+        # so without this fallback the resolver never sees user-configured
+        # providers.<name>.context_length and falls to the 256K default.
+        if custom_providers is None:
+            try:
+                from hermes_cli.config import load_config, get_compatible_custom_providers
+                custom_providers = get_compatible_custom_providers(load_config())
+            except Exception:
+                pass
         ctx = get_model_context_length(
             model,
             base_url=base_url or "",


### PR DESCRIPTION
## Problem

`/model` switch always shows `Context: 256,000 tokens` for custom providers configured via `providers:` in config.yaml, regardless of the actual `context_length` value set on the provider entry.

```
/model vertex-opus46
  ✓ Model switched: claude-opus-4.6
    Provider: vertex-opus46
    Context: 256,000 tokens    ← wrong, should be 1,000,000
```

This affects all custom provider setups (vertex-proxy, LiteLLM, or any `providers:` entry) using the common config shape:

```yaml
providers:
  vertex-opus46:
    base_url: http://127.0.0.1:8788/anthropic
    model: claude-opus-4.6
    context_length: 1000000
    api_mode: anthropic_messages
```

## Root Cause

Three bugs in the resolution chain:

### 1. `get_compatible_custom_providers()` early-returns on dict-shaped `custom_providers`

When `custom_providers: {}` exists in config.yaml (an empty dict, not a list), the `not isinstance(custom_providers, list)` guard returns `[]`, skipping the `providers:` dict loop below it. All user-configured providers become invisible to the context_length lookup.

### 2. `get_custom_provider_context_length()` only checks nested `models.<model>.context_length`

The common config shape has `model` and `context_length` as siblings at the provider level, with no nested `models:` dict. The lookup returns `None` and the chain falls through to `DEFAULT_FALLBACK_CONTEXT = 256_000`.

### 3. `resolve_display_context_length()` never loads `custom_providers`

The function accepts `custom_providers` as a parameter, but neither call site in `cli.py` passes it. When `custom_providers` is `None`, the resolver has nothing to check against and falls through to the default.

## Fix

**hermes_cli/config.py:**
- `get_compatible_custom_providers()`: gracefully handle dict-shaped `custom_providers` by normalizing it the same way as the `providers:` dict, instead of early-returning.
- `get_custom_provider_context_length()`: after the existing `models.<model>.context_length` lookup, fall back to the provider-level `context_length` when the entry's default `model` matches the requested model.

**hermes_cli/model_switch.py:**
- `resolve_display_context_length()`: when `custom_providers` is `None`, load it from config via `get_compatible_custom_providers(load_config())` so the resolver sees user-configured provider entries.

**agent/agent_runtime_helpers.py:**
- Persist the resolved `new_context_length` back to `agent._config_context_length` after `switch_model` completes, so the display path in cli.py reads the correct value on subsequent `/model` calls.

## Testing

**Manual:** Tested with `providers:` config entries pointing at a local proxy (vertex-proxy on port 8788, Anthropic wire protocol). Gateway restarted between tests.

Before fix:
```
/model vertex-opus46   → Context: 256,000 tokens
/model vertex-haiku    → Context: 256,000 tokens
```

After fix:
```
/model vertex-opus46   → Context: 1,000,000 tokens
/model vertex-haiku    → Context: 200,000 tokens
```

**Automated:** All existing tests pass:
- `test_config.py` -- 87 passed
- `test_config_validation.py` -- 21 passed (dict-shaped custom_providers detection still works)
- `test_model_switch_custom_providers.py` -- 19 passed
- `test_custom_provider_context_length` -- 12 passed, 2 skipped
- Full `custom_provider_context or model_switch_custom` -- 31 passed, 2 skipped

Supersedes #36199 and #37712.

Signed-off-by: Chris van Hoof <vanhoof@ouwish.com>