### PR TITLE
feat(gateway): support Feishu interactive card (msg_type=interactive) in send_message

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4307,7 +4307,44 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    @staticmethod
+    def _is_feishu_card_json(content: str) -> bool:
+        """Check if content is a Feishu interactive card JSON.
+
+        A valid Feishu card contains at least one of these key structures:
+        - "config" and "elements" (standard card)
+        - "header" and "elements" (card with header)
+        - "type": "template" (template card)
+        - "i18n" (internationalized card)
+
+        This allows agents to send card JSON directly, which will be
+        routed as msg_type="interactive" instead of being treated as text.
+        """
+        try:
+            parsed = json.loads(content.strip())
+            if not isinstance(parsed, dict):
+                return False
+
+            # Check for standard card structure keys
+            card_keys = {"config", "header", "elements", "i18n"}
+            # A valid card should have at least "elements" or "i18n"
+            has_card_structure = (
+                "elements" in parsed
+                or "i18n" in parsed
+                or ("type" in parsed and parsed["type"] == "template")
+            )
+            # And optionally "config" or "header"
+            has_optional_keys = any(key in parsed for key in ("config", "header"))
+
+            return has_card_structure and (has_optional_keys or "elements" in parsed)
+        except (json.JSONDecodeError, ValueError):
+            return False
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        # Check if content is a Feishu interactive card JSON
+        if self._is_feishu_card_json(content):
+            return "interactive", content
+
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Feishu interactive cards (msg_type=interactive) in the send_message pipeline. Previously, agents could only send plain text or markdown post messages to Feishu, which rendered structured data (like tables) poorly.

## Related Issue

Fixes #37777

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- gateway/platforms/feishu.py: Added _is_feishu_card_json static method to detect Feishu interactive card JSON format
- gateway/platforms/feishu.py: Modified _build_outbound_payload to route card JSON as msg_type='interactive'
- Supports standard card structures: config+elements, header+elements, template type, i18n
- Enables agents to send structured Feishu cards with proper formatting, colors, and layout control

## How to Test

1. Send a Feishu card JSON through the agent send_message interface
2. The card should be rendered with proper formatting instead of being treated as plain text

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix/feature
- Tested on: Windows 10

### Documentation & Housekeeping

- [x] N/A - Code comments explain the new functionality
