### PR TITLE
fix(debug): redact PII in debug share logs

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -40,6 +40,28 @@ _EMAIL_ADDRESS_RE = re.compile(
     r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
     r"(?![A-Za-z0-9._%+-])"
 )
+_MESSAGE_FIELD_SINGLE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content)="
+    r"'(?:\\.|[^'\\])*'"
+)
+_MESSAGE_FIELD_DOUBLE_RE = re.compile(
+    r'\b(?P<key>msg|message|prompt|response|content)="'
+    r'(?:\\.|[^"\\])*"'
+)
+_MESSAGE_FIELD_BARE_RE = re.compile(
+    r"\b(?P<key>msg|message|prompt|response|content)=(?!['\"])[^\s]+"
+)
+_USER_FIELD_RE = re.compile(
+    r"\b(?P<key>user|user_id)="
+    r".*?"
+    r"(?=\s+(?:platform|user|user_id|chat|chat_id|session|session_id|thread|"
+    r"thread_id|msg|message|prompt|response|content)=|$)"
+)
+_IDENTITY_TOKEN_FIELD_RE = re.compile(
+    r"\b(?P<key>chat|chat_id|session|session_id|thread|thread_id)=[^\s]+"
+)
+_UNIX_HOME_COMPONENT_RE = re.compile(r"(?<![\w.-])/(?:home|Users)/[^/\s:'\"]+")
+_WINDOWS_HOME_COMPONENT_RE = re.compile(r"(?i)\b[A-Z]:\\Users\\[^\\\s:'\"]+")
 
 
 # ---------------------------------------------------------------------------
@@ -382,20 +404,65 @@ def _resolve_log_path(log_name: str) -> Optional[Path]:
 
 
 def _redact_log_text(text: str) -> str:
-    """Run ``redact_sensitive_text`` with ``force=True`` over upload-bound text.
+    """Run forced secret and privacy redaction over upload-bound text.
 
-    Uses ``force=True`` so redaction fires regardless of the operator's
-    ``security.redact_secrets`` setting. The local on-disk log file is
-    not modified; only the in-memory copy headed for the public paste
-    service is sanitized. Returns the redacted text (or the original
-    when empty / non-string).
+    Uses ``force=True`` so secret redaction fires regardless of the operator's
+    ``security.redact_secrets`` setting. A second debug-share-only pass removes
+    common PII-bearing log fields such as user/chat identifiers, message
+    snippets, and local home paths. The on-disk log file is never modified;
+    only the in-memory copy headed for the public paste service is sanitized.
     """
     if not text:
         return text
     from agent.redact import redact_sensitive_text
 
     text = redact_sensitive_text(text, force=True)
-    return _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    return _redact_debug_share_privacy(text)
+
+
+def _redact_debug_share_privacy(text: str) -> str:
+    """Remove personal context that is not covered by secret redaction."""
+    text = _EMAIL_ADDRESS_RE.sub("[REDACTED_EMAIL]", text)
+    text = _MESSAGE_FIELD_SINGLE_RE.sub(
+        lambda m: f"{m.group('key')}='[REDACTED_MESSAGE]'", text
+    )
+    text = _MESSAGE_FIELD_DOUBLE_RE.sub(
+        lambda m: f'{m.group("key")}="[REDACTED_MESSAGE]"', text
+    )
+    text = _MESSAGE_FIELD_BARE_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_MESSAGE]", text
+    )
+    text = _USER_FIELD_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_ID]", text
+    )
+    text = _IDENTITY_TOKEN_FIELD_RE.sub(
+        lambda m: f"{m.group('key')}=[REDACTED_ID]", text
+    )
+
+    for raw_path, replacement in _privacy_path_replacements():
+        text = text.replace(raw_path, replacement)
+        text = text.replace(raw_path.replace("\\", "/"), replacement.replace("\\", "/"))
+
+    text = _UNIX_HOME_COMPONENT_RE.sub("~", text)
+    return _WINDOWS_HOME_COMPONENT_RE.sub("~", text)
+
+
+def _privacy_path_replacements() -> list[tuple[str, str]]:
+    """Return local paths that should not be exposed in public debug pastes."""
+    replacements: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    candidates = [
+        (get_hermes_home(), "~/.hermes"),
+        (Path.home(), "~"),
+    ]
+
+    for path, replacement in candidates:
+        raw = str(path)
+        if raw and raw not in seen:
+            seen.add(raw)
+            replacements.append((raw, replacement))
+
+    return replacements
 
 
 def _capture_log_snapshot(

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -198,7 +198,7 @@ class TestCaptureLogSnapshot:
         # backward-reading loop so the truncation path actually fires.
         line = "A" * 99 + "\n"  # 100 bytes per line
         num_lines = 200  # 20000 bytes
-        (hermes_home / "logs" / "agent.log").write_text(line * num_lines)
+        (hermes_home / "logs" / "agent.log").write_text(line * num_lines, newline="\n")
 
         # max_bytes = 1000 = 100 * 10 → cut at byte 20000 - 1000 = 19000,
         # and byte 19000 - 1 is '\n'.  Boundary hit → keep all 10 lines.
@@ -359,15 +359,44 @@ class TestCaptureLogSnapshotRedaction:
         log_path.write_text(
             "2026-04-12 17:00:00 INFO gateway.run: "
             "inbound message: platform=bluebubbles "
-            "user=person@example.com chat=iMessage;-;person@example.com msg='hello'\n"
+            "user=person@example.com chat=iMessage;-;person@example.com "
+            "owner=person@example.com msg='hello'\n"
         )
 
         snap = _capture_log_snapshot("agent", tail_lines=10)
 
         assert "person@example.com" not in snap.tail_text
         assert "[REDACTED_EMAIL]" in snap.tail_text
+        assert "user=[REDACTED_ID]" in snap.tail_text
+        assert "chat=[REDACTED_ID]" in snap.tail_text
         assert snap.full_text is not None
         assert "person@example.com" not in snap.full_text
+
+    def test_default_redacts_identity_message_and_home_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "inbound message: platform=telegram "
+            "user=Alice Smith chat=9876543210 "
+            "msg='private medical question' "
+            f"cwd={hermes_home_with_secret / 'sessions'}\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        for text in (snap.tail_text, snap.full_text or ""):
+            assert "Alice Smith" not in text
+            assert "9876543210" not in text
+            assert "private medical question" not in text
+            assert str(hermes_home_with_secret) not in text
+            assert "user=[REDACTED_ID]" in text
+            assert "chat=[REDACTED_ID]" in text
+            assert "msg='[REDACTED_MESSAGE]'" in text
+            assert "~/.hermes" in text
 
     def test_no_redact_preserves_email_addresses(self, hermes_home_with_secret):
         from hermes_cli.debug import _capture_log_snapshot
@@ -383,6 +412,27 @@ class TestCaptureLogSnapshotRedaction:
 
         assert "person@example.com" in snap.tail_text
         assert "person@example.com" in (snap.full_text or "")
+
+    def test_no_redact_preserves_identity_message_and_home_path(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(
+            "2026-04-12 17:00:00 INFO gateway.run: "
+            "inbound message: platform=telegram "
+            "user=Alice Smith chat=9876543210 "
+            "msg='private medical question' "
+            f"cwd={hermes_home_with_secret / 'sessions'}\n"
+        )
+
+        snap = _capture_log_snapshot("agent", tail_lines=10, redact=False)
+
+        assert "Alice Smith" in snap.tail_text
+        assert "9876543210" in snap.tail_text
+        assert "private medical question" in snap.tail_text
+        assert str(hermes_home_with_secret) in snap.tail_text
 
     def test_capture_default_log_snapshots_threads_redact(
         self, hermes_home_with_secret


### PR DESCRIPTION
## Summary

- Extend debug-share redaction to cover message/prompt/content fields, user/chat/session identifiers, email addresses, and local home paths before logs are uploaded to a paste service.
- Keep local on-disk logs unchanged; only the upload-bound snapshot is sanitized.
- Make the truncation boundary test portable on Windows by writing LF-only fixture data.

## Verification

- `uv run --with pytest python -m pytest tests/hermes_cli/test_debug.py -o addopts=''` -> 70 passed
- `uv run ruff check hermes_cli/debug.py tests/hermes_cli/test_debug.py` -> passed
- `git diff --check` -> passed

## Duplicate check

Searched open and all PRs in `NousResearch/hermes-agent` for `redact PII debug share logs` and `debug share logs PII`; no duplicate PR was found.