### PR TITLE
fix(kanban): order dashboard lane cards newest-first

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2256,6 +2256,13 @@ VALID_SORT_ORDERS: dict[str, str] = {
     "created": "created_at ASC, id ASC",
     "created-desc": "created_at DESC, id DESC",
     "priority": "priority DESC, created_at ASC",
+    # Like ``priority`` but newest-first within each priority band. Uses
+    # ``rowid DESC`` (SQLite's monotonic insert order) as the tiebreaker
+    # because ``created_at`` is second-resolution and task ids are random
+    # (``secrets.token_hex``), so ``id`` is not a chronological tiebreaker.
+    # The dashboard uses this so recently-created cards surface at the top
+    # of each lane.
+    "priority-newest": "priority DESC, created_at DESC, rowid DESC",
     "priority-desc": "priority ASC, created_at ASC",
     "status": "status ASC, created_at ASC",
     "assignee": "assignee ASC, created_at ASC",

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -396,6 +396,11 @@ def get_board(
             include_archived=include_archived,
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
+            # Newest-first within each priority band so recently-created
+            # cards surface at the top of each lane. Scoped to the dashboard
+            # rather than changing the shared ``list_tasks`` default, which
+            # triage/dispatch paths rely on (FIFO).
+            order_by="priority-newest",
         )
         # Pre-fetch link counts per task (cheap: one query).
         link_counts: dict[str, dict[str, int]] = {}

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1178,6 +1178,34 @@ def test_list_tasks_order_by(kanban_home):
         except ValueError as e:
             assert "order_by must be one of" in str(e)
 
+
+def test_list_tasks_priority_newest_orders_newest_first(kanban_home):
+    """``priority-newest`` keeps priority bands but surfaces newest first.
+
+    Regression for the kanban dashboard showing cards oldest-first within a
+    lane. ``created_at`` is second-resolution and ids are random, so the
+    newest-first ordering relies on the ``rowid DESC`` tiebreaker for tasks
+    created in the same second.
+    """
+    with kb.connect() as conn:
+        # Same priority, created in insertion order. Within a second-bucket
+        # the rowid tiebreaker must yield reverse-insertion (newest first).
+        t1 = kb.create_task(conn, title="first", priority=1)
+        t2 = kb.create_task(conn, title="second", priority=1)
+        t3 = kb.create_task(conn, title="third", priority=1)
+        # A higher-priority task created last must still sort above the
+        # priority-1 band — priority dominates the created_at direction.
+        t_hi = kb.create_task(conn, title="urgent", priority=5)
+
+        newest = kb.list_tasks(conn, order_by="priority-newest")
+        assert [t.id for t in newest] == [t_hi, t3, t2, t1]
+
+        # Sanity: the shared default is unchanged (oldest-first within band),
+        # so triage/dispatch FIFO callers are unaffected by the new option.
+        default = kb.list_tasks(conn)
+        assert [t.id for t in default] == [t_hi, t1, t2, t3]
+
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -114,6 +114,35 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_board_lane_orders_newest_first(client):
+    """Cards within a lane surface newest-first (regression for #37472).
+
+    Same-priority tasks created in sequence must appear with the most
+    recent at the top of the lane, while higher priority still wins.
+    """
+    ids = []
+    for i in range(3):
+        r = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": f"task-{i}", "priority": 1},
+        )
+        assert r.status_code == 200, r.text
+        ids.append(r.json()["task"]["id"])
+    # A higher-priority task created last must still sit at the very top.
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "urgent", "priority": 5},
+    )
+    assert r.status_code == 200, r.text
+    urgent_id = r.json()["task"]["id"]
+
+    data = client.get("/api/plugins/kanban/board").json()
+    ready = next(c for c in data["columns"] if c["name"] == "ready")
+    lane_ids = [t["id"] for t in ready["tasks"]]
+    # urgent (higher priority) first, then the priority-1 band newest-first.
+    assert lane_ids == [urgent_id, ids[2], ids[1], ids[0]]
+
+
 def test_scheduled_tasks_have_their_own_column_not_todo(client):
     """Scheduled/time-delay tasks must not be silently bucketed into todo."""
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -651,7 +651,7 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--json]
 hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived]
         [--workflow-template-id <id>] [--current-step-key <key>]
-        [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]
+        [--sort created|created-desc|priority|priority-newest|priority-desc|status|assignee|title|updated]
         [--json]
 hermes kanban show <id> [--json]
 hermes kanban assign <id> <profile>                    # or 'none' to unassign


### PR DESCRIPTION
## What & why

Fixes #37472. The kanban dashboard rendered cards **oldest-first** within each lane, so the most recently created/active task sat at the *bottom*. Users expect newest-first, with priority still respected.

Root cause: the dashboard (`plugins/kanban/dashboard/plugin_api.py::get_board`) calls `kanban_db.list_tasks()` without an explicit `order_by`, falling back to the shared default `ORDER BY priority DESC, created_at ASC`. It then appends rows into lane columns in that order, so the oldest card lands on top.

## Approach — scoped, not a global default change

The issue suggested flipping the **default** `ORDER BY` in `list_tasks()`. I deliberately did **not** do that, because the default is shared by callers that rely on oldest-first / FIFO semantics:

- `hermes_cli/kanban_specify.py` & `kanban_decompose.py` — triage **processing order** (FIFO)
- `tools/kanban_tools.py` — the agent-facing list tool, which truncates with `limit` (flipping the order would change *which* tasks survive truncation)
- `hermes kanban list` — CLI default

So instead I added a dedicated sort order and pointed only the dashboard at it:

1. New `VALID_SORT_ORDERS` entry: `"priority-newest": "priority DESC, created_at DESC, rowid DESC"`.
2. `get_board()` now passes `order_by="priority-newest"`. The shared default is untouched.
3. As a bonus, `--sort priority-newest` is now available on `hermes kanban list` (choices are derived from `VALID_SORT_ORDERS`); docs updated.

**Tiebreaker note:** I used `rowid DESC`, not `id DESC`. Task ids are random (`secrets.token_hex(4)`) and `created_at` is second-resolution, so `id` is *not* a chronological tiebreaker — `rowid` (SQLite's monotonic insert order) is the only correct one for same-second creations.

## Tests

- `tests/hermes_cli/test_kanban_db.py::test_list_tasks_priority_newest_orders_newest_first` — verifies newest-first within a priority band (exercising the `rowid` tiebreaker) **and** that the shared default is unchanged.
- `tests/plugins/test_kanban_dashboard_plugin.py::test_board_lane_orders_newest_first` — end-to-end via the `/board` endpoint: higher priority on top, then priority band newest-first.

## How to test manually

```bash
# create a few tasks, then:
hermes dashboard           # newest cards now appear at the top of each lane
hermes kanban list --sort priority-newest
```

## Platforms

Logic is pure SQLite `ORDER BY` + Python; no platform-specific code. Developed/tested on macOS (Python 3.12).

Fixes #37472