### PR TITLE
fix(xiaomi): pad empty content on assistant messages with tool_calls

### DIFF
--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -1,9 +1,48 @@
 """Xiaomi MiMo provider profile."""
 
+import copy
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-xiaomi = ProviderProfile(
+
+class XiaomiProfile(ProviderProfile):
+    """Xiaomi MiMo — handles API-specific quirks.
+
+    MiMo API requires non-empty ``content`` on every assistant message,
+    even those carrying only ``tool_calls`` with no natural-language body.
+    Without this, replay of tool-call-only assistant turns causes
+    HTTP 400 "text is not set".
+    """
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Ensure assistant messages have non-empty content.
+
+        MiMo API rejects messages where ``content`` is empty or missing,
+        even when ``tool_calls`` are present.  Pad with a single space
+        so the API accepts the request while keeping visible output
+        identical.
+        """
+        prepared = copy.deepcopy(messages)
+        for msg in prepared:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "assistant":
+                continue
+            # Skip if content is already non-empty
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip():
+                continue
+            if isinstance(content, list) and content:
+                continue
+            # Has tool_calls but empty content — pad with space
+            if msg.get("tool_calls"):
+                msg["content"] = " "
+        return prepared
+
+
+xiaomi = XiaomiProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
     env_vars=("XIAOMI_API_KEY",),


### PR DESCRIPTION
## What does this PR do?

MiMo API requires non-empty `content` on every assistant message, even when carrying only `tool_calls` with no natural-language body. Without this, replay of tool-call-only assistant turns causes HTTP 400 "text is not set".

This fix adds a `prepare_messages()` override in the xiaomi provider plugin that pads empty content with a single space when `tool_calls` are present. The space is invisible to users but satisfies the API validation.

## Related Issue

No existing issue. Discovered during real-world usage with MiMo v2.5 via the xiaomi provider.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/model-providers/xiaomi/__init__.py`: Added `XiaomiProfile` class with `prepare_messages()` override that pads empty content on assistant messages with tool_calls

## How to Test

1. Configure Hermes with `provider: xiaomi` and `model: mimo-v2.5`
2. Send an image from Feishu (triggers vision_analyze + multiple tool calls)
3. After several tool-call iterations, verify no HTTP 400 error occurs
4. Run `pytest tests/providers/ -v` to verify all provider tests pass

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] N/A - No documentation changes needed for provider plugin fix
- [x] N/A - No config key changes
- [x] N/A - No architecture changes
- [x] N/A - No cross-platform impact (provider plugin only)
- [x] N/A - No tool schema changes