### PR TITLE
fix(disk-cleanup): revalidate cron-output paths before quick() deletes them

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -206,6 +206,25 @@ def forget(path_str: str) -> int:
     return removed
 
 
+def _is_under_cron_output(path: Path) -> bool:
+    """Return True if *path* is under ``$HERMES_HOME/cron/output/``.
+
+    Stale ``tracked.json`` entries from before #34840 may label control-plane
+    files (e.g. ``cron/jobs.json``) as ``cron-output``.  Both :func:`quick`
+    and :func:`dry_run` must revalidate before treating a path as disposable.
+    See #37721.
+    """
+    try:
+        rel = path.resolve().relative_to(get_hermes_home())
+        return (
+            len(rel.parts) >= 2
+            and rel.parts[0] == "cron"
+            and rel.parts[1] == "output"
+        )
+    except (ValueError, OSError):
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Dry run
 # ---------------------------------------------------------------------------
@@ -230,7 +249,7 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
             auto.append(item)
         elif cat == "temp" and age > 7:
             auto.append(item)
-        elif cat == "cron-output" and age > 14:
+        elif cat == "cron-output" and age > 14 and _is_under_cron_output(p):
             auto.append(item)
         elif cat == "research" and age > 30:
             prompt.append(item)
@@ -268,6 +287,19 @@ def quick() -> Dict[str, Any]:
             continue
 
         age = (now - datetime.fromisoformat(item["timestamp"])).days
+
+        # Revalidate cron-output paths: only files still under
+        # ``cron/output/`` are disposable.  Stale ``tracked.json``
+        # entries from before #34840 may mark control-plane state
+        # (e.g. ``cron/jobs.json``) as ``cron-output`` — deleting
+        # those wipes the live scheduler registry.  See #37721.
+        if cat == "cron-output" and not _is_under_cron_output(p):
+            _log(
+                f"SKIP: {p} (stale cron-output entry — "
+                f"path no longer under cron/output/)"
+            )
+            new_tracked.append(item)
+            continue
 
         should_delete = (
             cat == "test"

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -223,6 +223,54 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
+    def test_quick_skips_stale_cron_output_entry_for_jobs_json(self, _isolate_env):
+        """Regression for #37721: stale tracked.json marking cron/jobs.json
+        as cron-output must NOT cause quick() to delete the scheduler registry."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        jobs = cron_dir / "jobs.json"
+        jobs.write_text('{"jobs": []}')
+
+        # Simulate a stale tracked.json entry from before #34840
+        from datetime import datetime, timezone, timedelta
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        tracked_file.write_text(json.dumps([{
+            "path": str(jobs),
+            "timestamp": stale_ts,
+            "category": "cron-output",
+            "size": jobs.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+        assert summary["deleted"] == 0, "cron/jobs.json must not be deleted"
+        assert jobs.exists(), "cron/jobs.json must still exist"
+
+    def test_quick_deletes_legitimate_cron_output(self, _isolate_env):
+        """Files genuinely under cron/output/ should still be cleaned up."""
+        dg = _load_lib()
+        output_dir = _isolate_env / "cron" / "output" / "job_123"
+        output_dir.mkdir(parents=True)
+        run_log = output_dir / "run.md"
+        run_log.write_text("run output")
+
+        from datetime import datetime, timezone, timedelta
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        tracked_file.write_text(json.dumps([{
+            "path": str(run_log),
+            "timestamp": old_ts,
+            "category": "cron-output",
+            "size": run_log.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+        assert summary["deleted"] == 1, "legitimate cron/output/ file should be deleted"
+        assert not run_log.exists()
+
 
 class TestStatus:
     def test_empty_status(self, _isolate_env):
@@ -256,6 +304,29 @@ class TestDryRun:
         auto, prompt = dg.dry_run()
         # test → auto, other → neither (doesn't hit any rule)
         assert any(i["path"] == str(test_f) for i in auto)
+
+    def test_dry_run_skips_stale_cron_output_entry(self, _isolate_env):
+        """Regression for #37721: dry_run must not list stale cron-output entries."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        jobs = cron_dir / "jobs.json"
+        jobs.write_text('{"jobs": []}')
+
+        from datetime import datetime, timezone, timedelta
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        stale_ts = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        tracked_file.write_text(json.dumps([{
+            "path": str(jobs),
+            "timestamp": stale_ts,
+            "category": "cron-output",
+            "size": jobs.stat().st_size,
+        }]))
+
+        auto, prompt = dg.dry_run()
+        assert not any(i["path"] == str(jobs) for i in auto), \
+            "stale cron-output entry must not appear in auto-delete list"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a safety bug where `disk-cleanup`'s `quick()` function could delete `cron/jobs.json` (the live scheduler registry) when `tracked.json` contained stale entries from before #34840 that incorrectly labeled control-plane files as `cron-output`.

## Related Issue

Fixes #37721

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/disk-cleanup/disk_cleanup.py`: Added `_is_under_cron_output()` helper that revalidates whether a path is actually under `$HERMES_HOME/cron/output/` before treating it as disposable. Gated both `quick()` and `dry_run()` on this check for `cron-output` entries.
- `tests/plugins/test_disk_cleanup_plugin.py`: Added 3 regression tests — stale `cron/jobs.json` not deleted by `quick()`, legitimate `cron/output/` files still deleted, and stale entries excluded from `dry_run()` auto-delete list.

## How to Test

1. Run `pytest tests/plugins/test_disk_cleanup_plugin.py -v` — all 44 tests pass, including 3 new regression tests
2. The key regression test `test_quick_skips_stale_cron_output_entry_for_jobs_json` creates a stale `tracked.json` entry marking `cron/jobs.json` as `cron-output` with a 30-day-old timestamp, then verifies `quick()` does NOT delete it
3. `test_quick_deletes_legitimate_cron_output` confirms that files genuinely under `cron/output/` are still cleaned up normally

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/disk-cleanup/disk_cleanup.py` → `quick()`, `dry_run()`, `_is_under_cron_output()` (new)
- Blast radius: LOW — single plugin module, defensive guard only, no behavior change for correctly-tracked files
- Related patterns: `guess_category()` (line 483-491) already guards against tracking cron control-plane at track-time; this fix extends the same invariant to cleanup-time for stale entries
