### PR TITLE
fix(feishu): align approval resolver authorization

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2819,6 +2819,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 choice=choice,
                 user_name=user_name,
                 open_id=open_id,
+                user_id=str(getattr(operator, "user_id", "") or ""),
                 chat_id=chat_id,
             ),
         ):
@@ -2898,6 +2899,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Pop approval state and unblock the waiting agent thread."""
@@ -2905,10 +2907,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if not self._allow_group_message(sender_id, expected_chat_id, is_bot=False):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
-        expected_chat_id = str(state.get("chat_id", "") or "")
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(
                 "[Feishu] Approval %s chat mismatch (expected=%s, got=%s)",

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2853,7 +2853,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        user_id = str(getattr(operator, "user_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
         if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
@@ -2877,6 +2878,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 answer,
                 user_name,
                 open_id=open_id,
+                user_id=user_id,
                 chat_id=callback_chat_id,
             ),
         ):
@@ -2955,6 +2957,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Persist an update prompt answer for the detached update process."""
@@ -2962,12 +2965,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
-        if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-                logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
-                return
         expected_chat_id = str(state.get("chat_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        if not self._allow_group_message(sender_id, expected_chat_id, is_bot=False):
+            logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id or "<unknown>", prompt_id)
+            return
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(
                 "[Feishu] Update prompt %s chat mismatch (expected=%s, got=%s)",

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -503,6 +503,43 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_passes_user_id_to_update_prompt_resolver(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._update_prompt_state[2] = {
+            "session_key": "sess-up-2",
+            "message_id": "msg-up-2",
+            "chat_id": "oc_user_id_group",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 2},
+            chat_id="oc_user_id_group",
+            open_id="ou_not_in_allowlist",
+            user_id="u_bob",
+        )
+
+        submitted = {}
+
+        def capture_submit(coro, _loop):
+            submitted["coro"] = coro
+            coro.close()
+            return True
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=capture_submit), patch.object(
+            adapter, "_resolve_update_prompt", new_callable=AsyncMock
+        ) as mock_resolve:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert "coro" in submitted
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["open_id"] == "ou_not_in_allowlist"
+        assert kwargs["user_id"] == "u_bob"
+
 
     def test_update_prompt_chat_mismatch_returns_no_card(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -547,5 +584,31 @@ class TestResolveUpdatePrompt:
 
         assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
         assert 1 not in adapter._update_prompt_state
+
+    @pytest.mark.asyncio
+    async def test_user_id_only_group_allowlist_writes_response(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
+        adapter._allowed_group_users = {"u_alice"}
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+        adapter._update_prompt_state[2] = {
+            "session_key": "sess-up-2",
+            "message_id": "msg_up_004",
+            "chat_id": "oc_user_id_group",
+        }
+
+        await adapter._resolve_update_prompt(
+            2,
+            "y",
+            "Alice",
+            open_id="ou_alice",
+            user_id="u_alice",
+            chat_id="oc_user_id_group",
+        )
+
+        assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
+        assert 2 not in adapter._update_prompt_state
 
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -58,6 +58,7 @@ def _make_card_action_data(
     action_value: dict,
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
+    user_id: str = "",
     token: str = "tok_abc",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
@@ -65,7 +66,7 @@ def _make_card_action_data(
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
-            operator=SimpleNamespace(open_id=open_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=user_id),
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
@@ -223,7 +224,9 @@ class TestResolveApproval:
     @pytest.mark.asyncio
     async def test_unauthorized_click_does_not_resolve(self):
         adapter = _make_adapter()
-        adapter._admins = {"ou_admin"}
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
+        adapter._allowed_group_users = {"ou_admin"}
         adapter._approval_state[5] = {
             "session_key": "sess-5",
             "message_id": "msg_005",
@@ -235,6 +238,65 @@ class TestResolveApproval:
 
         mock_resolve.assert_not_called()
         assert 5 in adapter._approval_state
+
+
+    @pytest.mark.asyncio
+    async def test_open_group_policy_resolves_even_when_allowed_users_is_for_dm_admission(self):
+        adapter = _make_adapter()
+        adapter._group_policy = "open"
+        adapter._allowed_group_users = {"ou_someone_else"}
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg_007",
+            "chat_id": "oc_open_group",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(7, "always", "Bob", open_id="ou_bob", chat_id="oc_open_group")
+
+        mock_resolve.assert_called_once_with("sess-7", "always")
+        assert 7 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_user_id_only_group_allowlist_resolves_approval(self):
+        adapter = _make_adapter()
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._approval_state[8] = {
+            "session_key": "sess-8",
+            "message_id": "msg_008",
+            "chat_id": "oc_user_id_group",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(
+                8,
+                "always",
+                "Bob",
+                open_id="ou_bob",
+                user_id="u_bob",
+                chat_id="oc_user_id_group",
+            )
+
+        mock_resolve.assert_called_once_with("sess-8", "always")
+        assert 8 not in adapter._approval_state
+
+
+    @pytest.mark.asyncio
+    async def test_chat_mismatch_does_not_resolve(self):
+        adapter = _make_adapter()
+        adapter._approval_state[6] = {
+            "session_key": "sess-6",
+            "message_id": "msg_006",
+            "chat_id": "oc_expected",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._resolve_approval(6, "session", "Norbert", open_id="ou_user1", chat_id="oc_wrong")
+
+        mock_resolve.assert_not_called()
+        assert 6 in adapter._approval_state
 
 
 # ===========================================================================
@@ -333,6 +395,42 @@ class TestCardActionCallbackResponse:
         assert "Bob" in card["elements"][0]["content"]
 
 
+
+    def test_passes_user_id_to_approval_resolver(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"u_bob"}
+        adapter._approval_state[3] = {
+            "session_key": "sess-3",
+            "message_id": "msg-3",
+            "chat_id": "oc_user_id_group",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 3},
+            chat_id="oc_user_id_group",
+            open_id="ou_not_in_allowlist",
+            user_id="u_bob",
+        )
+
+        submitted = {}
+
+        def capture_submit(coro, _loop):
+            submitted["coro"] = coro
+            coro.close()
+            return True
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=capture_submit), patch.object(
+            adapter, "_resolve_approval", new_callable=AsyncMock
+        ) as mock_resolve:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert "coro" in submitted
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["open_id"] == "ou_not_in_allowlist"
+        assert kwargs["user_id"] == "u_bob"
+
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()
@@ -360,6 +458,8 @@ class TestCardActionCallbackResponse:
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
         adapter._allowed_group_users = {"ou_allowed"}
         adapter._approval_state[5] = {
             "session_key": "sess-5",
@@ -383,6 +483,8 @@ class TestCardActionCallbackResponse:
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._group_policy = "allowlist"
+        adapter._default_group_policy = "allowlist"
         adapter._update_prompt_state[1] = {
             "session_key": "sess-up-1",
             "message_id": "msg_up_006",


### PR DESCRIPTION
## What does this PR do?

Fixes a Feishu/Lark card-approval mismatch where the card callback could accept an operator and update the UI, but the asynchronous resolver reconstructed incomplete identity data and left the backend request blocked.

Both gated card flows now carry the same identity inputs through callback and resolver:

- execution approvals: `_handle_approval_card_action()` → `_resolve_approval()`
- update prompts: `_handle_update_prompt_card_action()` → `_resolve_update_prompt()`

Each path preserves both `operator.open_id` and `operator.user_id`, then applies `_allow_group_message()` with the originating chat. This is important for `u_*`-only global or per-chat allowlists, where dropping `user_id` makes the inline callback and asynchronous resolver disagree.

## Related Issue

No public issue filed. Reproduced while debugging a live Feishu approval flow where the card was clicked but the pending tool request timed out.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - Thread `operator.user_id` alongside `open_id` through approval resolution.
  - Apply the same identity propagation to update-prompt resolution.
  - Align resolver authorization with the group-policy-aware callback decision.
- `tests/gateway/test_feishu_approval_buttons.py`
  - Cover `u_*`-only allowlists.
  - Assert callback-to-resolver propagation for both approval and update-prompt flows.
  - Preserve unauthorized and chat-mismatch rejection coverage.

## How to Test

```bash
HERMES_HOME=$(mktemp -d) /home/ubuntu/.hermes/bin/uv run \
  --extra feishu --with pytest --with pytest-asyncio \
  python -m pytest tests/gateway/test_feishu_approval_buttons.py \
  -q -o 'addopts='
```

Result on current `origin/main` (`4f675cf2f`):

```text
19 passed
```

Also verified:

```text
git diff --check
# clean
```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] My PR contains only changes related to this fix.
- [x] I've added regression tests for both gated card flows.
- [x] I've tested on Ubuntu/Linux with Feishu enabled.
- [ ] I've run the complete repository test suite.

### Documentation & Housekeeping

- [x] No user-facing config keys or schemas changed.
- [x] Cross-platform impact considered; the change is limited to Feishu callback identity propagation.

## Screenshots / Logs

Latest refreshed head: `fdf23ffef`.
