### PR TITLE
fix(mcp): force OAuth login for preregistered clients

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -221,6 +221,40 @@ def _oauth_tokens_present(name: str) -> bool:
         return True
 
 
+def _mcp_oauth_config(config: dict) -> dict:
+    oauth_config = config.get("oauth")
+    return oauth_config if isinstance(oauth_config, dict) else {}
+
+
+def _has_preregistered_oauth_client(config: dict) -> bool:
+    return bool(_mcp_oauth_config(config).get("client_id"))
+
+
+def _force_oauth_login(name: str, config: dict) -> bool:
+    """Run an explicit OAuth flow for pre-registered MCP clients.
+
+    Some MCP servers allow initialize/tools-list without auth, so probing the
+    server is not enough to start the SDK's 401-driven OAuth flow.
+    """
+    from tools.mcp_oauth_manager import get_manager
+    from tools.mcp_tool import _ensure_mcp_loop, _run_on_mcp_loop, _stop_mcp_loop
+
+    url = config.get("url")
+    oauth_config = _mcp_oauth_config(config)
+    timeout = float(oauth_config.get("timeout", 300))
+
+    _ensure_mcp_loop()
+    try:
+        return bool(
+            _run_on_mcp_loop(
+                get_manager().force_login(name, url, oauth_config),
+                timeout=timeout + 10,
+            )
+        )
+    finally:
+        _stop_mcp_loop()
+
+
 def _unwrap_exception_group(exc: BaseException) -> Exception:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -644,8 +678,17 @@ def cmd_mcp_login(args):
     print()
     _info(f"Starting OAuth flow for '{name}'...")
 
-    # Probe triggers the OAuth flow (browser redirect + callback capture).
+    # If the user configured a pre-registered OAuth client, run the browser
+    # flow explicitly before probing.  Relying on the probe alone only works
+    # for servers that 401 initialize/tools-list; Google Drive's MCP server can
+    # list tools unauthenticated, so no SDK auth flow is triggered otherwise.
     try:
+        if _has_preregistered_oauth_client(server_config):
+            _force_oauth_login(name, server_config)
+
+        # Probe discovers tools after the token is available.  For servers
+        # without a pre-registered client, this remains the legacy path where
+        # the SDK starts OAuth lazily in response to a 401.
         tools = _probe_single_server(name, server_config)
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -623,6 +623,47 @@ class TestMcpLogin:
         assert "Authenticated" not in out
         assert "client_id" in out
 
+    def test_login_forces_preregistered_oauth_before_probe(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Pre-registered clients should auth even when tools/list is public."""
+        _seed_config(tmp_path, {
+            "googledrive": {
+                "url": "https://drivemcp.googleapis.com/mcp/v1",
+                "auth": "oauth",
+                "oauth": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                },
+            },
+        })
+        token_dir = tmp_path / "mcp-tokens"
+        calls = []
+
+        def mock_force_login(name, cfg):
+            calls.append((name, cfg["oauth"]["client_id"]))
+            token_dir.mkdir(exist_ok=True)
+            (token_dir / "googledrive.json").write_text('{"access_token": "x"}')
+            return True
+
+        def mock_probe(name, cfg):
+            assert (token_dir / "googledrive.json").exists()
+            return [("search_files", "d"), ("read_file_content", "d")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._force_oauth_login", mock_force_login
+        )
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="googledrive"))
+        out = capsys.readouterr().out
+
+        assert calls == [("googledrive", "client-id")]
+        assert "Authenticated — 2 tool(s) available" in out
+        assert "no OAuth token was obtained" not in out
+
     def test_login_genuine_success_with_token(self, tmp_path, capsys, monkeypatch):
         """Probe lists tools AND a token exists → report real success."""
         _seed_config(tmp_path, {

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -7,6 +7,7 @@ cache. See `tools/mcp_oauth_manager.py` for design rationale.
 import json
 import os
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -139,3 +140,93 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert isinstance(provider, _HERMES_PROVIDER_CLS)
     assert provider._hermes_server_name == "srv"
 
+
+@pytest.mark.asyncio
+async def test_force_login_runs_authorization_without_401(tmp_path, monkeypatch):
+    """Explicit login must not depend on the server first returning HTTP 401."""
+    import httpx
+
+    from tools.mcp_oauth_manager import MCPOAuthManager, _ProviderEntry
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir()
+    token_file = token_dir / "srv.json"
+    sent_requests = []
+
+    class FakeStorage:
+        def _tokens_path(self):
+            return token_file
+
+    class FakeProvider:
+        _initialized = False
+
+        def __init__(self):
+            self.initialized = False
+            self.prefetched = False
+            self.authorized = False
+            self.handled_token = False
+            self.persisted = False
+            self.context = SimpleNamespace(
+                oauth_metadata=None,
+                storage=FakeStorage(),
+            )
+
+        async def _initialize(self):
+            self._initialized = True
+            self.initialized = True
+
+        async def _prefetch_oauth_metadata(self):
+            self.prefetched = True
+            self.context.oauth_metadata = object()
+
+        async def _perform_authorization(self):
+            self.authorized = True
+            return httpx.Request("POST", "https://auth.example/token")
+
+        async def _handle_token_response(self, response):
+            self.handled_token = True
+            token_file.write_text(json.dumps({
+                "access_token": "tok",
+                "status": response.status_code,
+            }))
+
+        def _persist_oauth_metadata_if_changed(self):
+            self.persisted = True
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def send(self, request):
+            sent_requests.append((request.method, str(request.url), self.timeout))
+            return httpx.Response(200, request=request)
+
+    provider = FakeProvider()
+    mgr = MCPOAuthManager()
+    mgr._entries["srv"] = _ProviderEntry(
+        server_url="https://mcp.example/mcp",
+        oauth_config={"timeout": 12},
+        provider=provider,
+    )
+    monkeypatch.setattr(mgr, "get_or_build_provider", lambda *args: provider)
+    monkeypatch.setattr("httpx.AsyncClient", FakeAsyncClient)
+
+    assert await mgr.force_login(
+        "srv",
+        "https://mcp.example/mcp",
+        {"timeout": 12},
+    )
+
+    assert provider.initialized is True
+    assert provider.prefetched is True
+    assert provider.authorized is True
+    assert provider.handled_token is True
+    assert provider.persisted is True
+    assert sent_requests == [("POST", "https://auth.example/token", 12.0)]
+    assert mgr._entries["srv"].last_mtime_ns == token_file.stat().st_mtime_ns

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -461,6 +461,61 @@ class MCPOAuthManager:
             server_name,
         )
 
+    async def force_login(
+        self,
+        server_name: str,
+        server_url: str,
+        oauth_config: Optional[dict],
+    ) -> bool:
+        """Run an explicit browser OAuth flow for ``hermes mcp login``.
+
+        The normal MCP SDK auth path starts OAuth only after an HTTP 401.
+        Some servers allow initialize/tools-list without auth, so a login
+        probe can succeed without ever obtaining a token.  This path drives
+        authorization directly for pre-registered clients.
+        """
+        provider = self.get_or_build_provider(server_name, server_url, oauth_config)
+        if provider is None:
+            return False
+
+        entry = self._entries.get(server_name)
+        if entry is None:
+            return False
+
+        async with entry.lock:
+            if not getattr(provider, "_initialized", False):
+                await provider._initialize()
+
+            prefetch = getattr(provider, "_prefetch_oauth_metadata", None)
+            if (
+                callable(prefetch)
+                and getattr(provider.context, "oauth_metadata", None) is None
+            ):
+                await prefetch()
+
+            token_request = await provider._perform_authorization()
+
+            import httpx
+
+            timeout = float((oauth_config or {}).get("timeout", 300))
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                token_response = await client.send(token_request)
+
+            await provider._handle_token_response(token_response)
+
+            persist = getattr(provider, "_persist_oauth_metadata_if_changed", None)
+            if callable(persist):
+                persist()
+
+            storage = getattr(provider.context, "storage", None)
+            tokens_path_fn = getattr(storage, "_tokens_path", None)
+            if callable(tokens_path_fn):
+                try:
+                    entry.last_mtime_ns = tokens_path_fn().stat().st_mtime_ns
+                except OSError:
+                    entry.last_mtime_ns = 0
+            return True
+
     # -- Disk watch ----------------------------------------------------------
 
     async def invalidate_if_disk_changed(self, server_name: str) -> bool:


### PR DESCRIPTION
## Summary

- Add an explicit OAuth login path for pre-registered MCP clients so `hermes mcp login` does not depend on the server first returning HTTP 401.
- Preserve the existing lazy 401-driven flow for servers without pre-registered client metadata.
- Add regression coverage for Google Drive-style MCP servers that can list tools without an auth challenge.

## Verification

- `uv run --extra dev python -m pytest tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_oauth_manager.py -o addopts=''` -> 43 passed
- `uv run ruff check hermes_cli/mcp_config.py tools/mcp_oauth_manager.py tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_oauth_manager.py` -> passed
- `git diff --check` -> passed

## Duplicate check

Searched `NousResearch/hermes-agent` PRs for `force oauth login preregistered clients` and `mcp oauth preregistered clients`; no duplicate PR was found.