### PR TITLE
fix(security): gate dashboard auth on ASGI path

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -49,6 +49,19 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
 )
 
 
+def _request_path(request: Request) -> str:
+    """Return the ASGI-dispatched path for auth decisions.
+
+    ``request.url.path`` is reconstructed from URL components and is not the
+    routing source of truth. Keep path-based gates tied to ``scope["path"]`` so
+    host/header parsing quirks cannot desync auth checks from dispatch.
+    """
+    path = request.scope.get("path") if hasattr(request, "scope") else None
+    if isinstance(path, str) and path:
+        return path
+    return request.url.path
+
+
 def _path_is_public(path: str) -> bool:
     """True if ``path`` bypasses the OAuth auth gate.
 
@@ -101,7 +114,7 @@ def _unauth_response(request: Request, *, reason: str) -> Response:
     """
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
-    path = request.url.path
+    path = _request_path(request)
     next_param = _safe_next_target(request)
     prefix = prefix_from_request(request)
     login_url = (
@@ -139,7 +152,7 @@ def _safe_next_target(request: Request) -> str:
     string return means the caller produces a bare ``/login`` URL — fine,
     user lands at the dashboard root after re-auth.
     """
-    path = request.url.path
+    path = _request_path(request)
     # Reject anything that doesn't start with "/" or starts with "//"
     # (protocol-relative URL — would open-redirect to an attacker host).
     if not path or not path.startswith("/") or path.startswith("//"):
@@ -180,7 +193,7 @@ async def gated_auth_middleware(
     if not getattr(request.app.state, "auth_required", False):
         return await call_next(request)
 
-    path = request.url.path
+    path = _request_path(request)
     if _path_is_public(path):
         return await call_next(request)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -323,7 +323,9 @@ async def auth_middleware(request: Request, call_next):
     # and is skipped here so the gate's session attachment isn't overridden.
     if getattr(request.app.state, "auth_required", False):
         return await call_next(request)
-    path = request.url.path
+    from hermes_cli.dashboard_auth.middleware import _request_path
+
+    path = _request_path(request)
     if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
         if not _has_valid_session_token(request):
             return JSONResponse(

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -23,6 +23,7 @@ import pytest
 # files that gate the app.
 pytestmark = pytest.mark.xdist_group("dashboard_auth_app_state")
 from fastapi.testclient import TestClient
+from fastapi.responses import Response
 
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
@@ -142,6 +143,80 @@ def test_gated_static_asset_path_is_public(gated_app):
     # 404 not 401 — proves middleware let the request through to the
     # static-files mount, which then 404'd because the file isn't there.
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_gate_uses_scope_path_for_auth_decision():
+    """Path auth gates must follow ASGI dispatch, not URL reconstruction."""
+    from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+
+    class FakeState:
+        auth_required = True
+
+    class FakeApp:
+        state = FakeState()
+
+    class FakeURL:
+        # A vulnerable implementation that trusts request.url.path would
+        # treat this as public and skip the gate.
+        path = "/login"
+        query = ""
+
+    class FakeClient:
+        host = "203.0.113.10"
+
+    class FakeRequest:
+        app = FakeApp()
+        url = FakeURL()
+        scope = {"path": "/api/sessions"}
+        headers = {}
+        cookies = {}
+        client = FakeClient()
+
+    called = False
+
+    async def call_next(_request):
+        nonlocal called
+        called = True
+        return Response("bypassed")
+
+    response = await gated_auth_middleware(FakeRequest(), call_next)
+
+    assert response.status_code == 401
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_legacy_token_gate_uses_scope_path_for_api_decision():
+    """Loopback token gate must also use the ASGI-dispatched path."""
+
+    class FakeState:
+        auth_required = False
+
+    class FakeApp:
+        state = FakeState()
+
+    class FakeURL:
+        path = "/"
+        query = ""
+
+    class FakeRequest:
+        app = FakeApp()
+        url = FakeURL()
+        scope = {"path": "/api/sessions"}
+        headers = {}
+
+    called = False
+
+    async def call_next(_request):
+        nonlocal called
+        called = True
+        return Response("bypassed")
+
+    response = await web_server.auth_middleware(FakeRequest(), call_next)
+
+    assert response.status_code == 401
+    assert called is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Use the ASGI-dispatched `scope["path"]` for dashboard auth decisions instead of relying on reconstructed URL path data.
- Apply the same path source to the OAuth gate, safe next-target generation, and the legacy token gate.
- Add regression tests for mismatched URL path vs dispatched ASGI path.

## Verification

- `uv run --with pytest --with pytest-asyncio python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py -o addopts=''` -> 24 passed, 1 warning
- `uv run ruff check hermes_cli/dashboard_auth/middleware.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_middleware.py` -> passed
- `git diff --check` -> passed

## Duplicate check

Searched `NousResearch/hermes-agent` PRs for `gate dashboard auth ASGI path`; no duplicate PR was found.