### PR TITLE
fix: pad empty content on tool-call-only assistant messages for MiMo compatibility

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -854,6 +854,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         from agent.redact import redact_sensitive_text
         _san_content = redact_sensitive_text(_san_content)
 
+    # MiMo (xiaomi) API requires non-empty ``text``/``content`` on every
+    # assistant message — even those carrying only tool_calls with no
+    # natural-language body.  Without this, replay of tool-call-only
+    # assistant turns causes HTTP 400 "text is not set".  Pad with a
+    # single space so the API accepts the request while keeping the
+    # visible output identical.  (#github-pr-fix/mimo-empty-content)
+    if assistant_tool_calls and not (_san_content or "").strip():
+        _san_content = " "
+
     msg = {
         "role": "assistant",
         "content": _san_content,


### PR DESCRIPTION
## Problem

MiMo (xiaomi) API requires non-empty `text`/`content` on every assistant message. When an assistant turn carries only `tool_calls` with no natural-language body, the content field was left as an empty string, causing HTTP 400 `text is not set` on subsequent API calls that replay the conversation history.

This affects users running Hermes with MiMo v2.5 models via the xiaomi provider, especially when the agent makes multiple tool calls in sequence (e.g., image analysis, terminal commands).

## Solution

Pad the content field with a single space when there are tool_calls but no text content. This ensures the API accepts the request while keeping visible output identical.

## Reproduction

1. Configure Hermes with `provider: xiaomi` and `model: mimo-v2.5`
2. Send an image from Feishu (which triggers vision_analyze + multiple tool calls)
3. After several tool-call iterations, the API returns 400

## Testing

- Verified the fix resolves the 400 error on MiMo v2.5
- No visible change in output (space character is invisible)
- Compatible with other providers (OpenAI, Anthropic, etc.)