### PR TITLE
fix(dashboard): allow desktop websocket origins on remote binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6603,13 +6603,16 @@ def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:
 
     parsed = urllib.parse.urlparse(origin)
     if parsed.scheme not in {"http", "https"}:
-        # Packaged Electron loads the desktop renderer over file://, so its
-        # WebSocket handshake carries a non-web Origin such as file:// or null.
-        # DNS-rebinding attacks originate from an http(s) site; they cannot
-        # forge a file:// origin and still hold the loopback session token.
-        # Public/gated binds have no legitimate non-web client, so keep
-        # rejecting these origins there.
-        return bound_host.lower() in _LOOPBACK_HOST_VALUES
+        # Packaged Electron loads the desktop renderer over a non-web origin
+        # such as file:// or null. This helper is called only after _ws_auth_ok
+        # has accepted the WS credential; in non-gated mode that credential is
+        # the legacy dashboard session token, including for explicit Tailscale /
+        # LAN binds opened with --insecure. Real DNS-rebinding attacks arrive
+        # from http(s) origins and still have to match the bound host below.
+        #
+        # OAuth-gated public dashboards authenticate with cookies/tickets and
+        # have no legitimate file:// client, so keep them strict.
+        return not getattr(app.state, "auth_required", False)
 
     if not parsed.netloc:
         return False

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1425,6 +1425,7 @@ AUTHOR_MAP = {
     "2663402852@qq.com": "x1am1",  # PR #35098 (chown root-owned top-level HERMES_HOME state files)
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
     "wasdhkzk@gmail.com": "whyhkzk",  # PR #32407 (sandbox-mirror inner-container guard; commits authored as whyhkzk + zhukun)
+    "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
 }
 
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -381,8 +381,9 @@ class TestWsHostOriginGuardOrigins:
     Electron loads the packaged renderer over ``file://``, so its WebSocket
     handshake carries ``Origin: file://`` (or the opaque ``null``). The
     DNS-rebinding guard only needs to block cross-site http(s) origins. On a
-    loopback bind these non-web origins are trusted because the session token
-    is the real gate. Public/gated binds keep rejecting them.
+    loopback or explicit non-loopback insecure bind these non-web origins are
+    trusted because the session token is the real gate. OAuth-gated public
+    binds keep rejecting them.
     """
 
     def _ws(self, *, origin, host):
@@ -413,8 +414,29 @@ class TestWsHostOriginGuardOrigins:
         ws = self._ws(origin="http://evil.test", host="127.0.0.1:8080")
         assert web_server._ws_host_origin_is_allowed(ws) is False
 
+    def test_explicit_non_loopback_file_origin_allowed(self, insecure_explicit_host_app):
+        """Packaged Hermes Desktop also uses file:// when connecting to a
+        Tailscale/LAN dashboard bind.
+
+        The WebSocket route calls _ws_auth_ok before this guard, so in
+        non-gated mode the legacy session token remains the auth boundary.
+        """
+        ws = self._ws(origin="file://", host="100.64.0.10:9119")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_explicit_non_loopback_null_origin_allowed(self, insecure_explicit_host_app):
+        ws = self._ws(origin="null", host="100.64.0.10:9119")
+        assert web_server._ws_host_origin_is_allowed(ws) is True
+
+    def test_explicit_non_loopback_cross_site_http_origin_rejected(
+        self, insecure_explicit_host_app
+    ):
+        ws = self._ws(origin="http://localhost:9119", host="100.64.0.10:9119")
+        assert web_server._ws_host_origin_is_allowed(ws) is False
+
     def test_gated_file_origin_rejected(self, gated_app):
-        # A public/gated bind has no legitimate file:// client.
+        # OAuth-gated public dashboards authenticate with cookies/tickets,
+        # not the legacy desktop session token.
         ws = self._ws(origin="file://", host="fly-app.fly.dev")
         assert web_server._ws_host_origin_is_allowed(ws) is False
 


### PR DESCRIPTION
## Summary
Hermes Desktop now connects to a remote gateway bound to a Tailscale/LAN IP with `--host ... --insecure`. Salvage of #37405 by @leonardsellem onto current `main`.

Root cause: the WebSocket Origin guard (`_ws_host_origin_is_allowed`) only trusted the packaged Electron app's non-web origin (`file://` / `null`) when the dashboard was bound to loopback. On an explicit non-loopback bind (Tailscale/LAN) the upgrade was rejected — even though `_ws_auth_ok` had already validated the session token one line earlier. Symptom matched every community report: token test passes (status/config), but the chat WebSocket silently fails to connect.

## Changes
- `hermes_cli/web_server.py`: trust non-web WS origins after credential auth when the bind is not OAuth-gated (`not auth_required`), instead of loopback-only. OAuth-gated public dashboards stay strict; `http(s)` origins still must match the bound host (DNS-rebinding protection intact).
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: regression coverage for explicit non-loopback binds accepting `file://`/`null` and still rejecting a mismatched `http://` origin.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
| | Before | After |
|---|---|---|
| Desktop → Tailscale/LAN gateway WS | rejected (4403) | accepts with valid token |
| OAuth-gated public bind, `file://` origin | rejected | rejected |
| Cross-site `http(s)` origin | rejected | rejected |
| `tests/hermes_cli/test_dashboard_auth_ws_auth.py` | — | 33/33 |
| `tests/hermes_cli/test_web_server_host_header.py` | — | pass |

Salvaged from #37405 (fixes #37399). Contributor authorship preserved via cherry-pick + rebase-merge.

## Infographic

![desktop-ws-origin-guard](https://v3b.fal.media/files/b/0a9cbeec/TRaqM0pu8kHaD10rzUQDR_ib1VplGg.png)
