### PR TITLE
fix(gateway): start Matrix mautrix syncer

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -380,6 +380,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._client: Any = None  # mautrix.client.Client
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
+        self._client_sync_started = False
         self._closing = False
         self._startup_ts: float = 0.0
         # Clock-skew detection: count grace-check drops that happen well
@@ -958,7 +959,22 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.warning("Matrix: initial key share failed: %s", exc)
 
-        # Start the sync loop.
+        # Start mautrix's own syncer. add_event_handler() callbacks are
+        # dispatched by this syncer; direct client.sync() calls only return
+        # raw sync data and do not drive the dispatcher.
+        try:
+            maybe_start = client.start(None)
+            if asyncio.iscoroutine(maybe_start):
+                await maybe_start
+            self._client_sync_started = True
+        except Exception as exc:
+            logger.error(
+                "Matrix: failed to start mautrix syncer: %s", exc, exc_info=True
+            )
+            await api.session.close()
+            return False
+
+        # Start the maintenance loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
         self._mark_connected()
         return True
@@ -990,6 +1006,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.debug("Matrix: could not close crypto DB on disconnect: %s", exc)
 
         if self._client:
+            try:
+                if self._client_sync_started:
+                    maybe_stop = self._client.stop()
+                    if asyncio.iscoroutine(maybe_stop):
+                        await maybe_stop
+                    self._client_sync_started = False
+            except Exception as exc:
+                logger.debug("Matrix: could not stop mautrix syncer: %s", exc)
             try:
                 await self._client.api.session.close()
             except Exception:
@@ -1437,57 +1461,33 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _sync_loop(self) -> None:
-        """Continuously sync with the homeserver."""
+        """Run periodic Matrix maintenance while mautrix dispatches events."""
         client = self._client
-        # Resume from the token stored during the initial sync.
-        next_batch = await client.sync_store.get_next_batch()
         while not self._closing:
             try:
-                # Wrap in asyncio.wait_for to guard against TCP-level hangs
-                # that the Matrix long-poll timeout cannot catch. Long-poll
-                # is 30s, so 45s gives 15s slack for network drain.
-                sync_data = await asyncio.wait_for(
-                    client.sync(
-                        since=next_batch,
-                        timeout=30000,
-                    ),
-                    timeout=45.0,
-                )
+                await asyncio.sleep(60)
+                if self._closing:
+                    return
 
-                # nio returns SyncError objects (not exceptions) for auth
-                # failures like M_UNKNOWN_TOKEN.  Detect and stop immediately.
-                _sync_msg = getattr(sync_data, "message", None)
-                if _sync_msg and isinstance(_sync_msg, str):
-                    _lower = _sync_msg.lower()
-                    if "m_unknown_token" in _lower or "unknown_token" in _lower:
-                        logger.error(
-                            "Matrix: permanent auth error from sync: %s — stopping",
-                            _sync_msg,
-                        )
-                        return
-
-                if isinstance(sync_data, dict):
-                    # Update joined rooms from sync response.
-                    rooms_join = sync_data.get("rooms", {}).get("join", {})
-                    if rooms_join:
-                        self._joined_rooms.update(rooms_join.keys())
-
-                    # Advance the sync token so the next request is
-                    # incremental instead of a full initial sync.
-                    nb = sync_data.get("next_batch")
-                    if nb:
-                        next_batch = nb
-                        await client.sync_store.put_next_batch(nb)
-
-                    # Dispatch events to registered handlers so that
-                    # _on_room_message / _on_reaction / _on_invite fire.
+                get_joined_rooms = getattr(client, "get_joined_rooms", None)
+                if callable(get_joined_rooms):
                     try:
-                        tasks = client.handle_sync(sync_data)
-                        if tasks:
-                            await asyncio.gather(*tasks)
+                        joined = await get_joined_rooms()
+                        room_ids = getattr(joined, "joined_rooms", joined)
+                        if room_ids:
+                            self._joined_rooms.update(
+                                str(room_id) for room_id in room_ids
+                            )
                     except Exception as exc:
-                        logger.warning("Matrix: sync event dispatch error: %s", exc)
-                    await self._join_pending_invites(sync_data)
+                        logger.debug("Matrix: joined-room refresh failed: %s", exc)
+
+                await self._refresh_dm_cache()
+
+                if self._encryption and getattr(client, "crypto", None):
+                    try:
+                        await client.crypto.share_keys()
+                    except Exception as exc:
+                        logger.debug("Matrix: periodic key share failed: %s", exc)
 
             except asyncio.CancelledError:
                 return
@@ -1503,10 +1503,10 @@ class MatrixAdapter(BasePlatformAdapter):
                     or "forbidden" in err_str
                 ):
                     logger.error(
-                        "Matrix: permanent auth error: %s — stopping sync", exc
+                        "Matrix: permanent auth error: %s — stopping maintenance", exc
                     )
                     return
-                logger.warning("Matrix: sync error: %s — retrying in 5s", exc)
+                logger.warning("Matrix: maintenance error: %s — retrying in 5s", exc)
                 await asyncio.sleep(5)
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -109,6 +109,12 @@ def _make_fake_mautrix():
         def add_dispatcher(self, dispatcher_type):
             pass
 
+        def start(self, filter_id=None):
+            self.started_filter_id = filter_id
+
+        def stop(self):
+            self.stopped = True
+
     class InternalEventType:
         INVITE = "internal.invite"
 
@@ -1245,72 +1251,50 @@ class TestMatrixDeviceIdConfig:
 
 class TestMatrixSyncLoop:
     @pytest.mark.asyncio
-    async def test_sync_loop_dispatches_events_and_stores_token(self):
-        """_sync_loop should call handle_sync() and persist next_batch."""
+    async def test_sync_loop_refreshes_joined_rooms_without_manual_sync(self):
+        """_sync_loop should not compete with mautrix's dispatcher syncer."""
         adapter = _make_adapter()
         adapter._encryption = True
         adapter._closing = False
 
-        call_count = 0
-
-        async def _sync_once(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 1:
-                adapter._closing = True
-            return {"rooms": {"join": {"!room:example.org": {}}}, "next_batch": "s1234"}
-
         mock_crypto = MagicMock()
+        mock_crypto.share_keys = AsyncMock()
 
-        mock_sync_store = MagicMock()
-        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
-        mock_sync_store.put_next_batch = AsyncMock()
+        async def _refresh_once():
+            adapter._closing = True
 
         fake_client = MagicMock()
-        fake_client.sync = AsyncMock(side_effect=_sync_once)
+        fake_client.get_joined_rooms = AsyncMock(return_value=["!room:example.org"])
+        fake_client.sync = AsyncMock()
         fake_client.crypto = mock_crypto
-        fake_client.sync_store = mock_sync_store
         fake_client.handle_sync = MagicMock(return_value=[])
         adapter._client = fake_client
 
-        await adapter._sync_loop()
+        from gateway.platforms import matrix as matrix_mod
+        with patch.object(matrix_mod.asyncio, "sleep", AsyncMock()):
+            with patch.object(
+                adapter, "_refresh_dm_cache", AsyncMock(side_effect=_refresh_once)
+            ):
+                await adapter._sync_loop()
 
-        fake_client.sync.assert_awaited_once()
-        fake_client.handle_sync.assert_called_once()
-        mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
+        fake_client.sync.assert_not_awaited()
+        fake_client.handle_sync.assert_not_called()
+        mock_crypto.share_keys.assert_awaited_once()
+        assert "!room:example.org" in adapter._joined_rooms
 
     @pytest.mark.asyncio
-    async def test_sync_loop_reconciles_pending_invites(self):
-        """Pending rooms.invite entries should be joined if callbacks were missed."""
+    async def test_invite_handler_joins_rooms(self):
+        """mautrix's dispatcher should route invites to _on_invite()."""
         adapter = _make_adapter()
-        adapter._closing = False
-
-        async def _sync_once(**kwargs):
-            adapter._closing = True
-            return {
-                "rooms": {
-                    "join": {"!joined:example.org": {}},
-                    "invite": {"!invited:example.org": {}},
-                },
-                "next_batch": "s1234",
-            }
-
-        mock_sync_store = MagicMock()
-        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
-        mock_sync_store.put_next_batch = AsyncMock()
 
         fake_client = MagicMock()
-        fake_client.sync = AsyncMock(side_effect=_sync_once)
         fake_client.join_room = AsyncMock()
-        fake_client.sync_store = mock_sync_store
-        fake_client.handle_sync = MagicMock(return_value=[])
         adapter._client = fake_client
 
         with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-            await adapter._sync_loop()
+            await adapter._on_invite(MagicMock(room_id="!invited:example.org"))
 
         fake_client.join_room.assert_awaited_once()
-        assert "!joined:example.org" in adapter._joined_rooms
         assert "!invited:example.org" in adapter._joined_rooms
 
 
@@ -1480,6 +1464,87 @@ class TestMatrixEncryptedEventHandler:
         assert len(handler_calls) >= 3
 
         await adapter.disconnect()
+
+
+class TestMatrixSyncerLifecycle:
+    @pytest.mark.asyncio
+    async def test_connect_starts_mautrix_syncer_after_initial_sync(self):
+        """connect() must start mautrix's syncer so event handlers dispatch."""
+        from gateway.platforms.matrix import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client.sync = AsyncMock(
+            return_value={
+                "rooms": {"join": {"!room:server": {}}},
+                "next_batch": "s123",
+            }
+        )
+        mock_client.sync_store = MagicMock()
+        mock_client.sync_store.put_next_batch = AsyncMock()
+        mock_client.add_event_handler = MagicMock()
+        mock_client.add_dispatcher = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.start = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        mock_client.sync.assert_awaited_once_with(timeout=10000, full_state=True)
+        mock_client.start.assert_called_once_with(None)
+        assert adapter._client_sync_started is True
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_stops_started_mautrix_syncer(self):
+        """disconnect() should stop mautrix's background syncer."""
+        adapter = _make_adapter()
+        adapter._sync_task = None
+        adapter._client_sync_started = True
+
+        mock_session = MagicMock()
+        mock_session.close = AsyncMock()
+
+        mock_api = MagicMock()
+        mock_api.session = mock_session
+
+        fake_client = MagicMock()
+        fake_client.api = mock_api
+        fake_client.stop = MagicMock()
+        adapter._client = fake_client
+
+        await adapter.disconnect()
+
+        fake_client.stop.assert_called_once_with()
+        mock_session.close.assert_awaited_once()
+        assert adapter._client_sync_started is False
+        assert adapter._client is None
 
     @pytest.mark.asyncio
     async def test_connect_fails_on_stale_otk_conflict(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the Matrix gateway receive path by starting mautrix's own syncer after handlers are registered. Direct `client.sync()` calls return sync payloads but do not drive `add_event_handler(...)` callbacks, which left the adapter connected and able to send while never responding to incoming Matrix messages.

## Related Issue

Fixes #7914

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py`: start `client.start(None)` after auth, handler registration, initial sync, and initial key sharing; stop the mautrix syncer during disconnect; keep the Hermes background task for joined-room/DM/key-share maintenance instead of direct event-dispatch sync polling.
- `tests/gateway/test_matrix.py`: update the fake mautrix client, replace stale direct-sync-loop expectations, and add lifecycle coverage for starting/stopping the mautrix syncer.

## How to Test

1. `python -m pytest tests/gateway/test_matrix.py -q -x --timeout=60` → `152 passed`.
2. `python -m pytest tests/ -q -x --timeout=60` → stopped at `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`; this ACP approval-path failure is outside the Matrix gateway files changed by this PR.
3. `python -m ruff check gateway/platforms/matrix.py tests/gateway/test_matrix.py` → passed.
4. `python scripts/check-windows-footguns.py gateway/platforms/matrix.py tests/gateway/test_matrix.py` → passed.
5. `git diff --check` → passed.
6. `python -m ruff format --check gateway/platforms/matrix.py tests/gateway/test_matrix.py` → reported pre-existing whole-file formatting churn in these Matrix files, so no broad formatter rewrite was applied.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A.

<!-- autocontrib:worker-id=issue-new-3e13783f kind=pr-open -->