### PR TITLE
fix(hindsight): pass retain_async=True in hindsight_retain tool handler

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1506,6 +1506,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     content,
                     context=context,
                     tags=args.get("tags"),
+                    retain_async=True,
                 )
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)


### PR DESCRIPTION
The hindsight_retain tool calls client.aretain() without retain_async, defaulting to False (synchronous mode). On banks with significant data, synchronous processing exceeds the 120s timeout, producing:

  Tool hindsight_retain returned error (120.01s): {"error": "Failed to store memory: "}

The auto-retain path (sync_turn) works correctly because it passes retain_async=self._retain_async (True) to aretain_batch.

Fix add retain_async=True to _build_retain_kwargs in the tool handler (1 line).

## What does this PR do?

Add retain_async=True to the _build_retain_kwargs call in the hindsight_retain tool handler, making the tool use asynchronous processing consistent with the auto-retain path (sync_turn). Previously the tool defaulted to retain_async=False (synchronous mode), causing timeouts on banks with significant data when the Hindsight APIs LLM extraction took longer than 120 seconds.

## Related Issues

- Closes #29079 (Embedded Hindsight retain reports failure while async retain later appears in recall)
- References #7974 (Bug hindsight_retain tool fails with Connection refused while hindsight_recall works)
- Follow-up to PR #13987 (feat richer session-scoped retain metadata introduced _build_retain_kwargs without retain_async)
- Similar to PR #9869 (Hindsight plugin hardcoded 30s timeout causes hindsight_reflect to fail same timeout pattern)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- plugins/memory/hindsight/__init__.py Add retain_async=True parameter to _build_retain_kwargs() call in handle_tool_call for hindsight_retain (line 1508)

## How to Test

1. Start Hermes with memory provider hindsight (local or cloud)
2. Call hindsight_retain with any content via CLI or gateway session
3. Observe the tool returns success within seconds instead of timing out at 120s
4. Verify retained content appears in hindsight_recall

## Checklist

### Code

- [x] Ive read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isnt a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)

### Documentation

- [x] N/A Documentation update not needed (one-line fix

