### PR TITLE
fix: align Kanban dashboard status columns

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2019,7 +2019,8 @@ def create_task(
     """Create a new task and optionally link it under parent tasks.
 
     Returns the new task id.  Status is ``ready`` when there are no
-    parents (or all parents already ``done``), otherwise ``todo``.
+    parents (or all parents are already ``done`` or ``archived``),
+    otherwise ``todo``.
     If ``triage=True``, status is forced to ``triage`` regardless of
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
@@ -2158,13 +2159,16 @@ def create_task(
                         missing = _find_missing_parents(conn, parents)
                         if missing:
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
-                        # If any parent is not yet done, we're todo.
+                        # If any parent is not yet terminal, we're todo.
+                        # Archived parents satisfy dependency gates everywhere
+                        # else (recompute/claim/unblock), so creation must use
+                        # the same contract.
                         rows = conn.execute(
                             "SELECT status FROM tasks WHERE id IN "
                             "(" + ",".join("?" * len(parents)) + ")",
                             parents,
                         ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        if any(r["status"] not in ("done", "archived") for r in rows):
                             task_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -2368,13 +2372,16 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
+        # If child was dispatchable/reviewable but parent is not yet terminal,
+        # demote child to todo. Archived parents satisfy dependency gates, and
+        # review must be gated the same way as ready.
         parent_status = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (parent_id,)
         ).fetchone()["status"]
-        if parent_status != "done":
+        if parent_status not in ("done", "archived"):
             conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                "UPDATE tasks SET status = 'todo' "
+                "WHERE id = ? AND status IN ('ready', 'review')",
                 (child_id,),
             )
         _append_event(
@@ -3038,9 +3045,9 @@ def claim_review_task(
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``review`` status).
 
-    Unlike ``claim_task`` (which handles ``ready -> running``), this
-    does NOT check parent dependencies — the task already passed that
-    gate on its original ``todo -> ready -> running`` transition.
+    Mirrors ``claim_task``'s parent-dependency gate defensively: if any
+    parent is not ``done`` or ``archived``, demote the task back to
+    ``todo`` and refuse the claim.
 
     Creates a new run entry so the review agent's lifecycle is tracked
     independently from the original worker run.
@@ -3049,6 +3056,23 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        undone = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if undone:
+            conn.execute(
+                "UPDATE tasks SET status = 'todo' "
+                "WHERE id = ? AND status = 'review'",
+                (task_id,),
+            )
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": "parents_not_done", "source_status": "review"},
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4145,12 +4169,14 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # 'ready'. Unconditionally setting status='ready' here bypasses the
         # parent-completion invariant (the dispatcher trusts that column);
         # if parents are still in progress the task must wait in 'todo'
-        # until recompute_ready picks it up. RCA: Bug 2 at
+        # until recompute_ready picks it up. Archived parents satisfy the
+        # dependency gate, matching recompute_ready()/claim_task(). RCA: Bug 2 at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
         undone_parents = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            "WHERE l.child_id = ? "
+            "AND p.status NOT IN ('done', 'archived') LIMIT 1",
             (task_id,),
         ).fetchone()
         new_status = "todo" if undone_parents else "ready"
@@ -4659,7 +4685,7 @@ def schedule_task(
                    claim_expires= NULL,
                    worker_pid   = NULL
              WHERE id = ?
-               AND status IN ('todo', 'ready', 'running', 'blocked')
+               AND status IN ('todo', 'ready', 'running', 'blocked', 'review')
         """
         if expected_run_id is not None:
             sql += " AND current_run_id = ?"

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -87,25 +87,29 @@
   }
 
   // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
+    review: "Review",
     done: "Done",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Waiting for a scheduled follow-up time",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
+    review: "Needs human review before completion",
     done: "Completed",
     archived: "Archived",
   };
@@ -154,9 +158,11 @@
   const COLUMN_DOT = {
     triage: "hermes-kanban-dot-triage",
     todo: "hermes-kanban-dot-todo",
+    scheduled: "hermes-kanban-dot-scheduled",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
     blocked: "hermes-kanban-dot-blocked",
+    review: "hermes-kanban-dot-review",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
   };
@@ -2052,6 +2058,11 @@
         title: "Move selected tasks to Todo.",
       }, "→ todo"),
       h(Button, {
+        onClick: function () { props.onApply({ status: "scheduled" }); },
+        size: "sm",
+        title: "Move selected tasks to Scheduled.",
+      }, "→ scheduled"),
+      h(Button, {
         onClick: function () { props.onApply({ status: "ready" }); },
         size: "sm",
         title: "Move selected tasks to Ready. Ready tasks are picked up by the dispatcher on the next tick.",
@@ -2062,6 +2073,11 @@
         size: "sm",
         title: "Block selected tasks. Releases any active claims.",
       }, "Block"),
+      h(Button, {
+        onClick: function () { props.onApply({ status: "review" }); },
+        size: "sm",
+        title: "Move selected tasks to Review.",
+      }, "→ review"),
       h(Button, {
         onClick: function () { props.onApply({ status: "ready" },
           `Unblock ${props.count} task(s)?`); },
@@ -3783,7 +3799,9 @@
         specifyButton,
         decomposeButton,
         b("→ triage",  { status: "triage" },   task.status !== "triage"),
+        b("→ scheduled",  { status: "scheduled" }, task.status !== "scheduled"),
         b("→ ready",   { status: "ready" },    task.status !== "ready"),
+        b("→ review",  { status: "review" },   task.status !== "review"),
         // No direct → running button: /tasks/:id PATCH rejects status=running
         // with 400 (issue #19535). Tasks enter running only through the
         // dispatcher's claim_task path, which atomically creates the run row,

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -163,9 +163,11 @@
 }
 .hermes-kanban-dot-triage   { background: #b47dd6; }  /* lilac — fresh/unspecified */
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
+.hermes-kanban-dot-scheduled { background: #c8954f; }  /* ochre — waiting for time */
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
+.hermes-kanban-dot-review   { background: #8b8bdc; }  /* indigo — needs review */
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -859,7 +859,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     status_code=400,
                     detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
                 )
-            elif s in ("todo", "triage", "scheduled"):
+            elif s in ("todo", "triage", "review"):
                 ok = _set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
@@ -867,7 +867,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # For ``ready``, name the blocking parent(s) so the dashboard
                 # can render an actionable toast instead of a silent no-op.
                 # See #26744.
-                if s == "ready":
+                if s in ("ready", "review"):
                     blockers = _parents_blocking_ready(conn, task_id)
                     if blockers:
                         names = ", ".join(
@@ -877,8 +877,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                         raise HTTPException(
                             status_code=409,
                             detail=(
-                                f"Cannot move to 'ready': blocked by parent(s) "
-                                f"not done — {names}"
+                                f"Cannot move to {s!r}: blocked by parent(s) "
+                                f"not done/archived — {names}"
                             ),
                         )
                 raise HTTPException(
@@ -948,18 +948,19 @@ def delete_task(task_id: str, board: Optional[str] = Query(None)):
 def _parents_blocking_ready(
     conn: sqlite3.Connection, task_id: str,
 ) -> list:
-    """Return parent rows (``id``, ``title``, ``status``) that aren't ``done``
-    and therefore prevent ``task_id`` from being promoted to ``ready``.
+    """Return parent rows (``id``, ``title``, ``status``) that are not in a
+    dependency-satisfied terminal state and therefore prevent ``task_id`` from
+    being promoted to ``ready`` or ``review``.
 
     Used to enrich the 409 response from :func:`update_task` so the
     dashboard can show an actionable toast (#26744) instead of a silent
     no-op.  Returns ``[]`` when nothing blocks the transition (e.g. no
-    parents, or all parents already done).
+    parents, or all parents are already ``done``/``archived``).
     """
     rows = conn.execute(
         "SELECT t.id, t.title, t.status FROM tasks t "
         "JOIN task_links l ON l.parent_id = t.id "
-        "WHERE l.child_id = ? AND t.status != 'done'",
+        "WHERE l.child_id = ? AND t.status NOT IN ('done', 'archived')",
         (task_id,),
     ).fetchall()
     return [
@@ -990,10 +991,10 @@ def _set_status_direct(
         if prev is None:
             return False
 
-        # Guard: don't allow promoting to 'ready' unless all parents are done.
-        # Prevents the dispatcher from spawning a child whose upstream work
-        # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
-        if new_status == "ready":
+        # Guard: don't allow promoting to dispatchable/reviewable states unless
+        # all parents are done. ``claim_review_task`` assumes review tasks have
+        # already passed the dependency gate, just like ready tasks.
+        if new_status in {"ready", "review"}:
             parent_statuses = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -1001,7 +1002,7 @@ def _set_status_direct(
                 (task_id,),
             ).fetchall()
             if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
+                p["status"] in {"done", "archived"} for p in parent_statuses
             ):
                 return False
 
@@ -1045,7 +1046,7 @@ def _set_status_direct(
                 child_id = row["child_id"]
                 demoted = conn.execute(
                     "UPDATE tasks SET status = 'todo' "
-                    "WHERE id = ? AND status = 'ready'",
+                    "WHERE id = ? AND status IN ('ready', 'review')",
                     (child_id,),
                 )
                 if demoted.rowcount == 1:
@@ -1203,7 +1204,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         continue
                     elif s == "scheduled":
                         ok = kanban_db.schedule_task(conn, tid)
-                    elif s in {"todo", "triage"}:
+                    elif s in {"todo", "triage", "review"}:
                         ok = _set_status_direct(conn, tid, s)
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -7,8 +7,10 @@ REST surface without spinning up the whole dashboard.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -245,6 +247,311 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     assert "if (!storedBoard && !board && data && data.current)" in js
     assert "setBoard(data.current);" in js
     assert 'readSelectedBoard() || "default"' not in js
+
+
+def test_dashboard_bundle_columns_match_backend_board_columns():
+    """Frontend visible columns and status styling must track the backend list.
+
+    Regression for #37108: the backend added first-class ``scheduled`` and
+    ``review`` columns, but the bundled dashboard constants stayed on the old
+    six-column order and omitted fallback text/dot styling.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    css_file = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css"
+    js = bundle.read_text()
+    css = css_file.read_text()
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_columns_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    plugin = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = plugin
+    spec.loader.exec_module(plugin)
+
+    order_match = re.search(r"const COLUMN_ORDER = (\[[^;]+\]);", js)
+    assert order_match, "COLUMN_ORDER constant missing from dashboard bundle"
+    assert ast.literal_eval(order_match.group(1)) == plugin.BOARD_COLUMNS
+
+    for object_name in (
+        "FALLBACK_COLUMN_LABEL",
+        "FALLBACK_COLUMN_HELP",
+        "COLUMN_DOT",
+    ):
+        object_match = re.search(rf"const {object_name} = \{{(?P<body>.*?)\n  \}};", js, re.S)
+        assert object_match, f"{object_name} missing from dashboard bundle"
+        missing = [
+            status
+            for status in plugin.BOARD_COLUMNS
+            if not re.search(rf"\b{re.escape(status)}\s*:", object_match.group("body"))
+        ]
+        assert missing == [], f"{object_name} missing statuses: {missing}"
+
+    missing_dot_classes = [
+        status
+        for status in plugin.BOARD_COLUMNS
+        if f".hermes-kanban-dot-{status}" not in css
+    ]
+    assert missing_dot_classes == []
+
+
+def test_dashboard_status_actions_include_scheduled_and_review():
+    """Status menus must expose both new visible board statuses (#37108)."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    for status in ("scheduled", "review"):
+        assert f'props.onApply({{ status: "{status}" }});' in js
+        assert f'b("→ {status}",  {{ status: "{status}" }}' in js
+
+
+def test_task_status_patch_accepts_scheduled_and_review(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "status target"},
+    ).json()["task"]
+
+    for status in ("scheduled", "review", "scheduled", "todo"):
+        r = client.patch(
+            f"/api/plugins/kanban/tasks/{task['id']}", json={"status": status},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["task"]["status"] == status
+
+
+def test_bulk_status_patch_accepts_scheduled_and_review(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "bulk status target"},
+    ).json()["task"]
+
+    for status in ("scheduled", "review", "scheduled", "todo"):
+        r = client.post(
+            "/api/plugins/kanban/tasks/bulk",
+            json={"ids": [task["id"]], "status": status},
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()["results"][0]
+        assert result["ok"] is True, result
+        detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()["task"]
+        assert detail["status"] == status
+
+
+def test_review_status_requires_done_parents(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "unfinished parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "blocked child", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert child["status"] == "todo"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "review"},
+    )
+    assert r.status_code == 409
+    assert "Cannot move to 'review'" in r.text
+
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [child["id"]], "status": "review"},
+    )
+    assert r.status_code == 200, r.text
+    result = r.json()["results"][0]
+    assert result["ok"] is False
+    assert "transition to 'review' refused" in result["error"]
+
+
+def test_reopening_parent_demotes_review_children(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "done", "summary": "parent complete"},
+    )
+    assert r.status_code == 200, r.text
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "review"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "review"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "todo"},
+    )
+    assert r.status_code == 200, r.text
+    detail = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+    assert detail["status"] == "todo"
+
+
+def test_archived_parent_satisfies_review_gate_until_reopened(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "review"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "review"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "todo"},
+    )
+    assert r.status_code == 200, r.text
+    detail = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+    assert detail["status"] == "todo"
+
+
+def test_unblock_with_archived_parent_promotes_to_ready(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "scheduled"},
+    )
+    assert r.status_code == 200, r.text
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "ready"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["status"] == "ready"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "blocked"},
+    )
+    assert r.status_code == 200, r.text
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [child["id"]], "status": "ready"},
+    )
+    assert r.status_code == 200, r.text
+    result = r.json()["results"][0]
+    assert result["ok"] is True, result
+    detail = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+    assert detail["status"] == "ready"
+
+
+def test_create_task_with_archived_parent_starts_ready(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "archived parent"},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+
+    assert child["status"] == "ready"
+
+
+def test_linking_archived_parent_preserves_ready_and_review_children(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "archived parent"},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "archived"},
+    )
+    assert r.status_code == 200, r.text
+
+    ready_child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "ready child"},
+    ).json()["task"]
+    review_child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "review child"},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{review_child['id']}", json={"status": "review"},
+    )
+    assert r.status_code == 200, r.text
+
+    for child, expected_status in ((ready_child, "ready"), (review_child, "review")):
+        r = client.post(
+            "/api/plugins/kanban/links",
+            json={"parent_id": parent["id"], "child_id": child["id"]},
+        )
+        assert r.status_code == 200, r.text
+        detail = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+        assert detail["status"] == expected_status
+
+
+def test_linking_unfinished_parent_demotes_review_child(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "unfinished parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "review child"},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "review"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.post(
+        "/api/plugins/kanban/links",
+        json={"parent_id": parent["id"], "child_id": child["id"]},
+    )
+    assert r.status_code == 200, r.text
+    detail = client.get(f"/api/plugins/kanban/tasks/{child['id']}").json()["task"]
+    assert detail["status"] == "todo"
+
+
+def test_claim_review_task_rejects_unsatisfied_parents(client):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "unfinished parent"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "review child"},
+    ).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}", json={"status": "review"},
+    )
+    assert r.status_code == 200, r.text
+
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (parent["id"], child["id"]),
+            )
+        assert kb.claim_review_task(conn, child["id"], claimer="test") is None
+        stored_child = kb.get_task(conn, child["id"])
+        assert stored_child is not None
+        assert stored_child.status == "todo"
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Aligns the Kanban dashboard with the backend's canonical board statuses.

The dashboard bundle still used the old six-column order, so `scheduled` and `review` tasks were not represented as first-class columns/actions even though the backend already exposes them in `BOARD_COLUMNS`. This updates the visible dashboard statuses and keeps the backend dependency gates consistent for `ready` and `review`.

## Related Issue

Fixes #37108

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `plugins/kanban/dashboard/dist/index.js` so dashboard columns, fallback labels/help text, status dots, and status actions include `scheduled` and `review`.
- Updated `plugins/kanban/dashboard/dist/style.css` with dot styling for the added statuses.
- Updated `plugins/kanban/dashboard/plugin_api.py` so direct and bulk dashboard status changes support `scheduled` and `review` while preserving parent dependency checks.
- Updated `hermes_cli/kanban_db.py` so core task creation/linking/unblocking/review-claim paths consistently treat `done` and `archived` parents as dependency-satisfied, and refuse/demote `review` tasks with unfinished parents.
- Added regression coverage in `tests/plugins/test_kanban_dashboard_plugin.py` for dashboard/backend status parity, scheduled/review actions, archived-parent handling, review dependency gates, and review claim rejection.

## How to Test

1. Focused Kanban dashboard regression suite:

   ```bash
   pytest tests/plugins/test_kanban_dashboard_plugin.py -q
   ```

   Result: `106 passed, 1 warning`.

2. Existing review-claim behavior:

   ```bash
   pytest \
     tests/hermes_cli/test_kanban_db.py::test_claim_review_task_transitions_to_running \
     tests/hermes_cli/test_kanban_db.py::test_claim_review_task_fails_on_non_review \
     tests/hermes_cli/test_kanban_db.py::test_claim_review_task_fails_when_already_claimed -q
   ```

   Result: `3 passed`.

3. Lint/syntax/whitespace checks:

   ```bash
   ruff check tests/plugins/test_kanban_dashboard_plugin.py plugins/kanban/dashboard/plugin_api.py hermes_cli/kanban_db.py
   node --check plugins/kanban/dashboard/dist/index.js
   git diff --check
   ```

   Result: all passed.

4. Full suite attempt:

   ```bash
   scripts/run_tests.sh
   ```

   Result: `28473 passed, 6 failed`.

   The failures appear unrelated to this Kanban change:
   - `tests/hermes_cli/test_gui_command.py`: 5 failures due to missing `pathspec`.
   - `tests/tools/test_approval.py`: 1 existing approval-key uniqueness failure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted Kanban verification:

```text
pytest tests/plugins/test_kanban_dashboard_plugin.py -q
106 passed, 1 warning
```

```text
pytest tests/hermes_cli/test_kanban_db.py::test_claim_review_task_transitions_to_running \
       tests/hermes_cli/test_kanban_db.py::test_claim_review_task_fails_on_non_review \
       tests/hermes_cli/test_kanban_db.py::test_claim_review_task_fails_when_already_claimed -q
3 passed
```

```text
ruff check tests/plugins/test_kanban_dashboard_plugin.py plugins/kanban/dashboard/plugin_api.py hermes_cli/kanban_db.py
All checks passed
```

```text
node --check plugins/kanban/dashboard/dist/index.js
git diff --check
```

Full suite attempt:

```text
scripts/run_tests.sh
28473 passed, 6 failed
```

Unrelated failures observed in `tests/hermes_cli/test_gui_command.py` (`pathspec` missing) and `tests/tools/test_approval.py`.

## AI assistance

I used Codex to help reproduce and review the issue. I reviewed the final diff and ran the verification commands above before preparing this PR.
