### PR TITLE
fix(desktop): treat 'done' as terminal update stage to unstick UI on Linux (#37775)

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -28,7 +28,8 @@ const STAGE_LABELS: Record<DesktopUpdateStage, string> = {
   pydeps: 'Finishing up…',
   restart: 'Restarting Hermes…',
   manual: 'Update from your terminal',
-  error: 'Update paused'
+  error: 'Update paused',
+  done: 'Update complete'
 }
 
 function totalItems(groups: readonly CommitGroup[]) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -126,7 +126,7 @@ export interface DesktopUpdateApplyResult {
   hermesRoot?: string
 }
 
-export type DesktopUpdateStage = 'idle' | 'prepare' | 'fetch' | 'pull' | 'pydeps' | 'restart' | 'manual' | 'error'
+export type DesktopUpdateStage = 'idle' | 'prepare' | 'fetch' | 'pull' | 'pydeps' | 'restart' | 'manual' | 'error' | 'done'
 
 export interface DesktopUpdateProgress {
   stage: DesktopUpdateStage

--- a/apps/desktop/src/store/__tests__/updates.test.ts
+++ b/apps/desktop/src/store/__tests__/updates.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { DesktopUpdateProgress, DesktopUpdateStage } from '@/global'
+
+import { $updateApply, __ingestProgressForTests, resetUpdateApplyState } from '../updates'
+
+function progress(stage: DesktopUpdateStage, overrides: Partial<DesktopUpdateProgress> = {}): DesktopUpdateProgress {
+  return {
+    stage,
+    message: overrides.message ?? `stage:${stage}`,
+    percent: overrides.percent ?? null,
+    error: overrides.error ?? null,
+    at: overrides.at ?? 0
+  }
+}
+
+describe('updates store / ingestProgress', () => {
+  beforeEach(() => {
+    resetUpdateApplyState()
+    // Seed an "applying" state so we can verify terminal stages clear it.
+    __ingestProgressForTests(progress('prepare'))
+    expect($updateApply.get().applying).toBe(true)
+  })
+
+  it("clears applying when stage is 'done' (Linux/AppImage finishing path)", () => {
+    __ingestProgressForTests(progress('done', { message: 'Backend updated.', percent: 100 }))
+
+    const state = $updateApply.get()
+    expect(state.applying).toBe(false)
+    expect(state.stage).toBe('done')
+  })
+
+  it.each(['restart', 'error', 'manual'] as const)("clears applying when stage is '%s'", (stage) => {
+    __ingestProgressForTests(progress(stage))
+    expect($updateApply.get().applying).toBe(false)
+  })
+
+  it.each(['prepare', 'fetch', 'pull', 'pydeps'] as const)("keeps applying true for intermediate stage '%s'", (stage) => {
+    __ingestProgressForTests(progress(stage))
+    expect($updateApply.get().applying).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -249,7 +249,7 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 function ingestProgress(payload: DesktopUpdateProgress): void {
   const current = $updateApply.get()
   const log = [...current.log, { stage: payload.stage, message: payload.message, at: payload.at }].slice(-50)
-  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual'
+  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual' || payload.stage === 'done'
 
   $updateApply.set({
     applying: !terminal,
@@ -266,6 +266,8 @@ function ingestProgress(payload: DesktopUpdateProgress): void {
 let pollerStarted = false
 let backgroundTimer: ReturnType<typeof setInterval> | null = null
 let lastFocusAt = 0
+
+export { ingestProgress as __ingestProgressForTests }
 
 /** Wire up background polling + progress streaming. Idempotent. */
 export function startUpdatePoller(): void {


### PR DESCRIPTION
## Summary

Fixes #37775 — on Linux (Fedora/Wayland in the report, but really any Linux/AppImage or dev run), the desktop update overlay stays in `Updating…` forever after the update has actually finished, and the terminal logs:

```
Error occurred in handler for 'hermes:api': Error: connect ECONNREFUSED 127.0.0.1:9120
```

## Root cause

`applyUpdatesPosixInApp` in `apps/desktop/electron/main.cjs` emits a final progress event with **`stage: 'done'`** when there is no `.app` bundle to swap (Linux AppImage, dev runs, unresolved bundle paths):

```js
emitUpdateProgress({
  stage: 'done',
  message: 'Backend updated. Restart Hermes to load the new version.',
  percent: 100
})
return { ok: true, backendUpdated: true, rebuiltApp: rebuiltApp || null }
```

But `ingestProgress` in `apps/desktop/src/store/updates.ts` only treated three stages as terminal:

```ts
const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual'
```

So `'done'` left `applying: true` forever. The overlay stayed up while the renderer kept firing `hermes:api` calls into the briefly-stopped backend → the `ECONNREFUSED 9120` spam the user saw.

`'done'` also wasn't in the `DesktopUpdateStage` type union, so the type system never caught the gap.

## Fix

- `apps/desktop/src/store/updates.ts` — include `'done'` in the terminal stage set. **This is the actual one-line bug fix.**
- `apps/desktop/src/global.d.ts` — add `'done'` to `DesktopUpdateStage` (main process was already emitting it).
- `apps/desktop/src/app/updates-overlay.tsx` — add a `'Update complete'` entry to `STAGE_LABELS` so the exhaustive `Record<DesktopUpdateStage, string>` still type-checks.
- `apps/desktop/src/store/__tests__/updates.test.ts` — new vitest:
  - asserts `'done'` clears `applying` (regression for this bug),
  - asserts `'restart' | 'error' | 'manual'` still clear `applying` (guard),
  - asserts intermediate stages (`'prepare' | 'fetch' | 'pull' | 'pydeps'`) keep `applying: true`.
- Added a small `__ingestProgressForTests` named export so the function is testable without mocking the whole `window.hermesDesktop` IPC bridge.

## Testing

```
$ cd apps/desktop && npx vitest run src/store/__tests__/updates.test.ts
 ✓ src/store/__tests__/updates.test.ts (8 tests) 2ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

`npx tsc -b` also passes clean.

## Notes for reviewers

- The `ECONNREFUSED 9120` log message in the issue is a side effect, not the bug — the backend was legitimately stopped during update and comes back up shortly. The bug is purely the renderer not exiting the `applying` state, which is what kept the IPC calls firing into the gap.
- The Wayland presentation-feedback warning in the report is unrelated noise from the compositor.
- Scope intentionally tiny; not touching `main.cjs` or any other update flow.
