### PR TITLE
[codex] Append Feishu message id to user context

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3097,6 +3097,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text,
@@ -3170,6 +3171,8 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+            if existing.source is not None:
+                existing.source.message_id = event.message_id
         self._schedule_media_batch_flush(key)
 
     def _schedule_media_batch_flush(self, key: str) -> None:
@@ -3472,6 +3475,8 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+            if existing.source is not None:
+                existing.source.message_id = event.message_id
         self._pending_text_batch_counts[key] = next_count
         self._schedule_text_batch_flush(key)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -140,6 +140,29 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+def _append_platform_message_id_context(
+    text: str,
+    *,
+    platform: Any,
+    message_id: Any,
+) -> str:
+    """Append current platform message metadata to the user turn.
+
+    This intentionally modifies the current user message rather than the
+    system/session prompt so per-message IDs do not bust the prompt cache.
+    """
+    if _gateway_platform_value(platform) != "feishu":
+        return text
+    normalized = re.sub(r"\s+", " ", str(message_id or "").strip())
+    if not normalized:
+        return text
+    footer = f"[Feishu message_id: {normalized}]"
+    body = str(text or "").rstrip()
+    if body.endswith(footer):
+        return body
+    return f"{body}\n\n{footer}" if body else footer
+
+
 def _is_transient_network_error(exc: BaseException) -> bool:
     """Return True for transient network errors safe to log + swallow.
 
@@ -8685,6 +8708,11 @@ class GatewayRunner:
             except Exception as exc:
                 logger.debug("@ context reference expansion failed: %s", exc)
 
+        message_text = _append_platform_message_id_context(
+            message_text,
+            platform=source.platform,
+            message_id=event.message_id or source.message_id,
+        )
         return message_text
 
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1653,6 +1653,8 @@ class TestAdapterBehavior(unittest.TestCase):
         event = adapter.handle_message.await_args.args[0]
         self.assertEqual(event.text, "A\nB")
         self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertEqual(event.message_id, "om_2")
+        self.assertEqual(event.source.message_id, "om_2")
 
     @patch.dict(
         os.environ,
@@ -1756,6 +1758,8 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.await_args.args[0]
         self.assertEqual(event.media_urls, ["/tmp/a.png", "/tmp/b.png"])
+        self.assertEqual(event.message_id, "om_p2")
+        self.assertEqual(event.source.message_id, "om_p2")
         self.assertIn("第一张", event.text)
         self.assertIn("第二张", event.text)
 

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -36,6 +36,16 @@ def _source() -> SessionSource:
     )
 
 
+def _feishu_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_123",
+        chat_name="Feishu DM",
+        chat_type="dm",
+        user_name="Alice",
+    )
+
+
 @pytest.mark.asyncio
 async def test_reply_prefix_injected_when_text_absent_from_history():
     runner = _make_runner()
@@ -157,3 +167,56 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+@pytest.mark.asyncio
+async def test_feishu_message_id_appended_to_user_turn_tail():
+    runner = _make_runner()
+    source = _feishu_source()
+    event = MessageEvent(text="hello", source=source, message_id="om_123")
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "hello\n\n[Feishu message_id: om_123]"
+
+
+@pytest.mark.asyncio
+async def test_feishu_message_id_footer_stays_after_reply_context():
+    runner = _make_runner()
+    source = _feishu_source()
+    event = MessageEvent(
+        text="follow-up",
+        source=source,
+        message_id="om_reply",
+        reply_to_message_id="om_parent",
+        reply_to_text="parent message",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith('[Replying to: "parent message"]')
+    assert result.endswith("[Feishu message_id: om_reply]")
+
+
+@pytest.mark.asyncio
+async def test_non_feishu_message_id_not_appended():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(text="hello", source=source, message_id="telegram-1")
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "hello"


### PR DESCRIPTION
## What changed

- Appends the current Feishu `message_id` to the end of the user turn as `[Feishu message_id: ...]`.
- Keeps the ID out of the system/session prompt so per-message IDs do not break prompt-cache reuse.
- Stores Feishu inbound `message_id` on `SessionSource` and keeps text/media batch source IDs aligned with the latest merged event.

## Why

Feishu turns exposed the message ID to gateway routing/reply logic, but the model did not reliably see the triggering message ID in the user-visible context. This makes message-targeted follow-up work harder from IM.

## Validation

- `python3 -m py_compile gateway/run.py gateway/platforms/feishu.py`
- `./scripts/run_tests.sh tests/gateway/test_reply_to_injection.py tests/gateway/test_feishu.py` did not run because the local `.venv` is missing `pytest`.
