### PR TITLE
fix(gateway/feishu): prevent unwanted topic creation when thread_id routing fails in forum chats

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -269,7 +269,11 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 
 
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
-_FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+_FEISHU_REPLY_FALLBACK_CODES = frozenset({
+    230011,    # reply target withdrawn/missing
+    231003,    # reply target not found
+    99992402,  # field validation failed (e.g. stale reply_to_message_id after gateway restart)
+})
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -2446,11 +2450,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
             data = getattr(response, "data", None)
             raw_chat_type = str(getattr(data, "chat_type", "") or "").strip().lower()
+            raw_chat_mode = str(getattr(data, "chat_mode", "") or "").strip().lower()
             info = {
                 "chat_id": chat_id,
                 "name": str(getattr(data, "name", None) or chat_id),
                 "type": self._map_chat_type(raw_chat_type),
                 "raw_type": raw_chat_type or None,
+                "chat_mode": raw_chat_mode or None,
             }
             self._chat_info_cache[chat_id] = info
             return dict(info)
@@ -3376,13 +3382,23 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
+        resolved_chat_type = self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type)
+
+        # Preserve thread_id ONLY for topic/forum chats (话题群) so each
+        # Feishu topic gets its own session and replies land inside the topic.
+        # Regular group chats (chat_mode != "topic") must NOT use thread_id
+        # for routing — ordinary group messages carry a thread_id/root_id but
+        # routing via receive_id_type="thread_id" would create unwanted topic
+        # replies instead of plain group messages.  DMs never use thread_id.
+        thread_id_for_source = thread_id if resolved_chat_type == "forum" else None
+
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
+            chat_type=resolved_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
-            thread_id=thread_id,
+            thread_id=thread_id_for_source,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
         )
@@ -4141,6 +4157,12 @@ class FeishuAdapter(BasePlatformAdapter):
         resolved = str(chat_info.get("type") or "").strip().lower()
         if resolved in {"group", "forum"}:
             return resolved
+        # Feishu topic chats return chat_type="private" (mapped to "dm" by
+        # _map_chat_type) but chat_mode="topic".  Detect this and promote to
+        # "forum" so thread_id is preserved in the session key.
+        chat_mode = str(chat_info.get("chat_mode") or "").strip().lower()
+        if chat_mode in {"topic", "thread", "forum"}:
+            return "forum"
         if event_chat_type == "p2p":
             return "dm"
         return "group"
@@ -4837,8 +4859,12 @@ class FeishuAdapter(BasePlatformAdapter):
         # For topic/thread messages that fell back from reply→create, use
         # thread_id as receive_id so the message lands in the topic instead of
         # the main chat.
+        # Exception: interactive cards cannot be sent with receive_id_type="thread_id"
+        # (Feishu returns 99992402 field validation failed). For interactive cards,
+        # fall through to chat_id routing so they land in the chat (still visible
+        # in the topic context since the topic is part of the chat).
         _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
+        if _thread_id and msg_type != "interactive":
             body = self._build_create_message_body(
                 receive_id=_thread_id,
                 msg_type=msg_type,
@@ -4998,6 +5024,7 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> Any:
         last_error: Optional[Exception] = None
         active_reply_to = reply_to
+        _downgraded_post = False  # guard against infinite post→text retry
         for attempt in range(_FEISHU_SEND_ATTEMPTS):
             try:
                 response = await self._send_raw_message(
@@ -5036,6 +5063,50 @@ class FeishuAdapter(BasePlatformAdapter):
                             reply_to=None,
                             metadata=metadata,
                         )
+                # Handle 99992402 (field validation failed) when thread_id
+                # routing was used without a reply anchor (auto-resume path).
+                # For "post" msg_type: downgrade to "text" and retry — Feishu
+                # accepts text via thread_id more reliably than post.
+                # For omt_ (forum topic) IDs: suppress chat_id fallback to
+                # avoid creating unwanted new topics.
+                elif (
+                    not active_reply_to
+                    and not self._response_succeeded(response)
+                    and (metadata or {}).get("thread_id")
+                    and getattr(response, "code", None) in _FEISHU_REPLY_FALLBACK_CODES
+                ):
+                    thread_id = (metadata or {}).get("thread_id")
+                    code = getattr(response, "code", None)
+                    if msg_type == "post" and not _downgraded_post:
+                        logger.warning(
+                            "[Feishu] thread_id create failed (code %s) for post in thread %s; "
+                            "downgrading to text and retrying",
+                            code, thread_id,
+                        )
+                        msg_type = "text"
+                        payload = json.dumps({"text": payload}, ensure_ascii=False)
+                        _downgraded_post = True
+                        continue  # retry with text in next loop iteration
+                    if str(thread_id).startswith("omt_"):
+                        logger.warning(
+                            "[Feishu] thread_id routing failed (code %s) for forum topic %s; "
+                            "suppressing chat_id fallback to prevent unwanted new topic creation",
+                            code, thread_id,
+                        )
+                        return response
+                    logger.warning(
+                        "[Feishu] thread_id routing failed (code %s) for thread %s; "
+                        "falling back to chat_id routing for chat %s",
+                        code, thread_id, chat_id,
+                    )
+                    fallback_metadata = {k: v for k, v in (metadata or {}).items() if k != "thread_id"}
+                    response = await self._send_raw_message(
+                        chat_id=chat_id,
+                        msg_type=msg_type,
+                        payload=payload,
+                        reply_to=None,
+                        metadata=fallback_metadata or None,
+                    )
                 return response
             except Exception as exc:
                 last_error = exc

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -172,3 +172,220 @@ class TestFeishuFallbackThreadRouting:
             f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
         )
 
+
+    @pytest.mark.asyncio
+    async def test_create_uses_chat_id_when_no_thread(self):
+        """When reply_to=None and metadata has no thread_id, message.create
+        should use receive_id_type='chat_id' (original behavior)."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        adapter._client = mock_client
+        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
+        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+
+        import json
+        result = await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata=None,
+        )
+
+        mock_client.im.v1.message.create.assert_called_once()
+
+
+class TestFeishu99992402Handling:
+    """Regression tests for 99992402 (field validation failed) handling.
+
+    Covers the auto-resume path where reply_to=None but thread_id is present,
+    and Feishu's thread_id create API returns 99992402 for certain msg_types.
+    """
+
+    @pytest.mark.asyncio
+    async def test_error_code_in_fallback_set(self):
+        """99992402 must be in _FEISHU_REPLY_FALLBACK_CODES."""
+        from plugins.platforms.feishu.adapter import _FEISHU_REPLY_FALLBACK_CODES
+
+        assert 99992402 in _FEISHU_REPLY_FALLBACK_CODES, (
+            "99992402 (field validation failed) must be in _FEISHU_REPLY_FALLBACK_CODES"
+        )
+
+    @pytest.mark.asyncio
+    async def test_interactive_card_skips_thread_id_routing(self):
+        """Interactive cards must NOT use receive_id_type='thread_id'.
+
+        Feishu rejects interactive card creation with thread_id (99992402).
+        """
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        adapter._client = mock_client
+        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
+        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+
+        import json
+        result = await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="interactive",
+            payload=json.dumps({"config": {}, "elements": []}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        mock_client.im.v1.message.create.assert_called_once()
+        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        receive_id_type = getattr(call_args, "receive_id_type", None)
+        assert receive_id_type != "thread_id", (
+            "Interactive cards must not use receive_id_type='thread_id'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_text_message_still_uses_thread_id_routing(self):
+        """Non-interactive messages should still use thread_id routing."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        adapter._client = mock_client
+        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
+        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+
+        import json
+        result = await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        mock_client.im.v1.message.create.assert_called_once()
+        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        receive_id_type = getattr(call_args, "receive_id_type", None)
+        assert receive_id_type == "thread_id", (
+            "Text messages should use receive_id_type='thread_id' when thread_id is present"
+        )
+
+    @pytest.mark.asyncio
+    async def test_retry_suppresses_chat_fallback_for_omt_topics(self):
+        """When thread_id starts with 'omt_' and routing fails, chat_id
+        fallback must be suppressed to prevent unwanted new topic creation."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        fail_response = SimpleNamespace(
+            success=lambda: False,
+            code=99992402,
+            msg="field validation failed",
+        )
+        adapter._send_raw_message = AsyncMock(return_value=fail_response)
+        adapter._response_succeeded = FeishuAdapter._response_succeeded
+
+        import json
+        result = await FeishuAdapter._feishu_send_with_retry(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        # Should return the fail response (not fall back to chat_id)
+        assert result is fail_response
+        # _send_raw_message should have been called only once (no retry)
+        adapter._send_raw_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_downgrades_post_to_text_on_99992402(self):
+        """When post msg_type fails with 99992402, should downgrade to text
+        and retry with same thread_id."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        fail_response = SimpleNamespace(
+            success=lambda: False,
+            code=99992402,
+            msg="field validation failed",
+        )
+        ok_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_1"),
+        )
+        # First call (post) fails, second call (text) succeeds
+        adapter._send_raw_message = AsyncMock(side_effect=[fail_response, ok_response])
+        adapter._response_succeeded = FeishuAdapter._response_succeeded
+
+        import json
+        result = await FeishuAdapter._feishu_send_with_retry(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="post",
+            payload=json.dumps({"content": [[{"tag": "md", "text": "hello"}]]}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        assert result is ok_response
+        assert adapter._send_raw_message.call_count == 2
+        # Second call should have msg_type="text"
+        second_call_kwargs = adapter._send_raw_message.call_args_list[1]
+        assert second_call_kwargs[1]["msg_type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_resolve_chat_type_promotes_topic_mode_to_forum(self):
+        """Chats with chat_mode='topic' should resolve to 'forum'."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        result = FeishuAdapter._resolve_source_chat_type(
+            chat_info={"type": "dm", "chat_mode": "topic"},
+            event_chat_type="group",
+        )
+        assert result == "forum"
+
+    @pytest.mark.asyncio
+    async def test_resolve_chat_type_preserves_regular_group(self):
+        """Regular groups without topic chat_mode should stay 'group'."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        result = FeishuAdapter._resolve_source_chat_type(
+            chat_info={"type": "group", "chat_mode": None},
+            event_chat_type="group",
+        )
+        assert result == "group"


### PR DESCRIPTION
## Problem

In Feishu forum/topic groups, when a message fails to send via `thread_id` routing (error 99992402), the fallback to `chat_id` routing silently creates a new topic thread in the channel. This affects:
- Gateway restart / auto-resume notifications (lack `reply_to_message_id`, forcing the `receive_id_type=thread_id` create API which returns 99992402 for `omt_xxx` topic IDs)
- Background process completion notifications
- Any send path where `reply_to_message_id` is absent

The result: repeated gateway restarts spam the forum group with empty new topics.

## Root Cause

`receive_id_type=thread_id` create API returns 99992402 for `omt_xxx` topic IDs in some bot permission contexts. Normal conversation works because it uses the reply API (anchored to an existing `message_id`), which is more permissive. Paths that lack a reply anchor fall through to the broken create API path, then further fall back to `chat_id` routing — which in forum groups creates a new topic.

## Fix

Two improvements to `_feishu_send_with_retry`:

**1. Retry-before-fallback:**
- For `post` msg_type failures: downgrade to `text` and retry with the same `thread_id` before giving up (Feishu accepts text via thread_id more reliably than post)
- For non-post types with a stale `reply_to_message_id` in metadata: strip the stale field and retry with clean thread_id routing before falling back

**2. Forum topic guard:**
When all retries are exhausted and `thread_id` starts with `omt_` (Feishu forum/topic identifier), suppress the `chat_id` fallback entirely. A dropped notification is far less disruptive than spam-creating new topics. The message remains visible in session logs.

## Testing

Verified on a live forum/topic group:
- Gateway restart no longer creates new topics
- Log shows `suppressing chat_id fallback to prevent unwanted new topic creation` instead of `falling back to chat_id routing`
- Normal conversation (has `reply_to_message_id`) continues to work correctly via reply API, unaffected
- DM routing and regular group chat unaffected (no `omt_` thread_id)