### PR TITLE
Fix ACP sessions ignoring configured platform toolsets

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -155,6 +155,75 @@ def _expand_acp_enabled_toolsets(
     return expanded
 
 
+def _resolve_acp_enabled_toolsets(config: dict) -> List[str]:
+    """Resolve ACP toolsets, falling back to CLI config when ACP is unset."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    configured_mcp_servers = [
+        str(name)
+        for name, cfg in (config.get("mcp_servers") or {}).items()
+        if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
+    ]
+    configured_mcp_server_set = set(configured_mcp_servers)
+
+    platform_toolsets = config.get("platform_toolsets") or {}
+    selected_platform = None
+    selected_toolsets = None
+
+    if isinstance(platform_toolsets.get("acp"), list):
+        selected_platform = "acp"
+        selected_toolsets = [str(ts) for ts in platform_toolsets["acp"]]
+        lookup_config = config
+    elif isinstance(platform_toolsets.get("cli"), list):
+        selected_platform = "cli"
+        selected_toolsets = [str(ts) for ts in platform_toolsets["cli"]]
+        lookup_config = {
+            **config,
+            "platform_toolsets": {
+                **platform_toolsets,
+                "acp": list(platform_toolsets["cli"]),
+            },
+        }
+    else:
+        lookup_config = config
+
+    resolved_toolsets = sorted(
+        _get_platform_tools(
+            lookup_config,
+            "acp",
+            include_default_mcp_servers=False,
+        )
+    )
+
+    base_toolsets = [
+        name
+        for name in resolved_toolsets
+        if name not in configured_mcp_server_set
+    ]
+
+    explicit_mcp_servers: List[str] = []
+    disable_default_mcp = False
+    if selected_platform and selected_toolsets is not None:
+        disable_default_mcp = "no_mcp" in selected_toolsets
+        for name in selected_toolsets:
+            raw_name = str(name)
+            server_name = raw_name[4:] if raw_name.startswith("mcp-") else raw_name
+            if server_name in configured_mcp_server_set and server_name not in explicit_mcp_servers:
+                explicit_mcp_servers.append(server_name)
+
+    if disable_default_mcp:
+        mcp_server_names: List[str] = []
+    elif explicit_mcp_servers:
+        mcp_server_names = explicit_mcp_servers
+    else:
+        mcp_server_names = configured_mcp_servers
+
+    return _expand_acp_enabled_toolsets(
+        base_toolsets,
+        mcp_server_names=mcp_server_names,
+    )
+
+
 def _clear_task_cwd(task_id: str) -> None:
     """Remove task-specific cwd overrides for an ACP session."""
     if not task_id:
@@ -587,18 +656,9 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
-            name
-            for name, cfg in (config.get("mcp_servers") or {}).items()
-            if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
-        ]
-
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
-            ),
+            "enabled_toolsets": _resolve_acp_enabled_toolsets(config),
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -273,7 +273,88 @@ class TestPersistence:
             manager = SessionManager(db=db)
             manager.create_session(cwd="/work")
 
-        assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-olympus", "mcp-exa"]
+        assert "mcp-olympus" in captured["enabled_toolsets"]
+        assert "mcp-exa" in captured["enabled_toolsets"]
+        assert "mcp-disabled" not in captured["enabled_toolsets"]
+
+    def test_create_session_falls_back_to_cli_platform_toolsets(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), enabled_toolsets=kwargs.get("enabled_toolsets"))
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "platform_toolsets": {"cli": ["memory", "terminal"]},
+            "mcp_servers": {
+                "olympus": {"command": "python", "enabled": True},
+                "exa": {"url": "https://exa.ai/mcp"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == [
+            "memory",
+            "terminal",
+            "mcp-olympus",
+            "mcp-exa",
+        ]
+
+    def test_create_session_cli_fallback_preserves_no_mcp(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), enabled_toolsets=kwargs.get("enabled_toolsets"))
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"},
+            "platform_toolsets": {"cli": ["memory", "no_mcp"]},
+            "mcp_servers": {
+                "olympus": {"command": "python", "enabled": True},
+                "exa": {"url": "https://exa.ai/mcp"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert captured["enabled_toolsets"] == ["memory"]
 
     def test_create_session_writes_to_db(self, manager):
         state = manager.create_session(cwd="/project")


### PR DESCRIPTION
## Summary
- respect `platform_toolsets.acp` when present and fall back to `platform_toolsets.cli` for ACP sessions
- preserve ACP MCP behavior by normalizing configured MCP server names into runtime `mcp-*` toolsets and honoring `no_mcp`
- add ACP session tests covering default MCP registration, CLI fallback, and `no_mcp`

## Testing
- pytest -o addopts='' tests/acp/test_session.py -q
- ruff check acp_adapter/session.py tests/acp/test_session.py
- git diff --check

Closes #37813