### PR TITLE
docs(tools/send_message): clarify MEDIA path requirement in schema description

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -834,14 +834,19 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         channels_list tool. You can also use human-friendly channel names
         that will be resolved automatically.
 
+        To send an image or file as a native platform attachment, include
+        MEDIA:<local_path> in the message (e.g. "MEDIA:/tmp/screenshot.png").
+        The path must resolve to an existing local file (absolute path or ~/...).
+
         Examples:
             target="telegram:6308981865"
             target="discord:#general"
             target="slack:#engineering"
+            target="telegram:6308981865" message="MEDIA:/tmp/screenshot.png"
 
         Args:
             target: Platform target in "platform:identifier" format
-            message: The message text to send
+            message: The message text to send (supports MEDIA:<path> for attachments)
         """
         if not target or not message:
             return json.dumps({"error": "Both target and message are required"})

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -219,7 +219,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "message": {
                 "type": "string",
-                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
+                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/screenshot.png') in the message — the path must resolve to an existing local file (absolute path or ~/...), and the platform will deliver it as a native media attachment."
             },
             "emoji": {
                 "type": "string",

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -397,7 +397,10 @@ If neither a positional `message` argument nor `--file` is provided, `hermes sen
 hermes send --to telegram "MEDIA:/tmp/screenshot.png"
 hermes send --to telegram "Build chart for today MEDIA:/tmp/chart.png"   # with caption
 hermes send --to discord:#ops "MEDIA:/tmp/report.pdf"
+hermes send --to telegram "MEDIA:~/Downloads/photo.jpg"                  # ~/... paths are expanded
 ```
+
+The path must resolve to an existing local file — use an absolute path or `~/...` (the `~` is expanded to your home directory).
 
 By default, image files are sent as photos (platforms like Telegram recompress these). Add `[[as_document]]` to the message to deliver them as uncompressed file attachments instead:
 


### PR DESCRIPTION
Minor documentation improvement to the `send_message` tool's JSON schema.

Changes:
- Update the MEDIA example from `report.pdf` to `screenshot.png` (more representative of the common use case)
- Explicitly state that the MEDIA path must be an absolute path to an existing file on this machine

This makes the constraint clearer for LLMs and users reading the tool description.