### PR TITLE
fix: hide disabled toolsets from banner

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5356,7 +5356,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._show_status()
         else:
             # Get tools for display
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(
+                enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
+                quiet_mode=True,
+            )
             
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
@@ -5368,6 +5372,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 cwd=cwd,
                 tools=tools,
                 enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
                 session_id=self.session_id,
                 context_length=ctx_len,
             )
@@ -5676,7 +5681,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
             tool_status = "tools deferred"
         else:
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(
+                enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
+                quiet_mode=True,
+            )
             tool_count = len(tools) if tools else 0
             tool_status = f"{tool_count} tools"
 
@@ -5843,7 +5852,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
-        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+        tools = get_tool_definitions(
+            enabled_toolsets=self.enabled_toolsets,
+            disabled_toolsets=self.disabled_toolsets,
+            quiet_mode=True,
+        )
         
         if not tools:
             print("(;_;) No tools available")
@@ -7542,7 +7555,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if self.compact or term_w < 80:
                     cc.print(_build_compact_banner())
                 else:
-                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                    tools = get_tool_definitions(
+                        enabled_toolsets=self.enabled_toolsets,
+                        disabled_toolsets=self.disabled_toolsets,
+                        quiet_mode=True,
+                    )
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
                     ctx_len = None
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
@@ -7553,6 +7570,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         cwd=cwd,
                         tools=tools,
                         enabled_toolsets=self.enabled_toolsets,
+                        disabled_toolsets=self.disabled_toolsets,
                         session_id=self.session_id,
                         context_length=ctx_len,
                     )
@@ -9694,6 +9712,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 refresh_agent_mcp_tools(
                     self.agent,
                     enabled_override=enabled_override,
+                    disabled_override=getattr(self, "disabled_toolsets", None),
                     quiet_mode=True,
                 )
                 # Keep the CLI's own list in sync with what the agent now uses.

--- a/cli.py
+++ b/cli.py
@@ -5351,14 +5351,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         term_width = shutil.get_terminal_size().columns
         use_compact = self.compact or term_width < 80
         
+        enabled_toolsets = getattr(self, "enabled_toolsets", None) or []
+        disabled_toolsets = getattr(self, "disabled_toolsets", None) or []
+
         if use_compact:
             self._console_print(_build_compact_banner())
             self._show_status()
         else:
             # Get tools for display
             tools = get_tool_definitions(
-                enabled_toolsets=self.enabled_toolsets,
-                disabled_toolsets=self.disabled_toolsets,
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
                 quiet_mode=True,
             )
             
@@ -5371,8 +5374,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 model=self.model,
                 cwd=cwd,
                 tools=tools,
-                enabled_toolsets=self.enabled_toolsets,
-                disabled_toolsets=self.disabled_toolsets,
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
                 session_id=self.session_id,
                 context_length=ctx_len,
             )
@@ -5677,13 +5680,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     
     def _show_status(self):
         """Show compact startup status line."""
+        enabled_toolsets = getattr(self, "enabled_toolsets", None) or []
+        disabled_toolsets = getattr(self, "disabled_toolsets", None) or []
+
         # Avoid pulling the full tool registry into the bare Termux prompt path.
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
             tool_status = "tools deferred"
         else:
             tools = get_tool_definitions(
-                enabled_toolsets=self.enabled_toolsets,
-                disabled_toolsets=self.disabled_toolsets,
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
                 quiet_mode=True,
             )
             tool_count = len(tools) if tools else 0
@@ -5710,8 +5716,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             separator_color, accent_color, label_color = "#B8860B", "#FFBF00", "cyan"
         toolsets_info = ""
-        if self.enabled_toolsets and "all" not in self.enabled_toolsets:
-            toolsets_info = f" [dim {separator_color}]·[/] [{label_color}]toolsets: {', '.join(self.enabled_toolsets)}[/]"
+        if enabled_toolsets and "all" not in enabled_toolsets:
+            toolsets_info = f" [dim {separator_color}]·[/] [{label_color}]toolsets: {', '.join(enabled_toolsets)}[/]"
 
         provider_info = f" [dim {separator_color}]·[/] [dim]provider: {self.provider}[/]"
         if self._provider_source:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -552,7 +552,8 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                          enabled_toolsets: List[str] = None,
                          session_id: str = None,
                          get_toolset_for_tool=None,
-                         context_length: int = None):
+                         context_length: Optional[int] = None,
+                         disabled_toolsets: Optional[List[str]] = None):
     """Build and print a welcome banner with caduceus on left and info on right.
 
     Args:
@@ -564,6 +565,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         session_id: Session identifier.
         get_toolset_for_tool: Callable to map tool name -> toolset name.
         context_length: Model's context window size in tokens.
+        disabled_toolsets: Toolset names explicitly removed from the active session.
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
     from rich.panel import Panel
@@ -573,8 +575,52 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
 
     tools = tools or []
     enabled_toolsets = enabled_toolsets or []
+    disabled_toolsets = disabled_toolsets or []
 
     _, unavailable_toolsets = check_tool_availability(quiet=True)
+
+    enabled_scope = {str(ts) for ts in enabled_toolsets if ts}
+    disabled_scope = {str(ts) for ts in disabled_toolsets if ts}
+
+    def _scope_names(toolset_name: str) -> set:
+        """Return aliases that may refer to the same toolset in config/UI."""
+        if not toolset_name:
+            return {"unknown"}
+        display_name = _display_toolset_name(toolset_name)
+        names = {toolset_name, display_name}
+        if display_name and display_name != "unknown":
+            names.add(f"{display_name}_tools")
+        return names
+
+    def _item_matches_scope(item: dict, scope: set) -> bool:
+        if not scope:
+            return False
+        item_names = set()
+        for key in ("id", "name"):
+            value = item.get(key)
+            if value:
+                item_names.update(_scope_names(str(value)))
+        return bool(item_names.intersection(scope))
+
+    def _toolset_matches_scope(toolset_name: str, scope: set) -> bool:
+        return bool(scope and _scope_names(toolset_name).intersection(scope))
+
+    if disabled_scope:
+        unavailable_toolsets = [
+            item for item in unavailable_toolsets
+            if not _item_matches_scope(item, disabled_scope)
+        ]
+
+    show_all_unavailable = (
+        not enabled_scope
+        or "all" in enabled_scope
+        or "*" in enabled_scope
+    )
+    if not show_all_unavailable:
+        unavailable_toolsets = [
+            item for item in unavailable_toolsets
+            if _item_matches_scope(item, enabled_scope)
+        ]
     disabled_tools = set()
     # Tools whose toolset has a check_fn are lazy-initialized (e.g. honcho,
     # homeassistant) — they show as unavailable at banner time because the
@@ -628,7 +674,10 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
 
     for tool in tools:
         tool_name = tool["function"]["name"]
-        toolset = _display_toolset_name(get_toolset_for_tool(tool_name) or "other")
+        raw_toolset = get_toolset_for_tool(tool_name) or "other"
+        if _toolset_matches_scope(raw_toolset, disabled_scope):
+            continue
+        toolset = _display_toolset_name(raw_toolset)
         toolsets_dict.setdefault(toolset, []).append(tool_name)
 
     for item in unavailable_toolsets:

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -70,6 +70,55 @@ def test_build_welcome_banner_uses_normalized_toolset_names():
     assert "web_tools:" not in output
 
 
+def test_build_welcome_banner_honors_active_toolset_scope():
+    """Startup banner should not resurrect disabled/unconfigured toolsets."""
+    with (
+        patch.object(
+            model_tools,
+            "check_tool_availability",
+            return_value=(
+                ["web", "file"],
+                [
+                    {"name": "browser-cdp", "tools": ["browser_cdp", "browser_dialog"]},
+                    {"name": "homeassistant", "tools": ["ha_call_service"]},
+                ],
+            ),
+        ),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+    ):
+        console = Console(
+            record=True, force_terminal=False, color_system=None, width=160
+        )
+        banner.build_welcome_banner(
+            console=console,
+            model="anthropic/test-model",
+            cwd="/tmp/project",
+            tools=[
+                {"function": {"name": "web_search"}},
+                {"function": {"name": "read_file"}},
+                {"function": {"name": "computer_use"}},
+            ],
+            enabled_toolsets=["web", "file", "computer_use", "browser-cdp"],
+            disabled_toolsets=["computer_use", "browser-cdp"],
+            get_toolset_for_tool=lambda name: {
+                "web_search": "web",
+                "read_file": "file",
+                "computer_use": "computer_use",
+            }.get(name),
+        )
+
+    output = console.export_text()
+    assert "web:" in output
+    assert "file:" in output
+    assert "computer_use" not in output
+    assert "browser-cdp:" not in output
+    assert "browser_cdp" not in output
+    assert "browser_dialog" not in output
+    assert "homeassistant" not in output
+
+
 def test_build_welcome_banner_title_is_hyperlinked_to_release():
     """Panel title (version label) is wrapped in an OSC-8 hyperlink to the GitHub release."""
     import io


### PR DESCRIPTION
## What does this PR do?

Hides explicitly disabled toolsets from the Hermes startup banner. The banner was still able to show disabled or unavailable toolsets because it built display data from the broader availability check instead of the active session scope.

This keeps banner output aligned with the configured active toolsets by passing `disabled_toolsets` through the CLI banner paths and filtering both unavailable toolset rows and rendered tool groups. The follow-up commit also makes the banner/status paths tolerate minimal `HermesCLI.__new__` test instances that do not have `disabled_toolsets` initialized yet.

## Related Issue

No related issue found during duplicate search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: pass `disabled_toolsets` into banner/tool display calls, and default `enabled_toolsets` / `disabled_toolsets` safely inside banner/status rendering so minimal constructed CLI objects do not crash.
- `hermes_cli/banner.py`: filter unavailable and rendered toolset groups against the enabled/disabled session scope.
- `tests/hermes_cli/test_banner.py`: add regression coverage proving disabled toolsets do not reappear in the welcome banner.

## How to Test

1. Configure Hermes with a disabled toolset such as `computer_use` or a disabled browser-related toolset.
2. Start the CLI and confirm the startup banner does not list the disabled toolset or its tools.
3. Run the focused validation below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run, focused validation and GitHub matrix below)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no docs surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — CLI banner filtering only, no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schemas changed

## For New Skills

N/A, this PR does not add or change skills.

## Screenshots / Logs

Duplicate search summary:

- Searched open and closed PRs/issues for exact title `hide disabled toolsets from banner`.
- Searched disabled-toolset/banner wording and touched path terms including `hermes_cli/banner.py` and `tests/hermes_cli/test_banner.py`.
- No equivalent open or closed PR/issue was found.

CI failure follow-up:

- Previous `test (4)` failure was PR-caused: `tests/cli/test_cli_context_warning.py::TestLowContextWarning::*` crashed because minimal `HermesCLI.__new__` instances lacked `disabled_toolsets`. Fixed by safely defaulting active toolset scope in `show_banner()` and `_show_status()`.
- Previous `test (5)` Honcho failure is not caused by this branch. This PR does not touch Honcho code; the PR base SHA had `test (5)` green, the full Honcho session test file passed locally, and the fresh GitHub `test (5)` run passed after rerun on the updated head.

Focused local validation from this branch:

```text
$ python -m pytest tests/cli/test_cli_context_warning.py tests/hermes_cli/test_banner.py -o 'addopts=' -q
.................                                                        [100%]
17 passed, 1 warning in 3.13s

$ python -m py_compile cli.py hermes_cli/banner.py tests/hermes_cli/test_banner.py tests/cli/test_cli_context_warning.py
cli.py:11331: SyntaxWarning: 'return' in a 'finally' block
  return
py_compile: OK

$ git diff --check origin/main...HEAD
git diff --check: OK

$ python -m pytest tests/honcho_plugin/test_session.py::TestDialecticLifecycleSmoke::test_full_multi_turn_session -o 'addopts=' -q
.                                                                        [100%]
1 passed in 0.20s

$ python -m pytest tests/honcho_plugin/test_session.py -o 'addopts=' -q
........................................................................ [ 61%]
..............................................                           [100%]
118 passed in 1.17s
```

GitHub checks at head `6792bab3045bdddc923311f23da4894dca9b3b34`:

```text
Tests: pass, including test (4) and test (5) in run 26857130490
Lint (ruff + ty): pass
Nix: pass on ubuntu-latest and macos-latest
Docker Build and Publish: build-amd64 pass, build-arm64 pass, publish merge skipped as expected on PR
Supply Chain Audit: pass
Contributor Attribution Check: pass
History Check: pass
```
