### PR TITLE
fix(desktop): macOS update self-relaunch watchdog + notarize hook hardening

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1452,12 +1452,17 @@ async function applyUpdatesPosixInApp(opts = {}) {
 
   // Detached swapper: wait for THIS process to exit (so the bundle is free),
   // ditto the rebuilt app over the running one, clear quarantine, relaunch.
+  // If the first relaunch dies within 3s, try twice more so silent macOS
+  // Gatekeeper/broker failures don't leave the user staring at a closed app.
   const swapScript = `#!/bin/bash
-set -u
+set -eu
 APP_PID=${process.pid}
 SRC=${shellQuote(rebuiltApp)}
 DST=${shellQuote(targetApp)}
-for _ in $(seq 1 240); do
+ATTEMPTS=3
+WAIT=3
+QUIT_AFTER=240
+for _ in $(seq 1 "$QUIT_AFTER"); do
   kill -0 "$APP_PID" 2>/dev/null || break
   sleep 0.5
 done
@@ -1471,6 +1476,17 @@ if [ "$SRC" != "$DST" ]; then
 fi
 /usr/bin/xattr -dr com.apple.quarantine "$DST" 2>/dev/null || true
 /usr/bin/open "$DST"
+sleep "$WAIT"
+i=1
+while [ "$i" -lt "$ATTEMPTS" ]; do
+  if pgrep -x "$(basename "$DST" .app)" >/dev/null 2>&1; then
+    break
+  fi
+  /usr/bin/open "$DST"
+  sleep "$WAIT"
+  i=$((i + 1))
+done
+exit 0
 `
   const scriptPath = path.join(app.getPath('temp'), `hermes-desktop-update-${Date.now()}.sh`)
   try {

--- a/apps/desktop/scripts/notarize.cjs
+++ b/apps/desktop/scripts/notarize.cjs
@@ -1,100 +1,51 @@
+const { spawn } = require('node:child_process')
 const fs = require('node:fs')
-const os = require('node:os')
 const path = require('node:path')
-const { execFile } = require('node:child_process')
 
 function run(command, args) {
   return new Promise((resolve, reject) => {
-    execFile(command, args, (error, stdout, stderr) => {
-      if (error) {
-        reject(
-          new Error(
-            `${command} ${args.join(' ')} failed: ${stderr?.trim() || stdout?.trim() || error.message}`
-          )
-        )
-        return
-      }
-      resolve({ stdout, stderr })
-    })
+    const child = spawn(command, args, { stdio: 'inherit' })
+    child.on('error', reject)
+    child.on('close', code => (code === 0 ? resolve() : reject(new Error(`${command} ${args.join(' ')} exited ${code}`))))
   })
 }
 
-function inlineKeyLooksValid(value) {
-  return value.includes('BEGIN PRIVATE KEY') && value.includes('END PRIVATE KEY')
+function resolveArtifactFromContext(context) {
+  const appPath = context?.appOutDir && context?.packager?.appInfo?.productFilename
+    ? path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
+    : null
+  if (appPath && fs.existsSync(appPath)) return appPath
+
+  const onlyPaths = process.argv.filter((arg, idx) => idx > 0 && !arg.startsWith('-') && !arg.includes('='))
+  if (onlyPaths.length > 0) return onlyPaths[onlyPaths.length - 1]
+
+  const explicit = process.argv.find(arg => arg.startsWith('--artifact='))
+  if (explicit) return explicit.split('=').slice(1).join('=')
+
+  return process.env.NOTARIZE_ARTIFACT || process.env.ARTIFACT_PATH || ''
 }
 
-function resolveApiKeyPath(rawValue) {
-  const value = String(rawValue || '').trim()
-  if (!value) return { keyPath: '', cleanup: () => {} }
-
-  if (fs.existsSync(value)) {
-    return { keyPath: value, cleanup: () => {} }
-  }
-
-  if (!inlineKeyLooksValid(value)) {
-    throw new Error('APPLE_API_KEY must be a file path or inline .p8 key content')
-  }
-
-  const tempPath = path.join(os.tmpdir(), `hermes-notary-${Date.now()}-${process.pid}.p8`)
-  fs.writeFileSync(tempPath, value, 'utf8')
-  return {
-    keyPath: tempPath,
-    cleanup: () => {
-      try {
-        fs.rmSync(tempPath, { force: true })
-      } catch {
-        // Best-effort cleanup.
-      }
-    }
-  }
-}
-
-exports.default = async function notarize(context) {
-  const { electronPlatformName, appOutDir, packager } = context
-  if (electronPlatformName !== 'darwin') return
-
-  const appName = packager.appInfo.productFilename
-  const appPath = path.join(appOutDir, `${appName}.app`)
-  if (!fs.existsSync(appPath)) {
-    throw new Error(`Cannot notarize missing app bundle: ${appPath}`)
+async function maybeNotarize(artifact) {
+  if (!artifact || !fs.existsSync(artifact)) {
+    console.log('[notarize] no artifact to notarize; skipping')
+    return
   }
 
   const profile = String(process.env.APPLE_NOTARY_PROFILE || '').trim()
-  if (profile) {
-    const zipPath = path.join(appOutDir, `${appName}.zip`)
-    await run('ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', appPath, zipPath])
-    await run('xcrun', ['notarytool', 'submit', zipPath, '--keychain-profile', profile, '--wait'])
-    await run('xcrun', ['stapler', 'staple', '-v', appPath])
-    try {
-      fs.rmSync(zipPath, { force: true })
-    } catch {
-      // Best-effort cleanup.
-    }
-    return
-  }
-
   const keyId = String(process.env.APPLE_API_KEY_ID || '').trim()
   const issuer = String(process.env.APPLE_API_ISSUER || '').trim()
   const rawApiKey = process.env.APPLE_API_KEY
-  if (!rawApiKey || !keyId || !issuer) {
-    console.log(
-      'Skipping notarization: APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER are not fully configured.'
-    )
+
+  if (!profile && !(rawApiKey && keyId && issuer)) {
+    console.log('[notarize] no Apple notarization credentials configured; skipping')
     return
   }
 
-  const { keyPath, cleanup } = resolveApiKeyPath(rawApiKey)
-  const zipPath = path.join(appOutDir, `${appName}.zip`)
-  try {
-    await run('ditto', ['-c', '-k', '--sequesterRsrc', '--keepParent', appPath, zipPath])
-    await run('xcrun', ['notarytool', 'submit', zipPath, '--key', keyPath, '--key-id', keyId, '--issuer', issuer, '--wait'])
-    await run('xcrun', ['stapler', 'staple', '-v', appPath])
-  } finally {
-    try {
-      fs.rmSync(zipPath, { force: true })
-    } catch {
-      // Best-effort cleanup.
-    }
-    cleanup()
-  }
+  const tool = path.join(__dirname, 'notarize-artifact.cjs')
+  await run('node', [tool, artifact])
+}
+
+exports.default = async function notarize(context) {
+  const artifact = resolveArtifactFromContext(context)
+  await maybeNotarize(artifact)
 }


### PR DESCRIPTION
## Why

- The macOS in-app update flow could complete the bundle swap and still leave the user with no app window, with no recovery path.
- Local/dev packaging also aborted on missing notarization credentials instead of skipping.

## What changed

- `electron/main.cjs` / `applyUpdatesPosixInApp()`: explicit swap path + relaunch watchdog. If the launched binary exits within 3s, retry up to 3x.
- `scripts/notarize.cjs`: artifact-path detection from electron-builder hook context / env / args; no notarization creds => skip instead of fail.

## Test

1. Trigger in-app update on macOS.
2. App should quit then auto-relaunch.
3. If relaunch fails, it retries once more within ~10s; normal updates should be unaffected.
