### PR TITLE
Respect configured ZAI base URL

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -548,7 +548,21 @@ def _pool_runtime_api_key(entry: Any) -> str:
     return str(key or "").strip()
 
 
-def _pool_runtime_base_url(entry: Any, fallback: str = "") -> str:
+def _configured_provider_base_url(provider: Optional[str]) -> str:
+    provider_id = _normalize_aux_provider(provider)
+    if provider_id != "zai":
+        return ""
+    try:
+        from hermes_cli.auth import _config_model_base_url
+        return _config_model_base_url(provider_id)
+    except Exception:
+        return ""
+
+
+def _pool_runtime_base_url(entry: Any, fallback: str = "", provider: Optional[str] = None) -> str:
+    configured_url = _configured_provider_base_url(provider)
+    if configured_url:
+        return configured_url
     if entry is None:
         return str(fallback or "").strip().rstrip("/")
     # runtime_base_url handles provider-specific logic (e.g. nous prefers inference_base_url).
@@ -1427,7 +1441,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             if not api_key:
                 continue
 
-            raw_base_url = _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
+            raw_base_url = (
+                _pool_runtime_base_url(entry, pconfig.inference_base_url, provider_id)
+                or pconfig.inference_base_url
+            )
             base_url = _to_openai_base_url(raw_base_url)
             model = _get_aux_model_for_provider(provider_id) or None
             if model is None:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -531,6 +531,21 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
     return default_url
 
 
+def _config_model_base_url(provider_id: str) -> str:
+    """Return an explicit ``model.base_url`` for ``provider_id`` from config.yaml."""
+    try:
+        raw_config = read_raw_config()
+    except Exception:
+        return ""
+    model_cfg = raw_config.get("model") if isinstance(raw_config, dict) else None
+    if not isinstance(model_cfg, dict):
+        return ""
+    configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    if configured_provider != provider_id:
+        return ""
+    return str(model_cfg.get("base_url") or "").strip().rstrip("/")
+
+
 
 _PLACEHOLDER_SECRET_VALUES = {
     "*",
@@ -663,12 +678,18 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     """Return the correct Z.AI base URL by probing endpoints.
 
     If the user has explicitly set GLM_BASE_URL, that always wins.
-    Otherwise, probe the candidate endpoints to find one that accepts the
-    key.  The detected endpoint is cached in provider state (auth.json) keyed
-    on a hash of the API key so subsequent starts skip the probe.
+    Otherwise, config.yaml's explicit model.base_url wins before probing.
+    If neither is present, probe the candidate endpoints to find one that
+    accepts the key.  The detected endpoint is cached in provider state
+    (auth.json) keyed on a hash of the API key so subsequent starts skip
+    the probe.
     """
     if env_override:
-        return env_override
+        return env_override.rstrip("/")
+
+    config_url = _config_model_base_url("zai")
+    if config_url:
+        return config_url
 
     # No API key set → don't probe (would fire N×M HTTPS requests with an
     # empty Bearer token, all returning 401).  This path is hit during
@@ -5657,6 +5678,8 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
+    elif provider_id == "zai":
+        base_url = env_url.rstrip("/") or _config_model_base_url("zai") or pconfig.inference_base_url
     elif env_url:
         base_url = env_url
     else:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -29,6 +29,7 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
+    _pool_runtime_base_url,
 )
 
 
@@ -36,6 +37,27 @@ def _jwt_with_claims(claims: dict) -> str:
     header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').decode().rstrip("=")
     payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
     return f"{header}.{payload}.sig"
+
+
+def test_zai_pool_base_url_honors_config_override(tmp_path, monkeypatch):
+    import yaml
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(yaml.dump({
+        "model": {
+            "provider": "zai",
+            "default": "glm-5.1",
+            "base_url": "https://open.bigmodel.cn/api/anthropic",
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    stale_entry = SimpleNamespace(base_url="https://open.bigmodel.cn/api/paas/v4")
+
+    assert (
+        _pool_runtime_base_url(stale_entry, "https://api.z.ai/api/paas/v4", "zai")
+        == "https://open.bigmodel.cn/api/anthropic"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -990,6 +990,36 @@ class TestZaiEndpointAutoDetect:
         assert creds["base_url"] == "https://custom.example/v4"
         assert not probe_called
 
+    def test_config_base_url_skips_probe(self, monkeypatch, tmp_path):
+        """Explicit ZAI config.yaml base_url should win over probe/defaults."""
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml.dump({
+            "model": {
+                "provider": "zai",
+                "default": "glm-5.1",
+                "base_url": "https://open.bigmodel.cn/api/anthropic",
+            },
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("GLM_API_KEY", "glm-key")
+        monkeypatch.delenv("GLM_BASE_URL", raising=False)
+        probe_called = False
+
+        def _never_called(*a, **kw):
+            nonlocal probe_called
+            probe_called = True
+            return None
+
+        monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", _never_called)
+        creds = resolve_api_key_provider_credentials("zai")
+        status = get_api_key_provider_status("zai")
+        assert creds["base_url"] == "https://open.bigmodel.cn/api/anthropic"
+        assert status["base_url"] == "https://open.bigmodel.cn/api/anthropic"
+        assert not probe_called
+
     def test_no_key_skips_probe(self, monkeypatch):
         """Without an API key, no probe should occur."""
         monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)


### PR DESCRIPTION
Fixes #18302.

## Summary
- prefer explicit `model.base_url` for ZAI after `GLM_BASE_URL` and before endpoint probing/defaults
- make ZAI provider status report the configured base URL
- make auxiliary credential-pool resolution honor the configured ZAI base URL so stale pool entries do not send side tasks back to `/api/paas/v4`
- add regression coverage for resolver precedence and auxiliary stale-pool override

## Verification
- `python -m py_compile hermes_cli/auth.py agent/auxiliary_client.py tests/hermes_cli/test_api_key_providers.py tests/agent/test_auxiliary_client.py`
- `PYTHONPATH=/Users/zhangrong/Documents/home/.pytest-shim:/Users/zhangrong/Documents/home/hermes-agent python -m pytest -q tests/hermes_cli/test_api_key_providers.py::TestZaiEndpointAutoDetect::test_config_base_url_skips_probe tests/agent/test_auxiliary_client.py::test_zai_pool_base_url_honors_config_override`
  - Result: `2 passed, 8 warnings`

Note: local Conda Python segfaults when importing native `readline`, so the targeted pytest run used a temporary `sitecustomize.py` shim that preloads a no-op `readline` module.
