### PR TITLE
fix(api-server): redact provider errors at HTTP boundary

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -58,6 +58,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
@@ -530,11 +531,19 @@ else:
     cors_middleware = None  # type: ignore[assignment]
 
 
+def _redact_api_error_text(value: Any, *, limit: int | None = None) -> str:
+    """Redact API-bound error text before it crosses the HTTP boundary."""
+    redacted = redact_sensitive_text(str(value), force=True)
+    if limit is not None:
+        return redacted[:limit]
+    return redacted
+
+
 def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
     """OpenAI-style error envelope."""
     return {
         "error": {
-            "message": message,
+            "message": _redact_api_error_text(message),
             "type": err_type,
             "param": param,
             "code": code,
@@ -1914,7 +1923,8 @@ class APIServerAdapter(BasePlatformAdapter):
         is_partial = bool(result.get("partial"))
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
-        err_msg = result.get("error")
+        raw_err_msg = result.get("error")
+        err_msg = _redact_api_error_text(raw_err_msg) if raw_err_msg else raw_err_msg
 
         # Decide finish_reason. OpenAI uses "length" for truncation, "stop"
         # for normal completion, and downstream SDKs accept "error" / custom
@@ -1985,7 +1995,7 @@ class APIServerAdapter(BasePlatformAdapter):
             response_headers["X-Hermes-Completed"] = "false"
             response_headers["X-Hermes-Partial"] = "true" if is_partial else "false"
             if err_msg:
-                response_headers["X-Hermes-Error"] = err_msg[:200]
+                response_headers["X-Hermes-Error"] = _redact_api_error_text(err_msg, limit=200)
 
         return web.json_response(response_data, headers=response_headers)
 
@@ -2559,10 +2569,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if agent_final and not final_response_text:
                     final_response_text = agent_final
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
-                    agent_error = result["error"]
+                    agent_error = _redact_api_error_text(result["error"])
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
-                agent_error = str(e)
+                agent_error = _redact_api_error_text(e)
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
@@ -2624,14 +2634,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "type": "message",
                 "role": "assistant",
                 "content": [
-                    {"type": "output_text", "text": final_response_text or (agent_error or "")}
+                    {"type": "output_text", "text": final_response_text or (_redact_api_error_text(agent_error) if agent_error else "")}
                 ],
             })
 
             if agent_error:
                 failed_env = _envelope("failed")
                 failed_env["output"] = final_items
-                failed_env["error"] = {"message": agent_error, "type": "server_error"}
+                failed_env["error"] = {"message": _redact_api_error_text(agent_error), "type": "server_error"}
                 failed_env["usage"] = {
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
@@ -2642,7 +2652,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if final_response_text or agent_error:
                     _failed_history.append({
                         "role": "assistant",
-                        "content": final_response_text or agent_error,
+                        "content": final_response_text or _redact_api_error_text(agent_error),
                     })
                 _persist_response_snapshot(
                     failed_env,
@@ -2717,11 +2727,11 @@ class APIServerAdapter(BasePlatformAdapter):
             # get a TransferEncodingError from incomplete chunked encoding.
             import traceback as _tb
             _persist_incomplete_if_needed()
-            agent_error = _tb.format_exc()
+            agent_error = _redact_api_error_text(_tb.format_exc())
             try:
                 failed_env = _envelope("failed")
                 failed_env["output"] = list(emitted_items)
-                failed_env["error"] = {"message": str(_exc)[:500], "type": "server_error"}
+                failed_env["error"] = {"message": _redact_api_error_text(_exc, limit=500), "type": "server_error"}
                 failed_env["usage"] = {
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
@@ -2961,7 +2971,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response = result.get("final_response", "")
         if not final_response:
-            final_response = result.get("error", "(No response generated)")
+            final_response = _redact_api_error_text(result.get("error", "(No response generated)"))
 
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
@@ -3405,7 +3415,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Final assistant message
         final = result.get("final_response", "")
         if not final:
-            final = result.get("error", "(No response generated)")
+            final = _redact_api_error_text(result.get("error", "(No response generated)"))
 
         items.append({
             "type": "message",
@@ -3747,7 +3757,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 # 401/400 return failed=True instead of raising, so the except
                 # block below never fires — issue #15561).
                 if isinstance(result, dict) and result.get("failed"):
-                    error_msg = result.get("error") or "agent run failed"
+                    error_msg = _redact_api_error_text(result.get("error") or "agent run failed")
                     q.put_nowait({
                         "event": "run.failed",
                         "run_id": run_id,
@@ -3796,7 +3806,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._set_run_status(
                     run_id,
                     "failed",
-                    error=str(exc),
+                    error=_redact_api_error_text(exc),
                     last_event="run.failed",
                 )
                 try:
@@ -3804,7 +3814,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "error": str(exc),
+                        "error": _redact_api_error_text(exc),
                     })
                 except Exception:
                     pass

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1952,6 +1952,33 @@ class TestResponsesEndpoint:
             assert resp.status == 500
 
     @pytest.mark.asyncio
+    async def test_result_error_fallback_is_redacted(self, adapter):
+        raw_secret = "sk-responses-leak-1234567890"
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "",
+                        "error": f"provider auth failed OPENAI_API_KEY={raw_secret}",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "Hello"},
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            body = json.dumps(data)
+            assert raw_secret not in body
+            assert "OPENAI_API_KEY=" in body
+            assert data["output"][0]["content"][0]["text"] != f"provider auth failed OPENAI_API_KEY={raw_secret}"
+
+    @pytest.mark.asyncio
     async def test_invalid_input_type_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -2853,6 +2880,35 @@ class TestChatCompletionsAgentIncomplete:
             assert data["hermes"]["error_code"] == "output_truncated"
             assert resp.headers.get("X-Hermes-Completed") == "false"
             assert resp.headers.get("X-Hermes-Partial") == "true"
+
+    @pytest.mark.asyncio
+    async def test_hard_failure_redacts_secret_like_error_text(self, adapter):
+        raw_secret = "sk-api-server-leak-1234567890"
+        mock_result = {
+            "final_response": "",
+            "completed": False,
+            "partial": False,
+            "failed": True,
+            "error": f"provider auth failed OPENAI_API_KEY={raw_secret}",
+            "messages": [],
+            "api_calls": 1,
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hello"}]},
+                )
+
+            assert resp.status == 502
+            data = await resp.json()
+            body = json.dumps(data)
+            assert raw_secret not in body
+            assert raw_secret not in resp.headers.get("X-Hermes-Error", "")
+            assert "OPENAI_API_KEY=" in body
+            assert data["error"]["hermes"]["failed"] is True
 
     @pytest.mark.asyncio
     async def test_failure_with_no_text_returns_502_error_envelope(self, adapter):


### PR DESCRIPTION
## Summary
When a provider call fails and the exception string contains credential-bearing text, the API-server adapter can return that text in OpenAI-compatible error envelopes, response streams, assistant output fallbacks, and response-store snapshots. An API client that is authorized only for the local API surface can receive operator provider credential material that should remain inside the agent process.

- The API-server adapter imports no redaction helper on the inspected error paths.
- The affected paths write unsanitized failure text to external HTTP clients and, for responses streaming, to persisted response history.
- Sibling code already treats the same class of exception text as needing sanitization before returning it to tool or gateway clients.
- The exposed destination is outside the provider-credential trust envelope named by `SECURITY.md` sections 2.3 and 3.1.

Centralize API-server error serialization through a forced secret-redaction helper before building OpenAI-compatible error envelopes, streaming events, assistant fallback text, and persisted response snapshots. Cover both direct exception paths and `result.get("error")` values with focused API-server regression tests.

## Linked context
Closes #37733

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/gateway/platforms/api_server.py:1895-1911`
- `hermes-agent/gateway/platforms/api_server.py:1938-1944`
- `hermes-agent/gateway/platforms/api_server.py:2561-2565,2623-2634,2640-2648`
- `hermes-agent/gateway/platforms/api_server.py:2713-2724`
- `hermes-agent/gateway/platforms/api_server.py:2944-2964`
- `hermes-agent/agent/redact.py:326-427`; `hermes-agent/tools/mcp_tool.py:315-321,1078`

### Files changed in this PR
- `gateway/platforms/api_server.py`
- `tests/gateway/test_api_server.py`

### Behavior reproduced or verified
1. Use the local Hermes checkout at commit `6d5838f9b96fcb73e64772d1e39814ba017b5e3b`; after `git fetch origin main`, the inspected API-server file has no diff from `origin/main`.
2. Configure the API server with a valid API-server bearer token and a provider configuration that deterministically raises an auth or transport exception whose message includes credential-shaped material.
3. Call `/v1/chat/completions` or `/v1/responses` and let the agent call fail before producing a safe assistant response.
4. Observe the API-server code pass `str(e)`, `result.get("error")`, `agent_error`, or traceback-derived text into the HTTP body, SSE payload, assistant content, or response snapshot without redaction.
5. Expected result: every exception or agent-error string crossing the API-server HTTP boundary is forced through the same redaction helper already used by sibling outward-facing paths.

### Expected fixed behavior
Centralize API-server error serialization through a forced secret-redaction helper before building OpenAI-compatible error envelopes, streaming events, assistant fallback text, and persisted response snapshots. Cover both direct exception paths and `result.get("error")` values with focused API-server regression tests.

## Tests and validation
1. Use the local Hermes checkout at commit `6d5838f9b96fcb73e64772d1e39814ba017b5e3b`; after `git fetch origin main`, the inspected API-server file has no diff from `origin/main`.
2. Configure the API server with a valid API-server bearer token and a provider configuration that deterministically raises an auth or transport exception whose message includes credential-shaped material.
3. Call `/v1/chat/completions` or `/v1/responses` and let the agent call fail before producing a safe assistant response.
4. Observe the API-server code pass `str(e)`, `result.get("error")`, `agent_error`, or traceback-derived text into the HTTP body, SSE payload, assistant content, or response snapshot without redaction.
5. Expected result: every exception or agent-error string crossing the API-server HTTP boundary is forced through the same redaction helper already used by sibling outward-facing paths.

## Environment
Hermes commit inspected: `6d5838f9b96fcb73e64772d1e39814ba017b5e3b`; affected API-server paths match fetched `origin/main` after refresh. Runtime prerequisite: API server enabled and a provider failure containing credential-shaped error text. Redaction complete; no secrets, tokens, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
