### PR TITLE
fix(desktop): ignore IME composing Enter in composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -20,6 +20,7 @@ import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { chatMessageText } from '@/lib/chat-messages'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
+import { isImeComposing } from '@/lib/ime'
 import { cn } from '@/lib/utils'
 import {
   $composerAttachments,
@@ -555,6 +556,10 @@ export function ChatBar({
       return
     }
 
+    if (event.key === 'Enter' && isImeComposing(event)) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -1024,8 +1029,8 @@ export function ChatBar({
     <div className={cn('relative', stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1')}>
       <div
         aria-label="Message"
-        autoCorrect="off"
         autoCapitalize="off"
+        autoCorrect="off"
         className={cn(
           'min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) overflow-y-auto bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
           'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -48,14 +48,13 @@ import { detectTrigger, textBeforeCaret, type TriggerState } from '@/app/chat/co
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
 import { extractDroppedFiles, HERMES_PATHS_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
-import { DirectiveContent } from '@/components/assistant-ui/directive-text'
-import { UserMessageText } from '@/components/assistant-ui/user-message-text'
-import { hermesDirectiveFormatter } from '@/components/assistant-ui/directive-text'
+import { DirectiveContent, hermesDirectiveFormatter } from '@/components/assistant-ui/directive-text'
 import { MarkdownText } from '@/components/assistant-ui/markdown-text'
 import { VirtualizedThread } from '@/components/assistant-ui/thread-virtualizer'
 import { HoistedTodoPanel, todosFromMessageContent } from '@/components/assistant-ui/todo-tool'
 import { ToolFallback, ToolGroupSlot } from '@/components/assistant-ui/tool-fallback'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
+import { UserMessageText } from '@/components/assistant-ui/user-message-text'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { DisclosureRow } from '@/components/chat/disclosure-row'
@@ -77,6 +76,7 @@ import type { HermesGateway } from '@/hermes'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
 import { GitBranchIcon, Loader2Icon, Volume2Icon, VolumeXIcon } from '@/lib/icons'
+import { isImeComposing } from '@/lib/ime'
 import { extractPreviewTargets } from '@/lib/preview-targets'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
@@ -1197,6 +1197,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && isImeComposing(event)) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()

--- a/apps/desktop/src/lib/ime.test.ts
+++ b/apps/desktop/src/lib/ime.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { isImeComposing } from './ime'
+
+describe('isImeComposing', () => {
+  it('detects active composition from modern keyboard events', () => {
+    expect(isImeComposing({ key: 'Enter', nativeEvent: { isComposing: true } })).toBe(true)
+  })
+
+  it('detects legacy IME keyCode 229 events', () => {
+    expect(isImeComposing({ key: 'Enter', nativeEvent: { keyCode: 229 } })).toBe(true)
+  })
+
+  it('detects Process key events from IME input', () => {
+    expect(isImeComposing({ key: 'Process' })).toBe(true)
+  })
+
+  it('does not treat normal Enter as composition', () => {
+    expect(isImeComposing({ key: 'Enter', nativeEvent: { isComposing: false, keyCode: 13 } })).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/ime.ts
+++ b/apps/desktop/src/lib/ime.ts
@@ -1,0 +1,11 @@
+interface ImeKeyboardEventLike {
+  key: string
+  nativeEvent?: {
+    isComposing?: boolean
+    keyCode?: number
+  }
+}
+
+export function isImeComposing(event: ImeKeyboardEventLike): boolean {
+  return event.nativeEvent?.isComposing === true || event.nativeEvent?.keyCode === 229 || event.key === 'Process'
+}


### PR DESCRIPTION
## Summary
- Add a shared IME composition detector for Desktop keyboard events
- Ignore composing Enter before trigger selection/submission in both main and edit composers
- Add unit coverage for modern, legacy, and Process-key IME signals

## Test Plan
- npm run type-check
- npm run test:ui -- src/lib/ime.test.ts src/app/chat/composer/rich-editor.test.ts
- npx eslint src/lib/ime.ts src/lib/ime.test.ts src/app/chat/composer/index.tsx src/components/assistant-ui/thread.tsx
- npm run build

## Review
- Codex/gstack review found initial gaps around trigger popover and edit composer; fixed
- Independent pre-commit reviewer passed the staged diff