### PR TITLE
fix(langfuse): redact prompt and tool evidence

### DIFF
--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -42,6 +42,18 @@ HERMES_LANGFUSE_MAX_CHARS=12000      # max chars per field (default: 12000)
 HERMES_LANGFUSE_DEBUG=true           # verbose plugin logging
 ```
 
+## Evidence redaction
+
+Prompt, tool-argument, and tool-result payloads are redacted locally before
+being sent to Langfuse. The plugin uses Hermes' deterministic regex/key-name
+redactor with `force=True`; it does **not** call an LLM to decide what to mask.
+
+The redaction pass preserves useful audit context such as tool names, command
+shape, file paths, URLs/domains, and non-sensitive result fields, while masking
+Authorization headers, cookies, token/password/secret-like object keys,
+`.env`-style assignments, private keys, URL credentials, and sensitive query
+parameters.
+
 ## Disable
 
 ```bash

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -59,6 +59,29 @@ _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
 
+_SENSITIVE_EVIDENCE_KEYS = frozenset({
+    "api_key",
+    "apikey",
+    "authorization",
+    "auth",
+    "bearer",
+    "client_secret",
+    "cookie",
+    "database_url",
+    "id_token",
+    "jwt",
+    "key",
+    "openai_api_key",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "set-cookie",
+    "token",
+    "x-api-key",
+})
+_SECRET_PLACEHOLDER = "[REDACTED_SECRET]"
+
 # Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
 # the prefix is baked into the server-side issuance flow, not a UI hint).
 # Anything else (`placeholder`, `test-key`, `your-langfuse-key`, etc.) is a
@@ -361,6 +384,31 @@ def _normalize_payload(value: Any, *, tool_name: str = "", args: Any = None) -> 
     return value
 
 
+def _redact_evidence_text(value: str) -> str:
+    """Redact prompt/tool evidence locally before sending it to Langfuse.
+
+    Observability payloads can include prompts, tool args, commands, URLs,
+    and tool results.  They are useful audit evidence, but they must not
+    carry raw secrets to an external tracing sink.  This pass is deliberately
+    deterministic and local: no LLM is involved in deciding what to mask.
+    """
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(value, force=True)
+    except Exception:  # pragma: no cover - fail-open to existing truncation path
+        return value
+
+
+def _is_sensitive_evidence_key(key: Any) -> bool:
+    normalized = str(key).strip().lower().replace("-", "_")
+    if normalized in _SENSITIVE_EVIDENCE_KEYS:
+        return True
+    return any(
+        marker in normalized
+        for marker in ("api_key", "apikey", "auth", "cookie", "password", "private_key", "secret", "token")
+    )
+
+
 def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0,
                 parse_json_strings: bool = False) -> Any:
     max_chars = max_chars if max_chars is not None else int(_env("HERMES_LANGFUSE_MAX_CHARS", "12000") or "12000")
@@ -375,13 +423,17 @@ def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0,
             parsed = _maybe_parse_json_string(value)
             if parsed is not value:
                 return _safe_value(parsed, max_chars=max_chars, depth=depth, parse_json_strings=True)
-        return _truncate_text(value, max_chars)
+        return _truncate_text(_redact_evidence_text(value), max_chars)
     if isinstance(value, dict):
         normalized = _normalize_payload(value)
         if normalized is not value:
             return _safe_value(normalized, max_chars=max_chars, depth=depth, parse_json_strings=parse_json_strings)
         return {
-            str(k): _safe_value(v, max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings)
+            str(k): (
+                _SECRET_PLACEHOLDER
+                if _is_sensitive_evidence_key(k) and v not in (None, "")
+                else _safe_value(v, max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings)
+            )
             for k, v in list(value.items())[:50]
         }
     if isinstance(value, (list, tuple, set)):

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -558,6 +558,69 @@ class TestToolCallOutputBackfill:
         }]
 
 
+class TestDeterministicRedactedEvidence:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_safe_value_redacts_nested_sensitive_keys_without_llm(self):
+        mod = self._fresh_plugin()
+
+        raw = {
+            "command": "curl -H 'Authorization: Bearer sk-live-abcdef1234567890' https://api.example.com/users?access_token=opaque-token&ok=1",
+            "env": {
+                "OPENAI_API_KEY": "sk-test-abcdef1234567890",
+                "DATABASE_URL": "postgres://user:supersecret@db.example.com/app",
+                "normal": "keep me",
+            },
+            "headers": {
+                "Authorization": "Bearer ghp_abcdefghijklmnopqrstuvwxyz",
+                "Cookie": "sid=abc123; csrf=def456",
+            },
+        }
+
+        safe = mod._safe_value(raw, parse_json_strings=True)
+        rendered = repr(safe)
+
+        assert "sk-live-abcdef1234567890" not in rendered
+        assert "sk-test-abcdef1234567890" not in rendered
+        assert "supersecret" not in rendered
+        assert "ghp_abcdefghijklmnopqrstuvwxyz" not in rendered
+        assert "sid=abc123" not in rendered
+        assert "opaque-token" not in rendered
+
+        assert "api.example.com" in rendered
+        assert "OPENAI_API_KEY" in rendered
+        assert "DATABASE_URL" in rendered
+        assert safe["env"]["normal"] == "keep me"
+        assert safe["headers"]["Cookie"] == "[REDACTED_SECRET]"
+
+    def test_serialize_messages_redacts_prompt_and_tool_payload_evidence(self):
+        mod = self._fresh_plugin()
+
+        messages = [
+            {
+                "role": "user",
+                "content": "Use token sk-user-abcdef1234567890 against https://api.example.com?token=opaque",
+            },
+            {
+                "role": "tool",
+                "name": "terminal",
+                "tool_call_id": "call-1",
+                "content": '{"stdout": "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz\\n", "ok": true}',
+            },
+        ]
+
+        safe_messages = mod._serialize_messages(messages)
+        rendered = repr(safe_messages)
+
+        assert "sk-user-abcdef1234567890" not in rendered
+        assert "ghp_abcdefghijklmnopqrstuvwxyz" not in rendered
+        assert "opaque" not in rendered
+        assert "api.example.com" in rendered
+        assert safe_messages[1]["content"]["ok"] is True
+
+
 class TestToolObservationKeying:
     """Tests for pre/post tool_call observation matching when tool_call_id is absent."""
 


### PR DESCRIPTION
## Summary
- apply Hermes deterministic local secret redaction to Langfuse prompt/tool evidence before export
- mask sensitive structured keys such as Authorization, Cookie, tokens, passwords, secrets, private keys, and API keys
- document that Langfuse evidence redaction is local and non-LLM-based

Closes #37815

## Test Plan
- [x] python -m pytest tests/plugins/test_langfuse_plugin.py::TestDeterministicRedactedEvidence -q -o 'addopts='\n- [x] python -m pytest tests/plugins/test_langfuse_plugin.py -q -o 'addopts='\n- [x] git diff --check\n\n## Notes\nThis is the first implementation slice for richer audit evidence: it hardens the existing external observability sink so retained prompt/tool payloads are redacted before crossing the machine boundary. It does not add the full local audit ledger UI yet.