### PR TITLE
fix(desktop): honor upward wheel scroll in long threads

### DIFF
--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -415,6 +415,40 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
+  it('honors the first upward wheel scroll even when a programmatic bottom-pin scroll event is still pending', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+    await wait(0)
+
+    await act(async () => {
+      fireEvent.wheel(viewport, { deltaY: -120 })
+      viewport.scrollTop = 420
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(420)
+  })
+
   it('renders reasoning text without a leading token space', () => {
     const { container } = render(<ReasoningHarness />)
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -235,6 +235,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     const disarm = () => {
       armedRef.current = false
+      programmaticScrollPendingRef.current = 0
     }
 
     const onScroll = () => {


### PR DESCRIPTION
## Summary
- Fixes Desktop long-thread scrollback snapping back to the bottom after the first upward mouse-wheel scroll.
- Clears stale bottom-pin bookkeeping when explicit user scroll intent disarms sticky-bottom anchoring.
- Adds a focused renderer regression test for the exact stale-pending-programmatic-scroll path.

## Root Cause
`pinToBottom()` increments `programmaticScrollPendingRef` before writing `el.scrollTop` so the resulting scroll event is treated as programmatic, not user-driven. If the browser is already clamped at the bottom, the expected programmatic scroll event may not arrive, leaving the pending count stale.

The next real upward wheel scroll could then be consumed as if it were programmatic, re-arm sticky-bottom behavior, and let the next resize/content-growth pin pull the viewport back down.

## Test Plan
- RED / negative control on current main with only the regression test added:
  - `npm run test:ui -- src/components/assistant-ui/streaming.test.tsx -t "honors the first upward wheel scroll"`
  - Failed as expected: `AssertionError: expected 1200 to be 420`
- Patched focused regression:
  - `npm run test:ui -- src/components/assistant-ui/streaming.test.tsx -t "honors the first upward wheel scroll"`
  - Passed: 1 test passed, 9 skipped.
- Patched focused file:
  - `npm run test:ui -- src/components/assistant-ui/streaming.test.tsx`
  - Passed: 10 tests passed.
- TypeScript:
  - `npm run type-check`
  - Passed.
- Lint on changed files:
  - `npx eslint src/components/assistant-ui/thread-virtualizer.tsx src/components/assistant-ui/streaming.test.tsx`
  - 0 errors; 6 existing warnings in `thread-virtualizer.tsx`.
- Whitespace:
  - `git diff --check`
  - Passed.
- Full Desktop UI test command, scoped honestly:
  - `npm run test:ui`
  - Still fails with the same pre-existing baseline failures observed before this patch: four Electron `.test.cjs` files reported by Vitest as no-suite files, plus `src/components/pane-shell/pane-shell.test.tsx` / `uses widthOverride from the store when set`.
  - Baseline before this patch: 5 failed files, 39 passed, 1 failed test, 228 passed.
  - Patched branch: 5 failed files, 39 passed, 1 failed test, 229 passed. The extra passing test is this PR's new regression.
- Independent diff review:
  - Passed: no security concerns or logic errors reported.

## Manual / Real Behavior Proof
- Real source-level proof: the regression test drives the Desktop assistant-ui scroll anchor path with the same data shape as the bug: a pending programmatic bottom-pin event exists, the user wheels upward, scroll position moves to `420`, content grows, and the viewport must remain at `420` instead of being pinned to `1200`.
- Real negative-control proof: the same focused regression failed on current main before the production fix was applied.
- Real headless Electron/CDP proof performed after PR creation:
  - Started the Desktop renderer with Vite no-HMR mode and launched Electron against it with `--remote-debugging-port=9222 --ozone-platform=headless --disable-gpu --no-sandbox` using temporary `HERMES_HOME` and `HERMES_DESKTOP_USER_DATA_DIR`.
  - CDP verified the real Electron renderer mounted the Hermes Desktop UI: URL `http://127.0.0.1:5174/#/`, title `Hermes`, composer present, thread viewport present, and `window.__PERF_DRIVE__` available.
  - CDP then drove a tall live thread through the real React/assistant-ui message store, pinned the actual thread viewport to bottom, started a second synthetic stream to trigger programmatic bottom pins/content growth, dispatched an upward `Input.dispatchMouseEvent` wheel event over the viewport, and sampled real DOM `scrollTop`/`scrollHeight`/`clientHeight` events.
  - Result: before wheel `scrollTop=1735`, `scrollHeight=2463`, `clientHeight=728`, `distFromBottom=0`; after the upward wheel event `scrollTop=1354`, `distFromBottom=478`; after continued stream growth final `scrollTop=1354`, `scrollHeight=3613`, `distFromBottom=1531`. The viewport moved up on the first wheel and was not pinned back to bottom while content continued growing.
  - Local evidence artifact captured at `/tmp/desktop-wheel-proof.json`; summary output reported `passed: true`.
- Not claimed: no hand-driven/manual Desktop GUI session or full end-to-end production app proof was performed for this PR. The added real-app proof is headless Electron via CDP with synthetic message-store stream data.

## Security / Privacy Impact
- No credentials, tokens, chat IDs, message content, database files, local session handles, or screenshots are added.
- Added-line security-pattern scan found no matches.
- The code change only clears local scroll-anchor bookkeeping in the Desktop renderer.

## Risks
- Low implementation risk: the production change is one line in the existing disarm path.
- The main behavioral risk is accidental loss of sticky-bottom behavior during genuine programmatic pins; focused tests still cover existing “stay at user scroll position after scroll-up” behavior and the new stale-pending case.
- Full `npm run test:ui` is not clean on current main, so broad-suite proof is limited to baseline comparison rather than a green full suite.

## Scope Boundaries
- In scope: #37527, the Desktop long-thread upward wheel scroll snapback caused by stale `programmaticScrollPendingRef` state.
- Related but not fully fixed: #37549’s `programmaticScrollPendingRef` root-cause path is addressed, but this PR does not claim to fix the separate `flushPendingViewState` flicker path discussed there.
- Out of scope: broader scroll virtualization rewrites, performance tuning, pane-shell test failures, Electron no-suite Vitest configuration, and manual GUI verification.
- Supersedes closed PR #37530 with the same root fix, recreated from current `upstream/main` after explicit user request.

## Linked Issue
Fixes #37527
Related to #37549


## Commits
- Base commit: `b28dd3417`
- Patched commit: `154ea3b03`
