### PR TITLE
fix(desktop): auto-scroll trigger popover when navigating with arrow keys

### DIFF
--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -1,9 +1,14 @@
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Unstable_TriggerItem } from '@assistant-ui/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 
 import { ComposerTriggerPopover } from './trigger-popover'
+
+function makeItem(label: string, id?: string): Unstable_TriggerItem {
+  return { id: id ?? label, label, type: 'simple' }
+}
 
 function renderPopover(kind: '@' | '/', loading = false) {
   const onHover = vi.fn()
@@ -16,6 +21,26 @@ function renderPopover(kind: '@' | '/', loading = false) {
         items={[]}
         kind={kind}
         loading={loading}
+        onHover={onHover}
+        onPick={onPick}
+      />
+    </I18nProvider>
+  )
+
+  return { ...rendered, onHover, onPick }
+}
+
+function renderPopoverWithItems(kind: '@' | '/', activeIndex = 0, items?: readonly Unstable_TriggerItem[]) {
+  const onHover = vi.fn()
+  const onPick = vi.fn()
+
+  const rendered = render(
+    <I18nProvider configClient={null} initialLocale="zh">
+      <ComposerTriggerPopover
+        activeIndex={activeIndex}
+        items={items ?? [makeItem('cmd1'), makeItem('cmd2'), makeItem('cmd3')]}
+        kind={kind}
+        loading={false}
         onHover={onHover}
         onPick={onPick}
       />
@@ -53,5 +78,47 @@ describe('ComposerTriggerPopover i18n', () => {
 
     expect(screen.getByText('没有匹配项。')).toBeTruthy()
     expect(container.textContent).toContain('/help')
+  })
+})
+
+describe('ComposerTriggerPopover keyboard scroll', () => {
+  beforeEach(() => {
+    // jsdom does not implement scrollIntoView — stub it so the effect doesn't throw.
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('scrolls the active item into view when activeIndex changes', () => {
+    const { rerender } = renderPopoverWithItems('/', 0)
+
+    // The initial render with activeIndex=0 fires the effect once, scrolling the
+    // first item into view.
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled()
+
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>
+
+    // Change activeIndex to 2 (third item).
+    rerender(
+      <I18nProvider configClient={null} initialLocale="zh">
+        <ComposerTriggerPopover
+          activeIndex={2}
+          items={[makeItem('cmd1'), makeItem('cmd2'), makeItem('cmd3')]}
+          kind="/"
+          loading={false}
+          onHover={vi.fn()}
+          onPick={vi.fn()}
+        />
+      </I18nProvider>
+    )
+
+    // The effect triggers again with the new activeIndex — scrollIntoView is
+    // called once on mount (activeIndex=0) and once after re-render
+    // (activeIndex=2), each time with { block: 'nearest' } to scroll the
+    // active row into the visible area without moving the container.
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
   })
 })

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -1,5 +1,5 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
@@ -70,6 +70,12 @@ export function ComposerTriggerPopover({
   const copy = t.composer
   const isSlash = kind === '/'
 
+  const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
+
+  useEffect(() => {
+    itemRefs.current.get(activeIndex)?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
   let lastGroup: string | undefined
 
   return (
@@ -128,6 +134,10 @@ export function ComposerTriggerPopover({
                 data-highlighted={active ? '' : undefined}
                 onClick={() => onPick(item)}
                 onMouseEnter={() => onHover(index)}
+                ref={el => {
+                  if (el) itemRefs.current.set(index, el)
+                  else itemRefs.current.delete(index)
+                }}
                 type="button"
               >
                 {isSlash ? (


### PR DESCRIPTION
## Summary

When typing `/` or `@` in the desktop composer, the trigger popover has two issues with keyboard navigation:

1. **No auto-scroll** — ArrowUp/ArrowDown correctly updates the highlighted index, but the popover does not scroll to keep the active item visible when the list exceeds the viewport.
2. **Reset on keyup** — `refreshTrigger` unconditionally calls `setTriggerActive(0)` on every keyup/input event, resetting keyboard-navigation state back to the first item after every arrow-key release.

### Before
- Pressing ArrowDown past the visible items moves the highlight off-screen
- Releasing the arrow key snaps the highlight back to the first item
- Keyboard-only navigation is effectively broken for long completion lists

### Changes

**`trigger-popover.tsx`** (+10 lines)
- Add `useRef<Map<number, HTMLButtonElement>>` to track item DOM elements
- Add `useEffect` on `activeIndex` that calls `scrollIntoView({ block: 'nearest' })`
- Add `ref` callback to each `<button>` to register/unregister

**`index.tsx`** (+6 lines)
- Only reset `triggerActive` to 0 when the trigger state actually changes (new trigger appeared, cleared, or switched between `@` and `/`)
- Avoids clobbering navigation state on every keyup/input refresh

### Test Plan
- [x] `npm run test:ui` — all 228 relevant tests pass (1 pre-existing failure in pane-shell unrelated)
- [x] Manual: Open desktop, type `/`, press ArrowDown repeatedly — active item scrolls into view and stays
- [x] Manual: Release arrow key — highlight does NOT jump back to first item