### PR TITLE
fix(agent): suppress stale review tool summaries

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -429,6 +429,7 @@ def _run_review_in_thread(
     agent: Any,
     messages_snapshot: List[Dict],
     prompt: str,
+    baseline_snapshot: Optional[List[Dict]] = None,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
 
@@ -616,13 +617,16 @@ def _run_review_in_thread(
 
         # Scan the review agent's messages for successful tool actions
         # and surface a compact summary to the user. Tool messages
-        # already present in messages_snapshot must be skipped, since
+        # already present in the inherited context must be skipped, since
         # the review agent inherits that history and would otherwise
         # re-surface stale "created"/"updated" messages from the prior
-        # conversation as if they just happened (issue #14944).
+        # conversation as if they just happened (issue #14944).  Use the
+        # wider baseline when available: context compression can rewrite the
+        # final post-turn snapshot, but the original pre-turn history still
+        # knows which tool results were old (issue #8775).
         actions = summarize_background_review_actions(
             review_messages,
-            messages_snapshot,
+            baseline_snapshot if baseline_snapshot is not None else messages_snapshot,
             notification_mode=getattr(agent, "memory_notifications", "on"),
         )
 
@@ -677,6 +681,7 @@ def spawn_background_review_thread(
     messages_snapshot: List[Dict],
     review_memory: bool = False,
     review_skills: bool = False,
+    baseline_snapshot: Optional[List[Dict]] = None,
 ):
     """Build the review thread target and prompt for a background review.
 
@@ -695,7 +700,7 @@ def spawn_background_review_thread(
         prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
 
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt)
+        _run_review_in_thread(agent, messages_snapshot, prompt, baseline_snapshot)
 
     return _target, prompt
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -525,6 +525,7 @@ def run_conversation(
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
+    background_review_baseline = list(conversation_history) if conversation_history else []
     conversation_history = _ctx.conversation_history
     active_system_prompt = _ctx.active_system_prompt
     effective_task_id = _ctx.effective_task_id
@@ -534,7 +535,6 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
-    # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
     interrupted = False
@@ -4436,6 +4436,7 @@ def run_conversation(
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
+    agent._background_review_baseline_snapshot = background_review_baseline + list(messages)
     from agent.turn_finalizer import finalize_turn
     return finalize_turn(
         agent,
@@ -4452,7 +4453,6 @@ def run_conversation(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
     )
-
 
 
 __all__ = ["run_conversation"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -1428,6 +1428,7 @@ class AIAgent:
         messages_snapshot: List[Dict],
         review_memory: bool = False,
         review_skills: bool = False,
+        baseline_snapshot: Optional[List[Dict]] = None,
     ) -> None:
         """Spawn the background memory/skill review thread.
 
@@ -1438,11 +1439,14 @@ class AIAgent:
         keep working.
         """
         from agent.background_review import spawn_background_review_thread
+        if baseline_snapshot is None:
+            baseline_snapshot = getattr(self, "_background_review_baseline_snapshot", None)
         target, _prompt = spawn_background_review_thread(
             self,
             messages_snapshot,
             review_memory=review_memory,
             review_skills=review_skills,
+            baseline_snapshot=baseline_snapshot,
         )
         t = threading.Thread(target=target, daemon=True, name="bg-review")
         t.start()

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -150,6 +150,63 @@ def test_background_review_summarizer_receives_captured_messages_after_close(mon
     assert captured["notification_mode"] == "on"
 
 
+def test_background_review_uses_pre_compression_baseline(monkeypatch):
+    """Old tool results must stay filtered after context compression.
+
+    Compression can rewrite the post-turn snapshot so it no longer contains an
+    older tool result.  The review fork may still surface that result from its
+    inherited state, so the summary filter needs the pre-turn baseline too.
+    """
+    import json
+
+    old_tool_message = {
+        "role": "tool",
+        "tool_call_id": "call_old",
+        "content": json.dumps(
+            {"success": True, "message": "Cron job 'remind-me' created."}
+        ),
+    }
+    delivered: list[str] = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            self._session_messages = [old_tool_message]
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent.background_review_callback = delivered.append
+
+    compressed_snapshot = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] Summary..."},
+        {"role": "assistant", "content": "Current answer"},
+    ]
+    pre_compression_baseline = [
+        {"role": "user", "content": "create a reminder"},
+        old_tool_message,
+        {"role": "assistant", "content": "Done"},
+    ]
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=compressed_snapshot,
+        baseline_snapshot=pre_compression_baseline + compressed_snapshot,
+        review_memory=True,
+    )
+
+    assert delivered == []
+
+
 def test_background_review_installs_auto_deny_approval_callback(monkeypatch):
     """Regression guard for #15216.
 


### PR DESCRIPTION
Fixes a stale background-review notification path where context compression could remove an old tool result from the post-turn snapshot, causing the review summary filter to treat that old result as new and re-deliver messages such as `Cron job '...' created.`.

## What changed and why
- `agent/conversation_loop.py`: captures the incoming pre-turn history before compression can rewrite the live message list, then passes it with the final post-turn snapshot to background review.
- `agent/background_review.py`: accepts an optional wider baseline for stale tool-result filtering while preserving existing callers that only pass the post-turn snapshot.
- `run_agent.py`: threads the optional baseline through `AIAgent._spawn_background_review`.
- `tests/run_agent/test_background_review.py`: adds a regression for a compressed snapshot that no longer contains an old cron tool result, ensuring it is not emitted as a fresh self-improvement message.

## Addressing maintainer feedback
- #14521 is closed/completed and tracks the related context-compaction phantom-message family.
- #11475 is closed/completed and tracks related duplicate-response behavior after compression.
- #2224 is closed/completed and tracks an earlier synthetic post-compression user-message issue.
- This PR is intentionally narrower: it handles the remaining stale tool-result summary path described in #8775 without reopening those completed fixes.

## How to test
- `$VIRTUAL_ENV/bin/python -m pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_summary.py -q` passed: 14 passed.
- `$VIRTUAL_ENV/bin/python -m pytest tests/ -q -x --timeout=60` was run and stopped on unrelated `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`; the changed files do not touch ACP approval or `tools/approval.py`.
- `python scripts/check-windows-footguns.py run_agent.py agent/conversation_loop.py agent/background_review.py tests/run_agent/test_background_review.py` passed.
- `git diff --check` passed.
- `ruff check run_agent.py agent/conversation_loop.py agent/background_review.py tests/run_agent/test_background_review.py` passed.
- `ruff format --check .` was attempted but fails on broad pre-existing repository formatting drift outside this diff, so no unrelated reformat was applied.

## What platforms tested on
- macOS/Darwin local worker with Python 3.11 venv for the passing targeted tests and venv-backed full-suite attempt.

Refs #8775

<!-- autocontrib:worker-id=issue-new-60021bd2 kind=pr-open -->