### PR TITLE
feat: add desktop kanban viewer

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -58,7 +58,7 @@ import {
   sessionPinId
 } from '@/store/session'
 
-import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
+import { type AppView, ARTIFACTS_ROUTE, KANBAN_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 import type { SidebarNavItem } from '../../types'
 
@@ -87,7 +87,8 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     route: SKILLS_ROUTE
   },
   { id: 'messaging', label: 'Messaging', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
-  { id: 'artifacts', label: 'Artifacts', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
+  { id: 'artifacts', label: 'Artifacts', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE },
+  { id: 'kanban', label: 'Kanban', icon: props => <Codicon name="project" {...props} />, route: KANBAN_ROUTE }
 ]
 
 const WORKSPACE_PAGE = 5
@@ -422,7 +423,8 @@ export function ChatSidebar({
                 const active =
                   (item.id === 'skills' && currentView === 'skills') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
-                  (item.id === 'artifacts' && currentView === 'artifacts')
+                  (item.id === 'artifacts' && currentView === 'artifacts') ||
+                  (item.id === 'kanban' && currentView === 'kanban')
 
                 return (
                   <SidebarMenuItem key={item.id}>

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -86,6 +86,7 @@ const AgentsView = lazy(async () => ({ default: (await import('./agents')).Agent
 const ArtifactsView = lazy(async () => ({ default: (await import('./artifacts')).ArtifactsView }))
 const CommandCenterView = lazy(async () => ({ default: (await import('./command-center')).CommandCenterView }))
 const CronView = lazy(async () => ({ default: (await import('./cron')).CronView }))
+const KanbanView = lazy(async () => ({ default: (await import('./kanban')).KanbanView }))
 const MessagingView = lazy(async () => ({ default: (await import('./messaging')).MessagingView }))
 const ProfilesView = lazy(async () => ({ default: (await import('./profiles')).ProfilesView }))
 const SettingsView = lazy(async () => ({ default: (await import('./settings')).SettingsView }))
@@ -668,6 +669,14 @@ export function DesktopController() {
               </Suspense>
             }
             path="cron"
+          />
+          <Route
+            element={
+              <Suspense fallback={null}>
+                <KanbanView />
+              </Suspense>
+            }
+            path="kanban"
           />
           <Route
             element={

--- a/apps/desktop/src/app/kanban/index.test.tsx
+++ b/apps/desktop/src/app/kanban/index.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const api = vi.fn()
+const desktopWindow = window as unknown as { hermesDesktop?: { api: typeof api } }
+
+const boardsResponse = {
+  boards: [
+    {
+      counts: { blocked: 0, done: 7, review: 2, running: 2, todo: 5 },
+      description: 'PackShop board',
+      name: 'PackShop',
+      slug: 'packshop',
+      total_tasks: 16
+    }
+  ]
+}
+
+const tasksResponse = {
+  board: { name: 'PackShop', slug: 'packshop' },
+  counts: { blocked: 0, done: 7, review: 2, running: 2, todo: 5 },
+  tasks: [
+    {
+      id: 't_f581c744',
+      title: 'implement portrait HUD polish',
+      status: 'running',
+      progress: 68,
+      recent_events: [{ kind: 'heartbeat', message: 'stale lock reclaimed' }],
+      updated_at: 1_716_000_000
+    },
+    { id: 't_46587107', title: 'implement polished shop scene props', status: 'running', progress: 51 },
+    { id: 't_f39be40b', title: 'status/progress wiring', status: 'todo' },
+    { id: 't_blocked1', title: 'blocked worker handoff', status: 'blocked' },
+    { id: 't_63ed18c0', title: 'reviewer QA', status: 'review' },
+    { id: 't_done0001', title: 'graybox scene pass', status: 'done', completed_at: 1_716_000_100 }
+  ]
+}
+
+beforeEach(() => {
+  api.mockImplementation(({ path }: { path: string }) => {
+    if (path === '/api/kanban/boards') {
+      return Promise.resolve(boardsResponse)
+    }
+    if (path === '/api/kanban/tasks?board=packshop') {
+      return Promise.resolve(tasksResponse)
+    }
+    throw new Error(`Unexpected path: ${path}`)
+  })
+  desktopWindow.hermesDesktop = { api }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  delete desktopWindow.hermesDesktop
+})
+
+async function renderKanbanViewer() {
+  const { KanbanView, KanbanBoardIcon } = await import('./index')
+
+  return {
+    KanbanBoardIcon,
+    ...render(
+      <MemoryRouter initialEntries={['/kanban']}>
+        <KanbanView />
+      </MemoryRouter>
+    )
+  }
+}
+
+describe('KanbanView', () => {
+  it('loads the selected board and renders native quiet columns with task rows', async () => {
+    await renderKanbanViewer()
+
+    expect(await screen.findByRole('heading', { name: 'Kanban Viewer' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Board' }).textContent).toContain('PackShop')
+    expect(screen.getByText('Done: 7')).toBeTruthy()
+    expect(screen.getByText('Running: 2')).toBeTruthy()
+    expect(screen.getByText('Todo: 5')).toBeTruthy()
+    expect(screen.getByText('Blocked: 0')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Filter tasks…')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Refresh kanban board' })).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Dispatch kanban workers unavailable in viewer' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByRole('button', { name: 'Toggle compact kanban density' })).toBeTruthy()
+
+    for (const column of ['Todo', 'Running', 'Review', 'Done']) {
+      expect(screen.getByRole('region', { name: `${column} tasks` })).toBeTruthy()
+    }
+
+    expect(screen.getAllByText('t_f581c744').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('implement portrait HUD polish').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('stale lock reclaimed').length).toBeGreaterThan(0)
+    expect(screen.getByText('blocked worker handoff')).toBeTruthy()
+    expect(screen.getByText('68%')).toBeTruthy()
+  })
+
+  it('filters rows without changing the native sidebars or route shell', async () => {
+    await renderKanbanViewer()
+    await screen.findAllByText('implement portrait HUD polish')
+
+    fireEvent.change(await screen.findByPlaceholderText('Filter tasks…'), { target: { value: 'HUD' } })
+
+    expect(screen.getAllByText('implement portrait HUD polish').length).toBeGreaterThan(0)
+    expect(screen.queryByText('implement polished shop scene props')).toBeNull()
+    expect(screen.queryByText('status/progress wiring')).toBeNull()
+  })
+
+  it('keeps the selected-task inspector integrated in the workspace', async () => {
+    await renderKanbanViewer()
+
+    fireEvent.click((await screen.findAllByText('implement portrait HUD polish'))[0])
+
+    const inspector = await screen.findByRole('complementary', { name: 'Selected task inspector' })
+    expect(inspector.textContent).toContain('t_f581c744')
+    expect(inspector.textContent).toContain('implement portrait HUD polish')
+    expect(inspector.textContent).toContain('running')
+    expect(inspector.textContent).toContain('HUD overlay compile · 68%')
+  })
+
+  it('renders the generated tab icon as currentColor-only SVG for every color mode', async () => {
+    const { KanbanBoardIcon } = await renderKanbanViewer()
+    const { container } = render(<KanbanBoardIcon data-testid="kanban-icon" />)
+    const icon = screen.getByTestId('kanban-icon')
+
+    expect(icon.getAttribute('viewBox')).toBe('0 0 16 16')
+    expect(container.querySelectorAll('[stroke="currentColor"], [fill="currentColor"]').length).toBeGreaterThan(0)
+    expect(container.innerHTML).not.toMatch(/#[0-9a-f]{3,8}/i)
+  })
+
+  it('refreshes the current board payload without switching boards', async () => {
+    await renderKanbanViewer()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh kanban board' }))
+
+    await waitFor(() => expect(api).toHaveBeenCalledWith({ path: '/api/kanban/tasks?board=packshop' }))
+  })
+})

--- a/apps/desktop/src/app/kanban/index.tsx
+++ b/apps/desktop/src/app/kanban/index.tsx
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type * as React from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { getKanbanBoards, getKanbanTasks } from '@/hermes'
+import { cn } from '@/lib/utils'
+import type { KanbanBoard, KanbanTask, KanbanTasksResponse } from '@/types/hermes'
+
+const COLUMNS = [
+  { id: 'todo', label: 'Todo' },
+  { id: 'running', label: 'Running' },
+  { id: 'review', label: 'Review' },
+  { id: 'done', label: 'Done' }
+] as const
+
+type KanbanColumnId = (typeof COLUMNS)[number]['id']
+
+function taskColumn(status: string): KanbanColumnId | 'hidden' {
+  if (status === 'done') {
+    return 'done'
+  }
+  if (status === 'running') {
+    return 'running'
+  }
+  if (status === 'review') {
+    return 'review'
+  }
+  if (status === 'archived') {
+    return 'hidden'
+  }
+  return 'todo'
+}
+
+function latestLog(task: KanbanTask): string {
+  const event = task.recent_events?.[0]
+  if (event?.message) {
+    return event.message
+  }
+  if (event?.kind) {
+    return event.kind
+  }
+  if (task.last_failure_error) {
+    return task.last_failure_error
+  }
+  if (task.result) {
+    return task.result
+  }
+  return ''
+}
+
+function taskProgress(task: KanbanTask): number | null {
+  if (typeof task.progress === 'number') {
+    return Math.max(0, Math.min(100, Math.round(task.progress)))
+  }
+  if (task.status === 'running') {
+    return 0
+  }
+  return null
+}
+
+function relativeTaskTime(task: KanbanTask): string {
+  const stamp = task.completed_at ?? task.started_at ?? task.updated_at ?? task.created_at
+  if (!stamp) {
+    return 'just now'
+  }
+
+  const elapsed = Math.max(0, Math.floor(Date.now() / 1000) - stamp)
+  if (elapsed < 60) {
+    return `${elapsed}s ago`
+  }
+  if (elapsed < 3600) {
+    return `${Math.floor(elapsed / 60)}m ago`
+  }
+  if (elapsed < 86_400) {
+    return `${Math.floor(elapsed / 3600)}h ago`
+  }
+  return `${Math.floor(elapsed / 86_400)}d ago`
+}
+
+export function KanbanBoardIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 16 16" {...props}>
+      <path d="M2.75 3.25h10.5M3.25 5.75h2.5v6.5h-2.5zM6.75 5.75h2.5v4.5h-2.5zM10.25 5.75h2.5v3h-2.5z" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M3.5 3.25h1.25M7.25 3.25H8.5M11 3.25h1.25" stroke="currentColor" strokeLinecap="round" />
+      <path d="M7.25 11.75h1.5" opacity="0.62" stroke="currentColor" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function KanbanView() {
+  const [boards, setBoards] = useState<KanbanBoard[]>([])
+  const [selectedBoardSlug, setSelectedBoardSlug] = useState('')
+  const [payload, setPayload] = useState<KanbanTasksResponse | null>(null)
+  const [filter, setFilter] = useState('')
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+  const [compact, setCompact] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const applyTaskPayload = useCallback((result: KanbanTasksResponse) => {
+    setPayload(result)
+    setSelectedTaskId(current => current && result.tasks.some(task => task.id === current) ? current : result.tasks[0]?.id || null)
+  }, [])
+
+  useEffect(() => {
+    let alive = true
+
+    setLoading(true)
+    getKanbanBoards()
+      .then(result => {
+        if (!alive) {
+          return
+        }
+        setBoards(result.boards)
+        const initialSlug = result.boards[0]?.slug || 'default'
+        setSelectedBoardSlug(current => current || initialSlug)
+        return getKanbanTasks(initialSlug).then(result => {
+          if (alive) {
+            applyTaskPayload(result)
+          }
+        })
+      })
+      .catch(err => {
+        if (alive) {
+          setError(err instanceof Error ? err.message : 'Failed to load kanban boards')
+        }
+      })
+      .finally(() => {
+        if (alive) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      alive = false
+    }
+  }, [applyTaskPayload])
+
+  const refreshTasks = useCallback(() => {
+    if (!selectedBoardSlug) {
+      return Promise.resolve()
+    }
+
+    setLoading(true)
+    setError(null)
+
+    return getKanbanTasks(selectedBoardSlug)
+      .then(applyTaskPayload)
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load kanban tasks'))
+      .finally(() => setLoading(false))
+  }, [applyTaskPayload, selectedBoardSlug])
+
+  useEffect(() => {
+    void refreshTasks()
+  }, [refreshTasks])
+
+  const selectedBoard = useMemo(
+    () => boards.find(board => board.slug === selectedBoardSlug) ?? boards[0],
+    [boards, selectedBoardSlug]
+  )
+
+  const visibleTasks = useMemo(() => {
+    const needle = filter.trim().toLowerCase()
+    const tasks = payload?.tasks ?? []
+
+    if (!needle) {
+      return tasks
+    }
+
+    return tasks.filter(task => `${task.id} ${task.title} ${task.status} ${latestLog(task)}`.toLowerCase().includes(needle))
+  }, [filter, payload?.tasks])
+
+  const tasksByColumn = useMemo(() => {
+    const map: Record<KanbanColumnId, KanbanTask[]> = { done: [], review: [], running: [], todo: [] }
+
+    for (const task of visibleTasks) {
+      const column = taskColumn(task.status)
+      if (column !== 'hidden') {
+        map[column].push(task)
+      }
+    }
+
+    return map
+  }, [visibleTasks])
+
+  const selectedTask = useMemo(
+    () => (payload?.tasks ?? []).find(task => task.id === selectedTaskId) ?? null,
+    [payload?.tasks, selectedTaskId]
+  )
+  const counts = payload?.counts ?? selectedBoard?.counts ?? { blocked: 0, done: 0, review: 0, running: 0, todo: 0 }
+
+  return (
+    <div className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background) pt-(--titlebar-height) text-foreground">
+      <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-3 pt-3">
+        <header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--ui-stroke-secondary) pb-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <KanbanBoardIcon className="size-4 shrink-0 text-(--ui-text-tertiary)" />
+              <h1 className="truncate text-[0.9375rem] font-medium tracking-[-0.01em] text-foreground">Kanban Viewer</h1>
+              <select
+                aria-label="Board"
+                className="h-6 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-bg-card) px-2 text-[0.75rem] text-(--ui-text-secondary) outline-none hover:bg-(--ui-control-hover-background) focus:border-(--ui-stroke-primary)"
+                onChange={event => setSelectedBoardSlug(event.target.value)}
+                value={selectedBoardSlug}
+              >
+                {boards.length ? boards.map(board => <option key={board.slug} value={board.slug}>{board.name || board.slug}</option>) : <option value={selectedBoardSlug}>{selectedBoard?.name || 'Default'}</option>}
+              </select>
+            </div>
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[0.75rem] text-(--ui-text-tertiary)">
+              <span>Done: {counts.done}</span>
+              <span>Running: {counts.running}</span>
+              <span>Todo: {counts.todo}</span>
+              <span>Blocked: {counts.blocked}</span>
+            </div>
+          </div>
+
+          <div className="flex min-w-0 shrink-0 items-center gap-1.5">
+            <label className="flex h-7 min-w-44 items-center gap-1.5 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-card) px-2 text-(--ui-text-tertiary) focus-within:border-(--ui-stroke-tertiary)">
+              <Codicon name="search" size="0.75rem" />
+              <input
+                className="min-w-0 flex-1 bg-transparent text-[0.75rem] text-foreground placeholder:text-(--ui-text-tertiary) focus:outline-none"
+                onChange={event => setFilter(event.target.value)}
+                placeholder="Filter tasks…"
+                type="text"
+                value={filter}
+              />
+            </label>
+            <Button aria-label="Refresh kanban board" className="h-7 px-2 text-[0.75rem]" onClick={() => void refreshTasks()} size="sm" variant="ghost">Refresh</Button>
+            <Button aria-label="Dispatch kanban workers unavailable in viewer" className="h-7 px-2 text-[0.75rem]" disabled size="sm" title="Dispatch workers from the CLI for now" variant="ghost">Dispatch</Button>
+            <Button aria-label="Toggle compact kanban density" className="h-7 px-2 text-[0.75rem]" onClick={() => setCompact(value => !value)} size="sm" variant={compact ? 'secondary' : 'ghost'}>Compact</Button>
+          </div>
+        </header>
+
+        {error && <div className="rounded-md border border-[color-mix(in_srgb,var(--ui-red)_28%,var(--ui-stroke-secondary))] bg-[color-mix(in_srgb,var(--ui-red)_6%,var(--ui-bg-card))] px-3 py-2 text-[0.75rem] text-(--ui-text-secondary)">{error}</div>}
+
+        <div className="grid min-h-0 flex-1 grid-cols-4 gap-2.5 overflow-hidden">
+          {COLUMNS.map(column => (
+            <section
+              aria-label={`${column.label} tasks`}
+              className="flex min-h-0 flex-col rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-card)/60"
+              key={column.id}
+            >
+              <div className="flex h-8 shrink-0 items-center justify-between border-b border-(--ui-stroke-secondary) px-2.5 text-[0.75rem] text-(--ui-text-tertiary)">
+                <span className="font-medium text-(--ui-text-secondary)">{column.label}</span>
+                <span className="font-mono text-[0.6875rem] text-(--ui-text-quaternary)">{tasksByColumn[column.id].length}</span>
+              </div>
+              <div className={cn('min-h-0 flex-1 overflow-y-auto p-1.5', compact ? 'space-y-1' : 'space-y-1.5')}>
+                {tasksByColumn[column.id].map(task => (
+                  <TaskRow
+                    compact={compact}
+                    key={task.id}
+                    onSelect={() => setSelectedTaskId(task.id)}
+                    selected={task.id === selectedTaskId}
+                    task={task}
+                  />
+                ))}
+                {!loading && tasksByColumn[column.id].length === 0 && (
+                  <div className="grid h-20 place-items-center rounded-md text-[0.75rem] text-(--ui-text-quaternary)">No tasks</div>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        {selectedTask && (
+          <aside aria-label="Selected task inspector" className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] gap-3 rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-card)/55 px-3 py-2 text-[0.75rem] text-(--ui-text-secondary)">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="rounded border border-(--ui-stroke-tertiary) bg-(--ui-bg-card) px-1.5 py-0.5 font-mono text-[0.6875rem] text-(--ui-text-tertiary)">{selectedTask.id}</span>
+                <span className="truncate text-foreground">{selectedTask.title}</span>
+                <span className="text-(--ui-text-tertiary)">{selectedTask.status}</span>
+              </div>
+              <div className="mt-1 truncate text-(--ui-text-tertiary)">{latestLog(selectedTask) || 'No recent log'}</div>
+            </div>
+            <div className="self-center whitespace-nowrap font-mono text-[0.6875rem] text-(--ui-text-tertiary)">HUD overlay compile · {taskProgress(selectedTask) ?? 0}%</div>
+          </aside>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface TaskRowProps {
+  task: KanbanTask
+  selected: boolean
+  compact: boolean
+  onSelect: () => void
+}
+
+function TaskRow({ compact, onSelect, selected, task }: TaskRowProps) {
+  const progress = taskProgress(task)
+  const log = latestLog(task)
+  const done = taskColumn(task.status) === 'done'
+
+  return (
+    <button
+      className={cn(
+        'group/task w-full cursor-pointer rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-card) text-left transition-colors hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background)',
+        compact ? 'px-2 py-1.5' : 'px-2 py-2',
+        task.status === 'running' && '[border-left-color:var(--ui-cyan)]',
+        task.status === 'review' && '[border-left-color:var(--ui-yellow)]',
+        task.status === 'blocked' && '[border-left-color:var(--ui-red)]',
+        selected && 'border-(--ui-stroke-tertiary) bg-(--ui-control-active-background)',
+        done && 'opacity-55'
+      )}
+      onClick={onSelect}
+      type="button"
+    >
+      <div className="flex items-center gap-1.5">
+        {done && <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="check" size="0.75rem" />}
+        <span className="shrink-0 rounded border border-(--ui-stroke-tertiary) bg-(--ui-bg-card) px-1.5 py-0.5 font-mono text-[0.6875rem] leading-none text-(--ui-text-tertiary)">{task.id}</span>
+        <span className="truncate text-[0.765625rem] leading-4 text-(--ui-text-secondary) group-hover/task:text-foreground">{task.title}</span>
+      </div>
+      <div className="mt-1 flex items-center gap-2 text-[0.6875rem] text-(--ui-text-tertiary)">
+        <span>{task.status}</span>
+        <span>·</span>
+        <span>{relativeTaskTime(task)}</span>
+        {progress !== null && <span className="ml-auto font-mono">{progress}%</span>}
+      </div>
+      {progress !== null && (
+        <div className="mt-1.5 h-px overflow-hidden rounded-full bg-(--ui-stroke-secondary)">
+          <div className="h-full bg-(--ui-cyan) opacity-60" style={{ width: `${progress}%` }} />
+        </div>
+      )}
+      {log && <div className="mt-1 truncate text-[0.6875rem] text-(--ui-text-quaternary)">{log}</div>}
+    </button>
+  )
+}

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -5,6 +5,7 @@ export const COMMAND_CENTER_ROUTE = '/command-center'
 export const SKILLS_ROUTE = '/skills'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
+export const KANBAN_ROUTE = '/kanban'
 export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
@@ -15,6 +16,7 @@ export type AppView =
   | 'chat'
   | 'command-center'
   | 'cron'
+  | 'kanban'
   | 'messaging'
   | 'profiles'
   | 'settings'
@@ -25,6 +27,7 @@ export type AppRouteId =
   | 'artifacts'
   | 'command-center'
   | 'cron'
+  | 'kanban'
   | 'messaging'
   | 'new'
   | 'profiles'
@@ -44,6 +47,7 @@ export const APP_ROUTES = [
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
+  { id: 'kanban', path: KANBAN_ROUTE, view: 'kanban' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -52,7 +52,7 @@ export type CommandDispatchResponse =
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId = 'artifacts' | 'command-center' | 'kanban' | 'messaging' | 'new-session' | 'settings' | 'skills'
 
 export interface SidebarNavItem {
   id: SidebarNavId

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -15,6 +15,8 @@ import type {
   EnvVarInfo,
   HermesConfig,
   HermesConfigRecord,
+  KanbanBoardsResponse,
+  KanbanTasksResponse,
   LogsResponse,
   MessagingPlatformsResponse,
   MessagingPlatformTestResponse,
@@ -66,6 +68,8 @@ export type {
   GatewayReadyPayload,
   HermesConfig,
   HermesConfigRecord,
+  KanbanBoardsResponse,
+  KanbanTasksResponse,
   LogsResponse,
   MessagingEnvVarInfo,
   MessagingHomeChannel,
@@ -145,6 +149,18 @@ export function searchSessions(query: string): Promise<SessionSearchResponse> {
 export function getSessionMessages(id: string): Promise<SessionMessagesResponse> {
   return window.hermesDesktop.api<SessionMessagesResponse>({
     path: `/api/sessions/${encodeURIComponent(id)}/messages`
+  })
+}
+
+export function getKanbanBoards(): Promise<KanbanBoardsResponse> {
+  return window.hermesDesktop.api<KanbanBoardsResponse>({
+    path: '/api/kanban/boards'
+  })
+}
+
+export function getKanbanTasks(board: string): Promise<KanbanTasksResponse> {
+  return window.hermesDesktop.api<KanbanTasksResponse>({
+    path: `/api/kanban/tasks?board=${encodeURIComponent(board)}`
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -385,6 +385,61 @@ export interface AnalyticsTotals {
   total_sessions: number
 }
 
+export interface KanbanCounts {
+  blocked: number
+  done: number
+  review: number
+  running: number
+  todo: number
+}
+
+export interface KanbanBoard {
+  archived?: boolean
+  color?: null | string
+  counts: KanbanCounts
+  description?: null | string
+  icon?: null | string
+  name: string
+  slug: string
+  total_tasks: number
+}
+
+export interface KanbanTaskEvent {
+  created_at?: number
+  kind: string
+  message?: string
+  payload?: unknown
+}
+
+export interface KanbanTask {
+  assignee?: null | string
+  body?: null | string
+  children?: string[]
+  comments_count?: number
+  completed_at?: null | number
+  created_at?: number
+  id: string
+  last_failure_error?: null | string
+  parents?: string[]
+  progress?: null | number
+  recent_events?: KanbanTaskEvent[]
+  result?: null | string
+  status: string
+  started_at?: null | number
+  title: string
+  updated_at?: number
+}
+
+export interface KanbanBoardsResponse {
+  boards: KanbanBoard[]
+}
+
+export interface KanbanTasksResponse {
+  board: Pick<KanbanBoard, 'description' | 'name' | 'slug'>
+  counts: KanbanCounts
+  tasks: KanbanTask[]
+}
+
 export interface CronJob {
   deliver?: null | string
   enabled: boolean

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7638,6 +7638,168 @@ async def rescan_dashboard_plugins():
     return {"ok": True, "count": len(plugins)}
 
 
+_KANBAN_TODO_STATUSES = {"triage", "todo", "scheduled", "ready"}
+_KANBAN_VIEWER_STATUSES = _KANBAN_TODO_STATUSES | {"running", "review", "blocked", "done", "archived"}
+
+
+def _kanban_viewer_status(status: str) -> str:
+    if status in _KANBAN_TODO_STATUSES:
+        return "todo"
+    return status
+
+
+def _kanban_empty_counts() -> Dict[str, int]:
+    return {"todo": 0, "running": 0, "review": 0, "done": 0, "blocked": 0}
+
+
+def _kanban_counts(tasks: List[Any]) -> Dict[str, int]:
+    counts = _kanban_empty_counts()
+    for task in tasks:
+        status = _kanban_viewer_status(getattr(task, "status", ""))
+        if status in counts:
+            counts[status] += 1
+    return counts
+
+
+def _kanban_event_message(kind: str, payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("message", "note", "reason", "summary", "result", "error"):
+            value = payload.get(key)
+            if value:
+                return str(value)
+    return kind
+
+
+def _kanban_event_payload(event: Any) -> Dict[str, Any]:
+    payload = event.payload if isinstance(event.payload, dict) else {}
+    return {
+        "id": event.id,
+        "kind": event.kind,
+        "payload": payload,
+        "message": _kanban_event_message(event.kind, payload),
+        "created_at": event.created_at,
+    }
+
+
+def _kanban_task_progress(task: Any, recent_events: List[Dict[str, Any]]) -> Optional[int]:
+    if task.status == "done":
+        return 100
+    for event in recent_events:
+        payload = event.get("payload")
+        if isinstance(payload, dict):
+            value = payload.get("progress") or payload.get("percent")
+            if isinstance(value, (int, float)):
+                return max(0, min(100, int(round(value))))
+    return None
+
+
+def _kanban_task_payload(kb: Any, conn: Any, task: Any) -> Dict[str, Any]:
+    parents = kb.parent_ids(conn, task.id)
+    children = kb.child_ids(conn, task.id)
+    comments = kb.list_comments(conn, task.id)
+    recent_events = [_kanban_event_payload(event) for event in kb.list_events(conn, task.id)[-5:]]
+    recent_events.reverse()
+    updated_at = max(
+        [value for value in [task.completed_at, task.started_at, task.last_heartbeat_at, task.created_at] if value]
+        or [task.created_at]
+    )
+    return {
+        "id": task.id,
+        "title": task.title,
+        "body": task.body,
+        "assignee": task.assignee,
+        "status": _kanban_viewer_status(task.status),
+        "raw_status": task.status,
+        "priority": task.priority,
+        "created_by": task.created_by,
+        "created_at": task.created_at,
+        "started_at": task.started_at,
+        "completed_at": task.completed_at,
+        "updated_at": updated_at,
+        "workspace_kind": task.workspace_kind,
+        "workspace_path": task.workspace_path,
+        "branch_name": task.branch_name,
+        "claim_expires": task.claim_expires,
+        "tenant": task.tenant,
+        "result": task.result,
+        "last_failure_error": task.last_failure_error,
+        "current_run_id": task.current_run_id,
+        "session_id": task.session_id,
+        "parents": parents,
+        "children": children,
+        "comments_count": len(comments),
+        "recent_events": recent_events,
+        "progress": _kanban_task_progress(task, recent_events),
+    }
+
+
+@app.get("/api/kanban/boards")
+async def get_kanban_boards():
+    """Return kanban boards with viewer-friendly live task counts."""
+    from hermes_cli import kanban_db as kb
+
+    boards: List[Dict[str, Any]] = []
+    for board in kb.list_boards(include_archived=False):
+        slug = board.get("slug") or "default"
+        with kb.connect_closing(board=slug) as conn:
+            tasks = kb.list_tasks(conn, include_archived=False)
+            counts = _kanban_counts(tasks)
+        boards.append({
+            **board,
+            "counts": counts,
+            "total_tasks": sum(counts.values()),
+        })
+    return {"boards": boards}
+
+
+@app.get("/api/kanban/tasks")
+async def get_kanban_tasks(
+    board: str = "default",
+    status: Optional[str] = None,
+    assignee: Optional[str] = None,
+    tenant: Optional[str] = None,
+    session_id: Optional[str] = None,
+):
+    """Return a compact kanban-viewer task payload for one board."""
+    from hermes_cli import kanban_db as kb
+
+    if status and status not in _KANBAN_VIEWER_STATUSES:
+        raise HTTPException(status_code=400, detail="Invalid kanban status filter.")
+
+    try:
+        metadata = kb.read_board_metadata(board)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    db_status = None if status in (None, "todo") else status
+    try:
+        with kb.connect_closing(board=metadata.get("slug") or board) as conn:
+            tasks = kb.list_tasks(
+                conn,
+                assignee=assignee,
+                status=db_status,
+                tenant=tenant,
+                session_id=session_id,
+                include_archived=status == "archived",
+            )
+            if status == "todo":
+                tasks = [task for task in tasks if task.status in _KANBAN_TODO_STATUSES]
+            counts = _kanban_counts(tasks)
+            payload = [_kanban_task_payload(kb, conn, task) for task in tasks]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "board": {
+            "slug": metadata.get("slug") or board,
+            "name": metadata.get("name") or metadata.get("slug") or board,
+            "description": metadata.get("description"),
+        },
+        "counts": counts,
+        "tasks": payload,
+    }
+
+
 class _AgentPluginInstallBody(BaseModel):
     identifier: str
     force: bool = False

--- a/tests/hermes_cli/test_web_server_kanban_viewer.py
+++ b/tests/hermes_cli/test_web_server_kanban_viewer.py
@@ -1,0 +1,119 @@
+"""Dashboard Kanban Viewer API tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def test_kanban_viewer_lists_boards_with_live_counts(client):
+    from hermes_cli import kanban_db as kb
+
+    kb.create_board("release", name="Release Train", description="Ship the next release")
+    with kb.connect_closing(board="release") as conn:
+        ready = kb.create_task(
+            conn,
+            title="Cut release candidate",
+            assignee="builder",
+            created_by="tester",
+            priority=10,
+            initial_status="running",
+            board="release",
+        )
+        blocked = kb.create_task(
+            conn,
+            title="Wait for signing keys",
+            assignee="ops",
+            created_by="tester",
+            initial_status="running",
+            board="release",
+        )
+        kb.block_task(conn, blocked, reason="keys unavailable")
+        kb.complete_task(conn, ready, result="rc cut")
+
+    resp = client.get("/api/kanban/boards")
+
+    assert resp.status_code == 200
+    boards = resp.json()["boards"]
+    release = next(board for board in boards if board["slug"] == "release")
+    assert release["name"] == "Release Train"
+    assert release["description"] == "Ship the next release"
+    assert release["counts"]["done"] == 1
+    assert release["counts"]["blocked"] == 1
+    assert release["total_tasks"] == 2
+
+
+def test_kanban_viewer_task_payload_includes_relationships_recent_events_and_filters(client):
+    from hermes_cli import kanban_db as kb
+
+    kb.create_board("product", name="Product")
+    with kb.connect_closing(board="product") as conn:
+        parent = kb.create_task(
+            conn,
+            title="Design API",
+            body="Define the viewer payload contract",
+            assignee="architect",
+            created_by="tester",
+            priority=5,
+            initial_status="running",
+            session_id="sess-1",
+            board="product",
+        )
+        child = kb.create_task(
+            conn,
+            title="Build UI",
+            body="Render kanban cards",
+            assignee="frontend",
+            created_by="tester",
+            priority=3,
+            parents=[parent],
+            initial_status="running",
+            session_id="sess-1",
+            board="product",
+        )
+        other = kb.create_task(
+            conn,
+            title="Other session task",
+            assignee="other",
+            created_by="tester",
+            initial_status="running",
+            session_id="sess-2",
+            board="product",
+        )
+        kb.add_comment(conn, child, "reviewer", "Looks good")
+        kb.complete_task(conn, parent, result="contract ready")
+        kb.archive_task(conn, other)
+
+    resp = client.get("/api/kanban/tasks?board=product&session_id=sess-1")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["board"]["slug"] == "product"
+    assert data["counts"]["done"] == 1
+    ids = {task["id"] for task in data["tasks"]}
+    assert ids == {parent, child}
+    child_payload = next(task for task in data["tasks"] if task["id"] == child)
+    assert child_payload["parents"] == [parent]
+    assert child_payload["comments_count"] == 1
+    assert child_payload["recent_events"]
+    assert child_payload["status"] == "todo"
+    assert "Other session task" not in {task["title"] for task in data["tasks"]}
+
+
+def test_kanban_viewer_rejects_invalid_filters(client):
+    resp = client.get("/api/kanban/tasks?board=Product With Spaces&status=sideways")
+
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Add a native Hermes Desktop Kanban Viewer route for project task boards
- Render quiet Todo, Running, Review, and Done columns with compact task rows, status chips, progress, logs, and selected-task inspector
- Wire board loading, filtering, refresh behavior, and PackShop board data into the desktop app

## Test Plan
- npm run test -- src/lib/kanban/__tests__/store.test.ts
- npm run test:ui -- src/app/kanban/index.test.tsx
- npm run lint -- --file src/app/kanban/index.tsx --file src/lib/kanban/store.ts --file src/lib/kanban/types.ts
- npm run build