### PR TITLE
fix(cron): clarify schedule and prompt requirements in parameter descriptions

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -712,11 +712,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "prompt": {
                 "type": "string",
-                "description": "For create: the full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills."
+                "description": "REQUIRED for action=create (unless no_agent=True or script is set). The full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills."
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": "REQUIRED for action=create. You MUST always include this parameter if action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot)."
             },
             "name": {
                 "type": "string",


### PR DESCRIPTION
This PR resolves the issue where description-driven models (e.g., Grok) omit the required `schedule` and `prompt` parameters when calling `cronjob(action='create')`.

Since using the schema's root-level `required` array for this is not feasible (as it would reject non-create actions like `list` or `remove` if they omit `schedule`), this PR implements the maintainer-recommended targeted description update.

### Changes:
- Prefixed the `prompt` parameter description with `REQUIRED for action=create (unless no_agent=True or script is set)`.
- Clarified the `schedule` parameter description to explicitly start with `REQUIRED for action=create. You MUST always include this parameter if action=create`.
- Preserved clean Unix LF line endings to avoid CRLF diff noise.