### PR TITLE
feat(cron): per-job wrap_response override to skip the delivery header/footer

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -788,6 +788,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    wrap_response: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -866,6 +867,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_wrap_response = bool(wrap_response) if wrap_response is not None else None
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -965,6 +967,9 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        # None = inherit global cron.wrap_response config (default True);
+        # True/False = explicit per-job override of the header/footer wrapping.
+        "wrap_response": normalized_wrap_response,
     }
 
     with _jobs_lock():
@@ -1055,6 +1060,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            # Normalize wrap_response: None = inherit global config, bool = explicit override.
+            if "wrap_response" in updates:
+                _wr = updates["wrap_response"]
+                updates["wrap_response"] = bool(_wr) if _wr is not None else None
 
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1933,6 +1933,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    wrap_response: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2037,6 +2038,7 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    normalized_wrap_response = bool(wrap_response) if wrap_response is not None else None
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
@@ -2139,6 +2141,9 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        # None = inherit global cron.wrap_response config (default True);
+        # True/False = explicit per-job override of the header/footer wrapping.
+        "wrap_response": normalized_wrap_response,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -2263,6 +2268,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["reasoning_effort"] = _normalize_reasoning_effort(
                     updates["reasoning_effort"]
                 )
+
+            # Normalize wrap_response: None = inherit global config, bool = explicit override.
+            if "wrap_response" in updates:
+                _wr = updates["wrap_response"]
+                updates["wrap_response"] = bool(_wr) if _wr is not None else None
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -801,14 +801,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from gateway.config import load_gateway_config, Platform
 
     # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
-    wrap_response = True
-    try:
-        user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
-    except Exception:
-        pass
+    # is a cron delivery.  Per-job ``wrap_response`` overrides the global
+    # ``cron.wrap_response`` config (default True) when explicitly set.
+    job_wrap = job.get("wrap_response")
+    if isinstance(job_wrap, bool):
+        wrap_response = job_wrap
+    else:
+        wrap_response = True
+        try:
+            user_cfg = load_config()
+            wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        except Exception:
+            pass
 
     if wrap_response:
         task_name = job.get("name", job["id"])

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3102,15 +3102,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from gateway.config import load_gateway_config, Platform
 
     # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
-    wrap_response = True
+    # is a cron delivery.  Per-job ``wrap_response`` overrides the global
+    # ``cron.wrap_response`` config (default True) when explicitly set.
+    # ``user_cfg`` is loaded unconditionally because it is reused downstream
+    # (apply_media_policy_env), regardless of which wrap source wins.
     user_cfg = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
+    job_wrap = job.get("wrap_response")
+    if isinstance(job_wrap, bool):
+        wrap_response = job_wrap
+    elif user_cfg is not None:
+        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+    else:
+        wrap_response = True
 
     if wrap_response:
         task_name = job.get("name", job["id"])

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -278,6 +278,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        wrap_response=getattr(args, "wrap_response", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -341,6 +342,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        wrap_response=getattr(args, "wrap_response", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -510,6 +510,7 @@ def cron_create(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        wrap_response=getattr(args, "wrap_response", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -585,6 +586,7 @@ def cron_edit(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        wrap_response=getattr(args, "wrap_response", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -70,6 +70,21 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Force the cron header/footer ('Cronjob Response: …' / 'To stop or manage this job…') ON for this job, overriding the global config.",
+    )
+    cron_create.add_argument(
+        "--no-wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=False,
+        help="Deliver this job's output raw — without the cron header/footer. Useful for briefings you want to read clean.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -133,6 +148,21 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Turn the cron header/footer ON for this job (overrides the global config).",
+    )
+    cron_edit.add_argument(
+        "--no-wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=False,
+        help="Turn the cron header/footer OFF for this job — deliver raw output.",
     )
 
     # lifecycle actions

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -132,6 +132,21 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "monitors, incremental digests). First run is unchanged."
         ),
     )
+    cron_create.add_argument(
+        "--wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Force the cron header/footer ('Cronjob Response: ...' / 'To stop or manage this job...') ON for this job, overriding the global config.",
+    )
+    cron_create.add_argument(
+        "--no-wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=False,
+        help="Deliver this job's output raw - without the cron header/footer. Useful for briefings you want to read clean.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -253,6 +268,21 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "medium, high, xhigh, max, or ultra. Pass empty string to clear "
             "the pin and follow config resolution."
         ),
+    )
+    cron_edit.add_argument(
+        "--wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Turn the cron header/footer ON for this job (overrides the global config).",
+    )
+    cron_edit.add_argument(
+        "--no-wrap-response",
+        dest="wrap_response",
+        action="store_const",
+        const=False,
+        help="Turn the cron header/footer OFF for this job - deliver raw output.",
     )
 
     # lifecycle actions

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -391,6 +391,7 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    wrap_response: Optional[bool] = None
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7609,6 +7609,7 @@ class CronJobCreate(BaseModel):
     name: str = ""
     deliver: str = "local"
     skills: Optional[List[str]] = None
+    wrap_response: Optional[bool] = None
 
 
 class CronJobUpdate(BaseModel):
@@ -7781,6 +7782,7 @@ async def create_cron_job(body: CronJobCreate, profile: str = "default"):
             name=body.name,
             deliver=body.deliver,
             skills=body.skills,
+            wrap_response=body.wrap_response,
         )
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13272,6 +13272,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            wrap_response=body.wrap_response,
         )
     except HTTPException:
         raise

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -613,6 +613,56 @@ class TestDeliverResultWrapping:
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: abc-123" in sent_content
 
+    def test_per_job_wrap_response_false_overrides_global_true(self):
+        """A per-job wrap_response=False delivers raw output even when the global config wraps."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "test-job",
+                "name": "morning-briefing",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "wrap_response": False,
+            }
+            _deliver_result(job, "Good morning.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "Good morning."
+        assert "Cronjob Response" not in sent_content
+
+    def test_per_job_wrap_response_true_overrides_global_false(self):
+        """A per-job wrap_response=True forces wrapping even when global config disables it."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "test-job",
+                "name": "noisy-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "wrap_response": True,
+            }
+            _deliver_result(job, "Output.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Cronjob Response: noisy-job" in sent_content
+        assert "To stop or manage this job" in sent_content
+
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""
         from gateway.config import Platform

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -457,6 +457,82 @@ class TestDeliverResultWrapping:
         standalone_send.assert_not_awaited()
 
 
+    def test_per_job_wrap_response_false_overrides_global_true(self):
+        """A per-job wrap_response=False delivers raw output even when the global config wraps."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "test-job",
+                "name": "morning-briefing",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "wrap_response": False,
+            }
+            _deliver_result(job, "Good morning.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "Good morning."
+        assert "Cronjob Response" not in sent_content
+
+    def test_per_job_wrap_response_true_overrides_global_false(self):
+        """A per-job wrap_response=True forces wrapping even when global config disables it."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "test-job",
+                "name": "noisy-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "wrap_response": True,
+            }
+            _deliver_result(job, "Output.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Cronjob Response: noisy-job" in sent_content
+        assert "To stop or manage this job" in sent_content
+
+    def test_delivery_skips_wrapping_when_config_disabled(self):
+        """When cron.wrap_response is false, deliver raw content without header/footer."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Clean output only.")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "Clean output only."
+        assert "Cronjob Response" not in sent_content
+        assert "The agent cannot see" not in sent_content
+
     def test_live_adapter_sends_media_as_attachments(self, tmp_path, monkeypatch):
         """When a live adapter is available, MEDIA files should be sent as native
         platform attachments (e.g., Discord voice, Telegram audio) rather than

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -576,6 +576,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    wrap_response: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -642,6 +643,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                wrap_response=wrap_response,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -812,6 +814,8 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if wrap_response is not None:
+                updates["wrap_response"] = bool(wrap_response)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -952,6 +956,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "wrap_response": {
+                "type": "boolean",
+                "description": (
+                    "Per-job override for the 'Cronjob Response: <name>' header and "
+                    "'To stop or manage this job…' footer that wrap delivered output. "
+                    "True forces wrapping on; False delivers the raw agent output verbatim "
+                    "(useful for briefings the user wants to read clean). "
+                    "Omit to inherit the global cron.wrap_response config (defaults True)."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -1007,6 +1021,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        wrap_response=args.get("wrap_response"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1371,6 +1371,7 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    wrap_response: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1487,6 +1488,7 @@ def cronjob(
                     # dispatch below: models do not make model-config
                     # decisions (standing policy).
                     reasoning_effort=reasoning_effort,
+                    wrap_response=wrap_response,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1799,6 +1801,8 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if wrap_response is not None:
+                updates["wrap_response"] = bool(wrap_response)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -1907,6 +1911,16 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "boolean",
                 "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts. Scope: the job's own conversation only — the origin chat, the home-channel fallback when deliver='origin' captured no origin (script-created jobs), or the job's single explicit platform:chat target (this flag is the only way to attach an explicit target). Broadcast targets are never attached; no effect when deliver='local'."
             },
+            "wrap_response": {
+                "type": "boolean",
+                "description": (
+                    "Per-job override for the 'Cronjob Response: <name>' header and "
+                    "'To stop or manage this job...' footer that wrap delivered output. "
+                    "True forces wrapping on; False delivers the raw agent output verbatim "
+                    "(useful for briefings the user wants to read clean). "
+                    "Omit to inherit the global cron.wrap_response config (defaults True)."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -1975,6 +1989,7 @@ def _cronjob_handler(args, **kw):
         attach_to_session=args.get("attach_to_session"),
         monitor_script=_mon_script,
         monitor_url=_mon_url,
+        wrap_response=args.get("wrap_response"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     )


### PR DESCRIPTION
## What does this PR do?

Cron deliveries wrap the job output with a `Cronjob Response:` header and a `To stop or manage this job...` footer, controlled globally by `cron.wrap_response` (default true). It is all-or-nothing: you cannot keep the wrapper for most jobs while serving one job (for example a morning briefing) as a clean, raw message body.

This adds an optional per-job `wrap_response` boolean. `None` (the default) inherits the global config, so existing jobs are unchanged; `true`/`false` explicitly overrides it for that one job. The resolution order is **per-job override, then global `cron.wrap_response`**.

This is complementary to #36274, not competing. #36274 fixes delivery so a job honors its *profile's* `cron.wrap_response`. This adds a finer *per-job* layer on top. Together they form a clean precedence chain: per-job (this PR) > profile (#36274) > global default. Because the per-job `None` case falls through to the same global read that #36274 corrects, the two compose without conflict; once #36274 merges I am happy to rebase so the inherited value resolves from the job's profile.

## Related Issue

No issue; small self-contained feature.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `cron/jobs.py`: `wrap_response` field on `create_job`/`update_job`, normalised so `None` means inherit and a bool means explicit override.
- `cron/scheduler.py`: delivery resolves the per-job `wrap_response` first and falls back to the global `cron.wrap_response` (default true) when unset.
- `tools/cronjob_tools.py`: `wrap_response` added to the cronjob tool schema so the agent can set it.
- `hermes_cli/web_server.py`: `wrap_response` added to the web API `CronJobCreate` model.
- `hermes_cli/main.py`: `--wrap-response` / `--no-wrap-response` flags on `hermes cron create` and `hermes cron edit`.
- `hermes_cli/cron.py`: plumb the flag through.
- `tests/cron/test_scheduler.py`: tests for both override directions plus the existing global-disabled and wrapped-output cases.

## How to Test

Automated:
```
pytest tests/cron/test_scheduler.py -q
```
The relevant cases: `test_per_job_wrap_response_false_overrides_global_true`, `test_per_job_wrap_response_true_overrides_global_false`, alongside the existing `test_delivery_wraps_content_with_header_and_footer` and `test_delivery_skips_wrapping_when_config_disabled`.

Manual:
1. With global `cron.wrap_response: true`, create a job with `hermes cron create ... --no-wrap-response`.
2. Let it deliver and confirm the message arrives with no `Cronjob Response:` header or footer, while other jobs still get the wrapper.
3. Reverse it: global `false` plus a job created with `--wrap-response` gets the wrapper while others do not.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest is #36274, a profile-level fix; this is the per-job layer above it)
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS Tahoe 26.5 (Mac Mini M2, production)

### Documentation & Housekeeping
- [x] N/A, behavior is documented via the CLI flag help and the tool schema description
- [x] N/A, no new `config.yaml` key (per-job field lives in the job store, not `cli-config.yaml.example`)
- [x] N/A, no architecture or workflow change
- [x] Cross-platform: pure Python, no platform-specific calls
- [x] Updated the cronjob tool schema with the new `wrap_response` field