### PR TITLE
fix(gateway): recover reply context for inbound media replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12639,14 +12639,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
-        if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
+        reply_ctx_text = getattr(event, "reply_to_text", None)
+        if not reply_ctx_text and event.reply_to_message_id:
+            # Media-only replies carry an id without quoted text; recover the
+            # persisted transcript content when that platform id is available.
+            _target_id = str(event.reply_to_message_id)
+            for _entry in reversed(history):
+                if str(_entry.get("message_id") or "") == _target_id:
+                    _entry_content = _entry.get("content")
+                    if isinstance(_entry_content, str) and _entry_content.strip():
+                        reply_ctx_text = _entry_content.strip()
+                    break
+        if reply_ctx_text and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's
             # disambiguation: it tells the agent *which* prior message the user
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            reply_snippet = reply_ctx_text[:500]
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -160,6 +160,94 @@ async def test_no_prefix_when_reply_to_text_is_empty():
 
 
 @pytest.mark.asyncio
+async def test_reply_prefix_recovered_from_transcript_for_inbound_voice_reply():
+    """Replies to inbound voice/media messages recover their stored text."""
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="yes, book it",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=None,
+    )
+
+    history = [
+        {"role": "user", "content": "earlier unrelated turn"},
+        {
+            "role": "user",
+            "content": "Should I reserve the 7pm table?",
+            "message_id": "42",
+        },
+        {"role": "assistant", "content": "The 7pm slot is available."},
+    ]
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=history,
+    )
+
+    assert result is not None
+    assert result.startswith('[Replying to: "Should I reserve the 7pm table?"]')
+    assert result.endswith("yes, book it")
+
+
+@pytest.mark.asyncio
+async def test_recovered_reply_text_preserves_own_message_marker():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="this one",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=None,
+        reply_to_is_own_message=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[
+            {
+                "role": "assistant",
+                "content": "Use the direct train.",
+                "message_id": "42",
+            },
+        ],
+    )
+
+    assert result is not None
+    assert result.startswith('[Replying to your previous message: "Use the direct train."]')
+    assert result.endswith("this one")
+
+
+@pytest.mark.asyncio
+async def test_no_prefix_when_transcript_has_no_matching_message():
+    """If the replied-to message id isn't in the loaded transcript, there's
+    nothing to recover and no prefix should be injected."""
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="yes, book it",
+        source=source,
+        reply_to_message_id="999",
+        reply_to_text=None,
+    )
+
+    history = [
+        {"role": "user", "content": "Should I reserve the 7pm table?", "message_id": "42"},
+    ]
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=history,
+    )
+
+    assert result == "yes, book it"
+
+
+@pytest.mark.asyncio
 async def test_reply_snippet_truncated_to_500_chars():
     runner = _make_runner()
     source = _source()


### PR DESCRIPTION
## Problem

When a user replies to an earlier voice or media message they sent, the platform can provide `reply_to_message_id` without `reply_to_text`. The gateway then drops the `[Replying to: \"...\"]` pointer, leaving the agent to infer which prior message was referenced.

This PR covers inbound media messages whose platform IDs are persisted on user transcript entries. Outbound bot-media IDs are not currently persisted on assistant entries and remain out of scope.

## Solution

When `reply_to_text` is empty but `reply_to_message_id` is present, search the already-loaded session history for the matching `message_id` and use its stored content before passing through the existing reply formatter.

- Explicit quoted text still takes precedence.
- The existing own-message marker is preserved.
- The existing 500-character cap is unchanged.
- If no matching transcript entry exists, no prefix is injected.
- No additional store calls or dependencies are added.

## Risks

The fallback only works when the referenced platform ID exists in the loaded transcript. Supporting replies to outbound bot media requires separate outbound-ID persistence.

## Verification

- `scripts/run_tests.sh tests/gateway/test_reply_to_injection.py -q` — 9 passed
- `.venv/bin/ruff check gateway/run.py tests/gateway/test_reply_to_injection.py` — clean