### PR TITLE
fix(cli): render skin goodbye markup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12665,7 +12665,11 @@ class HermesCLI:
                 goodbye = get_active_goodbye("Goodbye! ⚕")
             except Exception:
                 goodbye = "Goodbye! ⚕"
-            print(goodbye)
+            # Skin branding may include Rich markup (for example
+            # ``[#BFA46A]Loops closed.[/]``). Route it through the same
+            # console path as the welcome line so colors render instead of
+            # leaking literal tags on exit.
+            self._console_print(goodbye)
 
     def _get_tui_prompt_symbols(self) -> tuple[str, str]:
         """Return ``(normal_prompt, state_suffix)`` for the active skin.

--- a/tests/cli/test_exit_summary_resume_hint.py
+++ b/tests/cli/test_exit_summary_resume_hint.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock, patch
 from cli import HermesCLI
 
 
+MARKUP_GOODBYE = "[#BFA46A]Loops closed.[/] [#FFD37A]Engine halted.[/]"
+
+
 def _make_cli(session_id="20260524_000001_abc123"):
     cli_obj = HermesCLI.__new__(HermesCLI)
     cli_obj.session_id = session_id
@@ -81,3 +84,21 @@ class TestExitSummaryResumeHint:
         # Resume hint still printed without -p.
         assert "hermes --resume 20260524_000001_abc123" in out
         assert " -p " not in out
+
+    def test_empty_session_goodbye_uses_rich_console_path(self, capsys):
+        """Skin goodbye strings can contain Rich color markup.
+
+        Empty sessions print only the skin goodbye line, so that path must use
+        HermesCLI._console_print instead of raw print(); otherwise users see
+        literal tags like ``[#BFA46A]Loops closed.[/]`` on exit.
+        """
+        cli_obj = _make_cli()
+        cli_obj.conversation_history = []
+        cli_obj.console = MagicMock()
+
+        with patch("hermes_cli.skin_engine.get_active_goodbye", return_value=MARKUP_GOODBYE):
+            cli_obj._print_exit_summary()
+
+        out = capsys.readouterr().out
+        assert MARKUP_GOODBYE not in out
+        cli_obj.console.print.assert_called_once_with(MARKUP_GOODBYE)


### PR DESCRIPTION
## What does this PR do?

Fixes the empty-session CLI exit path so skin goodbye strings are printed through the Rich console instead of raw `print()`. Some skins include Rich color markup in the goodbye text, for example `[#BFA46A]Loops closed.[/] [#FFD37A]Engine halted.[/]`; the old path leaked those tags literally on exit.

The fix routes the goodbye line through the same console rendering path used elsewhere in the CLI and adds regression coverage for the empty-session exit case.

## Related Issue

No linked issue found. Duplicate search before opening covered PRs and issues for `render skin goodbye markup`, `goodbye markup`, `skin goodbye`, `raw Rich tags`, `Loops closed`, `Engine halted`, `test_exit_summary_resume_hint.py`, and the touched file pair `cli.py` + `test_exit_summary_resume_hint.py`; no equivalent open or closed result was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: replaces the raw empty-session goodbye `print()` call with `HermesCLI._console_print()` so Rich markup is rendered.
- `tests/cli/test_exit_summary_resume_hint.py`: adds a regression test proving a Rich-markup goodbye string does not leak literal tags through stdout and is sent to the console path.

## How to Test

1. Run the focused regression test:
   `python -m pytest tests/cli/test_exit_summary_resume_hint.py -o 'addopts=' -q`
2. Compile the touched files:
   `python -m py_compile cli.py tests/cli/test_exit_summary_resume_hint.py`
3. Check whitespace in the branch diff:
   `git diff --check origin/main...HEAD`
4. Optional render smoke: instantiate `HermesCLI`, patch `get_active_goodbye()` to a Rich-markup string, render through a forced Rich console, and verify the output contains ANSI color codes but not literal `[#BFA46A]` or `[/]` tags.

Validation run locally:

```text
python -m pytest tests/cli/test_exit_summary_resume_hint.py -o 'addopts=' -q
......                                                                   [100%]
6 passed in 0.46s

python -m py_compile cli.py tests/cli/test_exit_summary_resume_hint.py
cli.py:11305: SyntaxWarning: 'return' in a 'finally' block
  return

# exit code 0

git diff --check origin/main...HEAD
# exit code 0, no output

render smoke output:
'\x1b[38;2;191;164;106mLoops closed.\x1b[0m \x1b[38;2;255;211;122mEngine halted.\x1b[0m\n'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused validation logs are included above. The render smoke confirms Rich markup is converted to ANSI color output instead of leaking literal tags.
