### PR TITLE
fix(installer): reap Windows update locker processes

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -3,8 +3,9 @@
 //! Driven when the installer is launched as `Hermes-Setup.exe --update` (see
 //! `AppMode` in lib.rs). The desktop app hands off to us — it exits, then we:
 //!
-//!   1. wait for the old Hermes desktop process to fully exit (so the venv
-//!      shim is free; otherwise `hermes update` aborts with exit code 2),
+//!   1. stop any install-scoped Windows locker processes, then wait for the
+//!      old Hermes desktop process to fully exit (so the venv shim is free;
+//!      otherwise `hermes update` aborts with exit code 2),
 //!   2. run `hermes update --yes --gateway` (Python/repo update; this does NOT
 //!      rebuild apps/desktop by design — see cmd_update in hermes_cli/main.py),
 //!   3. run `hermes desktop --build-only` (the rebuild step update skips),
@@ -19,6 +20,7 @@
 //! the no-window creation flag — both already cfg-gated. Keep new logic
 //! OS-agnostic so the mac/linux port stays "fill in the paths".
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -93,6 +95,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
     );
 
     // ---- pre-step: wait for the old desktop to die -----------------------
+    reap_windows_update_lockers(&install_root, &app).await;
     // The desktop exec'd us then called app.exit(), but process teardown is
     // async on Windows. If it still holds the venv shim, `hermes update`
     // aborts with exit 2. Give it a bounded window to clear.
@@ -116,14 +119,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
 
     emit_stage(&app, "update", StageState::Running, None, None);
     let started = Instant::now();
-    let update = run_streamed(
-        &app,
-        &hermes,
-        &update_args,
-        &install_root,
-        Some("update"),
-    )
-    .await?;
+    let update = run_streamed(&app, &hermes, &update_args, &install_root, Some("update")).await?;
     let update_ms = started.elapsed().as_millis() as u64;
 
     match update.exit_code {
@@ -215,7 +211,13 @@ async fn run_update(app: AppHandle) -> Result<()> {
         );
         return Err(anyhow!(msg));
     }
-    emit_stage(&app, "rebuild", StageState::Succeeded, Some(rebuild_ms), None);
+    emit_stage(
+        &app,
+        "rebuild",
+        StageState::Succeeded,
+        Some(rebuild_ms),
+        None,
+    );
 
     // ---- done: signal complete, then launch the fresh desktop ------------
     emit(
@@ -227,9 +229,11 @@ async fn run_update(app: AppHandle) -> Result<()> {
     );
 
     // Reuse the same detached-launch + app.exit(0) used post-install.
-    if let Err(err) =
-        crate::bootstrap::launch_hermes_desktop(app.clone(), install_root.to_string_lossy().into_owned())
-            .await
+    if let Err(err) = crate::bootstrap::launch_hermes_desktop(
+        app.clone(),
+        install_root.to_string_lossy().into_owned(),
+    )
+    .await
     {
         // Launch failed: don't hard-fail the update (it succeeded); surface a
         // log line so the success screen can still tell the user to launch
@@ -269,6 +273,139 @@ async fn wait_for_venv_free(install_root: &Path, app: &AppHandle) {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+async fn reap_windows_update_lockers(_install_root: &Path, _app: &AppHandle) {}
+
+#[cfg(target_os = "windows")]
+async fn reap_windows_update_lockers(install_root: &Path, app: &AppHandle) {
+    emit_log(
+        app,
+        Some("update"),
+        "[update] stopping stale Windows locker processes…",
+    );
+    match run_windows_locker_cleanup(install_root).await {
+        Ok(output) => {
+            for line in String::from_utf8_lossy(&output.stdout).lines() {
+                emit_log(app, Some("update"), line);
+            }
+            for line in String::from_utf8_lossy(&output.stderr).lines() {
+                emit_log(app, Some("update"), &format!("stderr: {line}"));
+            }
+            if !output.status.success() {
+                emit_log(
+                    app,
+                    Some("update"),
+                    &format!(
+                        "[update] locker cleanup exited {:?}; continuing with lock wait",
+                        output.status.code()
+                    ),
+                );
+            }
+        }
+        Err(err) => emit_log(
+            app,
+            Some("update"),
+            &format!("[update] locker cleanup failed: {err}; continuing with lock wait"),
+        ),
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn run_windows_locker_cleanup(install_root: &Path) -> Result<std::process::Output> {
+    let script = windows_locker_cleanup_script(
+        install_root,
+        crate::bootstrap::resolve_hermes_desktop_exe(install_root).as_deref(),
+    );
+
+    let mut cmd = Command::new("powershell.exe");
+    cmd.arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Command")
+        .arg(script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NO_WINDOW = 0x08000000 — keep the GUI update path silent.
+        cmd.creation_flags(0x0800_0000);
+    }
+
+    cmd.output()
+        .await
+        .map_err(|e| anyhow!("running locker cleanup PowerShell: {e}"))
+}
+
+fn windows_locker_cleanup_script(install_root: &Path, desktop_exe: Option<&Path>) -> String {
+    let venv_scripts = install_root.join("venv").join("Scripts");
+    let targets = [
+        ("python.exe", Some(venv_scripts.join("python.exe"))),
+        ("pythonw.exe", Some(venv_scripts.join("pythonw.exe"))),
+        ("hermes.exe", Some(venv_scripts.join("hermes.exe"))),
+        ("Hermes.exe", desktop_exe.map(Path::to_path_buf)),
+    ];
+
+    let mut lines = vec![
+        "$ErrorActionPreference = 'Continue'".to_string(),
+        "function Get-MatchingPids($name, $target) {".to_string(),
+        "  if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) { return @() }".to_string(),
+        "  $fullTarget = [System.IO.Path]::GetFullPath($target)".to_string(),
+        "  Get-CimInstance Win32_Process -Filter (\"Name='\" + $name + \"'\") |".to_string(),
+        "    Where-Object { $_.ExecutablePath -and ([System.IO.Path]::GetFullPath($_.ExecutablePath) -ieq $fullTarget) } |".to_string(),
+        "    ForEach-Object { $_.ProcessId }".to_string(),
+        "}".to_string(),
+        "$pids = @()".to_string(),
+    ];
+
+    for (name, path) in targets {
+        match path {
+            Some(path) => lines.push(format!(
+                "$pids += Get-MatchingPids '{}' '{}'",
+                name,
+                ps_single_quote(&path)
+            )),
+            None => lines.push(format!("$pids += Get-MatchingPids '{}' ''", name)),
+        }
+    }
+
+    lines.extend([
+        "$pids = @($pids | Where-Object { $_ } | Sort-Object -Unique)".to_string(),
+        "if ($pids.Count -eq 0) {".to_string(),
+        "  Write-Output '[update] no Windows locker processes found'".to_string(),
+        "  exit 0".to_string(),
+        "}".to_string(),
+        "foreach ($pid in $pids) {".to_string(),
+        "  try {".to_string(),
+        "    $proc = Get-Process -Id $pid -ErrorAction Stop".to_string(),
+        "    Write-Output ((\"[update] stopping PID {0} ({1})\" -f $pid, $proc.ProcessName))".to_string(),
+        "  } catch {".to_string(),
+        "    Write-Output ((\"[update] stopping PID {0}\" -f $pid))".to_string(),
+        "  }".to_string(),
+        "  & taskkill /PID $pid /T /F | Out-Null".to_string(),
+        "  if ($LASTEXITCODE -eq 0) {".to_string(),
+        "    Write-Output ((\"[update] taskkill succeeded for PID {0}\" -f $pid))".to_string(),
+        "  } else {".to_string(),
+        "    Write-Output ((\"[update] taskkill failed for PID {0} (exit {1})\" -f $pid, $LASTEXITCODE))".to_string(),
+        "  }".to_string(),
+        "}".to_string(),
+        "exit 0".to_string(),
+    ]);
+
+    lines.join("\n")
+}
+
+fn ps_single_quote(path: &Path) -> Cow<'_, str> {
+    let rendered = path.to_string_lossy();
+    if rendered.contains('\'') {
+        Cow::Owned(rendered.replace('\'', "''"))
+    } else {
+        rendered
+    }
+}
+
 /// Best-effort lock probe: try to open the file for read+write. On Windows an
 /// exclusively-held running .exe refuses the open with a sharing violation.
 /// On Unix this almost always succeeds (no mandatory locking), which is fine —
@@ -277,7 +414,11 @@ fn is_locked(path: &Path) -> bool {
     if !path.exists() {
         return false;
     }
-    match std::fs::OpenOptions::new().read(true).write(true).open(path) {
+    match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+    {
         Ok(_) => false,
         Err(_) => true,
     }
@@ -338,7 +479,10 @@ async fn run_streamed(
         emit_log(app, stage_owned.as_deref(), &format!("stderr: {l}"));
     }
 
-    let status = child.wait().await.map_err(|e| anyhow!("waiting for child: {e}"))?;
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| anyhow!("waiting for child: {e}"))?;
     Ok(CmdResult {
         exit_code: status.code(),
     })
@@ -365,9 +509,17 @@ fn resolve_hermes(install_root: &Path) -> Option<PathBuf> {
         return Some(shim);
     }
     // PATH fallback. which-style probe via env, kept dependency-free.
-    let exe = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
+    let exe = if cfg!(target_os = "windows") {
+        "hermes.exe"
+    } else {
+        "hermes"
+    };
     if let Ok(path) = std::env::var("PATH") {
-        let sep = if cfg!(target_os = "windows") { ';' } else { ':' };
+        let sep = if cfg!(target_os = "windows") {
+            ';'
+        } else {
+            ':'
+        };
         for dir in path.split(sep) {
             let cand = Path::new(dir).join(exe);
             if cand.exists() {
@@ -458,5 +610,34 @@ mod tests {
     #[test]
     fn missing_file_is_not_locked() {
         assert!(!is_locked(Path::new("/nonexistent/does/not/exist/xyz")));
+    }
+
+    #[test]
+    fn powershell_quote_escapes_single_quotes() {
+        let rendered = ps_single_quote(Path::new(r"C:\Users\O'Neil\hermes-agent"));
+        assert_eq!(rendered, "C:\\Users\\O''Neil\\hermes-agent");
+    }
+
+    #[test]
+    fn windows_locker_cleanup_targets_install_scoped_processes() {
+        let root = Path::new(r"C:\Users\me\AppData\Local\hermes\hermes-agent");
+        let python = root.join("venv").join("Scripts").join("python.exe");
+        let desktop = root
+            .join("apps")
+            .join("desktop")
+            .join("release")
+            .join("win-unpacked")
+            .join("Hermes.exe");
+
+        let script = windows_locker_cleanup_script(root, Some(&desktop));
+
+        assert!(script.contains("python.exe"));
+        assert!(script.contains("pythonw.exe"));
+        assert!(script.contains("hermes.exe"));
+        assert!(script.contains("Hermes.exe"));
+        assert!(script.contains("Get-CimInstance Win32_Process"));
+        assert!(script.contains("taskkill /PID $pid /T /F"));
+        assert!(script.contains(ps_single_quote(&python).as_ref()));
+        assert!(script.contains(ps_single_quote(&desktop).as_ref()));
     }
 }


### PR DESCRIPTION
## Summary
- reap install-scoped Windows locker processes before the bootstrap installer runs `hermes update`
- target the staged desktop exe plus venv-scoped `python.exe` / `pythonw.exe` / `hermes.exe`, then fall back to the existing lock wait
- add focused unit coverage for the PowerShell path quoting and locker-selection script

Fixes #37731.

## Verification
- `cargo test update::tests --lib`
- `rustfmt --edition 2021 --check apps/bootstrap-installer/src-tauri/src/update.rs`
- `git diff --check`
