### PR TITLE
fix(agent): pass original base_url to Anthropic wrapper in auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3539,7 +3539,18 @@ def resolve_provider_client(
                 except Exception:
                     pass
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass the ORIGINAL base_url (before _to_openai_base_url rewrite)
+            # to _wrap_if_needed so that _maybe_wrap_anthropic builds the
+            # Anthropic SDK client with the correct endpoint.  When the URL
+            # ends in /anthropic, _to_openai_base_url rewrites it to /v1 for
+            # OpenAI-wire clients, but if we're going to wrap in Anthropic
+            # transport the SDK needs the original /anthropic path (it appends
+            # /v1/messages itself).
+            _wrap_base = (explicit_base_url or "").strip().rstrip("/") if (
+                api_mode == "anthropic_messages"
+                or _endpoint_speaks_anthropic_messages(explicit_base_url or "")
+            ) else custom_base
+            client = _wrap_if_needed(client, final_model, _wrap_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:


### PR DESCRIPTION
## Problem

When a custom proxy endpoint ends in `/anthropic` (e.g. `https://proxy.example.com/aws/claude/anthropic`), the function `_to_openai_base_url()` rewrites it to `/v1` for OpenAI-wire compatibility. However, when the auxiliary client detects it should use the Anthropic Messages adapter (via `api_mode='anthropic_messages'` or URL heuristics), `_wrap_if_needed` still receives the **rewritten** `/v1` URL.

The Anthropic SDK then appends its own `/v1/messages` suffix, resulting in:

```
.../proxy/aws/claude/v1/v1/messages  →  404 page not found
```

This causes all auxiliary tasks (context compression, title generation) to silently fail with `404 page not found` when routed through Anthropic-protocol custom proxies.

## Root Cause

In `resolve_provider_client()` (the `provider == "custom"` + `explicit_base_url` branch), the code passes `custom_base` (already rewritten by `_to_openai_base_url()`) to `_wrap_if_needed`:

```python
custom_base = _to_openai_base_url(explicit_base_url).strip()  # /anthropic → /v1
# ...
client = _wrap_if_needed(client, final_model, custom_base, custom_key)  # passes /v1
```

When `_wrap_if_needed` → `_maybe_wrap_anthropic` detects Anthropic transport is needed, it builds the Anthropic SDK client with the `/v1` base URL. The SDK then appends `/v1/messages`, producing the double `/v1/v1/messages` path.

## Fix

When Anthropic transport will be used (detected via `api_mode == "anthropic_messages"` or `_endpoint_speaks_anthropic_messages()` heuristic), pass the **original** `explicit_base_url` (with the `/anthropic` path intact) to `_wrap_if_needed`, so the Anthropic SDK constructs the correct path:

```
.../proxy/aws/claude/anthropic/v1/messages  →  200 OK ✅
```

## Changes

- `agent/auxiliary_client.py`: Add conditional `_wrap_base` that preserves the original URL when Anthropic transport is detected, falling back to the rewritten `custom_base` for OpenAI-wire clients.

## Testing

- Verified on a live deployment using an Anthropic-protocol proxy (`/anthropic` suffix)
- Context compression and title generation tasks now succeed (previously 404)
- Non-Anthropic custom endpoints continue working as before (they still get the rewritten `/v1` URL)