### PR TITLE
fix(gateway): restore gateway sessions from JSON snapshots

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1297,17 +1297,41 @@ class SessionStore:
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
-        state.db is the canonical store. The legacy JSONL fallback was removed
-        in spec 002 — pre-DB sessions on existing disks have already been
-        migrated (their DB row holds the full message history).
+        state.db is the canonical store.  The optional per-session JSON
+        snapshot is a fail-open replay source for installs where the DB row is
+        empty/unavailable but the same session's snapshot is intact.
         """
-        if not self._db:
+        if not session_id:
             return []
+        if self._db:
+            try:
+                messages = self._db.get_messages_as_conversation(session_id)
+                if messages:
+                    return messages
+            except Exception as e:
+                logger.debug("Could not load messages from DB: %s", e)
+        return self._load_transcript_snapshot(session_id)
+
+    def _load_transcript_snapshot(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load a same-session JSON snapshot when SQLite has no replay rows."""
+        snapshot_path = self.sessions_dir / f"session_{session_id}.json"
         try:
-            return self._db.get_messages_as_conversation(session_id)
+            data = json.loads(snapshot_path.read_text(encoding="utf-8"))
         except Exception as e:
-            logger.debug("Could not load messages from DB: %s", e)
+            logger.debug("Could not load session snapshot %s: %s", snapshot_path, e)
             return []
+        if isinstance(data, dict):
+            messages = data.get("messages", [])
+        elif isinstance(data, list):
+            messages = data
+        else:
+            return []
+        if not isinstance(messages, list):
+            return []
+        return [
+            msg for msg in messages
+            if isinstance(msg, dict) and msg.get("role")
+        ]
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
         """Back up ``n`` user turns via soft-delete, keeping rows for audit.

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -545,10 +545,10 @@ class TestSessionStoreRewriteTranscript:
         assert reloaded == []
 
 
-class TestLoadTranscriptDBOnly:
-    """After spec 002, load_transcript reads only from state.db."""
+class TestLoadTranscript:
+    """Transcript replay prefers state.db and can salvage same-session snapshots."""
 
-    def test_db_only_returns_empty_for_nonexistent(self, tmp_path, monkeypatch):
+    def test_returns_empty_for_nonexistent(self, tmp_path, monkeypatch):
         import hermes_state
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
         config = GatewayConfig()
@@ -556,7 +556,7 @@ class TestLoadTranscriptDBOnly:
         result = store.load_transcript("nonexistent")
         assert result == []
 
-    def test_db_only_returns_messages(self, tmp_path, monkeypatch):
+    def test_returns_db_messages(self, tmp_path, monkeypatch):
         import hermes_state
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
         config = GatewayConfig()
@@ -570,6 +570,58 @@ class TestLoadTranscriptDBOnly:
         assert len(result) == 2
         assert result[0]["content"] == "db-q"
         assert result[1]["content"] == "db-a"
+
+    def test_db_messages_win_over_json_snapshot(self, tmp_path, monkeypatch):
+        import hermes_state
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        sid = "db_primary_session"
+        store._db.create_session(session_id=sid, source="gateway", model="m")
+        store._db.append_message(session_id=sid, role="user", content="db-q")
+        store._db.append_message(session_id=sid, role="assistant", content="db-a")
+        (tmp_path / f"session_{sid}.json").write_text(
+            json.dumps({
+                "session_id": sid,
+                "messages": [
+                    {"role": "user", "content": "snapshot-q"},
+                    {"role": "assistant", "content": "snapshot-a"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+        result = store.load_transcript(sid)
+
+        assert [msg["content"] for msg in result] == ["db-q", "db-a"]
+
+    def test_loads_json_snapshot_when_db_history_empty(self, tmp_path, monkeypatch):
+        import hermes_state
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        sid = "snapshot_salvage_session"
+        store._db.create_session(session_id=sid, source="gateway", model="m")
+        (tmp_path / f"session_{sid}.json").write_text(
+            json.dumps({
+                "session_id": sid,
+                "messages": [
+                    {"role": "system", "content": "ignored by gateway replay later"},
+                    {"role": "user", "content": "snapshot-q"},
+                    {"role": "assistant", "content": "snapshot-a"},
+                    {"content": "missing role"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+        result = store.load_transcript(sid)
+
+        assert [msg["content"] for msg in result] == [
+            "ignored by gateway replay later",
+            "snapshot-q",
+            "snapshot-a",
+        ]
 
 
 class TestSessionStoreSwitchSession:


### PR DESCRIPTION
## What does this PR do?

Adds a fail-open transcript replay path for gateway sessions whose SQLite history is empty or unavailable but whose opt-in `session_<id>.json` snapshot still contains the conversation. SQLite remains the canonical source and wins whenever it has rows, so normal DB-backed gateway history is unchanged. This lets a fresh Discord thread turn restore the intact same-session snapshot instead of starting cold when the DB replay row is missing.

## Related Issue

Fixes #8385

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Security
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] Other

## Changes Made

- `gateway/session.py`: load transcripts from `state.db` first, then fall back to the matching `session_<id>.json` snapshot only when DB replay rows are absent or unavailable.
- `tests/gateway/test_session.py`: cover empty transcripts, DB transcript loading, DB-over-snapshot precedence, and snapshot salvage when DB history is empty.

## How to Test

1. `pytest tests/gateway/test_session.py tests/gateway/test_load_transcript_db_only.py -q` -> `77 passed`.
2. `python scripts/check-windows-footguns.py gateway/session.py tests/gateway/test_session.py` -> clean.
3. `git diff --check` -> clean.
4. `ruff check gateway/session.py tests/gateway/test_session.py` -> clean.
5. `ruff format --check gateway/session.py tests/gateway/test_session.py` -> fails because both touched files have existing full-file formatting drift; I did not reformat them to avoid a broad unrelated diff.
6. `scripts/run_tests.sh` -> ran via the repo wrapper and failed with `27333 passed, 776 failed` on this sandbox. Relevant gateway/session coverage passed under the wrapper, including `tests/gateway/test_session.py`, `tests/gateway/test_load_transcript_db_only.py`, `tests/gateway/test_discord_thread_persistence.py`, `tests/gateway/test_discord_free_response.py`, and `tests/gateway/test_discord_slash_commands.py`. The failures are outside this diff and cluster around restricted `$HOME/.hermes` writes, localhost socket bind permission errors, live-system guard process-signal blocks, shared-venv import timeouts, missing optional modules, DNS/network lookup failures, and `/tmp` versus `/private/tmp` path expectations.

## Checklist

- [x] Conventional Commits format used for the PR title.
- [x] Tests added or updated.
- [x] Cross-platform compatibility considered; Windows footgun scan is clean for touched files.
- [ ] Full local test suite passed.
- [ ] Documentation updated.
- [ ] CLI config updated.

## For New Skills

Not applicable.

## Screenshots / Logs

No screenshots. Local platform tested: macOS darwin-arm64 sandbox with Python 3.11.15 through `scripts/run_tests.sh`.

<!-- autocontrib:worker-id=issue-new-51cc93e7 kind=pr-open -->