### PR TITLE
[fix] gateway pairing hint for profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,22 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+
+def _pairing_approve_command_hint(platform_name: str, code: str) -> str:
+    """Return profile-aware CLI instructions for approving a DM pairing code."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile_name = get_active_profile_name()
+    except Exception:
+        profile_name = "default"
+
+    if profile_name in ("default", "custom"):
+        return f"`hermes pairing approve {platform_name} {code}`"
+
+    return f"`{profile_name} pairing approve {platform_name} {code}`"
+
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -7377,7 +7393,7 @@ class GatewayRunner:
                             f"Hi~ I don't recognize you yet!\n\n"
                             f"Here's your pairing code: `{code}`\n\n"
                             f"Ask the bot owner to run:\n"
-                            f"`hermes pairing approve {platform_name} {code}`"
+                            f"{_pairing_approve_command_hint(platform_name, code)}"
                         )
                 else:
                     adapter = self.adapters.get(source.platform)

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -509,6 +509,33 @@ async def test_unauthorized_dm_pairs_by_default(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_unauthorized_dm_pairing_hint_includes_active_profile(monkeypatch, tmp_path):
+    _clear_auth_env(monkeypatch)
+    profile_home = tmp_path / ".hermes" / "profiles" / "invest"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    config = GatewayConfig(
+        platforms={Platform.FEISHU: PlatformConfig(enabled=True)},
+    )
+    runner, adapter = _make_runner(Platform.FEISHU, config)
+    runner.pairing_store.generate_code.return_value = "UXWBV4E8"
+
+    result = await runner._handle_message(
+        _make_event(
+            Platform.FEISHU,
+            "ou_unknown",
+            "ou_unknown",
+        )
+    )
+
+    assert result is None
+    adapter.send.assert_awaited_once()
+    message = adapter.send.await_args.args[1]
+    assert "`invest pairing approve feishu UXWBV4E8`" in message
+    assert "`hermes pairing approve feishu UXWBV4E8`" not in message
+
+
+@pytest.mark.asyncio
 async def test_unauthorized_whatsapp_dm_can_be_ignored(monkeypatch):
     _clear_auth_env(monkeypatch)
     config = GatewayConfig(


### PR DESCRIPTION
## Summary

- Make unauthorized DM pairing instructions profile-aware.
- Keep the default profile hint unchanged, while non-default profiles now show the profile alias command, for example `invest pairing approve feishu UXWBV4E8`.
- Add a regression test covering a Feishu DM pairing request from a named profile.

## Root cause

The gateway pairing response always rendered `hermes pairing approve <platform> <code>`. Pairing state is stored under the active profile's Hermes home, so approving a code from the default profile can miss pending requests created by a non-default profile gateway.

## Validation

- `uv run --python C:\Python313\python.exe python -m pytest tests/gateway/test_unauthorized_dm_behavior.py::test_unauthorized_dm_pairing_hint_includes_active_profile tests/gateway/test_unauthorized_dm_behavior.py::test_unauthorized_dm_pairs_by_default --timeout-method=thread -q`
- `git diff --check -- gateway/run.py tests/gateway/test_unauthorized_dm_behavior.py`