### PR TITLE
fix: prevent config dual-write conflict in gateway model switch (#37751)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11295,34 +11295,23 @@ class GatewayRunner:
         self._evict_cached_agent(session_key)
 
         # Persist to config if --global
+        # NOTE: Use save_config_value (atomic roundtrip) instead of the full
+        # save_config(cfg) to avoid the dual-write conflict described in #37751.
+        # save_config does a full dict rewrite via atomic_yaml_write() which can
+        # overwrite concurrent Desktop UI changes (regex field replacements).
+        # save_config_value uses atomic_roundtrip_yaml_update() which updates
+        # only the requested dotted keys, preserving any other changes that may
+        # have been made by another process between read and write.
         if persist_global:
             try:
-                if config_path.exists():
-                    with open(config_path, encoding="utf-8") as f:
-                        cfg = yaml.safe_load(f) or {}
-                else:
-                    cfg = {}
-                # Coerce scalar/None ``model:`` into a dict before mutation —
-                # otherwise ``cfg.setdefault("model", {})`` returns the existing
-                # scalar and the next assignment raises
-                # ``TypeError: 'str' object does not support item assignment``.
-                # Reproduces when ``config.yaml`` has ``model: <name>`` (flat
-                # string) instead of the proper nested ``model: {default: ...}``.
-                raw_model = cfg.get("model")
-                if isinstance(raw_model, dict):
-                    model_cfg = raw_model
-                elif isinstance(raw_model, str) and raw_model.strip():
-                    model_cfg = {"default": raw_model.strip()}
-                    cfg["model"] = model_cfg
-                else:
-                    model_cfg = {}
-                    cfg["model"] = model_cfg
-                model_cfg["default"] = result.new_model
-                model_cfg["provider"] = result.target_provider
+                # Use save_config_value for atomic per-key updates,
+                # matching the CLI behavior at cli.py:7802-7805.
+                from cli import save_config_value as _save_config_value
+                _save_config_value("model.default", result.new_model)
+                if result.provider_changed:
+                    _save_config_value("model.provider", result.target_provider)
                 if result.base_url:
-                    model_cfg["base_url"] = result.base_url
-                from hermes_cli.config import save_config
-                save_config(cfg)
+                    _save_config_value("model.base_url", result.base_url)
             except Exception as e:
                 logger.warning("Failed to persist model switch: %s", e)
 


### PR DESCRIPTION
## Summary

Fixes the Desktop↔Gateway config dual-write conflict described in #37751 by replacing the full-dict `save_config()` call with atomic per-key `save_config_value()` calls in the gateway's `_handle_model_command` `--global` path.

## Root Cause

When `/model <name> --global` is used in the gateway, the old code:
1. Read the full config.yaml
2. Mutated the model dict in memory
3. Called `save_config(cfg)` which does a **full YAML rewrite** via `atomic_yaml_write()`

This full-dict rewrite can **overwrite concurrent changes** made by the Desktop UI (which uses regex field replacements), causing the contradictory config states described in #37751.

## Fix

The CLI already avoids this problem by using `save_config_value()` (at `cli.py:7802-7805`) which calls `atomic_roundtrip_yaml_update()` — this updates **only the requested dotted keys** while preserving any other changes in the file.

This fix aligns the gateway with the same safe pattern:
- `save_config_value("model.default", result.new_model)`
- `save_config_value("model.provider", result.target_provider)` (only if provider changed)
- `save_config_value("model.base_url", result.base_url)` (only if base URL changed)

The scalar model coercion (`model: <name>` → `model: {default: ...}`) is handled internally by `atomic_roundtrip_yaml_update()`, so the explicit YAML parsing and dict manipulation code is no longer needed.

## Testing

- [ ] Verified the gateway `/model <name> --global` command path uses `save_config_value` instead of `save_config`
- [ ] `save_config_value` is already tested in `tests/cli/test_cli_save_config_value.py`
- [ ] CLI `/model --global` behavior is unchanged (still uses `save_config_value`)
- [ ] Gateway picker flow (non-global session override) is unchanged

Closes #37751