### PR TITLE
fix: allow Desktop remote gateway file origins

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6279,10 +6279,12 @@ def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
         # Packaged Electron loads the desktop renderer over file://, so its
         # WebSocket handshake carries a non-web Origin such as file:// or null.
         # DNS-rebinding attacks originate from an http(s) site; they cannot
-        # forge a file:// origin and still hold the loopback session token.
-        # Public/gated binds have no legitimate non-web client, so keep
-        # rejecting these origins there.
-        return bound_host.lower() in _LOOPBACK_HOST_VALUES
+        # forge a file:// origin and still hold the already-validated session
+        # token. Remote Desktop mode is an explicit non-loopback bind guarded
+        # by that token, so allow Electron's non-web origin there as well.
+        # Gated public dashboards use browser/OAuth ticket auth and have no
+        # legitimate file:// client; keep those rejected.
+        return not bool(getattr(app.state, "auth_required", False))
 
     if not parsed.netloc:
         return False

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3232,6 +3232,33 @@ class TestPtyWebSocket:
                 pass
         assert exc.value.code == 4401
 
+    def test_remote_desktop_file_origin_allowed_after_token(self, monkeypatch):
+        """Packaged Desktop uses file:// origin for remote /api/ws.
+
+        Test remote only probes REST, but Save and reconnect opens the browser
+        WebSocket from Electron's renderer. Non-loopback, token-authenticated
+        Desktop sessions must therefore accept file:// origins after token auth.
+        """
+        monkeypatch.setattr(
+            self.ws_module.app.state,
+            "bound_host",
+            "ubuntu-server.tailf31bf8.ts.net",
+            raising=False,
+        )
+        monkeypatch.setattr(self.ws_module.app.state, "auth_required", False, raising=False)
+        headers = {
+            "host": "ubuntu-server.tailf31bf8.ts.net:9119",
+            "origin": "file://",
+        }
+
+        with self.client.websocket_connect(
+            f"/api/ws?token={self.token}", headers=headers
+        ) as conn:
+            ready = conn.receive_json()
+
+        assert ready["method"] == "event"
+        assert ready["params"]["type"] == "gateway.ready"
+
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(
             self.ws_module,


### PR DESCRIPTION
## Summary
- Allow packaged Hermes Desktop remote gateway WebSockets to connect with `Origin: file://` after dashboard session-token auth.
- Keep non-web origins rejected for gated/public dashboard auth modes.
- Add a regression test for remote Desktop `/api/ws` connection behavior.

## Why
`Test remote` can pass because it uses REST, while `Save and reconnect` fails because the Electron renderer opens a WebSocket with a `file://` origin. Previously Hermes only allowed that non-web origin on loopback binds, which breaks explicit remote Desktop mode over a trusted/tailnet backend guarded by the session token.

## Test plan
- `python -m pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_remote_desktop_file_origin_allowed_after_token -q -o 'addopts='`
