### PR TITLE
fix(honcho): route conclusions through _resolve_observer_target for workspace context

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1169,26 +1169,21 @@ class HonchoSessionManager:
             return False
 
         try:
-            target_peer_id = self._resolve_peer_id(session, peer)
-            if target_peer_id is None:
+            observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
+            if observer_peer_id is None:
                 logger.warning("Could not resolve conclusion peer '%s' for session '%s'", peer, session_key)
                 return False
-
-            if target_peer_id == session.assistant_peer_id:
-                assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-                conclusions_scope = assistant_peer.conclusions_of(session.assistant_peer_id)
-            elif self._ai_observe_others:
-                assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-                conclusions_scope = assistant_peer.conclusions_of(target_peer_id)
-            else:
-                target_peer = self._get_or_create_peer(target_peer_id)
-                conclusions_scope = target_peer.conclusions_of(target_peer_id)
+            observer_peer = self._get_or_create_peer(observer_peer_id)
+            conclusions_scope = observer_peer.conclusions_of(
+                target_peer_id if target_peer_id is not None else observer_peer_id,
+            )
 
             conclusions_scope.create([{
                 "content": content.strip(),
                 "session_id": session.honcho_session_id,
             }])
-            logger.info("Created conclusion about %s for %s: %s", target_peer_id, session_key, content[:80])
+            logger.info("Created conclusion about %s for %s: %s",
+                        target_peer_id or observer_peer_id, session_key, content[:80])
             return True
         except Exception as e:
             logger.error("Failed to create conclusion: %s", e)
@@ -1209,16 +1204,13 @@ class HonchoSessionManager:
         if not session:
             return False
         try:
-            target_peer_id = self._resolve_peer_id(session, peer)
-            if target_peer_id == session.assistant_peer_id:
-                observer = self._get_or_create_peer(session.assistant_peer_id)
-                scope = observer.conclusions_of(session.assistant_peer_id)
-            elif self._ai_observe_others:
-                observer = self._get_or_create_peer(session.assistant_peer_id)
-                scope = observer.conclusions_of(target_peer_id)
-            else:
-                target_peer = self._get_or_create_peer(target_peer_id)
-                scope = target_peer.conclusions_of(target_peer_id)
+            observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
+            if observer_peer_id is None:
+                return False
+            observer_peer = self._get_or_create_peer(observer_peer_id)
+            scope = observer_peer.conclusions_of(
+                target_peer_id if target_peer_id is not None else observer_peer_id,
+            )
             scope.delete(conclusion_id)
             logger.info("Deleted conclusion %s for %s", conclusion_id, session_key)
             return True

--- a/tests/test_honcho_conclusion_peer_resolution.py
+++ b/tests/test_honcho_conclusion_peer_resolution.py
@@ -1,0 +1,168 @@
+"""Tests for Honcho conclusion peer resolution.
+
+Regression: create_conclusion / delete_conclusion must route through
+_resolve_observer_target (the same path used by get_peer_card,
+set_peer_card, search_context, etc.) so that the observer peer object
+carries workspace context into the conclusions_of() call.
+
+See issue #37759 and PR #35988 for the original bug report.
+"""
+
+from types import SimpleNamespace
+
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class _FakeConclusionsScope:
+    """Records create/delete calls for assertions."""
+
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+
+    def create(self, items):
+        self.created.extend(items)
+
+    def delete(self, conclusion_id):
+        self.deleted.append(conclusion_id)
+
+
+class _FakePeer:
+    """Minimal peer stub that records conclusions_of calls."""
+
+    def __init__(self, peer_id):
+        self.peer_id = peer_id
+        self.conclusions_scopes = {}
+
+    def conclusions_of(self, target_peer_id):
+        if target_peer_id not in self.conclusions_scopes:
+            self.conclusions_scopes[target_peer_id] = _FakeConclusionsScope()
+        return self.conclusions_scopes[target_peer_id]
+
+
+def _make_manager(ai_observe_others=True):
+    """Build a manager with a cached session and controllable peer factory."""
+    cfg = SimpleNamespace(
+        write_frequency="turn",
+        dialectic_reasoning_level="low",
+        dialectic_dynamic=True,
+        dialectic_max_chars=600,
+        observation_mode="directional",
+        user_observe_me=True,
+        user_observe_others=True,
+        ai_observe_me=True,
+        ai_observe_others=ai_observe_others,
+        message_max_chars=25000,
+        dialectic_max_input_chars=10000,
+    )
+    mgr = HonchoSessionManager(honcho=SimpleNamespace(), config=cfg)
+    session = HonchoSession(
+        key="test-session",
+        user_peer_id="chris",
+        assistant_peer_id="hermes",
+        honcho_session_id="test-session",
+    )
+    mgr._cache[session.key] = session
+
+    # Inject fake peers so _get_or_create_peer returns our stubs
+    peers = {}
+
+    def _fake_get_or_create(peer_id):
+        if peer_id not in peers:
+            peers[peer_id] = _FakePeer(peer_id)
+        return peers[peer_id]
+
+    mgr._get_or_create_peer = _fake_get_or_create
+    return mgr, session, peers
+
+
+# --- create_conclusion tests ---
+
+
+def test_create_conclusion_user_alias_uses_assistant_observer():
+    """When ai_observe_others=True, conclusions about 'user' should route
+    through the assistant peer (observer) targeting the user peer."""
+    mgr, session, peers = _make_manager(ai_observe_others=True)
+
+    result = mgr.create_conclusion("test-session", "likes dark mode", peer="user")
+
+    assert result is True
+    hermes_peer = peers["hermes"]
+    scope = hermes_peer.conclusions_scopes["chris"]
+    assert len(scope.created) == 1
+    assert scope.created[0]["content"] == "likes dark mode"
+
+
+def test_create_conclusion_user_alias_uses_user_observer_when_ai_cannot_observe():
+    """When ai_observe_others=False, conclusions about 'user' should route
+    through the user peer (self-observation)."""
+    mgr, session, peers = _make_manager(ai_observe_others=False)
+
+    result = mgr.create_conclusion("test-session", "likes dark mode", peer="user")
+
+    assert result is True
+    chris_peer = peers["chris"]
+    scope = chris_peer.conclusions_scopes["chris"]
+    assert len(scope.created) == 1
+    assert scope.created[0]["content"] == "likes dark mode"
+
+
+def test_create_conclusion_assistant_self_observation():
+    """Conclusions about the assistant itself should route through the
+    assistant peer targeting itself."""
+    mgr, session, peers = _make_manager(ai_observe_others=True)
+
+    result = mgr.create_conclusion("test-session", "should be concise", peer="hermes")
+
+    assert result is True
+    hermes_peer = peers["hermes"]
+    scope = hermes_peer.conclusions_scopes["hermes"]
+    assert len(scope.created) == 1
+    assert scope.created[0]["content"] == "should be concise"
+
+
+def test_create_conclusion_empty_content_returns_false():
+    mgr, _, _ = _make_manager()
+    assert mgr.create_conclusion("test-session", "") is False
+    assert mgr.create_conclusion("test-session", "   ") is False
+
+
+def test_create_conclusion_missing_session_returns_false():
+    mgr, _, _ = _make_manager()
+    assert mgr.create_conclusion("nonexistent", "content") is False
+
+
+# --- delete_conclusion tests ---
+
+
+def test_delete_conclusion_user_alias_uses_assistant_observer():
+    mgr, session, peers = _make_manager(ai_observe_others=True)
+
+    result = mgr.delete_conclusion("test-session", "conc-123", peer="user")
+
+    assert result is True
+    hermes_peer = peers["hermes"]
+    scope = hermes_peer.conclusions_scopes["chris"]
+    assert scope.deleted == ["conc-123"]
+
+
+def test_delete_conclusion_user_alias_uses_user_observer_when_ai_cannot_observe():
+    mgr, session, peers = _make_manager(ai_observe_others=False)
+
+    result = mgr.delete_conclusion("test-session", "conc-456", peer="user")
+
+    assert result is True
+    chris_peer = peers["chris"]
+    scope = chris_peer.conclusions_scopes["chris"]
+    assert scope.deleted == ["conc-456"]
+
+
+def test_delete_conclusion_assistant_self_observation():
+    mgr, session, peers = _make_manager(ai_observe_others=True)
+
+    result = mgr.delete_conclusion("test-session", "conc-789", peer="hermes")
+
+    assert result is True
+    hermes_peer = peers["hermes"]
+    scope = hermes_peer.conclusions_scopes["hermes"]
+    assert scope.deleted == ["conc-789"]


### PR DESCRIPTION
## What does this PR do?

Fixes `honcho_conclude` silently failing on self-hosted Honcho instances by routing `create_conclusion()` and `delete_conclusion()` through `_resolve_observer_target()` — the same peer-resolution path used by all other session methods (`get_peer_card`, `set_peer_card`, `search_context`, `get_session_context`).

## Related Issue

Fixes #37759
Closes #35988 (previous abandoned attempt)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/session.py`: Refactored `create_conclusion()` and `delete_conclusion()` to use `_resolve_observer_target()` instead of inline peer resolution. The inline logic selected the wrong peer object in the `ai_observe_others=False` case, causing `conclusions_of()` to lack workspace context. The Honcho API requires `workspace_id` in the request path (`POST /v3/workspaces/{workspace_id}/conclusions`), so every write request silently failed.
- `tests/test_honcho_conclusion_peer_resolution.py`: Added 8 regression tests covering all three observer-target resolution paths (assistant self-observation, assistant observing user, user self-observation) for both create and delete.

## How to Test

1. Run `pytest tests/test_honcho_conclusion_peer_resolution.py tests/test_honcho_session_context.py -v` — all 11 tests should pass
2. The fix is in peer resolution only — no API contract or schema changes
3. On a self-hosted Honcho instance: configure `memory.provider: honcho` with a local `honcho.json`, then ask Hermes to save a conclusion (e.g., "remember that I prefer dark mode"). Before this fix: "Failed to save conclusion." After: conclusion saved successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/memory/honcho/session.py` → `create_conclusion()`, `delete_conclusion()`, `_resolve_observer_target()`
- Callers: `create_conclusion` called from `__init__.py:1177,1300`; `delete_conclusion` called from `__init__.py:1296`
- Blast radius: LOW — two methods in one file, same resolver already used by 4 other methods
- Related patterns: `_resolve_observer_target()` is the canonical peer resolution path for all Honcho session operations. `set_peer_card()` at line 1244 uses the same pattern this PR adopts.
