### PR TITLE
fix(mcp): reconnect stale server entries

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3724,6 +3724,30 @@ class TestRegisterMcpServers:
         finally:
             _servers.pop("existing", None)
 
+    def test_reconnects_disconnected_servers(self):
+        from tools.mcp_tool import register_mcp_servers, _servers, _ensure_mcp_loop
+
+        stale_server = _make_mock_server("existing", session=None)
+        stale_server._registered_tool_names = ["mcp_existing_tool"]
+        _servers["existing"] = stale_server
+
+        async def fake_register(name, cfg):
+            server = _make_mock_server(name)
+            server._registered_tool_names = ["mcp_existing_tool"]
+            _servers[name] = server
+            return ["mcp_existing_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register) as mock_register, \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=["mcp_existing_tool"]):
+                _ensure_mcp_loop()
+                result = register_mcp_servers({"existing": {"command": "test"}})
+            assert result == ["mcp_existing_tool"]
+            mock_register.assert_called_once_with("existing", {"command": "test"})
+        finally:
+            _servers.pop("existing", None)
+
     def test_skips_disabled_servers(self):
         from tools.mcp_tool import register_mcp_servers, _servers
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3506,13 +3506,19 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
-    # Only attempt servers that aren't already connected and are enabled
-    # (enabled: false skips the server entirely without removing its config)
+    # Only skip servers with an active live session. Stale entries can linger
+    # in ``_servers`` after disconnects; those must be reconnected rather than
+    # treated as healthy, or the agent ends up with registered tools whose
+    # handlers only return "not connected".
     with _lock:
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
+            if _parse_boolish(v.get("enabled", True), default=True)
+            and (
+                k not in _servers
+                or getattr(_servers[k], "session", None) is None
+            )
         }
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():


### PR DESCRIPTION
## Summary
- reconnect configured MCP servers when a stale `_servers[name]` entry exists but its `session` has already dropped to `None`
- keep `register_mcp_servers()` from treating disconnected entries as healthy, which avoids exposing handlers that only return `"MCP server '<name>' is not connected"`
- add a targeted regression test covering reconnect of a stale same-name server entry

Fixes #37768.

## Verification
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/pytest -o addopts='' tests/tools/test_mcp_tool.py -q -k 'TestRegisterMcpServers'`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py`
- `git diff --check`
