### PR TITLE
fix(gateway): isolate session context from process env

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -975,14 +975,15 @@ def init_agent(
 
     # Expose session ID to tools (terminal, execute_code) so agents can
     # reference their own session for --resume commands, cross-session
-    # coordination, and logging. Keep the ContextVar and os.environ
-    # fallback synchronized because different tool paths still read both.
+    # coordination, and logging.  In gateway workers this is ContextVar-only;
+    # CLI-style entrypoints may mirror to env via set_current_session_id's
+    # non-gateway default.
     try:
         from gateway.session_context import set_current_session_id
 
         set_current_session_id(agent.session_id)
-    except Exception:
-        os.environ["HERMES_SESSION_ID"] = agent.session_id
+    except Exception as exc:
+        logger.debug("Could not set session ContextVar: %s", exc)
 
     # Session logs go into ~/.hermes/sessions/ alongside gateway sessions
     hermes_home = get_hermes_home()

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -511,8 +511,8 @@ def compress_context(
                 from gateway.session_context import set_current_session_id
 
                 set_current_session_id(agent.session_id)
-            except Exception:
-                os.environ["HERMES_SESSION_ID"] = agent.session_id
+            except Exception as exc:
+                logger.debug("Could not set compression session ContextVar: %s", exc)
             agent._session_db_created = False
             agent._session_db.create_session(
                 session_id=agent.session_id,

--- a/cli.py
+++ b/cli.py
@@ -826,7 +826,7 @@ def _sync_process_session_id(session_id: str) -> None:
     """Keep process-local session-id consumers aligned after CLI switches."""
     from gateway.session_context import set_current_session_id
 
-    set_current_session_id(session_id)
+    set_current_session_id(session_id, sync_process_env=True)
 
 # Cron job system for scheduled tasks (execution is handled by the gateway)
 def get_job(*args, **kwargs):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15349,6 +15349,7 @@ class GatewayRunner:
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
         )
 
@@ -17367,9 +17368,12 @@ class GatewayRunner:
             # `_resolve_turn_agent_config(message, …)`.
             nonlocal message
 
-            # session_key is now set via contextvars in _set_session_env()
-            # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
-            os.environ["HERMES_SESSION_KEY"] = session_key or ""
+            # session_key is already set via contextvars in _set_session_env()
+            # (concurrency-safe). Do not mirror it into os.environ here: the
+            # gateway worker handles concurrent sessions, and process-global
+            # HERMES_SESSION_KEY writes can route tools/background notices to
+            # the wrong chat. CLI/cron compatibility still falls back to env
+            # when no gateway contextvar is set.
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -37,7 +37,7 @@ needs to replace the import + call site:
 """
 
 from contextvars import ContextVar
-from typing import Any
+from typing import Any, Optional
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
@@ -83,19 +83,39 @@ _VAR_MAP = {
 }
 
 
-def set_current_session_id(session_id: str) -> None:
-    """Synchronize ``HERMES_SESSION_ID`` across ContextVar and ``os.environ``.
+def set_current_session_id(
+    session_id: str,
+    *,
+    sync_process_env: Optional[bool] = None,
+) -> None:
+    """Set the current session ID in ContextVar, optionally mirroring to env.
 
-    Long-lived single-process entrypoints like the CLI can rotate sessions via
-    ``/new``, ``/resume``, ``/branch``, or compression splits without
-    reconstructing the entire agent. Tools still consult
-    ``get_session_env("HERMES_SESSION_ID")`` with an ``os.environ`` fallback,
-    so both storage paths must move together when the active session changes.
+    Gateway workers must not write per-message session IDs into ``os.environ``:
+    the gateway processes concurrent sessions in one process, so a global write
+    can leak one chat/session into another worker.  CLI-style single-session
+    entrypoints can still request process-env sync for subprocess compatibility
+    by passing ``sync_process_env=True``.
     """
-    import os
-
-    os.environ["HERMES_SESSION_ID"] = session_id
     _SESSION_ID.set(session_id)
+    if sync_process_env is None:
+        # Default to env sync for CLI-style callers, but suppress it when a
+        # gateway session context is active.  Do not key only off
+        # ``_HERMES_GATEWAY``: importing gateway.run sets it process-wide, and
+        # tests/CLI helpers may import gateway modules without being inside a
+        # concurrent gateway worker.
+        sync_process_env = all(
+            var.get() is _UNSET
+            for var in (
+                _SESSION_PLATFORM,
+                _SESSION_CHAT_ID,
+                _SESSION_KEY,
+                _SESSION_MESSAGE_ID,
+            )
+        )
+    if sync_process_env:
+        import os
+
+        os.environ["HERMES_SESSION_ID"] = session_id
 
 
 def set_session_vars(
@@ -106,6 +126,7 @@ def set_session_vars(
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
+    session_id: Optional[str] = None,
     message_id: str = "",
     cwd: str = "",
 ) -> list:
@@ -117,7 +138,11 @@ def set_session_vars(
     helpers are not nestable/stack-safe, and the returned tokens are accepted
     only for API compatibility.
 
-    ``cwd`` pins the logical working directory for this context.
+    ``cwd`` pins the logical working directory for this context. ``session_id``
+    is optional: callers that omit it keep the legacy ``os.environ`` fallback
+    available for ``HERMES_SESSION_ID`` (ACP does this while it bridges the
+    session id around a single agent call).  Gateway callers pass an explicit
+    value, so concurrent gateway workers do not fall back to stale process env.
     """
     tokens = [
         _SESSION_PLATFORM.set(platform),
@@ -129,6 +154,8 @@ def set_session_vars(
         _SESSION_KEY.set(session_key),
         _SESSION_MESSAGE_ID.set(message_id),
     ]
+    if session_id is not None:
+        tokens.append(_SESSION_ID.set(session_id))
     try:
         from agent.runtime_cwd import set_session_cwd
 
@@ -157,6 +184,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,
+        _SESSION_ID,
         _SESSION_MESSAGE_ID,
     ):
         var.set("")

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -10,6 +10,7 @@ from gateway.session_context import (
     get_session_env,
     set_session_vars,
     clear_session_vars,
+    set_current_session_id,
     _VAR_MAP,
     _UNSET,
 )
@@ -50,7 +51,9 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
 
+    context.session_id = "session-abc123"
     tokens = runner._set_session_env(context)
 
     # Values should be readable via get_session_env (contextvar path)
@@ -60,10 +63,12 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
+    assert get_session_env("HERMES_SESSION_ID") == "session-abc123"
 
     # os.environ should NOT be touched
     assert os.getenv("HERMES_SESSION_PLATFORM") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
+    assert os.getenv("HERMES_SESSION_ID") is None
 
     # Clean up
     runner._clear_session_env(tokens)
@@ -104,6 +109,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     assert get_session_env("HERMES_SESSION_USER_ID") == ""
     assert get_session_env("HERMES_SESSION_USER_NAME") == ""
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
+    assert get_session_env("HERMES_SESSION_ID") == ""
 
 
 def test_get_session_env_falls_back_to_os_environ(monkeypatch):
@@ -130,6 +136,23 @@ def test_get_session_env_default_when_nothing_set(monkeypatch):
 
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
     assert get_session_env("HERMES_SESSION_PLATFORM", "fallback") == "fallback"
+
+
+def test_omitted_session_id_keeps_env_fallback_for_acp(monkeypatch):
+    """ACP sets session vars for routing but bridges SESSION_ID through env."""
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+    tokens = set_session_vars(session_key="acp-session-id")
+    try:
+        monkeypatch.setenv("HERMES_SESSION_ID", "acp-session-id")
+        assert get_session_env("HERMES_SESSION_KEY") == "acp-session-id"
+        assert get_session_env("HERMES_SESSION_ID") == "acp-session-id"
+    finally:
+        clear_session_vars(tokens)
+
+    # After an explicit clear, stale env fallback is suppressed inside this
+    # context until the next task/test starts with fresh ContextVars.
+    assert get_session_env("HERMES_SESSION_ID") == ""
 
 
 def test_set_session_env_handles_missing_optional_fields():
@@ -277,6 +300,7 @@ async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
         connected_platforms=[],
         home_channels={},
         session_key="agent:main:telegram:dm:2144471399",
+        session_id="20260602_120000_gatewayabc",
     )
 
     tokens = runner._set_session_env(context)
@@ -287,6 +311,7 @@ async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
                 "chat_id": get_session_env("HERMES_SESSION_CHAT_ID"),
                 "user_id": get_session_env("HERMES_SESSION_USER_ID"),
                 "session_key": get_session_env("HERMES_SESSION_KEY"),
+                "session_id": get_session_env("HERMES_SESSION_ID"),
             }
         )
     finally:
@@ -297,7 +322,60 @@ async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
         "chat_id": "2144471399",
         "user_id": "123456",
         "session_key": "agent:main:telegram:dm:2144471399",
+        "session_id": "20260602_120000_gatewayabc",
     }
+
+
+@pytest.mark.asyncio
+async def test_repeated_gateway_turns_copy_active_session_id_into_executor(monkeypatch):
+    """Cached-agent gateway turns should still expose the active session id."""
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-global")
+
+    async def run_turn(session_id: str) -> str:
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="2144471399",
+            chat_type="dm",
+        )
+        context = SessionContext(
+            source=source,
+            connected_platforms=[],
+            home_channels={},
+            session_key="agent:main:telegram:dm:2144471399",
+            session_id=session_id,
+        )
+        tokens = runner._set_session_env(context)
+        try:
+            return await runner._run_in_executor_with_context(
+                lambda: get_session_env("HERMES_SESSION_ID")
+            )
+        finally:
+            runner._clear_session_env(tokens)
+
+    assert await run_turn("session-one") == "session-one"
+    assert await run_turn("session-two") == "session-two"
+    assert os.environ["HERMES_SESSION_ID"] == "stale-global"
+
+
+def test_kanban_worker_metadata_uses_context_session_id(monkeypatch):
+    """Kanban tools should read gateway session id from ContextVars, not env."""
+    from tools.kanban_tools import _stamp_worker_session_metadata
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-global")
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id="chat-1",
+        session_key="telegram:chat-1",
+        session_id="ctx-session-id",
+    )
+    try:
+        stamped = _stamp_worker_session_metadata("task-1", {"existing": True})
+    finally:
+        clear_session_vars(tokens)
+
+    assert stamped == {"existing": True, "worker_session_id": "ctx-session-id"}
 
 
 @pytest.mark.asyncio
@@ -312,13 +390,59 @@ async def test_run_in_executor_with_context_forwards_args():
     assert result == 10
 
 
+def test_gateway_session_id_contextvar_does_not_clobber_process_env(monkeypatch):
+    """Gateway-mode session ID rotation is ContextVar-only, never global env."""
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-global")
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id="chat-1",
+        session_key="telegram:chat-1",
+    )
+    try:
+        set_current_session_id("gateway-session-1")
+
+        assert get_session_env("HERMES_SESSION_ID") == "gateway-session-1"
+        assert os.environ["HERMES_SESSION_ID"] == "stale-global"
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_cli_session_id_sync_can_explicitly_update_process_env(monkeypatch):
+    """Single-session CLI paths still have an explicit env-sync escape hatch."""
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+    set_current_session_id("cli-session-1", sync_process_env=True)
+
+    assert get_session_env("HERMES_SESSION_ID") == "cli-session-1"
+    assert os.environ["HERMES_SESSION_ID"] == "cli-session-1"
+
+
 @pytest.mark.asyncio
 async def test_run_in_executor_with_context_propagates_exceptions():
     """Exceptions inside the executor should propagate to the caller."""
     runner = object.__new__(GatewayRunner)
 
-    def blow_up():
-        raise ValueError("boom")
+    def boom():
+        raise RuntimeError("boom")
 
-    with pytest.raises(ValueError, match="boom"):
-        await runner._run_in_executor_with_context(blow_up)
+    with pytest.raises(RuntimeError, match="boom"):
+        await runner._run_in_executor_with_context(boom)
+
+
+def test_gateway_run_does_not_write_session_key_to_global_env():
+    """Gateway workers must not mirror per-message session keys into os.environ.
+
+    The gateway handles concurrent sessions in one process, so per-message
+    HERMES_SESSION_KEY belongs in gateway.session_context ContextVars only.
+    CLI/cron/ACP compatibility may still use env fallback outside gateway/run.py.
+    """
+    from pathlib import Path
+
+    gateway_run = (Path(__file__).parent.parent.parent / "gateway" / "run.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'os.environ["HERMES_SESSION_KEY"]' not in gateway_run
+    assert "os.environ['HERMES_SESSION_KEY']" not in gateway_run
+    assert 'os.environ["HERMES_SESSION_ID"]' not in gateway_run
+    assert "os.environ['HERMES_SESSION_ID']" not in gateway_run

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -33,6 +33,7 @@ import logging
 import os
 from typing import Any, Optional
 
+from gateway.session_context import get_session_env
 from tools.registry import registry, tool_error
 
 logger = logging.getLogger(__name__)
@@ -121,7 +122,7 @@ def _stamp_worker_session_metadata(
     """Add trusted worker session id metadata for this worker's own task."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return metadata
-    session_id = os.environ.get("HERMES_SESSION_ID")
+    session_id = get_session_env("HERMES_SESSION_ID")
     if not session_id:
         return metadata
     stamped = dict(metadata or {})
@@ -738,10 +739,10 @@ def _handle_create(args: dict, **kw) -> str:
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
-    # Stamp the originating session id when the agent loop runs under
-    # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
-    # CLI / dashboard paths and on legacy hosts that don't set the env.
-    session_id = args.get("session_id") or os.environ.get("HERMES_SESSION_ID")
+    # Stamp the originating session id from the active agent context. Gateway
+    # workers expose it through ContextVars; CLI/ACP paths still fall back to
+    # HERMES_SESSION_ID in the process environment for compatibility.
+    session_id = args.get("session_id") or get_session_env("HERMES_SESSION_ID")
     priority = args.get("priority")
     # Resolve workspace. If the caller passed one explicitly, honor it.
     # Otherwise, a dispatcher-spawned worker (HERMES_KANBAN_TASK set)


### PR DESCRIPTION
## Summary

Isolate gateway session identity from process-global environment variables while preserving CLI/ACP compatibility.

Problem:

- Gateway workers handle multiple chats/sessions in one process.
- Writing per-message values such as `HERMES_SESSION_ID` or `HERMES_SESSION_KEY` into `os.environ` can leak one session's identity into another concurrent worker or later tool call.

Changes:

- Store current session identity in `gateway.session_context` ContextVars for gateway workers.
- Make `set_current_session_id()` ContextVar-first, with explicit `sync_process_env=True` for CLI-style single-session paths.
- Pass `SessionContext.session_id` into gateway ContextVars so cached-agent turns and executor work see the active session id without touching `os.environ`.
- Stop `gateway/run.py` from mirroring per-message session keys into process env.
- Preserve legacy fallback behavior for ACP by leaving `HERMES_SESSION_ID` unset in ContextVars when `set_session_vars()` is called without an explicit `session_id`.
- Migrate Kanban worker metadata stamping to `get_session_env("HERMES_SESSION_ID")` so it reads the gateway ContextVar when present and env fallback otherwise.
- Add regression coverage for gateway executor context propagation, repeated/cached turns, CLI explicit env sync, ACP fallback, Kanban metadata, and source-level env-write guards in gateway runtime.

Related/adjacent work: #37356, #37407.

## Tests

```bash
python -m compileall -q \
  agent/agent_init.py \
  agent/conversation_compression.py \
  cli.py \
  gateway/run.py \
  gateway/session_context.py \
  tools/kanban_tools.py \
  tests/gateway/test_session_env.py

scripts/run_tests.sh \
  tests/gateway/test_session_env.py \
  tests/run_agent/test_session_id_env.py \
  tests/gateway/test_session_state_cleanup.py \
  tests/cli/test_cli_new_session.py \
  tests/cli/test_branch_command.py \
  tests/cli/test_cli_init.py \
  tests/acp/test_server.py
```

Result:

```text
173 passed
```

Additional checks:

```bash
git diff --cached --check
# clean

# staged added-line secret scan
# added_line_scan_hits=0
```

Independent re-review: no blockers found after the ACP fallback fix.
