### PR TITLE
fix(profiles): normalize name returned by get_active_profile()

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1190,14 +1190,27 @@ def get_active_profile() -> str:
     """Read the sticky active profile name.
 
     Returns ``"default"`` if no active_profile file exists or it's empty.
+
+    The on-disk ``~/.hermes/active_profile`` file is user-visible and may be
+    hand-edited (or carried over from an older release that stored display
+    labels), so the raw contents are normalized to the canonical id before
+    returning. This keeps the result consistent with what
+    :func:`set_active_profile` writes and with the ``canon`` values that
+    delete/rename cleanup paths compare against; a stray ``Coder`` or
+    ``" my-profile "`` would otherwise dodge those equality checks and leave a
+    dangling active pointer.
     """
     path = _get_active_profile_path()
     try:
         name = path.read_text().strip()
         if not name:
             return "default"
-        return name
+        return normalize_profile_name(name)
     except (FileNotFoundError, UnicodeDecodeError, OSError):
+        return "default"
+    except ValueError:
+        # normalize_profile_name rejects a blank/whitespace-only name; treat a
+        # corrupt active_profile file as "no active profile" rather than raising.
         return "default"
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -513,6 +513,55 @@ class TestActiveProfile:
         with pytest.raises(FileNotFoundError):
             set_active_profile("nonexistent")
 
+    def test_manually_edited_mixed_case_is_normalized(self, profile_env):
+        """A hand-edited active_profile with mixed case resolves to canonical id.
+
+        ``set_active_profile`` always normalizes before writing, but the file is
+        user-visible at ``~/.hermes/active_profile`` and may be edited by hand or
+        carried over from an older release that stored display labels. The reader
+        must return the canonical on-disk id so callers (delete/rename cleanup,
+        path resolution) compare against the same value ``normalize_profile_name``
+        produces.
+        """
+        tmp_path = profile_env
+        active_path = tmp_path / ".hermes" / "active_profile"
+        active_path.write_text("Coder\n")
+        assert get_active_profile() == "coder"
+        assert get_active_profile() == normalize_profile_name("Coder")
+
+    def test_manually_edited_surrounding_whitespace_is_normalized(self, profile_env):
+        """Leading/trailing whitespace around a name is stripped and lowered."""
+        tmp_path = profile_env
+        active_path = tmp_path / ".hermes" / "active_profile"
+        active_path.write_text("  MyProfile  \n")
+        assert get_active_profile() == "myprofile"
+
+    def test_default_alias_is_case_folded(self, profile_env):
+        """A hand-written ``Default`` alias folds to the special ``default`` id."""
+        tmp_path = profile_env
+        active_path = tmp_path / ".hermes" / "active_profile"
+        active_path.write_text("Default\n")
+        assert get_active_profile() == "default"
+
+    def test_delete_clears_active_pointer_for_legacy_mixed_case(self, profile_env):
+        """Deleting a profile clears a non-canonical active_profile pointer.
+
+        Regression: the cleanup in ``delete_profile`` compares the reader's
+        result against the normalized ``canon``. If the reader returned the raw
+        ``Coder`` text, the comparison ``"Coder" == "coder"`` would fail and the
+        active pointer would survive, dangling at a now-deleted profile.
+        """
+        tmp_path = profile_env
+        create_profile("coder", no_alias=True)
+        active_path = tmp_path / ".hermes" / "active_profile"
+        active_path.write_text("Coder\n")  # legacy / hand-edited, non-canonical
+
+        delete_profile("coder", yes=True)
+
+        # Pointer must have been reset to default (file removed).
+        assert not active_path.exists()
+        assert get_active_profile() == "default"
+
 
 # ===================================================================
 # TestGetActiveProfileName


### PR DESCRIPTION
## Summary

`get_active_profile()` returned the raw contents of the user-visible `~/.hermes/active_profile` file without normalizing. The file can be hand-edited or carried over from older releases storing mixed-case display labels.

When the stored name was non-canonical (e.g. `"Coder"` or `"  my-profile  "`), the delete and rename cleanup paths compared the reader's result against a normalized `canon`/`old_canon`. The equality check failed (`"Coder" == "coder"` → False), causing cleanup to silently skip resetting the sticky pointer—leaving `active_profile` dangling at a profile that had just been deleted or renamed.

## Changes

- Normalize the value through `normalize_profile_name()` on read so the result is consistent with what `set_active_profile()` writes and the canonical ids that cleanup paths compare against.
- A corrupt/blank value falls back to `"default"` instead of raising (ValueError guard).
- Add regression tests covering mixed-case, surrounding whitespace, the `"Default"` alias fold, and the delete-cleanup pointer reset (must-fire impact boundary).

## Verification

All 4 new regression tests in `TestActiveProfile` would fail on unmodified `main`:
- `test_manually_edited_mixed_case_is_normalized`: "Coder\n" → "coder"
- `test_manually_edited_surrounding_whitespace_is_normalized`: "  MyProfile  \n" → "myprofile"  
- `test_default_alias_is_case_folded`: "Default\n" → "default"
- `test_delete_clears_active_pointer_for_legacy_mixed_case`: Delete-cleanup pointer reset (critical boundary case)
