### PR TITLE
fix(approval): anchor dangerous-command patterns to command position to avoid echo/grep false positives

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2370,3 +2370,72 @@ class TestApprovalPromptRedaction:
         # The script's credential must not appear in the user-facing message.
         assert "sk-proj-abc123xyz4567890abcdef" not in result["message"]
         assert "sk-proj-abc123xyz4567890abcdef" not in result["command"]
+
+
+class TestCommandPositionAnchoring:
+    """Regression: command-leading destructive patterns (rm/chmod/chown/mkfs/dd)
+    must anchor to a command-start position so they don't false-positive when
+    the command name appears as plain text inside echo/grep/cat/heredoc.
+
+    HARDLINE_PATTERNS already anchor shutdown/reboot via ``_CMDPOS`` to avoid
+    matching "echo reboot" / "grep 'shutdown' log"; DANGEROUS_PATTERNS must get
+    the same protection for their command-leading entries. This guards both
+    directions: real danger still fires, non-execution mentions do not.
+    """
+
+    # ---- must NOT fire: command name is plain text, not an executed command ----
+    NON_EXECUTION_SAFE = [
+        # echo / print of a literal command (e.g. agent narrating an example)
+        "echo rm -rf /",
+        'echo "to delete a directory: rm -rf /some/path"',
+        "echo 'run chmod 777 file to fix perms'",
+        "echo dd if=/dev/sda of=backup.img",
+        "echo 'use mkfs.ext4 to format the disk'",
+        "echo chown -R root /opt",
+        # grep / search where the dangerous string is the search term or in data
+        'grep "rm -rf /" deploy.log',
+        'grep -r "chmod 777" .',
+        'grep -n "mkfs" install_notes.txt',
+        # cat / piping log content that mentions the command
+        "cat history.txt | grep 'rm -rf'",
+    ]
+
+    # ---- must STILL fire: real execution contexts ----
+    REAL_DANGER_FIRES = [
+        # plain command at start of line
+        "rm -rf /",
+        "rm -rf /home/user",
+        "chmod 777 /etc/passwd",
+        "chown -R root /opt",
+        "mkfs.ext4 /dev/sdb",
+        "dd if=/dev/zero of=/dev/sda",
+        # privilege / wrapper prefixes consumed by _CMDPOS
+        "sudo rm -rf /var",
+        "nohup rm -rf / &",
+        # after command separators (a real second command in the chain)
+        "cd /tmp; rm -rf /tmp/build",
+        "make clean && rm -rf /var/cache/app",
+        "false || rm -rf /opt/stale",
+        # after a pipe / inside a subshell (still executed)
+        "find . | rm -rf /tmp/x",
+        "$(rm -rf /tmp/x)",
+        # multiline continuation (DOTALL bypass guard) still caught
+        "dd \\\nif=/dev/sda of=/tmp/disk.img",
+        "chmod --recursive \\\n777 /var",
+    ]
+
+    def test_non_execution_mentions_do_not_false_positive(self):
+        for cmd in self.NON_EXECUTION_SAFE:
+            is_dangerous, _key, desc = detect_dangerous_command(cmd)
+            assert is_dangerous is False, (
+                f"false positive: {cmd!r} flagged dangerous as {desc!r}; the "
+                "command name is plain text, not an executed command"
+            )
+
+    def test_real_danger_still_fires(self):
+        for cmd in self.REAL_DANGER_FIRES:
+            is_dangerous, key, desc = detect_dangerous_command(cmd)
+            assert is_dangerous is True, (
+                f"missed real danger: {cmd!r} was not flagged dangerous"
+            )
+            assert key is not None and isinstance(desc, str) and desc

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -545,9 +545,15 @@ def _sudo_stdin_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
-    (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
-    (r'\brm\s+-[^\s]*r', "recursive delete"),
-    (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
+    # Command-leading destructive operations are anchored to a command-start
+    # position via _CMDPOS (start of line, after ; && || | newline, inside a
+    # subshell, or after a sudo/env/exec wrapper). Without the anchor, the bare
+    # \b<cmd> word boundary matches the command name anywhere in the string, so
+    # non-execution mentions like `echo rm -rf /`, `grep "chmod 777" .`, or a
+    # heredoc that quotes the command would false-positive.
+    (_CMDPOS + r'rm\s+(-[^\s]*\s+)*/', "delete in root path"),
+    (_CMDPOS + r'rm\s+-[^\s]*r', "recursive delete"),
+    (_CMDPOS + r'rm\s+--recursive\b', "recursive delete (long flag)"),
     # Windows shell front-ends have destructive built-ins that do not look like
     # Unix `rm`. Gate only when they are executed through cmd/powershell so
     # ordinary prose or filenames containing "del"/"rd" do not trip the guard.
@@ -560,12 +566,12 @@ DANGEROUS_PATTERNS = [
     # "del"/"rm" (e.g. `-File c:\del-logs\run.ps1`) is not.
     (r'\b(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+(?:-(?:command|c)\s+)?["\']?(?:remove-item|rmdir|erase|del|rd|ri|rm)\b', "Windows PowerShell destructive delete"),
     (r'\b(?:powershell|pwsh)(?:\.exe)?\b.*\s-(?:encodedcommand|enc|e)\b', "PowerShell encoded command execution"),
-    (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
-    (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
-    (r'\bchown\s+(-[^\s]*)?R\s+root', "recursive chown to root"),
-    (r'\bchown\s+--recur[a-z]*\b.*root', "recursive chown to root (long flag)"),
-    (r'\bmkfs\b', "format filesystem"),
-    (r'\bdd\s+.*if=', "disk copy"),
+    (_CMDPOS + r'chmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
+    (_CMDPOS + r'chmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
+    (_CMDPOS + r'chown\s+(-[^\s]*)?R\s+root', "recursive chown to root"),
+    (_CMDPOS + r'chown\s+--recur[a-z]*\b.*root', "recursive chown to root (long flag)"),
+    (_CMDPOS + r'mkfs\b', "format filesystem"),
+    (_CMDPOS + r'dd\s+.*if=', "disk copy"),
     (r'>\s*/dev/sd', "write to block device"),
     (r'\bDROP\s+(TABLE|DATABASE)\b', "SQL DROP"),
     # Use [^\n]* instead of .* so DOTALL mode does not cause a WHERE clause on the


### PR DESCRIPTION
## Summary

`detect_dangerous_command()` matched command-leading destructive patterns (rm, chmod, chown, mkfs, dd) with a bare `\b<cmd>` word boundary, so the command name was flagged anywhere in the string. Non-execution mentions such as `echo rm -rf /`, `grep "chmod 777" .`, or a heredoc that quotes the command were reported as dangerous even though nothing was executed.

`HARDLINE_PATTERNS` already anchors shutdown/reboot to a command-start position via `_CMDPOS` (start of line, after `;`, `&&`, `||`, `|`, newline, inside a subshell, or after a sudo/env/exec wrapper) precisely to avoid "echo reboot" / "grep 'shutdown' log" false positives. This PR applies the same `_CMDPOS` anchor to the command-leading entries in `DANGEROUS_PATTERNS`.

Real danger still fires: line start, after a separator or pipe, inside a subshell, sudo/nohup-wrapped, and multiline continuations remain caught.

## Test Plan

- [x] Added `TestCommandPositionAnchoring` regression class with two test methods:
  - `test_non_execution_mentions_do_not_false_positive()`: 10 cases (echo/grep/cat of literal commands) — all pass
  - `test_real_danger_still_fires()`: 15 cases (line start, separators, pipes, subshells, multiline) — all pass
- [x] Verified all 299 existing tests in test_approval.py still pass (was 297 baseline; +2 new)
- [x] HARDLINE_PATTERNS baseline (100 tests for shutdown/reboot floor) unchanged and passing
- [x] Consumer tests (test_yolo_mode, test_cron_approval_mode, test_cli_approval_ui, test_session_boundary_security_state): 59 passed
