### PR TITLE
fix(cron): only silence exact [SILENT] marker

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -637,9 +637,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
-    # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
+    # Optionally append cron metadata so the user knows this is a cron delivery
+    # without pushing the actual result down in chat clients.  Wrapping is on by
+    # default; set cron.wrap_response: false in config.yaml for clean output.
     wrap_response = True
     try:
         user_cfg = load_config()
@@ -651,10 +651,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
         delivery_content = (
+            f"{content}\n\n"
+            f"-------------\n"
             f"Cronjob Response: {task_name}\n"
             f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
             f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
         )
     else:
@@ -1946,14 +1946,14 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     logger.info("Output saved to: %s", output_file)
 
                 # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
+                # If the agent responded with only [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 # Treat whitespace-only final responses the same as empty
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.
                 should_deliver = bool(deliver_content.strip())
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                if should_deliver and success and deliver_content.strip().upper() == SILENT_MARKER:
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -501,8 +501,8 @@ class TestDeliverResultWrapping:
         )
         return media_file.resolve()
 
-    def test_delivery_wraps_content_with_header_and_footer(self):
-        """Delivered content should include task name header and agent-invisible note."""
+    def test_delivery_appends_cron_metadata_as_footer(self):
+        """Delivered content should put the actual result first and cron metadata last."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -522,11 +522,11 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content.startswith("Here is today's summary.\n\n-------------\n")
         assert "Cronjob Response: daily-report" in sent_content
         assert "(job_id: test-job)" in sent_content
-        assert "-------------" in sent_content
-        assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
+        assert sent_content.index("Here is today's summary.") < sent_content.index("Cronjob Response: daily-report")
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
@@ -1830,7 +1830,7 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
-    def test_silent_with_note_suppresses_delivery(self):
+    def test_silent_with_note_is_delivered(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -1838,10 +1838,10 @@ class TestSilentDelivery:
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
 
-    def test_silent_trailing_suppresses_delivery(self):
-        """Agent appended [SILENT] after explanation text — must still suppress."""
+    def test_silent_trailing_is_delivered(self):
+        """Responses that contain real content must not be silenced by a marker substring."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
@@ -1850,11 +1850,11 @@ class TestSilentDelivery:
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
 
-    def test_silent_is_case_insensitive(self):
+    def test_silent_only_is_case_insensitive(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent]", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -308,15 +308,15 @@ This applies only to cron deliveries. `TELEGRAM_HOME_CHANNEL_THREAD_ID` (used el
 
 ### Response wrapping
 
-By default, delivered cron output is wrapped with a header and footer so the recipient knows it came from a scheduled task:
+By default, delivered cron output appends a footer so the recipient knows it came from a scheduled task without pushing the actual result below metadata:
 
 ```
-Cronjob Response: Morning feeds
--------------
-
 <agent output here>
 
-Note: The agent cannot see this message, and therefore cannot respond to it.
+-------------
+Cronjob Response: Morning feeds
+(job_id: abc123)
+To stop or manage this job, send me a new message (e.g. "stop reminder Morning feeds").
 ```
 
 To deliver the raw agent output without the wrapper, set `cron.wrap_response` to `false`:
@@ -329,7 +329,7 @@ cron:
 
 ### Silent suppression
 
-If the agent's final response starts with `[SILENT]`, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/`), but no message is sent to the delivery target.
+If the agent's final response is exactly `[SILENT]` after trimming whitespace, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/`), but no message is sent to the delivery target. Responses that contain real report text plus `[SILENT]` are still delivered.
 
 This is useful for monitoring jobs that should only report when something is wrong:
 


### PR DESCRIPTION
## Summary
- Deliver cron final responses that contain real report text even if they mention `[SILENT]`.
- Suppress delivery only when the trimmed final response is exactly `[SILENT]` (case-insensitive).
- Move cron response metadata to a footer so report text appears first in chat clients.

## Tests
- `pytest tests/cron/test_scheduler.py -q -o addopts=''`

## Context
APOM collection run reports can contain success/OK report text while also referencing `[SILENT]`. The broad substring check suppressed those successful Slack deliveries. This keeps truly silent watchdog runs silent while allowing generated reports to post.