### PR TITLE
fix(gateway): reliability hardening — streaming stall watchdog, Telegram poll heartbeat, supervised tasks, launchd respawn throttle

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1574,6 +1574,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # runtime client — mirroring the chat_completions stale watchdog.
         # Read the region with .get BEFORE the worker pops it from api_kwargs.
         _bedrock_last_chunk = {"t": time.time()}
+        # Monotonic count of REAL Bedrock deltas (text/tool/reasoning),
+        # incremented in the callbacks.  The stale-kill progress-reset reads
+        # this — not the timestamp — so a stall→recover→stall sequence isn't
+        # aborted prematurely (backport of the main-path chunk-count fix).
+        _bedrock_chunks_seen = {"n": 0}
+        # Set once the poll loop gives up on a wedged stream.  Late deltas from
+        # the lingering daemon worker must NOT bleed into a later turn, so the
+        # callbacks short-circuit on this flag; the worker's interrupt check
+        # also reads it so it exits if the wedged stream ever yields an event.
+        _bedrock_gave_up = {"v": False}
         _bedrock_region = api_kwargs.get("__bedrock_region__", "us-east-1")
 
         def _bedrock_call():
@@ -1597,18 +1607,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     raise
 
                 def _on_text(text):
+                    # If the poll loop already gave up on this wedged stream,
+                    # drop late deltas so they don't bleed into a later turn.
+                    if _bedrock_gave_up["v"]:
+                        return
                     _bedrock_last_chunk["t"] = time.time()
+                    _bedrock_chunks_seen["n"] += 1
                     _fire_first()
                     agent._fire_stream_delta(text)
                     deltas_were_sent["yes"] = True
 
                 def _on_tool(name):
+                    if _bedrock_gave_up["v"]:
+                        return
                     _bedrock_last_chunk["t"] = time.time()
+                    _bedrock_chunks_seen["n"] += 1
                     _fire_first()
                     agent._fire_tool_gen_started(name)
 
                 def _on_reasoning(text):
+                    if _bedrock_gave_up["v"]:
+                        return
                     _bedrock_last_chunk["t"] = time.time()
+                    _bedrock_chunks_seen["n"] += 1
                     _fire_first()
                     agent._fire_reasoning_delta(text)
 
@@ -1617,7 +1638,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     on_text_delta=_on_text if agent._has_stream_consumers() else None,
                     on_tool_start=_on_tool,
                     on_reasoning_delta=_on_reasoning if agent.reasoning_callback or agent.stream_delta_callback else None,
-                    on_interrupt_check=lambda: agent._interrupt_requested,
+                    # Exit if interrupted OR if the poll loop gave up — so a
+                    # wedged stream that finally yields an event lets the worker
+                    # return instead of lingering as a zombie daemon.
+                    on_interrupt_check=lambda: agent._interrupt_requested or _bedrock_gave_up["v"],
                 )
             except Exception as e:
                 result["error"] = e
@@ -1634,6 +1658,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _bedrock_stale_timeout = _bedrock_stale_base
         _BEDROCK_MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
         _bedrock_stale_kills = 0
+        _bedrock_chunks_at_last_kill = 0
 
         t = threading.Thread(target=_bedrock_call, daemon=True)
         t.start()
@@ -1641,6 +1666,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             t.join(timeout=0.3)
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
+            # If a REAL delta arrived since the last kill (chunk count
+            # advanced), the stream made genuine progress — reset the kill
+            # counter so a stall→recover→stall sequence isn't aborted
+            # prematurely (mirrors the main path's chunk-count progress-reset).
+            if _bedrock_stale_kills and _bedrock_chunks_seen["n"] > _bedrock_chunks_at_last_kill:
+                _bedrock_stale_kills = 0
             # Stale watchdog: a wedged Bedrock stream delivers no deltas and
             # no error.  Kill the cached runtime client so a fresh client/pool
             # is built, and give up after _BEDROCK_MAX_STALE_KILLS.
@@ -1653,9 +1684,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 try:
                     from agent.bedrock_adapter import invalidate_runtime_client
                     invalidate_runtime_client(_bedrock_region)
-                except Exception:
-                    pass
+                except Exception as _e:
+                    logger.debug("Bedrock runtime client invalidate failed: %s", _e)
                 _bedrock_last_chunk["t"] = time.time()
+                _bedrock_chunks_at_last_kill = _bedrock_chunks_seen["n"]
                 _bedrock_stale_kills += 1
                 if _bedrock_stale_kills >= _BEDROCK_MAX_STALE_KILLS:
                     logger.error(
@@ -1664,6 +1696,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         _bedrock_stale_kills, _bedrock_stale_timeout,
                         _BEDROCK_MAX_STALE_KILLS, _bedrock_region,
                     )
+                    # Signal the lingering worker + callbacks to stand down.
+                    # invalidate_runtime_client only evicts the cache for FUTURE
+                    # calls — it cannot abort the in-flight botocore EventStream
+                    # the worker is blocked on, so the worker may linger as a
+                    # daemon until that stream errors.  _bedrock_gave_up makes
+                    # the callbacks drop any late deltas (no cross-turn bleed)
+                    # and the worker's interrupt check exit if the stream ever
+                    # yields an event.
+                    _bedrock_gave_up["v"] = True
                     result["error"] = TimeoutError(
                         f"Bedrock stream stalled {_bedrock_stale_kills}x "
                         f"(>{int(_bedrock_stale_timeout)}s each); aborting."
@@ -1713,6 +1754,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # Monotonic count of REAL streamed chunks/events delivered by the worker,
+    # incremented only inside the chunk/event loop (never at attempt start).
+    # The stale-kill ceiling uses this — not last_chunk_time — to decide
+    # whether real progress was made between kills.  last_chunk_time is reset
+    # to time.time() at the start of every retry attempt (with no chunk
+    # delivered), so keying the progress-reset on the timestamp let a
+    # kill→client-close→worker-retry→re-wedge loop bump the timer without any
+    # real chunk, resetting _stale_kills forever and defeating the ceiling.
+    chunks_seen = {"n": 0}
 
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
@@ -1808,6 +1858,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         usage_obj = None
         for chunk in stream:
             last_chunk_time["t"] = time.time()
+            # Real chunk delivered this iteration — bump the monotonic counter
+            # the stale-kill ceiling reads.  Only ever incremented here (in the
+            # loop body), never at attempt start, so the kill→retry→re-wedge
+            # loop can't fake progress by resetting last_chunk_time.
+            chunks_seen["n"] += 1
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -2044,6 +2099,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # actively arriving (the chat_completions path
                 # already does this at the top of its chunk loop).
                 last_chunk_time["t"] = time.time()
+                # Real event delivered — bump the monotonic counter the
+                # stale-kill ceiling reads (loop body only, never at attempt
+                # start) so a kill→retry→re-wedge loop can't fake progress.
+                chunks_seen["n"] += 1
                 agent._touch_activity("receiving stream response")
 
                 # Update per-attempt diagnostic counters (best-effort).
@@ -2380,8 +2439,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # forever — the request wedges indefinitely.  After _MAX_STALE_KILLS
     # consecutive stale kills with no real progress, give up and surface a
     # TimeoutError so the outer retry/failover machinery can take over.
+    #
+    # The progress-reset is keyed on chunks_seen["n"] (a count of REAL chunks
+    # delivered by the worker), NOT on last_chunk_time.  last_chunk_time is
+    # reset to time.time() at the start of every retry attempt with no chunk
+    # delivered (workers reset it before the stream call), so a timestamp-based
+    # marker let the kill→client-close→worker-retry→re-wedge loop bump the
+    # timer without any real chunk — resetting _stale_kills forever and
+    # defeating this ceiling.  A chunk count only advances on genuine progress.
     _stale_kills = 0
-    _stale_kill_marker = None
+    _chunks_at_last_kill = 0
     _MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
     while t.is_alive():
         t.join(timeout=0.3)
@@ -2405,12 +2472,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
-        # If the worker advanced last_chunk_time past OUR reset marker, the
-        # stream made real progress (a chunk arrived) after the last kill —
-        # so a stall→recover→stall sequence isn't aborted prematurely.
-        if _stale_kill_marker is not None and last_chunk_time["t"] != _stale_kill_marker:
+        # If the worker delivered a REAL chunk since the last kill
+        # (chunks_seen advanced), the stream made genuine progress — so a
+        # stall→recover→stall sequence isn't aborted prematurely.  Keyed on
+        # the chunk count, this is immune to the retry-attempt last_chunk_time
+        # bump (which delivers no chunk) and to the prior TOCTOU that read the
+        # shared timestamp dict twice.
+        if _stale_kills and chunks_seen["n"] > _chunks_at_last_kill:
             _stale_kills = 0
-            _stale_kill_marker = None
         _stale_elapsed = time.time() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
@@ -2439,7 +2508,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()
-            _stale_kill_marker = last_chunk_time["t"]
+            # Snapshot the real-chunk count at this kill.  The progress-reset
+            # above only fires if chunks_seen advances PAST this snapshot —
+            # i.e. a genuine chunk arrived, not just an attempt-start timer
+            # bump from the worker's retry loop.
+            _chunks_at_last_kill = chunks_seen["n"]
             _stale_kills += 1
             if _stale_kills >= _MAX_STALE_KILLS:
                 logger.error(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1569,6 +1569,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 except Exception:
                     pass
 
+        # Track the timestamp of the last real delta so the poll loop can
+        # detect a wedged Bedrock stream (no chunks, no error) and kill the
+        # runtime client — mirroring the chat_completions stale watchdog.
+        # Read the region with .get BEFORE the worker pops it from api_kwargs.
+        _bedrock_last_chunk = {"t": time.time()}
+        _bedrock_region = api_kwargs.get("__bedrock_region__", "us-east-1")
+
         def _bedrock_call():
             try:
                 from agent.bedrock_adapter import (
@@ -1590,15 +1597,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     raise
 
                 def _on_text(text):
+                    _bedrock_last_chunk["t"] = time.time()
                     _fire_first()
                     agent._fire_stream_delta(text)
                     deltas_were_sent["yes"] = True
 
                 def _on_tool(name):
+                    _bedrock_last_chunk["t"] = time.time()
                     _fire_first()
                     agent._fire_tool_gen_started(name)
 
                 def _on_reasoning(text):
+                    _bedrock_last_chunk["t"] = time.time()
                     _fire_first()
                     agent._fire_reasoning_delta(text)
 
@@ -1612,12 +1622,53 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             except Exception as e:
                 result["error"] = e
 
+        # Compute the stale timeout with the same scaling as the main path:
+        # large contexts legitimately stall longer during prefill/thinking.
+        _bedrock_stale_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", "180.0"))
+        _bedrock_est_tokens = estimate_request_context_tokens(api_kwargs)
+        if _bedrock_est_tokens > 100_000:
+            _bedrock_stale_timeout = max(_bedrock_stale_base, 300.0)
+        elif _bedrock_est_tokens > 50_000:
+            _bedrock_stale_timeout = max(_bedrock_stale_base, 240.0)
+        else:
+            _bedrock_stale_timeout = _bedrock_stale_base
+        _BEDROCK_MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
+        _bedrock_stale_kills = 0
+
         t = threading.Thread(target=_bedrock_call, daemon=True)
         t.start()
         while t.is_alive():
             t.join(timeout=0.3)
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
+            # Stale watchdog: a wedged Bedrock stream delivers no deltas and
+            # no error.  Kill the cached runtime client so a fresh client/pool
+            # is built, and give up after _BEDROCK_MAX_STALE_KILLS.
+            if (time.time() - _bedrock_last_chunk["t"]) > _bedrock_stale_timeout:
+                logger.warning(
+                    "Bedrock stream stale for >%.0fs — no chunks received. "
+                    "region=%s. Invalidating runtime client.",
+                    _bedrock_stale_timeout, _bedrock_region,
+                )
+                try:
+                    from agent.bedrock_adapter import invalidate_runtime_client
+                    invalidate_runtime_client(_bedrock_region)
+                except Exception:
+                    pass
+                _bedrock_last_chunk["t"] = time.time()
+                _bedrock_stale_kills += 1
+                if _bedrock_stale_kills >= _BEDROCK_MAX_STALE_KILLS:
+                    logger.error(
+                        "Bedrock stream stalled %dx (>%.0fs each) — giving up "
+                        "after %d kills. region=%s",
+                        _bedrock_stale_kills, _bedrock_stale_timeout,
+                        _BEDROCK_MAX_STALE_KILLS, _bedrock_region,
+                    )
+                    result["error"] = TimeoutError(
+                        f"Bedrock stream stalled {_bedrock_stale_kills}x "
+                        f"(>{int(_bedrock_stale_timeout)}s each); aborting."
+                    )
+                    break
         if result["error"] is not None:
             raise result["error"]
         return result["response"]
@@ -2294,11 +2345,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     else:
         _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts.  Disable the stale detector unless
-    # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
+    # for prefill on large contexts.  Use a generous-but-finite stale
+    # timeout (default 900s) unless the user explicitly set
+    # HERMES_STREAM_STALE_TIMEOUT.  A wedged local server (process hung,
+    # GPU stuck) must eventually trip the watchdog instead of hanging the
+    # worker forever — float("inf") here used to make a wedge permanent.
     if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
+        _stream_stale_timeout = float(os.getenv("HERMES_LOCAL_STREAM_STALE_TIMEOUT", "900.0"))
+        logger.debug(
+            "Local provider detected (%s) — using generous stale stream timeout %.0fs",
+            agent.base_url, _stream_stale_timeout,
+        )
     else:
         # Scale the stale timeout for large contexts: slow models (like Opus)
         # can legitimately think for minutes before producing the first token
@@ -2317,6 +2374,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     t.start()
     _last_heartbeat = time.time()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
+    # Bounded stale-kill ceiling.  Without this, a provider that holds the
+    # connection open with SSE pings (no chunks, no error) makes the worker
+    # never return, and the watchdog's kill→rebuild→reset cycle repeats
+    # forever — the request wedges indefinitely.  After _MAX_STALE_KILLS
+    # consecutive stale kills with no real progress, give up and surface a
+    # TimeoutError so the outer retry/failover machinery can take over.
+    _stale_kills = 0
+    _stale_kill_marker = None
+    _MAX_STALE_KILLS = int(os.getenv("HERMES_STREAM_MAX_STALE_KILLS", "3"))
     while t.is_alive():
         t.join(timeout=0.3)
 
@@ -2339,6 +2405,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
         # inner retry loop can start a fresh connection.
+        # If the worker advanced last_chunk_time past OUR reset marker, the
+        # stream made real progress (a chunk arrived) after the last kill —
+        # so a stall→recover→stall sequence isn't aborted prematurely.
+        if _stale_kill_marker is not None and last_chunk_time["t"] != _stale_kill_marker:
+            _stale_kills = 0
+            _stale_kill_marker = None
         _stale_elapsed = time.time() - last_chunk_time["t"]
         if _stale_elapsed > _stream_stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
@@ -2367,6 +2439,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()
+            _stale_kill_marker = last_chunk_time["t"]
+            _stale_kills += 1
+            if _stale_kills >= _MAX_STALE_KILLS:
+                logger.error(
+                    "Stream stalled %dx (>%.0fs each) with no progress — "
+                    "giving up after %d kills. model=%s",
+                    _stale_kills, _stream_stale_timeout, _MAX_STALE_KILLS,
+                    api_kwargs.get("model", "unknown"),
+                )
+                result["error"] = TimeoutError(
+                    f"Stream stalled {_stale_kills}x "
+                    f"(>{int(_stream_stale_timeout)}s each); aborting."
+                )
+                break
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -430,6 +430,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             if meta is None:
                                 continue
                             _idx, _name, _args = meta
+                            # Only synthesize a timeout result if the slot is
+                            # still empty.  An abandoned daemon worker may later
+                            # finish and write results[_idx] itself — that race
+                            # is harmless and intentionally tolerated: the turn's
+                            # tool-results are already assembled downstream from
+                            # this synthesized value, so a late real write only
+                            # mutates an array nothing reads anymore.
                             if results[_idx] is None:
                                 results[_idx] = (
                                     _name, _args,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -353,9 +353,20 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if block_result is None
         ]
         futures = []
+        # Aggregate batch deadline.  A single wedged tool would otherwise
+        # hang forever: the ThreadPoolExecutor's context-manager __exit__
+        # calls shutdown(wait=True), which blocks indefinitely on the stuck
+        # worker.  We manage the executor manually so that on timeout we can
+        # shutdown(wait=False, cancel_futures=True) and not block on the wedge.
+        _batch_timeout = float(os.getenv("HERMES_TOOL_BATCH_TIMEOUT", "900.0"))
+        _batch_timed_out = False
         if runnable_calls:
             max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+            # Map each submitted future → (index, name, args) so we can
+            # synthesize a timeout result into results[index] on abandonment.
+            _future_meta = {}
+            try:
                 for i, tc, name, args in runnable_calls:
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo
@@ -364,6 +375,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         propagate_context_to_thread(_run_tool), i, tc, name, args
                     )
                     futures.append(f)
+                    _future_meta[f] = (i, name, args)
 
                 # Wait for all to complete with periodic heartbeats so the
                 # gateway's inactivity monitor doesn't kill us during long
@@ -399,6 +411,35 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
+                    # Aggregate batch deadline: a wedged tool that ignores the
+                    # interrupt signal (no interrupt check, blocking syscall)
+                    # must not hang the whole turn forever.  After the deadline,
+                    # cancel/abandon the stragglers and synthesize timeout
+                    # results so the conversation loop can continue.
+                    if (time.time() - _conc_start) > _batch_timeout:
+                        _batch_timed_out = True
+                        logger.error(
+                            "Concurrent tool batch exceeded %.0fs deadline — "
+                            "abandoning %d unfinished tool(s).",
+                            _batch_timeout, len(not_done),
+                        )
+                        _elapsed = time.time() - _conc_start
+                        for f in not_done:
+                            f.cancel()
+                            meta = _future_meta.get(f)
+                            if meta is None:
+                                continue
+                            _idx, _name, _args = meta
+                            if results[_idx] is None:
+                                results[_idx] = (
+                                    _name, _args,
+                                    f"Error: tool '{_name}' exceeded the "
+                                    f"{int(_batch_timeout)}s batch timeout and "
+                                    f"was abandoned.",
+                                    float(_elapsed), True, False,
+                                )
+                        break
+
                     _conc_elapsed = int(time.time() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
@@ -411,6 +452,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             f"concurrent tools running ({_conc_elapsed}s, "
                             f"{len(not_done)} remaining: {', '.join(_still_running[:3])})"
                         )
+            finally:
+                # On a clean finish (or interrupt) we still want to reap the
+                # workers (wait=True).  On batch timeout, a wedged worker would
+                # block shutdown forever, so don't wait — cancel pending work
+                # and let the daemon thread leak rather than hang the turn.
+                executor.shutdown(
+                    wait=not _batch_timed_out, cancel_futures=True
+                )
     finally:
         if spinner:
             # Build a summary message for the spinner stop

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -438,6 +438,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
+        self._polling_heartbeat_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
@@ -1067,6 +1068,59 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, HEARTBEAT_PROBE_DELAY, probe_err,
             )
             await self._handle_polling_network_error(probe_err)
+
+    async def _polling_heartbeat_loop(self) -> None:
+        """Always-on polling liveness heartbeat.
+
+        Background (2026-05-29 silent-wedge incident): all other polling
+        self-healing is *reactive* — it depends either on PTB firing an
+        error callback (`_handle_polling_*`) or on a prior successful
+        reconnect scheduling the one-shot `_verify_polling_after_reconnect`
+        probe. A network blip that wedges the long-poll WITHOUT firing a
+        callback and WITHOUT a preceding reconnect leaves the bot deaf
+        forever: `Updater.running` stays True, no callback fires, no probe
+        is ever scheduled, and inbound messages are silently dropped.
+
+        This loop runs unconditionally for the lifetime of the polling
+        connection. Every INTERVAL seconds it confirms the updater is
+        running and that a tight-timeout `get_me()` probe succeeds. On
+        either failure it re-enters the existing reconnect ladder via
+        `_handle_polling_network_error`, which can ultimately escalate to
+        a fatal error and trigger a full platform reconnect.
+        """
+        INTERVAL = float(os.getenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "90"))
+        PROBE_TIMEOUT = 10
+
+        while not self.has_fatal_error:
+            try:
+                await asyncio.sleep(INTERVAL)
+            except asyncio.CancelledError:
+                return
+
+            if self.has_fatal_error:
+                return
+
+            # A reconnect ladder is already in flight — let it run; probing
+            # mid-reconnect would race with stop()/start_polling().
+            if self._polling_error_task and not self._polling_error_task.done():
+                continue
+
+            updater = getattr(self._app, "updater", None) if self._app else None
+            if updater is None:
+                return
+
+            if not updater.running:
+                await self._handle_polling_network_error(
+                    RuntimeError("Updater not running (heartbeat)")
+                )
+                continue
+
+            try:
+                await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                await self._handle_polling_network_error(e)
 
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":
@@ -1767,6 +1821,20 @@ class TelegramAdapter(BasePlatformAdapter):
             mode = "webhook" if self._webhook_mode else "polling"
             logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
 
+            # Start the always-on polling liveness heartbeat (2026-05-29
+            # silent-wedge defense). Polling mode only; opt-out via
+            # HERMES_TELEGRAM_HEARTBEAT_INTERVAL=0 so tests that globally
+            # mock asyncio.sleep don't spin a tight loop.
+            try:
+                _hb = float(os.getenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "90"))
+            except ValueError:
+                _hb = 90.0
+            if _hb > 0 and not getattr(self, "_webhook_mode", False) and not self.has_fatal_error:
+                hb_task = asyncio.ensure_future(self._polling_heartbeat_loop())
+                self._polling_heartbeat_task = hb_task
+                self._background_tasks.add(hb_task)
+                hb_task.add_done_callback(self._background_tasks.discard)
+
             # Set up DM topics (Bot API 9.4 — Private Chat Topics)
             # Runs after connection is established so the bot can call createForumTopic.
             # Failures here are non-fatal — the bot works fine without topics.
@@ -1789,6 +1857,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending album flushes, and disconnect."""
+        hb = getattr(self, "_polling_heartbeat_task", None)
+        if hb and not hb.done():
+            hb.cancel()
+            self._polling_heartbeat_task = None
+
         pending_media_group_tasks = list(self._media_group_tasks.values())
         for task in pending_media_group_tasks:
             task.cancel()

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1088,7 +1088,10 @@ class TelegramAdapter(BasePlatformAdapter):
         `_handle_polling_network_error`, which can ultimately escalate to
         a fatal error and trigger a full platform reconnect.
         """
-        INTERVAL = float(os.getenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "90"))
+        try:
+            INTERVAL = float(os.getenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "90"))
+        except ValueError:
+            INTERVAL = 90.0
         PROBE_TIMEOUT = 10
 
         while not self.has_fatal_error:
@@ -1107,20 +1110,35 @@ class TelegramAdapter(BasePlatformAdapter):
 
             updater = getattr(self._app, "updater", None) if self._app else None
             if updater is None:
-                return
+                # `self._app` is transiently None during a reconnect (the app
+                # gets rebuilt). Keep looping rather than returning — returning
+                # would permanently kill the heartbeat. disconnect() cancels
+                # this task, so looping here is safe.
+                continue
 
             if not updater.running:
-                await self._handle_polling_network_error(
-                    RuntimeError("Updater not running (heartbeat)")
-                )
+                try:
+                    await self._handle_polling_network_error(
+                        RuntimeError("Updater not running (heartbeat)")
+                    )
+                except Exception as _he:
+                    logger.warning(
+                        "[%s] heartbeat recovery raised: %s", self.name, _he
+                    )
                 continue
 
             try:
                 await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
+                self._send_path_degraded = False
             except asyncio.CancelledError:
                 return
             except Exception as e:
-                await self._handle_polling_network_error(e)
+                try:
+                    await self._handle_polling_network_error(e)
+                except Exception as _he:
+                    logger.warning(
+                        "[%s] heartbeat recovery raised: %s", self.name, _he
+                    )
 
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":
@@ -1830,10 +1848,24 @@ class TelegramAdapter(BasePlatformAdapter):
             except ValueError:
                 _hb = 90.0
             if _hb > 0 and not getattr(self, "_webhook_mode", False) and not self.has_fatal_error:
+                # Cancel any pre-existing heartbeat so a reconnect can't leave
+                # two heartbeat loops running concurrently.
+                _old = getattr(self, "_polling_heartbeat_task", None)
+                if _old and not _old.done():
+                    _old.cancel()
                 hb_task = asyncio.ensure_future(self._polling_heartbeat_loop())
                 self._polling_heartbeat_task = hb_task
                 self._background_tasks.add(hb_task)
-                hb_task.add_done_callback(self._background_tasks.discard)
+
+                def _hb_done(t: asyncio.Task) -> None:
+                    self._background_tasks.discard(t)
+                    if not t.cancelled() and t.exception() is not None:
+                        logger.error(
+                            "[%s] polling heartbeat loop died: %r",
+                            self.name, t.exception(),
+                        )
+
+                hb_task.add_done_callback(_hb_done)
 
             # Set up DM topics (Bot API 9.4 — Private Chat Topics)
             # Runs after connection is established so the bot can call createForumTopic.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4674,7 +4674,11 @@ class GatewayRunner:
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
-                asyncio.create_task(self._run_process_watcher(watcher))
+                self._spawn_supervised(
+                    lambda w=watcher: self._run_process_watcher(w),
+                    f"process_watcher:{watcher.get('session_id')}",
+                    restart=False,
+                )
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
@@ -4682,18 +4686,18 @@ class GatewayRunner:
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        asyncio.create_task(self._session_expiry_watcher())
+        self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
 
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
         # so human-in-the-loop workflows hear back without polling.
-        asyncio.create_task(self._kanban_notifier_watcher())
+        self._spawn_supervised(self._kanban_notifier_watcher, "kanban_notifier_watcher")
 
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
         # simply don't use kanban; this loop becomes a no-op.
-        asyncio.create_task(self._kanban_dispatcher_watcher())
+        self._spawn_supervised(self._kanban_dispatcher_watcher, "kanban_dispatcher_watcher")
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -4702,17 +4706,62 @@ class GatewayRunner:
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        self._spawn_supervised(self._platform_reconnect_watcher, "platform_reconnect_watcher")
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
         # destination platform's home channel, then forges a synthetic user
         # turn so the agent kicks off the new chat.
-        asyncio.create_task(self._handoff_watcher())
+        self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
 
         logger.info("Press Ctrl+C to stop")
-        
+
         return True
+
+    def _spawn_supervised(self, coro_factory, name, *, restart=True):
+        """Launch a long-lived background task with supervision.
+
+        Bare ``asyncio.create_task(...)`` for the gateway's long-lived
+        watchers means a transient unhandled exception silently kills the
+        task with no log and no recovery — e.g. one raise inside
+        ``_platform_reconnect_watcher`` permanently disables the only
+        platform-reconnect mechanism while the gateway keeps running and
+        looking healthy.
+
+        This wrapper keeps a handle in ``_background_tasks``, logs any
+        non-cancellation exception with a traceback, and (when ``restart``
+        is True and the gateway is still running) respawns the task after a
+        short back-off so a one-off blip doesn't permanently lose the
+        watcher.
+        """
+        # Some test harnesses construct the runner without running __init__.
+        if getattr(self, "_background_tasks", None) is None:
+            self._background_tasks = set()
+
+        # NOTE: deliberately do NOT pass name= to create_task — a test
+        # replaces create_task with a fake that rejects the name kwarg.
+        task = asyncio.create_task(coro_factory())
+        self._background_tasks.add(task)
+
+        def _done(t):
+            self._background_tasks.discard(t)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is None:
+                return
+            logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
+            if restart and self._running:
+                async def _respawn():
+                    await asyncio.sleep(1.0)
+                    if self._running:
+                        self._spawn_supervised(coro_factory, name, restart=restart)
+                respawn_task = asyncio.create_task(_respawn())
+                self._background_tasks.add(respawn_task)
+                respawn_task.add_done_callback(self._background_tasks.discard)
+
+        task.add_done_callback(_done)
+        return task
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4718,7 +4718,9 @@ class GatewayRunner:
 
         return True
 
-    def _spawn_supervised(self, coro_factory, name, *, restart=True):
+    _MAX_SUPERVISED_RESTARTS = 5
+
+    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0):
         """Launch a long-lived background task with supervision.
 
         Bare ``asyncio.create_task(...)`` for the gateway's long-lived
@@ -4730,9 +4732,14 @@ class GatewayRunner:
 
         This wrapper keeps a handle in ``_background_tasks``, logs any
         non-cancellation exception with a traceback, and (when ``restart``
-        is True and the gateway is still running) respawns the task after a
-        short back-off so a one-off blip doesn't permanently lose the
-        watcher.
+        is True and the gateway is still running) respawns the task with a
+        bounded exponential back-off so a one-off blip doesn't permanently
+        lose the watcher — while a *deterministic* crash can't flood the
+        logs forever. ``_attempt`` is the count of consecutive immediate
+        failures; it grows the back-off (``min(60, 2 ** min(_attempt, 6))``
+        seconds) and, once it reaches ``_MAX_SUPERVISED_RESTARTS``, restarts
+        are abandoned. A clean return (no exception) resets the counter by
+        spawning a fresh task at ``_attempt=0``.
         """
         # Some test harnesses construct the runner without running __init__.
         if getattr(self, "_background_tasks", None) is None:
@@ -4749,13 +4756,38 @@ class GatewayRunner:
                 return
             exc = t.exception()
             if exc is None:
+                # Clean return — these are infinite ``while self._running``
+                # loops, so a clean completion means the loop exited normally
+                # (e.g. shutdown). If we still need to restart, do so with a
+                # reset attempt counter.
+                if restart and self._running:
+                    async def _respawn_clean():
+                        if self._running:
+                            self._spawn_supervised(
+                                coro_factory, name, restart=restart, _attempt=0
+                            )
+                    respawn_task = asyncio.create_task(_respawn_clean())
+                    self._background_tasks.add(respawn_task)
+                    respawn_task.add_done_callback(self._background_tasks.discard)
                 return
             logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
             if restart and self._running:
+                if _attempt >= self._MAX_SUPERVISED_RESTARTS:
+                    logger.error(
+                        "Supervised task %s died %d times consecutively — "
+                        "giving up restarts",
+                        name, _attempt,
+                    )
+                    return
+                backoff = min(60, 2 ** min(_attempt, 6))
+
                 async def _respawn():
-                    await asyncio.sleep(1.0)
+                    await asyncio.sleep(backoff)
                     if self._running:
-                        self._spawn_supervised(coro_factory, name, restart=restart)
+                        self._spawn_supervised(
+                            coro_factory, name, restart=restart,
+                            _attempt=_attempt + 1,
+                        )
                 respawn_task = asyncio.create_task(_respawn())
                 self._background_tasks.add(respawn_task)
                 respawn_task.add_done_callback(self._background_tasks.discard)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4738,8 +4738,10 @@ class GatewayRunner:
         logs forever. ``_attempt`` is the count of consecutive immediate
         failures; it grows the back-off (``min(60, 2 ** min(_attempt, 6))``
         seconds) and, once it reaches ``_MAX_SUPERVISED_RESTARTS``, restarts
-        are abandoned. A clean return (no exception) resets the counter by
-        spawning a fresh task at ``_attempt=0``.
+        are abandoned. A clean return (no exception) is NOT respawned: these
+        ``while self._running`` loops only return cleanly on shutdown or when
+        they deliberately short-circuit (e.g. a watcher disabled by config),
+        and respawning either case would busy-spin.
         """
         # Some test harnesses construct the runner without running __init__.
         if getattr(self, "_background_tasks", None) is None:
@@ -4757,18 +4759,12 @@ class GatewayRunner:
             exc = t.exception()
             if exc is None:
                 # Clean return — these are infinite ``while self._running``
-                # loops, so a clean completion means the loop exited normally
-                # (e.g. shutdown). If we still need to restart, do so with a
-                # reset attempt counter.
-                if restart and self._running:
-                    async def _respawn_clean():
-                        if self._running:
-                            self._spawn_supervised(
-                                coro_factory, name, restart=restart, _attempt=0
-                            )
-                    respawn_task = asyncio.create_task(_respawn_clean())
-                    self._background_tasks.add(respawn_task)
-                    respawn_task.add_done_callback(self._background_tasks.discard)
+                # loops, so a clean completion means either shutdown
+                # (self._running is False) or a deliberate short-circuit
+                # (e.g. a watcher disabled by config returns synchronously).
+                # Neither should respawn: respawning a synchronously-returning
+                # watcher would busy-spin the event loop with no backoff and
+                # the exception-only ceiling would never engage.
                 return
             logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
             if restart and self._running:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1109,10 +1109,13 @@ def record_start_and_check_storm(
         # Ring-buffer the on-disk log so it can't grow unbounded.
         keep = max(max_starts * 4, 40)
         to_write = existing[-keep:]
-        log_path.write_text(
-            "\n".join(f"{ts:.6f}" for ts in to_write) + "\n",
-            encoding="utf-8",
-        )
+        # Write atomically (temp file in the same dir + os.replace) so a
+        # concurrent overlapping restart during a storm — the exact case this
+        # runs in — can never observe a truncated/corrupt half-written log.
+        payload = "\n".join(f"{ts:.6f}" for ts in to_write) + "\n"
+        tmp_path = log_path.with_suffix(".tmp")
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, log_path)
 
         if len(recent) > max_starts:
             over = len(recent) - max_starts

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -20,7 +20,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 from utils import atomic_json_write
 
 if sys.platform == "win32":
@@ -1043,3 +1043,82 @@ def is_gateway_running(
 ) -> bool:
     """Check if the gateway daemon is currently running."""
     return get_running_pid(pid_path, cleanup_stale=cleanup_stale) is not None
+
+
+class StormInfo(NamedTuple):
+    """Result of a respawn-storm check.
+
+    ``count`` is how many starts were recorded inside ``window_s`` seconds,
+    ``window_s`` is the observation window, and ``backoff_s`` is how long the
+    caller should sleep to break the storm.
+    """
+
+    count: int
+    window_s: float
+    backoff_s: float
+
+
+def _get_starts_log_path() -> Path:
+    """Return the path to the gateway start-times log, respecting HERMES_HOME."""
+    return get_hermes_home() / "gateway-starts.log"
+
+
+def record_start_and_check_storm(
+    max_starts: int = 5,
+    window_s: float = 120.0,
+    *,
+    backoff_cap_s: float = 300.0,
+) -> Optional[StormInfo]:
+    """Record a gateway start and detect a respawn storm.
+
+    Appends the current UTC timestamp to ``{HERMES_HOME}/gateway-starts.log``,
+    prunes entries older than ``window_s``, and ring-buffers the file so it can
+    never grow unbounded. If more than ``max_starts`` starts have happened
+    inside the window, returns a :class:`StormInfo` describing an exponential
+    backoff the caller should sleep for to break the storm; otherwise returns
+    ``None``.
+
+    This is a portable, app-level circuit breaker that works regardless of the
+    supervisor (launchd ``KeepAlive``, systemd ``Restart=``, or bare manual
+    re-runs) — anything that re-invokes the gateway process gets counted.
+
+    The entire body is wrapped in a broad ``try/except`` that returns ``None``
+    on any failure: the breaker must never block or crash startup.
+    """
+    try:
+        now = datetime.now(timezone.utc).timestamp()
+        log_path = _get_starts_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: list[float] = []
+        if log_path.exists():
+            for line in log_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    existing.append(float(line))
+                except ValueError:
+                    continue
+
+        existing.append(now)
+
+        # Keep only entries within the observation window.
+        recent = [ts for ts in existing if now - ts <= window_s]
+
+        # Ring-buffer the on-disk log so it can't grow unbounded.
+        keep = max(max_starts * 4, 40)
+        to_write = existing[-keep:]
+        log_path.write_text(
+            "\n".join(f"{ts:.6f}" for ts in to_write) + "\n",
+            encoding="utf-8",
+        )
+
+        if len(recent) > max_starts:
+            over = len(recent) - max_starts
+            backoff_s = min(backoff_cap_s, 5.0 * (2 ** min(over, 6)))
+            return StormInfo(count=len(recent), window_s=window_s, backoff_s=backoff_s)
+
+        return None
+    except Exception:
+        return None

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3586,7 +3586,26 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         import time as _time
         from gateway.status import record_start_and_check_storm
 
-        _storm = record_start_and_check_storm()
+        # Operator overrides: HERMES_GATEWAY_MAX_STARTS <= 0 disables the breaker
+        # entirely (e.g. deliberate rapid `gateway run --replace` config iteration),
+        # and HERMES_GATEWAY_START_WINDOW_S tunes the observation window. Parse
+        # defensively so a bad value never blocks startup.
+        try:
+            _max_starts = int(os.environ.get("HERMES_GATEWAY_MAX_STARTS", "5"))
+        except ValueError:
+            _max_starts = 5
+        try:
+            _start_window_s = float(os.environ.get("HERMES_GATEWAY_START_WINDOW_S", "120"))
+        except ValueError:
+            _start_window_s = 120.0
+
+        _storm = (
+            None
+            if _max_starts <= 0
+            else record_start_and_check_storm(
+                max_starts=_max_starts, window_s=_start_window_s
+            )
+        )
         if _storm is not None:
             logger.warning(
                 "Gateway (re)started %d times in %.0fs — backing off %.0fs to break a respawn storm.",
@@ -3601,8 +3620,8 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
                 backoff_s=_storm.backoff_s,
             )
             _time.sleep(_storm.backoff_s)
-    except Exception:
-        pass
+    except Exception as _be:
+        logger.debug("respawn-storm breaker check failed (non-fatal): %s", _be)
 
     success = False
     try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3087,7 +3087,17 @@ def generate_launchd_plist() -> str:
         <key>SuccessfulExit</key>
         <false/>
     </dict>
-    
+
+    <!-- ThrottleInterval raises launchd's default 10s respawn floor to 30s so a
+         repeatedly-SIGTERM'd gateway can't trigger a tight respawn storm (~40
+         restarts in 7 min observed 2026-05-23). ExitTimeOut gives the process
+         25s of graceful-drain headroom before launchd SIGKILLs it on stop. -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ExitTimeOut</key>
+    <integer>25</integer>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     
@@ -3566,6 +3576,33 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         _exit_diag("atexit.hook", sys_exc=repr(sys.exc_info()))
 
     _atexit.register(_atexit_hook)
+
+    # Portable, supervisor-agnostic respawn-storm circuit breaker. If this
+    # process has been (re)started too many times in a short window — e.g. a
+    # launchd KeepAlive / systemd Restart= loop — back off before re-entering
+    # the event loop so we don't melt the machine. Never let this block or
+    # crash startup.
+    try:
+        import time as _time
+        from gateway.status import record_start_and_check_storm
+
+        _storm = record_start_and_check_storm()
+        if _storm is not None:
+            logger.warning(
+                "Gateway (re)started %d times in %.0fs — backing off %.0fs to break a respawn storm.",
+                _storm.count,
+                _storm.window_s,
+                _storm.backoff_s,
+            )
+            _exit_diag(
+                "gateway.respawn_storm_backoff",
+                count=_storm.count,
+                window_s=_storm.window_s,
+                backoff_s=_storm.backoff_s,
+            )
+            _time.sleep(_storm.backoff_s)
+    except Exception:
+        pass
 
     success = False
     try:

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -228,6 +228,22 @@ _ensure_telegram_mock()
 _ensure_discord_mock()
 
 
+@pytest.fixture(autouse=True)
+def _disable_telegram_polling_heartbeat(monkeypatch):
+    """Disable the always-on Telegram polling heartbeat in gateway tests.
+
+    ``TelegramAdapter.connect()`` spawns ``_polling_heartbeat_loop`` in
+    polling mode. Many gateway tests globally patch ``asyncio.sleep`` to a
+    no-op (or a fast fake) to drive time-based logic deterministically;
+    with the heartbeat live, that turns ``await asyncio.sleep(INTERVAL)``
+    into a tight CPU-spinning loop that never yields control. Setting the
+    interval env var to ``0`` makes ``connect()`` skip spawning the loop
+    entirely (the ``_hb > 0`` guard). Tests that exercise the heartbeat
+    directly override this via ``monkeypatch.setenv`` to a positive value.
+    """
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0")
+
+
 # ---------------------------------------------------------------------------
 # Plugin-adapter anti-pattern guard
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -718,3 +718,55 @@ class TestPlatformSlashCommand:
         out = await runner._handle_platform_command(self._make_event("/platform"))
         assert "Gateway platforms" in out
 
+
+
+class TestSpawnSupervisedRestart:
+    """Regression guards for _spawn_supervised restart semantics."""
+
+    @pytest.mark.asyncio
+    async def test_clean_synchronous_return_is_not_respawned(self):
+        """A supervised watcher that returns cleanly+synchronously (e.g.
+        kanban dispatcher when disabled by config) must NOT be respawned —
+        respawning a synchronously-returning coro busy-spins the event loop
+        with no backoff and the exception-only ceiling never engages.
+        Regression for the pass-2 clean-return respawn loop."""
+        runner = _make_runner()
+        runner._background_tasks = set()
+        runner._running = True
+        calls = {"n": 0}
+
+        async def _disabled_watcher():
+            calls["n"] += 1
+            return  # clean, immediate return (watcher disabled)
+
+        runner._spawn_supervised(_disabled_watcher, "disabled_watcher", restart=True)
+        await asyncio.sleep(0.15)  # ample time for any (buggy) respawn storm
+        assert calls["n"] == 1, (
+            f"clean-returning supervised task was respawned {calls['n']}x (busy-spin)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_exception_restart_is_bounded_by_ceiling(self, monkeypatch):
+        """A deterministically-crashing watcher is restarted with backoff but
+        abandoned after _MAX_SUPERVISED_RESTARTS — not an infinite flood."""
+        runner = _make_runner()
+        runner._background_tasks = set()
+        runner._running = True
+        calls = {"n": 0}
+
+        async def _boom():
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+        real_sleep = asyncio.sleep
+
+        async def _instant(_d):
+            await real_sleep(0)
+
+        # Make the restart backoff instant so the ceiling is reached fast.
+        monkeypatch.setattr("gateway.run.asyncio.sleep", _instant)
+        runner._spawn_supervised(_boom, "boom_watcher", restart=True)
+        await real_sleep(0.3)  # let the (instant-backoff) restart chain converge
+
+        # initial attempt + _MAX_SUPERVISED_RESTARTS restarts, then it gives up.
+        assert calls["n"] == runner._MAX_SUPERVISED_RESTARTS + 1, calls["n"]

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1065,6 +1065,36 @@ class TestRespawnStormBreaker:
         result = status.record_start_and_check_storm(max_starts=5, window_s=120)
         assert result is None
 
+    def test_breaker_respects_custom_window(self, tmp_path, monkeypatch):
+        # A low custom max_starts must be honored: with max_starts=2, the 3rd
+        # start within the window should trip the breaker.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        result = None
+        for _ in range(3):
+            result = status.record_start_and_check_storm(max_starts=2, window_s=120)
+        assert result is not None
+        assert result.count >= 3
+        assert result.window_s == 120
+        assert result.backoff_s > 0
+
+    def test_starts_log_written_atomically(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for _ in range(5):
+            status.record_start_and_check_storm(max_starts=5, window_s=120)
+
+        # The atomic rename must leave no leftover temp file behind.
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == []
+
+        log_path = tmp_path / "gateway-starts.log"
+        assert log_path.exists()
+        # Every non-empty line must be a valid float timestamp.
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            float(line)  # raises ValueError if the log is corrupt
+
 
 class TestLaunchdPlistRespawnGovernance:
     def test_plist_has_throttle_interval(self, tmp_path, monkeypatch):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1036,3 +1036,42 @@ class TestReadProcessCmdlinePsFallback:
         )
         result = status._read_process_cmdline(12345)
         assert "hermes_cli/main.py" in result
+
+
+class TestRespawnStormBreaker:
+    def test_no_storm_under_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for _ in range(5):
+            result = status.record_start_and_check_storm(max_starts=5, window_s=120)
+            assert result is None
+
+    def test_storm_detected_over_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        result = None
+        for _ in range(7):
+            result = status.record_start_and_check_storm(max_starts=5, window_s=120)
+        assert result is not None
+        assert result.count >= 6
+        assert result.backoff_s > 0
+
+    def test_old_starts_pruned_outside_window(self, tmp_path, monkeypatch):
+        import time
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        log_path = tmp_path / "gateway-starts.log"
+        old_ts = time.time() - 10000
+        log_path.write_text("\n".join(f"{old_ts:.6f}" for _ in range(10)) + "\n")
+
+        result = status.record_start_and_check_storm(max_starts=5, window_s=120)
+        assert result is None
+
+
+class TestLaunchdPlistRespawnGovernance:
+    def test_plist_has_throttle_interval(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.gateway import generate_launchd_plist
+
+        plist = generate_launchd_plist()
+        assert "<key>ThrottleInterval</key>" in plist
+        assert "<key>ExitTimeOut</key>" in plist
+        assert "<key>KeepAlive</key>" in plist

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -309,3 +309,79 @@ async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     app.stop.assert_not_awaited()
     app.shutdown.assert_awaited_once()
     warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_heartbeat_detects_wedged_poll(monkeypatch):
+    """A wedged long-poll (get_me() hangs/fails) must re-enter the reconnect ladder."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._polling_error_task = None
+
+    calls = []
+
+    async def _handler(err):
+        calls.append(err)
+        # Trip fatal so the heartbeat loop exits after this one iteration —
+        # robust against tests that globally mock asyncio.sleep.
+        adapter._set_fatal_error("test_heartbeat_stop", "stop", retryable=False)
+
+    adapter._handle_polling_network_error = _handler
+    adapter._app = SimpleNamespace(
+        updater=SimpleNamespace(running=True),
+        bot=SimpleNamespace(get_me=AsyncMock(side_effect=RuntimeError("wedged"))),
+    )
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    assert len(calls) >= 1
+    assert isinstance(calls[0], Exception)
+
+
+@pytest.mark.asyncio
+async def test_polling_heartbeat_detects_stopped_updater(monkeypatch):
+    """An updater that has stopped running must re-enter the reconnect ladder."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._polling_error_task = None
+
+    calls = []
+
+    async def _handler(err):
+        calls.append(err)
+        adapter._set_fatal_error("test_heartbeat_stop", "stop", retryable=False)
+
+    adapter._handle_polling_network_error = _handler
+    adapter._app = SimpleNamespace(
+        updater=SimpleNamespace(running=False),
+        bot=SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(username="bot"))),
+    )
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    assert len(calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_polling_heartbeat_quiet_when_healthy(monkeypatch):
+    """A healthy poll (updater running, get_me() succeeds) must not trip recovery."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._polling_error_task = None
+
+    handler = AsyncMock()
+    adapter._handle_polling_network_error = handler
+
+    async def _get_me():
+        # Trip fatal so the loop exits after one healthy probe.
+        adapter._set_fatal_error("test_heartbeat_stop", "stop", retryable=False)
+        return SimpleNamespace(username="bot")
+
+    adapter._app = SimpleNamespace(
+        updater=SimpleNamespace(running=True),
+        bot=SimpleNamespace(get_me=_get_me),
+    )
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    handler.assert_not_awaited()

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -385,3 +385,94 @@ async def test_polling_heartbeat_quiet_when_healthy(monkeypatch):
     await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
 
     handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_polling_heartbeat_survives_handler_raise(monkeypatch):
+    """If the recovery handler itself raises, the heartbeat must NOT propagate
+    the exception out (a raising handler can't be allowed to kill the loop)."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._polling_error_task = None
+
+    # Recovery handler always blows up — the loop must swallow it.
+    adapter._handle_polling_network_error = AsyncMock(
+        side_effect=RuntimeError("recovery exploded")
+    )
+
+    # updater.running is False -> enters the `not updater.running` recovery
+    # branch every iteration, where the handler raises. A counter on the
+    # `running` property trips fatal after a couple of iterations so the loop
+    # self-terminates (get_me() is never reached in this branch).
+    term = {"n": 0}
+
+    class _FlakyUpdater:
+        @property
+        def running(self):
+            term["n"] += 1
+            if term["n"] >= 2:
+                adapter._set_fatal_error(
+                    "test_heartbeat_stop", "stop", retryable=False
+                )
+            return False
+
+    adapter._app = SimpleNamespace(
+        updater=_FlakyUpdater(),
+        bot=SimpleNamespace(get_me=AsyncMock()),
+    )
+
+    # Must NOT raise the RuntimeError out of the loop.
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    # Handler was invoked (and raised) at least once but was swallowed.
+    assert adapter._handle_polling_network_error.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_polling_heartbeat_continues_when_app_none(monkeypatch):
+    """When self._app is transiently None, the loop must `continue`, not return
+    permanently — otherwise a reconnect (which rebuilds the app) permanently
+    kills the heartbeat."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HEARTBEAT_INTERVAL", "0.01")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._polling_error_task = None
+
+    handler = AsyncMock()
+    adapter._handle_polling_network_error = handler
+
+    # First iteration: app is None (transient reconnect window). The loop must
+    # NOT return here. Second iteration: a healthy app whose get_me() trips
+    # fatal so the loop self-terminates — proving it survived the None.
+    healthy_app = SimpleNamespace(
+        updater=SimpleNamespace(running=True),
+        bot=None,  # filled in below
+    )
+
+    async def _get_me():
+        adapter._set_fatal_error("test_heartbeat_stop", "stop", retryable=False)
+        return SimpleNamespace(username="bot")
+
+    healthy_app.bot = SimpleNamespace(get_me=_get_me)
+
+    # Start with _app None (transient reconnect window), then flip it to a
+    # healthy app after the first loop tick by intercepting asyncio.sleep. On
+    # the FIRST iteration _app is still None, exercising the `continue` path;
+    # on the SECOND, get_me() trips fatal and the loop self-terminates.
+    adapter._app = None
+    ticks = {"n": 0}
+    real_sleep = asyncio.sleep
+
+    async def _sleep(delay, *a, **k):
+        ticks["n"] += 1
+        if ticks["n"] >= 2:
+            adapter._app = healthy_app
+        return await real_sleep(0)
+
+    monkeypatch.setattr("asyncio.sleep", _sleep)
+
+    await asyncio.wait_for(adapter._polling_heartbeat_loop(), timeout=5)
+
+    # The loop reached the healthy app and tripped fatal — proving the None
+    # iteration did NOT return-and-die. Recovery handler was never needed.
+    handler.assert_not_awaited()
+    assert adapter.has_fatal_error is True

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -3,6 +3,7 @@
 Tests the unified streaming API call, delta callbacks, tool-call
 suppression, provider fallback, and CLI streaming display.
 """
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -1573,3 +1574,68 @@ class TestCopilotACPStreamingDecision:
             _use_streaming = False
 
         assert _use_streaming is True
+
+
+# ── Test: Stale-stream watchdog kill ceiling ─────────────────────────────
+
+
+class _BlockingStreamIterator:
+    """An iterator whose __next__ blocks for a long time and then raises
+    StopIteration — never yields, never errors.  Simulates a provider that
+    holds the SSE connection open with keepalive pings but delivers no real
+    chunks, wedging the worker thread forever (the scenario FIX 1 guards)."""
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        time.sleep(20)
+        raise StopIteration
+
+
+class TestStreamWatchdogKillCeiling:
+    """The stale-stream watchdog must give up after HERMES_STREAM_MAX_STALE_KILLS
+    consecutive kills instead of kill→rebuild→reset forever."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    def test_streaming_watchdog_aborts_after_max_stale_kills(
+        self, mock_replace, mock_abort, mock_close, mock_create, monkeypatch
+    ):
+        """A wedged stream (no chunks, no error) must trip the bounded
+        watchdog and raise TimeoutError within ~10s, not hang."""
+        import time as _time
+
+        from run_agent import AIAgent
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.3")
+        monkeypatch.setenv("HERMES_STREAM_MAX_STALE_KILLS", "2")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _BlockingStreamIterator()
+        mock_create.return_value = mock_client
+        mock_close.return_value = None
+        mock_abort.return_value = None
+        mock_replace.return_value = True
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        _start = _time.time()
+        with pytest.raises(TimeoutError):
+            agent._interruptible_streaming_api_call({})
+        _elapsed = _time.time() - _start
+
+        # 2 kills × 0.3s threshold ≈ <1s of real stall detection; allow
+        # generous slack but well under the 20s blocking sleep.
+        assert _elapsed < 10.0, f"watchdog took {_elapsed:.1f}s — it hung"

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1639,3 +1639,128 @@ class TestStreamWatchdogKillCeiling:
         # 2 kills × 0.3s threshold ≈ <1s of real stall detection; allow
         # generous slack but well under the 20s blocking sleep.
         assert _elapsed < 10.0, f"watchdog took {_elapsed:.1f}s — it hung"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    def test_streaming_watchdog_aborts_even_when_retries_bump_timer(
+        self, mock_replace, mock_abort, mock_close, mock_create, monkeypatch
+    ):
+        """Regression for the timestamp-based progress-reset bug.
+
+        The kill→client-close→worker-retry loop re-enters the inner retry
+        loop, which resets last_chunk_time["t"] = time.time() at the start of
+        every attempt WITHOUT delivering any real chunk.  The old
+        timestamp-keyed progress-reset saw the timer change and reset
+        _stale_kills to 0 on every poll — so the bounded ceiling never tripped
+        and the request looped until HERMES_STREAM_RETRIES (50 here) was
+        exhausted.  With the chunk-count-keyed reset, _stale_kills accumulates
+        because no real chunk ever arrives, and the ceiling trips with
+        TimeoutError after HERMES_STREAM_MAX_STALE_KILLS kills.
+        """
+        import time as _time
+
+        from run_agent import AIAgent
+
+        import threading as _threading
+
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.3")
+        monkeypatch.setenv("HERMES_STREAM_MAX_STALE_KILLS", "2")
+        # Retries set high so the inner retry loop keeps re-entering (bumping
+        # last_chunk_time at attempt start) long past the kill ceiling —
+        # proving the ceiling, not retry exhaustion, is what aborts.
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "50")
+
+        _create_calls = {"n": 0}
+        _done = _threading.Event()  # set by the test after the assertion
+
+        class _WedgeStream:
+            """Yields nothing.  __next__ blocks until the watchdog aborts the
+            client (mock_abort sets self.aborted), then raises a retryable
+            connection error.  This re-wedges the worker every attempt WITHOUT
+            ever delivering a real chunk — so chunks_seen never advances, but
+            last_chunk_time IS bumped at attempt start (line ~1774) on each
+            retry.  The old timestamp-keyed progress-reset saw that bump and
+            zeroed _stale_kills every cycle; the chunk-count reset does not."""
+
+            def __init__(self):
+                self.aborted = _threading.Event()
+                self.response = None
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                # Wait for the stale watchdog to abort us (or test teardown).
+                while not self.aborted.wait(timeout=0.05):
+                    if _done.is_set():
+                        raise StopIteration
+                raise ConnectionError("peer closed connection (simulated wedge)")
+
+        _streams = []
+
+        def _make_stream(*args, **kwargs):
+            _create_calls["n"] += 1
+            s = _WedgeStream()
+            _streams.append(s)
+            return s
+
+        def _abort_signals_streams(*args, **kwargs):
+            # The watchdog kill aborts the worker's client from the poll
+            # (stranger) thread — release whatever stream is currently wedged.
+            for s in _streams:
+                s.aborted.set()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _make_stream
+        mock_create.return_value = mock_client
+        mock_close.return_value = None
+        mock_abort.side_effect = _abort_signals_streams
+        mock_replace.return_value = True
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        # Snapshot live threads so the finally block can join any worker the
+        # streaming call spawns — a lingering daemon worker would otherwise
+        # keep retrying in the background and pollute the next test (it steals
+        # CPU and races timing-sensitive interrupt tests).
+        _threads_before = set(_threading.enumerate())
+
+        _start = _time.time()
+        try:
+            with pytest.raises(TimeoutError):
+                agent._interruptible_streaming_api_call({})
+            _elapsed = _time.time() - _start
+        finally:
+            # Release any lingering daemon worker so it can't pollute the
+            # next test by retrying in the background, then JOIN it so it is
+            # fully dead before this test returns.
+            _done.set()
+            for s in _streams:
+                s.aborted.set()
+            for _t in set(_threading.enumerate()) - _threads_before:
+                if _t is not _threading.current_thread():
+                    _t.join(timeout=5.0)
+
+        # 2 kills × 0.3s stale window + poll granularity — well under 10s.
+        # With the OLD timestamp logic, the attempt-start timer bump on each
+        # retry resets _stale_kills, so the ceiling never trips and this loops
+        # to HERMES_STREAM_RETRIES=50 exhaustion (raising ConnectionError, not
+        # TimeoutError) — the pytest.raises(TimeoutError) above would fail.
+        assert _elapsed < 10.0, f"watchdog took {_elapsed:.1f}s — ceiling didn't trip"
+        # The worker genuinely retried (re-creating the client and bumping the
+        # attempt-start timer) more than once, exercising the timer-bump path.
+        assert _create_calls["n"] >= 2, (
+            f"expected ≥2 retry attempts to exercise the timer bump, "
+            f"got {_create_calls['n']}"
+        )


### PR DESCRIPTION
## Gateway & streaming reliability hardening

Three independent fixes for "the daemon is alive but not doing its job" failure modes observed running the gateway as a long-lived launchd service. Each is small, isolated, and covered by a regression test. (A fourth issue — the codex null-output `TypeError` — is already fixed on `main` via #33042, so it's not included here.)

### 1. Streaming stall watchdog can loop forever / gaps for local & Bedrock
`agent/chat_completion_helpers.py`, `agent/tool_executor.py`
- The stale-stream watchdog killed+rebuilt the client and reset its timer on each stall but had **no kill ceiling**. A provider that holds the connection open with SSE keep-alive pings (no real chunks, no error) makes the worker thread never return, so the watchdog kills→rebuilds→resets indefinitely — a permanent mid-stream hang. Added `HERMES_STREAM_MAX_STALE_KILLS` (default 3) with a progress-reset so a stall→recover→stall sequence isn't aborted prematurely; mirrors the non-streaming path's terminal `TimeoutError`.
- Local providers (Ollama/oMLX/llama-cpp) were given `float("inf")` stale timeout (watchdog fully disabled) → a wedged local server hangs forever. Now a finite ceiling, `HERMES_LOCAL_STREAM_STALE_TIMEOUT` (default 900s).
- The Bedrock streaming branch had **no stale watchdog at all**. Added one (per-chunk timestamp, bounded kills, runtime-client invalidation).
- Concurrent tool batches had no aggregate deadline, and the `ThreadPoolExecutor` context-manager `__exit__` blocks forever on a tool that ignores cancellation. Switched to a manual executor with `shutdown(wait=False)` on the timeout path, `HERMES_TOOL_BATCH_TIMEOUT` (default 900s), and synthesized timeout tool-results so the next turn isn't left with a tool_call that has no tool_result.

### 2. Telegram polling can wedge silently; supervisor tasks die silently
`gateway/platforms/telegram.py`, `gateway/run.py`
- Telegram polling self-healing was reactive-only (PTB `error_callback`) plus a **one-shot** post-reconnect probe. A network blip that wedges the long-poll without firing a callback (and without a prior reconnect) leaves `updater.running == True` but the bot permanently deaf, process alive. Added an **always-on heartbeat** that re-enters the existing reconnect ladder when the updater isn't running or a `get_me()` probe times out. `HERMES_TELEGRAM_HEARTBEAT_INTERVAL` (default 90s, `<=0` disables).
- Six long-lived supervisor tasks (`_session_expiry_watcher`, `_kanban_notifier_watcher`, `_kanban_dispatcher_watcher`, `_platform_reconnect_watcher`, `_handoff_watcher`, recovered process watchers) were launched with bare `asyncio.create_task` — no handle retained, no exception logging, no restart. A transient raise in `_platform_reconnect_watcher` silently kills the only task that re-establishes a dropped platform. Routed them through a `_spawn_supervised` helper that tracks and auto-restarts on unexpected death.

### 3. launchd respawn storm
`hermes_cli/gateway.py`, `gateway/status.py`
- The launchd plist uses `KeepAlive {SuccessfulExit=false}` with **no `ThrottleInterval`**, so a gateway that is repeatedly SIGTERM'd is revived at launchd's 10s default floor with nothing to dampen the spin (a healthy process killed and respawned every ~10s). Added `ThrottleInterval=30` + `ExitTimeOut=25`. (#30719 only guards against an agent scheduling its *own* restart — not external respawn triggers.)
- Added `record_start_and_check_storm` — a portable, service-manager-agnostic circuit breaker that records starts and backs off when too many land in a short window. Covers launchd, systemd, and bare runs.

## Test plan
- `pytest tests/run_agent/test_streaming.py tests/gateway/test_telegram_conflict.py tests/gateway/test_status.py tests/gateway/test_platform_reconnect.py` — all green; includes new regressions for the unbounded-watchdog abort, the Telegram heartbeat (wedged / stopped-updater / healthy-quiet), and the respawn-storm breaker + plist throttle keys.
- All new behavior is env-gated with conservative defaults; no change to the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)