### PR TITLE
fix: honor force_ipv4 in run_agent and legacy cli bootstrap

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -165,7 +165,11 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import (
+    apply_configured_ipv4_preference,
+    display_hermes_home,
+    get_hermes_home,
+)
 from hermes_cli.browser_connect import (
     DEFAULT_BROWSER_CDP_URL,
     is_browser_debug_ready,
@@ -176,6 +180,7 @@ from hermes_cli.env_loader import load_hermes_dotenv
 from utils import base_url_host_matches
 
 _hermes_home = get_hermes_home()
+apply_configured_ipv4_preference(hermes_home=_hermes_home)
 _project_env = Path(__file__).parent / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -451,6 +451,30 @@ def apply_ipv4_preference(force: bool = False) -> None:
     socket.getaddrinfo = _ipv4_getaddrinfo  # type: ignore[assignment]
 
 
+def apply_configured_ipv4_preference(hermes_home: Path | None = None) -> bool:
+    """Apply ``network.force_ipv4`` from ``config.yaml`` when enabled."""
+    try:
+        import yaml
+    except Exception:
+        return False
+
+    config_path = (hermes_home or get_hermes_home()) / "config.yaml"
+    try:
+        with config_path.open(encoding="utf-8") as fh:
+            config = yaml.safe_load(fh) or {}
+    except OSError:
+        return False
+    except Exception:
+        return False
+
+    network_cfg = config.get("network", {})
+    if not isinstance(network_cfg, dict):
+        return False
+    force = bool(network_cfg.get("force_ipv4"))
+    apply_ipv4_preference(force=force)
+    return force
+
+
 # ─── Streaming Response Constants ────────────────────────────────────────────
 
 # Response ID for partial stream stubs used during error recovery

--- a/run_agent.py
+++ b/run_agent.py
@@ -61,7 +61,7 @@ from typing import List, Dict, Any, Optional
 from datetime import datetime
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, apply_configured_ipv4_preference
 
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
 # `OpenAI` is re-exported here so `patch("run_agent.OpenAI", ...)` in tests works.
@@ -84,6 +84,7 @@ from hermes_cli.timeouts import (
 )
 
 _hermes_home = get_hermes_home()
+apply_configured_ipv4_preference(hermes_home=_hermes_home)
 _project_env = Path(__file__).parent / '.env'
 _loaded_env_paths = load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 if _loaded_env_paths:

--- a/tests/test_ipv4_preference.py
+++ b/tests/test_ipv4_preference.py
@@ -2,6 +2,7 @@
 
 import importlib
 import socket
+import sys
 
 
 
@@ -101,6 +102,92 @@ class TestApplyIPv4Preference:
         # Should have tried AF_INET first, then fallen back to AF_UNSPEC
         assert call_families == [socket.AF_INET, 0]
         assert result[0][0] == socket.AF_INET6
+
+
+class TestApplyConfiguredIPv4Preference:
+    """Tests for apply_configured_ipv4_preference()."""
+
+    def test_returns_false_when_config_missing(self, monkeypatch, tmp_path):
+        hermes_constants = _reload_constants()
+        calls = []
+        monkeypatch.setattr(
+            hermes_constants,
+            "apply_ipv4_preference",
+            lambda force=False: calls.append(force),
+        )
+
+        assert hermes_constants.apply_configured_ipv4_preference(tmp_path) is False
+        assert calls == []
+
+    def test_reads_force_ipv4_from_config(self, monkeypatch, tmp_path):
+        hermes_constants = _reload_constants()
+        (tmp_path / "config.yaml").write_text("network:\n  force_ipv4: true\n", encoding="utf-8")
+        calls = []
+        monkeypatch.setattr(
+            hermes_constants,
+            "apply_ipv4_preference",
+            lambda force=False: calls.append(force),
+        )
+
+        assert hermes_constants.apply_configured_ipv4_preference(tmp_path) is True
+        assert calls == [True]
+
+    def test_ignores_invalid_network_section(self, monkeypatch, tmp_path):
+        hermes_constants = _reload_constants()
+        (tmp_path / "config.yaml").write_text("network: enabled\n", encoding="utf-8")
+        calls = []
+        monkeypatch.setattr(
+            hermes_constants,
+            "apply_ipv4_preference",
+            lambda force=False: calls.append(force),
+        )
+
+        assert hermes_constants.apply_configured_ipv4_preference(tmp_path) is False
+        assert calls == []
+
+
+class TestBootstrapWiring:
+    """Entry points should apply the config-driven IPv4 preference on import."""
+
+    def setup_method(self):
+        self._saved = {name: sys.modules.get(name) for name in ("cli", "run_agent")}
+
+    def teardown_method(self):
+        for name, module in self._saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    def test_run_agent_bootstrap_applies_configured_ipv4(self, monkeypatch):
+        import hermes_constants
+
+        calls = []
+        monkeypatch.setattr(
+            hermes_constants,
+            "apply_configured_ipv4_preference",
+            lambda hermes_home=None: calls.append(hermes_home),
+        )
+        sys.modules.pop("run_agent", None)
+
+        run_agent = importlib.import_module("run_agent")
+
+        assert calls == [run_agent._hermes_home]
+
+    def test_cli_bootstrap_applies_configured_ipv4(self, monkeypatch):
+        import hermes_constants
+
+        calls = []
+        monkeypatch.setattr(
+            hermes_constants,
+            "apply_configured_ipv4_preference",
+            lambda hermes_home=None: calls.append(hermes_home),
+        )
+        sys.modules.pop("cli", None)
+
+        cli = importlib.import_module("cli")
+
+        assert calls == [cli._hermes_home]
 
 
 class TestConfigDefault:


### PR DESCRIPTION
## Summary
- add a small helper that reads `network.force_ipv4` from `config.yaml` and applies the existing socket patch
- call that helper during `run_agent.py` and legacy `cli.py` bootstrap so `hermes-agent` and `python cli.py` honor the same workaround as `hermes`
- extend the IPv4 regression tests to cover config loading plus both uncovered entry points

## Testing
- `pytest -o addopts='' tests/test_ipv4_preference.py -q`
- `ruff check hermes_constants.py run_agent.py cli.py tests/test_ipv4_preference.py`
- `git diff --check`

Fixes #37662
