### PR TITLE
fix(cleanup): revalidate cron-output paths before deletion in quick()

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -231,7 +231,13 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
         elif cat == "temp" and age > 7:
             auto.append(item)
         elif cat == "cron-output" and age > 14:
-            auto.append(item)
+            # Revalidate stale entries (see #37721).
+            try:
+                rel = p.resolve().relative_to(get_hermes_home())
+                if len(rel.parts) >= 2 and rel.parts[1] == "output":
+                    auto.append(item)
+            except (ValueError, OSError):
+                pass
         elif cat == "research" and age > 30:
             prompt.append(item)
         elif cat == "chrome-profile" and age > 14:
@@ -268,6 +274,20 @@ def quick() -> Dict[str, Any]:
             continue
 
         age = (now - datetime.fromisoformat(item["timestamp"])).days
+
+        # Revalidate the stored category before deleting.  Stale
+        # tracked.json entries from older versions may have classified
+        # cron control-plane state (e.g. jobs.json) as "cron-output".
+        # Current guess_category() restricts cron-output to files
+        # under cron/output/**, so re-check the path at delete time
+        # to avoid wiping live scheduler registry.  See issue #37721.
+        if cat == "cron-output":
+            try:
+                rel = p.resolve().relative_to(get_hermes_home())
+                if not (len(rel.parts) >= 2 and rel.parts[1] == "output"):
+                    cat = None
+            except (ValueError, OSError):
+                cat = None
 
         should_delete = (
             cat == "test"

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -223,6 +223,44 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
+    def test_quick_skips_stale_cron_output_entry_for_jobs_json(self, _isolate_env):
+        """Regression for #37721: stale tracked.json entries must not
+        delete cron control-plane state even if stored category says
+        "cron-output"."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        jobs = cron_dir / "jobs.json"
+        jobs.write_text("[]")
+        # Simulate a stale tracked.json entry from an older version
+        # that classified jobs.json as cron-output.
+        tracked = [{
+            "path": str(jobs),
+            "category": "cron-output",
+            "timestamp": "2020-01-01T00:00:00+00:00",
+            "size": 2,
+        }]
+        dg.save_tracked(tracked)
+        summary = dg.quick()
+        assert summary["deleted"] == 0
+        assert jobs.exists(), "jobs.json must survive quick()"
+
+    def test_quick_deletes_cron_output_subdir(self, _isolate_env):
+        """Files under cron/output/ are still eligible for cleanup."""
+        dg = _load_lib()
+        out_dir = _isolate_env / "cron" / "output"
+        out_dir.mkdir(parents=True)
+        old = out_dir / "old_result.json"
+        old.write_text("{}")
+        dg.track(str(old), "cron-output", silent=True)
+        # Fake an old timestamp
+        tracked = dg.load_tracked()
+        tracked[0]["timestamp"] = "2020-01-01T00:00:00+00:00"
+        dg.save_tracked(tracked)
+        summary = dg.quick()
+        assert summary["deleted"] == 1
+        assert not old.exists()
+
 
 class TestStatus:
     def test_empty_status(self, _isolate_env):


### PR DESCRIPTION
## Summary

Fixes #37721 — `disk-cleanup.quick()` can delete `$HERMES_HOME/cron/jobs.json` from stale `tracked.json` entries.

### Problem

Old `tracked.json` entries (from before #32164) may have classified cron control-plane state as `cron-output`. The `guess_category()` function was fixed, but `quick()` and `dry_run()` still trusted the stored category without revalidating the path at delete time.

### Fix

Add a revalidation step in both `quick()` and `dry_run()`: for entries with `category == "cron-output"`, verify the path is still under `$HERMES_HOME/cron/output/**` before marking for deletion. Paths that don't match are skipped (not deleted).

### Changes

- `plugins/disk-cleanup/disk_cleanup.py`: Revalidate cron-output paths in `quick()` and `dry_run()`
- `tests/plugins/test_disk_cleanup_plugin.py`: 2 new regression tests
  - `test_quick_skips_stale_cron_output_entry_for_jobs_json` — verifies jobs.json survives
  - `test_quick_deletes_cron_output_subdir` — verifies actual cron output files are still cleaned up

All 43 tests pass.
