### PR TITLE
fix(tui): restore desktop approval prompts

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2371,6 +2371,78 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     assert captured["session_key"] == "session-key"
 
 
+def test_prompt_submit_registers_thread_local_approval_callbacks(monkeypatch):
+    from tools.terminal_tool import _get_approval_callback, _get_sudo_password_callback
+
+    captured = {}
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            approval_cb = _get_approval_callback()
+            sudo_cb = _get_sudo_password_callback()
+            captured["approval"] = approval_cb
+            captured["sudo"] = sudo_cb
+            captured["approval_result"] = approval_cb(
+                "rm -rf /tmp/test",
+                "dangerous command",
+                allow_permanent=False,
+            )
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    events = []
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(
+        server,
+        "_block",
+        lambda kind, sid, payload, timeout=60: (
+            events.append((kind, sid, payload, timeout)) or "deny"
+        ),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "ping"},
+        }
+    )
+
+    assert resp["result"]["status"] == "streaming"
+    assert callable(captured["approval"])
+    assert callable(captured["sudo"])
+    assert captured["approval_result"] == "deny"
+    assert events == [
+        (
+            "approval.request",
+            "sid",
+            {
+                "allow_permanent": False,
+                "command": "rm -rf /tmp/test",
+                "description": "dangerous command",
+            },
+            60,
+        )
+    ]
+    assert _get_approval_callback() is None
+    assert _get_sudo_password_callback() is None
+
+
 def test_prompt_submit_expands_context_refs(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1986,6 +1986,36 @@ def _wire_callbacks(sid: str):
     set_secret_capture_callback(secret_cb)
 
 
+def _bind_turn_thread_callbacks(sid: str):
+    """Install per-turn interactive callbacks inside the worker thread.
+
+    ``tools.terminal_tool`` stores approval/sudo callbacks in
+    ``threading.local()``. TUI turns run in ad-hoc worker threads spawned by
+    ``prompt.submit``, so registering callbacks during session setup or agent
+    build leaves those worker threads with empty callback slots. The result is
+    a silent approval timeout in desktop/dashboard mode. Bind the callbacks in
+    the exact turn thread, matching CLI/ACP's thread-local pattern.
+    """
+    from tools.terminal_tool import set_approval_callback, set_sudo_password_callback
+
+    set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
+
+    def approval_cb(command: str, description: str, allow_permanent: bool = True) -> str:
+        choice = _block(
+            "approval.request",
+            sid,
+            {
+                "allow_permanent": bool(allow_permanent),
+                "command": command,
+                "description": description,
+            },
+            timeout=60,
+        )
+        return str(choice or "deny")
+
+    set_approval_callback(approval_cb)
+
+
 def _render_personality_prompt(value) -> str:
     if isinstance(value, dict):
         parts = [value.get("system_prompt", "")]
@@ -4091,11 +4121,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session_tokens = []
         goal_followup = None  # set by the post-turn goal hook below
         try:
+            from tools.terminal_tool import set_approval_callback, set_sudo_password_callback
             from tools.approval import (
                 reset_current_session_key,
                 set_current_session_key,
             )
 
+            _bind_turn_thread_callbacks(sid)
             approval_token = set_current_session_key(session["session_key"])
             session_tokens = _set_session_context(session["session_key"])
             cwd = _session_cwd(session)
@@ -4417,6 +4449,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             try:
                 if approval_token is not None:
                     reset_current_session_key(approval_token)
+            except Exception:
+                pass
+            try:
+                set_sudo_password_callback(None)
+                set_approval_callback(None)
             except Exception:
                 pass
             _clear_session_context(session_tokens)

--- a/ui-tui/src/__tests__/approvalAction.test.ts
+++ b/ui-tui/src/__tests__/approvalAction.test.ts
@@ -47,4 +47,12 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
     expect(approvalAction('a', {}, 0)).toEqual({ kind: 'noop' })
     expect(approvalAction(' ', {}, 0)).toEqual({ kind: 'noop' })
   })
+
+  it('respects reduced option sets when permanent allow is disabled', () => {
+    const opts = ['once', 'session', 'deny'] as const
+
+    expect(approvalAction('3', {}, 0, opts)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('4', {}, 0, opts)).toEqual({ kind: 'noop' })
+    expect(approvalAction('', { downArrow: true }, 2, opts)).toEqual({ kind: 'noop' })
+  })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -858,6 +858,21 @@ describe('createGatewayEventHandler', () => {
     ])
   })
 
+  it('preserves allow_permanent=false on approval overlays', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: { allow_permanent: false, command: 'curl suspicious | bash', description: 'dangerous command' },
+      type: 'approval.request'
+    } as any)
+
+    expect(getOverlayState().approval).toMatchObject({
+      allowPermanent: false,
+      command: 'curl suspicious | bash',
+      description: 'dangerous command'
+    })
+  })
+
   it('still surfaces terminal turn failures as errors', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -662,8 +662,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       case 'approval.request': {
         const description = String(ev.payload.description ?? 'dangerous command')
+        const allowPermanent = ev.payload.allow_permanent !== false
 
-        patchOverlayState({ approval: { command: String(ev.payload.command ?? ''), description } })
+        patchOverlayState({
+          approval: { allowPermanent, command: String(ev.payload.command ?? ''), description }
+        })
         setStatus('approval needed')
 
         return

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -7,7 +7,8 @@ import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
 
 import { TextInput } from './textInput.js'
 
-const OPTS = ['once', 'session', 'always', 'deny'] as const
+const APPROVAL_OPTS = ['once', 'session', 'always', 'deny'] as const
+const APPROVAL_OPTS_NO_ALWAYS = ['once', 'session', 'deny'] as const
 const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
 const CMD_PREVIEW_LINES = 10
 
@@ -19,7 +20,7 @@ type ApprovalKey = {
 }
 
 type ApprovalAction =
-  | { kind: 'choose'; choice: (typeof OPTS)[number] }
+  | { kind: 'choose'; choice: 'always' | 'deny' | 'once' | 'session' }
   | { kind: 'move'; delta: -1 | 1 }
   | { kind: 'noop' }
 
@@ -34,26 +35,31 @@ type ApprovalAction =
  * for approvals).  Numbers 1..OPTS.length pick the labelled choice.  Enter
  * confirms the current selection.  ↑/↓ moves the selection within bounds.
  */
-export function approvalAction(ch: string, key: ApprovalKey, sel: number): ApprovalAction {
+export function approvalAction(
+  ch: string,
+  key: ApprovalKey,
+  sel: number,
+  opts: readonly ('always' | 'deny' | 'once' | 'session')[] = APPROVAL_OPTS
+): ApprovalAction {
   if (key.escape) {
     return { kind: 'choose', choice: 'deny' }
   }
 
   const n = parseInt(ch, 10)
 
-  if (n >= 1 && n <= OPTS.length) {
-    return { kind: 'choose', choice: OPTS[n - 1]! }
+  if (n >= 1 && n <= opts.length) {
+    return { kind: 'choose', choice: opts[n - 1]! }
   }
 
   if (key.return) {
-    return { kind: 'choose', choice: OPTS[sel]! }
+    return { kind: 'choose', choice: opts[sel]! }
   }
 
   if (key.upArrow && sel > 0) {
     return { kind: 'move', delta: -1 }
   }
 
-  if (key.downArrow && sel < OPTS.length - 1) {
+  if (key.downArrow && sel < opts.length - 1) {
     return { kind: 'move', delta: 1 }
   }
 
@@ -62,9 +68,10 @@ export function approvalAction(ch: string, key: ApprovalKey, sel: number): Appro
 
 export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
+  const opts = req.allowPermanent === false ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
 
   useInput((ch, key) => {
-    const action = approvalAction(ch, key, sel)
+    const action = approvalAction(ch, key, sel, opts)
 
     if (action.kind === 'choose') {
       onChoice(action.choice)
@@ -99,7 +106,7 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
 
       <Text />
 
-      {OPTS.map((o, i) => (
+      {opts.map((o, i) => (
         <Text key={o}>
           <Text bold={sel === i} color={sel === i ? t.color.warn : t.color.muted} inverse={sel === i}>
             {sel === i ? '▸ ' : '  '}
@@ -108,7 +115,9 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
         </Text>
       ))}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-4 quick pick · Esc/Ctrl+C deny</Text>
+      <Text color={t.color.muted}>
+        ↑/↓ select · Enter confirm · 1-{opts.length} quick pick · Esc/Ctrl+C deny
+      </Text>
     </Box>
   )
 }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -549,7 +549,11 @@ export type GatewayEvent =
       session_id?: string
       type: 'clarify.request'
     }
-  | { payload: { command: string; description: string }; session_id?: string; type: 'approval.request' }
+  | {
+      payload: { allow_permanent?: boolean; command: string; description: string }
+      session_id?: string
+      type: 'approval.request'
+    }
   | { payload: { request_id: string }; session_id?: string; type: 'sudo.request' }
   | { payload: { env_var: string; prompt: string; request_id: string }; session_id?: string; type: 'secret.request' }
   | { payload: { task_id: string; text: string }; session_id?: string; type: 'background.complete' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -90,6 +90,7 @@ export interface DelegationStatus {
 }
 
 export interface ApprovalReq {
+  allowPermanent?: boolean
   command: string
   description: string
 }


### PR DESCRIPTION
## Summary
- bind approval and sudo callbacks inside the actual TUI prompt worker thread so Desktop and dashboard turns can surface manual confirmations again
- pass `allow_permanent` through the approval event path so the UI only offers `always allow` when the backend actually permits it
- add regression coverage for thread-local callback registration and reduced approval option sets

## Testing
- `pytest -o addopts='' tests/test_tui_gateway_server.py -q -k 'prompt_submit_sets_approval_session_key or prompt_submit_registers_thread_local_approval_callbacks'`
- `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`

## Notes
- `ui-tui` Vitest coverage for the new prompt-state plumbing was not runnable locally in this environment because `ui-tui/node_modules` was absent and `npm --prefix ui-tui install` did not complete.
