### PR TITLE
fix: persist gateway model-switch provider route

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11012,6 +11012,11 @@ class GatewayRunner:
                                 _sess_db.update_session_model(
                                     _sess_entry.session_id, result.new_model
                                 )
+                                _sess_db.update_session_billing_route(
+                                    _sess_entry.session_id,
+                                    provider=result.target_provider,
+                                    base_url=result.base_url,
+                                )
                             except Exception as exc:
                                 logger.debug(
                                     "Failed to persist model switch to DB: %s", exc
@@ -11162,6 +11167,11 @@ class GatewayRunner:
                 _sess_entry = self.session_store.get_or_create_session(source)
                 _sess_db.update_session_model(
                     _sess_entry.session_id, result.new_model
+                )
+                _sess_db.update_session_billing_route(
+                    _sess_entry.session_id,
+                    provider=result.target_provider,
+                    base_url=result.base_url,
                 )
             except Exception as exc:
                 logger.debug(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1128,6 +1128,50 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_billing_route(
+        self,
+        session_id: str,
+        *,
+        provider: Optional[str] = None,
+        base_url: Optional[str] = None,
+        billing_mode: Optional[str] = None,
+    ) -> None:
+        """Update the persisted billing route after a mid-session switch.
+
+        Gateway ``/model`` changes can move an existing session onto a
+        different provider/base URL. Keep the billing columns in sync so the
+        dashboard reflects the active route instead of the session's original
+        config defaults.
+        """
+        def _do(conn):
+            conn.execute(
+                """UPDATE sessions SET
+                   billing_provider = CASE
+                       WHEN ? IS NULL OR ? = '' THEN billing_provider
+                       ELSE ?
+                   END,
+                   billing_base_url = CASE
+                       WHEN ? IS NULL THEN billing_base_url
+                       ELSE ?
+                   END,
+                   billing_mode = CASE
+                       WHEN ? IS NULL THEN billing_mode
+                       ELSE ?
+                   END
+                   WHERE id = ?""",
+                (
+                    provider,
+                    provider,
+                    provider,
+                    base_url,
+                    base_url,
+                    billing_mode,
+                    billing_mode,
+                    session_id,
+                ),
+            )
+        self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,

--- a/tests/gateway/test_model_command_flat_string_config.py
+++ b/tests/gateway/test_model_command_flat_string_config.py
@@ -13,6 +13,8 @@ the proper ``model: {default: ..., provider: ...}`` form.
 
 import yaml
 import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
@@ -26,6 +28,12 @@ def _make_runner():
     runner._voice_mode = {}
     runner._session_model_overrides = {}
     runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SimpleNamespace(
+        session_id="sess-1"
+    )
     return runner
 
 
@@ -156,3 +164,64 @@ async def test_model_global_persists_when_config_has_proper_dict_model(tmp_path,
     written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert written["model"]["default"] == "gpt-5.5"
     assert written["model"]["provider"] == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_model_switch_persists_provider_for_dashboard(tmp_path, monkeypatch):
+    """Session-scoped /model must rewrite the stored provider/base_url too.
+
+    Regression for #37794: gateway /model already updated the session's model
+    column, but left billing_provider on the original config route. The
+    dashboard grouped by the stale provider and showed the wrong label.
+    """
+    from hermes_cli.model_switch import ModelSwitchResult
+    from hermes_state import SessionDB
+
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {
+            "default": "gpt-5.5",
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: ModelSwitchResult(
+            success=True,
+            new_model="deepseek-v4-flash",
+            target_provider="opencode-go",
+            provider_changed=True,
+            api_key="sk-test",
+            base_url="https://api.opencode-go.example/v1",
+            api_mode="chat_completions",
+            provider_label="OpenCode Go",
+            is_global=False,
+        ),
+    )
+
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session(session_id="sess-1", source="discord", model="gpt-5.5")
+        db.update_session_billing_route(
+            "sess-1",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+
+        runner = _make_runner()
+        runner._session_db = db
+
+        result = await runner._handle_model_command(
+            _make_event("/model deepseek-v4-flash --provider opencode-go")
+        )
+
+        session = db.get_session("sess-1")
+        assert result is not None
+        assert session["model"] == "deepseek-v4-flash"
+        assert session["billing_provider"] == "opencode-go"
+        assert session["billing_base_url"] == "https://api.opencode-go.example/v1"
+    finally:
+        db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -196,6 +196,26 @@ class TestSessionLifecycle:
                                model="xiaomi/mimo-v2.5-pro")
         assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5"
 
+    def test_update_session_billing_route_overwrites_existing(self, db):
+        db.create_session(session_id="s1", source="discord", model="deepseek-v4-flash")
+        db.update_session_billing_route(
+            "s1",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            billing_mode="subscription_included",
+        )
+
+        db.update_session_billing_route(
+            "s1",
+            provider="opencode-go",
+            base_url="https://api.opencode-go.example/v1",
+        )
+
+        session = db.get_session("s1")
+        assert session["billing_provider"] == "opencode-go"
+        assert session["billing_base_url"] == "https://api.opencode-go.example/v1"
+        assert session["billing_mode"] == "subscription_included"
+
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")


### PR DESCRIPTION
## Summary
- persist the session billing provider/base_url alongside gateway /model switches
- keep dashboard model analytics aligned with the active provider after a mid-session switch
- add regression coverage for the DB helper and gateway /model persistence path

Fixes #37794