### PR TITLE
docs: propose workflow knowledge database architecture

### DIFF
--- a/docs/workflow-knowledge-db-access-model.md
+++ b/docs/workflow-knowledge-db-access-model.md
@@ -1,0 +1,226 @@
+# Workflow Knowledge DB Access Model
+
+## Status
+
+This is a docs-only access model. It defines intended roles and boundaries before migrations, APIs, or UI are implemented.
+
+## Actors
+
+### Internal member
+
+A normal employee or collaborator using approved workflow context.
+
+Allowed:
+
+- read approved Knowledge,
+- read approved Skills,
+- request Resolver recommendations,
+- create improvement candidates,
+- create Skill candidates when they discover a reusable procedure gap.
+
+Not allowed:
+
+- approve candidates,
+- mutate approved Knowledge or Skills,
+- mutate Resolver rules,
+- access backend-only elevated keys,
+- store credential material.
+
+### AI assistant / work support tool
+
+A tool that helps with research, review, development, operations, or summarization.
+
+Allowed:
+
+- read approved Knowledge,
+- read approved Skills,
+- request Resolver recommendations,
+- create improvement candidates,
+- create Skill candidates.
+
+Not allowed:
+
+- update approved Knowledge,
+- update approved Skills,
+- update Resolver rules,
+- approve or reject candidates,
+- write production data outside candidate tables,
+- execute automatically based on Resolver output,
+- access backend-only elevated keys.
+
+### Improvement extraction tool
+
+A narrow tool that processes redacted logs or review notes to propose reusable lessons.
+
+Allowed:
+
+- read approved context needed for deduplication,
+- create improvement candidates,
+- create Skill candidates,
+- write audit rows through the approved API boundary.
+
+Not allowed:
+
+- promote candidates,
+- modify approved records,
+- store raw transcripts by default,
+- store credential material.
+
+### Reviewer
+
+A human reviewer responsible for candidate triage.
+
+Allowed:
+
+- read approved Knowledge, Skills, Resolver rules, and candidates,
+- approve candidates through the approval workflow,
+- reject candidates with reason,
+- request more evidence or redaction,
+- create audit-visible review notes.
+
+Not allowed:
+
+- bypass audit logging,
+- expose backend-only elevated keys,
+- approve records without sufficient evidence or redaction.
+
+### Admin
+
+A human administrator or system owner.
+
+Allowed:
+
+- manage access policies,
+- manage approved Knowledge and Skill records,
+- manage Resolver rules,
+- read audit logs,
+- manage export mirrors,
+- run maintenance workflows.
+
+Required:
+
+- use audited APIs for normal operations,
+- keep backend-only elevated access out of client and AI-assisted tool contexts,
+- preserve candidate/approved separation.
+
+### Backend-only service role
+
+Server-side capability used by Edge Functions or controlled backend jobs.
+
+Allowed:
+
+- perform transactional promotions,
+- write audit rows,
+- generate approved export mirrors,
+- run maintenance tasks.
+
+Not allowed:
+
+- be exposed to browser clients,
+- be exposed to AI assistants,
+- be pasted into chat,
+- be used from local ad hoc scripts without approval and audit.
+
+## Permission model
+
+### Knowledge
+
+- Internal member: read approved.
+- AI assistant: read approved.
+- Improvement extraction tool: read approved for deduplication.
+- Reviewer: read approved and review candidate promotions.
+- Admin: full management.
+- Backend-only service: backend transaction support only.
+
+### Skill
+
+- Internal member: read approved.
+- AI assistant: read approved.
+- Improvement extraction tool: read approved and create candidates.
+- Reviewer: read approved and review Skill candidates.
+- Admin: full management.
+- Backend-only service: backend transaction support only.
+
+### Resolver
+
+- Internal member: request recommendations.
+- AI assistant: request recommendations.
+- Improvement extraction tool: request recommendations for routing.
+- Reviewer: inspect recommendations and rule effects.
+- Admin: manage rules.
+- Backend-only service: backend transaction support only.
+
+### Candidate tables
+
+- Internal member: create candidates and read own candidates.
+- AI assistant: create candidates and read own candidates.
+- Improvement extraction tool: create candidates.
+- Reviewer: approve, reject, or request changes.
+- Admin: full management.
+- Backend-only service: transactional promotion support.
+
+### Audit
+
+- Normal actors: append via API only.
+- Reviewer: read relevant review audit as needed.
+- Admin: read organization audit logs.
+- Backend-only service: append transactional audit rows.
+
+## Approval requirements
+
+A candidate can become approved Knowledge only when:
+
+- the content is reusable,
+- evidence is sufficient,
+- sensitivity is acceptable,
+- redaction is complete,
+- duplicate approved Knowledge has been checked,
+- a human reviewer approves it.
+
+A Skill candidate can become an approved Skill only when:
+
+- the procedure is reusable,
+- the scope is clear,
+- inputs and outputs are explicit,
+- constraints and failure handling are defined,
+- a human reviewer approves it,
+- versioning is assigned.
+
+A Resolver rule can become approved only when:
+
+- match conditions are specific enough,
+- returned Skills and Knowledge are appropriate,
+- high-risk approval requirements are represented,
+- recommendation-only behavior is preserved,
+- a human reviewer or admin approves it.
+
+## Candidate rejection reasons
+
+Rejected candidates should preserve a reason. Common reasons:
+
+- information is vague,
+- evidence is insufficient,
+- one-off lesson with low reuse value,
+- sensitive material requires redaction,
+- duplicates existing Knowledge,
+- proposed rule is too strong,
+- proposed Skill is too heavy,
+- Resolver condition is ambiguous.
+
+## Safety boundaries
+
+- Approved state is read-only for AI-assisted tools.
+- Candidate generation is allowed; promotion is not automatic.
+- Resolver output is recommendation-only at first.
+- High-risk tasks should include human approval requirements.
+- Raw transcript storage is out of scope by default.
+- Credential material is never stored.
+- All writes are audit-visible.
+
+## GitHub and Notion mirrors
+
+GitHub and Notion are optional mirrors, not the primary authority.
+
+- GitHub mirror: approved artifacts exported as Markdown or JSONL for backup and review.
+- Notion mirror: optional human-friendly browsing layer.
+- Supabase remains the primary source of truth unless a later design explicitly changes that.

--- a/docs/workflow-knowledge-db-architecture.md
+++ b/docs/workflow-knowledge-db-architecture.md
@@ -1,0 +1,261 @@
+# 社内ワークフロー改善DB アーキテクチャ
+
+## Status
+
+This is a **docs-only architecture proposal** for a Supabase-backed internal workflow knowledge database.
+It does not create a Supabase project, run migrations, implement Edge Functions, connect any AI assistant, store credentials, or write production data.
+
+## Executive summary
+
+The Workflow Knowledge DB centralizes approved business knowledge, reusable workflow skills, resolver rules, and audit evidence so internal members and AI-assisted tools can reuse context without starting from zero each time.
+
+The goal is **not** to make an AI agent autonomously rewrite its own behavior. The goal is to improve:
+
+- reproducibility of internal workflows,
+- handoff quality,
+- review quality,
+- speed of repeated work,
+- discoverability of prior decisions and failure lessons.
+
+The platform manages three related layers:
+
+1. **Knowledge**: approved project context, decisions, rules, human corrections, review lessons, failure lessons, and handoff notes.
+2. **Skill**: approved procedures, checklists, review rubrics, and work templates.
+3. **Resolver**: read-only selection logic that recommends relevant Knowledge and Skill for a given task.
+
+## Problems addressed
+
+### Scattered knowledge
+
+Important decisions and lessons currently live across chat, meetings, PRs, individual notes, and ad hoc review comments. This makes it hard to answer:
+
+- why a decision was made,
+- where similar work previously failed,
+- which review feedback mattered,
+- which workflow checklist should apply,
+- what to avoid next time.
+
+### Person-dependent procedures
+
+Review, research, release checks, meeting notes, handoffs, and redaction workflows become inconsistent when each person remembers a different procedure. Capturing procedures as approved Skills makes quality more repeatable.
+
+### Growing retrieval burden
+
+As Knowledge and Skills grow, manually finding the right material becomes its own cost. Resolver rules reduce that burden by selecting relevant approved material for a task context.
+
+## Terminology
+
+Use internal implementation terms sparingly in employee-facing documents. Prefer the employee-facing terms below.
+
+- GBrain: 社内ワークフロー改善DB
+- Dream Cycle: 業務改善ループ
+- Memory: ナレッジ
+- Memory candidate: 改善候補 / ナレッジ候補
+- Production memory: 承認済みナレッジ
+- Skill: 業務手順 / 作業テンプレート
+- Resolver: 必要情報の選択・取得ロジック
+- Agent: AIアシスタント / 業務補助ツール
+
+## Core flow
+
+```text
+業務ログ / 会議メモ / レビュー指摘 / 失敗事例
+  ↓
+改善候補・Skill改善候補の抽出
+  ↓
+人間レビュー
+  ↓
+承認済みKnowledge / Skillへ昇格
+  ↓
+Resolverが作業内容に応じて必要情報を取得
+  ↓
+次回以降の業務で活用
+```
+
+Important invariant: automated tools may create candidates, but they must not directly update approved Knowledge, approved Skill, or Resolver rules. Promotion to approved status requires human review.
+
+## Architecture
+
+```text
+                 ┌─────────────────────────────┐
+                 │ Supabase Postgres            │
+                 │ Workflow Knowledge DB        │
+                 └──────────────┬──────────────┘
+                                │
+           ┌────────────────────┼────────────────────┐
+           │                    │                    │
+   ┌───────▼───────┐    ┌───────▼───────┐    ┌───────▼───────┐
+   │ Knowledge      │    │ Skill Registry │    │ Resolver Rules │
+   │ approved info  │    │ procedures     │    │ selection logic │
+   └───────┬───────┘    └───────┬───────┘    └───────┬───────┘
+           │                    │                    │
+           └────────────────────┼────────────────────┘
+                                │
+                         ┌──────▼──────┐
+                         │ Resolver     │
+                         │ context load │
+                         └──────┬──────┘
+                                │
+      ┌─────────────────────────┼─────────────────────────┐
+      │                         │                         │
+┌─────▼─────┐             ┌─────▼─────┐             ┌─────▼─────┐
+│ 人間       │             │ AI補助     │             │ 管理者     │
+│ メンバー   │             │ ツール     │             │ 承認者     │
+└───────────┘             └───────────┘             └───────────┘
+```
+
+## Why Supabase
+
+Supabase Postgres is a good primary database because it supports:
+
+- row-level security for per-organization and per-role controls,
+- SQL and full-text search,
+- future pgvector-based retrieval,
+- review status columns and approval workflows,
+- audit tables,
+- Edge Functions for API boundaries,
+- GitHub and Notion mirrors as exports rather than primary state.
+
+Recommended split:
+
+- **Supabase**: primary database and access control source.
+- **GitHub**: export, backup, and audit mirror for approved artifacts.
+- **Notion**: optional human-friendly mirror after the core workflow is stable.
+
+## Minimum database areas
+
+The first version should contain these areas:
+
+- `workflow_knowledge`: approved knowledge.
+- `workflow_improvement_candidates`: knowledge improvement candidates.
+- `workflow_skills`: approved Skills.
+- `workflow_skill_candidates`: Skill improvement candidates.
+- `workflow_resolver_rules`: Resolver recommendation rules.
+- `workflow_sources`: redacted source summaries from logs, meetings, PRs, and reviews.
+- `workflow_artifacts`: generated reports, proposals, evaluation cases, and mirrors.
+- `workflow_access_audit`: access and mutation audit log.
+
+## Knowledge scope
+
+Approved Knowledge can include:
+
+- principles,
+- workflow rules,
+- project context,
+- decisions,
+- failure lessons,
+- human corrections,
+- review lessons,
+- handoff notes,
+- risk rules,
+- evaluation cases.
+
+Raw transcripts should not be stored by default. Store summarized and redacted source records instead.
+
+## Skill scope
+
+Approved Skills are not just prompts. They should include:
+
+- purpose,
+- applicability conditions,
+- required inputs,
+- procedure,
+- constraints,
+- output contract,
+- checklist,
+- failure handling,
+- related Knowledge tags,
+- owner and approval metadata.
+
+## Resolver scope
+
+The Resolver is initially **recommendation only**. It should return required and optional context, not execute actions.
+
+A Resolver result can include:
+
+- required Skills,
+- optional Skills,
+- required Knowledge tags,
+- relevant failure lessons,
+- relevant decisions,
+- required safety rules,
+- output contract,
+- approval requirements.
+
+## Security and privacy invariants
+
+- Enable RLS on all workflow tables.
+- Normal users and AI-assisted tools read only approved material.
+- Automated tools may create candidates only.
+- Approved Knowledge, Skill, and Resolver changes require human approval.
+- Backend-only elevated keys must never be exposed to assistants or clients.
+- Credential material must not be stored.
+- Raw transcripts are out of scope by default.
+- Write operations are audited.
+- Resolver rule changes are approval-gated.
+
+## Rollout plan
+
+### Phase 1: Docs only
+
+Create and review these documents:
+
+- `docs/workflow-knowledge-db-architecture.md`
+- `docs/workflow-knowledge-db-schema.sql`
+- `docs/workflow-knowledge-db-rls-policy.md`
+- `docs/workflow-knowledge-db-access-model.md`
+- `docs/workflow-skill-registry.md`
+- `docs/workflow-resolver-design.md`
+
+### Phase 2: Supabase schema draft
+
+Create migration drafts only after the docs are reviewed.
+
+### Phase 3: Read-only Resolver API
+
+Implement read-only context APIs such as `POST /workflow-resolve`, `GET /workflow-context`, and `GET /workflow-search`.
+
+### Phase 4: Candidate APIs
+
+Allow tools to create improvement and Skill candidates without updating approved state.
+
+### Phase 5: Human approval flow
+
+Build UI or CLI flows to approve and reject candidates.
+
+### Phase 6: pgvector / RAG
+
+Add vector search only after approval, redaction, and audit boundaries are stable.
+
+### Phase 7: GitHub export mirror
+
+Export approved Knowledge, Skills, and Resolver rules to Markdown or JSONL for backup and review.
+
+### Phase 8: Notion mirror
+
+Optionally publish a human-friendly mirror.
+
+## Initial scope
+
+In scope first:
+
+- development review,
+- research notes,
+- meeting notes,
+- failure lessons,
+- work handoffs,
+- Skill management,
+- Resolver design.
+
+Out of scope first:
+
+- company-wide HR data,
+- confidential contracts,
+- bulk raw transcript storage,
+- automatic approved-Knowledge updates,
+- automatic configuration changes by AI-assisted tools,
+- automatic execution by Resolver output.
+
+## Direction decision
+
+Adopt Supabase as the primary database. Keep approved and candidate data separate. Treat AI-assisted tools as read-only for approved state and candidate-only for proposed improvements. Use the Resolver as recommendation-only at first. Keep a GitHub export mirror for backup and optional review.

--- a/docs/workflow-knowledge-db-rls-policy.md
+++ b/docs/workflow-knowledge-db-rls-policy.md
@@ -1,0 +1,275 @@
+# Workflow Knowledge DB RLS Policy Draft
+
+## Status
+
+This is a docs-only RLS design. It does not apply policies to any Supabase project.
+Executable policies should be created later in `supabase/migrations/create_workflow_rls.sql` after review.
+
+## Goals
+
+Row-level security must enforce these invariants:
+
+- Members and AI-assisted tools can read approved Knowledge, approved Skills, and approved Resolver recommendations for their organization.
+- Automated tools can create candidates but cannot approve candidates or mutate approved records.
+- Reviewers can approve or reject candidates for their organization.
+- Admins can manage approved records, Resolver rules, and candidate lifecycle for their organization.
+- Backend-only elevated access is reserved for server code and never exposed to AI-assisted tools or client applications.
+- All write operations have audit coverage.
+
+## Assumed JWT claims
+
+The executable implementation should standardize these claims or equivalent server-side role mapping:
+
+- `org_id`: organization identifier.
+- `workflow_role`: one of `member`, `assistant`, `improvement_tool`, `reviewer`, `admin`.
+- `actor_id`: stable user or tool identifier.
+
+Example helper functions for the migration version:
+
+```sql
+create function workflow_current_org_id()
+returns uuid
+language sql stable as $$
+  select nullif(auth.jwt() ->> 'org_id', '')::uuid;
+$$;
+
+create function workflow_current_role()
+returns text
+language sql stable as $$
+  select coalesce(auth.jwt() ->> 'workflow_role', 'member');
+$$;
+
+create function workflow_current_actor_id()
+returns text
+language sql stable as $$
+  select coalesce(auth.jwt() ->> 'actor_id', auth.uid()::text);
+$$;
+```
+
+## Enable RLS on every table
+
+The migration version should enable RLS for all workflow tables:
+
+```sql
+alter table workflow_sources enable row level security;
+alter table workflow_knowledge enable row level security;
+alter table workflow_improvement_candidates enable row level security;
+alter table workflow_skills enable row level security;
+alter table workflow_skill_candidates enable row level security;
+alter table workflow_resolver_rules enable row level security;
+alter table workflow_artifacts enable row level security;
+alter table workflow_access_audit enable row level security;
+```
+
+## Read policies
+
+### Approved Knowledge read
+
+Members, AI-assisted tools, improvement tools, reviewers, and admins can read approved Knowledge for their organization.
+
+```sql
+create policy workflow_knowledge_read_approved
+on workflow_knowledge
+for select
+using (
+  org_id = workflow_current_org_id()
+  and review_status in ('approved', 'deprecated', 'archived', 'superseded')
+  and workflow_current_role() in ('member', 'assistant', 'improvement_tool', 'reviewer', 'admin')
+);
+```
+
+### Approved Skill read
+
+```sql
+create policy workflow_skills_read_approved
+on workflow_skills
+for select
+using (
+  org_id = workflow_current_org_id()
+  and status in ('approved', 'deprecated', 'archived', 'superseded')
+  and workflow_current_role() in ('member', 'assistant', 'improvement_tool', 'reviewer', 'admin')
+);
+```
+
+### Approved Resolver rule read
+
+Resolver rules are read as recommendations. They do not authorize execution.
+
+```sql
+create policy workflow_resolver_rules_read_approved
+on workflow_resolver_rules
+for select
+using (
+  org_id = workflow_current_org_id()
+  and status = 'approved'
+  and workflow_current_role() in ('member', 'assistant', 'improvement_tool', 'reviewer', 'admin')
+);
+```
+
+### Candidate read
+
+Reviewers and admins can read all candidates. Candidate creators can read their own candidate records. Normal members and AI-assisted tools should not browse every candidate by default.
+
+```sql
+create policy workflow_improvement_candidates_read_review_scope
+on workflow_improvement_candidates
+for select
+using (
+  org_id = workflow_current_org_id()
+  and (
+    workflow_current_role() in ('reviewer', 'admin')
+    or created_by = workflow_current_actor_id()
+  )
+);
+```
+
+Apply the same pattern to `workflow_skill_candidates`.
+
+## Candidate creation policies
+
+Automated tools and members can create candidates only. They cannot insert approved records.
+
+```sql
+create policy workflow_improvement_candidates_insert
+on workflow_improvement_candidates
+for insert
+with check (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() in ('member', 'assistant', 'improvement_tool', 'reviewer', 'admin')
+  and review_status in ('pending', 'needs_redaction', 'needs_more_evidence')
+  and created_by = workflow_current_actor_id()
+);
+```
+
+```sql
+create policy workflow_skill_candidates_insert
+on workflow_skill_candidates
+for insert
+with check (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() in ('member', 'assistant', 'improvement_tool', 'reviewer', 'admin')
+  and review_status in ('pending', 'needs_redaction', 'needs_more_evidence')
+  and created_by = workflow_current_actor_id()
+);
+```
+
+## Candidate review policies
+
+Reviewers and admins can move candidates through review states. Promotion to approved Knowledge or Skill should happen inside a transaction or Edge Function that also writes audit rows.
+
+```sql
+create policy workflow_improvement_candidates_review_update
+on workflow_improvement_candidates
+for update
+using (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() in ('reviewer', 'admin')
+)
+with check (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() in ('reviewer', 'admin')
+  and review_status in ('approved', 'rejected', 'needs_redaction', 'needs_more_evidence', 'superseded')
+);
+```
+
+Apply the same pattern to `workflow_skill_candidates`.
+
+## Approved record mutation policies
+
+Only admins should directly manage approved Knowledge, Skills, and Resolver rules. Reviewer approval APIs may promote candidates through server-side functions, but client roles should not directly insert approved rows unless explicitly designed and audited.
+
+```sql
+create policy workflow_knowledge_admin_write
+on workflow_knowledge
+for all
+using (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() = 'admin'
+)
+with check (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() = 'admin'
+);
+```
+
+Apply the same admin pattern to:
+
+- `workflow_skills`,
+- `workflow_resolver_rules`,
+- `workflow_artifacts` when the artifact represents an approved mirror or export.
+
+## Source policies
+
+Sources should contain summarized and redacted source records, not raw transcripts by default.
+
+- Members, assistants, and tools can insert redacted source summaries if the source is within their organization.
+- Reviewers and admins can read source records for review.
+- Broader source read access should be conservative and sensitivity-aware.
+
+## Audit policies
+
+Audit rows should be append-only from normal application roles.
+
+```sql
+create policy workflow_access_audit_insert
+on workflow_access_audit
+for insert
+with check (
+  org_id = workflow_current_org_id()
+  and actor_role = workflow_current_role()
+);
+```
+
+Admins can read audit rows for their organization:
+
+```sql
+create policy workflow_access_audit_admin_read
+on workflow_access_audit
+for select
+using (
+  org_id = workflow_current_org_id()
+  and workflow_current_role() = 'admin'
+);
+```
+
+Do not expose update or delete policies for audit rows to normal client roles.
+
+## Edge Function boundary
+
+Prefer Edge Functions for write workflows that need multiple changes in one transaction, such as:
+
+- approve improvement candidate,
+- reject improvement candidate,
+- approve Skill candidate,
+- reject Skill candidate,
+- update Resolver rule after human approval,
+- write audit log and approved record together.
+
+The Edge Function should validate:
+
+- actor organization,
+- actor role,
+- candidate status,
+- redaction status,
+- approval evidence,
+- target record idempotency,
+- audit row creation.
+
+## Redaction and sensitivity rules
+
+- `confidential_redacted` records require explicit sensitivity handling.
+- Raw transcript ingestion is out of scope by default.
+- Candidate extraction must strip credential material and unnecessary personal data before storage.
+- If redaction is uncertain, the candidate status should be `needs_redaction`, not `approved`.
+
+## Resolver-specific guardrails
+
+Resolver output is recommendation-only in early phases. RLS should not be treated as an execution approval mechanism. High-risk tasks may include approval requirements in Resolver output, but a separate workflow must enforce those approvals before any external side effect.
+
+## Open questions for implementation review
+
+- Whether `workflow_role` comes from JWT claims, a membership table, or Edge Function middleware.
+- Whether source summaries should be readable by normal members or reviewer/admin only.
+- Whether candidate creators can update their own pending candidates.
+- How to represent cross-project Knowledge that is global within an organization.
+- Whether GitHub export mirrors should be stored as artifacts or generated on demand.

--- a/docs/workflow-knowledge-db-schema.sql
+++ b/docs/workflow-knowledge-db-schema.sql
@@ -1,0 +1,255 @@
+-- Workflow Knowledge DB schema draft
+--
+-- Status: docs-only proposal. Do not run this file as a migration.
+-- The executable migration version should be created later under supabase/migrations/
+-- after architecture, access model, and RLS policy review.
+
+-- Optional future extensions:
+-- create extension if not exists pgcrypto;
+-- create extension if not exists pg_trgm;
+-- create extension if not exists vector;
+
+create type workflow_review_status as enum (
+  'draft',
+  'pending',
+  'approved',
+  'rejected',
+  'needs_redaction',
+  'needs_more_evidence',
+  'superseded',
+  'deprecated',
+  'archived'
+);
+
+create type workflow_knowledge_type as enum (
+  'principle',
+  'workflow_rule',
+  'project_context',
+  'decision',
+  'failure_lesson',
+  'human_correction',
+  'review_lesson',
+  'handoff_note',
+  'risk_rule',
+  'eval_case'
+);
+
+create type workflow_sensitivity as enum (
+  'public_internal',
+  'internal',
+  'restricted',
+  'confidential_redacted'
+);
+
+create type workflow_source_type as enum (
+  'work_log',
+  'meeting_note',
+  'review_comment',
+  'pull_request',
+  'incident_note',
+  'handoff',
+  'manual_note',
+  'other'
+);
+
+create table workflow_sources (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  project text not null default 'global',
+  source_type workflow_source_type not null,
+  source_ref text,
+  title text not null,
+  summary text not null,
+  redaction_status workflow_review_status not null default 'pending',
+  sensitivity workflow_sensitivity not null default 'internal',
+  source_created_at timestamptz,
+  captured_by text,
+  captured_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  search_text tsvector generated always as (
+    to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(summary, ''))
+  ) stored
+);
+
+create table workflow_knowledge (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  project text not null default 'global',
+  knowledge_type workflow_knowledge_type not null,
+  title text not null,
+  body text not null,
+  tags text[] not null default '{}',
+  source_ids uuid[] not null default '{}',
+  sensitivity workflow_sensitivity not null default 'internal',
+  review_status workflow_review_status not null default 'approved',
+  owner text,
+  approved_by text not null,
+  approved_at timestamptz not null default now(),
+  supersedes_id uuid references workflow_knowledge(id),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  search_text tsvector generated always as (
+    to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(body, '') || ' ' || array_to_string(tags, ' '))
+  ) stored,
+  constraint workflow_knowledge_only_approved check (review_status in ('approved', 'deprecated', 'archived', 'superseded'))
+);
+
+create table workflow_improvement_candidates (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  project text not null default 'global',
+  source_id uuid references workflow_sources(id),
+  candidate_type workflow_knowledge_type not null,
+  title text not null,
+  proposed_body text not null,
+  evidence_summary text not null,
+  tags text[] not null default '{}',
+  sensitivity workflow_sensitivity not null default 'internal',
+  review_status workflow_review_status not null default 'pending',
+  reviewer_notes text,
+  rejection_reason text,
+  approved_knowledge_id uuid references workflow_knowledge(id),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  reviewed_by text,
+  reviewed_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  search_text tsvector generated always as (
+    to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(proposed_body, '') || ' ' || coalesce(evidence_summary, '') || ' ' || array_to_string(tags, ' '))
+  ) stored
+);
+
+create table workflow_skills (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  name text not null,
+  version text not null,
+  status workflow_review_status not null default 'approved',
+  purpose text not null,
+  applies_to text[] not null default '{}',
+  inputs jsonb not null default '{}'::jsonb,
+  procedure jsonb not null default '[]'::jsonb,
+  constraints text[] not null default '{}',
+  output_contract jsonb not null default '{}'::jsonb,
+  checklist jsonb not null default '[]'::jsonb,
+  failure_handling jsonb not null default '{}'::jsonb,
+  related_knowledge_tags text[] not null default '{}',
+  owner text,
+  approved_by text not null,
+  approved_at timestamptz not null default now(),
+  supersedes_id uuid references workflow_skills(id),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  unique (org_id, name, version),
+  constraint workflow_skills_only_approved check (status in ('approved', 'deprecated', 'archived', 'superseded'))
+);
+
+create table workflow_skill_candidates (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  proposed_name text not null,
+  proposed_version text not null default '0.1.0',
+  purpose text not null,
+  applies_to text[] not null default '{}',
+  proposed_inputs jsonb not null default '{}'::jsonb,
+  proposed_procedure jsonb not null default '[]'::jsonb,
+  proposed_constraints text[] not null default '{}',
+  proposed_output_contract jsonb not null default '{}'::jsonb,
+  proposed_checklist jsonb not null default '[]'::jsonb,
+  proposed_failure_handling jsonb not null default '{}'::jsonb,
+  related_knowledge_tags text[] not null default '{}',
+  evidence_summary text not null,
+  review_status workflow_review_status not null default 'pending',
+  reviewer_notes text,
+  rejection_reason text,
+  approved_skill_id uuid references workflow_skills(id),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  reviewed_by text,
+  reviewed_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table workflow_resolver_rules (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  rule_name text not null,
+  status workflow_review_status not null default 'approved',
+  priority integer not null default 100,
+  match jsonb not null,
+  return_config jsonb not null,
+  owner text,
+  approved_by text not null,
+  approved_at timestamptz not null default now(),
+  supersedes_id uuid references workflow_resolver_rules(id),
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  unique (org_id, rule_name),
+  constraint workflow_resolver_rules_only_approved check (status in ('approved', 'deprecated', 'archived', 'superseded')),
+  constraint workflow_resolver_rules_object_shape check (jsonb_typeof(match) = 'object' and jsonb_typeof(return_config) = 'object')
+);
+
+create table workflow_artifacts (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  project text not null default 'global',
+  artifact_type text not null,
+  title text not null,
+  body text,
+  storage_ref text,
+  related_knowledge_ids uuid[] not null default '{}',
+  related_skill_ids uuid[] not null default '{}',
+  related_resolver_rule_ids uuid[] not null default '{}',
+  sensitivity workflow_sensitivity not null default 'internal',
+  review_status workflow_review_status not null default 'pending',
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table workflow_access_audit (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  actor_id text,
+  actor_role text not null,
+  action text not null,
+  table_name text not null,
+  record_id uuid,
+  request_id text,
+  outcome text not null,
+  reason text,
+  created_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create index workflow_sources_org_project_idx on workflow_sources (org_id, project, source_type);
+create index workflow_sources_search_idx on workflow_sources using gin (search_text);
+
+create index workflow_knowledge_org_project_type_idx on workflow_knowledge (org_id, project, knowledge_type, review_status);
+create index workflow_knowledge_tags_idx on workflow_knowledge using gin (tags);
+create index workflow_knowledge_search_idx on workflow_knowledge using gin (search_text);
+
+create index workflow_improvement_candidates_review_idx on workflow_improvement_candidates (org_id, review_status, candidate_type);
+create index workflow_improvement_candidates_tags_idx on workflow_improvement_candidates using gin (tags);
+create index workflow_improvement_candidates_search_idx on workflow_improvement_candidates using gin (search_text);
+
+create index workflow_skills_org_name_idx on workflow_skills (org_id, name, status);
+create index workflow_skills_applies_to_idx on workflow_skills using gin (applies_to);
+create index workflow_skills_related_tags_idx on workflow_skills using gin (related_knowledge_tags);
+
+create index workflow_skill_candidates_review_idx on workflow_skill_candidates (org_id, review_status, proposed_name);
+create index workflow_skill_candidates_applies_to_idx on workflow_skill_candidates using gin (applies_to);
+
+create index workflow_resolver_rules_org_status_priority_idx on workflow_resolver_rules (org_id, status, priority);
+create index workflow_resolver_rules_match_idx on workflow_resolver_rules using gin (match jsonb_path_ops);
+
+create index workflow_artifacts_org_project_idx on workflow_artifacts (org_id, project, artifact_type, review_status);
+create index workflow_access_audit_org_created_idx on workflow_access_audit (org_id, created_at desc);
+
+-- RLS must be enabled by the migration version. See docs/workflow-knowledge-db-rls-policy.md.

--- a/docs/workflow-resolver-design.md
+++ b/docs/workflow-resolver-design.md
@@ -1,0 +1,216 @@
+# Workflow Resolver Design
+
+## Status
+
+This is a docs-only Resolver design. It does not implement an API, connect to Supabase, or trigger any action.
+
+## Purpose
+
+The Resolver selects relevant approved Knowledge and Skills for a work request. It reduces the burden of manually finding the right context and helps maintain consistent workflows.
+
+The first version is **recommendation-only**. It returns what to read and what output contract to follow. It does not execute tasks or change state.
+
+## Resolver inputs
+
+A Resolver request can include:
+
+- `project`: project or domain, such as `gstack`.
+- `task_type`: task category, such as `code_review`, `research_note`, `meeting_summary`, or `handoff`.
+- `agent_type`: human, review assistant, research assistant, operations assistant, or improvement extraction tool.
+- `risk_level`: low, medium, high.
+- `requested_action`: review, summarize, implement, approve, reject, export, etc.
+- `files_or_domains`: files, systems, teams, or domains involved.
+- `active_tools`: tools available in the current workflow.
+- `sensitivity`: public internal, internal, restricted, or confidential redacted.
+
+## Resolver outputs
+
+A Resolver response can include:
+
+- `required_skills`: Skills that must be loaded or read.
+- `optional_skills`: useful but not mandatory Skills.
+- `required_knowledge`: approved Knowledge records or tags.
+- `relevant_failure_lessons`: failure lessons to avoid repeating mistakes.
+- `relevant_decisions`: prior decisions that constrain the task.
+- `required_safety_rules`: safety or risk rules.
+- `output_contract`: expected final output shape.
+- `approval_requirements`: required human review or approval gates.
+
+## Rule model
+
+A rule contains:
+
+- `rule_name`: stable identifier.
+- `priority`: lower numbers win first.
+- `match`: JSON object describing conditions.
+- `return_config`: JSON object describing returned Skills, Knowledge tags, output contract, and approvals.
+- `status`: approved, deprecated, archived, or superseded.
+- approval metadata.
+
+Example:
+
+```json
+{
+  "rule_name": "gstack_code_review",
+  "priority": 10,
+  "match": {
+    "project": "gstack",
+    "task_type": "code_review"
+  },
+  "return_config": {
+    "required_skills": [
+      "review-readonly",
+      "tool-budget-guard"
+    ],
+    "optional_skills": [
+      "redteam-readonly",
+      "closeout-pr-readiness"
+    ],
+    "required_knowledge_tags": [
+      "gstack",
+      "safety",
+      "pr-review"
+    ],
+    "required_output_contract": "review_findings_v1",
+    "approval_requirements": []
+  }
+}
+```
+
+## Resolution algorithm
+
+Initial deterministic algorithm:
+
+1. Validate request shape and organization context.
+2. Fetch approved Resolver rules for the organization.
+3. Match rules by project, task type, risk level, requested action, and sensitivity.
+4. Sort matches by priority and specificity.
+5. Merge required Skills, optional Skills, Knowledge tags, output contract, and approval requirements.
+6. Fetch approved Knowledge by tags and full-text search.
+7. Return a recommendation response.
+8. Write an audit row for the resolution request.
+
+The Resolver should not directly write approved records or execute tools.
+
+## API proposal
+
+### POST /workflow-resolve
+
+Request:
+
+```json
+{
+  "project": "gstack",
+  "task_type": "code_review",
+  "agent_type": "review",
+  "risk_level": "medium"
+}
+```
+
+Response:
+
+```json
+{
+  "required_skills": [
+    "review-readonly",
+    "tool-budget-guard"
+  ],
+  "optional_skills": [
+    "redteam-readonly",
+    "closeout-pr-readiness"
+  ],
+  "knowledge": [
+    {
+      "type": "project_context",
+      "title": "gstack current architecture"
+    },
+    {
+      "type": "failure_lesson",
+      "title": "Do targeted checks before broad checks"
+    }
+  ],
+  "output_contract": "review_findings_v1",
+  "approval_requirements": []
+}
+```
+
+### GET /workflow-context
+
+Returns approved Knowledge and Skill context by explicit ids or tags.
+
+### GET /workflow-search
+
+Searches approved Knowledge and Skills. Candidate tables are not broadly searchable by normal users unless policy allows it.
+
+## Candidate-related APIs
+
+Candidate APIs are separate from Resolver APIs:
+
+- `POST /workflow-improvement-candidate`
+- `POST /workflow-skill-candidate`
+- `POST /workflow-approve-candidate`
+- `POST /workflow-reject-candidate`
+- `POST /workflow-approve-skill-candidate`
+- `POST /workflow-reject-skill-candidate`
+
+Approvals should require reviewer/admin role and audit logging.
+
+## Safety behavior
+
+Resolver output must preserve these boundaries:
+
+- recommendation-only by default,
+- no automatic execution,
+- no automatic approved Knowledge updates,
+- no automatic Skill updates,
+- no automatic Resolver rule updates,
+- high-risk tasks include explicit approval requirements,
+- all resolution calls are auditable.
+
+## Audit behavior
+
+Each Resolver call should log:
+
+- actor id,
+- actor role,
+- project,
+- task type,
+- matched rule ids,
+- returned Skill names,
+- returned Knowledge ids or tags,
+- outcome,
+- request id,
+- timestamp.
+
+Audit logs help detect Resolver rules that are unused, overbroad, or frequently overridden by humans.
+
+## Quality controls
+
+To reduce bad recommendations:
+
+- keep initial rules narrow,
+- prefer recommendation-only behavior,
+- audit matched rules,
+- review high-risk matches manually,
+- record user feedback as candidates rather than automatic rule changes,
+- periodically review unused Skills and overbroad rules.
+
+## Non-goals for the first version
+
+- No automatic task execution.
+- No direct assistant configuration changes.
+- No production data writes.
+- No automatic approved state updates.
+- No implicit approvals.
+- No RAG requirement before the basic rule-based Resolver is working.
+
+## Future extensions
+
+After the basic workflow is stable:
+
+- pgvector similarity search for Knowledge and Skills,
+- GitHub export mirror of approved Resolver rules,
+- UI for rule testing,
+- Resolver result feedback loop,
+- per-project rule ownership,
+- Notion mirror for human browsing.

--- a/docs/workflow-skill-registry.md
+++ b/docs/workflow-skill-registry.md
@@ -1,0 +1,175 @@
+# Workflow Skill Registry
+
+## Status
+
+This is a docs-only design for the approved Skill registry and Skill candidate lifecycle.
+It does not install, publish, or mutate any runtime Skill library.
+
+## Purpose
+
+The Skill Registry stores reusable business procedures, checklists, review rubrics, and work templates. It improves repeatability by making the expected workflow explicit and approved.
+
+A Skill is not just a prompt. It is a structured procedure that can be read by humans and AI-assisted tools.
+
+## Approved Skill fields
+
+An approved Skill should include:
+
+- `name`: stable identifier such as `review-readonly`.
+- `version`: semantic or organization-approved version.
+- `status`: `approved`, `deprecated`, `archived`, or `superseded`.
+- `purpose`: what the Skill is for.
+- `applies_to`: task types and contexts where it applies.
+- `inputs`: required and optional inputs.
+- `procedure`: ordered steps.
+- `constraints`: actions the operator must not take.
+- `output_contract`: required output shape.
+- `checklist`: verification items.
+- `failure_handling`: what to do when the workflow cannot complete.
+- `related_knowledge_tags`: tags used to retrieve supporting Knowledge.
+- `owner`: accountable maintainer.
+- `approved_by`: human reviewer.
+- `approved_at`: approval timestamp.
+
+## Example Skill
+
+```json
+{
+  "name": "review-readonly",
+  "version": "1.0.0",
+  "status": "approved",
+  "purpose": "Review code diffs or plans without mutating files or external state.",
+  "applies_to": ["code_review", "pr_review", "diff_review"],
+  "inputs": {
+    "required": ["diff_or_plan", "task_scope"],
+    "optional": ["test_results", "known_constraints"]
+  },
+  "procedure": [
+    "Confirm the review scope.",
+    "Inspect only the supplied diff, plan, and referenced files needed for verification.",
+    "Identify blockers, high-risk findings, medium-risk findings, and test gaps.",
+    "Do not modify files or create external side effects."
+  ],
+  "constraints": [
+    "Do not edit files.",
+    "Do not commit.",
+    "Do not push.",
+    "Do not create a PR.",
+    "Do not change config, auth, identity, or credentials."
+  ],
+  "output_contract": [
+    "summary",
+    "blockers",
+    "high_risk_findings",
+    "medium_risk_findings",
+    "test_gaps",
+    "recommended_next_action"
+  ],
+  "checklist": [
+    "Scope was respected.",
+    "No mutation was performed.",
+    "Findings cite concrete evidence.",
+    "Unverified concerns are labeled as such."
+  ],
+  "failure_handling": {
+    "insufficient_context": "Return a blocked verdict and list the missing evidence.",
+    "potential_sensitive_data": "Stop and request redaction review."
+  },
+  "related_knowledge_tags": ["review", "safety", "read-only"]
+}
+```
+
+## Skill candidate lifecycle
+
+Skill candidates are stored separately from approved Skills.
+
+Lifecycle states:
+
+- `pending`: proposed and awaiting review.
+- `needs_redaction`: may contain sensitive material.
+- `needs_more_evidence`: needs examples or proof of repeated usefulness.
+- `approved`: promoted to `workflow_skills`.
+- `rejected`: rejected with reason.
+- `superseded`: replaced by a newer candidate or existing Skill.
+
+## Candidate sources
+
+A Skill candidate may come from:
+
+- repeated review feedback,
+- repeated operational mistakes,
+- meeting retrospectives,
+- incident analysis,
+- handoff failures,
+- process gaps discovered during work,
+- human-authored procedure proposals.
+
+## Promotion criteria
+
+A candidate should become an approved Skill only when:
+
+- it is reusable beyond one incident,
+- the scope is clear,
+- required inputs are explicit,
+- procedure steps are actionable,
+- constraints prevent unsafe overreach,
+- output contract is testable,
+- failure handling is defined,
+- redaction is complete,
+- the owner and approver are recorded.
+
+## Rejection reasons
+
+Common rejection reasons:
+
+- one-off and not reusable,
+- too vague to execute,
+- too broad for one Skill,
+- duplicates an existing Skill,
+- contains sensitive material,
+- lacks evidence,
+- too heavy for the value it provides,
+- belongs in Knowledge rather than Skill.
+
+## Versioning
+
+Use versioning to preserve reviewability:
+
+- Minor changes can update checklist items or wording.
+- Major behavior changes should create a new version.
+- Deprecated Skills should remain readable for audit and migration.
+- Superseded Skills should point to the replacement.
+
+## Resolver integration
+
+Resolver rules should reference Skills by stable name and optionally version constraints. Resolver output should separate:
+
+- required Skills,
+- optional Skills,
+- output contract,
+- approval requirements.
+
+The Resolver must not mutate Skills. It only recommends what to read.
+
+## Review checklist for Skill changes
+
+Before approval, reviewers should check:
+
+- Is this a Skill rather than a Knowledge note?
+- Is the procedure reusable?
+- Are inputs and outputs explicit?
+- Are constraints strong enough?
+- Does it avoid automatic production changes?
+- Does it avoid storing credential material?
+- Does it define failure handling?
+- Does it reference relevant Knowledge tags?
+- Is ownership clear?
+
+## Non-goals for the first version
+
+- No automatic Skill promotion.
+- No runtime Skill installation.
+- No automatic rewrite of assistant behavior.
+- No direct config changes.
+- No automatic execution based on Skill content.
+- No bulk import of raw transcripts.


### PR DESCRIPTION
## Summary
- Adds a docs-only proposal for a Supabase-backed internal Workflow Knowledge DB.
- Documents the Knowledge, Skill Registry, and Resolver layers.
- Defines draft schema, RLS policy, access model, Skill lifecycle, and Resolver recommendation behavior.

## Scope
- `docs/workflow-knowledge-db-architecture.md`
- `docs/workflow-knowledge-db-schema.sql`
- `docs/workflow-knowledge-db-rls-policy.md`
- `docs/workflow-knowledge-db-access-model.md`
- `docs/workflow-skill-registry.md`
- `docs/workflow-resolver-design.md`

## Explicit non-goals
- Does not create a Supabase project.
- Does not add executable migrations.
- Does not implement Edge Functions or APIs.
- Does not connect any AI assistant.
- Does not store credentials or production data.
- Does not enable automatic Resolver execution.

## Verification
- `git diff --cached --check` before commit: pass.
- Docs-only scope check: pass; only `docs/` files staged.
- Required file/invariant check: pass.
- Staged diff secret scan with gitleaks stdin: no leaks found.
- Each new file secret scan with gitleaks stdin: no leaks found.
- Exact outgoing commit secret scan with `gitleaks git --log-opts <base>..HEAD`: no leaks found.
- Hermes pre-push gate: PASS.
