### PR TITLE
fix(honcho): drop vacuous memory summaries when facts exist

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -189,6 +189,17 @@ ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCH
 # ---------------------------------------------------------------------------
 
 class HonchoMemoryProvider(MemoryProvider):
+    _VACUOUS_DIALECTIC_PREFIXES = (
+        "i don't have any gathered information about this person",
+        "i do not have any gathered information about this person",
+        "i don't have enough information about this person",
+        "i do not have enough information about this person",
+        "i can't reliably identify who they are",
+        "i cannot reliably identify who they are",
+        "no gathered information about this person",
+        "no profile facts available yet.",
+    )
+
     """Honcho AI-native memory with dialectic Q&A and persistent user modeling."""
 
     def __init__(self):
@@ -546,6 +557,17 @@ class HonchoMemoryProvider(MemoryProvider):
             return True
         return not (self._init_thread and self._init_thread.is_alive())
 
+    @classmethod
+    def _is_vacuous_dialectic_result(cls, text: str) -> bool:
+        """Detect generic empty-memory summaries that contradict base context."""
+        if not text or not text.strip():
+            return False
+        normalized = re.sub(r"\s+", " ", text.strip().lower())
+        return any(
+            normalized.startswith(prefix)
+            for prefix in cls._VACUOUS_DIALECTIC_PREFIXES
+        )
+
     def _format_first_turn_context(self, ctx: dict) -> str:
         """Format the prefetch context dict into a readable system prompt block."""
         parts = []
@@ -748,6 +770,17 @@ class HonchoMemoryProvider(MemoryProvider):
             logger.debug(
                 "Honcho pending dialectic discarded as stale: fired_at=%d, "
                 "turn=%d, limit=%d", fired_at, self._turn_count, stale_limit,
+            )
+            dialectic_result = ""
+
+        if (
+            base_context
+            and dialectic_result
+            and self._is_vacuous_dialectic_result(dialectic_result)
+        ):
+            logger.debug(
+                "Honcho dialectic summary discarded because base context already "
+                "contains concrete profile facts"
             )
             dialectic_result = ""
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1454,6 +1454,41 @@ class TestDialecticLiveness:
         result = p.prefetch("what's new")
         assert "recent synthesis" in result
 
+    def test_vacuous_pending_result_is_dropped_when_base_context_exists(self):
+        """Generic "I know nothing" summaries must not contradict cached facts."""
+        p = self._make_provider(cfg_extra={"raw": {"dialecticCadence": 3}})
+        p._session_key = "test"
+        p._base_context_cache = "## User Representation\nBrendon prefers concise replies."
+        with p._prefetch_lock:
+            p._prefetch_result = (
+                "I don't have any gathered information about this person in memory, "
+                "so I can't reliably identify who they are."
+            )
+            p._prefetch_result_fired_at = 8
+        p._turn_count = 9
+        p._last_dialectic_turn = 8
+
+        result = p.prefetch("what's new")
+        assert "Brendon prefers concise replies." in result
+        assert "gathered information about this person" not in result.lower()
+
+    def test_vacuous_pending_result_is_kept_without_base_context(self):
+        """Cold-start sessions still surface the dialectic result they have."""
+        p = self._make_provider(cfg_extra={"raw": {"dialecticCadence": 3}})
+        p._session_key = "test"
+        p._base_context_cache = ""
+        with p._prefetch_lock:
+            p._prefetch_result = (
+                "I don't have any gathered information about this person in memory, "
+                "so I can't reliably identify who they are."
+            )
+            p._prefetch_result_fired_at = 8
+        p._turn_count = 9
+        p._last_dialectic_turn = 8
+
+        result = p.prefetch("what's new")
+        assert "gathered information about this person" in result.lower()
+
     def test_empty_streak_widens_effective_cadence(self):
         """After N empty returns, the gate waits cadence + N turns."""
         p = self._make_provider(cfg_extra={"raw": {"dialecticCadence": 1}})


### PR DESCRIPTION
Fixes #37655

## Summary
- discard vacuous Honcho dialectic summaries when cached base context already contains concrete profile facts
- keep the same summaries on true cold starts where no base context exists yet
- add regression coverage for both paths in honcho session prefetch handling

## Testing
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/pytest -o addopts='' tests/honcho_plugin/test_session.py -q -k "vacuous_pending_result or fresh_pending_result or stale_pending_result"
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/ruff check plugins/memory/honcho/__init__.py tests/honcho_plugin/test_session.py
- git diff --check