### PR TITLE
fix(desktop): skip local updater in remote mode

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -26,6 +26,7 @@ const { execFileSync, spawn } = require('node:child_process')
 const { isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { shouldUseLocalUpdater } = require('./update-mode.cjs')
 const {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
@@ -1158,6 +1159,17 @@ async function resolveHealedBranch(updateRoot, branch) {
 }
 
 async function checkUpdates() {
+  const connectionMode = currentDesktopConnectionMode()
+  if (!shouldUseLocalUpdater({ mode: connectionMode })) {
+    return {
+      supported: false,
+      reason: 'remote-mode',
+      message: 'Desktop is connected to a remote Hermes backend; update that host instead of this local checkout.',
+      branch: readDesktopUpdateConfig().branch,
+      fetchedAt: Date.now()
+    }
+  }
+
   const updateRoot = resolveUpdateRoot()
   let { branch } = readDesktopUpdateConfig()
   const gitDir = path.join(updateRoot, '.git')
@@ -1260,6 +1272,13 @@ async function applyUpdates(opts = {}) {
   updateInFlight = true
 
   try {
+    const connectionMode = currentDesktopConnectionMode()
+    if (!shouldUseLocalUpdater({ mode: connectionMode })) {
+      const message = 'Remote mode is active; skipping local Hermes updater handoff.'
+      rememberLog(`[updates] ${message}`)
+      return { ok: true, skipped: true, remote: true, message }
+    }
+
     const updater = resolveUpdaterBinary()
     if (!updater && !IS_WINDOWS) {
       // macOS/Linux drag-install: no staged Tauri hermes-setup. Unlike Windows
@@ -3079,6 +3098,16 @@ function coerceDesktopConnectionConfig(input = {}, existing = readDesktopConnect
   }
 
   return { mode, remote: nextRemote }
+}
+
+function currentDesktopConnectionMode() {
+  if (process.env.HERMES_DESKTOP_REMOTE_URL) return 'remote'
+
+  try {
+    return readDesktopConnectionConfig().mode === 'remote' ? 'remote' : 'local'
+  } catch {
+    return 'local'
+  }
 }
 
 function resolveRemoteBackend() {

--- a/apps/desktop/electron/update-mode.cjs
+++ b/apps/desktop/electron/update-mode.cjs
@@ -1,0 +1,8 @@
+'use strict'
+
+function shouldUseLocalUpdater(connection) {
+  if (!connection) return true
+  return connection.mode !== 'remote'
+}
+
+module.exports = { shouldUseLocalUpdater }

--- a/apps/desktop/electron/update-mode.test.cjs
+++ b/apps/desktop/electron/update-mode.test.cjs
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { shouldUseLocalUpdater } = require('./update-mode.cjs')
+
+test('shouldUseLocalUpdater blocks local updater handoff for remote desktop connections', () => {
+  assert.equal(
+    shouldUseLocalUpdater({ mode: 'remote', baseUrl: 'https://hermes.example.test', source: 'settings' }),
+    false
+  )
+})
+
+test('shouldUseLocalUpdater allows local updater for local desktop connections', () => {
+  assert.equal(shouldUseLocalUpdater({ mode: 'local', baseUrl: 'http://127.0.0.1:9120' }), true)
+})
+
+test('shouldUseLocalUpdater allows local updater when connection state is unavailable', () => {
+  assert.equal(shouldUseLocalUpdater(null), true)
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,7 +32,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/update-mode.test.cjs",
     "type-check": "tsc -b",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -124,6 +124,10 @@ export interface DesktopUpdateApplyResult {
   manual?: boolean
   command?: string
   hermesRoot?: string
+  /** True when the local update action was intentionally skipped. */
+  skipped?: boolean
+  /** True when the skip applies because Desktop is connected to a remote backend. */
+  remote?: boolean
 }
 
 export type DesktopUpdateStage = 'idle' | 'prepare' | 'fetch' | 'pull' | 'pydeps' | 'restart' | 'manual' | 'error'

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -235,6 +235,12 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
         message: result.command ?? 'hermes update',
         command: result.command ?? 'hermes update'
       })
+    } else if (result?.skipped && result?.remote) {
+      $updateApply.set({
+        ...IDLE,
+        applying: false,
+        message: result.message ?? 'Remote mode is active; update the remote Hermes host instead.'
+      })
     }
 
     return result


### PR DESCRIPTION
## Summary
- Skip Desktop local update checks when remote mode is active.
- Prevent remote-mode clients from handing off to the local `hermes-setup --update` flow.
- Add a small regression helper/test so remote connections are treated as ineligible for local updater actions.

## Test Plan
- `node --test electron/update-mode.test.cjs`
- `npm run test:desktop:platforms`
- `npm run type-check`
- `npm run build`
- `git diff --check`

## Notes
- `npm run lint` still reports existing repo-wide lint violations unrelated to this change.
