### PR TITLE
fix(agent): add MiniMax 'new_sensitive' to content_policy_blocked patterns

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -327,6 +327,14 @@ _CONTENT_POLICY_BLOCKED_PATTERNS = [
     # echo back; the underscore form is provider-specific enough.
     "content_filter",
     "responsibleaipolicyviolation",
+    # MiniMax output-layer safety filter. The error string is surfaced
+    # verbatim by MiniMax SDK / OpenAI-compatible endpoints, usually in the
+    # form "output new_sensitive (1027)" when the model's *output* (often a
+    # large tool-call argument block) trips the upstream safety filter and
+    # the SSE stream is truncated mid-flight. ``new_sensitive`` is the
+    # filter name and is narrow enough that billing / format / auth error
+    # strings will not collide. See #32421.
+    "new_sensitive",
 ]
 
 # Auth patterns (non-status-code signals)

--- a/tests/run_agent/test_18028_content_policy_blocked.py
+++ b/tests/run_agent/test_18028_content_policy_blocked.py
@@ -41,6 +41,27 @@ class TestContentPolicyBlockedClassification:
         assert result.should_compress is False
         assert result.should_rotate_credential is False
 
+    def test_minimax_output_safety_filter(self):
+        """#32421 — MiniMax output-layer safety filter (e.g. ``output
+        new_sensitive (1027)``) trips mid-stream when the model emits a
+        large tool-call argument block. Must classify as
+        ``content_policy_blocked`` so the loop aborts the 3x retry burn and
+        routes to a configured fallback model.
+        """
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        e = Exception(
+            "Stream stalled mid tool-call: output new_sensitive (1027) "
+            "[MiniMax-M2.7] — request was rejected by upstream safety "
+            "filter, see provider response for details."
+        )
+        result = classify_api_error(e, provider="MiniMax", model="MiniMax-M2.7")
+        assert result.reason == FailoverReason.content_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.should_compress is False
+        assert result.should_rotate_credential is False
+
 
 class TestContentPolicyTriggersClientErrorAbort:
     """Mirror the ``is_client_error`` predicate in


### PR DESCRIPTION
## Summary

Adds the MiniMax output-layer safety filter (`new_sensitive`) to the
`_CONTENT_POLICY_BLOCKED_PATTERNS` list, so that stream-stalling
refusals (e.g. `output new_sensitive (1027)`) trigger immediate
provider fallback instead of being retried 3x on the same model.

## Motivation

The MiniMax output-layer safety filter trips when the model emits a
large tool-call argument block, truncating the SSE stream mid-flight
and surfacing as `Stream stalled mid tool-call: output new_sensitive
(1027)`. The current implementation classifies this as a generic
`unknown` error, retries it 3 times on the same provider, and burns
paid attempts reproducing the same refusal. A configured
`fallback_model` is never reached.

Reported in #32421.

## Changes

- `agent/error_classifier.py` — add `new_sensitive` to
  `_CONTENT_POLICY_BLOCKED_PATTERNS` (with comment explaining the
  filter name and the verbatim error format)
- `tests/run_agent/test_18028_content_policy_blocked.py` — add
  `test_minimax_output_safety_filter` regression test

## Test

- All 6 tests in `test_18028_content_policy_blocked.py` pass
- New test confirms MiniMax errors classify as
  `FailoverReason.content_policy_blocked` with
  `retryable=False`, `should_fallback=True`

## Compatibility

- Pattern is intentionally narrow (`new_sensitive` is the specific
  filter name, not generic "policy"/"violation" wording) so it
  cannot collide with billing / format / auth errors.
- No new dependencies. No config schema change.
- No breaking changes to the public classifier API.

Refs #32421
