### PR TITLE
fix: normalize Discord message prefix

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -573,6 +573,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # Discord message limits
     MAX_MESSAGE_LENGTH = 2000
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
+    _LEADING_INVISIBLE_MESSAGE_CHARS = "\ufeff\u200b\u200c\u200e\u200f"
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
@@ -2910,8 +2911,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Discord uses its own markdown variant.
         """
-        # Discord markdown is fairly standard, no special escaping needed
-        return content
+        return content.lstrip(self._LEADING_INVISIBLE_MESSAGE_CHARS)
 
     async def _run_simple_slash(
         self,

--- a/tests/gateway/test_discord_format_message.py
+++ b/tests/gateway/test_discord_format_message.py
@@ -1,0 +1,23 @@
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _adapter() -> DiscordAdapter:
+    return object.__new__(DiscordAdapter)
+
+
+def test_format_message_strips_leading_invisible_unicode():
+    adapter = _adapter()
+
+    assert adapter.format_message("\ufeff\u200b\u200c\u200e\u200fHello") == "Hello"
+
+
+def test_format_message_preserves_invisible_unicode_after_start():
+    adapter = _adapter()
+
+    assert adapter.format_message("A\ufeffB\u200bC") == "A\ufeffB\u200bC"
+
+
+def test_format_message_leaves_regular_content_unchanged():
+    adapter = _adapter()
+
+    assert adapter.format_message("Hello **Discord**") == "Hello **Discord**"


### PR DESCRIPTION
## Summary

Normalizes Discord message content by removing leading invisible Unicode characters before formatting and sending the message.

This was observed with `moonshotai/kimi-k2.6:free` via OpenRouter: responses could appear on Discord with the first visible characters clipped when the model output started with invisible Unicode characters such as a BOM or zero-width mark.

## Root Cause

`DiscordAdapter.format_message()` currently returns content unchanged. If a provider response starts with invisible format-control characters, those characters are passed directly to Discord. Discord rendering can then make the message appear as if the first visible characters were missing.

## Fix

Strip only leading invisible characters before sending Discord messages:

- U+FEFF byte order mark / zero-width no-break space
- U+200B zero-width space
- U+200C zero-width non-joiner
- U+200E left-to-right mark
- U+200F right-to-left mark

Invisible characters later in the message are preserved.

## Related Context

Hermes already handles invisible Unicode in other gateway/runtime contexts, for example command parsing, Telegram output sanitization, and cron prompt sanitization. This applies the same class of normalization to Discord outbound message formatting.

## Testing

```bash
python3 -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_format_message.py
python3 -m pytest tests/gateway/test_discord_format_message.py -q -o 'addopts='
```

Added regression coverage for:

- stripping leading invisible Unicode characters
- preserving invisible Unicode characters after the start of the message
- leaving regular Discord markdown content unchanged
