### PR TITLE
fix(gateway): scope Telegram topic toolsets per topic

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1496,6 +1496,76 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _telegram_topic_enabled_toolsets(user_config: dict, source: "SessionSource") -> Optional[List[str]]:
+    """Return a Telegram group-topic toolset allowlist when configured."""
+    if source.platform != Platform.TELEGRAM:
+        return None
+    if str(getattr(source, "chat_type", "") or "") != "group":
+        return None
+
+    thread_id = getattr(source, "thread_id", None)
+    if thread_id is None:
+        return None
+
+    telegram_cfg = user_config.get("telegram") or {}
+    if not isinstance(telegram_cfg, dict):
+        return None
+
+    group_topics = telegram_cfg.get("group_topics") or []
+    if not isinstance(group_topics, list):
+        return None
+
+    chat_id = str(getattr(source, "chat_id", "") or "")
+    thread_id = str(thread_id)
+
+    for chat_entry in group_topics:
+        if not isinstance(chat_entry, dict):
+            continue
+        if str(chat_entry.get("chat_id", "")) != chat_id:
+            continue
+        topics = chat_entry.get("topics") or []
+        if not isinstance(topics, list):
+            return None
+        for topic in topics:
+            if not isinstance(topic, dict):
+                continue
+            topic_thread_id = topic.get("thread_id")
+            if topic_thread_id is None or str(topic_thread_id) != thread_id:
+                continue
+            enabled_toolsets = topic.get("enabled_toolsets")
+            if isinstance(enabled_toolsets, list):
+                return [str(toolset) for toolset in enabled_toolsets]
+            return None
+        return None
+
+    return None
+
+
+def _resolve_enabled_toolsets_for_source(user_config: dict, source: "SessionSource") -> List[str]:
+    """Resolve the effective toolset list for a gateway source."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    platform_key = _platform_config_key(source.platform)
+    topic_toolsets = _telegram_topic_enabled_toolsets(user_config, source)
+    if topic_toolsets is None:
+        return sorted(_get_platform_tools(user_config, platform_key))
+
+    scoped_config = dict(user_config or {})
+    platform_toolsets = dict(scoped_config.get("platform_toolsets") or {})
+    platform_toolsets[platform_key] = list(topic_toolsets)
+    scoped_config["platform_toolsets"] = platform_toolsets
+
+    resolved = sorted(
+        _get_platform_tools(
+            scoped_config,
+            platform_key,
+            include_default_mcp_servers=False,
+        )
+    )
+    topic_toolset_names = set(topic_toolsets)
+    return [toolset for toolset in resolved if toolset in topic_toolset_names]
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -12479,9 +12549,7 @@ class GatewayRunner:
                 return
 
             platform_key = _platform_config_key(source.platform)
-
-            from hermes_cli.tools_config import _get_platform_tools
-            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets = _resolve_enabled_toolsets_for_source(user_config, source)
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
@@ -16822,9 +16890,7 @@ class GatewayRunner:
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
-
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        enabled_toolsets = _resolve_enabled_toolsets_for_source(user_config, source)
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/tests/gateway/test_telegram_topic_toolsets.py
+++ b/tests/gateway/test_telegram_topic_toolsets.py
@@ -1,0 +1,141 @@
+"""Regression tests for Telegram topic-specific toolset scoping."""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._session_reasoning_overrides = {}
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def test_resolve_enabled_toolsets_for_telegram_topic_uses_topic_allowlist():
+    user_config = {
+        "platform_toolsets": {
+            "telegram": ["web", "file", "memory"],
+        },
+        "mcp_servers": {
+            "mcp-custom": {"enabled": True},
+        },
+        "telegram": {
+            "group_topics": [
+                {
+                    "chat_id": "-1001",
+                    "topics": [
+                        {
+                            "thread_id": 3,
+                            "name": "Ops",
+                            "enabled_toolsets": ["file", "web", "mcp-custom"],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="3",
+        user_id="user-1",
+    )
+
+    enabled = gateway_run._resolve_enabled_toolsets_for_source(user_config, source)
+
+    assert enabled == ["file", "mcp-custom", "web"]
+
+
+def test_run_agent_telegram_topic_scopes_enabled_toolsets(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platform_toolsets:\n"
+        "  telegram: [web, file, memory]\n"
+        "telegram:\n"
+        "  group_topics:\n"
+        "    - chat_id: \"-1001\"\n"
+        "      topics:\n"
+        "        - thread_id: 3\n"
+        "          name: Ops\n"
+        "          enabled_toolsets: [file, web]\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+        },
+    )
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    _CapturingAgent.last_init = None
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Team Chat",
+        chat_type="group",
+        thread_id="3",
+        user_id="user-1",
+        user_name="Test User",
+    )
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key="agent:main:telegram:group:-1001:3",
+        )
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["enabled_toolsets"] == ["file", "web"]


### PR DESCRIPTION
## Summary
- honor `telegram.group_topics[].topics[].enabled_toolsets` when a Telegram group topic starts a session
- reuse the same source-aware toolset resolver for both foreground turns and `/background` tasks
- add regression coverage for topic-scoped toolsets in the gateway runtime

## Problem
Fixes #37743.

`gateway/run.py` always resolved the full platform toolset for Telegram sessions, so topic-level `enabled_toolsets` config was parsed but never applied. Every topic inherited the same full toolset list.

## Verification
- `uv run --frozen --extra dev python -m pytest tests/gateway/test_telegram_topic_toolsets.py`
- `uv run --frozen --extra dev python -m ruff check gateway/run.py tests/gateway/test_telegram_topic_toolsets.py`
- `git diff --check`

## Notes
- Recent Leon PRs show repeated unrelated GitHub `Tests` shard failures, especially `test (5)`, so any matching CI red should be treated as preexisting baseline noise unless this diff is directly implicated.
