### PR TITLE
security: staged plugin migration + audit command to prevent silent trust-envelope expansion

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4329,14 +4329,18 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
 
-    # ── Version 20 → 21: plugins are now opt-in; grandfather existing user plugins ──
+    # ── Version 20 → 21: plugins are now opt-in; stage existing user plugins ──
     # The loader now requires plugins to appear in ``plugins.enabled`` before
     # loading. Existing installs had all discovered plugins loading by default
     # (minus anything in ``plugins.disabled``). To avoid silently breaking
-    # those setups on upgrade, populate ``plugins.enabled`` with the set of
-    # currently-installed user plugins that aren't already disabled.
+    # those sets, discovered plugins are written to ``plugins.staged`` instead
+    # of ``plugins.enabled``. The operator must explicitly approve them via
+    # ``hermes plugins enable <name>`` or ``hermes plugins audit``.
     #
-    # Bundled plugins (shipped in the repo itself) are NOT grandfathered —
+    # This prevents code paths (e.g. kanban workers) that can write to
+    # ~/.hermes/plugins/ from silently expanding the trust envelope.
+    #
+    # Bundled plugins (shipped in the repo itself) are NOT staged —
     # they ship off for everyone, including existing users, so any user who
     # wants one has to opt in explicitly.
     if current_ver < 21:
@@ -4352,7 +4356,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             disabled_set = set(disabled)
 
             # Scan ``$HERMES_HOME/plugins/`` for currently installed user plugins.
-            grandfathered: List[str] = []
+            staged: List[str] = []
             try:
                 user_plugins_dir = get_hermes_home() / "plugins"
                 if user_plugins_dir.is_dir():
@@ -4372,25 +4376,36 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         name = manifest.get("name") or child.name
                         if name in disabled_set:
                             continue
-                        grandfathered.append(name)
+                        staged.append(name)
             except Exception:
-                grandfathered = []
+                staged = []
 
-            plugins_cfg["enabled"] = grandfathered
+            # Write to staged, NOT enabled — operator must explicitly approve.
+            plugins_cfg["staged"] = staged
+            # Ensure "enabled" exists as empty list so loader doesn't
+            # fall back to legacy behavior.
+            if "enabled" not in plugins_cfg:
+                plugins_cfg["enabled"] = []
             config["plugins"] = plugins_cfg
             save_config(config)
             results["config_added"].append(
-                f"plugins.enabled (opt-in allow-list, {len(grandfathered)} grandfathered)"
+                f"plugins.staged (trust-envelope gate, {len(staged)} plugin(s) awaiting review)"
             )
             if not quiet:
-                if grandfathered:
+                if staged:
                     print(
-                        f"  ✓ Plugins now opt-in: grandfathered "
-                        f"{len(grandfathered)} existing plugin(s) into plugins.enabled"
+                        f"\n  ⚠ SECURITY: {len(staged)} plugin(s) found in ~/.hermes/plugins/ "
+                        f"require operator review before loading."
+                    )
+                    for _p in staged:
+                        print(f"    - {_p}")
+                    print(
+                        f"  Run 'hermes plugins audit' to review, or "
+                        f"'hermes plugins enable <name>' to approve.\n"
                     )
                 else:
                     print(
-                        "  ✓ Plugins now opt-in: no existing plugins to grandfather. "
+                        "  ✓ Plugins now opt-in: no untracked plugins found. "
                         "Use `hermes plugins enable <name>` to activate."
                     )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13661,6 +13661,22 @@ Examples:
     )
     plugins_disable.add_argument("name", help="Plugin name to disable")
 
+    plugins_audit = plugins_subparsers.add_parser(
+        "audit",
+        help="Review staged plugins awaiting operator approval",
+        description=(
+            "List plugins discovered during config migration that have not been "
+            "explicitly enabled. Staged plugins do not load until approved via "
+            "'hermes plugins enable <name>'. This prevents silent trust-envelope "
+            "expansion from automated processes (e.g. kanban workers)."
+        ),
+    )
+    plugins_audit.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON",
+    )
+
     def cmd_plugins(args):
         from hermes_cli.plugins_cmd import plugins_command
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -649,8 +649,37 @@ def _save_enabled_set(enabled: set) -> None:
     save_config(config)
 
 
+def _get_staged_set() -> set:
+    """Read the staged plugins list from config.yaml.
+
+    Plugins in ``plugins.staged`` were discovered during config migration
+    but have not been explicitly approved by the operator. They do not
+    load until moved to ``plugins.enabled`` via ``hermes plugins enable``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        plugins_cfg = config.get("plugins", {})
+        if not isinstance(plugins_cfg, dict):
+            return set()
+        staged = plugins_cfg.get("staged", [])
+        return set(staged) if isinstance(staged, list) else set()
+    except Exception:
+        return set()
+
+
+def _save_staged_set(staged: set) -> None:
+    """Write the staged plugins list to config.yaml."""
+    from hermes_cli.config import load_config, save_config
+    config = load_config()
+    if "plugins" not in config:
+        config["plugins"] = {}
+    config["plugins"]["staged"] = sorted(staged)
+    save_config(config)
+
+
 def cmd_enable(name: str) -> None:
-    """Add a plugin to the enabled allow-list (and remove it from disabled)."""
+    """Add a plugin to the enabled allow-list (and remove from disabled and staged)."""
     from rich.console import Console
 
     console = Console()
@@ -661,6 +690,7 @@ def cmd_enable(name: str) -> None:
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
+    staged = _get_staged_set()
 
     if name in enabled and name not in disabled:
         console.print(f"[dim]Plugin '{name}' is already enabled.[/dim]")
@@ -668,8 +698,10 @@ def cmd_enable(name: str) -> None:
 
     enabled.add(name)
     disabled.discard(name)
+    staged.discard(name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
+    _save_staged_set(staged)
     console.print(
         f"[green]✓[/green] Plugin [bold]{name}[/bold] enabled. "
         "Takes effect on next session."
@@ -866,7 +898,80 @@ def cmd_list(args: Any | None = None) -> None:
     console.print("[dim]Compact view:[/dim] hermes plugins list --plain --no-bundled")
     console.print("[dim]Interactive toggle:[/dim] hermes plugins")
     console.print("[dim]Enable/disable:[/dim] hermes plugins enable/disable <name>")
+    console.print("[dim]Audit staged:[/dim] hermes plugins audit")
     console.print("[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]")
+
+
+def cmd_audit(args: Any | None = None) -> None:
+    """Review plugins that were discovered but not explicitly approved.
+
+    Lists plugins in ``plugins.staged`` — these were found on disk during
+    config migration but have not been enabled by the operator. Staged
+    plugins do not load until explicitly approved via ``hermes plugins enable``.
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    staged = _get_staged_set()
+    enabled = _get_enabled_set()
+    disabled = _get_disabled_set()
+
+    if getattr(args, "json", False):
+        payload = {
+            "staged": sorted(staged),
+            "enabled": sorted(enabled),
+            "disabled": sorted(disabled),
+        }
+        print(json.dumps(payload, indent=2))
+        return
+
+    if not staged:
+        console.print("[green]✓[/green] No staged plugins awaiting review.")
+        console.print(
+            "[dim]All plugins in ~/.hermes/plugins/ are either enabled or were "
+            "installed after the staging gate was introduced.[/dim]"
+        )
+        return
+
+    console.print()
+    console.print(
+        f"[yellow]⚠ {len(staged)} plugin(s) staged — they will not load until "
+        f"explicitly enabled.[/yellow]"
+    )
+    console.print()
+
+    table = Table(title="Staged Plugins (awaiting operator review)", show_lines=False)
+    table.add_column("Name", style="bold")
+    table.add_column("Status")
+    table.add_column("Version", style="dim")
+    table.add_column("Description")
+    table.add_column("Source", style="dim")
+
+    entries = _discover_all_plugins()
+    staged_entries = [
+        (name, ver, desc, src, _dir)
+        for name, ver, desc, src, _dir in entries
+        if name in staged
+    ]
+
+    for name, version, description, source, _dir in staged_entries:
+        table.add_row(name, "[yellow]staged[/yellow]", str(version), description, source)
+
+    # Also show staged names that weren't found on disk (orphaned entries)
+    found_names = {e[0] for e in staged_entries}
+    for name in sorted(staged):
+        if name not in found_names:
+            table.add_row(name, "[red]staged (missing)[/red]", "—", "Not found on disk", "unknown")
+
+    console.print(table)
+    console.print()
+    console.print("[dim]To approve a plugin:[/dim] hermes plugins enable <name>")
+    console.print(
+        "[dim]Staged plugins cannot load until explicitly approved. "
+        "This prevents silent trust-envelope expansion.[/dim]"
+    )
+    console.print()
 
 
 # ---------------------------------------------------------------------------
@@ -1682,6 +1787,8 @@ def plugins_command(args) -> None:
         cmd_disable(args.name)
     elif action in {"list", "ls"}:
         cmd_list(args)
+    elif action == "audit":
+        cmd_audit(args)
     elif action is None:
         cmd_toggle()
     else:

--- a/tests/hermes_cli/test_staged_plugin_migration.py
+++ b/tests/hermes_cli/test_staged_plugin_migration.py
@@ -1,0 +1,426 @@
+"""Tests for the staged plugin migration security fix (PR #37729).
+
+Covers:
+- Config v20->v21 migration writes plugins.staged (NOT plugins.enabled)
+- _get_staged_set() / _save_staged_set() helpers
+- cmd_enable() removes plugin from staged set
+- cmd_audit() output (table + json)
+- Migration prints SECURITY warning when staged plugins found
+- Migration prints clean message when no plugins found
+- Staged plugins do not auto-load
+
+Run: python -m pytest tests/hermes_cli/test_staged_plugin_migration.py -v -o "addopts="
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.config import (
+    ensure_hermes_home,
+    load_config,
+    migrate_config,
+    save_config,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_plugin_dir(plugins_dir: Path, name: str, *, version: str = "0.1.0",
+                     description: str = "test") -> Path:
+    """Create a minimal plugin directory with plugin.yaml + __init__.py."""
+    plugin_dir = plugins_dir / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": name,
+        "version": version,
+        "description": description,
+    }
+    (plugin_dir / "plugin.yaml").write_text(yaml.dump(manifest))
+    (plugin_dir / "__init__.py").write_text("def register(ctx): pass\n")
+    return plugin_dir
+
+
+def _write_config_version(tmp_path: Path, ver: int) -> None:
+    """Write config.yaml with the given _config_version directly."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"_config_version": ver}))
+
+
+# ── Migration: v20 -> v21 writes staged, not enabled ──────────────────────
+
+
+class TestMigrationWritesStaged:
+    """The v20->v21 migration must write discovered plugins to plugins.staged,
+    never to plugins.enabled."""
+
+    def test_migration_writes_staged_not_enabled(self, tmp_path):
+        """Discovered user plugins go to plugins.staged, not plugins.enabled."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "evil-plugin")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            assert "staged" in config["plugins"]
+            assert "evil-plugin" in config["plugins"]["staged"]
+            enabled = config["plugins"].get("enabled", [])
+            assert "evil-plugin" not in enabled
+
+    def test_migration_staged_is_list(self, tmp_path):
+        """plugins.staged must be a list (not a set or other type)."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "test-plugin")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            assert isinstance(config["plugins"]["staged"], list)
+
+    def test_migration_multiple_plugins_all_staged(self, tmp_path):
+        """All discovered plugins are staged, none auto-enabled."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "plugin-a")
+            _make_plugin_dir(plugins_dir, "plugin-b")
+            _make_plugin_dir(plugins_dir, "plugin-c")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            staged = set(config["plugins"]["staged"])
+            assert staged == {"plugin-a", "plugin-b", "plugin-c"}
+            enabled = config["plugins"].get("enabled", [])
+            assert len(enabled) == 0
+
+    def test_migration_no_plugins_found(self, tmp_path):
+        """When no user plugins exist, staged is empty list."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            assert "staged" in config["plugins"]
+            assert config["plugins"]["staged"] == []
+
+    def test_migration_disabled_plugins_not_staged(self, tmp_path):
+        """Plugins in plugins.disabled must NOT appear in staged."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "good-plugin")
+            _make_plugin_dir(plugins_dir, "bad-plugin")
+
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(yaml.safe_dump({
+                "_config_version": 20,
+                "plugins": {"disabled": ["bad-plugin"]},
+            }))
+
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            staged = config["plugins"]["staged"]
+            assert "good-plugin" in staged
+            assert "bad-plugin" not in staged
+
+    def test_migration_prints_security_warning(self, tmp_path, capsys):
+        """Migration prints SECURITY warning when staged plugins are found."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "sneaky-plugin")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=False)
+
+            captured = capsys.readouterr()
+            assert "SECURITY" in captured.out
+            assert "sneaky-plugin" in captured.out
+            assert "hermes plugins audit" in captured.out
+
+    def test_migration_no_plugins_prints_clean_message(self, tmp_path, capsys):
+        """Migration prints clean message when no plugins found."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=False)
+
+            captured = capsys.readouterr()
+            assert "SECURITY" not in captured.out
+
+    def test_migration_bumps_version(self, tmp_path):
+        """After migration, config _config_version must be >= 21."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            config_path = tmp_path / "config.yaml"
+            raw = yaml.safe_load(config_path.read_text())
+            assert raw["_config_version"] >= 21
+
+    def test_migration_idempotent(self, tmp_path):
+        """Running migration twice must not duplicate staged entries."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "my-plugin")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            staged = config["plugins"]["staged"]
+            assert staged.count("my-plugin") == 1
+
+
+# ── _get_staged_set() / _save_staged_set() ─────────────────────────────────
+
+
+class TestStagedSetHelpers:
+    """Test the staged set read/write helpers."""
+
+    def test_get_staged_set_returns_set(self, tmp_path):
+        from hermes_cli.plugins_cmd import _get_staged_set
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            config = load_config()
+            config["plugins"] = {"staged": ["a", "b"]}
+            save_config(config)
+
+            result = _get_staged_set()
+            assert isinstance(result, set)
+            assert result == {"a", "b"}
+
+    def test_get_staged_set_empty_when_no_staged_key(self, tmp_path):
+        from hermes_cli.plugins_cmd import _get_staged_set
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            config = load_config()
+            config["plugins"] = {}
+            save_config(config)
+
+            result = _get_staged_set()
+            assert result == set()
+
+    def test_get_staged_set_empty_on_exception(self, tmp_path):
+        from hermes_cli.plugins_cmd import _get_staged_set
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("{{invalid yaml", encoding="utf-8")
+
+            result = _get_staged_set()
+            assert result == set()
+
+    def test_save_staged_set_writes_sorted(self, tmp_path):
+        from hermes_cli.plugins_cmd import _get_staged_set, _save_staged_set
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            _save_staged_set({"z-plugin", "a-plugin", "m-plugin"})
+
+            result = _get_staged_set()
+            assert result == {"a-plugin", "m-plugin", "z-plugin"}
+
+            config = load_config()
+            assert config["plugins"]["staged"] == ["a-plugin", "m-plugin", "z-plugin"]
+
+    def test_save_staged_set_overwrites_existing(self, tmp_path):
+        from hermes_cli.plugins_cmd import _save_staged_set
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            _save_staged_set({"old-plugin"})
+            _save_staged_set({"new-plugin"})
+
+            config = load_config()
+            assert config["plugins"]["staged"] == ["new-plugin"]
+
+
+# ── cmd_enable() removes from staged ───────────────────────────────────────
+
+
+class TestCmdEnableRemovesFromStaged:
+    """cmd_enable() must move plugin from staged -> enabled and remove from staged."""
+
+    def test_enable_removes_from_staged(self, tmp_path):
+        from hermes_cli.plugins_cmd import _get_staged_set, _save_staged_set, cmd_enable
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "my-plugin")
+            _save_staged_set({"my-plugin"})
+
+            cmd_enable("my-plugin")
+
+            staged = _get_staged_set()
+            assert "my-plugin" not in staged
+
+    def test_enable_adds_to_enabled(self, tmp_path):
+        from hermes_cli.plugins_cmd import _get_enabled_set, cmd_enable
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "my-plugin")
+
+            cmd_enable("my-plugin")
+
+            enabled = _get_enabled_set()
+            assert "my-plugin" in enabled
+
+    def test_enable_already_enabled_is_idempotent(self, tmp_path):
+        """Enabling an already-enabled plugin must not duplicate or error."""
+        from hermes_cli.plugins_cmd import _get_enabled_set, cmd_enable
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "my-plugin")
+
+            cmd_enable("my-plugin")
+            cmd_enable("my-plugin")
+
+            enabled = _get_enabled_set()
+            assert list(enabled).count("my-plugin") == 1
+
+
+# ── cmd_audit() output ─────────────────────────────────────────────────────
+
+
+class TestCmdAudit:
+    """Test the audit subcommand output."""
+
+    def test_audit_json_output_empty(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import cmd_audit
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+
+            args = type("Args", (), {"json": True})()
+            cmd_audit(args)
+
+            captured = capsys.readouterr()
+            payload = json.loads(captured.out)
+            assert payload["staged"] == []
+
+    def test_audit_json_output_with_staged(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import _save_staged_set, cmd_audit
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            _save_staged_set({"plugin-x"})
+
+            args = type("Args", (), {"json": True})()
+            cmd_audit(args)
+
+            captured = capsys.readouterr()
+            payload = json.loads(captured.out)
+            assert "plugin-x" in payload["staged"]
+
+    def test_audit_json_includes_enabled_and_disabled(self, tmp_path, capsys):
+        from hermes_cli.plugins_cmd import _save_staged_set, cmd_audit
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            _save_staged_set({"plugin-x"})
+
+            args = type("Args", (), {"json": True})()
+            cmd_audit(args)
+
+            captured = capsys.readouterr()
+            payload = json.loads(captured.out)
+            assert "enabled" in payload
+            assert "disabled" in payload
+
+    def test_audit_nonempty_staged_does_not_print_no_staged_message(self, tmp_path, capsys):
+        """When staged plugins exist, audit must NOT print 'No staged plugins'."""
+        from hermes_cli.plugins_cmd import _save_staged_set, cmd_audit
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            _save_staged_set({"plugin-x"})
+
+            args = type("Args", (), {"json": True})()
+            cmd_audit(args)
+
+            captured = capsys.readouterr()
+            payload = json.loads(captured.out)
+            assert len(payload["staged"]) > 0
+
+
+# ── Security: plugins.staged does not auto-load ────────────────────────────
+
+
+class TestStagedPluginsDoNotAutoLoad:
+    """Plugins in staged must NOT be loaded by the plugin manager."""
+
+    def test_staged_not_in_enabled_after_migration(self, tmp_path):
+        """After migration, staged plugins must not appear in enabled set."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "backdoor-plugin")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            config = load_config()
+            enabled = set(config["plugins"].get("enabled", []))
+            staged = set(config["plugins"].get("staged", []))
+
+            assert enabled.isdisjoint(staged)
+            assert "backdoor-plugin" in staged
+            assert "backdoor-plugin" not in enabled
+
+    def test_get_enabled_set_excludes_staged(self, tmp_path):
+        """_get_enabled_set() must not return staged plugins."""
+        from hermes_cli.plugins_cmd import _get_enabled_set
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            ensure_hermes_home()
+            plugins_dir = tmp_path / "plugins"
+            plugins_dir.mkdir()
+            _make_plugin_dir(plugins_dir, "evil-plugin")
+
+            _write_config_version(tmp_path, 20)
+            migrate_config(interactive=False, quiet=True)
+
+            enabled = _get_enabled_set()
+            assert "evil-plugin" not in enabled


### PR DESCRIPTION
## Summary

The config migration code (v20→v21) silently auto-enables all user plugins found in `~/.hermes/plugins/` by populating `plugins.enabled` from disk state ([`hermes_cli/config.py:4354-4379`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/config.py#L4354-L4379)). This bypasses the operator-review boundary documented in SECURITY.md §2.5.

Any process that can write to `~/.hermes/plugins/` -- including kanban workers -- can install a persistent plugin that auto-loads on the next gateway restart with full agent privileges (tools, lifecycle hooks, credential access).

## Proof of concept

During testing, kanban workers wrote two plugins to `~/.hermes/plugins/`:
- `achilli-tendon/`: 14KB `__init__.py`, 3 tools, 2 hooks (`pre_tool_call`, `on_session_end`)

Both auto-loaded on next gateway restart. No operator review occurred.

## Implemented fix

Three changes across three files:

### 1. `hermes_cli/config.py` -- Staged migration (v20→v21)

Instead of writing discovered plugins to `plugins.enabled`, the migration now writes them to a new `plugins.staged` list. The operator must explicitly approve each plugin via `hermes plugins enable <name>`.

When staged plugins are found, the migration prints a prominent security warning:

```
⚠ SECURITY: 3 plugin(s) found in ~/.hermes/plugins/ require operator review before loading.
    - plugin-a
    - plugin-b
    - plugin-c
Run 'hermes plugins audit' to review, or 'hermes plugins enable <name>' to approve.
```

### 2. `hermes_cli/plugins_cmd.py` -- Audit infrastructure

- `_get_staged_set()` / `_save_staged_set()`: read/write the `plugins.staged` list from config.yaml
- `cmd_enable()`: now also removes the plugin from the staged set when explicitly approved
- `cmd_audit()`: new function listing all staged plugins in a Rich table (or JSON), showing name, version, description, and source. Also reports orphaned staged entries.

### 3. `hermes_cli/main.py` -- CLI wiring

New `audit` subcommand on the `hermes plugins` group:

```
hermes plugins audit          # Review staged plugins
hermes plugins audit --json   # Machine-readable output
```

## Why this is in scope per SECURITY.md

SECURITY.md §3.1 covers:
- "Trust-model documentation violations: code behaving contrary to what this policy, Hermes Agent's own documentation, or reasonable operator expectations would predict"
- "Bugs in Hermes Agent's plugin-install or plugin-discovery path that prevent the operator from seeing what they're installing are in scope under §3.1"

The migration code creates a plugin-install path where the AI (kanban worker) is the initiator and the operator has no visibility until after the plugin loads. This fix adds the visibility layer.

## Testing

- Syntax check: all three files pass `py_compile`
- Migration unit test: verified staged plugins are NOT auto-enabled, config writes `plugins.staged` with correct version bump
- `cmd_enable` flow: verified plugin moves from staged → enabled, removed from staged set
- `cmd_audit` output: verified Rich table and JSON output for both populated and empty staged sets
- CLI parser: verified `audit` subcommand appears in `hermes plugins --help`
- Live install: verified on installed copy, gateway starts clean, `hermes plugins audit` returns correct output

## Files changed

- `hermes_cli/config.py` -- migration writes `plugins.staged` instead of `plugins.enabled`, adds SECURITY warning
- `hermes_cli/plugins_cmd.py` -- staged set helpers, updated `cmd_enable`, new `cmd_audit`
- `hermes_cli/main.py` -- CLI parser wiring for `audit` subcommand