### PR TITLE
feat(feishu): interactive clarify cards with button callbacks

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2014,6 +2014,123 @@ class FeishuAdapter(BasePlatformAdapter):
             ],
         }
 
+    @staticmethod
+    def _build_clarify_card(*, question: str, choices: list, clarify_id: str) -> Dict[str, Any]:
+        """Build an interactive card with one button per choice plus an 'Other' button."""
+        option_lines = "\n".join(
+            f"{i + 1}. {str(c)}"
+            for i, c in enumerate(choices)
+        )
+        elements = [
+            {"tag": "markdown", "content": f"**❓ {question}**\n\n{option_lines}"},
+        ]
+        # Build choice buttons in rows (Feishu supports up to 2 buttons per row in action)
+        actions = []
+        for i, choice in enumerate(choices):
+            actions.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": str(i + 1)},
+                "type": "default",
+                "value": {
+                    "hermes_clarify_action": "choose",
+                    "clarify_id": clarify_id,
+                    "choice_index": i,
+                },
+            })
+        # "Other" button
+        actions.append({
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "✏️ Other (type answer)"},
+            "type": "default",
+            "value": {
+                "hermes_clarify_action": "other",
+                "clarify_id": clarify_id,
+            },
+        })
+        elements.append({"tag": "action", "actions": actions})
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "❓ Clarification Needed", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": elements,
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, choice: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"✅ Answered: {choice}", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"**You selected:** {choice}"},
+            ],
+        }
+
+    @staticmethod
+    def _build_clarify_awaiting_text_card() -> Dict[str, Any]:
+        """Card shown when the user picks 'Other' — tells them to type."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✏️ Type Your Answer", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": "Please type your answer in the chat."},
+            ],
+        }
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt as an interactive card with buttons.
+
+        Multi-choice mode: renders one button per choice plus an 'Other' button.
+        Open-ended mode: falls back to plain text (next message captured as response).
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            if choices:
+                card = self._build_clarify_card(
+                    question=question,
+                    choices=choices,
+                    clarify_id=clarify_id,
+                )
+                payload = json.dumps(card, ensure_ascii=False)
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="interactive",
+                    payload=payload,
+                    reply_to=None,
+                    metadata=metadata,
+                )
+                return self._finalize_send_result(response, "send_clarify failed")
+
+            # Open-ended: plain text, gateway text-intercept captures the reply
+            from tools.clarify_gateway import mark_awaiting_text
+            mark_awaiting_text(clarify_id)
+            return await self.send(
+                chat_id=chat_id,
+                content=f"❓ {question}",
+                metadata=metadata,
+            )
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
@@ -2578,11 +2695,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if clarify_action:
+            return self._handle_clarify_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2712,6 +2839,79 @@ class FeishuAdapter(BasePlatformAdapter):
             card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
             response.card = card
         return response
+
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Handle clarify card button clicks and resolve the pending clarify synchronously.
+
+        Returns a P2CardActionTriggerResponse with an updated card so the user
+        sees immediate feedback.
+        """
+        clarify_id = action_value.get("clarify_id")
+        if not clarify_id:
+            logger.debug("[Feishu] Card action missing clarify_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        clarify_action = str(action_value.get("hermes_clarify_action", "") or "")
+
+        if clarify_action == "choose":
+            choice_index = action_value.get("choice_index")
+            if choice_index is None:
+                logger.debug("[Feishu] Clarify card action missing choice_index")
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+            # Resolve the clarify on the event loop
+            if not self._submit_on_loop(
+                loop,
+                self._resolve_clarify_choice(clarify_id=clarify_id, choice_index=int(choice_index)),
+            ):
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_resolved_clarify_card(
+                    choice=f"Option {int(choice_index) + 1}"
+                )
+                response.card = card
+            return response
+
+        elif clarify_action == "other":
+            # Switch to text-capture mode — next message resolves the clarify
+            from tools.clarify_gateway import mark_awaiting_text
+            mark_awaiting_text(clarify_id)
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_clarify_awaiting_text_card()
+                response.card = card
+            return response
+
+        logger.debug("[Feishu] Unknown clarify action: %s", clarify_action)
+        return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+    async def _resolve_clarify_choice(self, *, clarify_id: str, choice_index: int) -> None:
+        """Resolve a clarify by looking up the choice text from the pending entry."""
+        from tools.clarify_gateway import _entries as _clarify_entries
+        entry = _clarify_entries.get(clarify_id)
+        if entry is None:
+            logger.debug("[Feishu] Clarify %s not found or already resolved", clarify_id)
+            return
+        choices = entry.choices or []
+        if choice_index < 0 or choice_index >= len(choices):
+            logger.debug("[Feishu] Clarify %s choice index %d out of range (choices=%d)",
+                         clarify_id, choice_index, len(choices))
+            return
+        choice_text = choices[choice_index]
+
+        from tools.clarify_gateway import resolve_gateway_clarify
+        resolved = resolve_gateway_clarify(clarify_id, choice_text)
+        if not resolved:
+            logger.debug("[Feishu] resolve_gateway_clarify returned False for clarify %s", clarify_id)
 
     async def _resolve_approval(
         self,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1320,6 +1320,60 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
+
+    # Monkey-patch _handle_data_frame to dispatch CARD-type messages
+    # (card.action.trigger) to the event handler instead of dropping them.
+    # Upstream lark-oapi WS client (v1.5.3) has:
+    #   elif message_type == MessageType.CARD: return
+    # which silently discards all card action callbacks.
+    _original_handle_data_frame = ws_client._handle_data_frame
+
+    async def _patched_handle_data_frame(self, frame):
+        import lark_oapi.ws.client as _ws_mod
+        hs = frame.headers
+        type_ = _ws_mod._get_by_key(hs, _ws_mod.HEADER_TYPE)
+        message_type = _ws_mod.MessageType(type_)
+
+        if message_type == _ws_mod.MessageType.CARD:
+            # Dispatch CARD events to the event handler, same as EVENT type.
+            pl = frame.payload
+            if int(_ws_mod._get_by_key(hs, _ws_mod.HEADER_SUM)) > 1:
+                pl = self._combine(
+                    _ws_mod._get_by_key(hs, _ws_mod.HEADER_MESSAGE_ID),
+                    int(_ws_mod._get_by_key(hs, _ws_mod.HEADER_SUM)),
+                    int(_ws_mod._get_by_key(hs, _ws_mod.HEADER_SEQ)),
+                    pl,
+                )
+                if pl is None:
+                    return
+
+            resp = _ws_mod.Response(code=_ws_mod.http.HTTPStatus.OK)
+            try:
+                start = int(round(time.time() * 1000))
+                result = self._event_handler.do_without_validation(pl)
+                end = int(round(time.time() * 1000))
+                header = hs.add()
+                header.key = _ws_mod.HEADER_BIZ_RT
+                header.value = str(end - start)
+                if result is not None:
+                    resp.data = _ws_mod.base64.b64encode(
+                        _ws_mod.JSON.marshal(result).encode("utf-8")
+                    )
+            except Exception as e:
+                logger.error(
+                    "[Feishu] CARD message dispatch failed: %s", e, exc_info=True
+                )
+                resp = _ws_mod.Response(code=_ws_mod.http.HTTPStatus.INTERNAL_SERVER_ERROR)
+
+            frame.payload = _ws_mod.JSON.marshal(resp).encode("utf-8")
+            await self._write_message(frame.SerializeToString())
+            return
+
+        await _original_handle_data_frame(frame)
+
+    import types
+    ws_client._handle_data_frame = types.MethodType(_patched_handle_data_frame, ws_client)
+
     try:
         ws_client.start()
     except Exception:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -160,6 +160,77 @@ class TestFeishuMessageNormalization(unittest.TestCase):
         )
 
 
+class TestFeishuClarifyCardBuilders(unittest.TestCase):
+    """Tests for Feishu interactive card builder methods for clarify prompts."""
+
+    def test_build_clarify_card_creates_correct_structure(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_clarify_card(
+            question="What is your favorite color?",
+            choices=["Red", "Blue", "Green"],
+            clarify_id="abc123",
+        )
+
+        self.assertEqual(card["config"]["wide_screen_mode"], True)
+        self.assertEqual(
+            card["header"]["title"]["content"],
+            "❓ Clarification Needed",
+        )
+        self.assertEqual(card["header"]["template"], "blue")
+        self.assertEqual(len(card["elements"]), 2)
+        # First element is markdown with the question and options
+        self.assertEqual(card["elements"][0]["tag"], "markdown")
+        self.assertIn("What is your favorite color?", card["elements"][0]["content"])
+        self.assertIn("1. Red", card["elements"][0]["content"])
+        self.assertIn("2. Blue", card["elements"][0]["content"])
+        self.assertIn("3. Green", card["elements"][0]["content"])
+        # Second element is the action group with buttons
+        self.assertEqual(card["elements"][1]["tag"], "action")
+        actions = card["elements"][1]["actions"]
+        self.assertEqual(len(actions), 4)  # 3 choices + 1 Other
+        # Check first choice button
+        self.assertEqual(actions[0]["text"]["content"], "1")
+        self.assertEqual(actions[0]["value"]["hermes_clarify_action"], "choose")
+        self.assertEqual(actions[0]["value"]["clarify_id"], "abc123")
+        self.assertEqual(actions[0]["value"]["choice_index"], 0)
+        # Check last button is "Other"
+        self.assertEqual(actions[3]["text"]["content"], "✏️ Other (type answer)")
+        self.assertEqual(actions[3]["value"]["hermes_clarify_action"], "other")
+
+    def test_build_clarify_card_single_choice(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_clarify_card(
+            question="Proceed?",
+            choices=["Yes"],
+            clarify_id="xyz789",
+        )
+
+        actions = card["elements"][1]["actions"]
+        self.assertEqual(len(actions), 2)  # 1 choice + 1 Other
+        self.assertEqual(actions[0]["value"]["choice_index"], 0)
+        self.assertEqual(actions[0]["value"]["clarify_id"], "xyz789")
+
+    def test_build_resolved_clarify_card(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_resolved_clarify_card(choice="Option 1")
+        self.assertEqual(card["header"]["title"]["content"], "✅ Answered: Option 1")
+        self.assertEqual(card["header"]["template"], "green")
+        self.assertEqual(
+            card["elements"][0]["content"],
+            "**You selected:** Option 1",
+        )
+
+    def test_build_clarify_awaiting_text_card(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_clarify_awaiting_text_card()
+        self.assertEqual(card["header"]["title"]["content"], "✏️ Type Your Answer")
+        self.assertEqual(card["header"]["template"], "blue")
+
+
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",


### PR DESCRIPTION
## Problem

The Feishu adapter uses the base `send_clarify` implementation, which renders multiple-choice questions as a numbered text list. This means:

1. Users must manually type their choice number or text instead of clicking a button
2. The generic card action handler (`_handle_card_action_event`) creates a synthetic `/card` command with no registered handler, so any card action not matching approval/update/model-picker is silently dropped

Additionally, the upstream `lark-oapi` WS client (v1.5.3) has:
```python
elif message_type == MessageType.CARD: return
```
which silently discards all card action trigger callbacks (`card.action.trigger`) received over the WebSocket connection, making all interactive card clicks unresponsive in WS mode.

## Fix

Two commits:

**Commit 1** — Monkey-patch the lark-oapi WS client `_handle_data_frame` method to dispatch CARD-type messages to the event handler instead of returning early. This is the same dispatch path used for EVENT-type messages.

**Commit 2** — Add a Feishu-specific `send_clarify` override that renders interactive cards with one button per choice (plus an "✏️ Other" button for free-text answers). Includes:

- `_build_clarify_card`: constructs the Feishu interactive card with choice buttons
- `_build_resolved_clarify_card`: card shown after a choice is selected (immediate visual feedback)
- `_build_clarify_awaiting_text_card`: card shown when user picks "Other," prompting them to type
- `_handle_clarify_card_action`: routes card button clicks to `resolve_gateway_clarify()`, unblocking the waiting agent thread
- `_resolve_clarify_choice`: async helper that looks up the choice text from the pending clarify entry

## Test Plan

- `test_build_clarify_card_creates_correct_structure` — verifies card JSON has correct header, elements, choice buttons, and "Other" button with proper action values
- `test_build_clarify_card_single_choice` — edge case with 1 choice
- `test_build_resolved_clarify_card` — resolved card shows correct header
- `test_build_clarify_awaiting_text_card` — awaiting-text card shows correct header
- All 4 tests pass: `python -m pytest tests/gateway/test_feishu.py::TestFeishuClarifyCardBuilders -q`

## Verification

```bash
cd ~/.hermes/hermes-agent
python -m py_compile gateway/platforms/feishu.py
python -m pytest tests/gateway/test_feishu.py::TestFeishuClarifyCardBuilders -q
```

## Notes

- The `_entries` private import pattern matches the existing Telegram clarify handler (`from tools.clarify_gateway import _entries as _clarify_entries`)
- The card builder methods are all `@staticmethod` and purely functional (no adapter state), making them easy to test and reuse
- The monkey-patch is scoped to the WS client instance and does not modify module-level lark-oapi code