### PR TITLE
fix(plugins/google-meet): force English Meet UI via hl=en so the bot works on any locale

### DIFF
--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -37,6 +37,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 # Match ``https://meet.google.com/abc-defg-hij`` or ``.../lookup/...`` — the
 # short three-segment code or a lookup URL. Anything else is rejected.
@@ -59,6 +60,19 @@ def _is_safe_meet_url(url: str) -> bool:
     if not isinstance(url, str):
         return False
     return bool(MEET_URL_RE.match(url.strip()))
+
+
+def _force_english_ui(url: str) -> str:
+    """Pin the Meet page to English via the standard ``hl`` param.
+
+    Every selector in this file (join buttons, leave button, denial text,
+    caption region) matches English UI labels; without ``hl=en`` a non-English
+    account/browser locale renders localized labels and the bot goes blind.
+    """
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query))
+    query["hl"] = "en"
+    return urlunsplit(parts._replace(query=urlencode(query)))
 
 
 def _meeting_id_from_url(url: str) -> str:
@@ -511,6 +525,7 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
                 rt["enabled"] = False
 
     try:
+        from playwright.sync_api import TimeoutError as PlaywrightTimeout
         from playwright.sync_api import sync_playwright
     except ImportError as e:
         state.set(error=f"playwright not installed: {e}", exited=True)
@@ -560,10 +575,22 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             page = context.new_page()
 
             try:
-                page.goto(url, wait_until="domcontentloaded", timeout=30_000)
+                page.goto(_force_english_ui(url), wait_until="domcontentloaded", timeout=30_000)
             except Exception as e:
                 state.set(error=f"navigate failed: {e}", exited=True)
                 return 4
+
+            # Meet renders the pre-join controls well after DOMContentLoaded;
+            # wait for them so the name fill / join click below don't race the
+            # UI. On timeout we fall through — a missed join surfaces later as
+            # lobby timeout rather than aborting here.
+            try:
+                page.locator(
+                    'input[aria-label*="name" i], button:has-text("Join now"), '
+                    'button:has-text("Ask to join"), button:has-text("Join here too")'
+                ).first.wait_for(state="visible", timeout=15_000)
+            except PlaywrightTimeout:
+                pass
 
             # Guest-mode: Meet shows a name field before "Ask to join". When
             # we're authed, we instead see "Join now".
@@ -825,7 +852,9 @@ def _click_join(page, state: _BotState) -> None:
     Flags ``lobby_waiting`` when we hit the "waiting for host to admit you"
     state so the agent can surface that in status.
     """
-    for label in ("Join now", "Ask to join"):
+    # "Join here too" is the primary action on the "Switch here?" dialog Meet
+    # shows when the same account is already in the call on another device.
+    for label in ("Join now", "Ask to join", "Join here too"):
         try:
             btn = page.get_by_role("button", name=label, exact=False).first
             if btn.count() and btn.is_visible():

--- a/tests/plugins/test_google_meet_bot.py
+++ b/tests/plugins/test_google_meet_bot.py
@@ -1,0 +1,32 @@
+"""Tests for plugins.google_meet.meet_bot URL handling."""
+
+from __future__ import annotations
+
+
+def test_force_english_ui_appends_hl():
+    from plugins.google_meet.meet_bot import _force_english_ui
+
+    assert (
+        _force_english_ui("https://meet.google.com/abc-defg-hij")
+        == "https://meet.google.com/abc-defg-hij?hl=en"
+    )
+
+
+def test_force_english_ui_overrides_existing_hl_and_keeps_params():
+    from plugins.google_meet.meet_bot import _force_english_ui
+
+    assert (
+        _force_english_ui("https://meet.google.com/abc-defg-hij?hl=zh-TW&authuser=1")
+        == "https://meet.google.com/abc-defg-hij?hl=en&authuser=1"
+    )
+
+
+def test_force_english_ui_result_stays_safe():
+    from plugins.google_meet.meet_bot import _force_english_ui, _is_safe_meet_url
+
+    for url in (
+        "https://meet.google.com/abc-defg-hij",
+        "https://meet.google.com/lookup/some-id",
+        "https://meet.google.com/new",
+    ):
+        assert _is_safe_meet_url(_force_english_ui(url))


### PR DESCRIPTION
## What does this PR do?

Fixes the Google Meet bot being unable to join, detect admission, or leave when the host account / browser uses a non-English locale (e.g. Traditional Chinese). Every selector in `meet_bot.py` — join buttons, leave button, denial text, the caption region — matches English UI labels, so on a localized Meet page the bot goes blind.

**Approach (reworked):** instead of translating selectors per locale, pin the page language at the single URL seam: append `?hl=en` (Google's standard UI-language parameter) to the URL the bot navigates to. Meet honors `hl` on the meeting pre-join page, keeps it through SPA navigation into the call, and it works for both signed-in accounts and guests — so **every existing English selector works in every locale** (join, admission detection, denial text, leave click, captions), with no per-language lists to maintain.

An earlier revision added zh-TW label alternates plus obfuscated `jsname` fallbacks; review showed that approach false-positives on broad CJK substrings (離開/結束 match unrelated buttons and can latch `in_call=True` permanently, disabling lobby-timeout and denial detection), left the leave click and `_detect_denied` English-only (the bot could enter a zh meeting it could never cleanly leave), and still broke on every other locale (ja/ko/de/...). The `hl=en` seam fixes all locales at once.

Also in this PR:

- **Pre-join settle wait**: Meet renders the pre-join controls well after `domcontentloaded`; a single Playwright `locator.wait_for(state="visible", timeout=15_000)` on the join controls/name field replaces racing the UI (on timeout we fall through — a missed join surfaces as lobby timeout).
- **"Join here too"**: handle the primary action on the "Switch here?" dialog Meet shows when the same account is already in the call on another device (the original repro scenario).

## Related Issue

The OpenAI Realtime beta-header fix that was previously bundled here moved to #57448 (full GA protocol migration) per the one-logical-change-per-PR guideline.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/google_meet/meet_bot.py` — `_force_english_ui()` helper (sets `hl=en`, preserves other query params), applied at `page.goto`; pre-join settle wait; `"Join here too"` in `_click_join`
- `tests/plugins/test_google_meet_bot.py` — new: URL helper behavior (appends/overrides `hl`, keeps params, result stays `_is_safe_meet_url`-valid)

## How to Test

1. `pytest tests/plugins/test_google_meet_bot.py tests/plugins/test_google_meet_realtime.py -q` → 12 passed
2. Set a zh-TW (or any non-English) Google account / browser locale, then `HERMES_MEET_URL=https://meet.google.com/<code> ... python -m plugins.google_meet.meet_bot` — the opened page renders English (`Join now`), the bot joins, and `status.json` shows `inCall: true`
3. Live locale proof (CDP, no bot): opening a real meeting URL with `?hl=en` renders English on both a signed-in zh-TW profile and a signed-out Japanese profile — see logs below

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains **only** changes related to this fix (realtime fix split out)
- [x] I've run the full `tests/plugins/` tree locally (all pass); `tests/gateway`/`tests/integration`/`tests/acp_adapter` need optional deps not in my env (aiohttp etc.) — relying on CI for those
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (kernel 7.0.9), Python 3.13, Chromium/Edge 147

### Documentation & Housekeeping

- [x] Docs — N/A (behavior fix, no API change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (URL parameter + Playwright wait; no platform-specific code)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Live CDP verification that Meet honors `hl=en` (signed-in **zh-TW** Edge 147 profile):

```
https://meet.google.com/qeo-ngsk-cqw      → lang="zh-TW", buttons: 立即加入, 使用夥伴模式
https://meet.google.com/qeo-ngsk-cqw?hl=en → lang="en",   buttons: Join now, Use Companion mode
```

Same check, signed-out **Japanese** Chromium 148 (`--lang=ja`, fresh profile — guest path):

```
https://meet.google.com/qeo-ngsk-cqw       → lang="ja", マイクとカメラを使用せずに続行
https://meet.google.com/qeo-ngsk-cqw?hl=en → lang="en", Continue without microphone and camera
```

The param also survives Meet's SPA redirect (`meet.google.com/new?hl=en` → `meet.google.com/xxx-xxxx-xxx?hl=en`, in-call UI shows `Turn off microphone`), so in-call selectors (leave button, captions) stay English too.
