### PR TITLE
kanban: make card workspace terminal-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,23 @@ hermes-agent/
 `gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
 Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
 
+## Runtime restart discipline
+
+Gateway/dashboard restarts can interrupt live Telegram/dashboard turns. Agents must
+know their execution surface before applying changes that require a restart:
+
+- Foreground/live user sessions may restart only when explicitly asked, or after
+  a concise warning + confirmation if the user is actively waiting.
+- Background agents must not directly restart/`kickstart` gateway or dashboard
+  services. They should finish code/config changes, verify them where possible,
+  and report `restart_required` with the exact service + reason back to the
+  foreground/orchestrating session.
+- If a background task truly must restart a runtime, delegate that decision to a
+  foreground Rolly session or a maintenance window job designed to be silent and
+  noninteractive.
+- Config writes that change gateway behavior should be treated as restart-needed
+  unless the code path explicitly hot-reloads that setting.
+
 ## File Dependency Chain
 
 ```

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1,6 +1,6 @@
 """Curator — background skill maintenance orchestrator.
 
-The curator is an auxiliary-model task that periodically reviews agent-created
+The curator is an auxiliary-model task that periodically reviews curator-scope
 skills and maintains the collection. It runs inactivity-triggered (no cron
 daemon): when the agent is idle and the last curator run was longer than
 ``interval_hours`` ago, ``maybe_run_curator()`` spawns a forked AIAgent to do
@@ -13,7 +13,10 @@ Responsibilities:
   - Persist curator state (last_run_at, paused, etc.) in .curator_state
 
 Strict invariants:
-  - Only touches agent-created skills (see tools/skill_usage.is_agent_created)
+  - Scope defaults to agent-created skills (see tools/skill_usage.list_agent_created_skill_names);
+    curator.scope=non_manual opts in agent-created, bundled, and hub skills while
+    excluding manual local skills; curator.scope=all opts in every installed
+    profile-local skill copy
   - Never auto-deletes — only archives. Archive is recoverable.
   - Pinned skills bypass all auto-transitions
   - Uses the auxiliary client; never touches the main session's prompt cache
@@ -183,6 +186,21 @@ def get_archive_after_days() -> int:
         return DEFAULT_ARCHIVE_AFTER_DAYS
 
 
+def get_scope() -> str:
+    """Return curator scope: ``agent_created`` (default), ``non_manual``, or ``all``."""
+    cfg = _load_config()
+    raw = str(cfg.get("scope", "agent_created") or "agent_created").strip().lower().replace("-", "_")
+    if raw in {"non_manual", "not_manual", "non_user", "not_user", "not_made_by_me", "managed"}:
+        return "non_manual"
+    if raw in {"all", "installed", "all_installed"}:
+        return "all"
+    return "agent_created"
+
+
+def _scope_allows_upstream() -> bool:
+    return get_scope() in {"non_manual", "all"}
+
+
 # ---------------------------------------------------------------------------
 # Idle / interval check
 # ---------------------------------------------------------------------------
@@ -266,7 +284,7 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
 
     counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
 
-    for row in _u.agent_created_report():
+    for row in _u.curator_report(get_scope(), persist_missing=True):
         counts["checked"] += 1
         name = row["name"]
         if row.get("pinned"):
@@ -282,7 +300,7 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
         current = row.get("state", _u.STATE_ACTIVE)
 
         if anchor <= archive_cutoff and current != _u.STATE_ARCHIVED:
-            ok, _msg = _u.archive_skill(name)
+            ok, _msg = _u.archive_skill(name, allow_upstream=_scope_allows_upstream())
             if ok:
                 counts["archived"] += 1
         elif anchor <= stale_cutoff and current == _u.STATE_ACTIVE:
@@ -342,8 +360,13 @@ CURATOR_REVIEW_PROMPT = (
     "bodies + `references/`, `templates/`, and `scripts/` subfiles for "
     "session-specific detail — not one-session-one-skill micro-entries.\n\n"
     "Hard rules — do not violate:\n"
-    "1. DO NOT touch bundled or hub-installed skills. The candidate list "
-    "below is already filtered to agent-created skills only.\n"
+    "1. Only touch skills in the candidate list below. By default the "
+    "candidate list is agent-created only. If the list explicitly contains "
+    "provenance=bundled or provenance=hub, curator.scope=non_manual or "
+    "curator.scope=all is enabled and you may clean up those installed "
+    "profile-local copies too; never edit the upstream bundled repo or hub "
+    "source. If the list contains provenance=manual, curator.scope=all is "
+    "enabled; treat those as user-authored and be extra conservative.\n"
     "2. DO NOT delete any skill. Archiving (moving the skill's directory "
     "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
     "Archives are recoverable; deletion is not.\n"
@@ -1366,14 +1389,21 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 def _render_candidate_list() -> str:
-    """Human/agent-readable list of agent-created skills with usage stats."""
-    rows = skill_usage.agent_created_report()
+    """Human/agent-readable list of curator-scope skills with usage stats."""
+    scope = get_scope()
+    rows = skill_usage.curator_report(scope)
     if not rows:
-        return "No agent-created skills to review."
-    lines = [f"Agent-created skills ({len(rows)}):\n"]
+        return f"No {scope} skills to review."
+    title = (
+        "All installed skills" if scope == "all" else
+        "Non-manual skills" if scope == "non_manual" else
+        "Agent-created skills"
+    )
+    lines = [f"{title} ({len(rows)}):\n"]
     for r in rows:
         lines.append(
             f"- {r['name']}  "
+            f"provenance={r.get('provenance', 'unknown')}  "
             f"state={r['state']}  "
             f"pinned={'yes' if r.get('pinned') else 'no'}  "
             f"activity={r.get('activity_count', 0)}  "
@@ -1394,7 +1424,7 @@ def run_curator_review(
 
     Steps:
       1. Apply automatic state transitions (pure, no LLM).
-      2. If there are agent-created skills, spawn a forked AIAgent that runs
+      2. If there are curator-scope skills, spawn a forked AIAgent that runs
          the LLM review prompt against the current candidate list.
       3. Update .curator_state with last_run_at and a one-line summary.
       4. Invoke *on_summary* with a user-visible description.
@@ -1412,7 +1442,7 @@ def run_curator_review(
     if dry_run:
         # Count candidates without mutating state.
         try:
-            report = skill_usage.agent_created_report()
+            report = skill_usage.curator_report(get_scope())
             counts = {
                 "checked": len(report),
                 "marked_stale": 0,
@@ -1465,7 +1495,7 @@ def run_curator_review(
         nonlocal auto_summary
         # Snapshot skill state BEFORE the LLM pass so the report can diff.
         try:
-            before_report = skill_usage.agent_created_report()
+            before_report = skill_usage.curator_report(get_scope())
         except Exception:
             before_report = []
         before_names = {r.get("name") for r in before_report if isinstance(r, dict)}
@@ -1473,7 +1503,7 @@ def run_curator_review(
         llm_meta: Dict[str, Any] = {}
         try:
             candidate_list = _render_candidate_list()
-            if "No agent-created skills" in candidate_list:
+            if candidate_list.startswith("No "):
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {
                     "final": "",
@@ -1515,7 +1545,7 @@ def run_curator_review(
         try:
             rename_lines = _build_rename_summary(
                 before_names=before_names,
-                after_report=skill_usage.agent_created_report(),
+                after_report=skill_usage.curator_report(get_scope()),
                 tool_calls=llm_meta.get("tool_calls", []) or [],
                 model_final=llm_meta.get("final", "") or "",
             )
@@ -1533,7 +1563,7 @@ def run_curator_review(
         # reporting bug never breaks the curator itself. Report path is
         # recorded in state so `hermes curator status` can point at it.
         try:
-            after_report = skill_usage.agent_created_report()
+            after_report = skill_usage.curator_report(get_scope())
         except Exception:
             after_report = []
         try:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -383,6 +383,85 @@ def _iter_home_target_platforms():
         pass
 
 
+def _lookup_gateway_session_id(platform_name: str, chat_id: str, thread_id: Optional[str] = None) -> Optional[str]:
+    """Return the active gateway session_id for a delivered cron target, if known."""
+    try:
+        sessions_path = get_hermes_home() / "sessions" / "sessions.json"
+        with open(sessions_path, "r", encoding="utf-8") as f:
+            sessions = json.load(f)
+    except Exception as exc:
+        logger.debug("Cron delivery could not load gateway sessions index: %s", exc)
+        return None
+
+    platform_key = str(platform_name).lower()
+    chat_key = str(chat_id)
+    thread_key = str(thread_id) if thread_id is not None else None
+    matches = []
+    for entry in (sessions or {}).values():
+        if not isinstance(entry, dict):
+            continue
+        origin = entry.get("origin") or {}
+        if str(origin.get("platform", "")).lower() != platform_key:
+            continue
+        if str(origin.get("chat_id", "")) != chat_key:
+            continue
+        origin_thread = origin.get("thread_id")
+        origin_thread_key = str(origin_thread) if origin_thread is not None else None
+        if origin_thread_key != thread_key:
+            continue
+        session_id = entry.get("session_id")
+        if session_id:
+            matches.append((entry.get("updated_at") or "", str(session_id)))
+    if not matches:
+        return None
+    matches.sort(reverse=True)
+    return matches[0][1]
+
+
+def _record_cron_delivery_in_gateway_history(
+    *,
+    job: dict,
+    target: dict,
+    delivery_content: str,
+    platform_message_id: Optional[str] = None,
+) -> None:
+    """Mirror a delivered cron response into the destination gateway session history.
+
+    Cron output is sent outside the normal chat loop, so without this mirror the
+    next user turn cannot see the reminder/report that appeared in the same
+    Telegram/Slack/etc. chat.  Store it as an observed user-context note instead
+    of an assistant turn: the cron agent is a separate session, and inserting a
+    synthetic assistant message here can create invalid role alternation in the
+    live gateway conversation.
+    """
+    try:
+        session_id = _lookup_gateway_session_id(
+            str(target.get("platform") or ""),
+            str(target.get("chat_id") or ""),
+            target.get("thread_id"),
+        )
+        if not session_id:
+            logger.debug(
+                "Job '%s': no gateway session found to mirror cron delivery to %s:%s",
+                job.get("id", "?"), target.get("platform"), target.get("chat_id"),
+            )
+            return
+        from hermes_state import SessionDB
+        SessionDB().append_message(
+            session_id=session_id,
+            role="user",
+            content=(
+                "[Observed cronjob response delivered in this chat; "
+                "include it as conversation context.]\n"
+                f"{delivery_content}"
+            ),
+            platform_message_id=platform_message_id or "",
+            observed=True,
+        )
+    except Exception as exc:
+        logger.debug("Job '%s': failed to mirror cron delivery into session history: %s", job.get("id", "?"), exc)
+
+
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
     """Resolve one concrete auto-delivery target for a cron job."""
 
@@ -721,6 +800,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
+                send_result = None
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
                     future = safe_schedule_threadsafe(
@@ -770,6 +850,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    _record_cron_delivery_in_gateway_history(
+                        job=job,
+                        target=target,
+                        delivery_content=cleaned_delivery_content.strip(),
+                        platform_message_id=str(getattr(send_result, "message_id", "") or ""),
+                    )
                     delivered = True
             except Exception as e:
                 logger.warning(
@@ -804,6 +890,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            _record_cron_delivery_in_gateway_history(
+                job=job,
+                target=target,
+                delivery_content=cleaned_delivery_content.strip(),
+                platform_message_id=str((result or {}).get("message_id") or ""),
+            )
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/docs/rolly-kanban-card-workspace-v0-acceptance-spec.md
+++ b/docs/rolly-kanban-card-workspace-v0-acceptance-spec.md
@@ -1,0 +1,126 @@
+# Rolly/Kanban Card Workspace v0 Acceptance Spec
+
+## Scope
+
+v0 is a focused card workspace layered on the existing Kanban dashboard/plugin API. It keeps the existing SQLite Kanban kernel and dashboard plugin shape, but adds first-class acceptance criteria, a human approval gate, and one server-side Claude Code/tmux terminal per card. Avoid workflow/template rewrites or multi-agent orchestration changes in v0.
+
+## Board model
+
+- Visible columns are exactly: `todo`, `ready`, `doing`, `review`, `done`.
+- Existing internal statuses may continue to exist, but dashboard serialization must map cards into these five columns without hiding `review`.
+- New cards default to `todo` until acceptance is explicitly approved.
+
+## Acceptance criteria model
+
+Each card has an ordered acceptance criteria checklist:
+
+```json
+{
+  "id": "stable item id",
+  "text": "observable requirement",
+  "verifier": "Rolly | User",
+  "passed": false,
+  "evidence": "optional evidence text/url/path"
+}
+```
+
+Card-level derived fields:
+
+- `acceptance_approved: boolean`
+- `acceptance_approved_at?: unix seconds`
+- `acceptance_approved_by?: string`
+
+Acceptance rules:
+
+- Approval toggle is disabled unless at least one criterion exists.
+- Approving criteria sets `acceptance_approved=true` and card status to `ready`.
+- Editing criterion `text` or `verifier` resets `acceptance_approved=false` and status to `todo`.
+- Editing card body/title/notes does **not** reset approval.
+- Changing `verifier` also sets that item `passed=false` but preserves existing `evidence`.
+- Rolly may mark passed only items where `verifier=Rolly`, and only when non-empty evidence is supplied.
+- User may mark any item passed/unpassed and may add/edit evidence.
+- If all Rolly-verifier items pass and any User-verifier items remain unpassed, status becomes `review`.
+- If all criteria pass, status becomes `done`.
+- If criteria exist but not approved, status remains/returns `todo` unless manually archived/deleted.
+
+## Human acceptance gate
+
+- Start CC is disabled until both are true:
+  - `acceptance_approved=true`
+  - card has a valid concrete workdir.
+- Before approval, Rolly card chat may research, clarify, and help draft/spec acceptance criteria only; it must not start implementation.
+- Missing workdir does not block card creation, chat, acceptance drafting, or approval UI visibility; it only blocks Start CC and should cause Rolly chat to ask for/confirm the repo path.
+
+## Workdir and execution mode
+
+- Workdir is inferred and persisted when high-confidence; otherwise remains empty and Start CC displays a blocking reason.
+- Workdir validity is checked server-side: path exists and is a directory.
+- Execution mode is inferred and displayed in the CC section, with a local override there only.
+- Do not add a top-level execution-mode field to the card form.
+- Persist effective execution settings needed to rebuild the launch context.
+
+## Claude Code/tmux terminal
+
+- Start CC launches immediately from the card workspace.
+- There is exactly one server-side tmux terminal/session per card.
+- Tmux session id/name is persisted on the card; browser reload only reads server state and reconnects/loads metadata.
+- Terminal logs are ephemeral; durable artifacts are summaries and evidence saved back to the card/runs/criteria.
+- Launch context is expandable after start, but the launch does not wait on a confirmation modal.
+- CC prompt includes only:
+  - card title/body
+  - acceptance criteria
+  - workdir
+  - execution mode/overrides
+  - global Rolly/MIX constraints
+- CC prompt must not include the Rolly/card chat transcript.
+
+## Rolly card chat
+
+- Chat operates against one card and can update title/body/workdir/criteria when useful.
+- It should use current card state, criteria, workdir, and persisted summaries/evidence; avoid injecting full chat transcript into CC launch context.
+- It must explain blockers clearly: missing approval, missing/invalid workdir, unclear criteria, or criteria requiring User verification.
+
+## API/backend acceptance
+
+Minimum endpoint behavior:
+
+- `GET /api/plugins/kanban/board` returns five visible columns and enough card summary fields for approval/workdir/CC disabled states.
+- `GET /api/plugins/kanban/tasks/{id}` returns full card data including criteria, acceptance approval fields, workdir validity, execution mode, tmux/CC session state, comments/events/runs as currently available.
+- `POST /api/plugins/kanban/tasks` accepts initial body/workdir and optional initial criteria.
+- `PATCH /api/plugins/kanban/tasks/{id}` can edit title/body/workdir and must not reset approval for body-only edits.
+- Criteria writes should be explicit, either via dedicated endpoints or a nested patch, and must enforce reset semantics transactionally.
+- Approval endpoint must reject empty criteria and must atomically set approval + `ready`.
+- Pass/fail endpoint must enforce verifier permissions, evidence requirements, and status roll-up (`review`/`done`).
+- Start CC endpoint must reject unapproved cards or invalid workdirs and persist tmux session state before returning.
+- CC state endpoint returns existing persisted session state after reload.
+
+## Likely backend files/endpoints needing changes
+
+- `hermes_cli/kanban_db.py`
+  - Add durable storage for acceptance criteria and approval fields. Prefer an additive table such as `task_acceptance_criteria` plus additive task columns for approval/workdir/execution/tmux state, or a small metadata table if preserving `tasks` width is preferred.
+  - Add transactional helpers for criteria CRUD, approval reset/approve, pass/fail roll-up, workdir validation, and tmux session state persistence.
+- `plugins/kanban/dashboard/plugin_api.py`
+  - Change `BOARD_COLUMNS` and `STATUS_TO_BOARD_COLUMN` to include `review` as its own visible column.
+  - Extend `CreateTaskBody`, `UpdateTaskBody`, `_task_dict`, `GET /board`, `GET /tasks/{id}`.
+  - Add/replace endpoints for acceptance criteria approval and pass/fail.
+  - Add Start CC + CC state endpoints; current `/tasks/{id}/claude-context` only builds context and validates workspace.
+- `hermes_cli/kanban_ready_review.py`
+  - Current heuristic/event-based ready-review is insufficient. Replace or bypass with checklist-backed acceptance approval while preserving explicit human gate semantics.
+- `hermes_cli/kanban_card_chat.py`
+  - Update system prompt and output schema so chat can draft/edit structured criteria and workdir, and respects pre-approval research/spec-only behavior.
+- `hermes_cli/kanban_card_context.py`
+  - Build CC prompt from card body + structured criteria + workdir/execution + global constraints only; remove comments/events/runs/chat transcript from launch prompt, except durable summaries/evidence if explicitly part of card state.
+  - Gate context/build launch on approval + valid workdir.
+- Tests likely affected/needed:
+  - `tests/plugins/test_kanban_dashboard_plugin.py`
+  - `tests/hermes_cli/test_kanban_card_chat.py`
+  - `tests/hermes_cli/test_kanban_mix_ready_guard.py`
+  - new tests for acceptance criteria CRUD/reset/approve/pass roll-up and CC launch gating.
+
+## Non-goals for v0
+
+- No new general workflow engine.
+- No multi-terminal-per-card support.
+- No durable full terminal log storage.
+- No top-level execution-mode field.
+- No automatic implementation before human approval.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1680,8 +1680,8 @@ class BasePlatformAdapter(ABC):
         self._pending_messages: Dict[str, MessageEvent] = {}
         self._session_tasks: Dict[str, asyncio.Task] = {}
         self._busy_text_mode: str = (
-            os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue").strip().lower()
-            or "queue"
+            os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "steer").strip().lower()
+            or "steer"
         )
         self._busy_text_debounce_seconds: float = _float_env(
             "HERMES_GATEWAY_BUSY_TEXT_DEBOUNCE_SECONDS", 0.35

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1671,8 +1671,8 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
-    _busy_text_mode: str = "interrupt"
+    _busy_input_mode: str = "steer"
+    _busy_text_mode: str = "steer"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -3035,9 +3035,9 @@ class GatewayRunner:
             mode = str(cfg_get(cfg, "display", "busy_input_mode", default="") or "").strip().lower()
         if mode == "queue":
             return "queue"
-        if mode == "steer":
-            return "steer"
-        return "interrupt"
+        if mode == "interrupt":
+            return "interrupt"
+        return "steer"
 
     @staticmethod
     def _load_busy_text_mode() -> str:
@@ -3048,7 +3048,9 @@ class GatewayRunner:
             mode = str(cfg_get(cfg, "display", "busy_text_mode", default="") or "").strip().lower()
         if mode == "interrupt":
             return "interrupt"
-        return "queue"
+        if mode == "queue":
+            return "queue"
+        return "steer"
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -10326,9 +10328,10 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # reliably under service managers (systemd KillMode/cgroups; launchd
+        # KeepAlive with SuccessfulExit=false) or Docker (tini exits when the
+        # gateway dies, taking the detached helper with it).
+        _under_service = self._running_under_service_manager()
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)
@@ -10387,6 +10390,24 @@ class GatewayRunner:
                 return False
         return event.platform_update_id <= recorded_uid
 
+
+    @staticmethod
+    def _running_under_service_manager() -> bool:
+        """Return True when the gateway process is supervised by a service manager.
+
+        systemd exposes ``INVOCATION_ID``. Hermes-generated launchd plists expose
+        ``HERMES_GATEWAY_SERVICE_MANAGER=launchd``; older launchd plists may not,
+        so also accept the generic ``HERMES_SERVICE_MANAGER`` spelling for hand-
+        rolled deployments.
+        """
+        if os.environ.get("INVOCATION_ID"):
+            return True
+        manager = (
+            os.environ.get("HERMES_GATEWAY_SERVICE_MANAGER")
+            or os.environ.get("HERMES_SERVICE_MANAGER")
+            or ""
+        ).strip().lower()
+        return manager in {"launchd", "systemd", "s6"}
 
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7516,32 +7516,6 @@ class GatewayRunner:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
-            )
-            _started_at = self._running_agents_ts.get(_quick_key, 0)
-            if (
-                source.platform == Platform.TELEGRAM
-                and event.message_type == MessageType.TEXT
-                and _telegram_followup_grace > 0
-                and _started_at
-                and (time.time() - _started_at) <= _telegram_followup_grace
-            ):
-                logger.debug(
-                    "Telegram follow-up arrived %.2fs after run start for %s — queueing without interrupt",
-                    time.time() - _started_at,
-                    _quick_key,
-                )
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
-                return None
-
             running_agent = self._running_agents.get(_quick_key)
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -315,7 +315,18 @@ def build_session_context_prompt(
         lines.append(f"**User ID:** {uid}")
 
     # Platform-specific behavioral notes
-    if context.source.platform == Platform.SLACK:
+    if context.source.platform == Platform.TELEGRAM:
+        lines.append("")
+        lines.append(
+            "**Platform notes:** You are responding on Telegram. "
+            "Default to brief mobile-chat replies: answer in under 700 characters "
+            "unless the user explicitly asks for detail, a document, or code. "
+            "Use at most one short bullet list, avoid tables, and do not dump logs, "
+            "diffs, or long verification output into chat. For tool-heavy work, "
+            "report only the outcome and the key verification result, then offer "
+            "to expand if useful."
+        )
+    elif context.source.platform == Platform.SLACK:
         lines.append("")
         lines.append(
             "**Platform notes:** You are running inside Slack. "

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1557,16 +1557,22 @@ DEFAULT_CONFIG = {
 
     # Curator — background skill maintenance.
     #
-    # Periodically reviews AGENT-CREATED skills (never bundled or
-    # hub-installed) and keeps the collection tidy: marks long-unused skills
-    # as stale, archives genuinely obsolete ones (archive only, never
-    # deletes), and spawns a forked aux-model agent to consolidate overlaps
-    # and patch drift. Runs inactivity-triggered from session start — no
-    # cron daemon.
+    # Periodically reviews curator-scope skills and keeps the collection tidy:
+    # marks long-unused skills as stale, archives genuinely obsolete ones
+    # (archive only, never deletes), and spawns a forked aux-model agent to
+    # consolidate overlaps and patch drift. Scope defaults to agent-created
+    # skills; set curator.scope=non_manual to include agent-created plus
+    # bundled/hub profile-local skill copies while excluding manual local
+    # skills, or curator.scope=all to include manual skills too. Runs inactivity-triggered from session
+    # start — no cron daemon.
     #
     # See `hermes curator status` for the last run summary.
     "curator": {
         "enabled": True,
+        # Scope: "agent_created" (safe default), "non_manual" (agent-created
+        # plus bundled/hub copies, excluding manual local skills), or "all"
+        # (all installed profile-local skills, including manual skills).
+        "scope": "agent_created",
         # How long to wait between curator runs (hours).  Default: 7 days.
         "interval_hours": 24 * 7,
         # Only run when the agent has been idle at least this long (hours).

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -78,9 +78,15 @@ def _cmd_status(args) -> int:
     print(f"  stale after:    {curator.get_stale_after_days()}d unused")
     print(f"  archive after:  {curator.get_archive_after_days()}d unused")
 
-    rows = skill_usage.agent_created_report()
+    scope = curator.get_scope()
+    rows = skill_usage.curator_report(scope)
+    label = (
+        "installed skills" if scope == "all" else
+        "non-manual skills" if scope == "non_manual" else
+        "agent-created skills"
+    )
     if not rows:
-        print("\nno agent-created skills")
+        print(f"\nno {label}")
         return 0
 
     by_state = {"active": [], "stale": [], "archived": []}
@@ -91,7 +97,7 @@ def _cmd_status(args) -> int:
         if r.get("pinned"):
             pinned.append(r["name"])
 
-    print(f"\nagent-created skills: {len(rows)} total")
+    print(f"\n{label}: {len(rows)} total")
     for state_name in ("active", "stale", "archived"):
         bucket = by_state.get(state_name, [])
         print(f"  {state_name:10s} {len(bucket)}")
@@ -232,11 +238,17 @@ def _cmd_resume(args) -> int:
 
 
 def _cmd_pin(args) -> int:
+    from agent import curator
     from tools import skill_usage
-    if not skill_usage.is_agent_created(args.skill):
+    scope = curator.get_scope()
+    if args.skill not in set(skill_usage.list_curator_skill_names(scope)):
+        extra = (
+            "; bundled/hub skills participate only when curator.scope is non_manual or all"
+            if not skill_usage.is_agent_created(args.skill) else ""
+        )
         print(
-            f"curator: '{args.skill}' is bundled or hub-installed — cannot pin "
-            "(only agent-created skills participate in curation)"
+            f"curator: '{args.skill}' is not in the current curator scope "
+            f"({scope}){extra}"
         )
         return 1
     skill_usage.set_pinned(args.skill, True)
@@ -245,11 +257,17 @@ def _cmd_pin(args) -> int:
 
 
 def _cmd_unpin(args) -> int:
+    from agent import curator
     from tools import skill_usage
-    if not skill_usage.is_agent_created(args.skill):
+    scope = curator.get_scope()
+    if args.skill not in set(skill_usage.list_curator_skill_names(scope)):
+        extra = (
+            "; bundled/hub skills participate only when curator.scope is non_manual or all"
+            if not skill_usage.is_agent_created(args.skill) else ""
+        )
         print(
-            f"curator: '{args.skill}' is bundled or hub-installed — "
-            "there's nothing to unpin (curator only tracks agent-created skills)"
+            f"curator: '{args.skill}' is not in the current curator scope "
+            f"({scope}){extra}"
         )
         return 1
     skill_usage.set_pinned(args.skill, False)
@@ -302,13 +320,14 @@ def _idle_days(record: dict) -> Optional[int]:
 
 
 def _cmd_prune(args) -> int:
-    """Bulk-archive agent-created skills idle for >= N days.
+    """Bulk-archive curator-scope skills idle for >= N days.
 
     Pinned skills are exempt. Already-archived skills are skipped. Default
     ``--days 90`` matches a conservative read of the curator's own archive
     threshold; adjust with ``--days``. Use ``--dry-run`` to preview.
     """
     from tools import skill_usage
+    from agent import curator
     days = getattr(args, "days", 90)
     if days < 1:
         print(f"curator: --days must be >= 1 (got {days})", file=sys.stderr)
@@ -318,7 +337,9 @@ def _cmd_prune(args) -> int:
     skip_confirm = bool(getattr(args, "yes", False))
 
     candidates = []
-    for r in skill_usage.agent_created_report():
+    scope = curator.get_scope()
+    report = skill_usage.curator_report(scope)
+    for r in report:
         if r.get("pinned"):
             continue
         if r.get("state") == skill_usage.STATE_ARCHIVED:
@@ -354,7 +375,10 @@ def _cmd_prune(args) -> int:
     archived = 0
     failures = []
     for name, _ in candidates:
-        ok, msg = skill_usage.archive_skill(name)
+        if scope in {"non_manual", "all"}:
+            ok, msg = skill_usage.archive_skill(name, allow_upstream=True)
+        else:
+            ok, msg = skill_usage.archive_skill(name)
         if ok:
             archived += 1
         else:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -112,20 +113,16 @@ def _get_service_pids() -> set:
         try:
             label = get_launchd_label()
             result = subprocess.run(
-                ["launchctl", "list", label],
+                ["launchctl", "print", _launchd_target(label)],
                 capture_output=True, text=True, timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
                 for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                    match = re.search(r"\bpid\s*=\s*(\d+)\b", line)
+                    if match:
+                        pid = int(match.group(1))
+                        if pid > 0:
+                            pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -959,7 +956,7 @@ def _probe_launchd_service_running() -> bool:
         return False
     try:
         result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
+            ["launchctl", "print", _launchd_target()],
             capture_output=True,
             text=True,
             timeout=10,
@@ -2830,7 +2827,30 @@ def get_launchd_label() -> str:
 
 
 def _launchd_domain() -> str:
-    return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    override = os.getenv("HERMES_LAUNCHD_DOMAIN")
+    if override:
+        domain = override.format(uid=os.getuid())
+        if not (domain.startswith("user/") or domain.startswith("gui/")):
+            raise ValueError("HERMES_LAUNCHD_DOMAIN must start with user/ or gui/")
+        return domain
+    return f"user/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+
+
+def _launchd_target(label: str | None = None) -> str:
+    return f"{_launchd_domain()}/{label or get_launchd_label()}"
+
+
+def _legacy_launchd_target(label: str | None = None) -> str:
+    return f"gui/{os.getuid()}/{label or get_launchd_label()}"
+
+
+def _launchd_targets_for_bootout(label: str | None = None) -> list[str]:
+    targets = [_launchd_target(label), _legacy_launchd_target(label)]
+    return list(dict.fromkeys(targets))
+
+
+def _launchd_session_type() -> str:
+    return "Background" if _launchd_domain().startswith("user/") else "Aqua"
 
 
 def generate_launchd_plist() -> str:
@@ -2893,6 +2913,9 @@ def generate_launchd_plist() -> str:
     
     <key>WorkingDirectory</key>
     <string>{working_dir}</string>
+
+    <key>LimitLoadToSessionType</key>
+    <string>{_launchd_session_type()}</string>
     
     <key>EnvironmentVariables</key>
     <dict>
@@ -2948,8 +2971,11 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
-    # Bootout/bootstrap so launchd picks up the new definition
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
+    # Bootout/bootstrap so launchd picks up the new definition. Also boot out
+    # the legacy gui-domain target from older installs so migration cannot leave
+    # two launchd jobs owning the same gateway profile.
+    for target in _launchd_targets_for_bootout(label):
+        subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
     subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
@@ -2985,7 +3011,8 @@ def launchd_install(force: bool = False):
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
+    for target in _launchd_targets_for_bootout(label):
+        subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
     
     if plist_path.exists():
         plist_path.unlink()
@@ -3003,24 +3030,26 @@ def launchd_start():
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode not in {3, 113}:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
+        for target in _launchd_targets_for_bootout(label):
+            subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
     print("✓ Service started")
 
 def launchd_stop():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    target = _launchd_target(label)
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
         pid = get_running_pid(cleanup_stale=False)
@@ -3086,7 +3115,7 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    target = _launchd_target(label)
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
@@ -3112,6 +3141,8 @@ def launchd_restart():
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
+        for bootout_target in _launchd_targets_for_bootout(label):
+            subprocess.run(["launchctl", "bootout", bootout_target], check=False, timeout=90)
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
@@ -3121,7 +3152,7 @@ def launchd_status(deep: bool = False):
     label = get_launchd_label()
     try:
         result = subprocess.run(
-            ["launchctl", "list", label],
+            ["launchctl", "print", _launchd_target(label)],
             capture_output=True,
             text=True,
             timeout=10,
@@ -4210,14 +4241,7 @@ def _is_service_running() -> bool:
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+        return _probe_launchd_service_running()
     elif is_windows():
         from hermes_cli import gateway_windows
         if gateway_windows.is_installed():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2902,6 +2902,8 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <key>HERMES_GATEWAY_SERVICE_MANAGER</key>
+        <string>launchd</string>
     </dict>
     
     <key>RunAtLoad</key>

--- a/hermes_cli/kanban_card_chat.py
+++ b/hermes_cli/kanban_card_chat.py
@@ -1,0 +1,305 @@
+"""Card-prep chat: let Rolly help prepare one Kanban card."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_ready_review
+
+logger = logging.getLogger(__name__)
+
+HERMES_KANBAN_CARD_CHAT_MAX_TOKENS = max(
+    1500,
+    int(os.getenv("HERMES_KANBAN_CARD_CHAT_MAX_TOKENS", "6000")),
+)
+
+_SYSTEM_PROMPT = """You are Rolly helping a human prepare one Kanban card for AI handoff.
+Your job: have a focused prep conversation. Only edit the card when the human explicitly asks you to update/save/change the card.
+The first-class job is helping the human create acceptance criteria; treat the chat like a normal Rolly conversation, not a form-filling wizard.
+
+Be pushy about handoff quality, but do not overstuff the visible card. The card is not ready until it has:
+- clear goal / outcome
+- concrete scope and out-of-scope
+- quantifiable acceptance criteria
+- verification command or manual verification steps
+- source/provenance for why the work exists
+- agent/workdir hints when relevant
+
+Return exactly one JSON object:
+{
+  "reply": "short conversational reply to the human; include the next missing question if not ready",
+  "title": "optional replacement title, <= 100 chars, or null",
+  "body": "complete replacement markdown body, or null if unchanged",
+  "ready": true|false,
+  "missing": ["one-line missing item", ...]
+}
+
+Rules:
+- Preserve the user's meaning; do not invent requirements.
+- Make acceptance criteria measurable/observable.
+- Keep the card body concise; detailed notes can stay in the conversation/comments.
+- Prefer concise markdown sections in body: Goal, Acceptance criteria, Verification, Notes.
+- If the human is only asking/thinking, reply conversationally and title/body must be null.
+- If the human asks for help/spec/criteria but does not explicitly ask to update or save the card, title/body must be null.
+- Only return replacement title/body when the human explicitly says to update/save/change the card.
+- If details are missing, ask one or two pointed questions in reply and still improve the card with what is known only when edits were explicitly requested.
+- No preamble outside JSON.
+"""
+
+_USER_TEMPLATE = """Task id: {task_id}
+Status: {status}
+Assignee: {assignee}
+Tenant: {tenant}
+Workspace: {workspace}
+
+Current title:
+{title}
+
+Current body:
+{body}
+
+Recent card conversation/comments:
+{comments}
+
+Human message:
+{message}
+"""
+
+_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class CardChatOutcome:
+    task_id: str
+    ok: bool
+    reply: str
+    title: Optional[str] = None
+    body: Optional[str] = None
+    ready: bool = False
+    missing: tuple[str, ...] = ()
+    ready_review: Optional[dict] = None
+    reason: str = ""
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _extract_json_blob(raw: str) -> Optional[dict]:
+    if not raw:
+        return None
+    stripped = _FENCE_RE.sub("", raw.strip())
+    first = stripped.find("{")
+    last = stripped.rfind("}")
+    if first == -1 or last == -1 or last <= first:
+        return None
+    try:
+        parsed = json.loads(stripped[first : last + 1])
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _comment_context(comments: list[kb.Comment], limit: int = 12) -> str:
+    if not comments:
+        return "(none)"
+    lines = []
+    for c in comments[-limit:]:
+        body = _truncate(c.body or "", 1200)
+        lines.append(f"[{c.author or 'anon'}] {body}")
+    return "\n\n".join(lines)
+
+
+def _profile_author() -> str:
+    return (
+        os.environ.get("HERMES_PROFILE")
+        or os.environ.get("USER")
+        or "rolly"
+    )
+
+
+_EXPLICIT_CARD_UPDATE_RE = re.compile(
+    r"\b(update|save|change|edit|rewrite|set|replace|apply)\b.{0,32}\b(card|task|title|body|description|acceptance|criteria)\b"
+    r"|\b(card|task|title|body|description|acceptance|criteria)\b.{0,32}\b(update|save|change|edit|rewrite|set|replace|apply)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _explicit_card_update_requested(message: str) -> bool:
+    return bool(_EXPLICIT_CARD_UPDATE_RE.search(message or ""))
+
+
+def _apply_card_update(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    user_message: str,
+    user_author: str,
+    reply: str,
+    title: Optional[str],
+    body: Optional[str],
+    missing: list[str],
+) -> None:
+    now = int(time.time())
+    with kb.write_txn(conn):
+        existing = conn.execute(
+            "SELECT title, body FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if existing is None:
+            raise ValueError(f"unknown task {task_id}")
+
+        sets: list[str] = []
+        vals: list[str] = []
+        changed_fields: list[str] = []
+        if title is not None:
+            next_title = title.strip()
+            if not next_title:
+                raise ValueError("title cannot be blank")
+            if next_title != (existing["title"] or ""):
+                sets.append("title = ?")
+                vals.append(next_title)
+                changed_fields.append("title")
+        if body is not None and body != (existing["body"] or ""):
+            sets.append("body = ?")
+            vals.append(body)
+            changed_fields.append("body")
+        if sets:
+            vals.append(task_id)
+            conn.execute(f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals)
+
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, user_author.strip() or "human", user_message.strip(), now),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, "rolly", reply.strip(), now),
+        )
+        kb._append_event(
+            conn,
+            task_id,
+            "card_chat",
+            {"changed_fields": changed_fields, "missing": missing},
+        )
+
+
+def chat_on_card(
+    task_id: str,
+    message: str,
+    *,
+    author: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> CardChatOutcome:
+    """Send one prep-chat message, live-update the card, and append transcript comments."""
+    message = (message or "").strip()
+    if not message:
+        return CardChatOutcome(task_id, False, "", reason="message is required")
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        comments = kb.list_comments(conn, task_id) if task else []
+    if task is None:
+        return CardChatOutcome(task_id, False, "", reason="unknown task id")
+
+    try:
+        from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client
+    except Exception as exc:  # pragma: no cover
+        logger.debug("card_chat: auxiliary client import failed: %s", exc)
+        return CardChatOutcome(task_id, False, "", reason="auxiliary client unavailable")
+
+    try:
+        client, model = get_text_auxiliary_client("kanban_card_chat")
+    except Exception as exc:
+        logger.debug("card_chat: get_text_auxiliary_client failed: %s", exc)
+        return CardChatOutcome(task_id, False, "", reason="auxiliary client unavailable")
+
+    if client is None or not model:
+        return CardChatOutcome(task_id, False, "", reason="no auxiliary client configured")
+
+    user_msg = _USER_TEMPLATE.format(
+        task_id=task.id,
+        status=task.status,
+        assignee=task.assignee or "(unassigned)",
+        tenant=task.tenant or "(none)",
+        workspace=f"{task.workspace_kind}{(': ' + task.workspace_path) if task.workspace_path else ''}",
+        title=_truncate(task.title or "", 500),
+        body=_truncate(task.body or "(no body)", 6000),
+        comments=_truncate(_comment_context(comments), 6000),
+        message=_truncate(message, 4000),
+    )
+
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": user_msg},
+            ],
+            temperature=0.2,
+            max_tokens=HERMES_KANBAN_CARD_CHAT_MAX_TOKENS,
+            timeout=timeout or 120,
+            extra_body=get_auxiliary_extra_body() or None,
+        )
+        raw = (resp.choices[0].message.content or "").strip()
+    except Exception as exc:
+        logger.info("card_chat: API call failed for %s (%s)", task_id, exc)
+        return CardChatOutcome(task_id, False, "", reason=f"LLM error: {type(exc).__name__}")
+
+    parsed = _extract_json_blob(raw)
+    if parsed is None:
+        return CardChatOutcome(task_id, False, "", reason="LLM returned malformed JSON")
+
+    reply = parsed.get("reply") if isinstance(parsed.get("reply"), str) else ""
+    title_val = parsed.get("title")
+    body_val = parsed.get("body")
+    title = title_val.strip() if isinstance(title_val, str) and title_val.strip() else None
+    body = body_val if isinstance(body_val, str) and body_val.strip() else None
+    ready = bool(parsed.get("ready"))
+    missing_raw = parsed.get("missing")
+    missing = [str(x).strip() for x in missing_raw if str(x).strip()] if isinstance(missing_raw, list) else []
+
+    if not reply.strip():
+        reply = "Updated the card. Next: define measurable acceptance criteria and verification."
+
+    if not _explicit_card_update_requested(message):
+        title = None
+        body = None
+
+    user_author = author or "human"
+    try:
+        with kb.connect() as conn:
+            _apply_card_update(
+                conn,
+                task_id,
+                user_message=message,
+                user_author=user_author,
+                reply=reply,
+                title=title,
+                body=body,
+                missing=missing,
+            )
+            ready_review = kanban_ready_review.status_for_task(conn, task_id).to_dict()
+    except ValueError as exc:
+        return CardChatOutcome(task_id, False, "", reason=str(exc))
+
+    return CardChatOutcome(
+        task_id,
+        True,
+        reply,
+        title=title,
+        body=body,
+        ready=ready,
+        missing=tuple(missing),
+        ready_review=ready_review,
+    )

--- a/hermes_cli/kanban_card_context.py
+++ b/hermes_cli/kanban_card_context.py
@@ -1,0 +1,127 @@
+"""Build deterministic Kanban-card context packets for external coding agents."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli import kanban_db
+
+
+class CardContextError(RuntimeError):
+    """Raised when a card cannot be converted into launchable agent context."""
+
+
+def _trim(text: Optional[str], limit: int) -> str:
+    if not text:
+        return ""
+    text = str(text).strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 20].rstrip() + "\n…[truncated]"
+
+
+def _workspace_path(task: kanban_db.Task) -> Path:
+    if not task.workspace_path:
+        raise CardContextError(
+            f"task {task.id} has no workspace_path; set a concrete repo/workspace before launching Claude Code"
+        )
+    path = Path(task.workspace_path).expanduser()
+    if not path.exists():
+        raise CardContextError(f"task {task.id} workspace_path does not exist: {path}")
+    if not path.is_dir():
+        raise CardContextError(f"task {task.id} workspace_path is not a directory: {path}")
+    return path.resolve()
+
+
+def build_card_context(task_id: str, *, board: Optional[str] = None) -> dict[str, Any]:
+    """Return canonical card data plus a launchable workspace path.
+
+    This intentionally fails when the card lacks a real workspace. Claude Code
+    sessions should not silently fall back to an unrelated repo.
+    """
+
+    kanban_db.init_db(board=board)
+    conn = kanban_db.connect(board=board)
+    try:
+        task = kanban_db.get_task(conn, task_id)
+        if task is None:
+            raise CardContextError(f"task {task_id} not found")
+        workspace = _workspace_path(task)
+        list_criteria = getattr(kanban_db, "list_acceptance_criteria", None)
+        criteria = list_criteria(conn, task_id) if callable(list_criteria) else []
+        task_dict = asdict(task)
+        return {
+            "task": task_dict,
+            "workspace_path": str(workspace),
+            "acceptance_criteria": criteria,
+            "latest_summary": kanban_db.latest_summary(conn, task_id),
+            "links": {
+                "parents": [r["parent_id"] for r in conn.execute("SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id", (task_id,)).fetchall()],
+                "children": [r["child_id"] for r in conn.execute("SELECT child_id FROM task_links WHERE parent_id = ? ORDER BY child_id", (task_id,)).fetchall()],
+            },
+        }
+    finally:
+        conn.close()
+
+
+def build_claude_prompt(context: dict[str, Any]) -> str:
+    """Build the initial Claude Code prompt for a card-scoped session."""
+
+    task = context["task"]
+    links = context.get("links") or {}
+    criteria = context.get("acceptance_criteria") or []
+    lines: list[str] = [
+        "You are Claude Code working on a Rolly Kanban card.",
+        "Do exactly the card asks: no scope creep, no mock implementations, fail fast.",
+        "If acceptance/verification is unclear, stop and explain the blocker instead of guessing.",
+        "Respect global Rolly/MIX constraints: preserve user work, do not reset/stash, run narrow verification, and report exact files/tests.",
+        "",
+        f"Card: {task.get('id')} — {task.get('title')}",
+        f"Status: {task.get('status')} | Priority: {task.get('priority')} | Tenant: {task.get('tenant') or 'none'} | Assignee: {task.get('assignee') or 'none'}",
+        f"Workspace: {context.get('workspace_path')}",
+        f"Execution mode: {task.get('execution_mode') or 'manual Claude Code'}",
+        "",
+        "## Body",
+        _trim(task.get("body"), 6000) or "(empty)",
+    ]
+    if context.get("latest_summary"):
+        lines += ["", "## Latest worker summary", _trim(context.get("latest_summary"), 2000)]
+    lines += [
+        "",
+        "## Acceptance criteria",
+    ]
+    if criteria:
+        for item in criteria:
+            lines.append(
+                f"- [{ 'x' if item.get('passed') else ' ' }] ({item.get('verifier')}) "
+                f"{_trim(item.get('text'), 1000)}"
+                + (f" — evidence: {_trim(item.get('evidence'), 700)}" if item.get('evidence') else "")
+            )
+    else:
+        lines.append("(none available in this board schema — rely on the card body and stop if acceptance is unclear)")
+    lines += [
+        "",
+        "## Links",
+        f"Parents: {', '.join(links.get('parents') or []) or 'none'}",
+        f"Children: {', '.join(links.get('children') or []) or 'none'}",
+    ]
+    lines += [
+        "",
+        "## Expected behavior",
+        "- First inspect the repo and card context.",
+        "- Make only changes needed for this card.",
+        "- Run the card's verification commands or the narrowest relevant tests.",
+        "- End with a concise handoff: files changed, tests run, remaining blockers.",
+    ]
+    return "\n".join(lines).strip() + "\n"
+
+
+def build_claude_card_launch(task_id: str, *, board: Optional[str] = None) -> dict[str, Any]:
+    context = build_card_context(task_id, board=board)
+    return {
+        "task_id": context["task"]["id"],
+        "workspace_path": context["workspace_path"],
+        "prompt": build_claude_prompt(context),
+    }

--- a/hermes_cli/kanban_card_context.py
+++ b/hermes_cli/kanban_card_context.py
@@ -24,6 +24,8 @@ def _trim(text: Optional[str], limit: int) -> str:
 
 def _workspace_path(task: kanban_db.Task) -> Path:
     if not task.workspace_path:
+        if task.workspace_kind == "scratch":
+            return Path.home().resolve()
         raise CardContextError(
             f"task {task.id} has no workspace_path; set a concrete repo/workspace before launching Claude Code"
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1992,6 +1992,86 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+_MIX_WORD_RE = re.compile(r"\bMIX\b", re.IGNORECASE)
+_READY_ACCEPTANCE_RE = re.compile(r"(?im)^\s*(?:#{1,6}\s*)?acceptance(?:\s+criteria)?\s*:")
+_READY_VERIFICATION_RE = re.compile(r"(?im)^\s*(?:#{1,6}\s*)?verification\s*:")
+_READY_SOURCE_RE = re.compile(r"(?im)^\s*(?:#{1,6}\s*)?(?:context/)?(?:source|provenance)\b")
+_READY_APPROVAL_RE = re.compile(r"(?i)\bapproved\s+by\s+([A-Za-z][A-Za-z ._-]*)")
+_GENERIC_APPROVERS = {"human", "reviewer", "another human reviewer", "user", "operator"}
+
+
+def _is_mix_task_row(row: sqlite3.Row | None) -> bool:
+    if row is None:
+        return False
+    tenant = (row["tenant"] or "").strip().casefold() if "tenant" in row.keys() else ""
+    if tenant == "mix":
+        return True
+    return bool(_MIX_WORD_RE.search(row["title"] or "") or _MIX_WORD_RE.search(row["body"] or ""))
+
+
+def _has_human_approval(text: str) -> bool:
+    for match in _READY_APPROVAL_RE.finditer(text):
+        approver = match.group(1).strip(" ._-").casefold()
+        if approver and approver not in _GENERIC_APPROVERS:
+            return True
+    return False
+
+
+def _mix_ready_guard_error(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT title, body, tenant FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not _is_mix_task_row(row):
+        return None
+
+    body = row["body"] or ""
+    comments = conn.execute(
+        "SELECT body FROM task_comments WHERE task_id = ? ORDER BY id ASC",
+        (task_id,),
+    ).fetchall()
+    comment_text = "\n".join(c["body"] or "" for c in comments)
+    combined_text = "\n".join(part for part in (body, comment_text) if part)
+
+    missing: list[str] = []
+    if not _READY_ACCEPTANCE_RE.search(body):
+        missing.append("missing acceptance criteria")
+    if not _READY_VERIFICATION_RE.search(body):
+        missing.append("missing verification")
+    if not _READY_SOURCE_RE.search(body):
+        missing.append("missing source/provenance")
+    if not _has_human_approval(combined_text):
+        missing.append("missing human approval")
+
+    if not missing:
+        return None
+    return "MIX ready guard: " + "; ".join(missing)
+
+
+def _append_mix_ready_guard_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    reason: str,
+    *,
+    suppress_duplicate: bool = False,
+) -> None:
+    if suppress_duplicate:
+        latest = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'ready_guard_blocked' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        if latest and latest["payload"]:
+            try:
+                payload = json.loads(latest["payload"])
+            except (TypeError, json.JSONDecodeError):
+                payload = None
+            if isinstance(payload, dict) and payload.get("reason") == reason:
+                return
+    _append_event(conn, task_id, "ready_guard_blocked", {"reason": reason})
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2204,6 +2284,15 @@ def create_task(
                         session_id,
                     ),
                 )
+                if task_status == "ready":
+                    guard_error = _mix_ready_guard_error(conn, task_id)
+                    if guard_error:
+                        task_status = "todo"
+                        conn.execute(
+                            "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                            (task_id,),
+                        )
+                        _append_mix_ready_guard_event(conn, task_id, guard_error)
                 for pid in parents:
                     conn.execute(
                         "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
@@ -2876,6 +2965,17 @@ def recompute_ready(
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
+                guard_error = _mix_ready_guard_error(conn, task_id)
+                if guard_error:
+                    if cur_status == "blocked":
+                        conn.execute(
+                            "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'blocked'",
+                            (task_id,),
+                        )
+                    _append_mix_ready_guard_event(
+                        conn, task_id, guard_error, suppress_duplicate=True,
+                    )
+                    continue
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -2951,6 +3051,18 @@ def claim_task(
             _append_event(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
+            )
+            return None
+        guard_error = _mix_ready_guard_error(conn, task_id)
+        if guard_error:
+            conn.execute(
+                "UPDATE tasks SET status = 'todo' "
+                "WHERE id = ? AND status = 'ready'",
+                (task_id,),
+            )
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": guard_error},
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4092,6 +4204,13 @@ def promote_task(
                 f"{', '.join(unsatisfied)} (use --force to override)"
             )
 
+    guard_error = _mix_ready_guard_error(conn, task_id)
+    if guard_error:
+        if not dry_run:
+            with write_txn(conn):
+                _append_mix_ready_guard_event(conn, task_id, guard_error)
+        return False, guard_error
+
     if dry_run:
         return True, None
 
@@ -4154,6 +4273,11 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             (task_id,),
         ).fetchone()
         new_status = "todo" if undone_parents else "ready"
+        guard_error = None
+        if new_status == "ready":
+            guard_error = _mix_ready_guard_error(conn, task_id)
+            if guard_error:
+                new_status = "todo"
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
             "consecutive_failures = 0, last_failure_error = NULL "
@@ -4166,6 +4290,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
         )
+        if guard_error:
+            _append_mix_ready_guard_event(conn, task_id, guard_error)
         return True
 
 

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -145,6 +145,60 @@ def _task_field(task, name, default=None):
     return getattr(task, name, default)
 
 
+def _string_set(value) -> set[str]:
+    """Normalize config values that may be a list or comma string."""
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        parts = value.split(",")
+    elif isinstance(value, Iterable):
+        parts = value
+    else:
+        return set()
+    return {
+        str(part).strip().lower()
+        for part in parts
+        if str(part).strip()
+    }
+
+
+def _rolly_user_assignee_slugs() -> set[str]:
+    """Optional Rolly-local human assignees from ``rolly-users.json``.
+
+    Upstream Hermes installs do not have this file. When present, these
+    slugs represent human card owners, not worker profiles, so diagnostics
+    should not treat ready cards assigned to them as stranded worker jobs.
+    """
+    try:
+        from hermes_cli import kanban_db
+        path = kanban_db.kanban_home() / "rolly-users.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return set()
+    users = data.get("users") if isinstance(data, dict) else None
+    if not isinstance(users, list):
+        return set()
+    out: set[str] = set()
+    for user in users:
+        if not isinstance(user, dict):
+            continue
+        slug = str(user.get("slug") or "").strip().lower()
+        if slug:
+            out.add(slug)
+    return out
+
+
+def _human_assignees(cfg: dict) -> set[str]:
+    """Return assignee names that are explicitly manual/human owners."""
+    names = _string_set(cfg.get("human_assignees"))
+    kanban_cfg = cfg.get("kanban")
+    if isinstance(kanban_cfg, dict):
+        names |= _string_set(kanban_cfg.get("human_assignees"))
+        names |= _string_set(kanban_cfg.get("manual_assignees"))
+    names |= _rolly_user_assignee_slugs()
+    return names
+
+
 def _parse_payload(ev) -> dict:
     """Tolerate event.payload being either a dict or a JSON string."""
     p = _task_field(ev, "payload", None)
@@ -890,10 +944,17 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     if _task_field(task, "claim_lock"):
         return []
     assignee = _task_field(task, "assignee") or ""
-    if not assignee.strip():
+    assignee_name = assignee.strip()
+    if not assignee_name:
         # Unassigned tasks: the dispatcher's ``skipped_unassigned`` is
         # already the right signal. A separate diagnostic here would
         # double-flag the same condition.
+        return []
+    if assignee_name.lower() in _human_assignees(cfg):
+        # Rolly's simplified board uses assignee for human ownership too
+        # (deniz/arman/buket/etc.). Those cards are not expected to be
+        # claimed by the dispatcher, so worker-stranding diagnostics are
+        # noise.
         return []
 
     # Find the most recent event that put this task into ready.

--- a/hermes_cli/kanban_ready_review.py
+++ b/hermes_cli/kanban_ready_review.py
@@ -1,0 +1,201 @@
+"""Ready-review affordances for MIX Kanban cards.
+
+This module is intentionally policy-light: it gives humans one shared view of
+whether a card has enough evidence to be moved to ``ready`` and records explicit
+approval provenance in the existing append-only event/comment surfaces. The core
+transition guard can consume the same event kind without a schema migration.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Optional
+
+from hermes_cli import kanban_db as kb
+
+APPROVAL_EVENT_KIND = "ready_review_approved"
+REQUIRED_FIELDS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "acceptance_criteria",
+        "acceptance criteria",
+        (r"acceptance\s+criteria", r"\bacceptance\b", r"\baccept\b"),
+    ),
+    (
+        "verification",
+        "verification plan/result",
+        (r"verification", r"verify", r"tested", r"tests?\s+(run|pass|passed)"),
+    ),
+    (
+        "source_provenance",
+        "source/provenance",
+        (r"source", r"provenance", r"citation", r"artifact"),
+    ),
+)
+
+_AGENT_APPROVER_NAMES = {"agent", "assistant", "default", "rolly", "hermes", "bot", "worker"}
+_GENERIC_APPROVER_NAMES = {"human", "reviewer"}
+
+
+@dataclass(frozen=True)
+class ReadyReviewStatus:
+    task_id: str
+    is_mix_card: bool
+    approved: bool
+    approver: Optional[str]
+    approved_at: Optional[int]
+    approval_event_id: Optional[int]
+    requirements: dict[str, bool]
+    missing: list[str]
+    eligible: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def is_mix_card(task: kb.Task) -> bool:
+    """Best-effort marker for the MIX-specific ready gate.
+
+    The Rolly board does not have first-class product/project metadata yet, so
+    tenant='mix' is the canonical signal and title/body mentions are a practical
+    bridge for existing cards.
+    """
+    haystack = " ".join(
+        part for part in [task.tenant, task.title, task.body] if part
+    ).lower()
+    return bool(re.search(r"\bmix\b", haystack))
+
+
+def _metadata_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        return str(value)
+
+
+def _review_corpus(
+    task: kb.Task,
+    comments: Iterable[kb.Comment],
+    runs: Iterable[kb.Run],
+) -> str:
+    parts: list[str] = [task.title or "", task.body or "", task.result or ""]
+    parts.extend(c.body or "" for c in comments)
+    for run in runs:
+        parts.append(run.summary or "")
+        parts.append(_metadata_text(run.metadata))
+    return "\n".join(p for p in parts if p).lower()
+
+
+def latest_approval(events: Iterable[kb.Event]) -> tuple[Optional[str], Optional[int], Optional[int]]:
+    latest: Optional[kb.Event] = None
+    for event in events:
+        if event.kind == APPROVAL_EVENT_KIND:
+            latest = event
+    if latest is None:
+        return None, None, None
+    payload = latest.payload or {}
+    approver = payload.get("approver") or payload.get("reviewer")
+    return (str(approver) if approver else None, latest.created_at, latest.id)
+
+
+def compute_ready_review_status(
+    task: kb.Task,
+    comments: Iterable[kb.Comment],
+    events: Iterable[kb.Event],
+    runs: Iterable[kb.Run],
+) -> ReadyReviewStatus:
+    corpus = _review_corpus(task, comments, runs)
+    requirements: dict[str, bool] = {}
+    missing: list[str] = []
+    for key, label, patterns in REQUIRED_FIELDS:
+        present = any(re.search(pattern, corpus, flags=re.IGNORECASE) for pattern in patterns)
+        requirements[key] = present
+        if not present:
+            missing.append(label)
+
+    approver, approved_at, event_id = latest_approval(events)
+    approver_key = approver.strip().lower() if approver else ""
+    approved = bool(
+        approver_key
+        and approver_key not in _AGENT_APPROVER_NAMES
+        and approver_key not in _GENERIC_APPROVER_NAMES
+    )
+    if not approved:
+        missing.append("explicit human approval")
+
+    return ReadyReviewStatus(
+        task_id=task.id,
+        is_mix_card=is_mix_card(task),
+        approved=approved,
+        approver=approver,
+        approved_at=approved_at,
+        approval_event_id=event_id,
+        requirements=requirements,
+        missing=missing,
+        eligible=not missing,
+    )
+
+
+def status_for_task(conn: sqlite3.Connection, task_id: str) -> ReadyReviewStatus:
+    task = kb.get_task(conn, task_id)
+    if task is None:
+        raise ValueError(f"no such task: {task_id}")
+    return compute_ready_review_status(
+        task,
+        kb.list_comments(conn, task_id),
+        kb.list_events(conn, task_id),
+        kb.list_runs(conn, task_id),
+    )
+
+
+def record_ready_review_approval(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    approver: str,
+    note: Optional[str] = None,
+    author: str = "dashboard",
+) -> ReadyReviewStatus:
+    task = kb.get_task(conn, task_id)
+    if task is None:
+        raise ValueError(f"no such task: {task_id}")
+    approver = (approver or "").strip()
+    if not approver:
+        raise ValueError("approver is required")
+    if approver.lower() in _AGENT_APPROVER_NAMES or approver.lower() in _GENERIC_APPROVER_NAMES:
+        raise ValueError("approver must be a specific human reviewer name, not an agent/profile/generic label")
+
+    before = compute_ready_review_status(
+        task,
+        kb.list_comments(conn, task_id),
+        kb.list_events(conn, task_id),
+        kb.list_runs(conn, task_id),
+    )
+    payload = {
+        "approver": approver,
+        "approved_at": int(time.time()),
+        "requirements": before.requirements,
+        "missing_before_approval": before.missing,
+    }
+    comment = f"READY REVIEW APPROVED by {approver}"
+    if note:
+        comment += f": {note.strip()}"
+
+    with kb.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, APPROVAL_EVENT_KIND, json.dumps(payload, ensure_ascii=False), payload["approved_at"]),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, author, comment, payload["approved_at"]),
+        )
+
+    return status_for_task(conn, task_id)

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -31,6 +31,8 @@ LOG_FILES = {
     "agent": "agent.log",
     "errors": "errors.log",
     "gateway": "gateway.log",
+    "dashboard-out": "dashboard-launchd.out.log",
+    "dashboard-err": "dashboard-launchd.err.log",
 }
 
 # Log line timestamp regex — matches "2026-04-05 22:35:00,123" or

--- a/hermes_cli/voice_task_runner.py
+++ b/hermes_cli/voice_task_runner.py
@@ -1,0 +1,158 @@
+"""Detached runner for Rolly Voice background tasks.
+
+This process is intentionally separate from the dashboard/FastAPI process so
+work queued from a live call can survive browser disconnects, call end, and
+best-effort dashboard restarts. It writes task state and transcript events to
+HERMES_HOME so the dashboard can rediscover status later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _voice_transcript_path(call_id: str) -> Path:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._") or "unknown-call"
+    root = Path(get_hermes_home()) / "voice-transcripts"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"{safe}.jsonl"
+
+
+def _voice_session_id(call_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._") or "unknown-call"
+    return f"dashboard_voice_{safe}"
+
+
+def _append_transcript(task: dict[str, Any], event_type: str, text: str, metadata: dict[str, Any] | None = None) -> None:
+    record = {
+        "timestamp": _now(),
+        "call_id": task["call_id"],
+        "session_id": _voice_session_id(task["call_id"]),
+        "user": task.get("user") or "unknown dashboard user",
+        "role": "tool",
+        "event_type": event_type,
+        "text": text,
+        "metadata": {
+            "task_id": task["task_id"],
+            "task_session_id": task["session_id"],
+            **(metadata or {}),
+        },
+    }
+    with _voice_transcript_path(task["call_id"]).open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _progress(task: dict[str, Any], status: str, message: str, *, result: str | None = None, error: str | None = None) -> None:
+    task["status"] = status
+    task["updated_at"] = _now()
+    if result is not None:
+        task["result"] = result
+    if error is not None:
+        task["error"] = error
+    task.setdefault("progress", []).append({"timestamp": task["updated_at"], "event_type": status, "message": message})
+
+
+def _filter_voice_cli_output(output: str, task: dict[str, Any]) -> str:
+    ansi = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+    lines: list[str] = []
+    for raw in (output or "").splitlines():
+        line = ansi.sub("", raw).strip()
+        if not line or line.startswith("session_id:"):
+            continue
+        if re.fullmatch(r"(?:⏭\s*)?Secret entry skipped", line):
+            continue
+        lines.append(line)
+    visible = "\n".join(lines).strip()
+    if visible:
+        return visible
+    raise RuntimeError(
+        f"Background Rolly task {task['task_id']} produced no user-safe visible output. "
+        f"Task session: {task['session_id']}."
+    )
+
+
+def _prompt(task: dict[str, Any]) -> str:
+    return (
+        f"Dashboard voice user: {task.get('user') or 'unknown dashboard user'}\n"
+        f"Voice call id: {task['call_id']}\n\n"
+        "You are handling work delegated from a live Rolly Voice call. Use normal Rolly context/tools. "
+        "The user-facing surface is only Rolly; do not mention internal Fast/Regular layers. "
+        "This is a durable background task: complete the requested work even if the originating call has ended. "
+        "Return a concise useful handoff answer with citations/links when relevant. "
+        "If more detail exists, say it is available and can be expanded.\n\n"
+        f"User request: {task['request']}"
+    )
+
+
+def run_task(task_file: Path) -> int:
+    task = json.loads(task_file.read_text(encoding="utf-8"))
+    _progress(task, "running", "Rolly is working in the background.")
+    _atomic_write_json(task_file, task)
+    _append_transcript(task, "delegation_started", "Rolly background task started.")
+
+    env = os.environ.copy()
+    env.setdefault("HERMES_HOME", str(get_hermes_home()))
+    timeout_seconds = int(os.getenv("HERMES_VOICE_BACKGROUND_TASK_TIMEOUT", "600"))
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "chat", "-q", _prompt(task), "--source", "dashboard-voice-background", "-Q"],
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or f"exit {proc.returncode}").strip()[:1200]
+            raise RuntimeError(f"Rolly CLI tool failed: {detail}")
+        result = _filter_voice_cli_output(proc.stdout or "", task)
+        _progress(task, "complete", "Rolly background task completed.", result=result)
+        _atomic_write_json(task_file, task)
+        _append_transcript(task, "delegation_result", result, {"status": "complete"})
+        return 0
+    except subprocess.TimeoutExpired as exc:
+        message = f"Rolly CLI tool timed out after {timeout_seconds}s"
+        _progress(task, "failed", f"Rolly background task failed: {message}", error=message)
+        _atomic_write_json(task_file, task)
+        _append_transcript(task, "delegation_error", message, {"status": "failed"})
+        return 1
+    except Exception as exc:
+        message = str(exc)[:1200]
+        _progress(task, "failed", f"Rolly background task failed: {message}", error=message)
+        _atomic_write_json(task_file, task)
+        _append_transcript(task, "delegation_error", message, {"status": "failed"})
+        return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a detached Rolly Voice background task")
+    parser.add_argument("--task-file", required=True)
+    args = parser.parse_args(argv)
+    return run_task(Path(args.task_file))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -24,6 +24,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+import urllib.error
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -160,16 +161,165 @@ class VoiceToolRequest(BaseModel):
     arguments: Dict[str, Any] = {}
 
 
-def _create_openai_realtime_session(user: str | None = None) -> Dict[str, Any]:
-    """Create an ephemeral OpenAI Realtime session for the dashboard voice UI."""
+class VoiceTranscriptEvent(BaseModel):
+    call_id: str
+    role: str
+    text: str
+    event_type: str = "transcript"
+    user: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+def _voice_api_key() -> str:
     api_key = os.getenv("OPENAI_API_KEY") or os.getenv("VOICE_TOOLS_OPENAI_KEY")
     if not api_key:
         raise HTTPException(status_code=503, detail="OpenAI voice credentials are not configured")
-    model = os.getenv("HERMES_VOICE_REALTIME_MODEL", "gpt-realtime")
-    voice = os.getenv("HERMES_VOICE_REALTIME_VOICE", "alloy")
-    body = json.dumps({"model": model, "voice": voice}).encode()
+    return api_key
+
+
+def _voice_speaker_label(user: str | None = None) -> str:
+    value = (user or "").strip()
+    return value or "unknown dashboard user"
+
+
+def _voice_user_from_request(request: Request) -> str | None:
+    sess = getattr(request.state, "session", None)
+    if sess is not None:
+        return getattr(sess, "display_name", None) or getattr(sess, "email", None) or getattr(sess, "user_id", None)
+    return request.headers.get("X-Rolly-User") or request.headers.get("X-Hermes-User")
+
+
+def _voice_auth_context(request: Request) -> str | None:
+    """Return authenticated/claimed dashboard user for voice attribution.
+
+    Gated dashboard sessions attach ``request.state.session``. Loopback / Tailscale
+    dashboard pages are honor-system and pass ``X-Rolly-User`` from the SPA.
+    """
+    return _voice_user_from_request(request)
+
+
+def _voice_transcript_path(call_id: str) -> Path:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._") or "unknown-call"
+    root = Path(get_hermes_home()) / "voice-transcripts"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"{safe}.jsonl"
+
+
+def _save_voice_transcript_event(event: VoiceTranscriptEvent, request: Request) -> Path:
+    user = event.user or _voice_auth_context(request) or "unknown dashboard user"
+    record = {
+        "timestamp": event.timestamp or datetime.now(timezone.utc).isoformat(),
+        "call_id": event.call_id,
+        "user": user,
+        "role": event.role,
+        "event_type": event.event_type,
+        "text": event.text,
+    }
+    path = _voice_transcript_path(event.call_id)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return path
+
+
+def _voice_session_config(user: str | None = None) -> Dict[str, Any]:
+    model = os.getenv("HERMES_VOICE_REALTIME_MODEL", "gpt-realtime-2")
+    voice = os.getenv("HERMES_VOICE_REALTIME_VOICE", "cedar")
+    speaker = _voice_speaker_label(user)
+    return {
+        "type": "realtime",
+        "model": model,
+        "instructions": (
+            "You are Rolly, the concise AI ops and dev colleague for MIX/Suelio. "
+            f"You are speaking with dashboard user: {speaker}. Use that identity for context and attribution. "
+            "This is a live phone-call style conversation: speak naturally, briefly, and do not mention implementation details. "
+            "You have no useful long-term/project context inside the realtime model itself. "
+            "When the user asks about Rolly state, past work, files, code, web/current facts, or wants an action, call the rolly tool with a short exact request. "
+            "Summarize tool results conversationally and ask at most one brief follow-up."
+        ),
+        "tools": [
+            {
+                "type": "function",
+                "name": "rolly",
+                "description": "Ask full Rolly/Hermes to use its normal context and tools for research, memory/session lookup, files, code, or actions. Use this whenever local realtime context is insufficient.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "request": {
+                            "type": "string",
+                            "description": "The concise task or question for full Rolly, preserving user wording when important.",
+                        }
+                    },
+                    "required": ["request"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+        "tool_choice": "auto",
+        "audio": {
+            "input": {
+                "transcription": {"model": "gpt-4o-mini-transcribe"},
+                "noise_reduction": {"type": "near_field"},
+                "turn_detection": {
+                    # Phone-call behavior: let the Realtime API decide when the
+                    # user has semantically finished speaking, then immediately
+                    # generate a spoken response and allow barge-in interrupts.
+                    "type": "semantic_vad",
+                    "create_response": True,
+                    "interrupt_response": True,
+                },
+            },
+            "output": {"voice": voice},
+        },
+    }
+
+
+def _create_openai_realtime_call(sdp: str, user: str | None = None) -> str:
+    """Create an OpenAI Realtime WebRTC call and return answer SDP."""
+    api_key = _voice_api_key()
+    boundary = f"----hermes-realtime-{uuid.uuid4().hex}"
+
+    def part(name: str, value: str, content_type: str | None = None) -> bytes:
+        headers = [f'--{boundary}', f'Content-Disposition: form-data; name="{name}"']
+        if content_type:
+            headers.append(f"Content-Type: {content_type}")
+        return ("\r\n".join(headers) + "\r\n\r\n" + value + "\r\n").encode("utf-8")
+
+    body = b"".join(
+        [
+            part("sdp", sdp, "application/sdp"),
+            part("session", json.dumps(_voice_session_config(user=user)), "application/json"),
+            f"--{boundary}--\r\n".encode("utf-8"),
+        ]
+    )
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+    }
+    if user:
+        headers["OpenAI-Safety-Identifier"] = user
     req = urllib.request.Request(
-        "https://api.openai.com/v1/realtime/sessions",
+        "https://api.openai.com/v1/realtime/calls",
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "ignore")[:800]
+        raise HTTPException(status_code=502, detail=f"Failed to create voice call: {exc.code} {detail}") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to create voice call: {exc}") from exc
+
+
+def _create_openai_realtime_session(user: str | None = None) -> Dict[str, Any]:
+    """Create an ephemeral OpenAI Realtime session for legacy dashboard voice UI."""
+    api_key = _voice_api_key()
+    session = _voice_session_config(user=user)
+    body = json.dumps({"session": session}).encode()
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/realtime/client_secrets",
         data=body,
         headers={
             "Authorization": f"Bearer {api_key}",
@@ -186,29 +336,62 @@ def _create_openai_realtime_session(user: str | None = None) -> Dict[str, Any]:
 
 
 def _run_voice_research(question: str, user: str | None = None) -> str:
-    """Bridge a constrained voice tool call into the existing agent runtime."""
-    from run_agent import AIAgent
-
-    agent = AIAgent(platform="dashboard", enabled_toolsets=["web", "session_search"])
-    return agent.chat(question)
+    """Bridge a voice tool call into the CLI-first Rolly runtime."""
+    speaker = _voice_speaker_label(user)
+    prompt = (
+        f"Dashboard voice user: {speaker}\n\n"
+        "You are answering a live voice call through Rolly Voice. Use normal Rolly context/tools. "
+        "Keep the final answer brief and spoken-conversation friendly.\n\n"
+        f"User request: {question}"
+    )
+    env = os.environ.copy()
+    env.setdefault("HERMES_HOME", str(get_hermes_home()))
+    proc = subprocess.run(
+        ["hermes", "chat", "-q", prompt, "--source", "dashboard-voice", "-Q"],
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=int(os.getenv("HERMES_VOICE_TOOL_TIMEOUT", "90")),
+    )
+    output = (proc.stdout or "").strip()
+    if proc.returncode != 0:
+        detail = (proc.stderr or output or f"exit {proc.returncode}").strip()
+        raise RuntimeError(f"Rolly CLI tool failed: {detail[:700]}")
+    # ``hermes chat -q`` prints a session_id line before the final answer.
+    lines = [line for line in output.splitlines() if not line.startswith("session_id:")]
+    return "\n".join(lines).strip() or output
 
 
 @app.post("/api/voice/session")
 async def create_voice_session(request: Request):
-    _require_token(request)
-    return _create_openai_realtime_session(user=request.headers.get("X-Hermes-User"))
+    return _create_openai_realtime_session(user=_voice_auth_context(request))
+
+
+@app.post("/api/voice/call")
+async def create_voice_call(request: Request):
+    sdp = (await request.body()).decode("utf-8", "ignore")
+    if not sdp.strip():
+        raise HTTPException(status_code=400, detail="Missing SDP offer")
+    answer = _create_openai_realtime_call(sdp, user=_voice_auth_context(request))
+    return Response(content=answer, media_type="application/sdp")
 
 
 @app.post("/api/voice/tool")
 async def run_voice_tool(payload: VoiceToolRequest, request: Request):
-    _require_token(request)
-    if payload.name != "research":
+    if payload.name not in {"research", "rolly"}:
         raise HTTPException(status_code=400, detail="Unsupported voice tool")
-    question = str(payload.arguments.get("question") or "").strip()
+    question = str(payload.arguments.get("request") or payload.arguments.get("question") or "").strip()
     if not question:
         raise HTTPException(status_code=400, detail="Missing question")
-    result = _run_voice_research(question, user=request.headers.get("X-Hermes-User"))
+    result = _run_voice_research(question, user=_voice_auth_context(request))
     return {"ok": True, "result": result, "error": None}
+
+
+@app.post("/api/voice/transcript")
+async def save_voice_transcript(payload: VoiceTranscriptEvent, request: Request):
+    path = _save_voice_transcript_event(payload, request)
+    return {"ok": True, "path": str(path)}
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks
@@ -238,12 +421,29 @@ def should_require_auth(host: str, allow_public: bool) -> bool:
     return (host not in _LOOPBACK_HOST_VALUES) and (not allow_public)
 
 
+def _host_header_name(host_header: str) -> str:
+    """Normalize a Host/Origin netloc to a bare lowercase host name."""
+    h = host_header.strip()
+    if h.startswith("["):
+        close = h.find("]")
+        if close != -1:
+            return h[1:close].lower()
+        return h.strip("[]").lower()
+    return (h.rsplit(":", 1)[0] if ":" in h else h).lower()
+
+
+def _dashboard_allowed_hosts() -> set[str]:
+    raw = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    return {_host_header_name(item) for item in raw.split(",") if item.strip()}
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
     - Exact bound host (with or without port suffix)
     - Loopback aliases when bound to loopback
+    - Explicit reverse-proxy hostnames listed in HERMES_DASHBOARD_ALLOWED_HOSTS
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
     """
@@ -255,17 +455,10 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     # Plain hosts/v4:
     #   localhost:9119
     #   127.0.0.1:9119
-    h = host_header.strip()
-    if h.startswith("["):
-        # IPv6 bracketed — port (if any) follows "]:"
-        close = h.find("]")
-        if close != -1:
-            host_only = h[1:close]  # strip brackets
-        else:
-            host_only = h.strip("[]")
-    else:
-        host_only = h.rsplit(":", 1)[0] if ":" in h else h
-    host_only = host_only.lower()
+    host_only = _host_header_name(host_header)
+
+    if host_only in _dashboard_allowed_hosts():
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
@@ -3854,6 +4047,8 @@ _event_lock = asyncio.Lock()
 def _resolve_chat_argv(
     resume: Optional[str] = None,
     sidecar_url: Optional[str] = None,
+    pty_mode: Optional[str] = None,
+    tmux_session: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve the argv + cwd + env for the chat PTY.
 
@@ -3871,6 +4066,11 @@ def _resolve_chat_argv(
     dashboard's ``/api/pub`` endpoint (see :func:`pub_ws`).
     """
     from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
+
+    if pty_mode == "tmux":
+        if not tmux_session or not re.fullmatch(r"[A-Za-z0-9_.:-]{1,80}", tmux_session):
+            raise SystemExit("Invalid tmux session")
+        return ["tmux", "attach-session", "-t", tmux_session], None, os.environ.copy()
 
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
@@ -3988,7 +4188,12 @@ async def pty_ws(ws: WebSocket) -> None:
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
     try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        resolve_kwargs = {"resume": resume, "sidecar_url": sidecar_url}
+        pty_mode = ws.query_params.get("pty_mode") or None
+        tmux_session = ws.query_params.get("tmux_session") or None
+        if pty_mode or tmux_session:
+            resolve_kwargs.update({"pty_mode": pty_mode, "tmux_session": tmux_session})
+        argv, cwd, env = _resolve_chat_argv(**resolve_kwargs)
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -792,12 +792,14 @@ def _voice_session_config(user: str | None = None, mode: str = "solo") -> Dict[s
         "model": model,
         "instructions": (
             "You are Rolly, the concise AI ops and dev colleague for MIX/Suelio. "
-            f"You are speaking with dashboard user: {speaker}. Use that identity for context and attribution. "
+            f"You are speaking with dashboard user: {speaker}. Use that identity for context and attribution, "
+            "but do not address them by raw dashboard username unless it sounds natural in speech. "
             "Session-start context pack follows; treat it as useful but possibly stale.\n"
             f"{context_pack}\n"
             f"{mode_instruction}"
             f"{rate_instruction}"
             "This is a live phone-call style conversation: speak naturally, briefly, and do not mention implementation details. "
+            "Do not give mic/headset/echo troubleshooting unless the user asks or a system error indicates a problem. "
             "Spoken responses should usually fit 10-15 seconds. If more exists, give the short answer first and offer to continue. "
             "Call transcript events, tool calls/results, timestamps, elapsed time, and an end-call marker are saved to local JSONL for later improvement. "
             "Prefer fast lookup tools (context_lookup, memory_lookup, kanban_lookup, brain_lookup, session_lookup) for context. "
@@ -1008,6 +1010,8 @@ async def create_voice_meet_invite(payload: VoiceMeetInviteRequest, request: Req
     call_id = re.sub(r"[^A-Za-z0-9_.-]", "_", payload.call_id).strip("._")
     if not call_id:
         raise HTTPException(status_code=400, detail="Missing call_id")
+    if _voice_call_has_ended(call_id):
+        raise HTTPException(status_code=409, detail="Cannot create meet invite for ended voice call")
     user = payload.user or _voice_auth_context(request) or "unknown dashboard user"
     _voice_ensure_state_session(call_id, user, mode="meet")
     base = os.getenv("HERMES_DASHBOARD_PUBLIC_URL") or str(request.base_url).rstrip("/")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -872,12 +872,15 @@ def _voice_session_config(user: str | None = None, mode: str = "solo") -> Dict[s
                 "turn_detection": {
                     # Phone-call behavior: let the Realtime API decide when the
                     # user has semantically finished speaking, then immediately
-                    # generate a spoken response in solo mode and allow barge-in
-                    # interrupts. Meet mode disables auto-response so the UI can
+                    # generate a spoken response in solo mode. Realtime barge-in
+                    # interrupts are disabled for dashboard calls because phone
+                    # speaker echo can be misdetected as user speech, causing the
+                    # assistant to stop itself and restart with audible beeps.
+                    # Meet mode disables auto-response so the UI can
                     # hard-gate speech on the "Hey Rolly" wake phrase.
                     "type": "semantic_vad",
                     "create_response": mode == "solo",
-                    "interrupt_response": True,
+                    "interrupt_response": False,
                 },
             },
             "output": {"voice": voice},

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -208,6 +208,7 @@ class VoiceTask:
         ]
         self.call_ended = False
         self.post_call_notification: Dict[str, Any] = {"status": "not_needed"}
+        self.runner_pid: Optional[int] = None
         self.created_at = now
         self.updated_at = now
 
@@ -235,9 +236,58 @@ class VoiceTask:
             "error": self.error,
             "call_ended": self.call_ended,
             "post_call_notification": dict(self.post_call_notification),
+            "runner_pid": self.runner_pid,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
+
+
+def _voice_tasks_root() -> Path:
+    root = Path(get_hermes_home()) / "voice-tasks"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _voice_task_state_path(task_id: str) -> Path:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", task_id).strip("._") or "unknown-task"
+    return _voice_tasks_root() / f"{safe}.json"
+
+
+def _voice_write_task_state(task: VoiceTask) -> None:
+    path = _voice_task_state_path(task.task_id)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(task.to_dict(), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _voice_task_from_dict(data: Dict[str, Any]) -> VoiceTask:
+    task = VoiceTask(
+        task_id=str(data["task_id"]),
+        call_id=str(data["call_id"]),
+        user=str(data.get("user") or "unknown dashboard user"),
+        request=str(data.get("request") or ""),
+        session_id=str(data.get("session_id") or f"voice_task_{data['task_id']}"),
+    )
+    task.status = str(data.get("status") or "queued")
+    task.progress = list(data.get("progress") or task.progress)
+    task.result = data.get("result")
+    task.error = data.get("error")
+    task.call_ended = bool(data.get("call_ended"))
+    task.post_call_notification = dict(data.get("post_call_notification") or {"status": "not_needed"})
+    task.runner_pid = data.get("runner_pid")
+    task.created_at = str(data.get("created_at") or task.created_at)
+    task.updated_at = str(data.get("updated_at") or task.updated_at)
+    return task
+
+
+def _voice_read_task_state(task_id: str) -> VoiceTask | None:
+    path = _voice_task_state_path(task_id)
+    if not path.exists():
+        return None
+    try:
+        return _voice_task_from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None
 
 
 def _voice_api_key() -> str:
@@ -368,6 +418,7 @@ def _voice_update_call_state(event: VoiceTranscriptEvent, user: str) -> None:
                 if task.call_id == event.call_id:
                     task.call_ended = True
                     task.updated_at = now
+                    _voice_write_task_state(task)
                     ended_tasks.append(task)
         for task in ended_tasks:
             if task.status in {"complete", "failed", "cancelled"}:
@@ -407,6 +458,7 @@ def _voice_maybe_notify_post_call(task: VoiceTask, final_status: str) -> None:
     if current in {"sent", "skipped_unconfigured", "failed"}:
         return
     task.post_call_notification = {"status": "pending", "final_status": final_status, "updated_at": datetime.now(timezone.utc).isoformat()}
+    _voice_write_task_state(task)
     try:
         sent = _voice_send_post_call_notification(task)
     except Exception as exc:
@@ -416,6 +468,7 @@ def _voice_maybe_notify_post_call(task: VoiceTask, final_status: str) -> None:
             "error": str(exc)[:500],
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
+        _voice_write_task_state(task)
         _voice_task_event(task, "post_call_notification_error", str(exc)[:700], {"task_id": task.task_id, "status": final_status})
         return
     task.post_call_notification = {
@@ -426,6 +479,7 @@ def _voice_maybe_notify_post_call(task: VoiceTask, final_status: str) -> None:
     }
     event = "post_call_notification_sent" if sent else "post_call_notification_skipped"
     text = "Telegram handoff sent after call end." if sent else "Telegram handoff skipped: HERMES_VOICE_TELEGRAM_HANDOFF_TARGET/TELEGRAM_BOT_TOKEN not configured."
+    _voice_write_task_state(task)
     _voice_task_event(task, event, text, {"task_id": task.task_id, "status": final_status})
 
 
@@ -466,12 +520,14 @@ def _voice_task_status_lookup(query: str | None = None, limit: int = 1600) -> st
     if not task_ids:
         return ""
     rows: list[str] = []
-    with _VOICE_TASKS_LOCK:
-        for task_id in task_ids:
-            task = _VOICE_TASKS.get(task_id)
-            if task is not None:
-                latest = task.progress[-1]["message"] if task.progress else task.status
-                rows.append(f"{task_id}: {task.status}; updated {task.updated_at}; {latest}")
+    for task_id in task_ids:
+        task = _voice_read_task_state(task_id)
+        if task is None:
+            with _VOICE_TASKS_LOCK:
+                task = _VOICE_TASKS.get(task_id)
+        if task is not None:
+            latest = task.progress[-1]["message"] if task.progress else task.status
+            rows.append(f"{task_id}: {task.status}; updated {task.updated_at}; {latest}")
     missing = [task_id for task_id in task_ids if not any(row.startswith(f"{task_id}:") for row in rows)]
     if missing:
         transcript_root = Path(get_hermes_home()) / "voice-transcripts"
@@ -517,20 +573,36 @@ def _voice_task_worker(task_id: str) -> None:
     with _VOICE_TASKS_LOCK:
         task = _VOICE_TASKS[task_id]
         task.mark("running", "Rolly is working in the background.")
+        _voice_write_task_state(task)
     _voice_task_event(task, "delegation_started", "Rolly background task started.")
     try:
         result = _run_voice_research(task.request, user=task.user, source="dashboard-voice-background", parent_call_id=task.call_id)
         result = _voice_visible_task_result(result, task)
         with _VOICE_TASKS_LOCK:
             task.mark("complete", "Rolly background task completed.", result=result)
+            _voice_write_task_state(task)
         _voice_task_event(task, "delegation_result", result, {"status": "complete"})
         _voice_maybe_notify_post_call(task, "complete")
     except Exception as exc:
         message = str(exc)[:1200]
         with _VOICE_TASKS_LOCK:
             task.mark("failed", f"Rolly background task failed: {message}", error=message)
+            _voice_write_task_state(task)
         _voice_task_event(task, "delegation_error", message, {"status": "failed"})
         _voice_maybe_notify_post_call(task, "failed")
+
+
+def _voice_spawn_task_process(task: VoiceTask) -> int:
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "hermes_cli.voice_task_runner", "--task-file", str(_voice_task_state_path(task.task_id))],
+        cwd=str(PROJECT_ROOT),
+        env={**os.environ, "HERMES_HOME": str(get_hermes_home())},
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return int(getattr(proc, "pid", 0) or 0)
 
 
 def _voice_start_background_task(call_id: str, request_text: str, user: str) -> VoiceTask:
@@ -539,8 +611,10 @@ def _voice_start_background_task(call_id: str, request_text: str, user: str) -> 
     task = VoiceTask(task_id=task_id, call_id=call_id, user=user, request=request_text, session_id=f"voice_task_{task_id}")
     with _VOICE_TASKS_LOCK:
         _VOICE_TASKS[task_id] = task
+        _voice_write_task_state(task)
     _voice_task_event(task, "delegation_queued", "Background Rolly task queued.", {"request": request_text})
-    _VOICE_TASK_EXECUTOR.submit(_voice_task_worker, task_id)
+    task.runner_pid = _voice_spawn_task_process(task)
+    _voice_write_task_state(task)
     return task
 
 
@@ -1102,11 +1176,13 @@ async def start_voice_task(payload: VoiceTaskStartRequest, request: Request):
 
 @app.get("/api/voice/tasks/{task_id}")
 async def get_voice_task(task_id: str, _request: Request):
-    with _VOICE_TASKS_LOCK:
-        task = _VOICE_TASKS.get(task_id)
-        if task is None:
-            raise HTTPException(status_code=404, detail="Voice task not found")
-        return task.to_dict()
+    task = _voice_read_task_state(task_id)
+    if task is None:
+        with _VOICE_TASKS_LOCK:
+            task = _VOICE_TASKS.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Voice task not found")
+    return task.to_dict()
 
 
 @app.post("/api/voice/transcript")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import asyncio
+import base64
 import hmac
 import hashlib
 import importlib.util
@@ -22,6 +23,7 @@ import sqlite3
 import stat
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -3736,6 +3738,8 @@ _AUDIO_EXTENSIONS = {
     ".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".mp4",
     ".oga", ".ogg", ".opus", ".wav", ".webm",
 }
+_OPENAI_AUDIO_DIARIZATION_MODEL = "gpt-audio-mini"
+_OPENAI_AUDIO_CHUNK_SECONDS = 600
 
 
 def _audio_uploads_dir() -> Path:
@@ -3818,14 +3822,21 @@ def _turns_from_words(words: Any) -> List[Dict[str, Any]]:
 def _turns_from_labelled_text(text: str) -> List[Dict[str, str]]:
     turns: List[Dict[str, str]] = []
     current: Optional[Dict[str, str]] = None
-    label_re = re.compile(r"^(?:\[?((?:SPEAKER[_ -]?\d+)|(?:Speaker\s*\d+))\]?\s*[:\-]\s*)(.+)$", re.I)
+    label_re = re.compile(
+        r"^(?:\[?((?:SPEAKER[_ -]?[A-Z0-9]+)|(?:Speaker\s*[A-Z0-9]+))\]?\s*[:\-]\s*)(.+)$",
+        re.I,
+    )
     for raw in text.splitlines():
         line = raw.strip()
         if not line:
             continue
         match = label_re.match(line)
         if match:
-            current = {"speaker": match.group(1).replace(" ", "_"), "text": match.group(2).strip()}
+            label = re.sub(r"\s+", " ", match.group(1).strip().replace("_", " "))
+            if label.upper().startswith("SPEAKER"):
+                rest = label[7:].strip()
+                label = f"Speaker {rest}" if rest else "Speaker"
+            current = {"speaker": label, "text": match.group(2).strip()}
             turns.append(current)
         elif current is not None:
             current["text"] = (current["text"] + " " + line).strip()
@@ -3840,6 +3851,135 @@ def _speaker_examples(turns: List[Dict[str, Any]]) -> List[Dict[str, str]]:
         if text_value and speaker not in examples:
             examples[speaker] = text_value[:240]
     return [{"speaker": speaker, "example": example} for speaker, example in examples.items()]
+
+
+def _ffmpeg_audio_chunks(audio_path: Path, *, chunk_seconds: int = _OPENAI_AUDIO_CHUNK_SECONDS) -> List[bytes]:
+    """Convert uploaded audio to <=chunk_seconds MP3 chunks for OpenAI audio input."""
+    with tempfile.TemporaryDirectory(prefix="hermes-audio-diarize-") as tmp:
+        out_pattern = Path(tmp) / "chunk-%03d.mp3"
+        proc = subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-i",
+                str(audio_path),
+                "-vn",
+                "-ac",
+                "1",
+                "-ar",
+                "16000",
+                "-codec:a",
+                "libmp3lame",
+                "-b:a",
+                "64k",
+                "-f",
+                "segment",
+                "-segment_time",
+                str(chunk_seconds),
+                "-reset_timestamps",
+                "1",
+                str(out_pattern),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=900,
+            check=False,
+        )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            raise RuntimeError(f"ffmpeg audio chunking failed ({proc.returncode}): {detail[:500]}")
+        chunks = [p.read_bytes() for p in sorted(Path(tmp).glob("chunk-*.mp3")) if p.stat().st_size > 0]
+        if not chunks:
+            raise RuntimeError("ffmpeg produced no audio chunks")
+        return chunks
+
+
+def _openai_audio_chat_completion(audio_mp3: bytes, *, chunk_index: int, total_chunks: int) -> str:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not set; cannot run OpenAI audio diarization")
+
+    prompt = (
+        "Transcribe this phone call / meeting audio and diarize speakers. "
+        "Return only speaker-labelled transcript lines in this exact style:\n"
+        "Speaker A: ...\nSpeaker B: ...\n"
+        "Use a new line whenever the speaker changes. Do not include timestamps, summaries, markdown, "
+        "or any text that is not part of the labelled transcript."
+    )
+    if total_chunks > 1:
+        prompt += f"\nThis is chunk {chunk_index + 1} of {total_chunks}; label speakers within this chunk as Speaker A, Speaker B, etc."
+    payload = {
+        "model": _OPENAI_AUDIO_DIARIZATION_MODEL,
+        "messages": [
+            {"role": "system", "content": "You are a careful audio transcription and speaker diarization assistant."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": base64.b64encode(audio_mp3).decode("ascii"),
+                            "format": "mp3",
+                        },
+                    },
+                ],
+            },
+        ],
+        "temperature": 0,
+    }
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=900) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"OpenAI audio diarization failed ({exc.code}): {detail}") from exc
+    except Exception as exc:
+        raise RuntimeError(f"OpenAI audio diarization request failed: {exc}") from exc
+    try:
+        content = body["choices"][0]["message"]["content"]
+    except Exception as exc:
+        raise RuntimeError(f"OpenAI audio diarization returned unexpected response: {body}") from exc
+    return str(content or "").strip()
+
+
+def _run_openai_audio_diarization(audio_path: Path) -> Dict[str, Any]:
+    chunks = _ffmpeg_audio_chunks(audio_path)
+    chunk_texts = [
+        _openai_audio_chat_completion(chunk, chunk_index=i, total_chunks=len(chunks))
+        for i, chunk in enumerate(chunks)
+    ]
+    named_transcript = "\n".join(text for text in chunk_texts if text.strip()).strip()
+    turns = _turns_from_labelled_text(named_transcript)
+    if not turns:
+        raise RuntimeError("OpenAI audio diarization returned no parseable speaker-labelled turns")
+    speakers = _speaker_examples(turns)
+    speaker_count = len({s["speaker"] for s in speakers})
+    status = "needs_speaker_names" if speaker_count > 1 else "complete"
+    return {
+        "status": status,
+        "provider": f"openai:{_OPENAI_AUDIO_DIARIZATION_MODEL}",
+        "transcript": "\n".join(str(turn.get("text") or "").strip() for turn in turns).strip(),
+        "turns": turns,
+        "speakers": speakers,
+        "speaker_names": {},
+        "named_transcript": named_transcript,
+        "chunks": len(chunks),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 def _run_audio_cli(audio_path: Path) -> Dict[str, Any]:
@@ -3926,8 +4066,7 @@ def _run_audio_diarization(audio_path: Path) -> None:
     running.update({"status": "running"})
     _write_audio_analysis(audio_path, running)
     try:
-        cli_result = _run_audio_cli(audio_path)
-        analysis = _load_cli_audio_result(cli_result)
+        analysis = _run_openai_audio_diarization(audio_path)
         _write_audio_analysis(audio_path, analysis)
         transcript_path = audio_path.with_suffix(audio_path.suffix + ".transcript.txt")
         transcript_path.write_text(analysis.get("named_transcript") or analysis.get("transcript") or "", encoding="utf-8")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import secrets
 import stat
 import subprocess
@@ -23,6 +24,8 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -150,6 +153,62 @@ def _require_token(request: Request) -> None:
     """Validate the ephemeral session token.  Raises 401 on mismatch."""
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+class VoiceToolRequest(BaseModel):
+    name: str
+    arguments: Dict[str, Any] = {}
+
+
+def _create_openai_realtime_session(user: str | None = None) -> Dict[str, Any]:
+    """Create an ephemeral OpenAI Realtime session for the dashboard voice UI."""
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("VOICE_TOOLS_OPENAI_KEY")
+    if not api_key:
+        raise HTTPException(status_code=503, detail="OpenAI voice credentials are not configured")
+    model = os.getenv("HERMES_VOICE_REALTIME_MODEL", "gpt-realtime")
+    voice = os.getenv("HERMES_VOICE_REALTIME_VOICE", "alloy")
+    body = json.dumps({"model": model, "voice": voice}).encode()
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/realtime/sessions",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to create voice session: {exc}") from exc
+    return data
+
+
+def _run_voice_research(question: str, user: str | None = None) -> str:
+    """Bridge a constrained voice tool call into the existing agent runtime."""
+    from run_agent import AIAgent
+
+    agent = AIAgent(platform="dashboard", enabled_toolsets=["web", "session_search"])
+    return agent.chat(question)
+
+
+@app.post("/api/voice/session")
+async def create_voice_session(request: Request):
+    _require_token(request)
+    return _create_openai_realtime_session(user=request.headers.get("X-Hermes-User"))
+
+
+@app.post("/api/voice/tool")
+async def run_voice_tool(payload: VoiceToolRequest, request: Request):
+    _require_token(request)
+    if payload.name != "research":
+        raise HTTPException(status_code=400, detail="Unsupported voice tool")
+    question = str(payload.arguments.get("question") or "").strip()
+    if not question:
+        raise HTTPException(status_code=400, detail="Missing question")
+    result = _run_voice_research(question, user=request.headers.get("X-Hermes-User"))
+    return {"ok": True, "result": result, "error": None}
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks
@@ -2553,6 +2612,306 @@ async def delete_session_endpoint(session_id: str):
         return {"ok": True}
     finally:
         db.close()
+
+
+
+# ---------------------------------------------------------------------------
+# Audio upload + diarization endpoints
+# ---------------------------------------------------------------------------
+
+_AUDIO_EXTENSIONS = {
+    ".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".mp4",
+    ".oga", ".ogg", ".opus", ".wav", ".webm",
+}
+
+
+def _audio_uploads_dir() -> Path:
+    path = get_hermes_home() / "uploads" / "audio"
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _safe_audio_filename(filename: str) -> str:
+    original = (filename or "").strip()
+    if not original:
+        raise HTTPException(status_code=400, detail="filename is required")
+    suffix = Path(original).suffix.lower()
+    if suffix not in _AUDIO_EXTENSIONS:
+        raise HTTPException(status_code=400, detail=f"Unsupported audio file extension: {suffix or '(none)'}")
+    stem = Path(original).stem
+    safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "-", stem).strip("-._") or "audio"
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}-{uuid.uuid4().hex[:8]}-{safe_stem}{suffix}"
+
+
+def _audio_path_for_stored_name(stored_name: str) -> Path:
+    name = Path(stored_name).name
+    if name != stored_name or not name:
+        raise HTTPException(status_code=400, detail="Invalid stored audio name")
+    path = (_audio_uploads_dir() / name).resolve()
+    root = _audio_uploads_dir().resolve()
+    if root not in path.parents and path != root:
+        raise HTTPException(status_code=400, detail="Invalid stored audio path")
+    return path
+
+
+def _audio_analysis_path(audio_path: Path) -> Path:
+    return audio_path.with_suffix(audio_path.suffix + ".analysis.json")
+
+
+def _write_audio_analysis(audio_path: Path, data: Dict[str, Any]) -> None:
+    path = _audio_analysis_path(audio_path)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _read_audio_analysis(audio_path: Path) -> Dict[str, Any]:
+    path = _audio_analysis_path(audio_path)
+    if not path.exists():
+        return {"status": "not_started"}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {"status": "failed", "error": f"Could not read analysis: {exc}"}
+
+
+def _turns_from_words(words: Any) -> List[Dict[str, Any]]:
+    if not isinstance(words, list):
+        return []
+    turns: List[Dict[str, Any]] = []
+    current: Optional[Dict[str, Any]] = None
+    for word in words:
+        if not isinstance(word, dict):
+            continue
+        speaker = word.get("speaker") or word.get("speaker_id") or word.get("speakerId")
+        token = str(word.get("word") or word.get("text") or "").strip()
+        if not token:
+            continue
+        if current is None or current.get("speaker") != speaker:
+            current = {"speaker": str(speaker if speaker is not None else "Speaker 1"), "text": token}
+            turns.append(current)
+        else:
+            current["text"] = (current.get("text", "") + " " + token).strip()
+    return turns
+
+
+def _turns_from_labelled_text(text: str) -> List[Dict[str, str]]:
+    turns: List[Dict[str, str]] = []
+    current: Optional[Dict[str, str]] = None
+    label_re = re.compile(r"^(?:\[?((?:SPEAKER[_ -]?\d+)|(?:Speaker\s*\d+))\]?\s*[:\-]\s*)(.+)$", re.I)
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        match = label_re.match(line)
+        if match:
+            current = {"speaker": match.group(1).replace(" ", "_"), "text": match.group(2).strip()}
+            turns.append(current)
+        elif current is not None:
+            current["text"] = (current["text"] + " " + line).strip()
+    return turns
+
+
+def _speaker_examples(turns: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    examples: Dict[str, str] = {}
+    for turn in turns:
+        speaker = str(turn.get("speaker") or "Speaker 1")
+        text_value = str(turn.get("text") or "").strip()
+        if text_value and speaker not in examples:
+            examples[speaker] = text_value[:240]
+    return [{"speaker": speaker, "example": example} for speaker, example in examples.items()]
+
+
+def _run_audio_cli(audio_path: Path) -> Dict[str, Any]:
+    """Run Rolly's canonical audio transcription CLI and return its JSON output."""
+    cli = Path("/Users/rolly/bin/rolly-transcribe-diarize")
+    if not cli.exists():
+        raise RuntimeError(f"Audio transcription CLI not found: {cli}")
+    proc = subprocess.run(
+        [str(cli), str(audio_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=900,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(f"rolly-transcribe-diarize exited {proc.returncode}: {detail[:500]}")
+    try:
+        result = json.loads(proc.stdout)
+    except Exception as exc:
+        raise RuntimeError(f"rolly-transcribe-diarize returned non-JSON output: {proc.stdout[:500]}") from exc
+    if not result.get("ok"):
+        raise RuntimeError(f"rolly-transcribe-diarize failed: {result}")
+    return result
+
+
+def _load_cli_audio_result(cli_result: Dict[str, Any]) -> Dict[str, Any]:
+    out_dir = Path(str(cli_result.get("out_dir") or "")).expanduser()
+    if not out_dir.exists():
+        raise RuntimeError(f"CLI analysis directory not found: {out_dir}")
+
+    transcript = ""
+    transcript_path = out_dir / "transcript.txt"
+    if transcript_path.exists():
+        transcript = transcript_path.read_text(encoding="utf-8", errors="replace").strip()
+
+    turns: List[Dict[str, Any]] = []
+    turns_path = out_dir / "speaker-turns.json"
+    if turns_path.exists():
+        raw_turns = json.loads(turns_path.read_text(encoding="utf-8"))
+        if isinstance(raw_turns, list):
+            for turn in raw_turns:
+                if isinstance(turn, dict):
+                    turns.append({
+                        "speaker": str(turn.get("speaker") if turn.get("speaker") is not None else "unknown"),
+                        "text": str(turn.get("text") or "").strip(),
+                        **({"start": turn.get("start")} if turn.get("start") is not None else {}),
+                        **({"end": turn.get("end")} if turn.get("end") is not None else {}),
+                    })
+
+    raw_path = out_dir / "xai-stt-raw.json"
+    if raw_path.exists() and not turns:
+        try:
+            raw_result = json.loads(raw_path.read_text(encoding="utf-8"))
+            transcript = transcript or str(raw_result.get("text") or "").strip()
+            turns = _turns_from_words(raw_result.get("words")) or _turns_from_words(raw_result.get("segments"))
+        except Exception:
+            pass
+
+    if not turns and transcript:
+        turns = [{"speaker": "Speaker 1", "text": transcript}]
+
+    speakers = _speaker_examples(turns)
+    speaker_count = len({s["speaker"] for s in speakers})
+    status = "needs_speaker_names" if speaker_count > 1 else "complete"
+    named_transcript = "\n".join(f"{turn.get('speaker')}: {turn.get('text', '')}" for turn in turns).strip()
+    return {
+        "status": status,
+        "provider": str(cli_result.get("provider") or "xai"),
+        "transcript": transcript,
+        "turns": turns,
+        "speakers": speakers,
+        "speaker_names": {},
+        "named_transcript": named_transcript,
+        "analysis_dir": str(out_dir),
+        "files": cli_result.get("files") or [],
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _run_audio_diarization(audio_path: Path) -> None:
+    running = _read_audio_analysis(audio_path)
+    running.update({"status": "running"})
+    _write_audio_analysis(audio_path, running)
+    try:
+        cli_result = _run_audio_cli(audio_path)
+        analysis = _load_cli_audio_result(cli_result)
+        _write_audio_analysis(audio_path, analysis)
+        transcript_path = audio_path.with_suffix(audio_path.suffix + ".transcript.txt")
+        transcript_path.write_text(analysis.get("named_transcript") or analysis.get("transcript") or "", encoding="utf-8")
+        try:
+            transcript_path.chmod(0o600)
+        except OSError:
+            pass
+    except Exception as exc:
+        _log.error("Audio diarization failed for %s: %s", audio_path, exc, exc_info=True)
+        failed = _read_audio_analysis(audio_path)
+        failed.update({"status": "failed", "error": str(exc), "updated_at": datetime.now(timezone.utc).isoformat()})
+        _write_audio_analysis(audio_path, failed)
+
+def _start_audio_diarization(audio_path: Path) -> None:
+    queued = _read_audio_analysis(audio_path)
+    queued.update({"status": "queued", "updated_at": datetime.now(timezone.utc).isoformat()})
+    _write_audio_analysis(audio_path, queued)
+    thread = threading.Thread(target=_run_audio_diarization, args=(audio_path,), daemon=True)
+    thread.start()
+
+
+class AudioSpeakersUpdate(BaseModel):
+    speakers: Dict[str, str]
+
+
+@app.post("/api/uploads/audio")
+async def upload_audio(request: Request, filename: str = ""):
+    stored_name = _safe_audio_filename(filename)
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="Audio upload body is empty")
+    audio_path = _audio_uploads_dir() / stored_name
+    audio_path.write_bytes(body)
+    try:
+        audio_path.chmod(0o600)
+    except OSError:
+        pass
+    rolly_user = request.headers.get("X-Rolly-User") or request.headers.get("x-rolly-user") or "unknown"
+    metadata = {
+        "ok": True,
+        "original_name": filename,
+        "stored_name": stored_name,
+        "path": str(audio_path),
+        "size_bytes": len(body),
+        "rolly_user": rolly_user,
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    metadata_path = audio_path.with_suffix(audio_path.suffix + ".json")
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+    try:
+        metadata_path.chmod(0o600)
+    except OSError:
+        pass
+    _start_audio_diarization(audio_path)
+    prompt = f"Uploaded meeting/call audio saved at:\n{audio_path}"
+    return {
+        **metadata,
+        "prompt": prompt,
+        "analysis_status": "queued",
+        "analysis_url": f"/api/uploads/audio/{stored_name}/analysis",
+    }
+
+
+@app.get("/api/uploads/audio/{stored_name}/analysis")
+async def get_audio_analysis(stored_name: str):
+    audio_path = _audio_path_for_stored_name(stored_name)
+    if not audio_path.exists():
+        raise HTTPException(status_code=404, detail="Uploaded audio not found")
+    return _read_audio_analysis(audio_path)
+
+
+@app.post("/api/uploads/audio/{stored_name}/speakers")
+async def set_audio_speakers(stored_name: str, body: AudioSpeakersUpdate):
+    audio_path = _audio_path_for_stored_name(stored_name)
+    if not audio_path.exists():
+        raise HTTPException(status_code=404, detail="Uploaded audio not found")
+    analysis = _read_audio_analysis(audio_path)
+    turns = analysis.get("turns") or []
+    named_lines: List[str] = []
+    for turn in turns:
+        if not isinstance(turn, dict):
+            continue
+        speaker = str(turn.get("speaker") or "Speaker 1")
+        name = body.speakers.get(speaker, speaker)
+        named_lines.append(f"{name}: {turn.get('text', '')}")
+    analysis["speaker_names"] = body.speakers
+    analysis["named_transcript"] = "\n".join(named_lines).strip() or analysis.get("transcript", "")
+    analysis["status"] = "complete"
+    analysis["updated_at"] = datetime.now(timezone.utc).isoformat()
+    _write_audio_analysis(audio_path, analysis)
+    transcript_path = audio_path.with_suffix(audio_path.suffix + ".transcript.txt")
+    transcript_path.write_text(analysis["named_transcript"], encoding="utf-8")
+    try:
+        transcript_path.chmod(0o600)
+    except OSError:
+        pass
+    return analysis
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11,12 +11,14 @@ Usage:
 
 import asyncio
 import hmac
+import hashlib
 import importlib.util
 import json
 import logging
 import os
 import re
 import secrets
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -26,6 +28,7 @@ import urllib.parse
 import urllib.request
 import urllib.error
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -53,6 +56,7 @@ from hermes_cli.config import (
     redact_key,
 )
 from gateway.status import get_running_pid, read_runtime_status
+import hermes_cli.kanban_db as kanban_db
 from utils import env_var_enabled
 
 try:
@@ -159,6 +163,9 @@ def _require_token(request: Request) -> None:
 class VoiceToolRequest(BaseModel):
     name: str
     arguments: Dict[str, Any] = {}
+    call_id: Optional[str] = None
+    realtime_call_id: Optional[str] = None
+    idempotency_key: Optional[str] = None
 
 
 class VoiceTranscriptEvent(BaseModel):
@@ -171,6 +178,66 @@ class VoiceTranscriptEvent(BaseModel):
     sequence: Optional[int] = None
     elapsed_ms: Optional[int] = None
     metadata: Dict[str, Any] = {}
+
+
+class VoiceTaskStartRequest(BaseModel):
+    call_id: str
+    request: str
+    user: Optional[str] = None
+    parent_event_sequence: Optional[int] = None
+
+
+class VoiceMeetInviteRequest(BaseModel):
+    call_id: str
+    user: Optional[str] = None
+
+
+class VoiceTask:
+    def __init__(self, task_id: str, call_id: str, user: str, request: str, session_id: str) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self.task_id = task_id
+        self.call_id = call_id
+        self.user = user
+        self.request = request
+        self.session_id = session_id
+        self.status = "queued"
+        self.result: Optional[str] = None
+        self.error: Optional[str] = None
+        self.progress: list[Dict[str, Any]] = [
+            {"timestamp": now, "event_type": "queued", "message": "Queued background Rolly work."}
+        ]
+        self.call_ended = False
+        self.post_call_notification: Dict[str, Any] = {"status": "not_needed"}
+        self.created_at = now
+        self.updated_at = now
+
+    def mark(self, status: str, message: str, *, error: str | None = None, result: str | None = None) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self.status = status
+        self.updated_at = now
+        if error is not None:
+            self.error = error
+        if result is not None:
+            self.result = result
+        self.progress.append({"timestamp": now, "event_type": status, "message": message})
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "task_id": self.task_id,
+            "call_id": self.call_id,
+            "user": self.user,
+            "request": self.request,
+            "session_id": self.session_id,
+            "status": self.status,
+            "progress": list(self.progress[-50:]),
+            "result": self.result,
+            "error": self.error,
+            "call_ended": self.call_ended,
+            "post_call_notification": dict(self.post_call_notification),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
 
 
 def _voice_api_key() -> str:
@@ -208,11 +275,57 @@ def _voice_transcript_path(call_id: str) -> Path:
     return root / f"{safe}.jsonl"
 
 
+def _voice_session_id(call_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._") or "unknown-call"
+    return f"dashboard_voice_{safe}"
+
+
+def _voice_session_db():
+    from hermes_state import SessionDB
+    return SessionDB()
+
+
+def _voice_ensure_state_session(call_id: str, user: str, *, mode: str | None = None) -> str:
+    session_id = _voice_session_id(call_id)
+    db = _voice_session_db()
+    if not db.get_session(session_id):
+        db.create_session(
+            session_id=session_id,
+            source="dashboard-voice",
+            user_id=user,
+            model=os.getenv("HERMES_VOICE_REALTIME_MODEL", "gpt-realtime-2"),
+            model_config={
+                "voice_call_id": call_id,
+                "voice_mode": mode,
+                "jsonl_path": str(_voice_transcript_path(call_id)),
+            },
+        )
+    return session_id
+
+
+def _voice_persist_state_event(event: VoiceTranscriptEvent, user: str) -> str | None:
+    session_id = _voice_ensure_state_session(event.call_id, user, mode=str(event.metadata.get("mode") or "solo"))
+    platform_id = f"{event.call_id}:{event.role}:{event.sequence or int(time.time() * 1000)}"
+    db = _voice_session_db()
+    if event.event_type == "call_end":
+        db.end_session(session_id, "voice_call_end")
+        return session_id
+    if event.event_type == "call_start":
+        return session_id
+    if event.event_type == "transcript" and event.role in {"user", "rolly", "assistant"} and event.text.strip():
+        role = "assistant" if event.role == "rolly" else event.role
+        db.append_message(session_id=session_id, role=role, content=event.text, platform_message_id=platform_id, observed=True)
+        return session_id
+    return session_id
+
+
 def _save_voice_transcript_event(event: VoiceTranscriptEvent, request: Request) -> Path:
     user = event.user or _voice_auth_context(request) or "unknown dashboard user"
+    session_id = _voice_persist_state_event(event, user)
     record: Dict[str, Any] = {
         "timestamp": event.timestamp or datetime.now(timezone.utc).isoformat(),
         "call_id": event.call_id,
+        "session_id": session_id,
         "user": user,
         "role": event.role,
         "event_type": event.event_type,
@@ -227,44 +340,523 @@ def _save_voice_transcript_event(event: VoiceTranscriptEvent, request: Request) 
     path = _voice_transcript_path(event.call_id)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    _voice_update_call_state(event, user)
     return path
 
 
-def _voice_session_config(user: str | None = None) -> Dict[str, Any]:
+def _voice_update_call_state(event: VoiceTranscriptEvent, user: str) -> None:
+    now = event.timestamp or datetime.now(timezone.utc).isoformat()
+    if event.event_type not in {"call_start", "call_end"}:
+        return
+    with _VOICE_CALLS_LOCK:
+        state = _VOICE_CALLS.setdefault(event.call_id, {"call_id": event.call_id, "participants": set()})
+        participants = state.get("participants")
+        if not isinstance(participants, set):
+            participants = set(participants or [])
+            state["participants"] = participants
+        participants.add(user)
+        state["updated_at"] = now
+        if event.event_type == "call_start":
+            state.setdefault("started_at", now)
+            state["ended_at"] = None
+        elif event.event_type == "call_end":
+            state["ended_at"] = now
+    if event.event_type == "call_end":
+        ended_tasks: list[VoiceTask] = []
+        with _VOICE_TASKS_LOCK:
+            for task in _VOICE_TASKS.values():
+                if task.call_id == event.call_id:
+                    task.call_ended = True
+                    task.updated_at = now
+                    ended_tasks.append(task)
+        for task in ended_tasks:
+            if task.status in {"complete", "failed", "cancelled"}:
+                _voice_maybe_notify_post_call(task, task.status)
+
+
+def _voice_call_has_ended(call_id: str) -> bool:
+    with _VOICE_CALLS_LOCK:
+        return bool((_VOICE_CALLS.get(call_id) or {}).get("ended_at"))
+
+
+def _voice_send_post_call_notification(task: VoiceTask) -> bool:
+    target = os.getenv("HERMES_VOICE_TELEGRAM_HANDOFF_TARGET", "").strip()
+    token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    if not target or not token:
+        return False
+    chat_id, _, thread_id = target.partition(":")
+    status = task.status
+    summary = task.result if status == "complete" else task.error
+    message = (
+        f"Rolly Voice background task {task.task_id}: {status}\n"
+        f"Call: {task.call_id}\n"
+        f"Transcript: {_voice_transcript_path(task.call_id)}\n"
+        f"{_voice_bound_text(summary or task.request, 900)}"
+    )
+    from tools.send_message_tool import _send_telegram
+
+    asyncio.run(_send_telegram(token, chat_id, message, thread_id=thread_id or None, disable_link_previews=True))
+    return True
+
+
+def _voice_maybe_notify_post_call(task: VoiceTask, final_status: str) -> None:
+    if not task.call_ended and not _voice_call_has_ended(task.call_id):
+        return
+    task.call_ended = True
+    current = task.post_call_notification.get("status")
+    if current in {"sent", "skipped_unconfigured", "failed"}:
+        return
+    task.post_call_notification = {"status": "pending", "final_status": final_status, "updated_at": datetime.now(timezone.utc).isoformat()}
+    try:
+        sent = _voice_send_post_call_notification(task)
+    except Exception as exc:
+        task.post_call_notification = {
+            "status": "failed",
+            "final_status": final_status,
+            "error": str(exc)[:500],
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _voice_task_event(task, "post_call_notification_error", str(exc)[:700], {"task_id": task.task_id, "status": final_status})
+        return
+    task.post_call_notification = {
+        "status": "sent" if sent else "skipped_unconfigured",
+        "final_status": final_status,
+        "target": "telegram" if sent else None,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    event = "post_call_notification_sent" if sent else "post_call_notification_skipped"
+    text = "Telegram handoff sent after call end." if sent else "Telegram handoff skipped: HERMES_VOICE_TELEGRAM_HANDOFF_TARGET/TELEGRAM_BOT_TOKEN not configured."
+    _voice_task_event(task, event, text, {"task_id": task.task_id, "status": final_status})
+
+
+_VOICE_TOOL_CACHE: Dict[str, tuple[float, Dict[str, Any]]] = {}
+_VOICE_TOOL_CACHE_LOCK = threading.Lock()
+_VOICE_TOOL_CACHE_TTL_SECONDS = 600
+_VOICE_TASKS: Dict[str, VoiceTask] = {}
+_VOICE_TASKS_LOCK = threading.Lock()
+_VOICE_CALLS: Dict[str, Dict[str, Any]] = {}
+_VOICE_CALLS_LOCK = threading.Lock()
+_VOICE_TASK_EXECUTOR = ThreadPoolExecutor(max_workers=int(os.getenv("HERMES_VOICE_TASK_WORKERS", "4")), thread_name_prefix="voice-rolly")
+
+
+def _voice_append_jsonl_record(call_id: str, record: Dict[str, Any]) -> None:
+    path = _voice_transcript_path(call_id)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _voice_task_event(task: VoiceTask, event_type: str, text: str, metadata: Dict[str, Any] | None = None) -> None:
+    _voice_append_jsonl_record(
+        task.call_id,
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "call_id": task.call_id,
+            "session_id": _voice_session_id(task.call_id),
+            "user": task.user,
+            "role": "tool",
+            "event_type": event_type,
+            "text": text,
+            "metadata": {"task_id": task.task_id, "task_session_id": task.session_id, **(metadata or {})},
+        },
+    )
+
+
+def _voice_task_status_lookup(query: str | None = None, limit: int = 1600) -> str:
+    task_ids = re.findall(r"\bvt_[A-Za-z0-9_-]+\b", query or "")
+    if not task_ids:
+        return ""
+    rows: list[str] = []
+    with _VOICE_TASKS_LOCK:
+        for task_id in task_ids:
+            task = _VOICE_TASKS.get(task_id)
+            if task is not None:
+                latest = task.progress[-1]["message"] if task.progress else task.status
+                rows.append(f"{task_id}: {task.status}; updated {task.updated_at}; {latest}")
+    missing = [task_id for task_id in task_ids if not any(row.startswith(f"{task_id}:") for row in rows)]
+    if missing:
+        transcript_root = Path(get_hermes_home()) / "voice-transcripts"
+        latest_by_task: dict[str, tuple[str, str, str]] = {}
+        for path in sorted(transcript_root.glob("*.jsonl"), key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)[:20]:
+            try:
+                lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+            except OSError:
+                continue
+            for line in lines:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+                task_id = str(metadata.get("task_id") or "")
+                if task_id in missing:
+                    status = str(metadata.get("status") or record.get("event_type") or "status unavailable")
+                    text = _voice_bound_text(str(record.get("text") or ""), 240)
+                    latest_by_task[task_id] = (status, str(record.get("timestamp") or "unknown time"), text)
+        for task_id in missing:
+            hit = latest_by_task.get(task_id)
+            if hit:
+                status, timestamp, text = hit
+                rows.append(f"{task_id}: {status}; updated {timestamp}; {text}")
+            else:
+                rows.append(f"{task_id}: status unavailable; no live task or recent transcript event found")
+    return _voice_bound_text("\n".join(rows), limit)
+
+
+def _voice_task_worker(task_id: str) -> None:
+    with _VOICE_TASKS_LOCK:
+        task = _VOICE_TASKS[task_id]
+        task.mark("running", "Rolly is working in the background.")
+    _voice_task_event(task, "delegation_started", "Rolly background task started.")
+    try:
+        result = _run_voice_research(task.request, user=task.user, source="dashboard-voice-background", parent_call_id=task.call_id)
+        with _VOICE_TASKS_LOCK:
+            task.mark("complete", "Rolly background task completed.", result=result)
+        _voice_task_event(task, "delegation_result", result, {"status": "complete"})
+        _voice_maybe_notify_post_call(task, "complete")
+    except Exception as exc:
+        message = str(exc)[:1200]
+        with _VOICE_TASKS_LOCK:
+            task.mark("failed", f"Rolly background task failed: {message}", error=message)
+        _voice_task_event(task, "delegation_error", message, {"status": "failed"})
+        _voice_maybe_notify_post_call(task, "failed")
+
+
+def _voice_start_background_task(call_id: str, request_text: str, user: str) -> VoiceTask:
+    _voice_ensure_state_session(call_id, user, mode="solo")
+    task_id = f"vt_{uuid.uuid4().hex[:12]}"
+    task = VoiceTask(task_id=task_id, call_id=call_id, user=user, request=request_text, session_id=f"voice_task_{task_id}")
+    with _VOICE_TASKS_LOCK:
+        _VOICE_TASKS[task_id] = task
+    _voice_task_event(task, "delegation_queued", "Background Rolly task queued.", {"request": request_text})
+    _VOICE_TASK_EXECUTOR.submit(_voice_task_worker, task_id)
+    return task
+
+
+def _voice_bound_text(text: str, limit: int) -> str:
+    text = re.sub(r"\s+", " ", text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _voice_read_markdown(path: Path, limit: int) -> str:
+    try:
+        return _voice_bound_text(path.read_text(encoding="utf-8", errors="ignore"), limit)
+    except OSError:
+        return ""
+
+
+def _voice_memory_snapshot(limit: int = 1800) -> str:
+    root = Path(get_hermes_home()) / "memories"
+    chunks: list[str] = []
+    for name in ("USER.md", "MEMORY.md"):
+        path = root / name
+        if path.exists():
+            text = _voice_read_markdown(path, limit // 2)
+            if text:
+                chunks.append(f"{name}: {text}")
+    return _voice_bound_text("\n".join(chunks), limit)
+
+
+def _voice_brain_lookup_text(query: str | None = None, limit: int = 1800) -> str:
+    root = Path(os.getenv("ROLLY_BRAIN_ROOT", "/Users/rolly/rolly-brain")) / "wiki"
+    if not root.exists():
+        return ""
+    terms = [t.lower() for t in re.findall(r"[A-Za-z0-9_-]{3,}", query or "")]
+    candidates = sorted(root.rglob("*.md"), key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)[:200]
+    hits: list[str] = []
+    scored: list[tuple[int, Path, str]] = []
+    for path in candidates:
+        rel = path.relative_to(root)
+        text = _voice_read_markdown(path, 900)
+        haystack = f"{rel} {text}".lower()
+        score = sum(1 for term in terms if term in haystack)
+        if terms and score == 0:
+            continue
+        scored.append((score, path, text))
+    for _score, path, text in sorted(scored, key=lambda item: item[0], reverse=True):
+        rel = path.relative_to(root)
+        hits.append(f"{rel}: {text}")
+        if len("\n".join(hits)) >= limit:
+            break
+    return _voice_bound_text("\n".join(hits), limit)
+
+
+def _voice_kanban_digest(query: str | None = None, limit: int = 2200) -> str:
+    active = ("triage", "todo", "scheduled", "ready", "running", "blocked", "review")
+    try:
+        con = kanban_db.connect()
+        con.row_factory = sqlite3.Row
+        rows = con.execute(
+            f"""
+            SELECT id, title, status, assignee, priority, body
+            FROM tasks
+            WHERE status IN ({','.join('?' for _ in active)})
+            ORDER BY priority DESC, created_at DESC
+            LIMIT 40
+            """,
+            active,
+        ).fetchall()
+        con.close()
+    except sqlite3.Error:
+        return ""
+    terms = [t.lower() for t in re.findall(r"[A-Za-z0-9_-]{3,}", query or "")]
+    lines: list[str] = []
+    for row in rows:
+        body = row["body"] or ""
+        haystack = f"{row['id']} {row['title']} {row['status']} {row['assignee'] or ''} {body}".lower()
+        if terms and not all(term in haystack for term in terms[:4]):
+            continue
+        preview = _voice_bound_text(body, 220)
+        assignee = f" @{row['assignee']}" if row["assignee"] else ""
+        lines.append(f"{row['id']} [{row['status']}]{assignee}: {row['title']} — {preview}".rstrip(" —"))
+        if len("\n".join(lines)) >= limit:
+            break
+    return _voice_bound_text("\n".join(lines), limit)
+
+
+def _voice_recent_sessions(query: str | None = None, limit: int = 1600) -> str:
+    db_path = Path(get_hermes_home()) / "state.db"
+    if not db_path.exists():
+        return ""
+    try:
+        con = sqlite3.connect(str(db_path))
+        con.row_factory = sqlite3.Row
+        if query:
+            rows = con.execute(
+                """
+                SELECT session_id, role, content, timestamp
+                FROM messages
+                WHERE content LIKE ? AND role IN ('user','assistant')
+                ORDER BY timestamp DESC
+                LIMIT 8
+                """,
+                (f"%{query}%",),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                """
+                SELECT session_id, role, content, timestamp
+                FROM messages
+                WHERE role IN ('user','assistant')
+                ORDER BY timestamp DESC
+                LIMIT 8
+                """
+            ).fetchall()
+        con.close()
+    except sqlite3.Error:
+        return ""
+    lines = [f"{r['session_id']} {r['role']}: {_voice_bound_text(r['content'], 260)}" for r in rows]
+    return _voice_bound_text("\n".join(lines), limit)
+
+
+def _voice_context_pack(user: str | None = None) -> Dict[str, Any]:
+    speaker = _voice_speaker_label(user)
+    return {
+        "user": speaker,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "memory": _voice_memory_snapshot(),
+        "kanban": _voice_kanban_digest(),
+        "brain": _voice_brain_lookup_text("MIX Rolly voice current work", limit=1600),
+        "sessions": _voice_recent_sessions(limit=1000),
+    }
+
+
+def _voice_render_context_pack(pack: Dict[str, Any], limit: int = 7000) -> str:
+    sections = [
+        f"Dashboard user: {pack.get('user')}",
+        f"Generated: {pack.get('generated_at')}",
+        f"Durable memory:\n{pack.get('memory') or '(none)'}",
+        f"Active Kanban:\n{pack.get('kanban') or '(none)'}",
+        f"Rolly brain/wiki:\n{pack.get('brain') or '(none)'}",
+        f"Recent sessions:\n{pack.get('sessions') or '(none)'}",
+    ]
+    return _voice_bound_text("\n\n".join(sections), limit)
+
+
+def _voice_tool_result(text: str, *, tool_name: str, data: Dict[str, Any] | None = None, cached: bool = False) -> Dict[str, Any]:
+    return {"ok": True, "result": _voice_bound_text(text, 2200), "data": data or {}, "error": None, "tool_name": tool_name, "cached": cached}
+
+
+def _voice_tool_cache_key(payload: VoiceToolRequest, user: str | None = None) -> str | None:
+    explicit = payload.idempotency_key or payload.realtime_call_id or str(payload.arguments.get("_realtime_call_id") or "")
+    if explicit or payload.call_id:
+        normalized = json.dumps(
+            {"user": _voice_speaker_label(user), "explicit": explicit, "name": payload.name, "arguments": payload.arguments, "call_id": payload.call_id},
+            sort_keys=True,
+            default=str,
+        )
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return None
+
+
+def _voice_tool_dispatch(payload: VoiceToolRequest, user: str | None = None) -> Dict[str, Any]:
+    args = payload.arguments or {}
+    name = payload.name
+    if name in {"research", "rolly"}:
+        question = str(args.get("request") or args.get("question") or "").strip()
+        if not question:
+            raise HTTPException(status_code=400, detail="Missing question")
+        return _voice_tool_result(_run_voice_research(question, user=user), tool_name=name)
+    if name == "memory_lookup":
+        return _voice_tool_result(_voice_memory_snapshot(), tool_name=name)
+    if name == "brain_lookup":
+        query = str(args.get("query") or "").strip()
+        if not query:
+            raise HTTPException(status_code=400, detail="Missing query")
+        return _voice_tool_result(_voice_brain_lookup_text(query), tool_name=name)
+    if name == "kanban_lookup":
+        return _voice_tool_result(_voice_kanban_digest(str(args.get("query") or "").strip() or None), tool_name=name)
+    if name == "session_lookup":
+        return _voice_tool_result(_voice_recent_sessions(str(args.get("query") or "").strip() or None), tool_name=name)
+    if name == "context_lookup":
+        query = str(args.get("query") or "").strip()
+        sources = args.get("sources") or ["memory", "kanban", "brain", "sessions", "voice_tasks"]
+        if not isinstance(sources, list):
+            sources = ["memory", "kanban", "brain", "sessions", "voice_tasks"]
+        parts: list[str] = []
+        task_status = _voice_task_status_lookup(query or None)
+        if task_status:
+            parts.append(f"Voice tasks:\n{task_status}")
+        if "memory" in sources:
+            parts.append(f"Memory:\n{_voice_memory_snapshot()}")
+        if "kanban" in sources:
+            parts.append(f"Kanban:\n{_voice_kanban_digest(query or None)}")
+        if "brain" in sources:
+            parts.append(f"Brain:\n{_voice_brain_lookup_text(query or None)}")
+        if "sessions" in sources:
+            parts.append(f"Sessions:\n{_voice_recent_sessions(query or None)}")
+        return _voice_tool_result("\n\n".join(parts), tool_name=name)
+    if name == "rolly_background":
+        request_text = str(args.get("request") or "").strip()
+        if not request_text:
+            raise HTTPException(status_code=400, detail="Missing request")
+        if not payload.call_id:
+            raise HTTPException(status_code=400, detail="Missing call_id")
+        task = _voice_start_background_task(payload.call_id, request_text, _voice_speaker_label(user))
+        return _voice_tool_result(
+            f"Queued background Rolly task {task.task_id}. The voice UI will inject the result back into this live call when it is ready; briefly tell the user you will jump back in if the call is still live.",
+            tool_name=name,
+            data=task.to_dict(),
+        )
+    raise HTTPException(status_code=400, detail="Unsupported voice tool")
+
+
+def _voice_mode(value: str | None) -> str:
+    return "meet" if (value or "").strip().lower() == "meet" else "solo"
+
+
+def _voice_speaking_rate_config() -> Dict[str, Any]:
+    raw = os.getenv("HERMES_VOICE_SPEAKING_RATE", "1.08").strip() or "1.08"
+    try:
+        requested = float(raw)
+    except ValueError:
+        requested = 1.08
+    requested = max(0.25, min(4.0, requested))
+    return {
+        "requested": requested,
+        "explicit_control_supported": False,
+        "provider": "openai-realtime-webrtc",
+        "status": "provider has no explicit realtime speech-rate field; applied as speaking-style instruction",
+    }
+
+
+def _voice_session_config(user: str | None = None, mode: str = "solo") -> Dict[str, Any]:
     model = os.getenv("HERMES_VOICE_REALTIME_MODEL", "gpt-realtime-2")
     voice = os.getenv("HERMES_VOICE_REALTIME_VOICE", "cedar")
     speaker = _voice_speaker_label(user)
+    mode = _voice_mode(mode)
+    context_pack = _voice_render_context_pack(_voice_context_pack(user))
+    speaking_rate = _voice_speaking_rate_config()
+    rate_instruction = (
+        f"Speak at a slightly faster but still natural and clear pace (configured rate preference {speaking_rate['requested']:.2f}x). "
+        "OpenAI Realtime WebRTC does not expose an explicit speech-rate field here, so treat this as a style instruction. "
+    )
+    mode_instruction = (
+        "MEET MODE: this may be a multi-person conversation. Stay silent unless someone explicitly says a wake phrase like 'Hey Rolly', 'Hey Rowley', or 'Hey Rowy', or directly asks Rolly to speak. "
+        "After answering, return to silent listening. Preserve speaker wording in transcript-derived context; dashboard auth identifies this browser participant. "
+        if mode == "meet"
+        else "SOLO MODE: this is a one-on-one Rolly call; answer naturally when the user speaks. "
+    )
     return {
         "type": "realtime",
         "model": model,
         "instructions": (
             "You are Rolly, the concise AI ops and dev colleague for MIX/Suelio. "
             f"You are speaking with dashboard user: {speaker}. Use that identity for context and attribution. "
+            "Session-start context pack follows; treat it as useful but possibly stale.\n"
+            f"{context_pack}\n"
+            f"{mode_instruction}"
+            f"{rate_instruction}"
             "This is a live phone-call style conversation: speak naturally, briefly, and do not mention implementation details. "
+            "Spoken responses should usually fit 10-15 seconds. If more exists, give the short answer first and offer to continue. "
             "Call transcript events, tool calls/results, timestamps, elapsed time, and an end-call marker are saved to local JSONL for later improvement. "
-            "You have no useful long-term/project context inside the realtime model itself. "
-            "When the user asks about Rolly state, past work, files, code, web/current facts, or wants an action, call the rolly tool with a short exact request. "
-            "Summarize tool results conversationally and ask at most one brief follow-up."
+            "Prefer fast lookup tools (context_lookup, memory_lookup, kanban_lookup, brain_lookup, session_lookup) for context. "
+            "Use rolly_background for long or action-oriented work; it queues real background Rolly work and returns a task id. "
+            "When rolly_background is queued, tell the user you will jump back in with the result if this call is still live; do not claim there is no live push channel. "
+            "During active work, interpret user follow-ups as steer by default; clear stop/cancel means cancel intent, and 'when done' means queue. "
+            "Never call a tool twice for the same user intent. Summarize tool results conversationally and ask at most one brief follow-up."
         ),
         "tools": [
             {
                 "type": "function",
-                "name": "rolly",
-                "description": "Ask full Rolly/Hermes to use its normal context and tools for research, memory/session lookup, files, code, or actions. Use this whenever local realtime context is insufficient.",
+                "name": "context_lookup",
+                "description": "Fast local lookup across Rolly memory, brain/wiki notes, Kanban active work, and recent sessions. Use before slow/background work.",
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "request": {
-                            "type": "string",
-                            "description": "The concise task or question for full Rolly, preserving user wording when important.",
-                        }
+                        "query": {"type": "string", "description": "Short lookup query."},
+                        "sources": {
+                            "type": "array",
+                            "items": {"type": "string", "enum": ["memory", "brain", "kanban", "sessions"]},
+                            "description": "Optional source subset.",
+                        },
                     },
-                    "required": ["request"],
+                    "required": ["query"],
                     "additionalProperties": False,
                 },
-            }
+            },
+            {
+                "type": "function",
+                "name": "memory_lookup",
+                "description": "Fast read-only lookup of durable Rolly/User memory.",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "additionalProperties": False},
+            },
+            {
+                "type": "function",
+                "name": "kanban_lookup",
+                "description": "Fast lookup of active Kanban/source-of-truth work items.",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "additionalProperties": False},
+            },
+            {
+                "type": "function",
+                "name": "brain_lookup",
+                "description": "Fast lookup of curated Rolly brain/wiki markdown notes with provenance.",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"], "additionalProperties": False},
+            },
+            {
+                "type": "function",
+                "name": "session_lookup",
+                "description": "Fast lookup of recent Rolly conversation history.",
+                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "additionalProperties": False},
+            },
+            {
+                "type": "function",
+                "name": "rolly_background",
+                "description": "Use only for long-running or action-oriented work. Returns pending status immediately; do not claim completion.",
+                "parameters": {"type": "object", "properties": {"request": {"type": "string"}}, "required": ["request"], "additionalProperties": False},
+            },
+            {
+                "type": "function",
+                "name": "rolly",
+                "description": "Slow full Rolly bridge for exceptional foreground questions only. Prefer fast lookup tools or rolly_background.",
+                "parameters": {"type": "object", "properties": {"request": {"type": "string"}}, "required": ["request"], "additionalProperties": False},
+            },
         ],
         "tool_choice": "auto",
+        "metadata": {
+            "speaking_rate": speaking_rate,
+        },
         "audio": {
             "input": {
                 "transcription": {"model": "gpt-4o-mini-transcribe"},
@@ -272,9 +864,11 @@ def _voice_session_config(user: str | None = None) -> Dict[str, Any]:
                 "turn_detection": {
                     # Phone-call behavior: let the Realtime API decide when the
                     # user has semantically finished speaking, then immediately
-                    # generate a spoken response and allow barge-in interrupts.
+                    # generate a spoken response in solo mode and allow barge-in
+                    # interrupts. Meet mode disables auto-response so the UI can
+                    # hard-gate speech on the "Hey Rolly" wake phrase.
                     "type": "semantic_vad",
-                    "create_response": True,
+                    "create_response": mode == "solo",
                     "interrupt_response": True,
                 },
             },
@@ -283,7 +877,7 @@ def _voice_session_config(user: str | None = None) -> Dict[str, Any]:
     }
 
 
-def _create_openai_realtime_call(sdp: str, user: str | None = None) -> str:
+def _create_openai_realtime_call(sdp: str, user: str | None = None, mode: str = "solo") -> str:
     """Create an OpenAI Realtime WebRTC call and return answer SDP."""
     api_key = _voice_api_key()
     boundary = f"----hermes-realtime-{uuid.uuid4().hex}"
@@ -297,7 +891,7 @@ def _create_openai_realtime_call(sdp: str, user: str | None = None) -> str:
     body = b"".join(
         [
             part("sdp", sdp, "application/sdp"),
-            part("session", json.dumps(_voice_session_config(user=user)), "application/json"),
+            part("session", json.dumps(_voice_session_config(user=user, mode=mode)), "application/json"),
             f"--{boundary}--\r\n".encode("utf-8"),
         ]
     )
@@ -323,10 +917,10 @@ def _create_openai_realtime_call(sdp: str, user: str | None = None) -> str:
         raise HTTPException(status_code=502, detail=f"Failed to create voice call: {exc}") from exc
 
 
-def _create_openai_realtime_session(user: str | None = None) -> Dict[str, Any]:
+def _create_openai_realtime_session(user: str | None = None, mode: str = "solo") -> Dict[str, Any]:
     """Create an ephemeral OpenAI Realtime session for legacy dashboard voice UI."""
     api_key = _voice_api_key()
-    session = _voice_session_config(user=user)
+    session = _voice_session_config(user=user, mode=mode)
     body = json.dumps({"session": session}).encode()
     req = urllib.request.Request(
         "https://api.openai.com/v1/realtime/client_secrets",
@@ -345,19 +939,22 @@ def _create_openai_realtime_session(user: str | None = None) -> Dict[str, Any]:
     return data
 
 
-def _run_voice_research(question: str, user: str | None = None) -> str:
+def _run_voice_research(question: str, user: str | None = None, *, source: str = "dashboard-voice", parent_call_id: str | None = None) -> str:
     """Bridge a voice tool call into the CLI-first Rolly runtime."""
     speaker = _voice_speaker_label(user)
     prompt = (
-        f"Dashboard voice user: {speaker}\n\n"
-        "You are answering a live voice call through Rolly Voice. Use normal Rolly context/tools. "
-        "Keep the final answer brief and spoken-conversation friendly.\n\n"
+        f"Dashboard voice user: {speaker}\n"
+        f"Voice call id: {parent_call_id or 'foreground'}\n\n"
+        "You are handling work delegated from a live Rolly Voice call. Use normal Rolly context/tools. "
+        "The user-facing surface is only Rolly; do not mention internal Fast/Regular layers. "
+        "Return a voice handoff answer, not a full report: 2-4 short spoken sentences unless the user explicitly asked for detail. "
+        "If more detail exists, say it is available and can be expanded.\n\n"
         f"User request: {question}"
     )
     env = os.environ.copy()
     env.setdefault("HERMES_HOME", str(get_hermes_home()))
     proc = subprocess.run(
-        [sys.executable, "-m", "hermes_cli.main", "chat", "-q", prompt, "--source", "dashboard-voice", "-Q"],
+        [sys.executable, "-m", "hermes_cli.main", "chat", "-q", prompt, "--source", source, "-Q"],
         cwd=str(PROJECT_ROOT),
         env=env,
         text=True,
@@ -375,7 +972,8 @@ def _run_voice_research(question: str, user: str | None = None) -> str:
 
 @app.post("/api/voice/session")
 async def create_voice_session(request: Request):
-    return _create_openai_realtime_session(user=_voice_auth_context(request))
+    mode = _voice_mode(request.query_params.get("mode") or request.headers.get("X-Rolly-Voice-Mode"))
+    return _create_openai_realtime_session(user=_voice_auth_context(request), mode=mode)
 
 
 @app.post("/api/voice/call")
@@ -383,22 +981,93 @@ async def create_voice_call(request: Request):
     sdp = (await request.body()).decode("utf-8", "ignore")
     if not sdp.strip():
         raise HTTPException(status_code=400, detail="Missing SDP offer")
-    answer = _create_openai_realtime_call(sdp, user=_voice_auth_context(request))
+    mode = _voice_mode(request.query_params.get("mode") or request.headers.get("X-Rolly-Voice-Mode"))
+    answer = _create_openai_realtime_call(sdp, user=_voice_auth_context(request), mode=mode)
     return Response(content=answer, media_type="application/sdp")
+
+
+@app.post("/api/voice/meet/invite")
+async def create_voice_meet_invite(payload: VoiceMeetInviteRequest, request: Request):
+    if not env_var_enabled("HERMES_VOICE_MEET_INVITES", default=False):
+        raise HTTPException(status_code=404, detail="Voice meet invites are disabled")
+    call_id = re.sub(r"[^A-Za-z0-9_.-]", "_", payload.call_id).strip("._")
+    if not call_id:
+        raise HTTPException(status_code=400, detail="Missing call_id")
+    user = payload.user or _voice_auth_context(request) or "unknown dashboard user"
+    _voice_ensure_state_session(call_id, user, mode="meet")
+    base = os.getenv("HERMES_DASHBOARD_PUBLIC_URL") or str(request.base_url).rstrip("/")
+    base = base.rstrip("/")
+    invite_url = f"{base}/voice?mode=meet&call_id={urllib.parse.quote(call_id)}"
+    return {
+        "ok": True,
+        "mode": "meet",
+        "call_id": call_id,
+        "invite_url": invite_url,
+        "feature_flag": "HERMES_VOICE_MEET_INVITES",
+    }
+
+
+@app.get("/api/voice/context")
+async def get_voice_context(request: Request, debug: bool = False):
+    user = _voice_auth_context(request)
+    pack = _voice_context_pack(user)
+    context = _voice_render_context_pack(pack)
+    response: Dict[str, Any] = {
+        "ok": True,
+        "user": _voice_speaker_label(user),
+        "context": context,
+        "chars": len(context),
+        "sections": {k: len(str(v or "")) for k, v in pack.items() if k not in {"user", "generated_at"}},
+    }
+    if debug:
+        response["pack"] = pack
+    return response
 
 
 @app.post("/api/voice/tool")
 async def run_voice_tool(payload: VoiceToolRequest, request: Request):
-    if payload.name not in {"research", "rolly"}:
-        raise HTTPException(status_code=400, detail="Unsupported voice tool")
-    question = str(payload.arguments.get("request") or payload.arguments.get("question") or "").strip()
-    if not question:
-        raise HTTPException(status_code=400, detail="Missing question")
+    user = _voice_auth_context(request)
+    key = _voice_tool_cache_key(payload, user=user)
+    now = time.time()
+    if key:
+        with _VOICE_TOOL_CACHE_LOCK:
+            stale = [cache_key for cache_key, (created, _value) in _VOICE_TOOL_CACHE.items() if now - created > _VOICE_TOOL_CACHE_TTL_SECONDS]
+            for cache_key in stale:
+                _VOICE_TOOL_CACHE.pop(cache_key, None)
+            cached = _VOICE_TOOL_CACHE.get(key)
+            if cached and now - cached[0] <= _VOICE_TOOL_CACHE_TTL_SECONDS:
+                result = dict(cached[1])
+                result["cached"] = True
+                return result
     try:
-        result = _run_voice_research(question, user=_voice_auth_context(request))
+        result = _voice_tool_dispatch(payload, user=user)
+    except HTTPException:
+        raise
     except Exception as exc:
         raise HTTPException(status_code=502, detail=str(exc)[:700]) from exc
-    return {"ok": True, "result": result, "error": None}
+    if key and payload.name != "rolly_background":
+        with _VOICE_TOOL_CACHE_LOCK:
+            _VOICE_TOOL_CACHE[key] = (time.time(), dict(result))
+    return result
+
+
+@app.post("/api/voice/tasks")
+async def start_voice_task(payload: VoiceTaskStartRequest, request: Request):
+    user = payload.user or _voice_auth_context(request) or "unknown dashboard user"
+    request_text = payload.request.strip()
+    if not request_text:
+        raise HTTPException(status_code=400, detail="Missing request")
+    task = _voice_start_background_task(payload.call_id, request_text, _voice_speaker_label(user))
+    return task.to_dict()
+
+
+@app.get("/api/voice/tasks/{task_id}")
+async def get_voice_task(task_id: str, _request: Request):
+    with _VOICE_TASKS_LOCK:
+        task = _VOICE_TASKS.get(task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="Voice task not found")
+        return task.to_dict()
 
 
 @app.post("/api/voice/transcript")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -863,9 +863,6 @@ def _voice_session_config(user: str | None = None, mode: str = "solo") -> Dict[s
             },
         ],
         "tool_choice": "auto",
-        "metadata": {
-            "speaking_rate": speaking_rate,
-        },
         "audio": {
             "input": {
                 "transcription": {"model": "gpt-4o-mini-transcribe"},

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -502,6 +502,17 @@ def _voice_task_status_lookup(query: str | None = None, limit: int = 1600) -> st
     return _voice_bound_text("\n".join(rows), limit)
 
 
+def _voice_visible_task_result(result: str, task: VoiceTask) -> str:
+    lines = [line.strip() for line in (result or "").splitlines() if line.strip()]
+    if lines and all(re.fullmatch(r"(?:⏭\s*)?Secret entry skipped", line) for line in lines):
+        return (
+            f"Background Rolly task {task.task_id} completed, but the only visible output was "
+            "redacted secret-entry placeholders. No user-safe implementation summary was produced. "
+            f"Task session: {task.session_id}."
+        )
+    return result
+
+
 def _voice_task_worker(task_id: str) -> None:
     with _VOICE_TASKS_LOCK:
         task = _VOICE_TASKS[task_id]
@@ -509,6 +520,7 @@ def _voice_task_worker(task_id: str) -> None:
     _voice_task_event(task, "delegation_started", "Rolly background task started.")
     try:
         result = _run_voice_research(task.request, user=task.user, source="dashboard-voice-background", parent_call_id=task.call_id)
+        result = _voice_visible_task_result(result, task)
         with _VOICE_TASKS_LOCK:
             task.mark("complete", "Rolly background task completed.", result=result)
         _voice_task_event(task, "delegation_result", result, {"status": "complete"})
@@ -1025,6 +1037,11 @@ async def create_voice_meet_invite(payload: VoiceMeetInviteRequest, request: Req
         "mode": "meet",
         "call_id": call_id,
         "invite_url": invite_url,
+        "participant_audio_routing": "not_supported",
+        "participant_audio_routing_detail": (
+            "Meet invites share a Rolly Voice room id, but participant-to-participant audio bridging "
+            "is not implemented yet; each browser connects to Rolly/OpenAI."
+        ),
         "feature_flag": "HERMES_VOICE_MEET_INVITES",
     }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -168,6 +168,9 @@ class VoiceTranscriptEvent(BaseModel):
     event_type: str = "transcript"
     user: Optional[str] = None
     timestamp: Optional[str] = None
+    sequence: Optional[int] = None
+    elapsed_ms: Optional[int] = None
+    metadata: Dict[str, Any] = {}
 
 
 def _voice_api_key() -> str:
@@ -207,7 +210,7 @@ def _voice_transcript_path(call_id: str) -> Path:
 
 def _save_voice_transcript_event(event: VoiceTranscriptEvent, request: Request) -> Path:
     user = event.user or _voice_auth_context(request) or "unknown dashboard user"
-    record = {
+    record: Dict[str, Any] = {
         "timestamp": event.timestamp or datetime.now(timezone.utc).isoformat(),
         "call_id": event.call_id,
         "user": user,
@@ -215,6 +218,12 @@ def _save_voice_transcript_event(event: VoiceTranscriptEvent, request: Request) 
         "event_type": event.event_type,
         "text": event.text,
     }
+    if event.sequence is not None:
+        record["sequence"] = event.sequence
+    if event.elapsed_ms is not None:
+        record["elapsed_ms"] = event.elapsed_ms
+    if event.metadata:
+        record["metadata"] = event.metadata
     path = _voice_transcript_path(event.call_id)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")
@@ -232,6 +241,7 @@ def _voice_session_config(user: str | None = None) -> Dict[str, Any]:
             "You are Rolly, the concise AI ops and dev colleague for MIX/Suelio. "
             f"You are speaking with dashboard user: {speaker}. Use that identity for context and attribution. "
             "This is a live phone-call style conversation: speak naturally, briefly, and do not mention implementation details. "
+            "Call transcript events, tool calls/results, timestamps, elapsed time, and an end-call marker are saved to local JSONL for later improvement. "
             "You have no useful long-term/project context inside the realtime model itself. "
             "When the user asks about Rolly state, past work, files, code, web/current facts, or wants an action, call the rolly tool with a short exact request. "
             "Summarize tool results conversationally and ask at most one brief follow-up."

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -678,6 +678,11 @@ def _voice_tool_result(text: str, *, tool_name: str, data: Dict[str, Any] | None
     return {"ok": True, "result": _voice_bound_text(text, 2200), "data": data or {}, "error": None, "tool_name": tool_name, "cached": cached}
 
 
+def _voice_lookup_no_match(source: str, query: str | None) -> str:
+    suffix = f" for query: {query}" if query else ""
+    return f"{source}: no matching results found{suffix}."
+
+
 def _voice_tool_cache_key(payload: VoiceToolRequest, user: str | None = None) -> str | None:
     explicit = payload.idempotency_key or payload.realtime_call_id or str(payload.arguments.get("_realtime_call_id") or "")
     if explicit or payload.call_id:
@@ -706,9 +711,13 @@ def _voice_tool_dispatch(payload: VoiceToolRequest, user: str | None = None) -> 
             raise HTTPException(status_code=400, detail="Missing query")
         return _voice_tool_result(_voice_brain_lookup_text(query), tool_name=name)
     if name == "kanban_lookup":
-        return _voice_tool_result(_voice_kanban_digest(str(args.get("query") or "").strip() or None), tool_name=name)
+        query = str(args.get("query") or "").strip() or None
+        result = _voice_kanban_digest(query)
+        return _voice_tool_result(result or _voice_lookup_no_match("Kanban", query), tool_name=name)
     if name == "session_lookup":
-        return _voice_tool_result(_voice_recent_sessions(str(args.get("query") or "").strip() or None), tool_name=name)
+        query = str(args.get("query") or "").strip() or None
+        result = _voice_recent_sessions(query)
+        return _voice_tool_result(result or _voice_lookup_no_match("Sessions", query), tool_name=name)
     if name == "context_lookup":
         query = str(args.get("query") or "").strip()
         sources = args.get("sources") or ["memory", "kanban", "brain", "sessions", "voice_tasks"]
@@ -953,14 +962,23 @@ def _run_voice_research(question: str, user: str | None = None, *, source: str =
     )
     env = os.environ.copy()
     env.setdefault("HERMES_HOME", str(get_hermes_home()))
-    proc = subprocess.run(
-        [sys.executable, "-m", "hermes_cli.main", "chat", "-q", prompt, "--source", source, "-Q"],
-        cwd=str(PROJECT_ROOT),
-        env=env,
-        text=True,
-        capture_output=True,
-        timeout=int(os.getenv("HERMES_VOICE_TOOL_TIMEOUT", "90")),
+    timeout_seconds = int(
+        os.getenv(
+            "HERMES_VOICE_BACKGROUND_TASK_TIMEOUT" if source == "dashboard-voice-background" else "HERMES_VOICE_TOOL_TIMEOUT",
+            "600" if source == "dashboard-voice-background" else "90",
+        )
     )
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "chat", "-q", prompt, "--source", source, "-Q"],
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"Rolly CLI tool timed out after {timeout_seconds}s") from exc
     output = (proc.stdout or "").strip()
     if proc.returncode != 0:
         detail = (proc.stderr or output or f"exit {proc.returncode}").strip()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -347,7 +347,7 @@ def _run_voice_research(question: str, user: str | None = None) -> str:
     env = os.environ.copy()
     env.setdefault("HERMES_HOME", str(get_hermes_home()))
     proc = subprocess.run(
-        ["hermes", "chat", "-q", prompt, "--source", "dashboard-voice", "-Q"],
+        [sys.executable, "-m", "hermes_cli.main", "chat", "-q", prompt, "--source", "dashboard-voice", "-Q"],
         cwd=str(PROJECT_ROOT),
         env=env,
         text=True,
@@ -384,7 +384,10 @@ async def run_voice_tool(payload: VoiceToolRequest, request: Request):
     question = str(payload.arguments.get("request") or payload.arguments.get("question") or "").strip()
     if not question:
         raise HTTPException(status_code=400, detail="Missing question")
-    result = _run_voice_research(question, user=_voice_auth_context(request))
+    try:
+        result = _run_voice_research(question, user=_voice_auth_context(request))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)[:700]) from exc
     return {"ok": True, "result": result, "error": None}
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -192,6 +192,14 @@ class VoiceMeetInviteRequest(BaseModel):
     user: Optional[str] = None
 
 
+class VoiceMeetSignalRequest(BaseModel):
+    call_id: str
+    type: str
+    payload: Dict[str, Any] = {}
+    to_user: Optional[str] = None
+    user: Optional[str] = None
+
+
 class VoiceTask:
     def __init__(self, task_id: str, call_id: str, user: str, request: str, session_id: str) -> None:
         now = datetime.now(timezone.utc).isoformat()
@@ -466,6 +474,36 @@ def _voice_read_room_state(call_id: str, since: int = 0, limit: int = 200) -> Di
     }
 
 
+async def _voice_wait_for_room_state(call_id: str, since: int = 0, limit: int = 200, wait_ms: int = 0) -> Dict[str, Any]:
+    deadline = time.monotonic() + max(0, min(wait_ms, 30000)) / 1000
+    while True:
+        state = _voice_read_room_state(call_id, since=since, limit=limit)
+        if state["events"] or time.monotonic() >= deadline:
+            return state
+        await asyncio.sleep(0.2)
+
+
+def _voice_room_signal_state(call_id: str, since: int = 0, limit: int = 200, *, user: str | None = None) -> Dict[str, Any]:
+    safe_since = max(0, since)
+    safe_limit = max(1, min(limit, 500))
+    with _VOICE_ROOM_SIGNAL_LOCK:
+        messages = list(_VOICE_ROOM_SIGNALS.get(call_id, []))
+    visible = [
+        msg for msg in messages
+        if int(msg.get("index") or 0) > safe_since and (not msg.get("to_user") or msg.get("to_user") == user or msg.get("from_user") == user)
+    ][:safe_limit]
+    return {"ok": True, "call_id": call_id, "cursor": len(messages), "signals": visible}
+
+
+async def _voice_wait_for_room_signals(call_id: str, since: int = 0, limit: int = 200, wait_ms: int = 0, *, user: str | None = None) -> Dict[str, Any]:
+    deadline = time.monotonic() + max(0, min(wait_ms, 30000)) / 1000
+    while True:
+        state = _voice_room_signal_state(call_id, since=since, limit=limit, user=user)
+        if state["signals"] or time.monotonic() >= deadline:
+            return state
+        await asyncio.sleep(0.2)
+
+
 def _voice_send_post_call_notification(task: VoiceTask) -> bool:
     target = os.getenv("HERMES_VOICE_TELEGRAM_HANDOFF_TARGET", "").strip()
     token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
@@ -526,6 +564,8 @@ _VOICE_TASKS: Dict[str, VoiceTask] = {}
 _VOICE_TASKS_LOCK = threading.Lock()
 _VOICE_CALLS: Dict[str, Dict[str, Any]] = {}
 _VOICE_CALLS_LOCK = threading.Lock()
+_VOICE_ROOM_SIGNALS: Dict[str, list[Dict[str, Any]]] = {}
+_VOICE_ROOM_SIGNAL_LOCK = threading.Lock()
 _VOICE_TASK_EXECUTOR = ThreadPoolExecutor(max_workers=int(os.getenv("HERMES_VOICE_TASK_WORKERS", "4")), thread_name_prefix="voice-rolly")
 
 
@@ -1147,10 +1187,10 @@ async def create_voice_meet_invite(payload: VoiceMeetInviteRequest, request: Req
         "mode": "meet",
         "call_id": call_id,
         "invite_url": invite_url,
-        "participant_audio_routing": "not_supported",
+        "participant_audio_routing": "peer_audio_signaling",
         "participant_audio_routing_detail": (
-            "Meet invites share a Rolly Voice room id, but participant-to-participant audio bridging "
-            "is not implemented yet; each browser connects to Rolly/OpenAI."
+            "Meet invites share a Rolly Voice room id and use browser peer audio between participants. "
+            "Each browser also keeps its own Rolly/OpenAI realtime connection."
         ),
         "feature_flag": "HERMES_VOICE_MEET_INVITES",
     }
@@ -1228,11 +1268,50 @@ async def save_voice_transcript(payload: VoiceTranscriptEvent, request: Request)
 
 
 @app.get("/api/voice/room")
-async def get_voice_room(call_id: str, since: int = 0, limit: int = 200):
+async def get_voice_room(call_id: str, since: int = 0, limit: int = 200, wait_ms: int = 0):
     safe_call_id = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._")
     if not safe_call_id:
         raise HTTPException(status_code=400, detail="Missing call_id")
+    if wait_ms > 0:
+        return await _voice_wait_for_room_state(safe_call_id, since=since, limit=limit, wait_ms=wait_ms)
     return _voice_read_room_state(safe_call_id, since=since, limit=limit)
+
+
+@app.post("/api/voice/meet/signal")
+async def post_voice_meet_signal(payload: VoiceMeetSignalRequest, request: Request):
+    safe_call_id = re.sub(r"[^A-Za-z0-9_.-]", "_", payload.call_id).strip("._")
+    if not safe_call_id:
+        raise HTTPException(status_code=400, detail="Missing call_id")
+    user = _voice_speaker_label(payload.user or _voice_auth_context(request))
+    signal_type = re.sub(r"[^A-Za-z0-9_.-]", "_", payload.type).strip("._")
+    if signal_type not in {"join", "leave", "offer", "answer", "ice"}:
+        raise HTTPException(status_code=400, detail="Unsupported signal type")
+    with _VOICE_ROOM_SIGNAL_LOCK:
+        messages = _VOICE_ROOM_SIGNALS.setdefault(safe_call_id, [])
+        message = {
+            "index": len(messages) + 1,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "call_id": safe_call_id,
+            "from_user": user,
+            "to_user": payload.to_user,
+            "type": signal_type,
+            "payload": payload.payload,
+        }
+        messages.append(message)
+        if len(messages) > 1000:
+            del messages[:-1000]
+    return {"ok": True, "signal": message}
+
+
+@app.get("/api/voice/meet/signals")
+async def get_voice_meet_signals(request: Request, call_id: str, since: int = 0, limit: int = 200, wait_ms: int = 0):
+    safe_call_id = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._")
+    if not safe_call_id:
+        raise HTTPException(status_code=400, detail="Missing call_id")
+    user = _voice_auth_context(request)
+    if wait_ms > 0:
+        return await _voice_wait_for_room_signals(safe_call_id, since=since, limit=limit, wait_ms=wait_ms, user=user)
+    return _voice_room_signal_state(safe_call_id, since=since, limit=limit, user=user)
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -430,6 +430,42 @@ def _voice_call_has_ended(call_id: str) -> bool:
         return bool((_VOICE_CALLS.get(call_id) or {}).get("ended_at"))
 
 
+def _voice_read_room_state(call_id: str, since: int = 0, limit: int = 200) -> Dict[str, Any]:
+    path = _voice_transcript_path(call_id)
+    safe_since = max(0, since)
+    safe_limit = max(1, min(limit, 500))
+    participants: Dict[str, Dict[str, Any]] = {}
+    events: list[Dict[str, Any]] = []
+    if not path.exists():
+        return {"ok": True, "call_id": call_id, "cursor": 0, "participants": [], "events": []}
+    lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    for index, line in enumerate(lines, start=1):
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        user = str(record.get("user") or "unknown dashboard user")
+        event_type = str(record.get("event_type") or "")
+        timestamp = record.get("timestamp")
+        if event_type == "call_start":
+            participants[user] = {"user": user, "status": "live", "joined_at": timestamp, "left_at": None}
+        elif event_type == "call_end":
+            state = participants.setdefault(user, {"user": user, "status": "unknown", "joined_at": None, "left_at": None})
+            state["status"] = "left"
+            state["left_at"] = timestamp
+        if index > safe_since and len(events) < safe_limit:
+            record = dict(record)
+            record["index"] = index
+            events.append(record)
+    return {
+        "ok": True,
+        "call_id": call_id,
+        "cursor": len(lines),
+        "participants": sorted(participants.values(), key=lambda row: str(row.get("joined_at") or "")),
+        "events": events,
+    }
+
+
 def _voice_send_post_call_notification(task: VoiceTask) -> bool:
     target = os.getenv("HERMES_VOICE_TELEGRAM_HANDOFF_TARGET", "").strip()
     token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
@@ -1189,6 +1225,14 @@ async def get_voice_task(task_id: str, _request: Request):
 async def save_voice_transcript(payload: VoiceTranscriptEvent, request: Request):
     path = _save_voice_transcript_event(payload, request)
     return {"ok": True, "path": str(path)}
+
+
+@app.get("/api/voice/room")
+async def get_voice_room(call_id: str, since: int = 0, limit: int = 200):
+    safe_call_id = re.sub(r"[^A-Za-z0-9_.-]", "_", call_id).strip("._")
+    if not safe_call_id:
+        raise HTTPException(status_code=400, detail="Missing call_id")
+    return _voice_read_room_state(safe_call_id, since=since, limit=limit)
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -232,6 +232,38 @@
     } catch (_e) { /* ignore quota / private mode */ }
   }
 
+  function readUrlParam(name) {
+    try { return new URLSearchParams(window.location.search).get(name); }
+    catch (_e) { return null; }
+  }
+
+  function writeUrlParams(patch) {
+    try {
+      const url = new URL(window.location.href);
+      Object.keys(patch).forEach(function (key) {
+        const value = patch[key];
+        if (value === null || value === undefined || value === "") url.searchParams.delete(key);
+        else url.searchParams.set(key, value);
+      });
+      window.history.replaceState({}, "", url.toString());
+    } catch (_e) { /* ignore */ }
+  }
+
+  function copyTextToClipboard(text, onCopied) {
+    const value = text || "";
+    const fallback = function () { window.prompt("Copy this text:", value); };
+    try {
+      const p = navigator.clipboard && navigator.clipboard.writeText(value);
+      if (p && p.then) {
+        p.then(function () { if (onCopied) onCopied(); }).catch(fallback);
+      } else {
+        fallback();
+      }
+    } catch (_e) {
+      fallback();
+    }
+  }
+
   function withBoard(url, board) {
     // Always append ?board=<slug> when we have one picked — including
     // "default". Omitting the param would fall through to the backend's
@@ -464,7 +496,7 @@
 
   function KanbanPage() {
     const { t } = useI18n();
-    const [board, setBoard] = useState(() => readSelectedBoard() || null);
+    const [board, setBoard] = useState(() => readUrlParam("board") || readSelectedBoard() || null);
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
 
@@ -488,13 +520,22 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
 
-    const [selectedTaskId, setSelectedTaskId] = useState(null);
+    const [selectedTaskId, setSelectedTaskId] = useState(() => readUrlParam("task"));
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
     const [failedIds, setFailedIds] = useState(() => new Set());
     const [draggingTaskId, setDraggingTaskId] = useState(null);
     const handleDragStart = useCallback(function (taskId) { setDraggingTaskId(taskId); }, []);
     const handleDragEnd = useCallback(function () { setDraggingTaskId(null); }, []);
+    const openTask = useCallback(function (taskId) {
+      if (!taskId) return;
+      setSelectedTaskId(taskId);
+      writeUrlParams({ task: taskId });
+    }, []);
+    const closeTask = useCallback(function () {
+      setSelectedTaskId(null);
+      writeUrlParams({ task: null });
+    }, []);
     // Per-task event counter incremented whenever the WS stream reports
     // a new event for that task id. TaskDrawer useEffect-depends on its
     // own task's counter so it reloads itself on live events instead of
@@ -506,6 +547,14 @@
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
     const wsClosedRef = useRef(false);
+
+    useEffect(function () {
+      function onPopState() {
+        setSelectedTaskId(readUrlParam("task"));
+      }
+      window.addEventListener("popstate", onPopState);
+      return function () { window.removeEventListener("popstate", onPopState); };
+    }, []);
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -898,6 +947,8 @@
       setLoading(true);
       setBoard(nextSlug);
       writeSelectedBoard(nextSlug);
+      setSelectedTaskId(null);
+      writeUrlParams({ board: nextSlug, task: null });
       // Reset filters so stale search/tenant/assignee don't persist across boards.
       setSearch("");
       setTenantFilter("");
@@ -993,7 +1044,7 @@
         h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
         }),
         h(BoardToolbar, {
           board: boardData,
@@ -1032,14 +1083,14 @@
           onMove: moveTask,
           onMoveSelected: moveSelected,
           onDelete: deleteTask,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
           boardSlug: board,
-          onClose: function () { setSelectedTaskId(null); },
+          onClose: closeTask,
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
@@ -3161,6 +3212,71 @@
     );
   }
 
+  function CardWorkspaceSection(props) {
+    const { t: i18n } = useI18n();
+    const task = props.task;
+    const [payload, setPayload] = useState(null);
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState(null);
+    const [copied, setCopied] = useState(null);
+    const hasWorkspace = !!(task && task.workspace_path);
+
+    const loadContext = function () {
+      if (!task || busy) return;
+      setBusy(true);
+      setErr(null);
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/claude-context`, props.boardSlug))
+        .then(function (d) { setPayload(d); })
+        .catch(function (e) { setErr(parseApiErrorMessage(e)); })
+        .finally(function () { setBusy(false); });
+    };
+    const markCopied = function (key) {
+      setCopied(key);
+      setTimeout(function () { setCopied(null); }, 2000);
+    };
+
+    return h("div", { className: "hermes-kanban-section" },
+      h("div", { className: "hermes-kanban-section-head" },
+        tx(i18n, "cardWorkspace", "Card workspace")),
+      h("div", { className: "text-xs text-muted-foreground mb-2" },
+        tx(i18n, "cardWorkspaceHint",
+          "Manual Claude Code launch only: copy the command and prompt; nothing is auto-started.")),
+      !hasWorkspace ? h("div", { className: "text-xs text-destructive mb-2" },
+        tx(i18n, "cardWorkspaceNoWorkspace",
+          "Set a concrete workspace_path before launching Claude Code.")) : null,
+      h("div", { className: "flex flex-wrap items-center gap-2 mb-2" },
+        h(Button, {
+          size: "sm",
+          variant: "outline",
+          disabled: busy || !hasWorkspace,
+          onClick: loadContext,
+        }, busy
+          ? tx(i18n, "preparing", "Preparing…")
+          : (payload ? tx(i18n, "refreshLaunchContext", "Refresh launch context")
+                     : tx(i18n, "prepareClaudeCode", "Prepare Claude Code prompt"))),
+        payload ? h(Button, {
+          size: "sm",
+          variant: "outline",
+          onClick: function () { copyTextToClipboard(payload.command, function () { markCopied("command"); }); },
+        }, copied === "command" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyCommand", "Copy command")) : null,
+        payload ? h(Button, {
+          size: "sm",
+          variant: "outline",
+          onClick: function () { copyTextToClipboard(payload.prompt, function () { markCopied("prompt"); }); },
+        }, copied === "prompt" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyPrompt", "Copy prompt")) : null,
+      ),
+      err ? h("div", { className: "text-xs text-destructive mb-2" }, err) : null,
+      payload ? h("div", { className: "space-y-2" },
+        h(MetaRow, { label: tx(i18n, "mode", "Mode"), value: payload.mode || "manual-copy" }),
+        h(MetaRow, { label: tx(i18n, "workspace", "Workspace"), value: payload.workspace_path || "" }),
+        h("div", { className: "text-xs font-medium" }, tx(i18n, "command", "Command")),
+        h("pre", { className: "hermes-kanban-codeblock text-xs whitespace-pre-wrap" }, payload.command || ""),
+        h("div", { className: "text-xs font-medium" }, tx(i18n, "prompt", "Prompt")),
+        h("pre", { className: "hermes-kanban-codeblock text-xs whitespace-pre-wrap" }, payload.prompt || ""),
+      ) : null,
+    );
+  }
+
   function TaskDetail(props) {
     const { t: i18n } = useI18n();
     const t = props.data.task;
@@ -3212,6 +3328,10 @@
         onPatch: props.onPatch,
         onSpecify: props.onSpecify,
         onDecompose: props.onDecompose,
+      }),
+      h(CardWorkspaceSection, {
+        task: t,
+        boardSlug: props.boardSlug,
       }),
       h(DiagnosticsSection, {
         task: t,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -87,8 +87,8 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  // Rolly uses a deliberately simple card schema: triage -> ready -> done.
+  const COLUMN_ORDER = ["triage", "ready", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
@@ -514,6 +514,8 @@
   function KanbanPage() {
     const { t } = useI18n();
     const [board, setBoard] = useState(() => readUrlParam("board") || readSelectedBoard() || null);
+    const path = window.location.pathname.replace(/\/$/, "");
+    const isPriorityListRoute = path === "/kanban/list" || path === "/kanban/priority";
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
 
@@ -721,9 +723,12 @@
         }
         return true;
       };
+      const byName = {};
+      for (const col of boardData.columns || []) byName[col.name] = col;
       return Object.assign({}, boardData, {
-        columns: boardData.columns.map(function (col) {
-          return Object.assign({}, col, { tasks: col.tasks.filter(filterTask) });
+        columns: COLUMN_ORDER.map(function (name) {
+          const col = byName[name] || { name, tasks: [] };
+          return Object.assign({}, col, { tasks: (col.tasks || []).filter(filterTask) });
         }),
       });
     }, [boardData, tenantFilter, assigneeFilter, search]);
@@ -1065,6 +1070,7 @@
         }),
         h(BoardToolbar, {
           board: boardData,
+          isPriorityListRoute,
           tenantFilter, setTenantFilter,
           assigneeFilter, setAssigneeFilter,
           includeArchived, setIncludeArchived,
@@ -1086,7 +1092,15 @@
          onDelete: deleteSelected,
        }) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
-        h(BoardColumns, {
+        isPriorityListRoute ? h(PriorityList, {
+          board: filteredBoard,
+          selectedIds,
+          failedIds,
+          draggingTaskId,
+          toggleSelected,
+          toggleRange,
+          onOpen: openTask,
+        }) : h(BoardColumns, {
           board: filteredBoard,
           laneByProfile,
           selectedIds,
@@ -1102,7 +1116,7 @@
           onDelete: deleteTask,
           onOpen: openTask,
           onCreate: createTask,
-          allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
+          allTasks: filteredBoard.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
@@ -2026,6 +2040,16 @@
     const tenants = (props.board && props.board.tenants) || [];
     const assignees = (props.board && props.board.assignees) || [];
     return h("div", { className: "flex flex-wrap items-end gap-3" },
+      h("div", { className: "hermes-kanban-view-tabs" },
+        h("a", {
+          href: "/kanban",
+          className: cn("hermes-kanban-view-tab", !props.isPriorityListRoute ? "hermes-kanban-view-tab--active" : ""),
+        }, "Board"),
+        h("a", {
+          href: "/kanban/list",
+          className: cn("hermes-kanban-view-tab", props.isPriorityListRoute ? "hermes-kanban-view-tab--active" : ""),
+        }, "Priority list"),
+      ),
       h("div", { className: "flex flex-col gap-1",
                  title: "Fuzzy-match tasks by id, title, or description. Matches across all columns." },
         h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "search", "Search")),
@@ -2115,27 +2139,15 @@
       h("span", { className: "hermes-kanban-bulk-count" },
         `${props.count} ${tx(t, "selected", "selected")}`),
       h(Button, {
-        onClick: function () { props.onApply({ status: "todo" }); },
+        onClick: function () { props.onApply({ status: "triage" }); },
         size: "sm",
-        title: "Move selected tasks to Todo.",
-      }, "→ todo"),
+        title: "Move selected tasks to Triage.",
+      }, "→ triage"),
       h(Button, {
         onClick: function () { props.onApply({ status: "ready" }); },
         size: "sm",
         title: "Move selected tasks to Ready. Ready tasks are picked up by the dispatcher on the next tick.",
       }, "→ ready"),
-      h(Button, {
-        onClick: function () { props.onApply({ status: "blocked" },
-          `Block ${props.count} task(s)?`); },
-        size: "sm",
-        title: "Block selected tasks. Releases any active claims.",
-      }, "Block"),
-      h(Button, {
-        onClick: function () { props.onApply({ status: "ready" },
-          `Unblock ${props.count} task(s)?`); },
-        size: "sm",
-        title: "Unblock selected tasks (promote to Ready).",
-      }, "Unblock"),
       h(Button, {
         onClick: function () {
           props.onApply({ status: "done" },
@@ -2285,6 +2297,44 @@
   // -------------------------------------------------------------------------
   // Columns
   // -------------------------------------------------------------------------
+
+  function priorityOrderedTasks(boardData) {
+    if (!boardData || !boardData.columns) return [];
+    const tasks = [];
+    for (const col of boardData.columns) {
+      for (const task of col.tasks || []) tasks.push(task);
+    }
+    return tasks.sort(function (a, b) {
+      const ap = Number(a.priority || 0);
+      const bp = Number(b.priority || 0);
+      if (ap !== bp) return bp - ap;
+      return String(a.created_at || "").localeCompare(String(b.created_at || ""));
+    });
+  }
+
+  function PriorityList(props) {
+    const tasks = useMemo(function () {
+      return priorityOrderedTasks(props.board);
+    }, [props.board]);
+    return h("div", { className: "hermes-kanban-priority-list" },
+      tasks.length === 0
+        ? h("div", { className: "hermes-kanban-empty" }, "— no cards —")
+        : tasks.map(function (tk, idx) {
+            return h("div", { key: tk.id, className: "hermes-kanban-priority-row" },
+              h("div", { className: "hermes-kanban-priority-rank" }, String(idx + 1)),
+              h(TaskCard, {
+                task: tk,
+                selected: props.selectedIds.has(tk.id),
+                failed: props.failedIds && props.failedIds.has(tk.id),
+                draggingTaskId: props.draggingTaskId,
+                toggleSelected: props.toggleSelected,
+                toggleRange: props.toggleRange,
+                onOpen: props.onOpen,
+              })
+            );
+          })
+    );
+  }
 
   function BoardColumns(props) {
     const handleDragStart = useCallback(function (e) {
@@ -4051,16 +4101,8 @@
         decomposeButton,
         b("→ triage",  { status: "triage" },   task.status !== "triage"),
         b("→ ready",   { status: "ready" },    task.status !== "ready"),
-        // No direct → running button: /tasks/:id PATCH rejects status=running
-        // with 400 (issue #19535). Tasks enter running only through the
-        // dispatcher's claim_task path, which atomically creates the run row,
-        // claim lock, and worker process metadata.
-        b(tx(t, "block", "Block"),     { status: "blocked" },
-          task.status === "running" || task.status === "ready",
-          getDestructiveConfirm(t, "blocked")),
-        b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
         b(tx(t, "complete", "Complete"),  { status: "done" },
-          task.status === "running" || task.status === "ready" || task.status === "blocked",
+          task.status !== "done" && task.status !== "archived",
           getDestructiveConfirm(t, "done")),
         b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
           getDestructiveConfirm(t, "archived")),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -104,7 +104,7 @@
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
-    ready: "Dependencies satisfied; assign a profile to dispatch",
+    ready: "Ready cards are prepared for manual execution; assign a profile when you are ready to run this manually",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
     done: "Completed",
@@ -1086,7 +1086,6 @@
             return createNewBoard(payload).then(function () { setShowNewBoard(false); });
           },
         }) : null,
-        h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
           onOpen: openTask,
@@ -2132,11 +2131,6 @@
       ),
       h("div", { className: "flex-1" }),
       h(Button, {
-        onClick: props.onNudgeDispatch,
-        size: "sm",
-        title: "Wake the dispatcher to claim ready tasks now instead of waiting for the next tick. Use this after adding tasks if you want them picked up immediately.",
-      }, tx(t, "nudgeDispatcher", "Nudge dispatcher")),
-      h(Button, {
         onClick: props.onRefresh,
         size: "sm",
         title: "Reload the board from the database. The board auto-refreshes on task events; this is for forcing a re-read.",
@@ -2694,7 +2688,7 @@
               : null,
             t.priority > 0
               ? h(Badge, { className: "hermes-kanban-priority",
-                           title: `Priority ${t.priority}. Higher-priority tasks are claimed first by the dispatcher.` }, `P${t.priority}`)
+                           title: `Priority ${t.priority}. Higher-priority cards appear earlier in the priority list.` }, `P${t.priority}`)
               : null,
             t.tenant
               ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
@@ -2852,7 +2846,7 @@
           onChange: function (e) { setPriority(e.target.value); },
           placeholder: "pri",
           className: "h-7 text-xs w-16",
-          title: "Priority. Higher-priority tasks are claimed first by the dispatcher. 0 = default.",
+          title: "Priority. Higher-priority cards appear earlier in the priority list. 0 = default.",
         }),
       ),
       h(Input, {
@@ -3406,6 +3400,23 @@
         .catch(function (e) { setErr(parseApiErrorMessage(e)); })
         .finally(function () { setBusy(false); });
     };
+    const copyCardPrompt = function () {
+      const doCopy = function (p) {
+        copyTextToClipboard((p && p.prompt) || "", function () { markCopied("prompt"); });
+      };
+      if (payload && payload.prompt) return doCopy(payload);
+      if (!task || busy || !hasLaunchWorkspace) return;
+      setBusy(true);
+      setErr(null);
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/claude-context`, props.boardSlug))
+        .then(function (d) { setPayload(d); doCopy(d); })
+        .catch(function (e) { setErr(parseApiErrorMessage(e)); })
+        .finally(function () { setBusy(false); });
+    };
+    const copyRollyPrompt = function () {
+      if (!payload || !payload.rolly_prompt) return;
+      copyTextToClipboard(payload.rolly_prompt, function () { markCopied("rolly"); });
+    };
     const markCopied = function (key) {
       setCopied(key);
       setTimeout(function () { setCopied(null); }, 2000);
@@ -3416,42 +3427,46 @@
       loadContext();
     }, [task && task.id, props.boardSlug]);
 
-    return h("div", { className: "hermes-kanban-section" },
-      h("div", { className: "hermes-kanban-section-head" },
-        tx(i18n, "cardWorkspace", "Card workspace")),
-      h("div", { className: "text-xs text-muted-foreground mb-2" },
-        tx(i18n, "cardWorkspaceHint",
-          "Create or attach to this card's tmux session. Use tmux keys like ctrl-b n to switch between Rolly Chat and the shell.")),
-      !hasLaunchWorkspace ? h("div", { className: "text-xs text-destructive mb-2" },
+    return h("div", { className: "hermes-kanban-section hermes-kanban-terminal-section" },
+      !hasLaunchWorkspace ? h("div", { className: "text-xs text-destructive" },
         tx(i18n, "cardWorkspaceNoWorkspace",
-          "Set a concrete workspace_path before launching Claude Code.")) : null,
-      task && !task.workspace_path && task.workspace_kind === "scratch" ? h("div", { className: "text-xs text-muted-foreground mb-2" },
+          "Set workspace_path to launch.")) : null,
+      task && !task.workspace_path && task.workspace_kind === "scratch" ? h("div", { className: "text-xs text-muted-foreground" },
         tx(i18n, "cardWorkspaceScratchHome",
-          "Scratch card: terminal starts in /Users/rolly; cd manually as needed.")) : null,
-      h("div", { className: "flex flex-wrap items-center gap-2 mb-2" },
-        h(Button, {
-          size: "sm",
-          variant: "outline",
-          disabled: busy || !hasLaunchWorkspace,
-          onClick: startTerminal,
-        }, busy
-          ? tx(i18n, "starting", "Starting…")
-          : (terminalReady ? tx(i18n, "reconnectTerminal", "Reconnect tmux session")
-                         : tx(i18n, "createTmuxSession", "Create tmux session"))),
-        h(Button, {
-          size: "sm",
-          variant: "outline",
-          disabled: busy || !hasLaunchWorkspace,
-          onClick: loadContext,
-        }, payload ? tx(i18n, "refreshPrompt", "Refresh prompt")
-                   : tx(i18n, "preparePrompt", "Prepare prompt")),
-        payload ? h(Button, {
-          size: "sm",
-          variant: "outline",
-          onClick: function () { copyTextToClipboard(payload.prompt, function () { markCopied("prompt"); }); },
-        }, copied === "prompt" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyPrompt", "Copy prompt")) : null,
+          "Scratch: starts in /Users/rolly.")) : null,
+      h("div", { className: "hermes-kanban-terminal-actions" },
+        h("div", { className: "hermes-kanban-terminal-actions-primary" },
+          h(Button, {
+            size: "sm",
+            disabled: busy || !hasLaunchWorkspace,
+            onClick: startTerminal,
+          }, busy
+            ? tx(i18n, "starting", "Starting…")
+            : (terminalReady ? tx(i18n, "reconnectTerminal", "Reconnect tmux session")
+                           : tx(i18n, "createTmuxSession", "Create tmux session"))),
+        ),
+        h("div", { className: "hermes-kanban-terminal-actions-secondary" },
+          h(Button, {
+            size: "sm",
+            variant: "outline",
+            disabled: busy || !hasLaunchWorkspace,
+            onClick: loadContext,
+          }, payload ? tx(i18n, "refreshPrompt", "Refresh prompt")
+                     : tx(i18n, "preparePrompt", "Prepare prompt")),
+          h(Button, {
+            size: "sm",
+            variant: "outline",
+            disabled: busy || !hasLaunchWorkspace,
+            onClick: copyCardPrompt,
+          }, copied === "prompt" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyCardPrompt", "Copy card prompt")),
+          payload && payload.rolly_prompt ? h(Button, {
+            size: "sm",
+            variant: "outline",
+            onClick: copyRollyPrompt,
+          }, copied === "rolly" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyRollyPrompt", "Copy Rolly prompt")) : null,
+        ),
       ),
-      err ? h("div", { className: "text-xs text-destructive mb-2" }, err) : null,
+      err ? h("div", { className: "text-xs text-destructive" }, err) : null,
       terminalReady && payload && payload.terminal_target && PtyTerminalPane ? h(PtyTerminalPane, {
         key: `${payload.terminal_target}:${terminalNonce}`,
         title: `Terminal for ${task.id}`,
@@ -3459,12 +3474,15 @@
         tmuxTarget: payload.terminal_target,
         autoFocus: true,
       }) : null,
-      payload ? h("div", { className: "space-y-2" },
-        h(MetaRow, { label: tx(i18n, "mode", "Mode"), value: payload.mode || "browser-tmux-plus-copy-prompt" }),
-        h(MetaRow, { label: tx(i18n, "workspace", "Workspace"), value: payload.workspace_path || "" }),
-        payload.attach_command ? h(MetaRow, { label: tx(i18n, "attach", "Attach"), value: payload.attach_command }) : null,
-        h("div", { className: "text-xs font-medium" }, tx(i18n, "prompt", "Prompt")),
-        h("pre", { className: "hermes-kanban-codeblock text-xs whitespace-pre-wrap" }, payload.prompt || ""),
+      payload ? h("details", { className: "hermes-kanban-terminal-context" },
+        h("summary", null, tx(i18n, "promptContext", "Prompt/context")),
+        h("div", { className: "space-y-2" },
+          h(MetaRow, { label: tx(i18n, "mode", "Mode"), value: payload.mode || "browser-tmux-plus-copy-prompt" }),
+          h(MetaRow, { label: tx(i18n, "workspace", "Workspace"), value: payload.workspace_path || "" }),
+          payload.attach_command ? h(MetaRow, { label: tx(i18n, "attach", "Attach"), value: payload.attach_command }) : null,
+          h("div", { className: "text-xs font-medium" }, tx(i18n, "prompt", "Prompt")),
+          h("pre", { className: "hermes-kanban-codeblock text-xs whitespace-pre-wrap" }, payload.prompt || ""),
+        ),
       ) : null,
     );
   }
@@ -3518,24 +3536,60 @@
         onClick: function () { setActivePane(key); },
       }, label);
     };
+    const chip = function (label, value) {
+      if (value === undefined || value === null || value === "") return null;
+      return h("span", { className: "hermes-kanban-compact-chip" },
+        h("span", { className: "hermes-kanban-compact-chip-label" }, label),
+        h("span", { className: "hermes-kanban-compact-chip-value" }, value));
+    };
+    const workspaceLabel = `${t.workspace_kind}${t.workspace_path ? ": " + t.workspace_path : ""}`;
 
-    return h("div", { className: "hermes-kanban-drawer-body" },
-      h("div", { className: "hermes-kanban-drawer-title" },
-        h("span", { className: cn("hermes-kanban-dot", COLUMN_DOT[t.status]) }),
-        props.editing
-          ? h(TitleEditor, {
-              initial: t.title || "",
-              onSave: function (newTitle) {
-                return props.onPatch({ title: newTitle }).then(function () { props.setEditing(false); });
-              },
-              onCancel: function () { props.setEditing(false); },
-            })
-          : h("span", {
-              className: "hermes-kanban-drawer-title-text",
-              title: tx(i18n, "clickToEdit", "Click to edit"),
-              onClick: function () { props.setEditing(true); },
-            }, t.title || tx(i18n, "untitled", "(untitled)")),
+    return h("div", { className: "hermes-kanban-drawer-body hermes-kanban-card-workspace" },
+      h("div", { className: "hermes-kanban-card-chrome" },
+        h("div", { className: "hermes-kanban-card-title-row" },
+          h("div", { className: "hermes-kanban-drawer-title" },
+            h("span", { className: cn("hermes-kanban-dot", COLUMN_DOT[t.status]) }),
+            props.editing
+              ? h(TitleEditor, {
+                  initial: t.title || "",
+                  onSave: function (newTitle) {
+                    return props.onPatch({ title: newTitle }).then(function () { props.setEditing(false); });
+                  },
+                  onCancel: function () { props.setEditing(false); },
+                })
+              : h("span", {
+                  className: "hermes-kanban-drawer-title-text",
+                  title: tx(i18n, "clickToEdit", "Click to edit"),
+                  onClick: function () { props.setEditing(true); },
+                }, t.title || tx(i18n, "untitled", "(untitled)")),
+          ),
+          h("div", { className: "hermes-kanban-card-status-actions" },
+            h(StatusActions, {
+              task: t,
+              onPatch: props.onPatch,
+              onSpecify: props.onSpecify,
+              onDecompose: props.onDecompose,
+            }),
+          ),
+        ),
+        h("div", { className: "hermes-kanban-compact-meta" },
+          chip(tx(i18n, "status", "Status"), t.status),
+          chip(tx(i18n, "assignee", "Assignee"), t.assignee || tx(i18n, "unassigned", "unassigned")),
+          chip(tx(i18n, "priority", "Priority"), String(t.priority || 0)),
+          chip(tx(i18n, "tenant", "Tenant"), t.tenant),
+          chip(tx(i18n, "workspace", "Workspace"), workspaceLabel),
+        ),
+        h("div", { className: "hermes-kanban-workspace-tabs", role: "tablist" },
+          tab("terminal", tx(i18n, "terminalCc", "Terminal / CC")),
+          tab("details", tx(i18n, "details", "Details")),
+        ),
       ),
+      h("div", { style: { display: activePane === "terminal" ? "block" : "none" } },
+        h(CardWorkspaceSection, {
+          task: t,
+          boardSlug: props.boardSlug,
+        })),
+      activePane === "details" ? h(React.Fragment, null,
       h("div", { className: "hermes-kanban-drawer-meta" },
         h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
         h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
@@ -3543,7 +3597,7 @@
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
         h(MetaRow, {
           label: tx(i18n, "workspace", "Workspace"),
-          value: `${t.workspace_kind}${t.workspace_path ? ": " + t.workspace_path : ""}`,
+          value: workspaceLabel,
         }),
         (t.skills && t.skills.length > 0) ? h(MetaRow, {
           label: tx(i18n, "skills", "Skills"),
@@ -3557,23 +3611,6 @@
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
       ),
-      h(StatusActions, {
-        task: t,
-        onPatch: props.onPatch,
-        onSpecify: props.onSpecify,
-        onDecompose: props.onDecompose,
-      }),
-      h(CardPromptActions, { task: t, boardSlug: props.boardSlug }),
-      h("div", { className: "hermes-kanban-workspace-tabs", role: "tablist" },
-        tab("details", tx(i18n, "details", "Details")),
-        tab("terminal", tx(i18n, "terminalCc", "Terminal / CC")),
-      ),
-      h("div", { style: { display: activePane === "terminal" ? "block" : "none" } },
-        h(CardWorkspaceSection, {
-          task: t,
-          boardSlug: props.boardSlug,
-        })),
-      activePane === "details" ? h(React.Fragment, null,
       h(DiagnosticsSection, {
         task: t,
         boardSlug: props.boardSlug,
@@ -3680,9 +3717,6 @@
     );
   }
 
-  // Per-attempt history. Closed runs first (most recent last), then the
-  // active run if any. Each row shows profile / outcome / elapsed /
-  // summary. Collapsed by default when there are more than three runs.
   function RunHistorySection(props) {
     const { t } = useI18n();
     const runs = props.runs || [];

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -245,12 +245,32 @@
     } catch (_e) { return null; }
   }
 
-  function writeCardPath(taskId) {
+  function readReturnToBoardPath() {
     try {
       const url = new URL(window.location.href);
-      url.pathname = taskId ? `/kanban/cards/${encodeURIComponent(taskId)}` : "/kanban";
+      const ret = url.searchParams.get("return");
+      if (ret === "/kanban/list" || ret === "/kanban/priority") return ret;
+    } catch (_e) { /* ignore */ }
+    return "/kanban";
+  }
+
+  function writeCardPath(taskId, returnPath) {
+    try {
+      const url = new URL(window.location.href);
+      if (taskId) {
+        url.pathname = `/kanban/cards/${encodeURIComponent(taskId)}`;
+        if (returnPath === "/kanban/list" || returnPath === "/kanban/priority") {
+          url.searchParams.set("return", returnPath);
+        } else {
+          url.searchParams.delete("return");
+        }
+      } else {
+        url.pathname = readReturnToBoardPath();
+        url.searchParams.delete("return");
+      }
       url.searchParams.delete("task");
       window.history.pushState({}, "", url.toString());
+      window.dispatchEvent(new PopStateEvent("popstate"));
     } catch (_e) { /* ignore */ }
   }
 
@@ -549,8 +569,8 @@
     const openTask = useCallback(function (taskId) {
       if (!taskId) return;
       setSelectedTaskId(taskId);
-      writeCardPath(taskId);
-    }, []);
+      writeCardPath(taskId, isPriorityListRoute ? "/kanban/list" : "/kanban");
+    }, [isPriorityListRoute]);
     const closeTask = useCallback(function () {
       setSelectedTaskId(null);
       writeCardPath(null);
@@ -2302,7 +2322,9 @@
     if (!boardData || !boardData.columns) return [];
     const tasks = [];
     for (const col of boardData.columns) {
-      for (const task of col.tasks || []) tasks.push(task);
+      for (const task of col.tasks || []) {
+        if (task && task.status !== "done" && task.status !== "archived") tasks.push(task);
+      }
     }
     return tasks.sort(function (a, b) {
       const ap = Number(a.priority || 0);

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -249,7 +249,7 @@
     try {
       const url = new URL(window.location.href);
       const ret = url.searchParams.get("return");
-      if (ret === "/kanban/list" || ret === "/kanban/priority") return ret;
+      if (ret === "/kanban" || ret === "/kanban/list" || ret === "/kanban/priority" || ret === "/kanban/board") return ret;
     } catch (_e) { /* ignore */ }
     return "/kanban";
   }
@@ -259,7 +259,7 @@
       const url = new URL(window.location.href);
       if (taskId) {
         url.pathname = `/kanban/cards/${encodeURIComponent(taskId)}`;
-        if (returnPath === "/kanban/list" || returnPath === "/kanban/priority") {
+        if (returnPath === "/kanban" || returnPath === "/kanban/list" || returnPath === "/kanban/priority" || returnPath === "/kanban/board") {
           url.searchParams.set("return", returnPath);
         } else {
           url.searchParams.delete("return");
@@ -535,7 +535,7 @@
     const { t } = useI18n();
     const [board, setBoard] = useState(() => readUrlParam("board") || readSelectedBoard() || null);
     const path = window.location.pathname.replace(/\/$/, "");
-    const isPriorityListRoute = path === "/kanban/list" || path === "/kanban/priority";
+    const isPriorityListRoute = path === "/kanban" || path === "/kanban/list" || path === "/kanban/priority";
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
 
@@ -569,7 +569,7 @@
     const openTask = useCallback(function (taskId) {
       if (!taskId) return;
       setSelectedTaskId(taskId);
-      writeCardPath(taskId, isPriorityListRoute ? "/kanban/list" : "/kanban");
+      writeCardPath(taskId, isPriorityListRoute ? "/kanban/list" : "/kanban/board");
     }, [isPriorityListRoute]);
     const closeTask = useCallback(function () {
       setSelectedTaskId(null);
@@ -2062,11 +2062,11 @@
     return h("div", { className: "flex flex-wrap items-end gap-3" },
       h("div", { className: "hermes-kanban-view-tabs" },
         h("a", {
-          href: "/kanban",
+          href: "/kanban/board",
           className: cn("hermes-kanban-view-tab", !props.isPriorityListRoute ? "hermes-kanban-view-tab--active" : ""),
         }, "Board"),
         h("a", {
-          href: "/kanban/list",
+          href: "/kanban",
           className: cn("hermes-kanban-view-tab", props.isPriorityListRoute ? "hermes-kanban-view-tab--active" : ""),
         }, "Priority list"),
       ),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3052,13 +3052,13 @@
         onClick: function (e) { e.stopPropagation(); },
       },
         h("div", { className: "hermes-kanban-drawer-head" },
-          h("span", { className: "text-xs text-muted-foreground" }, props.taskId),
           h("button", {
             type: "button",
             onClick: props.onClose,
-            className: "hermes-kanban-drawer-close",
-            title: tx(t, "close", "Close (Esc)"),
-          }, "×"),
+            className: "hermes-kanban-drawer-back",
+            title: tx(t, "backToBoard", "Back to board"),
+          }, "← ", tx(t, "backToBoard", "Back to board")),
+          h("span", { className: "text-xs text-muted-foreground" }, props.taskId),
         ),
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -20,6 +20,7 @@
   const {
     Card, CardContent,
     Badge, Button, Input, Label, Select, SelectOption,
+    PtyTerminalPane,
   } = SDK.components;
   const { useState, useEffect, useCallback, useMemo, useRef } = SDK.hooks;
   const { cn, timeAgo } = SDK.utils;
@@ -3219,7 +3220,9 @@
     const [busy, setBusy] = useState(false);
     const [err, setErr] = useState(null);
     const [copied, setCopied] = useState(null);
-    const hasWorkspace = !!(task && task.workspace_path);
+    const [terminalReady, setTerminalReady] = useState(false);
+    const [terminalNonce, setTerminalNonce] = useState(0);
+    const hasLaunchWorkspace = !!(task && (task.workspace_path || task.workspace_kind === "scratch"));
 
     const loadContext = function () {
       if (!task || busy) return;
@@ -3227,6 +3230,19 @@
       setErr(null);
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/claude-context`, props.boardSlug))
         .then(function (d) { setPayload(d); })
+        .catch(function (e) { setErr(parseApiErrorMessage(e)); })
+        .finally(function () { setBusy(false); });
+    };
+    const startTerminal = function () {
+      if (!task || busy) return;
+      setBusy(true);
+      setErr(null);
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/tmux-session`, props.boardSlug), { method: "POST" })
+        .then(function (d) {
+          setPayload(d);
+          setTerminalReady(true);
+          setTerminalNonce(function (n) { return n + 1; });
+        })
         .catch(function (e) { setErr(parseApiErrorMessage(e)); })
         .finally(function () { setBusy(false); });
     };
@@ -3240,25 +3256,30 @@
         tx(i18n, "cardWorkspace", "Card workspace")),
       h("div", { className: "text-xs text-muted-foreground mb-2" },
         tx(i18n, "cardWorkspaceHint",
-          "Manual Claude Code launch only: copy the command and prompt; nothing is auto-started.")),
-      !hasWorkspace ? h("div", { className: "text-xs text-destructive mb-2" },
+          "Start a card-scoped tmux session in the browser. Copy the prompt, then paste it into Claude Code when ready.")),
+      !hasLaunchWorkspace ? h("div", { className: "text-xs text-destructive mb-2" },
         tx(i18n, "cardWorkspaceNoWorkspace",
           "Set a concrete workspace_path before launching Claude Code.")) : null,
+      task && !task.workspace_path && task.workspace_kind === "scratch" ? h("div", { className: "text-xs text-muted-foreground mb-2" },
+        tx(i18n, "cardWorkspaceScratchHome",
+          "Scratch card: terminal starts in /Users/rolly; cd manually as needed.")) : null,
       h("div", { className: "flex flex-wrap items-center gap-2 mb-2" },
         h(Button, {
           size: "sm",
           variant: "outline",
-          disabled: busy || !hasWorkspace,
-          onClick: loadContext,
+          disabled: busy || !hasLaunchWorkspace,
+          onClick: startTerminal,
         }, busy
-          ? tx(i18n, "preparing", "Preparing…")
-          : (payload ? tx(i18n, "refreshLaunchContext", "Refresh launch context")
-                     : tx(i18n, "prepareClaudeCode", "Prepare Claude Code prompt"))),
-        payload ? h(Button, {
+          ? tx(i18n, "starting", "Starting…")
+          : (terminalReady ? tx(i18n, "restartTerminal", "Reconnect terminal")
+                         : tx(i18n, "startTerminal", "Start card tmux"))),
+        h(Button, {
           size: "sm",
           variant: "outline",
-          onClick: function () { copyTextToClipboard(payload.command, function () { markCopied("command"); }); },
-        }, copied === "command" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyCommand", "Copy command")) : null,
+          disabled: busy || !hasLaunchWorkspace,
+          onClick: loadContext,
+        }, payload ? tx(i18n, "refreshPrompt", "Refresh prompt")
+                   : tx(i18n, "preparePrompt", "Prepare prompt")),
         payload ? h(Button, {
           size: "sm",
           variant: "outline",
@@ -3266,14 +3287,51 @@
         }, copied === "prompt" ? tx(i18n, "copied", "Copied") : tx(i18n, "copyPrompt", "Copy prompt")) : null,
       ),
       err ? h("div", { className: "text-xs text-destructive mb-2" }, err) : null,
+      terminalReady && payload && payload.terminal_target && PtyTerminalPane ? h(PtyTerminalPane, {
+        key: `${payload.terminal_target}:${terminalNonce}`,
+        title: `Terminal for ${task.id}`,
+        className: "hermes-kanban-card-chat-frame hermes-kanban-card-terminal-frame",
+        tmuxTarget: payload.terminal_target,
+        autoFocus: true,
+      }) : null,
       payload ? h("div", { className: "space-y-2" },
-        h(MetaRow, { label: tx(i18n, "mode", "Mode"), value: payload.mode || "manual-copy" }),
+        h(MetaRow, { label: tx(i18n, "mode", "Mode"), value: payload.mode || "browser-tmux-plus-copy-prompt" }),
         h(MetaRow, { label: tx(i18n, "workspace", "Workspace"), value: payload.workspace_path || "" }),
-        h("div", { className: "text-xs font-medium" }, tx(i18n, "command", "Command")),
-        h("pre", { className: "hermes-kanban-codeblock text-xs whitespace-pre-wrap" }, payload.command || ""),
+        payload.attach_command ? h(MetaRow, { label: tx(i18n, "attach", "Attach"), value: payload.attach_command }) : null,
         h("div", { className: "text-xs font-medium" }, tx(i18n, "prompt", "Prompt")),
         h("pre", { className: "hermes-kanban-codeblock text-xs whitespace-pre-wrap" }, payload.prompt || ""),
       ) : null,
+    );
+  }
+
+  function RollyChatSection(props) {
+    const { t: i18n } = useI18n();
+    const task = props.task;
+    const [payload, setPayload] = useState(null);
+    const [err, setErr] = useState(null);
+
+    useEffect(function () {
+      if (!task) return;
+      var cancelled = false;
+      setErr(null);
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/tmux-session`, props.boardSlug), { method: "POST" })
+        .then(function (d) { if (!cancelled) setPayload(d); })
+        .catch(function (e) { if (!cancelled) setErr(parseApiErrorMessage(e)); });
+      return function () { cancelled = true; };
+    }, [task && task.id, props.boardSlug]);
+
+    return h("div", { className: "hermes-kanban-card-chat" },
+      h("div", { className: "text-xs text-muted-foreground mb-2" },
+        tx(i18n, "rollyChatHint", "Card-scoped Rolly chat. Use this to discuss or drive this card.")),
+      err ? h("div", { className: "text-xs text-destructive mb-2" }, err) : null,
+      payload && payload.rolly_target && PtyTerminalPane ? h(PtyTerminalPane, {
+        key: payload.rolly_target,
+        title: `Rolly chat for ${task.id}`,
+        className: "hermes-kanban-card-chat-frame",
+        tmuxTarget: payload.rolly_target,
+        autoFocus: true,
+      }) : h("div", { className: "hermes-kanban-card-chat-frame hermes-kanban-card-terminal-placeholder" },
+        tx(i18n, "starting", "Starting…")),
     );
   }
 
@@ -3284,6 +3342,17 @@
     const events = props.data.events || [];
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
+    const [activePane, setActivePane] = useState("chat");
+    const tab = function (key, label) {
+      return h("button", {
+        key,
+        type: "button",
+        role: "tab",
+        "aria-selected": activePane === key,
+        className: cn("hermes-kanban-workspace-tab", activePane === key ? "hermes-kanban-workspace-tab--active" : ""),
+        onClick: function () { setActivePane(key); },
+      }, label);
+    };
 
     return h("div", { className: "hermes-kanban-drawer-body" },
       h("div", { className: "hermes-kanban-drawer-title" },
@@ -3329,10 +3398,17 @@
         onSpecify: props.onSpecify,
         onDecompose: props.onDecompose,
       }),
-      h(CardWorkspaceSection, {
+      h("div", { className: "hermes-kanban-workspace-tabs", role: "tablist" },
+        tab("details", tx(i18n, "details", "Details")),
+        tab("chat", tx(i18n, "rollyChat", "Rolly Chat")),
+        tab("terminal", tx(i18n, "terminalCc", "Terminal / CC")),
+      ),
+      activePane === "chat" ? h(RollyChatSection, { task: t }) : null,
+      activePane === "terminal" ? h(CardWorkspaceSection, {
         task: t,
         boardSlug: props.boardSlug,
-      }),
+      }) : null,
+      activePane === "details" ? h(React.Fragment, null,
       h(DiagnosticsSection, {
         task: t,
         boardSlug: props.boardSlug,
@@ -3435,6 +3511,7 @@
       ),
       h(WorkerLogSection, { taskId: t.id, boardSlug: props.boardSlug }),
       h(RunHistorySection, { runs: props.data.runs || [] }),
+      ) : null,
     );
   }
 

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3229,6 +3229,51 @@
     );
   }
 
+  function CardPromptActions(props) {
+    const { t: i18n } = useI18n();
+    const task = props.task;
+    const [payload, setPayload] = useState(null);
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState(null);
+    const [copied, setCopied] = useState(false);
+    const hasLaunchWorkspace = !!(task && (task.workspace_path || task.workspace_kind === "scratch"));
+    const loadPrompt = function () {
+      if (!task || busy || !hasLaunchWorkspace) return;
+      setBusy(true);
+      setErr(null);
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/claude-context`, props.boardSlug))
+        .then(function (d) { setPayload(d); })
+        .catch(function (e) { setErr(parseApiErrorMessage(e)); })
+        .finally(function () { setBusy(false); });
+    };
+    useEffect(function () { loadPrompt(); }, [task && task.id, props.boardSlug]);
+    const copyPrompt = function () {
+      const doCopy = function (p) {
+        copyTextToClipboard(p.prompt || "", function () {
+          setCopied(true);
+          setTimeout(function () { setCopied(false); }, 2000);
+        });
+      };
+      if (payload && payload.prompt) return doCopy(payload);
+      if (!task || busy || !hasLaunchWorkspace) return;
+      setBusy(true);
+      setErr(null);
+      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/claude-context`, props.boardSlug))
+        .then(function (d) { setPayload(d); doCopy(d); })
+        .catch(function (e) { setErr(parseApiErrorMessage(e)); })
+        .finally(function () { setBusy(false); });
+    };
+    return h("div", { className: "flex flex-wrap items-center gap-2 mb-3" },
+      h(Button, {
+        size: "sm",
+        variant: "outline",
+        disabled: busy || !hasLaunchWorkspace,
+        onClick: copyPrompt,
+      }, copied ? tx(i18n, "copied", "Copied") : tx(i18n, "copyCardPrompt", "Copy card prompt")),
+      err ? h("span", { className: "text-xs text-destructive" }, err) : null,
+    );
+  }
+
   function CardWorkspaceSection(props) {
     const { t: i18n } = useI18n();
     const task = props.task;
@@ -3245,7 +3290,11 @@
       setBusy(true);
       setErr(null);
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/claude-context`, props.boardSlug))
-        .then(function (d) { setPayload(d); })
+        .then(function (d) {
+          setPayload(d);
+          setTerminalReady(!!(d && d.session_exists));
+          if (d && d.session_exists) setTerminalNonce(function (n) { return n + 1; });
+        })
         .catch(function (e) { setErr(parseApiErrorMessage(e)); })
         .finally(function () { setBusy(false); });
     };
@@ -3267,12 +3316,17 @@
       setTimeout(function () { setCopied(null); }, 2000);
     };
 
+    useEffect(function () {
+      if (!task) return;
+      loadContext();
+    }, [task && task.id, props.boardSlug]);
+
     return h("div", { className: "hermes-kanban-section" },
       h("div", { className: "hermes-kanban-section-head" },
         tx(i18n, "cardWorkspace", "Card workspace")),
       h("div", { className: "text-xs text-muted-foreground mb-2" },
         tx(i18n, "cardWorkspaceHint",
-          "Start a card-scoped tmux session in the browser. Copy the prompt, then paste it into Claude Code when ready.")),
+          "Create or attach to this card's tmux session. Use tmux keys like ctrl-b n to switch between Rolly Chat and the shell.")),
       !hasLaunchWorkspace ? h("div", { className: "text-xs text-destructive mb-2" },
         tx(i18n, "cardWorkspaceNoWorkspace",
           "Set a concrete workspace_path before launching Claude Code.")) : null,
@@ -3287,8 +3341,8 @@
           onClick: startTerminal,
         }, busy
           ? tx(i18n, "starting", "Starting…")
-          : (terminalReady ? tx(i18n, "restartTerminal", "Reconnect terminal")
-                         : tx(i18n, "startTerminal", "Start card tmux"))),
+          : (terminalReady ? tx(i18n, "reconnectTerminal", "Reconnect tmux session")
+                         : tx(i18n, "createTmuxSession", "Create tmux session"))),
         h(Button, {
           size: "sm",
           variant: "outline",
@@ -3358,7 +3412,7 @@
     const events = props.data.events || [];
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
-    const [activePane, setActivePane] = useState("chat");
+    const [activePane, setActivePane] = useState("terminal");
     const tab = function (key, label) {
       return h("button", {
         key,
@@ -3414,16 +3468,16 @@
         onSpecify: props.onSpecify,
         onDecompose: props.onDecompose,
       }),
+      h(CardPromptActions, { task: t, boardSlug: props.boardSlug }),
       h("div", { className: "hermes-kanban-workspace-tabs", role: "tablist" },
         tab("details", tx(i18n, "details", "Details")),
-        tab("chat", tx(i18n, "rollyChat", "Rolly Chat")),
         tab("terminal", tx(i18n, "terminalCc", "Terminal / CC")),
       ),
-      activePane === "chat" ? h(RollyChatSection, { task: t, boardSlug: props.boardSlug }) : null,
-      activePane === "terminal" ? h(CardWorkspaceSection, {
-        task: t,
-        boardSlug: props.boardSlug,
-      }) : null,
+      h("div", { style: { display: activePane === "terminal" ? "block" : "none" } },
+        h(CardWorkspaceSection, {
+          task: t,
+          boardSlug: props.boardSlug,
+        })),
       activePane === "details" ? h(React.Fragment, null,
       h(DiagnosticsSection, {
         task: t,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -238,6 +238,22 @@
     catch (_e) { return null; }
   }
 
+  function readPathTaskId() {
+    try {
+      const match = window.location.pathname.match(/\/kanban\/cards\/([^/?#]+)/);
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch (_e) { return null; }
+  }
+
+  function writeCardPath(taskId) {
+    try {
+      const url = new URL(window.location.href);
+      url.pathname = taskId ? `/kanban/cards/${encodeURIComponent(taskId)}` : "/kanban";
+      url.searchParams.delete("task");
+      window.history.pushState({}, "", url.toString());
+    } catch (_e) { /* ignore */ }
+  }
+
   function writeUrlParams(patch) {
     try {
       const url = new URL(window.location.href);
@@ -521,7 +537,7 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
 
-    const [selectedTaskId, setSelectedTaskId] = useState(() => readUrlParam("task"));
+    const [selectedTaskId, setSelectedTaskId] = useState(() => readPathTaskId() || readUrlParam("task"));
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
     const [failedIds, setFailedIds] = useState(() => new Set());
@@ -531,11 +547,11 @@
     const openTask = useCallback(function (taskId) {
       if (!taskId) return;
       setSelectedTaskId(taskId);
-      writeUrlParams({ task: taskId });
+      writeCardPath(taskId);
     }, []);
     const closeTask = useCallback(function () {
       setSelectedTaskId(null);
-      writeUrlParams({ task: null });
+      writeCardPath(null);
     }, []);
     // Per-task event counter incremented whenever the WS stream reports
     // a new event for that task id. TaskDrawer useEffect-depends on its
@@ -551,7 +567,7 @@
 
     useEffect(function () {
       function onPopState() {
-        setSelectedTaskId(readUrlParam("task"));
+        setSelectedTaskId(readPathTaskId() || readUrlParam("task"));
       }
       window.addEventListener("popstate", onPopState);
       return function () { window.removeEventListener("popstate", onPopState); };
@@ -3403,7 +3419,7 @@
         tab("chat", tx(i18n, "rollyChat", "Rolly Chat")),
         tab("terminal", tx(i18n, "terminalCc", "Terminal / CC")),
       ),
-      activePane === "chat" ? h(RollyChatSection, { task: t }) : null,
+      activePane === "chat" ? h(RollyChatSection, { task: t, boardSlug: props.boardSlug }) : null,
       activePane === "terminal" ? h(CardWorkspaceSection, {
         task: t,
         boardSlug: props.boardSlug,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -555,6 +555,7 @@
     const [tenantFilter, setTenantFilter] = useState("");
     const [assigneeFilter, setAssigneeFilter] = useState("");
     const [includeArchived, setIncludeArchived] = useState(false);
+    const [priorityShowCompleted, setPriorityShowCompleted] = useState(false);
     const [search, setSearch] = useState("");
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
@@ -609,6 +610,10 @@
         })
         .catch(function () { setConfig({ render_markdown: true }); });
     }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(function () {
+      if (!isPriorityListRoute && priorityShowCompleted) setPriorityShowCompleted(false);
+    }, [isPriorityListRoute, priorityShowCompleted]);
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
@@ -743,11 +748,8 @@
         }
         return true;
       };
-      const byName = {};
-      for (const col of boardData.columns || []) byName[col.name] = col;
       return Object.assign({}, boardData, {
-        columns: COLUMN_ORDER.map(function (name) {
-          const col = byName[name] || { name, tasks: [] };
+        columns: (boardData.columns || []).map(function (col) {
           return Object.assign({}, col, { tasks: (col.tasks || []).filter(filterTask) });
         }),
       });
@@ -996,6 +998,7 @@
       setTenantFilter("");
       setAssigneeFilter("");
       setIncludeArchived(false);
+      setPriorityShowCompleted(false);
       clearSelected();
     }, [board, clearSelected]);
 
@@ -1120,6 +1123,11 @@
           toggleSelected,
           toggleRange,
           onOpen: openTask,
+          showCompleted: priorityShowCompleted,
+          onShowCompletedChange: function (show) {
+            setPriorityShowCompleted(show === true);
+            if (show === true && !includeArchived) setIncludeArchived(true);
+          },
         }) : h(BoardColumns, {
           board: filteredBoard,
           laneByProfile,
@@ -2178,14 +2186,6 @@
       }, tx(t, "complete", "Complete")),
       h(Button, {
         onClick: function () {
-          props.onApply({ archive: true },
-            tx(t, "markArchived", "Archive {n} task(s)?", { n: props.count }));
-        },
-        size: "sm",
-        title: "Archive selected tasks. They disappear from the default board view but remain in the database.",
-      }, tx(t, "archive", "Archive")),
-      h(Button, {
-        onClick: function () {
           props.onDelete(props.count);
         },
         size: "sm",
@@ -2318,15 +2318,25 @@
   // Columns
   // -------------------------------------------------------------------------
 
-  function priorityOrderedTasks(boardData) {
+  function priorityOrderedTasks(boardData, showCompleted) {
     if (!boardData || !boardData.columns) return [];
     const tasks = [];
     for (const col of boardData.columns) {
       for (const task of col.tasks || []) {
-        if (task && task.status !== "done" && task.status !== "archived") tasks.push(task);
+        if (!task) continue;
+        if (showCompleted) {
+          if ((task.status === "done" || task.status === "archived") && task.completed_at) tasks.push(task);
+        } else if (task.status !== "done" && task.status !== "archived") {
+          tasks.push(task);
+        }
       }
     }
     return tasks.sort(function (a, b) {
+      if (showCompleted) {
+        const ac = Number(a.completed_at || 0);
+        const bc = Number(b.completed_at || 0);
+        if (ac !== bc) return bc - ac;
+      }
       const ap = Number(a.priority || 0);
       const bp = Number(b.priority || 0);
       if (ap !== bp) return bp - ap;
@@ -2336,11 +2346,24 @@
 
   function PriorityList(props) {
     const tasks = useMemo(function () {
-      return priorityOrderedTasks(props.board);
-    }, [props.board]);
+      return priorityOrderedTasks(props.board, props.showCompleted);
+    }, [props.board, props.showCompleted]);
     return h("div", { className: "hermes-kanban-priority-list" },
+      h("div", { className: "hermes-kanban-priority-mode" },
+        h(Button, {
+          onClick: function () { props.onShowCompletedChange(false); },
+          size: "sm",
+          className: !props.showCompleted ? "hermes-kanban-view-tab--active" : "",
+        }, "Active"),
+        h(Button, {
+          onClick: function () { props.onShowCompletedChange(true); },
+          size: "sm",
+          className: props.showCompleted ? "hermes-kanban-view-tab--active" : "",
+          title: "Completed tasks, newest first.",
+        }, "Completed"),
+      ),
       tasks.length === 0
-        ? h("div", { className: "hermes-kanban-empty" }, "— no cards —")
+        ? h("div", { className: "hermes-kanban-empty" }, props.showCompleted ? "— no completed cards —" : "— no cards —")
         : tasks.map(function (tk, idx) {
             return h("div", { key: tk.id, className: "hermes-kanban-priority-row" },
               h("div", { className: "hermes-kanban-priority-rank" }, String(idx + 1)),
@@ -4126,8 +4149,6 @@
         b(tx(t, "complete", "Complete"),  { status: "done" },
           task.status !== "done" && task.status !== "archived",
           getDestructiveConfirm(t, "done")),
-        b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
-          getDestructiveConfirm(t, "archived")),
       ),
       specifyMsg ? h("div", {
         className: specifyMsg.ok

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -352,38 +352,42 @@
 }
 
 .hermes-kanban-drawer-head {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.6rem 0.8rem;
-  /* Honor the top safe-area inset (notch) so the task id / close button are
-     not clipped on mobile. */
-  padding-top: max(0.6rem, env(safe-area-inset-top));
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  /* Honor the top safe-area inset (iPad/browser chrome) so the back button
+     and task id are never clipped under the dashboard/header rail. */
+  padding-top: max(0.75rem, calc(0.75rem + env(safe-area-inset-top)));
   border-bottom: 1px solid var(--color-border);
+  background: var(--color-card);
   font-family: var(--font-mono, ui-monospace, monospace);
 }
 
-/* On mobile the dashboard shell renders a fixed top bar (min-h-14, hidden at
-   the lg breakpoint). The drawer is a body-level z-60 overlay starting at the
-   viewport top, so its header would sit behind that bar. Push the header down
-   by the bar height (3.5rem) plus the top safe-area inset. */
-@media (max-width: 1023px) {
+/* On tablet/mobile the dashboard shell can render a fixed top bar above the
+   plugin content. Keep the full-screen card header below it. */
+@media (max-width: 1366px) {
   .hermes-kanban-drawer-head {
     padding-top: calc(3.5rem + env(safe-area-inset-top));
   }
 }
 
-.hermes-kanban-drawer-close {
+.hermes-kanban-drawer-back {
   appearance: none;
   background: transparent;
   border: 0;
   color: var(--color-muted-foreground);
-  font-size: 1.25rem;
+  font-size: 0.85rem;
   line-height: 1;
   cursor: pointer;
-  padding: 0 0.25rem;
+  padding: 0.35rem 0.45rem;
+  border-radius: var(--radius-sm, 0.25rem);
 }
-.hermes-kanban-drawer-close:hover { color: var(--color-foreground); }
+.hermes-kanban-drawer-back:hover { color: var(--color-foreground); background: color-mix(in srgb, var(--color-foreground) 6%, transparent); }
 
 /* Attachment download trigger — styled as a link, rendered as a <button>
    so the click handler can fetch with the session token (#35338). */

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -462,18 +462,40 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  padding: 0.9rem;
+  padding: 0.65rem 0.75rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.55rem;
+}
+
+.hermes-kanban-card-chrome {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 0 0 auto;
+}
+
+.hermes-kanban-card-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .hermes-kanban-drawer-title {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  min-width: 0;
   font-size: 1rem;
   font-weight: 600;
+}
+
+.hermes-kanban-card-status-actions {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  max-width: 52%;
 }
 
 .hermes-kanban-drawer-meta {
@@ -503,7 +525,39 @@
 .hermes-kanban-actions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.3rem;
+}
+
+.hermes-kanban-compact-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.hermes-kanban-compact-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  max-width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.12rem 0.45rem;
+  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.hermes-kanban-compact-chip-label {
+  color: var(--color-muted-foreground);
+}
+
+.hermes-kanban-compact-chip-value {
+  color: var(--color-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Specifier result banner — sits directly under the status action row. */
@@ -558,19 +612,22 @@
 
 .hermes-kanban-workspace-tabs {
   display: flex;
+  justify-content: flex-start;
   gap: 0.35rem;
   flex-wrap: wrap;
   border-bottom: 1px solid var(--color-border);
-  padding-bottom: 0.35rem;
+  padding-bottom: 0.2rem;
 }
 
 .hermes-kanban-workspace-tab {
   appearance: none;
-  border: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
   color: var(--color-muted-foreground);
-  border-radius: var(--radius-sm, 0.25rem) var(--radius-sm, 0.25rem) 0 0;
-  padding: 0.35rem 0.6rem;
+  border-radius: 0;
+  padding: 0.25rem 0.1rem 0.3rem;
+  margin-right: 0.55rem;
   font-size: 0.78rem;
   cursor: pointer;
 }
@@ -579,7 +636,37 @@
 .hermes-kanban-workspace-tab--active {
   color: var(--color-foreground);
   border-color: var(--color-ring);
-  background: color-mix(in srgb, var(--color-ring) 14%, transparent);
+  background: transparent;
+}
+
+.hermes-kanban-terminal-section {
+  gap: 0.4rem;
+}
+
+.hermes-kanban-terminal-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.hermes-kanban-terminal-actions-primary,
+.hermes-kanban-terminal-actions-secondary {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.hermes-kanban-terminal-context {
+  font-size: 0.78rem;
+  color: var(--color-muted-foreground);
+}
+
+.hermes-kanban-terminal-context > summary {
+  cursor: pointer;
+  width: fit-content;
 }
 
 .hermes-kanban-card-chat {

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -60,6 +60,60 @@
   color: var(--color-muted-foreground) !important;
 }
 
+
+/* ---- Simplified board / priority list -------------------------------- */
+
+.hermes-kanban-view-tabs {
+  display: flex;
+  gap: 0.35rem;
+  align-items: end;
+}
+
+.hermes-kanban-view-tab {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 0.25rem);
+  padding: 0.4rem 0.65rem;
+  font-size: 0.78rem;
+  color: var(--color-muted-foreground);
+  text-decoration: none;
+  background: color-mix(in srgb, var(--color-card) 80%, transparent);
+}
+
+.hermes-kanban-view-tab--active {
+  color: var(--color-foreground);
+  border-color: var(--color-ring);
+}
+
+.hermes-kanban-priority-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  max-width: 920px;
+}
+
+.hermes-kanban-priority-row {
+  display: grid;
+  grid-template-columns: 2.4rem minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.hermes-kanban-priority-rank {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 0.25rem);
+  color: var(--color-muted-foreground);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.hermes-kanban-priority-list .hermes-kanban-card {
+  width: 100%;
+}
+
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -325,31 +325,30 @@
 .hermes-kanban-drawer-shade {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: var(--color-background);
   z-index: 60;
   display: flex;
-  justify-content: flex-end;
+  justify-content: stretch;
 }
 
 .hermes-kanban-drawer {
-  width: min(var(--hermes-kanban-drawer-width, 640px), 92vw);
+  width: 100vw;
   height: 100vh;
-  /* Dynamic viewport unit excludes the mobile browser's collapsing chrome
-     (URL/nav bars) so the drawer's bottom row stays reachable. Falls back to
-     100vh on browsers without dvh support. */
+  /* Dynamic viewport unit excludes mobile/iPad browser chrome so the bottom
+     comment row stays reachable. Falls back to 100vh on older browsers. */
   height: 100dvh;
   max-height: 100dvh;
   background: var(--color-card);
-  border-left: 1px solid var(--color-border);
+  border-left: 0;
   display: flex;
   flex-direction: column;
-  box-shadow: -4px 0 18px rgba(0, 0, 0, 0.35);
-  animation: hermes-kanban-drawer-in 180ms ease-out;
+  box-shadow: none;
+  animation: hermes-kanban-drawer-in 140ms ease-out;
 }
 
 @keyframes hermes-kanban-drawer-in {
-  from { transform: translateX(100%); opacity: 0.3; }
-  to   { transform: translateX(0);    opacity: 1; }
+  from { transform: translateY(1rem); opacity: 0.3; }
+  to   { transform: translateY(0);    opacity: 1; }
 }
 
 .hermes-kanban-drawer-head {

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -326,18 +326,22 @@
   position: fixed;
   inset: 0;
   background: var(--color-background);
-  z-index: 60;
+  z-index: 45;
   display: flex;
   justify-content: stretch;
 }
 
+@media (min-width: 1024px) {
+  .hermes-kanban-drawer-shade {
+    left: var(--hermes-sidebar-width, 19.2rem);
+  }
+}
+
 .hermes-kanban-drawer {
-  width: 100vw;
+  width: 100%;
   height: 100vh;
-  /* Dynamic viewport unit excludes mobile/iPad browser chrome so the bottom
-     comment row stays reachable. Falls back to 100vh on older browsers. */
   height: 100dvh;
-  max-height: 100dvh;
+  min-height: 0;
   background: var(--color-card);
   border-left: 0;
   display: flex;
@@ -352,28 +356,14 @@
 }
 
 .hermes-kanban-drawer-head {
-  position: sticky;
-  top: 0;
-  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.75rem 0.9rem;
-  /* Honor the top safe-area inset (iPad/browser chrome) so the back button
-     and task id are never clipped under the dashboard/header rail. */
-  padding-top: max(0.75rem, calc(0.75rem + env(safe-area-inset-top)));
   border-bottom: 1px solid var(--color-border);
   background: var(--color-card);
   font-family: var(--font-mono, ui-monospace, monospace);
-}
-
-/* On tablet/mobile the dashboard shell can render a fixed top bar above the
-   plugin content. Keep the full-screen card header below it. */
-@media (max-width: 1366px) {
-  .hermes-kanban-drawer-head {
-    padding-top: calc(3.5rem + env(safe-area-inset-top));
-  }
 }
 
 .hermes-kanban-drawer-back {
@@ -409,13 +399,10 @@
 .hermes-kanban-attachment-link:hover { text-decoration: underline; }
 
 .hermes-kanban-drawer-body {
-  flex: 1;
-  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
   padding: 0.9rem;
-  /* When no comment row is rendered (loading / error states), the scrolling
-     body is the bottom-most element — extend its bottom padding past the
-     mobile browser chrome so the last content stays readable. */
-  padding-bottom: max(0.9rem, calc(0.9rem + env(safe-area-inset-bottom)));
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -509,6 +496,55 @@
   gap: 0.35rem;
 }
 
+.hermes-kanban-workspace-tabs {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.35rem;
+}
+
+.hermes-kanban-workspace-tab {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+  color: var(--color-muted-foreground);
+  border-radius: var(--radius-sm, 0.25rem) var(--radius-sm, 0.25rem) 0 0;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.hermes-kanban-workspace-tab:hover,
+.hermes-kanban-workspace-tab--active {
+  color: var(--color-foreground);
+  border-color: var(--color-ring);
+  background: color-mix(in srgb, var(--color-ring) 14%, transparent);
+}
+
+.hermes-kanban-card-chat {
+  min-height: min(62vh, 760px);
+  display: flex;
+  flex-direction: column;
+}
+
+.hermes-kanban-card-chat-frame {
+  width: 100%;
+  min-height: min(58vh, 720px);
+  flex: 1;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 0.25rem);
+  background: #0d2626;
+}
+
+.hermes-kanban-card-terminal-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-muted-foreground);
+  font-size: 0.8rem;
+}
+
 .hermes-kanban-section-head {
   font-size: 0.72rem;
   font-weight: 600;
@@ -574,8 +610,6 @@
   display: flex;
   gap: 0.4rem;
   padding: 0.55rem 0.75rem;
-  /* Keep the comment input clear of the mobile browser nav bar / home
-     indicator by extending the bottom padding with the safe-area inset. */
   padding-bottom: max(0.55rem, calc(0.55rem + env(safe-area-inset-bottom)));
   border-top: 1px solid var(--color-border);
   background: color-mix(in srgb, var(--color-card) 90%, transparent);

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -91,6 +91,12 @@
   max-width: 920px;
 }
 
+.hermes-kanban-priority-mode {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
 .hermes-kanban-priority-row {
   display: grid;
   grid-template-columns: 2.4rem minmax(0, 1fr);

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -40,6 +40,7 @@ import hmac
 import json
 import logging
 import os
+import shlex
 import sqlite3
 import time
 from dataclasses import asdict
@@ -52,6 +53,7 @@ from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
+from hermes_cli.kanban_card_context import CardContextError, build_claude_card_launch
 
 log = logging.getLogger(__name__)
 
@@ -562,6 +564,31 @@ def get_task(
         }
     finally:
         conn.close()
+
+
+@router.get("/tasks/{task_id}/claude-context")
+def get_task_claude_context(task_id: str, board: Optional[str] = Query(None)):
+    """Return a copy-paste Claude Code launch prompt for a card workspace.
+
+    v0 deliberately does not auto-launch Claude Code or touch tmux/user
+    sessions. The server validates the card and workdir, then returns the
+    exact prompt plus a shell hint the browser can copy.
+    """
+    board = _resolve_board(board)
+    try:
+        launch = build_claude_card_launch(task_id, board=board)
+    except CardContextError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    command = f"cd {shlex.quote(launch['workspace_path'])} && claude"
+    return {
+        "task_id": launch["task_id"],
+        "workspace_path": launch["workspace_path"],
+        "prompt": launch["prompt"],
+        "command": command,
+        "mode": "manual-copy",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -137,14 +137,9 @@ def _conn(board: Optional[str] = None):
 # Columns shown by the dashboard, in left-to-right order. "archived" is
 # available via a filter toggle rather than a visible column.
 #
-# Keep this in sync with kanban_db.VALID_STATUSES.  In particular,
-# ``scheduled`` is a first-class waiting column used for time-based follow-ups;
-# if it is omitted here, the board-level fallback below mis-buckets scheduled
-# tasks into ``todo`` and makes the dashboard look like the Scheduled column
-# disappeared.
-BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
-]
+# Rolly's dashboard card schema is deliberately simple: triage -> ready -> done.
+# Legacy/unknown statuses are shown as triage instead of preserving extra lanes.
+BOARD_COLUMNS: list[str] = ["triage", "ready", "done"]
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
@@ -470,7 +465,7 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            col = t.status if t.status in columns else "todo"
+            col = t.status if t.status in columns else "triage"
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -42,7 +42,9 @@ import logging
 import os
 import shlex
 import sqlite3
+import subprocess
 import time
+import urllib.parse
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
@@ -53,7 +55,7 @@ from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
-from hermes_cli.kanban_card_context import CardContextError, build_claude_card_launch
+from hermes_cli.kanban_card_context import CardContextError, build_card_context, build_claude_card_launch
 
 log = logging.getLogger(__name__)
 
@@ -566,28 +568,156 @@ def get_task(
         conn.close()
 
 
+def _run_tmux(args: list[str], *, timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["tmux", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _tmux_has_session(session_name: str) -> bool:
+    return _run_tmux(["has-session", "-t", session_name], timeout=5).returncode == 0
+
+
+def _tmux_has_window(target: str) -> bool:
+    return _run_tmux(["list-windows", "-t", target], timeout=5).returncode == 0
+
+
+def _tmux_target(session_name: str, window_name: str) -> str:
+    return f"{session_name}:{window_name}"
+
+
+def _build_rolly_chat_prompt(task_id: str, title: str | None) -> str:
+    title_line = f"Title: {title}" if title else "Title: (unknown)"
+    return (
+        f"You are Rolly Chat inside Kanban card {task_id}. {title_line}. "
+        "This conversation is specifically about this card. Start by briefly orienting yourself "
+        "to the card, then ask what Deniz wants to do next unless the next message already gives direction."
+    )
+
+
+def _tui_shell_command() -> str:
+    """Return a shell command that launches the production Hermes TUI."""
+    from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
+
+    argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
+    env = {
+        "NODE_ENV": "production",
+        "HERMES_TUI_INLINE": "1",
+        "HERMES_TUI_DISABLE_MOUSE": "1",
+    }
+    env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+    return f"cd {shlex.quote(str(cwd))} && {env_prefix} " + " ".join(shlex.quote(part) for part in argv)
+
+
+def _seed_tmux_window(target: str, text: str) -> None:
+    """Paste text into a tmux pane and submit it once."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as fh:
+        fh.write(text)
+        path = fh.name
+    try:
+        buffer_name = f"seed-{target.replace(':', '-')}"
+        proc = _run_tmux(["load-buffer", "-b", buffer_name, path], timeout=5)
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "tmux load-buffer failed").strip())
+        proc = _run_tmux(["paste-buffer", "-d", "-b", buffer_name, "-t", target], timeout=5)
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "tmux paste-buffer failed").strip())
+        _run_tmux(["send-keys", "-t", target, "Enter"], timeout=5)
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
 @router.get("/tasks/{task_id}/claude-context")
 def get_task_claude_context(task_id: str, board: Optional[str] = Query(None)):
-    """Return a copy-paste Claude Code launch prompt for a card workspace.
-
-    v0 deliberately does not auto-launch Claude Code or touch tmux/user
-    sessions. The server validates the card and workdir, then returns the
-    exact prompt plus a shell hint the browser can copy.
-    """
+    """Return a copy-paste Claude Code launch prompt for a card workspace."""
     board = _resolve_board(board)
     try:
+        card_context = build_card_context(task_id, board=board)
         launch = build_claude_card_launch(task_id, board=board)
     except CardContextError as exc:
         raise HTTPException(status_code=409, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    command = f"cd {shlex.quote(launch['workspace_path'])} && claude"
+    session_name = f"card-{task_id}".replace("_", "-")
+    command = f"tmux new-session -A -s {shlex.quote(session_name)} -c {shlex.quote(launch['workspace_path'])}"
     return {
         "task_id": launch["task_id"],
+        "title": (card_context.get("task") or {}).get("title"),
         "workspace_path": launch["workspace_path"],
         "prompt": launch["prompt"],
         "command": command,
-        "mode": "manual-copy",
+        "mode": "card-tmux-two-window",
+        "session_name": session_name,
+        "rolly_target": _tmux_target(session_name, "rolly-chat"),
+        "terminal_target": _tmux_target(session_name, "terminal"),
+    }
+
+
+@router.post("/tasks/{task_id}/tmux-session")
+def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
+    """Start/reuse a card-scoped tmux session with Rolly chat + terminal windows."""
+    context = get_task_claude_context(task_id, board=board)
+    session_name = str(context["session_name"])
+    workspace_path = str(context["workspace_path"])
+    rolly_target = str(context["rolly_target"])
+    terminal_target = str(context["terminal_target"])
+    prompt = str(context["prompt"])
+
+    session_exists = _tmux_has_session(session_name)
+    seeded_rolly = False
+    if not session_exists:
+        proc = _run_tmux([
+            "new-session", "-d", "-s", session_name, "-n", "rolly-chat", "-c", workspace_path,
+            _tui_shell_command(),
+        ])
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "tmux failed").strip()
+            raise HTTPException(status_code=500, detail=detail[:500])
+        proc = _run_tmux(["new-window", "-t", session_name, "-n", "terminal", "-c", workspace_path])
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "tmux new-window failed").strip()
+            raise HTTPException(status_code=500, detail=detail[:500])
+        seeded_rolly = True
+    else:
+        if not _tmux_has_window(rolly_target):
+            proc = _run_tmux(["new-window", "-t", session_name, "-n", "rolly-chat", "-c", workspace_path, _tui_shell_command()])
+            if proc.returncode != 0:
+                detail = (proc.stderr or proc.stdout or "tmux rolly-chat window failed").strip()
+                raise HTTPException(status_code=500, detail=detail[:500])
+            seeded_rolly = True
+        if not _tmux_has_window(terminal_target):
+            proc = _run_tmux(["new-window", "-t", session_name, "-n", "terminal", "-c", workspace_path])
+            if proc.returncode != 0:
+                detail = (proc.stderr or proc.stdout or "tmux terminal window failed").strip()
+                raise HTTPException(status_code=500, detail=detail[:500])
+
+    if seeded_rolly:
+        time.sleep(1.2)
+        try:
+            _seed_tmux_window(rolly_target, _build_rolly_chat_prompt(task_id, context.get("title")))
+        except Exception as exc:
+            log.warning("failed to seed Rolly card chat prompt for %s: %s", task_id, exc)
+
+    return {
+        **context,
+        "started": not session_exists,
+        "seeded_rolly": seeded_rolly,
+        "attach_command": f"tmux attach-session -t {shlex.quote(session_name)}",
+        "rolly_attach_command": f"tmux attach-session -t {shlex.quote(rolly_target)}",
+        "terminal_attach_command": f"tmux attach-session -t {shlex.quote(terminal_target)}",
+        "rolly_terminal_url": f"/api/pty?pty_mode=tmux&tmux_session={urllib.parse.quote(rolly_target)}",
+        "terminal_url": f"/api/pty?pty_mode=tmux&tmux_session={urllib.parse.quote(terminal_target)}",
+        "prompt": prompt,
     }
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -600,8 +600,8 @@ def _build_rolly_chat_prompt(task_id: str, title: str | None) -> str:
     )
 
 
-def _tui_shell_command() -> str:
-    """Return a shell command that launches the production Hermes TUI."""
+def _tui_shell_command(*, task_id: str | None = None, board: str | None = None) -> str:
+    """Return a shell command that launches a production, card-scoped Hermes TUI."""
     from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
 
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
@@ -610,6 +610,11 @@ def _tui_shell_command() -> str:
         "HERMES_TUI_INLINE": "1",
         "HERMES_TUI_DISABLE_MOUSE": "1",
     }
+    if task_id:
+        env["HERMES_SESSION_SOURCE"] = f"kanban-card:{task_id}"
+        env["HERMES_KANBAN_TASK"] = task_id
+    if board:
+        env["HERMES_KANBAN_BOARD"] = board
     env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
     return f"cd {shlex.quote(str(cwd))} && {env_prefix} " + " ".join(shlex.quote(part) for part in argv)
 
@@ -678,7 +683,7 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
     if not session_exists:
         proc = _run_tmux([
             "new-session", "-d", "-s", session_name, "-n", "rolly-chat", "-c", workspace_path,
-            _tui_shell_command(),
+            _tui_shell_command(task_id=task_id, board=board),
         ])
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "tmux failed").strip()
@@ -690,7 +695,7 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
         seeded_rolly = True
     else:
         if not _tmux_has_window(rolly_target):
-            proc = _run_tmux(["new-window", "-t", session_name, "-n", "rolly-chat", "-c", workspace_path, _tui_shell_command()])
+            proc = _run_tmux(["new-window", "-t", session_name, "-n", "rolly-chat", "-c", workspace_path, _tui_shell_command(task_id=task_id, board=board)])
             if proc.returncode != 0:
                 detail = (proc.stderr or proc.stdout or "tmux rolly-chat window failed").strip()
                 raise HTTPException(status_code=500, detail=detail[:500])

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -396,6 +396,10 @@ def get_board(
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
         )
+        if not include_archived:
+            # Completed cards leave the active board/list automatically.
+            # They are still retrievable from the completed/history view.
+            tasks = [t for t in tasks if t.status not in {"done", "archived"}]
         # Pre-fetch link counts per task (cheap: one query).
         link_counts: dict[str, dict[str, int]] = {}
         for row in conn.execute(
@@ -426,7 +430,7 @@ def get_board(
         ).fetchall():
             p = progress.setdefault(row["pid"], {"done": 0, "total": 0})
             p["total"] += 1
-            if row["cstatus"] == "done":
+            if row["cstatus"] in {"done", "archived"}:
                 p["done"] += 1
 
         # Diagnostics rollup for this board — see kanban_diagnostics.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -580,11 +580,17 @@ def _run_tmux(args: list[str], *, timeout: int = 15) -> subprocess.CompletedProc
 
 
 def _tmux_has_session(session_name: str) -> bool:
-    return _run_tmux(["has-session", "-t", session_name], timeout=5).returncode == 0
+    try:
+        return _run_tmux(["has-session", "-t", session_name], timeout=5).returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
 
 
 def _tmux_has_window(target: str) -> bool:
-    return _run_tmux(["list-windows", "-t", target], timeout=5).returncode == 0
+    try:
+        return _run_tmux(["list-windows", "-t", target], timeout=5).returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
 
 
 def _tmux_target(session_name: str, window_name: str) -> str:
@@ -655,6 +661,7 @@ def get_task_claude_context(task_id: str, board: Optional[str] = Query(None)):
         raise HTTPException(status_code=400, detail=str(exc))
     session_name = f"card-{task_id}".replace("_", "-")
     command = f"tmux new-session -A -s {shlex.quote(session_name)} -c {shlex.quote(launch['workspace_path'])}"
+    session_exists = _tmux_has_session(session_name)
     return {
         "task_id": launch["task_id"],
         "title": (card_context.get("task") or {}).get("title"),
@@ -663,8 +670,12 @@ def get_task_claude_context(task_id: str, board: Optional[str] = Query(None)):
         "command": command,
         "mode": "card-tmux-two-window",
         "session_name": session_name,
+        "session_exists": session_exists,
         "rolly_target": _tmux_target(session_name, "rolly-chat"),
-        "terminal_target": _tmux_target(session_name, "terminal"),
+        # Browser card terminal attaches to the whole session so tmux is the
+        # source of truth; users switch windows with ctrl-b n/p/etc.
+        "terminal_target": session_name,
+        "terminal_window_target": _tmux_target(session_name, "terminal"),
     }
 
 
@@ -675,7 +686,7 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
     session_name = str(context["session_name"])
     workspace_path = str(context["workspace_path"])
     rolly_target = str(context["rolly_target"])
-    terminal_target = str(context["terminal_target"])
+    terminal_target = str(context["terminal_window_target"])
     prompt = str(context["prompt"])
 
     session_exists = _tmux_has_session(session_name)
@@ -688,10 +699,11 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "tmux failed").strip()
             raise HTTPException(status_code=500, detail=detail[:500])
-        proc = _run_tmux(["new-window", "-t", session_name, "-n", "terminal", "-c", workspace_path])
+        proc = _run_tmux(["new-window", "-t", session_name, "-n", "terminal", "-c", "/Users/rolly"])
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "tmux new-window failed").strip()
             raise HTTPException(status_code=500, detail=detail[:500])
+        _run_tmux(["select-window", "-t", rolly_target], timeout=5)
         seeded_rolly = True
     else:
         if not _tmux_has_window(rolly_target):
@@ -701,7 +713,7 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
                 raise HTTPException(status_code=500, detail=detail[:500])
             seeded_rolly = True
         if not _tmux_has_window(terminal_target):
-            proc = _run_tmux(["new-window", "-t", session_name, "-n", "terminal", "-c", workspace_path])
+            proc = _run_tmux(["new-window", "-t", session_name, "-n", "terminal", "-c", "/Users/rolly"])
             if proc.returncode != 0:
                 detail = (proc.stderr or proc.stdout or "tmux terminal window failed").strip()
                 raise HTTPException(status_code=500, detail=detail[:500])
@@ -709,7 +721,7 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
     if seeded_rolly:
         time.sleep(1.2)
         try:
-            _seed_tmux_window(rolly_target, _build_rolly_chat_prompt(task_id, context.get("title")))
+            _seed_tmux_window(rolly_target, prompt)
         except Exception as exc:
             log.warning("failed to seed Rolly card chat prompt for %s: %s", task_id, exc)
 
@@ -721,7 +733,10 @@ def start_task_tmux_session(task_id: str, board: Optional[str] = Query(None)):
         "rolly_attach_command": f"tmux attach-session -t {shlex.quote(rolly_target)}",
         "terminal_attach_command": f"tmux attach-session -t {shlex.quote(terminal_target)}",
         "rolly_terminal_url": f"/api/pty?pty_mode=tmux&tmux_session={urllib.parse.quote(rolly_target)}",
-        "terminal_url": f"/api/pty?pty_mode=tmux&tmux_session={urllib.parse.quote(terminal_target)}",
+        "terminal_url": f"/api/pty?pty_mode=tmux&tmux_session={urllib.parse.quote(session_name)}",
+        "terminal_target": session_name,
+        "terminal_window_target": terminal_target,
+        "session_exists": True,
         "prompt": prompt,
     }
 

--- a/plugins/rolly-loops/dashboard/dist/index.js
+++ b/plugins/rolly-loops/dashboard/dist/index.js
@@ -1,0 +1,64 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+  const React = SDK.React;
+  const h = React.createElement;
+  const C = SDK.components;
+  const cards = [["Playbooks", "Loop playbooks live as durable Rolly brain notes until a dedicated loop runner is added."], ["Runs", "Scheduled or repeated work should use Cron or Kanban, not ad-hoc memory."], ["Retros", "Each loop should leave a short verified artifact before it is treated as complete."]];
+  const visibilityLinks = [["Kanban", "/kanban"], ["Sessions", "/sessions"], ["Logs", "/logs"], ["Cron", "/cron"], ["Chat", "/chat"]];
+
+  function navigate(path) {
+    const base = (window.__HERMES_BASE_PATH__ || "").replace(/\/+$/, "");
+    window.history.pushState(null, "", base + path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  function LinkButton(props) {
+    return h(C.Button || "button", {
+      onClick: function () { navigate(props.href); },
+      className: props.className || "",
+    }, props.children);
+  }
+
+  function SectionCard(props) {
+    return h(C.Card || "div", { className: "border border-current/15 bg-background-base/70" },
+      h(C.CardContent || "div", { className: "p-4" },
+        h("div", { className: "font-mondwest text-display text-sm uppercase tracking-[0.12em] text-midground" }, props.title),
+        h("p", { className: "mt-2 text-sm leading-6 text-text-secondary" }, props.body)
+      )
+    );
+  }
+
+  function RollyOpsPage() {
+    return h("main", { className: "mx-auto flex w-full max-w-6xl flex-col gap-5 pb-8" },
+      h("section", { className: "rounded border border-current/15 bg-background-base/70 p-5" },
+        h("div", { className: "text-xs uppercase tracking-[0.22em] text-text-tertiary" }, "Rolly ops"),
+        h("h1", { className: "mt-2 font-mondwest text-display text-3xl uppercase tracking-[0.08em] text-midground" }, "Loops"),
+        h("p", { className: "mt-3 max-w-3xl text-sm leading-6 text-text-secondary" }, "Recurring operating system for research, outreach, ingestion, and retros."),
+        h("div", { className: "mt-4 flex flex-wrap gap-2" },
+          h(LinkButton, { href: "/cron", className: "text-xs" }, "Open Cron"),
+          h(LinkButton, { href: "/kanban", className: "text-xs" }, "Open Kanban")
+        )
+      ),
+      h("section", { className: "grid gap-3 md:grid-cols-3" },
+        cards.map(function (card) { return h(SectionCard, { key: card[0], title: card[0], body: card[1] }); })
+      ),
+      h("section", { className: "grid gap-3 lg:grid-cols-2" },
+        h(SectionCard, { title: "Activity", body: "Use this tab as an operations landing page. Current activity still comes from Kanban task events, Sessions, Cron, and Logs." }),
+        h(C.Card || "div", { className: "border border-current/15 bg-background-base/70" },
+          h(C.CardContent || "div", { className: "p-4" },
+            h("div", { className: "font-mondwest text-display text-sm uppercase tracking-[0.12em] text-midground" }, "Visibility"),
+            h("div", { className: "mt-3 flex flex-wrap gap-2" },
+              visibilityLinks.map(function (link) {
+                return h(LinkButton, { key: link[0], href: link[1], className: "text-xs" }, link[0]);
+              })
+            )
+          )
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("rolly-loops", RollyOpsPage);
+})();

--- a/plugins/rolly-loops/dashboard/manifest.json
+++ b/plugins/rolly-loops/dashboard/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "rolly-loops",
+  "label": "Loops",
+  "description": "Rolly recurring operating loops \u2014 playbooks, retros, and scheduled runs",
+  "icon": "Zap",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/loops",
+    "position": "after:people"
+  },
+  "entry": "dist/index.js"
+}

--- a/plugins/rolly-people/dashboard/dist/index.js
+++ b/plugins/rolly-people/dashboard/dist/index.js
@@ -1,0 +1,64 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+  const React = SDK.React;
+  const h = React.createElement;
+  const C = SDK.components;
+  const cards = [["Follow-ups", "Use Kanban cards for person-specific next actions until the people-note backend is wired."], ["Source of truth", "Curated people context belongs in Rolly brain wiki notes; raw conversations stay in session history."], ["Human gate", "Outreach and contact changes stay human-approved by default."]];
+  const visibilityLinks = [["Kanban", "/kanban"], ["Sessions", "/sessions"], ["Logs", "/logs"], ["Cron", "/cron"], ["Chat", "/chat"]];
+
+  function navigate(path) {
+    const base = (window.__HERMES_BASE_PATH__ || "").replace(/\/+$/, "");
+    window.history.pushState(null, "", base + path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  function LinkButton(props) {
+    return h(C.Button || "button", {
+      onClick: function () { navigate(props.href); },
+      className: props.className || "",
+    }, props.children);
+  }
+
+  function SectionCard(props) {
+    return h(C.Card || "div", { className: "border border-current/15 bg-background-base/70" },
+      h(C.CardContent || "div", { className: "p-4" },
+        h("div", { className: "font-mondwest text-display text-sm uppercase tracking-[0.12em] text-midground" }, props.title),
+        h("p", { className: "mt-2 text-sm leading-6 text-text-secondary" }, props.body)
+      )
+    );
+  }
+
+  function RollyOpsPage() {
+    return h("main", { className: "mx-auto flex w-full max-w-6xl flex-col gap-5 pb-8" },
+      h("section", { className: "rounded border border-current/15 bg-background-base/70 p-5" },
+        h("div", { className: "text-xs uppercase tracking-[0.22em] text-text-tertiary" }, "Rolly ops"),
+        h("h1", { className: "mt-2 font-mondwest text-display text-3xl uppercase tracking-[0.08em] text-midground" }, "People"),
+        h("p", { className: "mt-3 max-w-3xl text-sm leading-6 text-text-secondary" }, "Relationship surface for leads, collaborators, and family onboarding."),
+        h("div", { className: "mt-4 flex flex-wrap gap-2" },
+          h(LinkButton, { href: "/kanban", className: "text-xs" }, "Open People Kanban"),
+          h(LinkButton, { href: "/kanban", className: "text-xs" }, "Open Kanban")
+        )
+      ),
+      h("section", { className: "grid gap-3 md:grid-cols-3" },
+        cards.map(function (card) { return h(SectionCard, { key: card[0], title: card[0], body: card[1] }); })
+      ),
+      h("section", { className: "grid gap-3 lg:grid-cols-2" },
+        h(SectionCard, { title: "Activity", body: "Use this tab as an operations landing page. Current activity still comes from Kanban task events, Sessions, Cron, and Logs." }),
+        h(C.Card || "div", { className: "border border-current/15 bg-background-base/70" },
+          h(C.CardContent || "div", { className: "p-4" },
+            h("div", { className: "font-mondwest text-display text-sm uppercase tracking-[0.12em] text-midground" }, "Visibility"),
+            h("div", { className: "mt-3 flex flex-wrap gap-2" },
+              visibilityLinks.map(function (link) {
+                return h(LinkButton, { key: link[0], href: link[1], className: "text-xs" }, link[0]);
+              })
+            )
+          )
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("rolly-people", RollyOpsPage);
+})();

--- a/plugins/rolly-people/dashboard/manifest.json
+++ b/plugins/rolly-people/dashboard/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "rolly-people",
+  "label": "People",
+  "description": "Rolly founder-PM people surface \u2014 contacts, follow-ups, and relationship visibility",
+  "icon": "Users",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/people",
+    "position": "after:kanban"
+  },
+  "entry": "dist/index.js"
+}

--- a/plugins/rolly-workbench/dashboard/dist/index.js
+++ b/plugins/rolly-workbench/dashboard/dist/index.js
@@ -1,0 +1,64 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+  const React = SDK.React;
+  const h = React.createElement;
+  const C = SDK.components;
+  const cards = [["Do work", "Use embedded Chat for operator-driven work and Kanban for durable delegated work."], ["Inspect", "Use Sessions, Logs, and Kanban together for activity/visibility."], ["No hidden state", "Prefer explicit cards, comments, and notes over implicit progress."]];
+  const visibilityLinks = [["Kanban", "/kanban"], ["Sessions", "/sessions"], ["Logs", "/logs"], ["Cron", "/cron"], ["Chat", "/chat"]];
+
+  function navigate(path) {
+    const base = (window.__HERMES_BASE_PATH__ || "").replace(/\/+$/, "");
+    window.history.pushState(null, "", base + path);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  function LinkButton(props) {
+    return h(C.Button || "button", {
+      onClick: function () { navigate(props.href); },
+      className: props.className || "",
+    }, props.children);
+  }
+
+  function SectionCard(props) {
+    return h(C.Card || "div", { className: "border border-current/15 bg-background-base/70" },
+      h(C.CardContent || "div", { className: "p-4" },
+        h("div", { className: "font-mondwest text-display text-sm uppercase tracking-[0.12em] text-midground" }, props.title),
+        h("p", { className: "mt-2 text-sm leading-6 text-text-secondary" }, props.body)
+      )
+    );
+  }
+
+  function RollyOpsPage() {
+    return h("main", { className: "mx-auto flex w-full max-w-6xl flex-col gap-5 pb-8" },
+      h("section", { className: "rounded border border-current/15 bg-background-base/70 p-5" },
+        h("div", { className: "text-xs uppercase tracking-[0.22em] text-text-tertiary" }, "Rolly ops"),
+        h("h1", { className: "mt-2 font-mondwest text-display text-3xl uppercase tracking-[0.08em] text-midground" }, "Workbench"),
+        h("p", { className: "mt-3 max-w-3xl text-sm leading-6 text-text-secondary" }, "Operator cockpit for doing work and seeing what Rolly is doing."),
+        h("div", { className: "mt-4 flex flex-wrap gap-2" },
+          h(LinkButton, { href: "/chat", className: "text-xs" }, "Open Chat"),
+          h(LinkButton, { href: "/kanban", className: "text-xs" }, "Open Kanban")
+        )
+      ),
+      h("section", { className: "grid gap-3 md:grid-cols-3" },
+        cards.map(function (card) { return h(SectionCard, { key: card[0], title: card[0], body: card[1] }); })
+      ),
+      h("section", { className: "grid gap-3 lg:grid-cols-2" },
+        h(SectionCard, { title: "Activity", body: "Use this tab as an operations landing page. Current activity still comes from Kanban task events, Sessions, Cron, and Logs." }),
+        h(C.Card || "div", { className: "border border-current/15 bg-background-base/70" },
+          h(C.CardContent || "div", { className: "p-4" },
+            h("div", { className: "font-mondwest text-display text-sm uppercase tracking-[0.12em] text-midground" }, "Visibility"),
+            h("div", { className: "mt-3 flex flex-wrap gap-2" },
+              visibilityLinks.map(function (link) {
+                return h(LinkButton, { key: link[0], href: link[1], className: "text-xs" }, link[0]);
+              })
+            )
+          )
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("rolly-workbench", RollyOpsPage);
+})();

--- a/plugins/rolly-workbench/dashboard/manifest.json
+++ b/plugins/rolly-workbench/dashboard/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "rolly-workbench",
+  "label": "Workbench",
+  "description": "Rolly workbench \u2014 embedded chat, active sessions, logs, and operator visibility",
+  "icon": "Wrench",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/workbench",
+    "position": "after:loops"
+  },
+  "entry": "dist/index.js"
+}

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -65,6 +65,21 @@ def test_curator_defaults(curator_env):
     assert c.get_min_idle_hours() == 2
     assert c.get_stale_after_days() == 30
     assert c.get_archive_after_days() == 90
+    assert c.get_scope() == "agent_created"
+
+
+def test_curator_scope_all_config(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "_load_config", lambda: {"scope": "all"})
+    assert c.get_scope() == "all"
+
+
+def test_curator_scope_non_manual_config(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "_load_config", lambda: {"scope": "not_made_by_me"})
+    assert c.get_scope() == "non_manual"
+    monkeypatch.setattr(c, "_load_config", lambda: {"scope": "non_manual"})
+    assert c.get_scope() == "non_manual"
 
 
 def test_curator_config_overrides(curator_env, monkeypatch):
@@ -280,9 +295,59 @@ def test_bundled_skill_not_touched_by_transitions(curator_env):
     u.save_usage(data)
 
     counts = c.apply_automatic_transitions()
-    # bundled skills are excluded from the agent-created list entirely
+    # bundled skills are excluded from the default agent-created scope entirely
     assert counts["checked"] == 0
     assert (skills_dir / "bundled").exists()  # never moved
+
+
+def test_scope_all_allows_bundled_transitions(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    monkeypatch.setattr(c, "_load_config", lambda: {"scope": "all"})
+    skills_dir = curator_env["home"] / "skills"
+    skill_dir = _write_skill(skills_dir, "bundled")
+    (skills_dir / ".bundled_manifest").write_text(
+        "bundled:abc\n", encoding="utf-8",
+    )
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=500)).isoformat()
+    data = u.load_usage()
+    data["bundled"] = u._empty_record()
+    data["bundled"]["last_used_at"] = super_old
+    data["bundled"]["created_at"] = super_old
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["checked"] == 1
+    assert counts["archived"] == 1
+    assert not skill_dir.exists()
+    assert (skills_dir / ".archive" / "bundled" / "SKILL.md").exists()
+
+
+def test_scope_non_manual_allows_bundled_but_excludes_manual(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    monkeypatch.setattr(c, "_load_config", lambda: {"scope": "non_manual"})
+    skills_dir = curator_env["home"] / "skills"
+    bundled_dir = _write_skill(skills_dir, "bundled")
+    manual_dir = _write_skill(skills_dir, "manual")
+    (skills_dir / ".bundled_manifest").write_text(
+        "bundled:abc\n", encoding="utf-8",
+    )
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=500)).isoformat()
+    data = u.load_usage()
+    for name in ("bundled", "manual"):
+        data[name] = u._empty_record()
+        data[name]["last_used_at"] = super_old
+        data[name]["created_at"] = super_old
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["checked"] == 1
+    assert counts["archived"] == 1
+    assert not bundled_dir.exists()
+    assert manual_dir.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -528,6 +528,49 @@ class TestDeliverResultWrapping:
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
 
+    def test_delivery_mirrors_response_into_gateway_session_history(self, tmp_path, monkeypatch):
+        """Cron deliveries should be visible to the next turn in that chat."""
+        from gateway.config import Platform
+
+        hermes_home = tmp_path / ".hermes"
+        sessions_dir = hermes_home / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / "sessions.json").write_text(json.dumps({
+            "agent:main:telegram:dm:123": {
+                "session_id": "session-123",
+                "updated_at": "2026-06-02T18:36:00",
+                "origin": {"platform": "telegram", "chat_id": "123", "thread_id": None},
+            }
+        }), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        db = MagicMock()
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True, "message_id": "m-1"})), \
+             patch("hermes_state.SessionDB", return_value=db):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        db.append_message.assert_called_once()
+        kwargs = db.append_message.call_args.kwargs
+        assert kwargs["session_id"] == "session-123"
+        assert kwargs["role"] == "user"
+        assert kwargs["observed"] is True
+        assert kwargs["platform_message_id"] == "m-1"
+        assert "Observed cronjob response delivered in this chat" in kwargs["content"]
+        assert "Cronjob Response: daily-report" in kwargs["content"]
+        assert "Here is today's summary." in kwargs["content"]
+
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
         from gateway.config import Platform

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -89,6 +89,7 @@ class TestSlashCommands:
             pytest.skip("Plaintext restart shortcut is intentionally DM/Telegram-focused")
 
         monkeypatch.setenv("INVOCATION_ID", "e2e-systemd")
+        monkeypatch.delenv("HERMES_GATEWAY_SERVICE_MANAGER", raising=False)
         runner.request_restart = MagicMock(return_value=True)
 
         send = await send_and_capture(adapter, "restart gateway", platform)

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -352,16 +352,17 @@ async def test_single_followup_is_stored_as_is():
     assert not adapter._active_sessions[session_key].is_set()
 
 
-def test_adapter_defaults_to_queue_mode(monkeypatch):
+def test_adapter_defaults_to_steer_mode(monkeypatch):
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
     adapter = _make_initialized_adapter()
-    assert adapter._busy_text_mode == "queue"
-    assert adapter._is_queue_text_debounce_candidate(_make_event("hello"))
+    assert adapter._busy_text_mode == "steer"
+    assert not adapter._is_queue_text_debounce_candidate(_make_event("hello"))
 
 
-def test_adapter_is_queue_text_debounce_candidate_by_default():
-    adapter = _make_adapter()
-    assert adapter._is_queue_text_debounce_candidate(_make_event("hello world"))
+def test_initialized_adapter_is_not_queue_text_debounce_candidate_by_default(monkeypatch):
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)
+    adapter = _make_initialized_adapter()
+    assert not adapter._is_queue_text_debounce_candidate(_make_event("hello world"))
 
 
 def test_command_messages_bypass_debounce_even_in_queue_mode():

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -84,10 +84,34 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under launchd, /restart exits non-zero so KeepAlive relaunches it."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SERVICE_MANAGER", "launchd")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_service_manager(tmp_path, monkeypatch):
+    """Without a service manager, /restart uses the detached subprocess approach."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SERVICE_MANAGER", raising=False)
+    monkeypatch.delenv("HERMES_SERVICE_MANAGER", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -193,6 +193,9 @@ class TestBuildSessionContextPrompt:
 
         assert "Telegram" in prompt
         assert "Home Chat" in prompt
+        assert "under 700 characters" in prompt
+        assert "one short bullet list" in prompt
+        assert "do not dump logs" in prompt
 
     def test_bluebubbles_prompt_mentions_short_conversational_i_message_format(self):
         config = GatewayConfig(

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -260,12 +260,13 @@ def test_merge_pending_message_event_promotes_document_followups_over_text():
 
 
 @pytest.mark.asyncio
-async def test_recent_telegram_text_followup_is_queued_without_interrupt():
+async def test_recent_telegram_text_followup_steers_without_interrupt_or_queue():
     runner = _make_runner()
     event = _make_event(text="follow-up")
     session_key = build_session_key(event.source)
 
     fake_agent = MagicMock()
+    fake_agent.steer.return_value = True
     fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
     runner._running_agents[session_key] = fake_agent
     import time as _time
@@ -274,19 +275,21 @@ async def test_recent_telegram_text_followup_is_queued_without_interrupt():
     result = await runner._handle_message(event)
 
     assert result is None
+    fake_agent.steer.assert_called_once_with("follow-up")
     fake_agent.interrupt.assert_not_called()
     adapter = runner.adapters[Platform.TELEGRAM]
-    assert adapter._pending_messages[session_key].text == "follow-up"
+    assert session_key not in adapter._pending_messages
 
 
 @pytest.mark.asyncio
-async def test_recent_telegram_followups_append_in_pending_queue():
+async def test_recent_telegram_followups_append_via_agent_steer():
     runner = _make_runner()
     first = _make_event(text="part one")
     second = _make_event(text="part two")
     session_key = build_session_key(first.source)
 
     fake_agent = MagicMock()
+    fake_agent.steer.return_value = True
     fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
     runner._running_agents[session_key] = fake_agent
     import time as _time
@@ -295,9 +298,10 @@ async def test_recent_telegram_followups_append_in_pending_queue():
     await runner._handle_message(first)
     await runner._handle_message(second)
 
+    assert [call.args[0] for call in fake_agent.steer.call_args_list] == ["part one", "part two"]
     fake_agent.interrupt.assert_not_called()
     adapter = runner.adapters[Platform.TELEGRAM]
-    assert adapter._pending_messages[session_key].text == "part one\npart two"
+    assert session_key not in adapter._pending_messages
 
 
 # ------------------------------------------------------------------

--- a/tests/hermes_cli/test_curator_status.py
+++ b/tests/hermes_cli/test_curator_status.py
@@ -32,7 +32,8 @@ def test_status_uses_last_activity_not_only_last_used(monkeypatch, capsys):
     monkeypatch.setattr(curator_state, "get_interval_hours", lambda: 168)
     monkeypatch.setattr(curator_state, "get_stale_after_days", lambda: 30)
     monkeypatch.setattr(curator_state, "get_archive_after_days", lambda: 90)
-    monkeypatch.setattr(skill_usage, "agent_created_report", lambda: [
+    monkeypatch.setattr(curator_state, "get_scope", lambda: "agent_created")
+    monkeypatch.setattr(skill_usage, "curator_report", lambda scope: [
         {
             "name": "recently-viewed",
             "state": "active",
@@ -194,7 +195,8 @@ def test_status_marks_missing_last_report_path(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(curator_state, "get_interval_hours", lambda: 168)
     monkeypatch.setattr(curator_state, "get_stale_after_days", lambda: 30)
     monkeypatch.setattr(curator_state, "get_archive_after_days", lambda: 90)
-    monkeypatch.setattr(skill_usage, "agent_created_report", lambda: [])
+    monkeypatch.setattr(curator_state, "get_scope", lambda: "agent_created")
+    monkeypatch.setattr(skill_usage, "curator_report", lambda scope: [])
 
     assert curator_cli._cmd_status(SimpleNamespace()) == 0
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -76,6 +76,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_start()
 
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"
@@ -106,6 +107,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_restart()
 
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"
@@ -198,6 +200,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_restart()
 
         output = capsys.readouterr().out
@@ -773,6 +776,7 @@ class TestGatewaySystemServiceRouting:
             lambda system=False, previous_pid=None: calls.append(("wait", system, previous_pid)) or True,
         )
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_restart()
 
         assert ("graceful", 654, 17.0) in calls
@@ -813,6 +817,7 @@ class TestGatewaySystemServiceRouting:
             lambda system=False, previous_pid=None: calls.append(("wait", system, previous_pid)) or True,
         )
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_restart()
 
         assert ("graceful", 777, 15.0) in calls
@@ -866,6 +871,7 @@ class TestGatewaySystemServiceRouting:
 
         monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_restart()
 
         assert ["restart", gateway_cli.get_service_name()] in calls
@@ -922,6 +928,7 @@ class TestGatewaySystemServiceRouting:
             lambda pid: {"pid": pid, "gateway_state": "running"},
         )
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         gateway_cli.systemd_restart()
 
         assert any(call[0] == "reset-failed" for call in calls)
@@ -2579,3 +2586,13 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+    def test_launchd_plist_marks_gateway_as_launchd_managed(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>HERMES_GATEWAY_SERVICE_MANAGER</key>" in plist
+        assert "<string>launchd</string>" in plist

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -478,6 +479,26 @@ class TestLaunchdServiceRecovery:
             == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
         )
 
+    def test_launchd_domain_defaults_to_user_domain_and_allows_override(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LAUNCHD_DOMAIN", raising=False)
+        assert gateway_cli._launchd_domain() == f"user/{os.getuid()}"
+
+        monkeypatch.setenv("HERMES_LAUNCHD_DOMAIN", "gui/{uid}")
+        assert gateway_cli._launchd_domain() == f"gui/{os.getuid()}"
+
+        monkeypatch.setenv("HERMES_LAUNCHD_DOMAIN", "system")
+        with pytest.raises(ValueError, match="user/ or gui/"):
+            gateway_cli._launchd_domain()
+
+    def test_generated_launchd_plist_targets_background_user_session(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LAUNCHD_DOMAIN", raising=False)
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        assert plist["LimitLoadToSessionType"] == "Background"
+
+        monkeypatch.setenv("HERMES_LAUNCHD_DOMAIN", "gui/{uid}")
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        assert plist["LimitLoadToSessionType"] == "Aqua"
+
     def test_launchd_install_repairs_outdated_plist_without_force(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
@@ -496,9 +517,14 @@ class TestLaunchdServiceRecovery:
 
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
+        bootout_targets = [
+            f"{domain}/{label}",
+            f"gui/{os.getuid()}/{label}",
+        ]
         assert "--replace" in plist_path.read_text(encoding="utf-8")
-        assert calls[:2] == [
-            ["launchctl", "bootout", f"{domain}/{label}"],
+        assert calls[:3] == [
+            ["launchctl", "bootout", bootout_targets[0]],
+            ["launchctl", "bootout", bootout_targets[1]],
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
 
@@ -523,8 +549,14 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_start()
 
+        bootout_targets = [
+            f"{domain}/{label}",
+            f"gui/{os.getuid()}/{label}",
+        ]
         assert calls == [
             ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", bootout_targets[0]],
+            ["launchctl", "bootout", bootout_targets[1]],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]
@@ -551,8 +583,14 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_start()
 
+        bootout_targets = [
+            f"{domain}/{label}",
+            f"gui/{os.getuid()}/{label}",
+        ]
         assert calls == [
             ["launchctl", "kickstart", target],
+            ["launchctl", "bootout", bootout_targets[0]],
+            ["launchctl", "bootout", bootout_targets[1]],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
         ]
@@ -681,8 +719,37 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_queries_explicit_launchd_target(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        target = gateway_cli._launchd_target()
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="service = { pid = 123 }\n", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        assert calls == [["launchctl", "print", target]]
+        assert "loaded" in capsys.readouterr().out.lower()
+
 
 class TestGatewayServiceDetection:
+    def test_macos_service_running_uses_explicit_launchd_probe(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: SimpleNamespace(exists=lambda: True))
+        monkeypatch.setattr(gateway_cli, "_probe_launchd_service_running", lambda: True)
+
+        assert gateway_cli._is_service_running() is True
+
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)

--- a/tests/hermes_cli/test_kanban_card_chat.py
+++ b/tests/hermes_cli/test_kanban_card_chat.py
@@ -1,0 +1,186 @@
+"""Tests for card-prep chat on Kanban cards."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import kanban_card_chat as card_chat
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_aux_response(content: str):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    return resp
+
+
+def _patch_aux_client(content: str):
+    client = MagicMock()
+    client.chat.completions.create = MagicMock(return_value=_fake_aux_response(content))
+    return patch(
+        "agent.auxiliary_client.get_text_auxiliary_client",
+        return_value=(client, "test-model"),
+    ), client
+
+
+def test_chat_on_card_live_edits_body_and_records_transcript(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="rough card",
+            body="need dashboard card prep",
+            tenant="mix",
+        )
+
+    body = """**Goal**
+Let users prep cards with Rolly.
+
+**Context/source**
+Source: Deniz asked for card-level conversation that live modifies card contents.
+
+**Scope**
+- Add a card prep chat control in the drawer.
+
+**Acceptance criteria**
+- Sending one message updates the visible card body without page reload.
+- The Rolly reply is stored in comments.
+- Missing readiness items are listed when acceptance or verification is incomplete.
+
+**Verification**
+Run targeted kanban card chat tests.
+
+**Handoff notes**
+Use auxiliary LLM, no fake data.
+"""
+    content = json.dumps({
+        "reply": "I tightened it; missing only explicit human approval.",
+        "title": "Add Rolly card prep chat",
+        "body": body,
+        "ready": False,
+        "missing": ["explicit human approval"],
+    })
+    p, client = _patch_aux_client(content)
+    with p:
+        outcome = card_chat.chat_on_card(
+            tid,
+            "update the card to make it ready for ai handoff",
+            author="deniz",
+        )
+
+    assert outcome.ok is True
+    assert outcome.title == "Add Rolly card prep chat"
+    assert outcome.missing == ("explicit human approval",)
+    assert client.chat.completions.create.call_count == 1
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert task.title == "Add Rolly card prep chat"
+    assert "**Acceptance criteria**" in (task.body or "")
+    assert [c.author for c in comments] == ["deniz", "rolly"]
+    assert comments[0].body == "update the card to make it ready for ai handoff"
+    assert "I tightened it" in comments[1].body
+    assert any(e.kind == "card_chat" for e in events)
+
+
+def test_chat_on_card_prompt_treats_acceptance_help_as_first_class(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough card", body="Goal: improve cards")
+
+    content = json.dumps({
+        "reply": "Good start. What would make this accepted?",
+        "title": None,
+        "body": None,
+        "ready": False,
+        "missing": ["acceptance criteria"],
+    })
+    p, client = _patch_aux_client(content)
+    with p:
+        outcome = card_chat.chat_on_card(tid, "help me write acceptance criteria", author="deniz")
+
+    assert outcome.ok is True
+    messages = client.chat.completions.create.call_args.kwargs["messages"]
+    system_prompt = messages[0]["content"]
+    assert "first-class job is helping the human create acceptance criteria" in system_prompt
+    assert "title/body must be null" in system_prompt
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+    assert task is not None
+    assert task.body == "Goal: improve cards"
+    assert [c.author for c in comments] == ["deniz", "rolly"]
+
+
+def test_chat_on_card_ignores_unsolicited_card_edits(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough card", body="original")
+
+    content = json.dumps({
+        "reply": "Here is a possible tighter shape.",
+        "title": "New title",
+        "body": "new body",
+        "ready": False,
+        "missing": ["approval"],
+    })
+    p, _client = _patch_aux_client(content)
+    with p:
+        outcome = card_chat.chat_on_card(tid, "help me think this through", author="deniz")
+
+    assert outcome.ok is True
+    assert outcome.title is None
+    assert outcome.body is None
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+    assert task is not None
+    assert task.title == "rough card"
+    assert task.body == "original"
+    assert [c.author for c in comments] == ["deniz", "rolly"]
+
+
+def test_chat_on_card_rejects_empty_message_without_llm(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough card")
+
+    p, client = _patch_aux_client("unused")
+    with p:
+        outcome = card_chat.chat_on_card(tid, "   ")
+
+    assert outcome.ok is False
+    assert "message is required" in outcome.reason
+    assert client.chat.completions.create.call_count == 0
+
+
+def test_chat_on_card_malformed_json_does_not_edit(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough card", body="original")
+
+    p, _client = _patch_aux_client("not json")
+    with p:
+        outcome = card_chat.chat_on_card(tid, "tighten it")
+
+    assert outcome.ok is False
+    assert "malformed JSON" in outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+    assert task.body == "original"
+    assert comments == []

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -496,6 +496,35 @@ def test_stranded_in_ready_skips_unassigned_tasks():
     assert [d for d in diags if d.kind == "stranded_in_ready"] == []
 
 
+def test_stranded_in_ready_skips_configured_human_assignees():
+    """Human card owners are not worker profiles; leaving a ready card
+    assigned to Deniz should not produce a worker-pool error."""
+    now = 100_000
+    task = _task(status="ready", assignee="Deniz", claim_lock=None)
+    events = [_event("created", ts=now - 6 * 3600)]
+    diags = kd.compute_task_diagnostics(
+        task,
+        events,
+        [],
+        now=now,
+        config={"human_assignees": ["deniz", "arman"]},
+    )
+    assert [d for d in diags if d.kind == "stranded_in_ready"] == []
+
+
+def test_stranded_in_ready_skips_rolly_user_registry_slugs(kanban_home):
+    """Rolly-local rolly-users.json slugs are manual owners too."""
+    (kanban_home / "rolly-users.json").write_text(
+        '{"users":[{"slug":"deniz"},{"slug":"arman"}]}',
+        encoding="utf-8",
+    )
+    now = 100_000
+    task = _task(status="ready", assignee="deniz", claim_lock=None)
+    events = [_event("created", ts=now - 6 * 3600)]
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+    assert [d for d in diags if d.kind == "stranded_in_ready"] == []
+
+
 def test_stranded_in_ready_skips_claimed_tasks():
     """A live claim_lock means a worker is on it — even an old one. Don't
     second-guess: the run-level liveness signal owns that decision."""

--- a/tests/hermes_cli/test_kanban_mix_ready_guard.py
+++ b/tests/hermes_cli/test_kanban_mix_ready_guard.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import json
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    with kb.connect() as c:
+        yield c
+
+
+COMPLETE_MIX_BODY = """
+Goal: prepare the MIX lead card.
+
+Context/provenance:
+- Source: /Users/rolly/rolly-brain/wiki/mix/leads.md
+
+Acceptance:
+- Lead row contains contact, basis, and next action.
+
+Verification:
+- Check the L2 note and kanban card source links.
+
+Human approval:
+- Approved by Deniz.
+""".strip()
+
+
+INCOMPLETE_MIX_BODY = """
+Goal: prepare the MIX lead card.
+
+Acceptance:
+- Lead row exists.
+""".strip()
+
+
+def _ready_guard_failure(err: str | None) -> str:
+    assert err is not None
+    assert "MIX ready guard" in err
+    return err
+
+
+def _status(conn, task_id: str) -> str:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task.status
+
+
+def _ready_guard_events(conn, task_id: str) -> list[dict]:
+    rows = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'ready_guard_blocked' ORDER BY id ASC",
+        (task_id,),
+    ).fetchall()
+    return [json.loads(row["payload"]) for row in rows]
+
+
+def test_promote_refuses_mix_card_missing_ready_fields(conn):
+    tid = kb.create_task(
+        conn,
+        title="MIX lead outreach",
+        body=INCOMPLETE_MIX_BODY,
+        tenant="mix",
+        triage=True,
+    )
+    assert kb.specify_triage_task(conn, tid)
+    assert _status(conn, tid) == "todo"
+
+    ok, err = kb.promote_task(conn, tid, actor="tester")
+
+    assert ok is False
+    message = _ready_guard_failure(err)
+    assert "missing verification" in message
+    assert "missing source/provenance" in message
+    assert "missing human approval" in message
+    assert _status(conn, tid) == "todo"
+
+
+def test_promote_allows_complete_human_approved_mix_card(conn):
+    tid = kb.create_task(
+        conn,
+        title="MIX lead outreach",
+        body=COMPLETE_MIX_BODY,
+        tenant="mix",
+        triage=True,
+    )
+    assert kb.specify_triage_task(conn, tid)
+    assert _status(conn, tid) == "ready"
+
+
+def test_recompute_ready_keeps_incomplete_mix_card_in_todo(conn):
+    tid = kb.create_task(
+        conn,
+        title="MIX competitive research",
+        body=INCOMPLETE_MIX_BODY,
+        tenant="mix",
+        triage=True,
+    )
+
+    assert kb.specify_triage_task(conn, tid)
+    assert _status(conn, tid) == "todo"
+    assert kb.recompute_ready(conn) == 0
+    assert _status(conn, tid) == "todo"
+
+
+def test_recompute_ready_suppresses_duplicate_unchanged_ready_guard_events(conn):
+    tid = kb.create_task(
+        conn,
+        title="MIX passive ready review",
+        body=INCOMPLETE_MIX_BODY,
+        tenant="mix",
+        triage=True,
+    )
+
+    assert kb.specify_triage_task(conn, tid)
+    assert kb.recompute_ready(conn) == 0
+    assert kb.recompute_ready(conn) == 0
+
+    events = _ready_guard_events(conn, tid)
+    assert len(events) == 1
+    assert "missing verification" in events[0]["reason"]
+
+
+def test_manual_promote_records_each_blocked_ready_guard_attempt(conn):
+    tid = kb.create_task(
+        conn,
+        title="MIX manual ready review",
+        body=INCOMPLETE_MIX_BODY,
+        tenant="mix",
+        triage=True,
+    )
+    assert kb.specify_triage_task(conn, tid)
+
+    before = len(_ready_guard_events(conn, tid))
+
+    first_ok, first_err = kb.promote_task(conn, tid, actor="tester")
+    second_ok, second_err = kb.promote_task(conn, tid, actor="tester")
+
+    assert first_ok is False
+    assert second_ok is False
+    assert "missing human approval" in _ready_guard_failure(first_err)
+    assert "missing human approval" in _ready_guard_failure(second_err)
+    assert len(_ready_guard_events(conn, tid)) == before + 2
+
+
+def test_claim_demotes_direct_sql_ready_mix_card_missing_approval(conn):
+    tid = kb.create_task(
+        conn,
+        title="MIX direct SQL bypass",
+        body=COMPLETE_MIX_BODY.replace("Approved by Deniz", "Approval pending"),
+        tenant="mix",
+        triage=True,
+    )
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+
+    claimed = kb.claim_task(conn, tid, claimer="test:1")
+
+    assert claimed is None
+    assert _status(conn, tid) == "todo"
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'claim_rejected' ORDER BY id DESC LIMIT 1",
+        (tid,),
+    ).fetchone()
+    assert event is not None
+    assert "missing human approval" in event["payload"]
+
+
+@pytest.mark.parametrize("placeholder", ["human", "reviewer"])
+def test_generic_approval_placeholders_do_not_satisfy_ready_gate(conn, placeholder):
+    tid = kb.create_task(
+        conn,
+        title="MIX generic approval placeholder",
+        body=COMPLETE_MIX_BODY.replace("Approved by Deniz", f"Approved by {placeholder}"),
+        tenant="mix",
+        triage=True,
+    )
+
+    assert kb.specify_triage_task(conn, tid)
+    assert _status(conn, tid) == "todo"
+    ok, err = kb.promote_task(conn, tid, actor="tester")
+
+    assert ok is False
+    assert "missing human approval" in _ready_guard_failure(err)
+
+
+def test_non_mix_card_ready_flow_is_unchanged(conn):
+    tid = kb.create_task(
+        conn,
+        title="Generic lead outreach",
+        body="Acceptance:\n- exists",
+        triage=True,
+    )
+
+    assert kb.specify_triage_task(conn, tid)
+    assert _status(conn, tid) == "ready"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2102,6 +2102,13 @@ class TestPtyWebSocket:
         assert env["HERMES_TUI_INLINE"] == "1"
         assert env["HERMES_TUI_DISABLE_MOUSE"] == "1"
 
+    def test_resolve_chat_argv_can_attach_tmux_session(self):
+        argv, cwd, env = self.ws_module._resolve_chat_argv(pty_mode="tmux", tmux_session="card-t-123")
+
+        assert argv == ["tmux", "attach-session", "-t", "card-t-123"]
+        assert cwd is None
+        assert isinstance(env, dict)
+
     def test_rejects_when_embedded_chat_disabled(self, monkeypatch):
         monkeypatch.setattr(self.ws_module, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", False)
         from starlette.websockets import WebSocketDisconnect

--- a/tests/hermes_cli/test_web_server_audio_upload.py
+++ b/tests/hermes_cli/test_web_server_audio_upload.py
@@ -107,3 +107,86 @@ def test_audio_analysis_speaker_name_assignment(upload_client, tmp_path):
     assert "Deniz: hello from one" in body["named_transcript"]
     assert "Arman: hello from two" in body["named_transcript"]
     assert "Deniz: hello from one" in audio_path.with_suffix(audio_path.suffix + ".transcript.txt").read_text()
+
+
+def test_audio_labelled_text_parses_openai_speaker_letters(upload_client):
+    _client, web_server = upload_client
+
+    turns = web_server._turns_from_labelled_text(
+        "Speaker A: hello there\n"
+        "continued thought\n"
+        "Speaker B: hi back\n"
+        "[SPEAKER_02] - third voice"
+    )
+
+    assert turns == [
+        {"speaker": "Speaker A", "text": "hello there continued thought"},
+        {"speaker": "Speaker B", "text": "hi back"},
+        {"speaker": "Speaker 02", "text": "third voice"},
+    ]
+
+
+def test_openai_audio_diarization_provider_path(upload_client, monkeypatch, tmp_path):
+    _client, web_server = upload_client
+    audio_path = tmp_path / "call.m4a"
+    audio_path.write_bytes(b"fake audio")
+    calls = []
+
+    monkeypatch.setattr(web_server, "_ffmpeg_audio_chunks", lambda path: [b"mp3 one", b"mp3 two"])
+
+    def fake_openai(chunk, *, chunk_index, total_chunks):
+        calls.append((chunk, chunk_index, total_chunks))
+        if chunk_index == 0:
+            return "Speaker A: hello\nSpeaker B: hey"
+        return "Speaker A: following up"
+
+    monkeypatch.setattr(web_server, "_openai_audio_chat_completion", fake_openai)
+
+    analysis = web_server._run_openai_audio_diarization(audio_path)
+
+    assert calls == [(b"mp3 one", 0, 2), (b"mp3 two", 1, 2)]
+    assert analysis["provider"] == "openai:gpt-audio-mini"
+    assert analysis["status"] == "needs_speaker_names"
+    assert analysis["chunks"] == 2
+    assert analysis["turns"] == [
+        {"speaker": "Speaker A", "text": "hello"},
+        {"speaker": "Speaker B", "text": "hey"},
+        {"speaker": "Speaker A", "text": "following up"},
+    ]
+    assert {speaker["speaker"] for speaker in analysis["speakers"]} == {"Speaker A", "Speaker B"}
+
+
+def test_run_audio_diarization_uses_openai_and_writes_transcript(upload_client, monkeypatch):
+    _client, web_server = upload_client
+    audio_path = web_server._audio_uploads_dir() / "call.m4a"
+    audio_path.write_bytes(b"audio")
+    called = []
+
+    def fake_openai(path):
+        called.append(path)
+        return {
+            "status": "needs_speaker_names",
+            "provider": "openai:gpt-audio-mini",
+            "transcript": "hello\nhey",
+            "turns": [
+                {"speaker": "Speaker A", "text": "hello"},
+                {"speaker": "Speaker B", "text": "hey"},
+            ],
+            "speakers": [
+                {"speaker": "Speaker A", "example": "hello"},
+                {"speaker": "Speaker B", "example": "hey"},
+            ],
+            "speaker_names": {},
+            "named_transcript": "Speaker A: hello\nSpeaker B: hey",
+            "updated_at": "now",
+        }
+
+    monkeypatch.setattr(web_server, "_run_openai_audio_diarization", fake_openai)
+    monkeypatch.setattr(web_server, "_run_audio_cli", lambda path: (_ for _ in ()).throw(AssertionError("xAI CLI should not run")))
+
+    web_server._run_audio_diarization(audio_path)
+
+    assert called == [audio_path]
+    analysis = web_server._read_audio_analysis(audio_path)
+    assert analysis["provider"] == "openai:gpt-audio-mini"
+    assert audio_path.with_suffix(audio_path.suffix + ".transcript.txt").read_text() == "Speaker A: hello\nSpeaker B: hey"

--- a/tests/hermes_cli/test_web_server_audio_upload.py
+++ b/tests/hermes_cli/test_web_server_audio_upload.py
@@ -1,0 +1,109 @@
+"""Tests for dashboard audio upload endpoint."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def upload_client(_isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_cli.web_server as web_server
+
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client, web_server
+
+
+def test_audio_upload_requires_dashboard_token(_isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app
+
+    client = TestClient(app)
+    resp = client.post("/api/uploads/audio?filename=meeting.m4a", content=b"audio")
+    assert resp.status_code == 401
+
+
+def test_audio_upload_saves_file_and_metadata(upload_client, monkeypatch):
+    client, web_server = upload_client
+    started = []
+    monkeypatch.setattr(web_server, "_start_audio_diarization", lambda path: started.append(path))
+
+    resp = client.post(
+        "/api/uploads/audio?filename=Team%20Meeting.m4a",
+        content=b"fake audio bytes",
+        headers={
+            "content-type": "audio/mp4",
+            "x-rolly-user": "deniz",
+            web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN,
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["original_name"] == "Team Meeting.m4a"
+    assert body["stored_name"].endswith("Team-Meeting.m4a")
+    assert body["size_bytes"] == len(b"fake audio bytes")
+    assert body["rolly_user"] in {"deniz", "unknown"}
+    assert body["prompt"].endswith(body["path"])
+    assert body["analysis_status"] == "queued"
+    assert body["analysis_url"].endswith("/analysis")
+
+    saved = Path(body["path"])
+    assert started == [saved]
+    assert saved.read_bytes() == b"fake audio bytes"
+    metadata = json.loads(saved.with_suffix(saved.suffix + ".json").read_text())
+    assert metadata["path"] == body["path"]
+    assert saved.parent == web_server.get_hermes_home() / "uploads" / "audio"
+
+
+def test_audio_upload_rejects_non_audio_extension(upload_client):
+    client, _web_server = upload_client
+
+    resp = client.post("/api/uploads/audio?filename=notes.txt", content=b"not audio")
+
+    assert resp.status_code == 400
+    assert "Unsupported audio file extension" in resp.text
+
+
+def test_audio_analysis_speaker_name_assignment(upload_client, tmp_path):
+    client, web_server = upload_client
+    audio_path = web_server._audio_uploads_dir() / "call.m4a"
+    audio_path.write_bytes(b"audio")
+    web_server._write_audio_analysis(
+        audio_path,
+        {
+            "status": "needs_speaker_names",
+            "turns": [
+                {"speaker": "SPEAKER_00", "text": "hello from one"},
+                {"speaker": "SPEAKER_01", "text": "hello from two"},
+            ],
+            "speakers": [
+                {"speaker": "SPEAKER_00", "example": "hello from one"},
+                {"speaker": "SPEAKER_01", "example": "hello from two"},
+            ],
+            "transcript": "hello from one hello from two",
+        },
+    )
+
+    resp = client.post(
+        "/api/uploads/audio/call.m4a/speakers",
+        json={"speakers": {"SPEAKER_00": "Deniz", "SPEAKER_01": "Arman"}},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "complete"
+    assert "Deniz: hello from one" in body["named_transcript"]
+    assert "Arman: hello from two" in body["named_transcript"]
+    assert "Deniz: hello from one" in audio_path.with_suffix(audio_path.suffix + ".transcript.txt").read_text()

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -83,6 +83,14 @@ class TestHostHeaderValidator:
         assert _is_accepted_host("LOCALHOST", "127.0.0.1")
         assert _is_accepted_host("LocalHost:9119", "127.0.0.1")
 
+    def test_allowed_reverse_proxy_host_env(self, monkeypatch):
+        """Trusted local reverse proxies can expose loopback dashboards under HTTPS."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_HOSTS", "dash.tailnet.ts.net")
+        assert _is_accepted_host("dash.tailnet.ts.net:9119", "127.0.0.1")
+        assert not _is_accepted_host("evil.example:9119", "127.0.0.1")
+
 
 class TestHostHeaderMiddleware:
     """End-to-end test via the FastAPI app — verify the middleware

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -320,6 +320,47 @@ def test_voice_background_tool_starts_real_task_contract(voice_client, monkeypat
     assert started[0].request == "do the thing"
 
 
+def test_voice_background_task_spawns_durable_process_and_can_be_reloaded(voice_client, monkeypatch):
+    client, web_server = voice_client
+    popen_calls = []
+
+    class FakePopen:
+        pid = 12345
+
+    def fake_popen(args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return FakePopen()
+
+    monkeypatch.setattr(web_server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        web_server._VOICE_TASK_EXECUTOR,
+        "submit",
+        lambda *_args, **_kwargs: pytest.fail("voice background tasks must not depend on the dashboard thread pool"),
+    )
+
+    resp = client.post(
+        "/api/voice/tool",
+        json={"name": "rolly_background", "call_id": "voice-durable", "arguments": {"request": "do durable work"}},
+        headers={"X-Rolly-User": "deniz"},
+    )
+
+    assert resp.status_code == 200
+    task_id = resp.json()["data"]["task_id"]
+    assert popen_calls
+    assert "hermes_cli.voice_task_runner" in popen_calls[0][0]
+    assert web_server._voice_task_state_path(task_id).exists()
+
+    with web_server._VOICE_TASKS_LOCK:
+        web_server._VOICE_TASKS.clear()
+
+    status = client.get(f"/api/voice/tasks/{task_id}")
+    assert status.status_code == 200
+    body = status.json()
+    assert body["task_id"] == task_id
+    assert body["status"] == "queued"
+    assert body["request"] == "do durable work"
+
+
 def test_voice_context_lookup_reports_live_voice_task_status(voice_client, monkeypatch):
     client, web_server = voice_client
     task = web_server.VoiceTask("vt_live", "call-live", "deniz", "do work", "voice_task_vt_live")

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -58,6 +58,8 @@ def test_voice_session_config_uses_phone_call_turn_detection(voice_client):
 
     config = web_server._voice_session_config(user="deniz")
     assert "dashboard user: deniz" in config["instructions"]
+    assert "do not address them by raw dashboard username" in config["instructions"]
+    assert "Do not give mic/headset/echo troubleshooting" in config["instructions"]
     assert config["audio"]["output"]["voice"] == "cedar"
     tool_names = [tool["name"] for tool in config["tools"]]
     assert "context_lookup" in tool_names
@@ -388,6 +390,30 @@ def test_voice_invite_returns_share_url_when_enabled(voice_client, monkeypatch):
     assert body["call_id"] == "voice-call"
     assert "mode=meet" in body["invite_url"]
     assert "call_id=voice-call" in body["invite_url"]
+
+
+def test_voice_invite_rejects_ended_call(voice_client, monkeypatch):
+    client, _web_server = voice_client
+    monkeypatch.setenv("HERMES_VOICE_MEET_INVITES", "1")
+
+    end_resp = client.post(
+        "/api/voice/transcript",
+        json={
+            "call_id": "ended-invite-call",
+            "role": "system",
+            "text": "ended",
+            "event_type": "call_end",
+            "user": "deniz",
+        },
+    )
+    assert end_resp.status_code == 200
+
+    resp = client.post(
+        "/api/voice/meet/invite",
+        json={"call_id": "ended-invite-call", "user": "deniz"},
+    )
+
+    assert resp.status_code == 409
 
 
 def test_voice_call_end_marks_task_and_sends_single_post_call_notification(voice_client, monkeypatch):

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -1,5 +1,7 @@
 """Tests for dashboard voice-call prototype endpoints."""
 
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -51,6 +53,21 @@ def test_voice_session_returns_ephemeral_session(voice_client, monkeypatch):
     assert resp.json()["model"] == "gpt-realtime"
 
 
+def test_voice_session_config_uses_phone_call_turn_detection(voice_client):
+    _client, web_server = voice_client
+
+    config = web_server._voice_session_config(user="deniz")
+    assert "dashboard user: deniz" in config["instructions"]
+    assert config["audio"]["output"]["voice"] == "cedar"
+    assert config["tools"][0]["name"] == "rolly"
+    turn_detection = config["audio"]["input"]["turn_detection"]
+    assert turn_detection == {
+        "type": "semantic_vad",
+        "create_response": True,
+        "interrupt_response": True,
+    }
+
+
 def test_voice_tool_rejects_unknown_tool(voice_client):
     client, _web_server = voice_client
 
@@ -77,3 +94,55 @@ def test_voice_tool_runs_research_bridge(voice_client, monkeypatch):
         "result": "answered: what is Rolly Voice?",
         "error": None,
     }
+
+
+def test_voice_tool_runs_rolly_bridge_with_request_arg(voice_client, monkeypatch):
+    client, web_server = voice_client
+
+    monkeypatch.setattr(
+        web_server,
+        "_run_voice_research",
+        lambda question, user: f"answered: {user}: {question}",
+    )
+
+    resp = client.post(
+        "/api/voice/tool",
+        json={"name": "rolly", "arguments": {"request": "what were we doing yesterday?"}},
+        headers={"X-Rolly-User": "deniz"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "answered: deniz: what were we doing yesterday?"
+
+
+def test_voice_transcript_persists_jsonl(voice_client):
+    client, _web_server = voice_client
+
+    resp = client.post(
+        "/api/voice/transcript",
+        json={"call_id": "call/1", "role": "user", "text": "hello", "user": "deniz"},
+    )
+
+    assert resp.status_code == 200
+    path = resp.json()["path"]
+    assert path.endswith("voice-transcripts/call_1.jsonl")
+    with open(path, encoding="utf-8") as fh:
+        body = fh.read()
+    assert '"user": "deniz"' in body
+    assert '"text": "hello"' in body
+
+
+def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):
+    _client, web_server = voice_client
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(returncode=0, stdout="session_id: abc\nspoken answer\n", stderr="")
+
+    monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+    result = web_server._run_voice_research("who am I?", user="deniz")
+
+    assert result == "spoken answer"
+    assert calls[0][0][:3] == ["hermes", "chat", "-q"]
+    assert "Dashboard voice user: deniz" in calls[0][0][3]
+    assert calls[0][0][-3:] == ["--source", "dashboard-voice", "-Q"]

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -1,0 +1,79 @@
+"""Tests for dashboard voice-call prototype endpoints."""
+
+import pytest
+
+
+@pytest.fixture()
+def voice_client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_cli.web_server as web_server
+
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client, web_server
+
+
+def test_voice_session_requires_dashboard_token(_isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app
+
+    client = TestClient(app)
+    resp = client.post("/api/voice/session", json={})
+    assert resp.status_code == 401
+
+
+def test_voice_session_returns_ephemeral_session(voice_client, monkeypatch):
+    client, web_server = voice_client
+
+    monkeypatch.setattr(
+        web_server,
+        "_create_openai_realtime_session",
+        lambda user: {
+            "client_secret": "ek_test",
+            "endpoint": "https://api.openai.com/v1/realtime",
+            "model": "gpt-realtime",
+            "voice": "alloy",
+            "expires_at": 123,
+        },
+    )
+
+    resp = client.post("/api/voice/session", json={})
+    assert resp.status_code == 200
+    assert resp.json()["client_secret"] == "ek_test"
+    assert resp.json()["model"] == "gpt-realtime"
+
+
+def test_voice_tool_rejects_unknown_tool(voice_client):
+    client, _web_server = voice_client
+
+    resp = client.post("/api/voice/tool", json={"name": "shell", "arguments": {}})
+    assert resp.status_code == 400
+
+
+def test_voice_tool_runs_research_bridge(voice_client, monkeypatch):
+    client, web_server = voice_client
+
+    monkeypatch.setattr(
+        web_server,
+        "_run_voice_research",
+        lambda question, user: f"answered: {question}",
+    )
+
+    resp = client.post(
+        "/api/voice/tool",
+        json={"name": "research", "arguments": {"question": "what is Rolly Voice?"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "ok": True,
+        "result": "answered: what is Rolly Voice?",
+        "error": None,
+    }

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -72,7 +72,7 @@ def test_voice_session_config_uses_phone_call_turn_detection(voice_client):
     assert turn_detection == {
         "type": "semantic_vad",
         "create_response": True,
-        "interrupt_response": True,
+        "interrupt_response": False,
     }
 
 

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -358,10 +358,8 @@ def test_voice_session_config_reports_speaking_rate_support(voice_client, monkey
     config = web_server._voice_session_config(user="deniz")
 
     assert "slightly faster" in config["instructions"]
-    rate = config["metadata"]["speaking_rate"]
-    assert rate["requested"] == 1.08
-    assert rate["explicit_control_supported"] is False
-    assert rate["provider"] == "openai-realtime-webrtc"
+    assert "configured rate preference 1.08x" in config["instructions"]
+    assert "metadata" not in config
 
 
 def test_voice_invite_requires_feature_flag(voice_client, monkeypatch):

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -163,6 +163,21 @@ def test_voice_tool_memory_lookup_does_not_spawn_cli(voice_client, monkeypatch):
     assert resp.json()["tool_name"] == "memory_lookup"
 
 
+def test_voice_lookup_tools_return_explicit_no_match_text(voice_client, monkeypatch):
+    client, web_server = voice_client
+
+    monkeypatch.setattr(web_server, "_voice_kanban_digest", lambda query=None: "")
+    monkeypatch.setattr(web_server, "_voice_recent_sessions", lambda query=None: "")
+
+    kanban = client.post("/api/voice/tool", json={"name": "kanban_lookup", "arguments": {"query": "blocked mix card"}})
+    sessions = client.post("/api/voice/tool", json={"name": "session_lookup", "arguments": {"query": "recent mix message"}})
+
+    assert kanban.status_code == 200
+    assert kanban.json()["result"] == "Kanban: no matching results found for query: blocked mix card."
+    assert sessions.status_code == 200
+    assert sessions.json()["result"] == "Sessions: no matching results found for query: recent mix message."
+
+
 def test_voice_tool_dedupes_same_realtime_call_id(voice_client, monkeypatch):
     client, web_server = voice_client
     calls = []
@@ -230,6 +245,23 @@ def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):
     assert calls[0][0][1:5] == ["-m", "hermes_cli.main", "chat", "-q"]
     assert "Dashboard voice user: deniz" in calls[0][0][5]
     assert calls[0][0][-3:] == ["--source", "dashboard-voice", "-Q"]
+    assert calls[0][1]["timeout"] == 90
+
+
+def test_run_voice_research_background_timeout_is_longer_and_concise(monkeypatch, voice_client):
+    _client, web_server = voice_client
+
+    def fake_run(_args, **_kwargs):
+        raise web_server.subprocess.TimeoutExpired(cmd=["python", "-m", "hermes_cli.main", "chat", "huge prompt"], timeout=600)
+
+    monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        web_server._run_voice_research("long task", user="deniz", source="dashboard-voice-background")
+
+    message = str(exc_info.value)
+    assert message == "Rolly CLI tool timed out after 600s"
+    assert "huge prompt" not in message
 
 
 def test_voice_transcript_creates_state_session(voice_client):

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -353,6 +353,20 @@ def test_voice_task_status_lookup_reports_unavailable_for_missing_id(voice_clien
     assert "vt_missing: status unavailable" in result
 
 
+def test_voice_visible_task_result_replaces_secret_only_output(voice_client):
+    _client, web_server = voice_client
+    task = web_server.VoiceTask("vt_secret", "call-secret", "deniz", "do work", "voice_task_vt_secret")
+
+    result = web_server._voice_visible_task_result(
+        "⏭ Secret entry skipped\n\n  ⏭ Secret entry skipped\n\n  ⏭ Secret entry skipped",
+        task,
+    )
+
+    assert "only visible output was redacted secret-entry placeholders" in result
+    assert "voice_task_vt_secret" in result
+    assert "⏭ Secret entry skipped" not in result
+
+
 def test_voice_session_config_reports_speaking_rate_support(voice_client, monkeypatch):
     _client, web_server = voice_client
     monkeypatch.setenv("HERMES_VOICE_SPEAKING_RATE", "1.08")
@@ -390,6 +404,8 @@ def test_voice_invite_returns_share_url_when_enabled(voice_client, monkeypatch):
     assert body["call_id"] == "voice-call"
     assert "mode=meet" in body["invite_url"]
     assert "call_id=voice-call" in body["invite_url"]
+    assert body["participant_audio_routing"] == "not_supported"
+    assert "participant-to-participant audio bridging is not implemented" in body["participant_audio_routing_detail"]
 
 
 def test_voice_invite_rejects_ended_call(voice_client, monkeypatch):

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -253,6 +253,37 @@ def test_voice_room_returns_participants_and_incremental_events(voice_client):
     assert {row["user"]: row["status"] for row in body["participants"]} == {"deniz": "live", "arman": "left"}
 
 
+def test_voice_meet_signaling_routes_to_room_participants(voice_client):
+    client, web_server = voice_client
+    with web_server._VOICE_ROOM_SIGNAL_LOCK:
+        web_server._VOICE_ROOM_SIGNALS.clear()
+
+    join = client.post(
+        "/api/voice/meet/signal",
+        json={"call_id": "signal/1", "type": "join", "user": "deniz"},
+        headers={"X-Rolly-User": "deniz"},
+    )
+    offer = client.post(
+        "/api/voice/meet/signal",
+        json={"call_id": "signal/1", "type": "offer", "to_user": "arman", "user": "deniz", "payload": {"type": "offer", "sdp": "offer-sdp"}},
+        headers={"X-Rolly-User": "deniz"},
+    )
+
+    assert join.status_code == 200
+    assert offer.status_code == 200
+    assert offer.json()["signal"]["call_id"] == "signal_1"
+
+    arman = client.get("/api/voice/meet/signals?call_id=signal/1&since=0", headers={"X-Rolly-User": "arman"})
+    buket = client.get("/api/voice/meet/signals?call_id=signal/1&since=0", headers={"X-Rolly-User": "buket"})
+
+    assert arman.status_code == 200
+    assert [(signal["type"], signal["from_user"], signal["to_user"]) for signal in arman.json()["signals"]] == [
+        ("join", "deniz", None),
+        ("offer", "deniz", "arman"),
+    ]
+    assert [(signal["type"], signal["to_user"]) for signal in buket.json()["signals"]] == [("join", None)]
+
+
 def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):
     _client, web_server = voice_client
     calls = []
@@ -466,8 +497,8 @@ def test_voice_invite_returns_share_url_when_enabled(voice_client, monkeypatch):
     assert body["call_id"] == "voice-call"
     assert "mode=meet" in body["invite_url"]
     assert "call_id=voice-call" in body["invite_url"]
-    assert body["participant_audio_routing"] == "not_supported"
-    assert "participant-to-participant audio bridging is not implemented" in body["participant_audio_routing_detail"]
+    assert body["participant_audio_routing"] == "peer_audio_signaling"
+    assert "browser peer audio" in body["participant_audio_routing_detail"]
 
 
 def test_voice_invite_rejects_ended_call(voice_client, monkeypatch):

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -38,7 +38,7 @@ def test_voice_session_returns_ephemeral_session(voice_client, monkeypatch):
     monkeypatch.setattr(
         web_server,
         "_create_openai_realtime_session",
-        lambda user: {
+        lambda user, mode="solo": {
             "client_secret": "ek_test",
             "endpoint": "https://api.openai.com/v1/realtime",
             "model": "gpt-realtime",
@@ -59,13 +59,30 @@ def test_voice_session_config_uses_phone_call_turn_detection(voice_client):
     config = web_server._voice_session_config(user="deniz")
     assert "dashboard user: deniz" in config["instructions"]
     assert config["audio"]["output"]["voice"] == "cedar"
-    assert config["tools"][0]["name"] == "rolly"
+    tool_names = [tool["name"] for tool in config["tools"]]
+    assert "context_lookup" in tool_names
+    assert "memory_lookup" in tool_names
+    assert "kanban_lookup" in tool_names
+    assert "brain_lookup" in tool_names
+    assert "session_lookup" in tool_names
+    assert "rolly_background" in tool_names
     turn_detection = config["audio"]["input"]["turn_detection"]
     assert turn_detection == {
         "type": "semantic_vad",
         "create_response": True,
         "interrupt_response": True,
     }
+
+
+def test_voice_session_config_meet_mode_waits_for_hey_rolly(voice_client):
+    _client, web_server = voice_client
+
+    config = web_server._voice_session_config(user="arman", mode="meet")
+
+    assert "MEET MODE" in config["instructions"]
+    assert "Hey Rolly" in config["instructions"]
+    assert "dashboard user: arman" in config["instructions"]
+    assert config["audio"]["input"]["turn_detection"]["create_response"] is False
 
 
 def test_voice_tool_rejects_unknown_tool(voice_client):
@@ -81,7 +98,7 @@ def test_voice_tool_runs_research_bridge(voice_client, monkeypatch):
     monkeypatch.setattr(
         web_server,
         "_run_voice_research",
-        lambda question, user: f"answered: {question}",
+        lambda question, user, **_kwargs: f"answered: {question}",
     )
 
     resp = client.post(
@@ -89,11 +106,11 @@ def test_voice_tool_runs_research_bridge(voice_client, monkeypatch):
         json={"name": "research", "arguments": {"question": "what is Rolly Voice?"}},
     )
     assert resp.status_code == 200
-    assert resp.json() == {
-        "ok": True,
-        "result": "answered: what is Rolly Voice?",
-        "error": None,
-    }
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["result"] == "answered: what is Rolly Voice?"
+    assert body["error"] is None
+    assert body["tool_name"] == "research"
 
 
 def test_voice_tool_runs_rolly_bridge_with_request_arg(voice_client, monkeypatch):
@@ -102,7 +119,7 @@ def test_voice_tool_runs_rolly_bridge_with_request_arg(voice_client, monkeypatch
     monkeypatch.setattr(
         web_server,
         "_run_voice_research",
-        lambda question, user: f"answered: {user}: {question}",
+        lambda question, user, **_kwargs: f"answered: {user}: {question}",
     )
 
     resp = client.post(
@@ -112,6 +129,62 @@ def test_voice_tool_runs_rolly_bridge_with_request_arg(voice_client, monkeypatch
     )
     assert resp.status_code == 200
     assert resp.json()["result"] == "answered: deniz: what were we doing yesterday?"
+
+
+def test_voice_context_endpoint_returns_fast_context(voice_client, monkeypatch):
+    client, web_server = voice_client
+
+    monkeypatch.setattr(web_server, "_voice_memory_snapshot", lambda: "memory facts")
+    monkeypatch.setattr(web_server, "_voice_kanban_digest", lambda query=None: "kanban facts")
+    monkeypatch.setattr(web_server, "_voice_brain_lookup_text", lambda query=None, limit=1800: "brain facts")
+    monkeypatch.setattr(web_server, "_voice_recent_sessions", lambda query=None, limit=1600: "session facts")
+
+    resp = client.get("/api/voice/context?debug=true", headers={"X-Rolly-User": "deniz"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["user"] == "deniz"
+    assert "memory facts" in body["context"]
+    assert "kanban facts" in body["context"]
+    assert body["chars"] == len(body["context"])
+
+
+def test_voice_tool_memory_lookup_does_not_spawn_cli(voice_client, monkeypatch):
+    client, web_server = voice_client
+
+    monkeypatch.setattr(web_server, "_voice_memory_snapshot", lambda: "remembered preference")
+    monkeypatch.setattr(web_server.subprocess, "run", lambda *args, **kwargs: pytest.fail("slow CLI should not run"))
+
+    resp = client.post("/api/voice/tool", json={"name": "memory_lookup", "arguments": {"query": "preference"}})
+
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "remembered preference"
+    assert resp.json()["tool_name"] == "memory_lookup"
+
+
+def test_voice_tool_dedupes_same_realtime_call_id(voice_client, monkeypatch):
+    client, web_server = voice_client
+    calls = []
+
+    def fake_run(question, user=None, **_kwargs):
+        calls.append((question, user))
+        return "answer once"
+
+    monkeypatch.setattr(web_server, "_run_voice_research", fake_run)
+    payload = {
+        "name": "rolly",
+        "arguments": {"request": "status"},
+        "realtime_call_id": "call_same",
+    }
+
+    first = client.post("/api/voice/tool", json=payload, headers={"X-Rolly-User": "deniz"})
+    second = client.post("/api/voice/tool", json=payload, headers={"X-Rolly-User": "deniz"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(calls) == 1
+    assert second.json()["cached"] is True
 
 
 def test_voice_transcript_persists_jsonl(voice_client):
@@ -157,3 +230,154 @@ def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):
     assert calls[0][0][1:5] == ["-m", "hermes_cli.main", "chat", "-q"]
     assert "Dashboard voice user: deniz" in calls[0][0][5]
     assert calls[0][0][-3:] == ["--source", "dashboard-voice", "-Q"]
+
+
+def test_voice_transcript_creates_state_session(voice_client):
+    client, _web_server = voice_client
+
+    resp = client.post(
+        "/api/voice/transcript",
+        json={
+            "call_id": "state-call",
+            "role": "user",
+            "text": "remember this voice line",
+            "user": "deniz",
+            "event_type": "transcript",
+            "sequence": 1,
+            "metadata": {"mode": "solo"},
+        },
+    )
+
+    assert resp.status_code == 200
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    session = db.get_session("dashboard_voice_state-call")
+    assert session is not None
+    assert session["source"] == "dashboard-voice"
+    assert session["user_id"] == "deniz"
+    messages = db.get_messages("dashboard_voice_state-call")
+    assert messages[-1]["role"] == "user"
+    assert messages[-1]["content"] == "remember this voice line"
+
+
+def test_voice_background_tool_starts_real_task_contract(voice_client, monkeypatch):
+    client, web_server = voice_client
+    started = []
+
+    def fake_start(call_id, request_text, user):
+        task = web_server.VoiceTask("vt_test", call_id, user, request_text, "voice_task_vt_test")
+        started.append(task)
+        return task
+
+    monkeypatch.setattr(web_server, "_voice_start_background_task", fake_start)
+    resp = client.post(
+        "/api/voice/tool",
+        json={"name": "rolly_background", "call_id": "voice-call", "arguments": {"request": "do the thing"}},
+        headers={"X-Rolly-User": "deniz"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tool_name"] == "rolly_background"
+    assert body["data"]["task_id"] == "vt_test"
+    assert body["data"]["status"] == "queued"
+    assert started[0].call_id == "voice-call"
+    assert started[0].request == "do the thing"
+
+
+def test_voice_context_lookup_reports_live_voice_task_status(voice_client, monkeypatch):
+    client, web_server = voice_client
+    task = web_server.VoiceTask("vt_live", "call-live", "deniz", "do work", "voice_task_vt_live")
+    task.mark("failed", "Rolly background task failed: timeout", error="timeout")
+    with web_server._VOICE_TASKS_LOCK:
+        web_server._VOICE_TASKS["vt_live"] = task
+
+    monkeypatch.setattr(web_server, "_voice_memory_snapshot", lambda: "")
+    monkeypatch.setattr(web_server, "_voice_kanban_digest", lambda query=None: "")
+    monkeypatch.setattr(web_server, "_voice_brain_lookup_text", lambda query=None, limit=1800: "")
+    monkeypatch.setattr(web_server, "_voice_recent_sessions", lambda query=None, limit=1600: "")
+
+    resp = client.post(
+        "/api/voice/tool",
+        json={"name": "context_lookup", "arguments": {"query": "status for vt_live", "sources": ["sessions"]}},
+        headers={"X-Rolly-User": "deniz"},
+    )
+
+    assert resp.status_code == 200
+    result = resp.json()["result"]
+    assert "Voice tasks:" in result
+    assert "vt_live: failed" in result
+    assert "timeout" in result
+
+
+def test_voice_task_status_lookup_reports_unavailable_for_missing_id(voice_client):
+    _client, web_server = voice_client
+
+    result = web_server._voice_task_status_lookup("check vt_missing")
+
+    assert "vt_missing: status unavailable" in result
+
+
+def test_voice_session_config_reports_speaking_rate_support(voice_client, monkeypatch):
+    _client, web_server = voice_client
+    monkeypatch.setenv("HERMES_VOICE_SPEAKING_RATE", "1.08")
+
+    config = web_server._voice_session_config(user="deniz")
+
+    assert "slightly faster" in config["instructions"]
+    rate = config["metadata"]["speaking_rate"]
+    assert rate["requested"] == 1.08
+    assert rate["explicit_control_supported"] is False
+    assert rate["provider"] == "openai-realtime-webrtc"
+
+
+def test_voice_invite_requires_feature_flag(voice_client, monkeypatch):
+    client, _web_server = voice_client
+    monkeypatch.delenv("HERMES_VOICE_MEET_INVITES", raising=False)
+
+    resp = client.post("/api/voice/meet/invite", json={"call_id": "voice-call", "user": "deniz"})
+
+    assert resp.status_code == 404
+
+
+def test_voice_invite_returns_share_url_when_enabled(voice_client, monkeypatch):
+    client, _web_server = voice_client
+    monkeypatch.setenv("HERMES_VOICE_MEET_INVITES", "1")
+
+    resp = client.post(
+        "/api/voice/meet/invite",
+        json={"call_id": "voice-call", "user": "deniz"},
+        headers={"host": "dashboard.local:9119"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["mode"] == "meet"
+    assert body["call_id"] == "voice-call"
+    assert "mode=meet" in body["invite_url"]
+    assert "call_id=voice-call" in body["invite_url"]
+
+
+def test_voice_call_end_marks_task_and_sends_single_post_call_notification(voice_client, monkeypatch):
+    client, web_server = voice_client
+    sent = []
+    task = web_server.VoiceTask("vt_done", "call-ended", "deniz", "do work", "voice_task_vt_done")
+    with web_server._VOICE_TASKS_LOCK:
+        web_server._VOICE_TASKS[task.task_id] = task
+
+    monkeypatch.setattr(web_server, "_voice_send_post_call_notification", lambda task: sent.append(task.task_id) or True)
+
+    end_resp = client.post(
+        "/api/voice/transcript",
+        json={"call_id": "call-ended", "role": "system", "text": "ended", "event_type": "call_end", "user": "deniz"},
+    )
+    assert end_resp.status_code == 200
+
+    web_server._voice_maybe_notify_post_call(task, "complete")
+    web_server._voice_maybe_notify_post_call(task, "complete")
+
+    assert sent == ["vt_done"]
+    assert task.to_dict()["call_ended"] is True
+    assert task.to_dict()["post_call_notification"]["status"] == "sent"

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -232,6 +232,27 @@ def test_voice_transcript_persists_jsonl(voice_client):
     assert '"source": "test"' in body
 
 
+def test_voice_room_returns_participants_and_incremental_events(voice_client):
+    client, _web_server = voice_client
+    for event in [
+        {"call_id": "room/1", "role": "system", "text": "Call started.", "event_type": "call_start", "user": "deniz", "timestamp": "2026-06-02T00:00:01Z", "sequence": 1},
+        {"call_id": "room/1", "role": "system", "text": "Call started.", "event_type": "call_start", "user": "arman", "timestamp": "2026-06-02T00:00:02Z", "sequence": 1},
+        {"call_id": "room/1", "role": "system", "text": "Call ended.", "event_type": "call_end", "user": "arman", "timestamp": "2026-06-02T00:00:03Z", "sequence": 2},
+    ]:
+        assert client.post("/api/voice/transcript", json=event).status_code == 200
+
+    resp = client.get("/api/voice/room?call_id=room/1&since=1&limit=1")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["call_id"] == "room_1"
+    assert body["cursor"] == 3
+    assert [(event["index"], event["user"], event["event_type"]) for event in body["events"]] == [
+        (2, "arman", "call_start")
+    ]
+    assert {row["user"]: row["status"] for row in body["participants"]} == {"deniz": "live", "arman": "left"}
+
+
 def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):
     _client, web_server = voice_client
     calls = []

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -143,6 +143,6 @@ def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):
     result = web_server._run_voice_research("who am I?", user="deniz")
 
     assert result == "spoken answer"
-    assert calls[0][0][:3] == ["hermes", "chat", "-q"]
-    assert "Dashboard voice user: deniz" in calls[0][0][3]
+    assert calls[0][0][1:5] == ["-m", "hermes_cli.main", "chat", "-q"]
+    assert "Dashboard voice user: deniz" in calls[0][0][5]
     assert calls[0][0][-3:] == ["--source", "dashboard-voice", "-Q"]

--- a/tests/hermes_cli/test_web_server_voice.py
+++ b/tests/hermes_cli/test_web_server_voice.py
@@ -119,7 +119,15 @@ def test_voice_transcript_persists_jsonl(voice_client):
 
     resp = client.post(
         "/api/voice/transcript",
-        json={"call_id": "call/1", "role": "user", "text": "hello", "user": "deniz"},
+        json={
+            "call_id": "call/1",
+            "role": "user",
+            "text": "hello",
+            "user": "deniz",
+            "sequence": 3,
+            "elapsed_ms": 1200,
+            "metadata": {"source": "test"},
+        },
     )
 
     assert resp.status_code == 200
@@ -129,6 +137,9 @@ def test_voice_transcript_persists_jsonl(voice_client):
         body = fh.read()
     assert '"user": "deniz"' in body
     assert '"text": "hello"' in body
+    assert '"sequence": 3' in body
+    assert '"elapsed_ms": 1200' in body
+    assert '"source": "test"' in body
 
 
 def test_run_voice_research_uses_cli_bridge(monkeypatch, voice_client):

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -57,6 +57,16 @@ def test_start_meeting_invite_starts_meet_call_path():
     assert "onClick={() => void startCall()}" in source
 
 
+def test_meet_transcripts_use_active_call_mode_not_stale_react_state():
+    source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
+
+    assert "const activeCallModeRef = useRef<\"solo\" | \"meet\">(\"solo\")" in source
+    assert "activeCallModeRef.current = callMode" in source
+    assert "const currentMode = activeCallModeRef.current" in source
+    assert "currentMode === \"meet\"" in source
+    assert "mode === \"meet\"\n              ? { mode" not in source
+
+
 @pytest.fixture()
 def voice_client(monkeypatch, _isolate_hermes_home):
     try:

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -57,6 +57,20 @@ def test_start_meeting_invite_starts_meet_call_path():
     assert "onClick={() => void startCall()}" in source
 
 
+def test_start_meeting_invite_mints_fresh_call_id_before_invite_and_blocks_double_tap():
+    source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
+    start = source.index("const startMeetingInvite = useCallback")
+    end = source.index("const toggleMute", start)
+    body = source[start:end]
+
+    assert "const [invitePending, setInvitePending] = useState(false)" in source
+    assert "const busy = invitePending ||" in source
+    assert body.index("setInvitePending(true)") < body.index("api.createVoiceMeetInvite")
+    assert body.index("callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`") < body.index("api.createVoiceMeetInvite")
+    assert "setCallIdDisplay(callIdRef.current)" in body
+    assert "setInvitePending(false)" in body
+
+
 def test_meet_transcripts_use_active_call_mode_not_stale_react_state():
     source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
 

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -1,0 +1,85 @@
+"""Regression tests for dashboard Meet-mode voice behavior."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEB_DIR = REPO_ROOT / "web"
+
+
+def test_meet_wake_detection_accepts_direct_rolly_address():
+    if not shutil.which("node"):
+        pytest.skip("node is not installed")
+    if not (WEB_DIR / "node_modules" / "typescript").exists():
+        pytest.skip("web TypeScript dependency is not installed")
+
+    script = r"""
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const webDir = process.argv[1];
+const ts = require(path.join(webDir, 'node_modules', 'typescript'));
+const source = fs.readFileSync(path.join(webDir, 'src/lib/voiceMeet.ts'), 'utf8');
+const compiled = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 } }).outputText;
+const module = { exports: {} };
+vm.runInNewContext(compiled, { module, exports: module.exports, RegExp, String });
+const { isRollyWakePhrase } = module.exports;
+const cases = [
+  ['Hey Rolly, summarize this', true],
+  ['hey rowley can you hear me', true],
+  ['Rolly, can you hear me?', true],
+  ['Rollie should we ship?', true],
+  ['Hey, can you hear me?', false],
+  ['we should ask rolly later', false]
+];
+const failures = cases.filter(([text, expected]) => isRollyWakePhrase(text) !== expected);
+if (failures.length) {
+  console.error(JSON.stringify(failures));
+  process.exit(1);
+}
+"""
+    result = subprocess.run(["node", "-e", script, str(WEB_DIR)], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.fixture()
+def voice_client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_cli.web_server as web_server
+
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client, web_server
+
+
+def test_voice_call_endpoint_passes_meet_mode(voice_client, monkeypatch):
+    client, web_server = voice_client
+    seen = {}
+
+    def fake_create_call(sdp, user=None, mode="solo"):
+        seen.update({"sdp": sdp, "user": user, "mode": mode})
+        return "answer-sdp"
+
+    monkeypatch.setattr(web_server, "_create_openai_realtime_call", fake_create_call)
+
+    resp = client.post(
+        "/api/voice/call?mode=meet",
+        data="offer-sdp",
+        headers={"Content-Type": "application/sdp", "X-Rolly-User": "deniz"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.text == "answer-sdp"
+    assert seen == {"sdp": "offer-sdp", "user": "deniz", "mode": "meet"}
+    assert resp.headers["content-type"].startswith("application/sdp")

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -110,6 +110,25 @@ def test_voice_page_filters_realtime_noise_until_verbose_and_uses_compact_rows()
     assert "bg-background-base/50 p-3" not in source
 
 
+def test_voice_page_transcript_and_events_stick_to_latest_without_forcing_manual_scroll():
+    source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
+
+    assert "const AUTO_SCROLL_NEAR_BOTTOM_PX = 64" in source
+    assert "function isNearScrollBottom(element: HTMLElement): boolean" in source
+    assert "element.scrollHeight - element.scrollTop - element.clientHeight <= AUTO_SCROLL_NEAR_BOTTOM_PX" in source
+    assert "const transcriptScrollRef = useRef<HTMLDivElement | null>(null)" in source
+    assert "const eventsScrollRef = useRef<HTMLDivElement | null>(null)" in source
+    assert "const [transcriptAtLatest, setTranscriptAtLatest] = useState(true)" in source
+    assert "const [eventsAtLatest, setEventsAtLatest] = useState(true)" in source
+    assert "if (transcriptAtLatest) scrollColumnToBottom(transcriptScrollRef.current)" in source
+    assert "if (eventsAtLatest) scrollColumnToBottom(eventsScrollRef.current)" in source
+    assert "onScroll={(event) => updateScrollLock(\"transcript\", event.currentTarget)}" in source
+    assert "onScroll={(event) => updateScrollLock(\"events\", event.currentTarget)}" in source
+    assert "!transcriptAtLatest" in source
+    assert "!eventsAtLatest" in source
+    assert source.count("Jump to latest") == 2
+
+
 @pytest.fixture()
 def voice_client(monkeypatch, _isolate_hermes_home):
     try:

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -55,7 +55,8 @@ def test_start_meeting_invite_starts_meet_call_path():
     assert "await startCall(\"meet\", true)" in source
     assert "preserveCallId = false" in source
     assert "if (!preserveCallId && !new URLSearchParams(window.location.search).get(\"call_id\"))" in source
-    assert "onClick={startMeetingInvite}" in source
+    assert "hasMeetInvite ? () => void startCall(\"meet\", true) : startMeetingInvite" in source
+    assert "Join meeting" in source
     assert "onClick={() => void startCall()}" in source
 
 

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -78,6 +78,17 @@ def test_start_call_owns_mic_permission_and_live_mic_switching():
     assert "replaceTrack(nextTrack)" in source
 
 
+def test_voice_page_filters_realtime_noise_until_verbose_and_uses_compact_rows():
+    source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
+
+    assert "const [verboseEvents, setVerboseEvents] = useState(false)" in source
+    assert "isRealtimeSpeechEvent" in source
+    assert "verboseEvents || !isRealtimeSpeechEvent(entry)" in source
+    assert "Verbose: {verboseEvents ? \"on\" : \"off\"}" in source
+    assert "bg-background-base/50 px-2 py-1" in source
+    assert "bg-background-base/50 p-3" not in source
+
+
 @pytest.fixture()
 def voice_client(monkeypatch, _isolate_hermes_home):
     try:

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -57,6 +57,10 @@ def test_start_meeting_invite_starts_meet_call_path():
     assert "if (!preserveCallId && !new URLSearchParams(window.location.search).get(\"call_id\"))" in source
     assert "hasMeetInvite ? () => void startCall(\"meet\", true) : startMeetingInvite" in source
     assert "Join meeting" in source
+    assert "startMeetPeerAudio(callIdRef.current, stream)" in source
+    assert "api.postVoiceMeetSignal({ call_id: roomCallId, type: \"join\", user: speaker }" in source
+    assert "api.getVoiceMeetSignals(roomCallId, voiceSignalCursorRef.current, 200, speaker, 10000)" in source
+    assert "new RTCPeerConnection({ iceServers: [{ urls: \"stun:stun.l.google.com:19302\" }] })" in source
     assert "onClick={() => void startCall()}" in source
 
 

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -67,6 +67,17 @@ def test_meet_transcripts_use_active_call_mode_not_stale_react_state():
     assert "mode === \"meet\"\n              ? { mode" not in source
 
 
+def test_start_call_owns_mic_permission_and_live_mic_switching():
+    source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
+
+    assert "Enable mic list" not in source
+    assert "onClick={enableMicList}" not in source
+    assert "navigator.mediaDevices.getUserMedia({ audio })" in source
+    assert "if (live) void switchMicrophone(next)" in source
+    assert "disabled={busy}" in source
+    assert "replaceTrack(nextTrack)" in source
+
+
 @pytest.fixture()
 def voice_client(monkeypatch, _isolate_hermes_home):
     try:

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -14,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WEB_DIR = REPO_ROOT / "web"
 
 
-def test_meet_wake_detection_accepts_direct_rolly_address():
+def test_meet_wake_detection_requires_hey_rolly():
     if not shutil.which("node"):
         pytest.skip("node is not installed")
     if not (WEB_DIR / "node_modules" / "typescript").exists():
@@ -34,8 +33,8 @@ const { isRollyWakePhrase } = module.exports;
 const cases = [
   ['Hey Rolly, summarize this', true],
   ['hey rowley can you hear me', true],
-  ['Rolly, can you hear me?', true],
-  ['Rollie should we ship?', true],
+  ['Rolly, can you hear me?', false],
+  ['Rollie should we ship?', false],
   ['Hey, can you hear me?', false],
   ['we should ask rolly later', false]
 ];
@@ -47,6 +46,15 @@ if (failures.length) {
 """
     result = subprocess.run(["node", "-e", script, str(WEB_DIR)], text=True, capture_output=True, check=False)
     assert result.returncode == 0, result.stderr
+
+
+def test_start_meeting_invite_starts_meet_call_path():
+    source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
+
+    assert "const startMeetingInvite = useCallback" in source
+    assert "await startCall(\"meet\")" in source
+    assert "onClick={startMeetingInvite}" in source
+    assert "onClick={() => void startCall()}" in source
 
 
 @pytest.fixture()

--- a/tests/hermes_cli/test_web_voice_meet.py
+++ b/tests/hermes_cli/test_web_voice_meet.py
@@ -52,7 +52,9 @@ def test_start_meeting_invite_starts_meet_call_path():
     source = (WEB_DIR / "src/pages/VoiceCallPage.tsx").read_text(encoding="utf-8")
 
     assert "const startMeetingInvite = useCallback" in source
-    assert "await startCall(\"meet\")" in source
+    assert "await startCall(\"meet\", true)" in source
+    assert "preserveCallId = false" in source
+    assert "if (!preserveCallId && !new URLSearchParams(window.location.search).get(\"call_id\"))" in source
     assert "onClick={startMeetingInvite}" in source
     assert "onClick={() => void startCall()}" in source
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -250,6 +250,22 @@ def test_dashboard_select_filters_use_sdk_value_change_handler():
     assert "selectChangeHandler(props.setAssigneeFilter)" in js
 
 
+def test_dashboard_card_detail_is_fullscreen_not_sidebar():
+    """Card clicks should open a full-screen detail view, not a narrow side drawer."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    style = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css"
+    css = style.read_text()
+
+    drawer_block = css.split(".hermes-kanban-drawer {")[1].split("}", 1)[0]
+    shade_block = css.split(".hermes-kanban-drawer-shade {")[1].split("}", 1)[0]
+
+    assert "width: 100vw;" in drawer_block
+    assert "max-height: 100dvh;" in drawer_block
+    assert "justify-content: stretch;" in shade_block
+    assert "--hermes-kanban-drawer-width" not in drawer_block
+
+
 def test_dashboard_client_side_filtering_includes_tenant_filter():
     """The rendered board must also filter by tenant.
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -264,6 +264,8 @@ def test_dashboard_card_detail_is_fullscreen_not_sidebar():
     assert "max-height: 100dvh;" in drawer_block
     assert "justify-content: stretch;" in shade_block
     assert "--hermes-kanban-drawer-width" not in drawer_block
+    assert "hermes-kanban-drawer-back" in css
+    assert "max-width: 1366px" in css
 
 
 def test_dashboard_client_side_filtering_includes_tenant_filter():

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -268,10 +268,13 @@ def test_dashboard_rolly_chat_passes_board_slug_to_tmux_session():
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
     js = bundle.read_text()
 
-    assert "h(CardPromptActions, { task: t, boardSlug: props.boardSlug })" in js
+    assert "h(CardPromptActions, { task: t, boardSlug: props.boardSlug })" not in js
     assert "withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/tmux-session`, props.boardSlug)" in js
     assert "setTerminalReady(!!(d && d.session_exists))" in js
     assert "copyCardPrompt" in js
+    assert "hermes-kanban-card-status-actions" in js
+    assert "hermes-kanban-compact-meta" in js
+    assert "terminalCc" in js and "Details" in js
     assert "h(RollyChatSection, { task: t, boardSlug: props.boardSlug })" not in js
     assert "readPathTaskId() || readUrlParam(\"task\")" in js
     assert "function readReturnToBoardPath()" in js

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -114,6 +114,45 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_claude_context_endpoint_returns_manual_copy_launch(client, tmp_path):
+    workspace = tmp_path / "work dir"
+    workspace.mkdir()
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "Implement card workspace",
+            "body": "Keep launch manual.",
+            "workspace_kind": "dir",
+            "workspace_path": str(workspace),
+        },
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+
+    r = client.get(f"/api/plugins/kanban/tasks/{task_id}/claude-context")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["mode"] == "manual-copy"
+    assert data["task_id"] == task_id
+    assert data["workspace_path"] == str(workspace.resolve())
+    assert data["command"] == f"cd '{workspace.resolve()}' && claude"
+    assert "Implement card workspace" in data["prompt"]
+    assert "manual Claude Code" in data["prompt"]
+
+
+def test_claude_context_endpoint_rejects_missing_workspace(client):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "No workspace yet"},
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+
+    r = client.get(f"/api/plugins/kanban/tasks/{task_id}/claude-context")
+    assert r.status_code == 409
+    assert "workspace_path" in r.json()["detail"]
+
+
 def test_scheduled_tasks_have_their_own_column_not_todo(client):
     """Scheduled/time-delay tasks must not be silently bucketed into todo."""
 
@@ -240,7 +279,7 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
     js = bundle.read_text()
 
-    assert 'useState(() => readSelectedBoard() || null)' in js
+    assert 'useState(() => readUrlParam("board") || readSelectedBoard() || null)' in js
     assert "const storedBoard = readSelectedBoard();" in js
     assert "if (!storedBoard && !board && data && data.current)" in js
     assert "setBoard(data.current);" in js

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -68,11 +68,9 @@ def test_board_empty(client):
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
     data = r.json()
-    # All canonical columns present (triage + the rest), each empty.
+    # Rolly's dashboard schema is intentionally simple.
     names = [c["name"] for c in data["columns"]]
-    assert set(names) == kb.VALID_STATUSES - {"archived"}
-    for expected in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
-        assert expected in names, f"missing column {expected}: {names}"
+    assert names == ["triage", "ready", "done"]
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
     assert data["assignees"] == []
@@ -230,8 +228,22 @@ def test_dashboard_rolly_chat_passes_board_slug_to_tmux_session():
     assert "url.pathname = taskId ? `/kanban/cards/${encodeURIComponent(taskId)}` : \"/kanban\"" in js
 
 
-def test_scheduled_tasks_have_their_own_column_not_todo(client):
-    """Scheduled/time-delay tasks must not be silently bucketed into todo."""
+def test_dashboard_has_simple_columns_and_priority_list_route():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    style = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css"
+    js = bundle.read_text()
+    css = style.read_text()
+
+    assert 'const COLUMN_ORDER = ["triage", "ready", "done"]' in js
+    assert "function PriorityList" in js
+    assert 'path === "/kanban/list" || path === "/kanban/priority"' in js
+    assert 'className: "hermes-kanban-priority-list"' in js
+    assert ".hermes-kanban-priority-list" in css
+
+
+def test_legacy_statuses_bucket_into_triage(client):
+    """The dashboard hard-cuts old workflow states into the simple card schema."""
 
     task = client.post(
         "/api/plugins/kanban/tasks",
@@ -251,8 +263,8 @@ def test_scheduled_tasks_have_their_own_column_not_todo(client):
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
     columns = {c["name"]: c["tasks"] for c in r.json()["columns"]}
-    assert any(t["id"] == task["id"] for t in columns["scheduled"])
-    assert not any(t["id"] == task["id"] for t in columns["todo"])
+    assert list(columns) == ["triage", "ready", "done"]
+    assert any(t["id"] == task["id"] for t in columns["triage"])
 
 
 def test_tenant_filter(client):
@@ -467,9 +479,9 @@ def test_patch_schedule_then_unblock(client):
     assert r.json()["task"]["status"] == "scheduled"
 
     columns = client.get("/api/plugins/kanban/board").json()["columns"]
-    assert "scheduled" in [c["name"] for c in columns]
-    scheduled = next(c for c in columns if c["name"] == "scheduled")
-    assert any(x["id"] == t["id"] for x in scheduled["tasks"])
+    assert [c["name"] for c in columns] == ["triage", "ready", "done"]
+    triage = next(c for c in columns if c["name"] == "triage")
+    assert any(x["id"] == t["id"] for x in triage["tasks"])
 
     r = client.patch(
         f"/api/plugins/kanban/tasks/{t['id']}",
@@ -2289,15 +2301,16 @@ def test_dashboard_search_includes_body_and_result():
 
 
 def test_dashboard_bulk_actions_include_reclaim_first():
-    """Bulk action bar must expose reclaim_first checkbox and expanded status buttons."""
+    """Bulk action bar must expose reclaim_first and the simplified status buttons."""
     repo_root = Path(__file__).resolve().parents[2]
     dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
 
     assert "reclaim_first: reclaimFirst" in dist
     assert "hermes-kanban-bulk-reclaim-first" in dist
-    assert '"→ todo"' in dist
-    assert '"Block"' in dist
-    assert '"Unblock"' in dist
+    assert '"→ triage"' in dist
+    assert '"→ ready"' in dist
+    assert '"Complete"' in dist
+    assert '"→ todo"' not in dist
 
 
 def test_dashboard_shift_click_range_selection_exists():

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -225,7 +225,9 @@ def test_dashboard_rolly_chat_passes_board_slug_to_tmux_session():
     assert "copyCardPrompt" in js
     assert "h(RollyChatSection, { task: t, boardSlug: props.boardSlug })" not in js
     assert "readPathTaskId() || readUrlParam(\"task\")" in js
-    assert "url.pathname = taskId ? `/kanban/cards/${encodeURIComponent(taskId)}` : \"/kanban\"" in js
+    assert "function readReturnToBoardPath()" in js
+    assert "writeCardPath(taskId, isPriorityListRoute ? \"/kanban/list\" : \"/kanban\")" in js
+    assert "window.dispatchEvent(new PopStateEvent(\"popstate\"))" in js
 
 
 def test_dashboard_has_simple_columns_and_priority_list_route():
@@ -238,6 +240,7 @@ def test_dashboard_has_simple_columns_and_priority_list_route():
     assert 'const COLUMN_ORDER = ["triage", "ready", "done"]' in js
     assert "function PriorityList" in js
     assert 'path === "/kanban/list" || path === "/kanban/priority"' in js
+    assert 'task.status !== "done" && task.status !== "archived"' in js
     assert 'className: "hermes-kanban-priority-list"' in js
     assert ".hermes-kanban-priority-list" in css
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -226,7 +226,7 @@ def test_dashboard_rolly_chat_passes_board_slug_to_tmux_session():
     assert "h(RollyChatSection, { task: t, boardSlug: props.boardSlug })" not in js
     assert "readPathTaskId() || readUrlParam(\"task\")" in js
     assert "function readReturnToBoardPath()" in js
-    assert "writeCardPath(taskId, isPriorityListRoute ? \"/kanban/list\" : \"/kanban\")" in js
+    assert "writeCardPath(taskId, isPriorityListRoute ? \"/kanban/list\" : \"/kanban/board\")" in js
     assert "window.dispatchEvent(new PopStateEvent(\"popstate\"))" in js
 
 
@@ -239,7 +239,9 @@ def test_dashboard_has_simple_columns_and_priority_list_route():
 
     assert 'const COLUMN_ORDER = ["triage", "ready", "done"]' in js
     assert "function PriorityList" in js
-    assert 'path === "/kanban/list" || path === "/kanban/priority"' in js
+    assert 'path === "/kanban" || path === "/kanban/list" || path === "/kanban/priority"' in js
+    assert 'href: "/kanban/board"' in js
+    assert 'href: "/kanban"' in js
     assert 'task.status !== "done" && task.status !== "archived"' in js
     assert 'className: "hermes-kanban-priority-list"' in js
     assert ".hermes-kanban-priority-list" in css

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -184,7 +184,7 @@ def test_tmux_session_endpoint_starts_card_tmux_windows(client, tmp_path, monkey
         return Result(0)
 
     monkeypatch.setattr("hermes_dashboard_plugin_kanban_test.subprocess.run", fake_run)
-    monkeypatch.setattr("hermes_dashboard_plugin_kanban_test._tui_shell_command", lambda: "hermes --tui")
+    monkeypatch.setattr("hermes_dashboard_plugin_kanban_test._tui_shell_command", lambda **_kwargs: "hermes --tui")
 
     r = client.post(f"/api/plugins/kanban/tasks/{task_id}/tmux-session")
     assert r.status_code == 200, r.text
@@ -201,6 +201,27 @@ def test_tmux_session_endpoint_starts_card_tmux_windows(client, tmp_path, monkey
         "tmux", "new-session", "-d", "-s", expected_session, "-n", "rolly-chat", "-c", str(workspace.resolve()), "hermes --tui",
     ]
     assert calls[2][0] == ["tmux", "new-window", "-t", expected_session, "-n", "terminal", "-c", str(workspace.resolve())]
+
+
+def test_card_tui_shell_command_sets_card_session_env(client):
+    mod = sys.modules["hermes_dashboard_plugin_kanban_test"]
+
+    command = mod._tui_shell_command(task_id="t_card_123", board="/tmp/kanban board.db")
+
+    assert "HERMES_SESSION_SOURCE=kanban-card:t_card_123" in command
+    assert "HERMES_KANBAN_TASK=t_card_123" in command
+    assert "HERMES_KANBAN_BOARD='/tmp/kanban board.db'" in command
+
+
+def test_dashboard_rolly_chat_passes_board_slug_to_tmux_session():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "h(RollyChatSection, { task: t, boardSlug: props.boardSlug })" in js
+    assert "withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/tmux-session`, props.boardSlug)" in js
+    assert "readPathTaskId() || readUrlParam(\"task\")" in js
+    assert "url.pathname = taskId ? `/kanban/cards/${encodeURIComponent(taskId)}` : \"/kanban\"" in js
 
 
 def test_scheduled_tasks_have_their_own_column_not_todo(client):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -192,15 +192,18 @@ def test_tmux_session_endpoint_starts_card_tmux_windows(client, tmp_path, monkey
     assert data["started"] is True
     assert data["session_name"] == expected_session
     assert data["rolly_target"] == f"{expected_session}:rolly-chat"
-    assert data["terminal_target"] == f"{expected_session}:terminal"
-    assert data["terminal_url"] == f"/api/pty?pty_mode=tmux&tmux_session={expected_session}%3Aterminal"
+    assert data["terminal_target"] == expected_session
+    assert data["terminal_window_target"] == f"{expected_session}:terminal"
+    assert data["terminal_url"] == f"/api/pty?pty_mode=tmux&tmux_session={expected_session}"
     assert data["rolly_terminal_url"] == f"/api/pty?pty_mode=tmux&tmux_session={expected_session}%3Arolly-chat"
     assert data["attach_command"] == f"tmux attach-session -t {expected_session}"
     assert calls[0][0] == ["tmux", "has-session", "-t", expected_session]
-    assert calls[1][0] == [
+    assert calls[1][0] == ["tmux", "has-session", "-t", expected_session]
+    assert calls[2][0] == [
         "tmux", "new-session", "-d", "-s", expected_session, "-n", "rolly-chat", "-c", str(workspace.resolve()), "hermes --tui",
     ]
-    assert calls[2][0] == ["tmux", "new-window", "-t", expected_session, "-n", "terminal", "-c", str(workspace.resolve())]
+    assert calls[3][0] == ["tmux", "new-window", "-t", expected_session, "-n", "terminal", "-c", "/Users/rolly"]
+    assert calls[4][0] == ["tmux", "select-window", "-t", f"{expected_session}:rolly-chat"]
 
 
 def test_card_tui_shell_command_sets_card_session_env(client):
@@ -218,8 +221,11 @@ def test_dashboard_rolly_chat_passes_board_slug_to_tmux_session():
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
     js = bundle.read_text()
 
-    assert "h(RollyChatSection, { task: t, boardSlug: props.boardSlug })" in js
+    assert "h(CardPromptActions, { task: t, boardSlug: props.boardSlug })" in js
     assert "withBoard(`${API}/tasks/${encodeURIComponent(task.id)}/tmux-session`, props.boardSlug)" in js
+    assert "setTerminalReady(!!(d && d.session_exists))" in js
+    assert "copyCardPrompt" in js
+    assert "h(RollyChatSection, { task: t, boardSlug: props.boardSlug })" not in js
     assert "readPathTaskId() || readUrlParam(\"task\")" in js
     assert "url.pathname = taskId ? `/kanban/cards/${encodeURIComponent(taskId)}` : \"/kanban\"" in js
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -112,6 +112,55 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_completed_tasks_hidden_by_default_but_available_in_history(client):
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "finish me", "priority": 4})
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "done", "summary": "finished"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200
+    data = r.json()
+    assert task_id not in {
+        t["id"] for col in data["columns"] for t in col["tasks"]
+    }
+
+    r = client.get("/api/plugins/kanban/board?include_archived=true")
+    assert r.status_code == 200
+    data = r.json()
+    done = next(c for c in data["columns"] if c["name"] == "done")
+    assert [t["id"] for t in done["tasks"]] == [task_id]
+    assert done["tasks"][0]["completed_at"] is not None
+
+
+def test_archived_children_count_as_completed_progress(client):
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "parent"})
+    assert r.status_code == 200, r.text
+    parent_id = r.json()["task"]["id"]
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent_id]},
+    )
+    assert r.status_code == 200, r.text
+    child_id = r.json()["task"]["id"]
+
+    r = client.patch(f"/api/plugins/kanban/tasks/{child_id}", json={"status": "archived"})
+    assert r.status_code == 200, r.text
+
+    r = client.get("/api/plugins/kanban/board?include_archived=true")
+    assert r.status_code == 200
+    data = r.json()
+    parent = next(
+        t for col in data["columns"] for t in col["tasks"] if t["id"] == parent_id
+    )
+    assert parent["progress"] == {"done": 1, "total": 1}
+
+
 def test_claude_context_endpoint_returns_manual_copy_launch(client, tmp_path):
     workspace = tmp_path / "work dir"
     workspace.mkdir()
@@ -243,6 +292,11 @@ def test_dashboard_has_simple_columns_and_priority_list_route():
     assert 'href: "/kanban/board"' in js
     assert 'href: "/kanban"' in js
     assert 'task.status !== "done" && task.status !== "archived"' in js
+    assert "h(OrchestrationPanel, null)" not in js
+    assert 'tx(t, "nudgeDispatcher", "Nudge dispatcher")' not in js
+    assert "Ready cards are prepared for manual execution" in js
+    assert "assign a profile when you are ready to run this manually" in js
+    assert "Higher-priority cards appear earlier in the priority list" in js
     assert 'className: "hermes-kanban-priority-list"' in js
     assert ".hermes-kanban-priority-list" in css
 
@@ -449,12 +503,17 @@ def test_patch_status_complete(client):
     assert r.status_code == 200
     assert r.json()["task"]["status"] == "done"
 
-    # Board reflects the move.
-    done = next(
+    # Completed cards leave the active board automatically, but remain in history.
+    default_done = next(
         c for c in client.get("/api/plugins/kanban/board").json()["columns"]
         if c["name"] == "done"
     )
-    assert any(x["id"] == t["id"] for x in done["tasks"])
+    assert not any(x["id"] == t["id"] for x in default_done["tasks"])
+    history_done = next(
+        c for c in client.get("/api/plugins/kanban/board?include_archived=true").json()["columns"]
+        if c["name"] == "done"
+    )
+    assert any(x["id"] == t["id"] for x in history_done["tasks"])
 
 
 def test_patch_block_then_unblock(client):
@@ -830,8 +889,8 @@ def test_board_progress_rollup(client):
         t = client.get(f"/api/plugins/kanban/tasks/{cid}").json()["task"]
         assert t["status"] == "ready", f"{cid} should be ready after parent done"
 
-    # 0/2 done.
-    r = client.get("/api/plugins/kanban/board")
+    # 0/2 done (visible from the completed/history view because the parent is done).
+    r = client.get("/api/plugins/kanban/board?include_archived=true")
     parent_row = next(
         t for col in r.json()["columns"] for t in col["tasks"]
         if t["id"] == parent["id"]
@@ -844,7 +903,7 @@ def test_board_progress_rollup(client):
         json={"status": "done"},
     )
     assert r.status_code == 200
-    r = client.get("/api/plugins/kanban/board")
+    r = client.get("/api/plugins/kanban/board?include_archived=true")
     parent_row = next(
         t for col in r.json()["columns"] for t in col["tasks"]
         if t["id"] == parent["id"]

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -132,15 +132,17 @@ def test_claude_context_endpoint_returns_manual_copy_launch(client, tmp_path):
     r = client.get(f"/api/plugins/kanban/tasks/{task_id}/claude-context")
     assert r.status_code == 200, r.text
     data = r.json()
-    assert data["mode"] == "manual-copy"
+    assert data["mode"] == "card-tmux-two-window"
     assert data["task_id"] == task_id
     assert data["workspace_path"] == str(workspace.resolve())
-    assert data["command"] == f"cd '{workspace.resolve()}' && claude"
+    expected_session = "card-" + task_id.replace("_", "-")
+    assert data["command"] == f"tmux new-session -A -s {expected_session} -c '{workspace.resolve()}'"
+    assert data["session_name"] == expected_session
     assert "Implement card workspace" in data["prompt"]
     assert "manual Claude Code" in data["prompt"]
 
 
-def test_claude_context_endpoint_rejects_missing_workspace(client):
+def test_claude_context_endpoint_defaults_scratch_workspace_to_home(client):
     r = client.post(
         "/api/plugins/kanban/tasks",
         json={"title": "No workspace yet"},
@@ -149,8 +151,56 @@ def test_claude_context_endpoint_rejects_missing_workspace(client):
     task_id = r.json()["task"]["id"]
 
     r = client.get(f"/api/plugins/kanban/tasks/{task_id}/claude-context")
-    assert r.status_code == 409
-    assert "workspace_path" in r.json()["detail"]
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["workspace_path"] == str(Path.home().resolve())
+    expected_session = "card-" + task_id.replace("_", "-")
+    assert data["command"] == f"tmux new-session -A -s {expected_session} -c {Path.home().resolve()}"
+    assert data["session_name"] == expected_session
+
+
+def test_tmux_session_endpoint_starts_card_tmux_windows(client, tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Run terminal", "workspace_kind": "dir", "workspace_path": str(workspace)},
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    expected_session = "card-" + task_id.replace("_", "-")
+    calls = []
+
+    class Result:
+        def __init__(self, returncode=0):
+            self.returncode = returncode
+            self.stdout = ""
+            self.stderr = ""
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        if args[:2] == ["tmux", "has-session"]:
+            return Result(1)
+        return Result(0)
+
+    monkeypatch.setattr("hermes_dashboard_plugin_kanban_test.subprocess.run", fake_run)
+    monkeypatch.setattr("hermes_dashboard_plugin_kanban_test._tui_shell_command", lambda: "hermes --tui")
+
+    r = client.post(f"/api/plugins/kanban/tasks/{task_id}/tmux-session")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["started"] is True
+    assert data["session_name"] == expected_session
+    assert data["rolly_target"] == f"{expected_session}:rolly-chat"
+    assert data["terminal_target"] == f"{expected_session}:terminal"
+    assert data["terminal_url"] == f"/api/pty?pty_mode=tmux&tmux_session={expected_session}%3Aterminal"
+    assert data["rolly_terminal_url"] == f"/api/pty?pty_mode=tmux&tmux_session={expected_session}%3Arolly-chat"
+    assert data["attach_command"] == f"tmux attach-session -t {expected_session}"
+    assert calls[0][0] == ["tmux", "has-session", "-t", expected_session]
+    assert calls[1][0] == [
+        "tmux", "new-session", "-d", "-s", expected_session, "-n", "rolly-chat", "-c", str(workspace.resolve()), "hermes --tui",
+    ]
+    assert calls[2][0] == ["tmux", "new-window", "-t", expected_session, "-n", "terminal", "-c", str(workspace.resolve())]
 
 
 def test_scheduled_tasks_have_their_own_column_not_todo(client):
@@ -260,12 +310,14 @@ def test_dashboard_card_detail_is_fullscreen_not_sidebar():
     drawer_block = css.split(".hermes-kanban-drawer {")[1].split("}", 1)[0]
     shade_block = css.split(".hermes-kanban-drawer-shade {")[1].split("}", 1)[0]
 
-    assert "width: 100vw;" in drawer_block
-    assert "max-height: 100dvh;" in drawer_block
+    assert "width: 100%;" in drawer_block
+    assert "height: 100dvh;" in drawer_block
+    assert "left: var(--hermes-sidebar-width, 19.2rem);" in css
+    assert "position: sticky;" not in css.split(".hermes-kanban-drawer-head {")[1].split("}", 1)[0]
     assert "justify-content: stretch;" in shade_block
     assert "--hermes-kanban-drawer-width" not in drawer_block
     assert "hermes-kanban-drawer-back" in css
-    assert "max-width: 1366px" in css
+    assert "max-width: 1366px" not in css
 
 
 def test_dashboard_client_side_filtering_includes_tenant_filter():

--- a/tests/plugins/test_rolly_ops_dashboard_plugins.py
+++ b/tests/plugins/test_rolly_ops_dashboard_plugins.py
@@ -1,0 +1,47 @@
+"""Rolly ops dashboard tabs.
+
+Source-backed backlog: Rolly wants Hermes dashboard tabs for Kanban,
+People, Loops, and Workbench. Kanban ships as its own plugin; these tests
+lock the companion Rolly ops tabs into the bundled plugin surface.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PLUGINS = ROOT / "plugins"
+
+
+def _manifest(plugin: str) -> dict:
+    path = PLUGINS / plugin / "dashboard" / "manifest.json"
+    assert path.exists(), f"missing manifest for {plugin}"
+    return json.loads(path.read_text())
+
+
+def test_rolly_ops_dashboard_tabs_are_registered_after_kanban():
+    expected = {
+        "kanban": ("Kanban", "/kanban", "after:skills"),
+        "rolly-people": ("People", "/people", "after:kanban"),
+        "rolly-loops": ("Loops", "/loops", "after:people"),
+        "rolly-workbench": ("Workbench", "/workbench", "after:loops"),
+    }
+
+    for plugin, (label, path, position) in expected.items():
+        manifest = _manifest(plugin)
+        assert manifest["label"] == label
+        assert manifest["tab"]["path"] == path
+        assert manifest["tab"]["position"] == position
+        assert manifest["entry"] == "dist/index.js"
+
+
+def test_rolly_ops_tabs_surface_activity_and_visibility_language():
+    for plugin in ("rolly-people", "rolly-loops", "rolly-workbench"):
+        bundle = PLUGINS / plugin / "dashboard" / "dist" / "index.js"
+        assert bundle.exists(), f"missing dashboard bundle for {plugin}"
+        text = bundle.read_text()
+        assert "Activity" in text
+        assert "Visibility" in text
+        assert "Rolly" in text

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -363,6 +363,18 @@ def test_archive_refuses_bundled_skill(skills_home):
     assert "bundled" in msg.lower() or "hub" in msg.lower()
 
 
+def test_archive_allows_bundled_when_explicitly_opted_in(skills_home):
+    from tools.skill_usage import archive_skill
+    skills_dir = skills_home / "skills"
+    skill_dir = _write_skill(skills_dir, "bundled")
+    (skills_dir / ".bundled_manifest").write_text("bundled:abc\n", encoding="utf-8")
+
+    ok, msg = archive_skill("bundled", allow_upstream=True)
+    assert ok, msg
+    assert not skill_dir.exists()
+    assert (skills_dir / ".archive" / "bundled" / "SKILL.md").exists()
+
+
 def test_archive_refuses_hub_skill(skills_home):
     from tools.skill_usage import archive_skill
     skills_dir = skills_home / "skills"
@@ -497,6 +509,60 @@ def test_agent_created_report_excludes_bundled_and_hub(skills_home):
     assert "hubbed" not in names
 
 
+def test_curator_report_all_includes_installed_provenance(skills_home):
+    from tools.skill_usage import curator_report, mark_agent_created
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "mine")
+    _write_skill(skills_dir, "manual")
+    _write_skill(skills_dir, "bundled")
+    _write_skill(skills_dir, "hubbed")
+    mark_agent_created("mine")
+    (skills_dir / ".bundled_manifest").write_text("bundled:abc\n", encoding="utf-8")
+    hub = skills_dir / ".hub"
+    hub.mkdir()
+    (hub / "lock.json").write_text(
+        json.dumps({"installed": {"hubbed": {}}}), encoding="utf-8",
+    )
+
+    by_name = {r["name"]: r for r in curator_report("all")}
+    assert by_name["mine"]["provenance"] == "agent"
+    assert by_name["manual"]["provenance"] == "manual"
+    assert by_name["bundled"]["provenance"] == "bundled"
+    assert by_name["hubbed"]["provenance"] == "hub"
+
+
+def test_curator_report_non_manual_excludes_manual(skills_home):
+    from tools.skill_usage import curator_report, mark_agent_created
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "mine")
+    _write_skill(skills_dir, "manual")
+    _write_skill(skills_dir, "bundled")
+    _write_skill(skills_dir, "hubbed")
+    mark_agent_created("mine")
+    (skills_dir / ".bundled_manifest").write_text("bundled:abc\n", encoding="utf-8")
+    hub = skills_dir / ".hub"
+    hub.mkdir()
+    (hub / "lock.json").write_text(
+        json.dumps({"installed": {"hubbed": {}}}), encoding="utf-8",
+    )
+
+    by_name = {r["name"]: r for r in curator_report("non_manual")}
+    assert set(by_name) == {"mine", "bundled", "hubbed"}
+    assert by_name["mine"]["provenance"] == "agent"
+    assert by_name["bundled"]["provenance"] == "bundled"
+    assert by_name["hubbed"]["provenance"] == "hub"
+
+
+def test_curator_report_can_seed_records_for_scope_all(skills_home):
+    from tools.skill_usage import curator_report, load_usage
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "never-used")
+
+    assert "never-used" not in load_usage()
+    curator_report("all", persist_missing=True)
+    assert load_usage()["never-used"]["created_at"]
+
+
 def test_agent_created_report_derives_activity_from_view_and_patch(skills_home, monkeypatch):
     import tools.skill_usage as skill_usage
 
@@ -520,12 +586,11 @@ def test_agent_created_report_derives_activity_from_view_and_patch(skills_home, 
 
 
 # ---------------------------------------------------------------------------
-# Provenance guard — telemetry must not leak records for bundled/hub skills
+# Provenance telemetry — bundled/hub usage can be tracked without default curation
 # ---------------------------------------------------------------------------
 
-def test_bump_view_no_op_for_bundled_skill(skills_home):
-    """Telemetry bumps on bundled skills are dropped — the sidecar must stay
-    focused on agent-created skills only."""
+def test_bump_view_records_bundled_skill_usage(skills_home):
+    """Bundled skills can accrue telemetry so scope=all has recency data."""
     from tools.skill_usage import bump_view, load_usage
     skills_dir = skills_home / "skills"
     (skills_dir / ".bundled_manifest").write_text(
@@ -533,12 +598,10 @@ def test_bump_view_no_op_for_bundled_skill(skills_home):
     )
 
     bump_view("ship-bundled")
-    assert "ship-bundled" not in load_usage(), (
-        "bundled skill leaked into .usage.json"
-    )
+    assert load_usage()["ship-bundled"]["view_count"] == 1
 
 
-def test_bump_patch_no_op_for_hub_skill(skills_home):
+def test_bump_patch_records_hub_skill_usage(skills_home):
     from tools.skill_usage import bump_patch, load_usage
     skills_dir = skills_home / "skills"
     hub = skills_dir / ".hub"
@@ -548,10 +611,10 @@ def test_bump_patch_no_op_for_hub_skill(skills_home):
     )
 
     bump_patch("from-hub")
-    assert "from-hub" not in load_usage()
+    assert load_usage()["from-hub"]["patch_count"] == 1
 
 
-def test_bump_use_no_op_for_hub_skill(skills_home):
+def test_bump_use_records_hub_skill_usage(skills_home):
     from tools.skill_usage import bump_use, load_usage
     skills_dir = skills_home / "skills"
     hub = skills_dir / ".hub"
@@ -561,18 +624,18 @@ def test_bump_use_no_op_for_hub_skill(skills_home):
     )
 
     bump_use("from-hub")
-    assert "from-hub" not in load_usage()
+    assert load_usage()["from-hub"]["use_count"] == 1
 
 
-def test_set_state_no_op_for_bundled_skill(skills_home):
-    """State transitions on bundled skills must not land in the sidecar."""
+def test_set_state_can_record_bundled_skill_when_explicit(skills_home):
+    """State sidecar updates are needed when curator.scope=all is enabled."""
     from tools.skill_usage import set_state, load_usage, STATE_ARCHIVED
     skills_dir = skills_home / "skills"
     (skills_dir / ".bundled_manifest").write_text(
         "locked:abc\n", encoding="utf-8",
     )
     set_state("locked", STATE_ARCHIVED)
-    assert "locked" not in load_usage()
+    assert load_usage()["locked"]["state"] == STATE_ARCHIVED
 
 
 def test_restore_refuses_to_shadow_bundled_skill(skills_home):
@@ -593,9 +656,8 @@ def test_restore_refuses_to_shadow_bundled_skill(skills_home):
     assert "bundled" in msg.lower() or "shadow" in msg.lower()
 
 
-def test_end_to_end_no_code_path_mutates_bundled_skill(skills_home):
-    """The combined guarantee: no curator code path can archive, mark stale,
-    set-state, or persist telemetry for a bundled or hub-installed skill."""
+def test_end_to_end_default_paths_do_not_archive_bundled_skill(skills_home):
+    """Default archive path still refuses bundled/hub skills while telemetry is kept."""
     from tools.skill_usage import (
         bump_view, bump_use, bump_patch, set_state, set_pinned,
         archive_skill, load_usage, STATE_STALE, STATE_ARCHIVED,
@@ -625,10 +687,12 @@ def test_end_to_end_no_code_path_mutates_bundled_skill(skills_home):
         ok, _msg = archive_skill(name)
         assert not ok, f"archive_skill(\"{name}\") should refuse"
 
-    # Sidecar must be clean of all three
+    # Sidecar keeps telemetry/state for scope=all recency decisions.
     data = load_usage()
-    assert "bundled-one" not in data
-    assert "hub-one" not in data
+    assert data["bundled-one"]["view_count"] == 1
+    assert data["bundled-one"]["state"] == STATE_ARCHIVED
+    assert data["hub-one"]["use_count"] == 1
+    assert data["hub-one"]["pinned"] is True
 
     # Directories must still be in place on disk
     assert (skills_dir / "bundled-one" / "SKILL.md").exists()

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -7,13 +7,14 @@ decide lifecycle transitions.
 
 Design notes:
   - Sidecar, not frontmatter. Keeps operational telemetry out of user-authored
-    SKILL.md content and avoids conflict pressure for bundled/hub skills.
+    SKILL.md content and avoids conflict pressure with skill package files.
   - Atomic writes via tempfile + os.replace (same pattern as .bundled_manifest).
   - All counter bumps are best-effort: failures log at DEBUG and return silently.
     A broken sidecar never breaks the underlying tool call.
-  - Provenance filter: curator-managed skills are explicitly marked when
-    created through skill_manage. Bundled / hub-installed skills stay
-    off-limits, and manually authored skills are not inferred from location.
+  - Provenance filter: curator-managed skills default to those explicitly
+    marked when created through skill_manage. Installations can opt the curator
+    into all installed skills; provenance is then tracked in reports so policy
+    can stay explicit.
 
 Lifecycle states:
     active    -> default
@@ -217,6 +218,41 @@ def _read_hub_installed_names() -> Set[str]:
     return set()
 
 
+def _iter_installed_skill_names() -> List[str]:
+    """Enumerate visible skill names under the active skills directory."""
+    base = _skills_dir()
+    if not base.exists():
+        return []
+    names: List[str] = []
+    for skill_md in base.rglob("SKILL.md"):
+        if is_excluded_skill_path(skill_md):
+            continue
+        try:
+            skill_md.relative_to(base)
+        except ValueError:
+            continue
+        names.append(_read_skill_name(skill_md, fallback=skill_md.parent.name))
+    return sorted(set(names))
+
+
+def _provenance_for_name(
+    skill_name: str, *, bundled: Optional[Set[str]] = None, hub: Optional[Set[str]] = None
+) -> str:
+    """Return a coarse provenance label for a skill name."""
+    if bundled is None:
+        bundled = _read_bundled_manifest_names()
+    if hub is None:
+        hub = _read_hub_installed_names()
+    if skill_name in bundled:
+        return "bundled"
+    if skill_name in hub:
+        return "hub"
+    rec = load_usage().get(skill_name)
+    if _is_curator_managed_record(rec):
+        return "agent"
+    return "manual"
+
+
 def list_agent_created_skill_names() -> List[str]:
     """Enumerate skills explicitly authored by the agent.
 
@@ -251,6 +287,39 @@ def list_agent_created_skill_names() -> List[str]:
             continue
         names.append(name)
     return sorted(set(names))
+
+
+def list_non_manual_skill_names() -> List[str]:
+    """Enumerate skills not authored manually by the user.
+
+    This is the middle curator scope: include skills explicitly created by the
+    agent plus bundled and hub-installed profile-local copies, but exclude
+    local/manual skills with no curator-managed provenance marker.
+    """
+    bundled = _read_bundled_manifest_names()
+    hub = _read_hub_installed_names()
+    usage = load_usage()
+    names: List[str] = []
+    for name in _iter_installed_skill_names():
+        if name in bundled or name in hub or _is_curator_managed_record(usage.get(name)):
+            names.append(name)
+    return sorted(set(names))
+
+
+def list_curator_skill_names(scope: str = "agent_created") -> List[str]:
+    """Enumerate skills eligible for curator lifecycle/review.
+
+    ``agent_created`` is the safe default used historically. ``non_manual``
+    opts in every non-user-authored skill (agent-created, bundled, and hub),
+    while leaving manually-authored local skills alone. ``all`` opts in every
+    installed local skill copy. Archiving remains recoverable.
+    """
+    normalized = str(scope or "agent_created").strip().lower().replace("-", "_")
+    if normalized in {"non_manual", "not_manual", "non_user", "not_user", "not_made_by_me", "managed"}:
+        return list_non_manual_skill_names()
+    if normalized in {"all", "installed", "all_installed"}:
+        return _iter_installed_skill_names()
+    return list_agent_created_skill_names()
 
 
 def list_archived_skill_names() -> List[str]:
@@ -380,15 +449,13 @@ def get_record(skill_name: str) -> Dict[str, Any]:
 def _mutate(skill_name: str, mutator) -> None:
     """Load, apply *mutator(record)* in place, save. Best-effort.
 
-    Bundled and hub-installed skills are NEVER recorded in the sidecar.
-    Local manual skills may still accrue usage telemetry, but they only
-    become curator-managed when ``created_by`` is explicitly marked.
+    All installed skills may accrue usage telemetry. Only agent-created skills
+    are curator-managed by default; broader curator scopes consult provenance
+    explicitly rather than inferring it from telemetry existence.
     """
     if not skill_name:
         return
     try:
-        if not is_agent_created(skill_name):
-            return
         with _usage_file_lock():
             data = load_usage()
             rec = data.get(skill_name)
@@ -479,13 +546,14 @@ def forget(skill_name: str) -> None:
 # Archive / restore
 # ---------------------------------------------------------------------------
 
-def archive_skill(skill_name: str) -> Tuple[bool, str]:
-    """Move an agent-created skill directory to ~/.hermes/skills/.archive/.
+def archive_skill(skill_name: str, *, allow_upstream: bool = False) -> Tuple[bool, str]:
+    """Move a skill directory to ~/.hermes/skills/.archive/.
 
-    Returns (ok, message). Never archives bundled or hub skills — callers are
-    responsible for checking provenance, but we double-check here as a safety net.
+    Returns (ok, message). Bundled and hub skills require ``allow_upstream`` so
+    command paths keep the historical safety rail while the curator can opt in
+    when configured with ``curator.scope: non_manual`` or ``curator.scope: all``.
     """
-    if not is_agent_created(skill_name):
+    if not allow_upstream and not is_agent_created(skill_name):
         return False, f"skill '{skill_name}' is bundled or hub-installed; never archive"
 
     skill_dir = _find_skill_dir(skill_name)
@@ -588,21 +656,44 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
 # Reporting — for the curator CLI / slash command
 # ---------------------------------------------------------------------------
 
+def curator_report(scope: str = "agent_created", *, persist_missing: bool = False) -> List[Dict[str, Any]]:
+    """Return report rows for skills eligible under *scope*.
+
+    When ``persist_missing`` is true, missing sidecar records are saved. The
+    automatic transition pass uses this to seed a stable ``created_at`` anchor
+    for never-used installed skills so they can eventually age out instead of
+    looking brand-new on every run.
+    """
+    data = load_usage()
+    changed = False
+    bundled = _read_bundled_manifest_names()
+    hub = _read_hub_installed_names()
+    rows: List[Dict[str, Any]] = []
+    for name in list_curator_skill_names(scope):
+        rec = data.get(name)
+        if not isinstance(rec, dict):
+            rec = _empty_record()
+            if persist_missing:
+                data[name] = rec
+                changed = True
+        base = _empty_record()
+        for k, v in base.items():
+            if k not in rec:
+                rec[k] = v
+                if persist_missing:
+                    changed = True
+        row = {"name": name, **rec}
+        row["provenance"] = _provenance_for_name(name, bundled=bundled, hub=hub)
+        row["last_activity_at"] = latest_activity_at(row)
+        row["activity_count"] = activity_count(row)
+        rows.append(row)
+    if changed:
+        save_usage(data)
+    return rows
+
+
 def agent_created_report() -> List[Dict[str, Any]]:
     """Return a list of {name, state, pinned, last_activity_at, ...}
     records for every agent-created skill. Missing usage records are backfilled
     with defaults so callers can always index fields."""
-    data = load_usage()
-    rows: List[Dict[str, Any]] = []
-    for name in list_agent_created_skill_names():
-        rec = data.get(name)
-        if not isinstance(rec, dict):
-            rec = _empty_record()
-        base = _empty_record()
-        for k, v in base.items():
-            rec.setdefault(k, v)
-        row = {"name": name, **rec}
-        row["last_activity_at"] = latest_activity_at(row)
-        row["activity_count"] = activity_count(row)
-        rows.append(row)
-    return rows
+    return curator_report("agent_created")

--- a/web/index.html
+++ b/web/index.html
@@ -3,11 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>Hermes Agent - Dashboard</title>
+    <meta name="theme-color" content="#050505" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="Rolly" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <title>Rolly Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Rolly Dashboard",
+  "short_name": "Rolly",
+  "description": "Rolly dashboard and realtime voice calls.",
+  "start_url": "/voice",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#050505",
+  "theme_color": "#050505",
+  "categories": ["productivity", "utilities"],
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "any",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,12 @@
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", () => {
+  // Registration-only service worker: keeps the app installable without
+  // pretending voice/WebRTC can work offline or from stale cached assets.
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,7 @@ import {
   Sparkles,
   Star,
   Terminal,
+  UploadCloud,
   Users,
   Wrench,
   X,
@@ -66,6 +67,7 @@ import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
 import LogsPage from "@/pages/LogsPage";
+import UploadPage from "@/pages/UploadPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
@@ -118,6 +120,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
+  "/upload": UploadPage,
   "/cron": CronPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
@@ -155,6 +158,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     icon: Cpu,
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
+  { path: "/upload", labelKey: "upload", label: "Upload", icon: UploadCloud },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
@@ -182,6 +186,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Puzzle,
   Sparkles,
   Terminal,
+  UploadCloud,
   Globe,
   Database,
   Shield,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type ComponentType,
+  type CSSProperties,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -23,6 +24,7 @@ import {
   Clock,
   Code,
   Cpu,
+  Mic,
   Database,
   Download,
   Eye,
@@ -75,6 +77,7 @@ import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
+import VoiceCallPage from "@/pages/VoiceCallPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -85,9 +88,38 @@ import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
+import {
+  getRollyUser,
+  getRollyUserSlug,
+  ROLLY_DASHBOARD_USERS,
+  setRollyUserSlug,
+} from "@/lib/rollyIdentity";
 
 function RootRedirect() {
   return <Navigate to="/sessions" replace />;
+}
+
+function RollyIdentityGate({ currentUser, onSelect }: { currentUser: string; onSelect: (slug: string) => void }) {
+  if (getRollyUser(currentUser)) return null;
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 px-4 backdrop-blur-sm">
+      <div className="w-full max-w-sm border border-current/20 bg-background-base/95 p-5 text-midground shadow-2xl">
+        <Typography className="font-mondwest text-display text-xl uppercase tracking-[0.12em]">
+          Who are you?
+        </Typography>
+        <p className="mt-2 text-sm text-text-secondary">
+          This labels every dashboard action and session. It is not security.
+        </p>
+        <div className="mt-4 grid gap-2">
+          {ROLLY_DASHBOARD_USERS.map((user) => (
+            <Button key={user.slug} onClick={() => onSelect(user.slug)} className="justify-start">
+              {user.label}{user.admin ? " · admin" : ""}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -117,6 +149,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/voice": VoiceCallPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -145,6 +178,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     label: "Sessions",
     icon: MessageSquare,
   },
+  { path: "/voice", labelKey: "voice", label: "Voice", icon: Mic },
   {
     path: "/analytics",
     labelKey: "analytics",
@@ -181,6 +215,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   FileText,
   KeyRound,
   MessageSquare,
+  Mic,
   Package,
   Settings,
   Puzzle,
@@ -321,7 +356,8 @@ const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
 
 export default function App() {
   const { t } = useI18n();
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const { pathname, search } = location;
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -350,7 +386,20 @@ export default function App() {
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
+  const isChromelessChatRoute =
+    isChatRoute && new URLSearchParams(search).get("embed") === "1";
   const embeddedChat = isDashboardEmbeddedChatEnabled();
+  const [rollyUser, setRollyUser] = useState(() => getRollyUserSlug());
+  const selectRollyUser = useCallback((slug: string) => {
+    const selected = setRollyUserSlug(slug);
+    if (selected) setRollyUser(selected);
+  }, []);
+  useEffect(() => {
+    const updateUser = () => setRollyUser(getRollyUserSlug());
+    window.addEventListener("rolly-user-change", updateUser);
+    updateUser();
+    return () => window.removeEventListener("rolly-user-change", updateUser);
+  }, []);
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The
   // page itself remains reachable by URL (it renders an explanation when
@@ -428,6 +477,10 @@ export default function App() {
   );
 
   const layoutVariant = theme.layoutVariant ?? "standard";
+  const sidebarWidth = isDesktopCollapsed ? "4.2rem" : "19.2rem";
+  const rootStyle = {
+    "--hermes-sidebar-width": sidebarWidth,
+  } as CSSProperties;
 
   useEffect(() => {
     if (!mobileOpen) return;
@@ -452,18 +505,41 @@ export default function App() {
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
+  if (isChromelessChatRoute) {
+    return (
+      <div
+        data-layout-variant={layoutVariant}
+        data-layout-chrome="none"
+        className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black text-text-primary antialiased"
+        style={rootStyle}
+      >
+        <SelectionSwitcher />
+        <RollyIdentityGate currentUser={rollyUser} onSelect={selectRollyUser} />
+        <Backdrop />
+        <PageHeaderProvider pluginTabs={pluginTabMeta}>
+          <main className="relative z-2 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-0">
+            <ChatPage isActive />
+          </main>
+        </PageHeaderProvider>
+        <PluginSlot name="overlay" />
+      </div>
+    );
+  }
+
   return (
     <div
       data-layout-variant={layoutVariant}
       className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black text-text-primary antialiased"
+      style={rootStyle}
     >
       <SelectionSwitcher />
+      <RollyIdentityGate currentUser={rollyUser} onSelect={selectRollyUser} />
       <Backdrop />
       <PluginSlot name="backdrop" />
 
       <header
         className={cn(
-          "lg:hidden fixed top-0 left-0 right-0 z-40 min-h-14",
+          "lg:hidden shrink-0 min-h-14",
           "flex items-center gap-2 px-4 py-2",
           "border-b border-current/20",
           "bg-background-base/90 backdrop-blur-sm",
@@ -508,7 +584,7 @@ export default function App() {
 
       <PluginSlot name="header-banner" />
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
           <aside
             id="app-sidebar"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -336,6 +336,14 @@ function buildRoutes(
       path: m.tab.path,
       element: <PluginPage name={m.name} />,
     });
+    const pluginBasePath = m.tab.path.replace(/\/$/, "");
+    if (pluginBasePath) {
+      routes.push({
+        key: `plugin:${m.name}:wildcard`,
+        path: `${pluginBasePath}/*`,
+        element: <PluginPage name={m.name} />,
+      });
+    }
   }
 
   for (const m of manifests) {
@@ -389,6 +397,10 @@ export default function App() {
   const isChromelessChatRoute =
     isChatRoute && new URLSearchParams(search).get("embed") === "1";
   const embeddedChat = isDashboardEmbeddedChatEnabled();
+  const [chatHostMounted, setChatHostMounted] = useState(() => isChatRoute);
+  useEffect(() => {
+    if (isChatRoute) setChatHostMounted(true);
+  }, [isChatRoute]);
   const [rollyUser, setRollyUser] = useState(() => getRollyUserSlug());
   const selectRollyUser = useCallback((slug: string) => {
     const selected = setRollyUserSlug(slug);
@@ -795,6 +807,7 @@ export default function App() {
                 </Routes>
 
                 {embeddedChat &&
+                  chatHostMounted &&
                   !chatOverriddenByPlugin &&
                   (pluginsLoading ? (
                     isChatRoute ? (

--- a/web/src/components/PtyTerminalPane.tsx
+++ b/web/src/components/PtyTerminalPane.tsx
@@ -4,7 +4,8 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -61,7 +62,37 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
       ? "Session token unavailable. Open this page through `hermes dashboard`, not directly."
       : null,
   );
+  const [composerDraft, setComposerDraft] = useState("");
   const channel = useMemo(() => generateChannelId(), [tmuxTarget, resume]);
+
+  const sendTextToTerminal = useCallback((text: string, submit = true) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const term = termRef.current;
+    const ws = wsRef.current;
+    if (!term || !ws || ws.readyState !== WebSocket.OPEN) return;
+    term.paste(trimmed);
+    if (submit) {
+      window.setTimeout(() => {
+        const s = wsRef.current;
+        if (s && s.readyState === WebSocket.OPEN) s.send("\r");
+      }, 80);
+    }
+    term.focus();
+  }, []);
+
+  const submitComposerDraft = useCallback((event?: FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
+    const text = composerDraft;
+    setComposerDraft("");
+    sendTextToTerminal(text);
+  }, [composerDraft, sendTextToTerminal]);
+
+  const handleComposerKeyDown = useCallback((event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    submitComposerDraft();
+  }, [submitComposerDraft]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -82,7 +113,8 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
       macOptionIsMeta: true,
       macOptionClickForcesSelection: true,
       rightClickSelectsWord: true,
-      scrollback: 5000,
+      scrollback: 100000,
+      scrollOnUserInput: false,
       theme: TERMINAL_THEME,
     });
     termRef.current = term;
@@ -116,15 +148,6 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
     term.unicode.activeVersion = "11";
     term.loadAddon(new WebLinksAddon());
     term.open(host);
-
-    const wheelHandler = (ev: WheelEvent) => {
-      if (!termRef.current) return;
-      const lineHeight = Math.max(1, Number(term.options.fontSize || 12) * Number(term.options.lineHeight || 1));
-      const lines = Math.max(1, Math.ceil(Math.abs(ev.deltaY) / lineHeight));
-      term.scrollLines(ev.deltaY > 0 ? lines : -lines);
-      ev.preventDefault();
-    };
-    host.addEventListener("wheel", wheelHandler, { passive: false });
 
     if (tierWidthPx(host) >= 768) {
       try {
@@ -185,10 +208,8 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
         else if (ev.code === 4403) setBanner("Terminal is only reachable from localhost.");
         else term.write("\r\n\x1b[90m[session ended]\x1b[0m\r\n");
       };
-      // eslint-disable-next-line no-control-regex -- xterm SGR mouse report parser
-      const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
       onDataDisposable = term.onData((data) => {
-        if (ws.readyState !== WebSocket.OPEN || SGR_MOUSE_RE.test(data)) return;
+        if (ws.readyState !== WebSocket.OPEN) return;
         ws.send(data);
       });
       onResizeDisposable = term.onResize(({ cols, rows }) => {
@@ -203,7 +224,6 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
       ro.disconnect();
-      host.removeEventListener("wheel", wheelHandler);
       window.removeEventListener("resize", scheduleSync);
       if (raf) cancelAnimationFrame(raf);
       wsRef.current?.close();
@@ -217,6 +237,28 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
     <div className={cn("relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg p-2", className)} style={{ backgroundColor: TERMINAL_THEME.background }} title={title}>
       {banner ? <div className="border border-warning/50 bg-warning/10 text-warning px-3 py-2 text-xs tracking-wide">{banner}</div> : null}
       <div ref={hostRef} className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1" />
+      <form
+        onSubmit={submitComposerDraft}
+        className="mt-2 flex shrink-0 items-end gap-1.5 rounded border border-current/20 bg-black/20 p-1.5"
+        style={{ color: TERMINAL_THEME.foreground }}
+      >
+        <textarea
+          value={composerDraft}
+          onChange={(event) => setComposerDraft(event.target.value)}
+          onKeyDown={handleComposerKeyDown}
+          placeholder="Dictate or paste text… Enter sends"
+          rows={1}
+          autoCapitalize="sentences"
+          className="min-h-8 max-h-24 flex-1 resize-none rounded bg-black/20 px-2 py-1.5 text-sm leading-snug outline-none placeholder:text-current/45 focus:ring-1 focus:ring-current/40"
+        />
+        <button
+          type="submit"
+          disabled={!composerDraft.trim()}
+          className="h-8 shrink-0 rounded border border-current/25 px-2 text-xs disabled:opacity-40"
+        >
+          send
+        </button>
+      </form>
     </div>
   );
 }

--- a/web/src/components/PtyTerminalPane.tsx
+++ b/web/src/components/PtyTerminalPane.tsx
@@ -116,6 +116,16 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
     term.unicode.activeVersion = "11";
     term.loadAddon(new WebLinksAddon());
     term.open(host);
+
+    const wheelHandler = (ev: WheelEvent) => {
+      if (!termRef.current) return;
+      const lineHeight = Math.max(1, Number(term.options.fontSize || 12) * Number(term.options.lineHeight || 1));
+      const lines = Math.max(1, Math.ceil(Math.abs(ev.deltaY) / lineHeight));
+      term.scrollLines(ev.deltaY > 0 ? lines : -lines);
+      ev.preventDefault();
+    };
+    host.addEventListener("wheel", wheelHandler, { passive: false });
+
     if (tierWidthPx(host) >= 768) {
       try {
         const webgl = new WebglAddon();
@@ -193,6 +203,7 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
       ro.disconnect();
+      host.removeEventListener("wheel", wheelHandler);
       window.removeEventListener("resize", scheduleSync);
       if (raf) cancelAnimationFrame(raf);
       wsRef.current?.close();

--- a/web/src/components/PtyTerminalPane.tsx
+++ b/web/src/components/PtyTerminalPane.tsx
@@ -1,0 +1,218 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { WebglAddon } from "@xterm/addon-webgl";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const TERMINAL_THEME = {
+  background: "#0d2626",
+  foreground: "#f0e6d2",
+  cursor: "#f0e6d2",
+  cursorAccent: "#0d2626",
+  selectionBackground: "#f0e6d244",
+};
+
+function generateChannelId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  return `pty-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function tierWidthPx(host: HTMLElement | null): number {
+  if (typeof window === "undefined") return 1280;
+  const fromHost = host?.clientWidth ?? 0;
+  if (fromHost > 2) return Math.round(fromHost);
+  const doc = document.documentElement?.clientWidth ?? 0;
+  return Math.max(1, Math.round(doc || window.innerWidth || 1280));
+}
+
+function fontSizeForWidth(width: number): number {
+  if (width < 300) return 7;
+  if (width < 360) return 8;
+  if (width < 420) return 9;
+  if (width < 520) return 10;
+  if (width < 720) return 11;
+  if (width < 1024) return 12;
+  return 14;
+}
+
+function lineHeightForWidth(width: number): number {
+  return width < 1024 ? 1.02 : 1.15;
+}
+
+export type PtyTerminalPaneProps = {
+  tmuxTarget?: string;
+  resume?: string | null;
+  className?: string;
+  title?: string;
+  autoFocus?: boolean;
+};
+
+export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocus = false }: PtyTerminalPaneProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const [banner, setBanner] = useState<string | null>(() =>
+    typeof window !== "undefined" && !window.__HERMES_SESSION_TOKEN__ && !window.__HERMES_AUTH_REQUIRED__
+      ? "Session token unavailable. Open this page through `hermes dashboard`, not directly."
+      : null,
+  );
+  const channel = useMemo(() => generateChannelId(), [tmuxTarget, resume]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const token = window.__HERMES_SESSION_TOKEN__;
+    const gated = !!window.__HERMES_AUTH_REQUIRED__;
+    if (!token && !gated) return;
+
+    const width = tierWidthPx(host);
+    const term = new Terminal({
+      allowProposedApi: true,
+      cursorBlink: true,
+      fontFamily: "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+      fontSize: fontSizeForWidth(width),
+      lineHeight: lineHeightForWidth(width),
+      fontWeight: "400",
+      fontWeightBold: "700",
+      macOptionIsMeta: true,
+      macOptionClickForcesSelection: true,
+      rightClickSelectsWord: true,
+      scrollback: 5000,
+      theme: TERMINAL_THEME,
+    });
+    termRef.current = term;
+
+    term.attachCustomKeyEventHandler((ev) => {
+      if (ev.type !== "keydown") return true;
+      const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+      const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      if (copyModifier && ev.key.toLowerCase() === "c") {
+        const sel = term.getSelection();
+        if (sel) {
+          navigator.clipboard.writeText(sel).catch(() => {});
+          term.clearSelection();
+          ev.preventDefault();
+          return false;
+        }
+      }
+      if (pasteModifier && ev.key.toLowerCase() === "v") {
+        navigator.clipboard.readText().then((text) => { if (text) term.paste(text); }).catch(() => {});
+        ev.preventDefault();
+        return false;
+      }
+      return true;
+    });
+
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    const unicode11 = new Unicode11Addon();
+    term.loadAddon(unicode11);
+    term.unicode.activeVersion = "11";
+    term.loadAddon(new WebLinksAddon());
+    term.open(host);
+    if (tierWidthPx(host) >= 768) {
+      try {
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => webgl.dispose());
+        term.loadAddon(webgl);
+      } catch {
+        // Canvas renderer fallback.
+      }
+    }
+
+    let raf = 0;
+    const sync = () => {
+      if (!host.isConnected || host.clientWidth <= 0 || host.clientHeight <= 0) return;
+      const nextWidth = tierWidthPx(host);
+      term.options.fontSize = fontSizeForWidth(nextWidth);
+      term.options.lineHeight = lineHeightForWidth(nextWidth);
+      try { fit.fit(); } catch { return; }
+      if (wsRef.current?.readyState === WebSocket.OPEN) wsRef.current.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
+    };
+    const scheduleSync = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(sync);
+    };
+    const ro = new ResizeObserver(scheduleSync);
+    ro.observe(host);
+    scheduleSync();
+    window.addEventListener("resize", scheduleSync);
+
+    let unmounting = false;
+    let onDataDisposable: { dispose(): void } | null = null;
+    let onResizeDisposable: { dispose(): void } | null = null;
+    void (async () => {
+      const authParam = await buildWsAuthParam();
+      if (unmounting) return;
+      const qs = new URLSearchParams({ [authParam[0]]: authParam[1], channel });
+      if (resume) qs.set("resume", resume);
+      if (tmuxTarget) {
+        qs.set("pty_mode", "tmux");
+        qs.set("tmux_session", tmuxTarget);
+      }
+      const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(`${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`);
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
+      ws.onopen = () => {
+        setBanner(null);
+        ws.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
+      };
+      ws.onmessage = (ev) => {
+        if (typeof ev.data === "string") term.write(ev.data);
+        else term.write(new Uint8Array(ev.data as ArrayBuffer));
+      };
+      ws.onclose = (ev) => {
+        wsRef.current = null;
+        if (unmounting || ev.code === 1011) return;
+        if (ev.code === 4401) setBanner("Auth failed. Reload the page to refresh the session token.");
+        else if (ev.code === 4403) setBanner("Terminal is only reachable from localhost.");
+        else term.write("\r\n\x1b[90m[session ended]\x1b[0m\r\n");
+      };
+      // eslint-disable-next-line no-control-regex -- xterm SGR mouse report parser
+      const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+      onDataDisposable = term.onData((data) => {
+        if (ws.readyState !== WebSocket.OPEN || SGR_MOUSE_RE.test(data)) return;
+        ws.send(data);
+      });
+      onResizeDisposable = term.onResize(({ cols, rows }) => {
+        if (ws.readyState === WebSocket.OPEN) ws.send(`\x1b[RESIZE:${cols};${rows}]`);
+      });
+    })();
+
+    if (autoFocus) term.focus();
+
+    return () => {
+      unmounting = true;
+      onDataDisposable?.dispose();
+      onResizeDisposable?.dispose();
+      ro.disconnect();
+      window.removeEventListener("resize", scheduleSync);
+      if (raf) cancelAnimationFrame(raf);
+      wsRef.current?.close();
+      wsRef.current = null;
+      term.dispose();
+      termRef.current = null;
+    };
+  }, [channel, resume, tmuxTarget, autoFocus]);
+
+  return (
+    <div className={cn("relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg p-2", className)} style={{ backgroundColor: TERMINAL_THEME.background }} title={title}>
+      {banner ? <div className="border border-warning/50 bg-warning/10 text-warning px-3 py-2 text-xs tracking-wide">{banner}</div> : null}
+      <div ref={hostRef} className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1" />
+    </div>
+  );
+}
+
+declare global {
+  interface Window {
+    __HERMES_SESSION_TOKEN__?: string;
+    __HERMES_AUTH_REQUIRED__?: boolean;
+  }
+}

--- a/web/src/components/PtyTerminalPane.tsx
+++ b/web/src/components/PtyTerminalPane.tsx
@@ -63,15 +63,16 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
       : null,
   );
   const [composerDraft, setComposerDraft] = useState("");
+  const [pasteState, setPasteState] = useState<"idle" | "pasted" | "blocked">("idle");
+  const pasteResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const channel = useMemo(() => generateChannelId(), [tmuxTarget, resume]);
 
   const sendTextToTerminal = useCallback((text: string, submit = true) => {
-    const trimmed = text.trim();
-    if (!trimmed) return;
+    if (!text.trim()) return;
     const term = termRef.current;
     const ws = wsRef.current;
     if (!term || !ws || ws.readyState !== WebSocket.OPEN) return;
-    term.paste(trimmed);
+    term.paste(text);
     if (submit) {
       window.setTimeout(() => {
         const s = wsRef.current;
@@ -87,6 +88,19 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
     setComposerDraft("");
     sendTextToTerminal(text);
   }, [composerDraft, sendTextToTerminal]);
+
+  const pasteClipboardIntoComposer = useCallback(() => {
+    navigator.clipboard
+      .readText()
+      .then((text) => {
+        if (!text) return;
+        setComposerDraft((prev) => (prev ? `${prev}\n${text}` : text));
+        setPasteState("pasted");
+      })
+      .catch(() => setPasteState("blocked"));
+    if (pasteResetRef.current) clearTimeout(pasteResetRef.current);
+    pasteResetRef.current = setTimeout(() => setPasteState("idle"), 1500);
+  }, []);
 
   const handleComposerKeyDown = useCallback((event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key !== "Enter" || event.shiftKey) return;
@@ -226,6 +240,10 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
       ro.disconnect();
       window.removeEventListener("resize", scheduleSync);
       if (raf) cancelAnimationFrame(raf);
+      if (pasteResetRef.current) {
+        clearTimeout(pasteResetRef.current);
+        pasteResetRef.current = null;
+      }
       wsRef.current?.close();
       wsRef.current = null;
       term.dispose();
@@ -234,27 +252,35 @@ export function PtyTerminalPane({ tmuxTarget, resume, className, title, autoFocu
   }, [channel, resume, tmuxTarget, autoFocus]);
 
   return (
-    <div className={cn("relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg p-2", className)} style={{ backgroundColor: TERMINAL_THEME.background }} title={title}>
+    <div className={cn("relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-sm p-1", className)} style={{ backgroundColor: TERMINAL_THEME.background }} title={title}>
       {banner ? <div className="border border-warning/50 bg-warning/10 text-warning px-3 py-2 text-xs tracking-wide">{banner}</div> : null}
       <div ref={hostRef} className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1" />
       <form
         onSubmit={submitComposerDraft}
-        className="mt-2 flex shrink-0 items-end gap-1.5 rounded border border-current/20 bg-black/20 p-1.5"
+        className="mt-1 flex shrink-0 items-end gap-1 rounded-sm border border-current/15 bg-black/15 p-1"
         style={{ color: TERMINAL_THEME.foreground }}
       >
         <textarea
           value={composerDraft}
           onChange={(event) => setComposerDraft(event.target.value)}
           onKeyDown={handleComposerKeyDown}
-          placeholder="Dictate or paste text… Enter sends"
+          placeholder="paste/dictate… Enter sends"
           rows={1}
           autoCapitalize="sentences"
-          className="min-h-8 max-h-24 flex-1 resize-none rounded bg-black/20 px-2 py-1.5 text-sm leading-snug outline-none placeholder:text-current/45 focus:ring-1 focus:ring-current/40"
+          className="min-h-6 max-h-20 flex-1 resize-none rounded-sm bg-black/15 px-1.5 py-1 text-xs leading-tight outline-none placeholder:text-current/40 focus:ring-1 focus:ring-current/35"
         />
+        <button
+          type="button"
+          onClick={pasteClipboardIntoComposer}
+          title={pasteState === "blocked" ? "Clipboard blocked" : "Paste clipboard into box"}
+          className="h-6 shrink-0 rounded-sm border border-current/20 px-1.5 text-[11px]"
+        >
+          paste
+        </button>
         <button
           type="submit"
           disabled={!composerDraft.trim()}
-          className="h-8 shrink-0 rounded border border-current/25 px-2 text-xs disabled:opacity-40"
+          className="h-6 shrink-0 rounded-sm border border-current/20 px-1.5 text-[11px] disabled:opacity-40"
         >
           send
         </button>

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -36,8 +36,8 @@ export function PageHeaderProvider({
 
   const isChatRoute = pathname === "/chat" || pathname === "/chat/";
   /** Env jump-nav is wide — stack below title on small screens so KEYS stays readable. */
-  const isEnvRoute =
-    pathname === "/env" || pathname.startsWith("/env/");
+  const isEnvRoute = pathname === "/env" || pathname.startsWith("/env/");
+  const isKanbanRoute = pathname === "/kanban" || pathname.startsWith("/kanban/");
 
   const value = useMemo(
     () => ({
@@ -51,7 +51,7 @@ export function PageHeaderProvider({
   return (
     <PageHeaderContext.Provider value={value}>
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
-        <header
+        {!isKanbanRoute ? <header
           className={cn(
             "z-1 w-full shrink-0",
             "box-border border-b border-current/20",
@@ -119,7 +119,7 @@ export function PageHeaderProvider({
               </div>
             ) : null}
           </div>
-        </header>
+        </header> : null}
 
         <main
           className={cn(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -246,6 +246,40 @@ export const api = {
     if (params.component && params.component !== "all") qs.set("component", params.component);
     return fetchJSON<LogsResponse>(`/api/logs?${qs.toString()}`);
   },
+  uploadAudio: async (file: File) => {
+    const token = await getSessionToken();
+    return fetchJSON<AudioUploadResponse>(
+      `/api/uploads/audio?filename=${encodeURIComponent(file.name)}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": file.type || "application/octet-stream",
+          [SESSION_HEADER]: token,
+        },
+        body: file,
+      },
+    );
+  },
+  getAudioAnalysis: (storedName: string) =>
+    fetchJSON<AudioAnalysisResponse>(
+      `/api/uploads/audio/${encodeURIComponent(storedName)}/analysis`,
+    ),
+  setAudioSpeakers: (storedName: string, speakers: Record<string, string>) =>
+    fetchJSON<AudioAnalysisResponse>(
+      `/api/uploads/audio/${encodeURIComponent(storedName)}/speakers`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ speakers }),
+      },
+    ),
+  createVoiceSession: () => fetchJSON<VoiceSessionResponse>("/api/voice/session", { method: "POST" }),
+  runVoiceTool: (body: VoiceToolRequest) =>
+    fetchJSON<VoiceToolResponse>("/api/voice/tool", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
   getAnalytics: (days: number) =>
     fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`),
   getModelsAnalytics: (days: number) =>
@@ -641,6 +675,55 @@ export interface SessionMessagesResponse {
 export interface LogsResponse {
   file: string;
   lines: string[];
+}
+
+export interface AudioUploadResponse {
+  ok: boolean;
+  original_name: string;
+  stored_name: string;
+  path: string;
+  size_bytes: number;
+  rolly_user: string;
+  prompt: string;
+  analysis_status: string;
+  analysis_url: string;
+}
+
+export interface AudioAnalysisSpeaker {
+  speaker: string;
+  example: string;
+}
+
+export interface AudioAnalysisTurn {
+  speaker: string;
+  text: string;
+}
+
+export interface AudioAnalysisResponse {
+  status: "not_started" | "queued" | "running" | "needs_speaker_names" | "complete" | "failed" | string;
+  speakers?: AudioAnalysisSpeaker[];
+  turns?: AudioAnalysisTurn[];
+  transcript?: string;
+  named_transcript?: string;
+  speaker_names?: Record<string, string>;
+  error?: string;
+}
+
+export interface VoiceToolRequest {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface VoiceToolResponse {
+  ok: boolean;
+  result: string;
+  error?: string;
+}
+
+export interface VoiceSessionResponse {
+  endpoint: string;
+  model: string;
+  client_secret: string;
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -273,11 +273,37 @@ export const api = {
         body: JSON.stringify({ speakers }),
       },
     ),
-  createVoiceSession: () => fetchJSON<VoiceSessionResponse>("/api/voice/session", { method: "POST" }),
-  runVoiceTool: (body: VoiceToolRequest) =>
+  createVoiceSession: (user?: string) =>
+    fetchJSON<VoiceSessionResponse>("/api/voice/session", {
+      method: "POST",
+      headers: user ? { "X-Rolly-User": user } : undefined,
+    }),
+  createVoiceCall: async (sdp: string, user?: string) => {
+    const headers = new Headers({ "Content-Type": "application/sdp" });
+    const token = window.__HERMES_SESSION_TOKEN__;
+    if (token) setSessionHeader(headers, token);
+    if (user) headers.set("X-Rolly-User", user);
+    const res = await fetch(`${BASE}/api/voice/call`, {
+      method: "POST",
+      headers,
+      body: sdp,
+      credentials: "include",
+    });
+    if (!res.ok) {
+      throw new Error(`${res.status}: ${await res.text()}`);
+    }
+    return res.text();
+  },
+  runVoiceTool: (body: VoiceToolRequest, user?: string) =>
     fetchJSON<VoiceToolResponse>("/api/voice/tool", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: user ? { "Content-Type": "application/json", "X-Rolly-User": user } : { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  saveVoiceTranscript: (body: VoiceTranscriptEvent, user?: string) =>
+    fetchJSON<{ ok: boolean; path: string }>("/api/voice/transcript", {
+      method: "POST",
+      headers: user ? { "Content-Type": "application/json", "X-Rolly-User": user } : { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }),
   getAnalytics: (days: number) =>
@@ -712,6 +738,15 @@ export interface AudioAnalysisResponse {
 export interface VoiceToolRequest {
   name: string;
   arguments: Record<string, unknown>;
+}
+
+export interface VoiceTranscriptEvent {
+  call_id: string;
+  role: string;
+  text: string;
+  event_type?: string;
+  user?: string;
+  timestamp?: string;
 }
 
 export interface VoiceToolResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -813,6 +813,8 @@ export interface VoiceMeetInviteResponse {
   mode: "meet";
   call_id: string;
   invite_url: string;
+  participant_audio_routing?: "not_supported" | "supported";
+  participant_audio_routing_detail?: string;
   feature_flag: string;
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -323,10 +323,26 @@ export const api = {
       headers: user ? { "Content-Type": "application/json", "X-Rolly-User": user } : { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }),
-  getVoiceRoom: (callId: string, since = 0, limit = 200, user?: string) =>
-    fetchJSON<VoiceRoomResponse>(`/api/voice/room?call_id=${encodeURIComponent(callId)}&since=${since}&limit=${limit}`, {
+  getVoiceRoom: (callId: string, since = 0, limit = 200, user?: string, waitMs = 0) => {
+    const qs = new URLSearchParams({ call_id: callId, since: String(since), limit: String(limit) });
+    if (waitMs > 0) qs.set("wait_ms", String(waitMs));
+    return fetchJSON<VoiceRoomResponse>(`/api/voice/room?${qs.toString()}`, {
       headers: user ? { "X-Rolly-User": user } : undefined,
+    });
+  },
+  postVoiceMeetSignal: (body: VoiceMeetSignalRequest, user?: string) =>
+    fetchJSON<{ ok: boolean; signal: VoiceMeetSignal }>("/api/voice/meet/signal", {
+      method: "POST",
+      headers: user ? { "Content-Type": "application/json", "X-Rolly-User": user } : { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
     }),
+  getVoiceMeetSignals: (callId: string, since = 0, limit = 200, user?: string, waitMs = 0) => {
+    const qs = new URLSearchParams({ call_id: callId, since: String(since), limit: String(limit) });
+    if (waitMs > 0) qs.set("wait_ms", String(waitMs));
+    return fetchJSON<VoiceMeetSignalsResponse>(`/api/voice/meet/signals?${qs.toString()}`, {
+      headers: user ? { "X-Rolly-User": user } : undefined,
+    });
+  },
   getAnalytics: (days: number) =>
     fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`),
   getModelsAnalytics: (days: number) =>
@@ -794,6 +810,31 @@ export interface VoiceRoomResponse {
   cursor: number;
   participants: VoiceRoomParticipant[];
   events: VoiceRoomEvent[];
+}
+
+export interface VoiceMeetSignalRequest {
+  call_id: string;
+  type: "join" | "leave" | "offer" | "answer" | "ice" | string;
+  payload?: Record<string, unknown>;
+  to_user?: string | null;
+  user?: string;
+}
+
+export interface VoiceMeetSignal {
+  index: number;
+  timestamp: string;
+  call_id: string;
+  from_user: string;
+  to_user?: string | null;
+  type: "join" | "leave" | "offer" | "answer" | "ice" | string;
+  payload: Record<string, unknown>;
+}
+
+export interface VoiceMeetSignalsResponse {
+  ok: boolean;
+  call_id: string;
+  cursor: number;
+  signals: VoiceMeetSignal[];
 }
 
 export interface VoiceToolResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -323,6 +323,10 @@ export const api = {
       headers: user ? { "Content-Type": "application/json", "X-Rolly-User": user } : { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }),
+  getVoiceRoom: (callId: string, since = 0, limit = 200, user?: string) =>
+    fetchJSON<VoiceRoomResponse>(`/api/voice/room?call_id=${encodeURIComponent(callId)}&since=${since}&limit=${limit}`, {
+      headers: user ? { "X-Rolly-User": user } : undefined,
+    }),
   getAnalytics: (days: number) =>
     fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`),
   getModelsAnalytics: (days: number) =>
@@ -770,6 +774,26 @@ export interface VoiceTranscriptEvent {
   sequence?: number;
   elapsed_ms?: number;
   metadata?: Record<string, unknown>;
+}
+
+export interface VoiceRoomParticipant {
+  user: string;
+  status: "live" | "left" | "unknown" | string;
+  joined_at?: string | null;
+  left_at?: string | null;
+}
+
+export interface VoiceRoomEvent extends VoiceTranscriptEvent {
+  index: number;
+  session_id?: string;
+}
+
+export interface VoiceRoomResponse {
+  ok: boolean;
+  call_id: string;
+  cursor: number;
+  participants: VoiceRoomParticipant[];
+  events: VoiceRoomEvent[];
 }
 
 export interface VoiceToolResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -747,6 +747,9 @@ export interface VoiceTranscriptEvent {
   event_type?: string;
   user?: string;
   timestamp?: string;
+  sequence?: number;
+  elapsed_ms?: number;
+  metadata?: Record<string, unknown>;
 }
 
 export interface VoiceToolResponse {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -18,6 +18,7 @@ export const HERMES_BASE_PATH = readBasePath();
 const BASE = HERMES_BASE_PATH;
 
 import type { DashboardTheme } from "@/themes/types";
+import { getRollyUserSlug } from "@/lib/rollyIdentity";
 
 // Ephemeral session token for protected endpoints.
 // Injected into index.html by the server — never fetched via API.
@@ -51,6 +52,10 @@ export async function fetchJSON<T>(
   const token = window.__HERMES_SESSION_TOKEN__;
   if (token) {
     setSessionHeader(headers, token);
+  }
+  const rollyUser = getRollyUserSlug();
+  if (rollyUser && !headers.has("X-Rolly-User")) {
+    headers.set("X-Rolly-User", rollyUser);
   }
   const res = await fetch(`${BASE}${url}`, {
     ...init,
@@ -278,12 +283,14 @@ export const api = {
       method: "POST",
       headers: user ? { "X-Rolly-User": user } : undefined,
     }),
-  createVoiceCall: async (sdp: string, user?: string) => {
+  createVoiceCall: async (sdp: string, user?: string, mode: "solo" | "meet" = "solo") => {
     const headers = new Headers({ "Content-Type": "application/sdp" });
     const token = window.__HERMES_SESSION_TOKEN__;
     if (token) setSessionHeader(headers, token);
-    if (user) headers.set("X-Rolly-User", user);
-    const res = await fetch(`${BASE}/api/voice/call`, {
+    const rollyUser = user || getRollyUserSlug();
+    if (rollyUser) headers.set("X-Rolly-User", rollyUser);
+    headers.set("X-Rolly-Voice-Mode", mode);
+    const res = await fetch(`${BASE}/api/voice/call?mode=${encodeURIComponent(mode)}`, {
       method: "POST",
       headers,
       body: sdp,
@@ -294,11 +301,21 @@ export const api = {
     }
     return res.text();
   },
+  createVoiceMeetInvite: (body: { call_id: string; user?: string }) =>
+    fetchJSON<VoiceMeetInviteResponse>("/api/voice/meet/invite", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
   runVoiceTool: (body: VoiceToolRequest, user?: string) =>
     fetchJSON<VoiceToolResponse>("/api/voice/tool", {
       method: "POST",
       headers: user ? { "Content-Type": "application/json", "X-Rolly-User": user } : { "Content-Type": "application/json" },
       body: JSON.stringify(body),
+    }),
+  getVoiceTask: (taskId: string, user?: string) =>
+    fetchJSON<VoiceTaskResponse>(`/api/voice/tasks/${encodeURIComponent(taskId)}`, {
+      headers: user ? { "X-Rolly-User": user } : undefined,
     }),
   saveVoiceTranscript: (body: VoiceTranscriptEvent, user?: string) =>
     fetchJSON<{ ok: boolean; path: string }>("/api/voice/transcript", {
@@ -738,6 +755,9 @@ export interface AudioAnalysisResponse {
 export interface VoiceToolRequest {
   name: string;
   arguments: Record<string, unknown>;
+  call_id?: string;
+  realtime_call_id?: string;
+  idempotency_key?: string;
 }
 
 export interface VoiceTranscriptEvent {
@@ -755,13 +775,45 @@ export interface VoiceTranscriptEvent {
 export interface VoiceToolResponse {
   ok: boolean;
   result: string;
+  data?: Record<string, unknown>;
+  tool_name?: string;
+  cached?: boolean;
   error?: string;
+}
+
+export interface VoiceTaskProgress {
+  timestamp: string;
+  event_type: string;
+  message: string;
+}
+
+export interface VoiceTaskResponse {
+  ok: boolean;
+  task_id: string;
+  call_id: string;
+  user: string;
+  request: string;
+  session_id: string;
+  status: "queued" | "running" | "complete" | "failed" | "cancelled" | string;
+  progress: VoiceTaskProgress[];
+  result?: string | null;
+  error?: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface VoiceSessionResponse {
   endpoint: string;
   model: string;
   client_secret: string;
+}
+
+export interface VoiceMeetInviteResponse {
+  ok: boolean;
+  mode: "meet";
+  call_id: string;
+  invite_url: string;
+  feature_flag: string;
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/lib/rollyIdentity.ts
+++ b/web/src/lib/rollyIdentity.ts
@@ -1,0 +1,51 @@
+export type RollyDashboardUser = {
+  slug: string;
+  label: string;
+  admin?: boolean;
+};
+
+export const ROLLY_DASHBOARD_USERS: RollyDashboardUser[] = [
+  { slug: "deniz", label: "Deniz", admin: true },
+  { slug: "arman", label: "Arman", admin: true },
+  { slug: "buket", label: "Buket" },
+  { slug: "metin", label: "Metin" },
+  { slug: "guest", label: "Guest" },
+];
+
+const STORAGE_KEY = "rolly-dashboard-user";
+const COOKIE_KEY = "rolly_user";
+const USER_SLUGS = new Set(ROLLY_DASHBOARD_USERS.map((user) => user.slug));
+
+export function normalizeRollyUserSlug(value: string | null | undefined): string {
+  const slug = (value ?? "").trim().toLowerCase();
+  return USER_SLUGS.has(slug) ? slug : "";
+}
+
+function readCookie(): string {
+  if (typeof document === "undefined") return "";
+  const prefix = `${COOKIE_KEY}=`;
+  const match = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return normalizeRollyUserSlug(match?.slice(prefix.length));
+}
+
+export function getRollyUserSlug(): string {
+  if (typeof window === "undefined") return "";
+  return normalizeRollyUserSlug(window.localStorage.getItem(STORAGE_KEY)) || readCookie();
+}
+
+export function getRollyUser(slug = getRollyUserSlug()): RollyDashboardUser | null {
+  const normalized = normalizeRollyUserSlug(slug);
+  return ROLLY_DASHBOARD_USERS.find((user) => user.slug === normalized) ?? null;
+}
+
+export function setRollyUserSlug(slug: string): string {
+  const normalized = normalizeRollyUserSlug(slug);
+  if (typeof window === "undefined" || !normalized) return normalized;
+  window.localStorage.setItem(STORAGE_KEY, normalized);
+  document.cookie = `${COOKIE_KEY}=${normalized}; path=/; max-age=31536000; SameSite=Lax`;
+  window.dispatchEvent(new CustomEvent("rolly-user-change", { detail: normalized }));
+  return normalized;
+}

--- a/web/src/lib/voiceMeet.ts
+++ b/web/src/lib/voiceMeet.ts
@@ -1,0 +1,17 @@
+const ROLLY_WAKE_NAMES = "(?:rolly|rollie|rowley|rowly|rowy|roley|rally)";
+const HEY_ROLLY_RE = new RegExp(`\\bhey\\s+${ROLLY_WAKE_NAMES}\\b`);
+const DIRECT_ROLLY_RE = new RegExp(`^${ROLLY_WAKE_NAMES}\\b`);
+
+export function normalizeMeetTranscript(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function isRollyWakePhrase(text: string): boolean {
+  const normalized = normalizeMeetTranscript(text);
+  return HEY_ROLLY_RE.test(normalized) || DIRECT_ROLLY_RE.test(normalized);
+}

--- a/web/src/lib/voiceMeet.ts
+++ b/web/src/lib/voiceMeet.ts
@@ -1,6 +1,5 @@
 const ROLLY_WAKE_NAMES = "(?:rolly|rollie|rowley|rowly|rowy|roley|rally)";
 const HEY_ROLLY_RE = new RegExp(`\\bhey\\s+${ROLLY_WAKE_NAMES}\\b`);
-const DIRECT_ROLLY_RE = new RegExp(`^${ROLLY_WAKE_NAMES}\\b`);
 
 export function normalizeMeetTranscript(text: string): string {
   return text
@@ -13,5 +12,5 @@ export function normalizeMeetTranscript(text: string): string {
 
 export function isRollyWakePhrase(text: string): boolean {
   const normalized = normalizeMeetTranscript(text);
-  return HEY_ROLLY_RE.test(normalized) || DIRECT_ROLLY_RE.test(normalized);
+  return HEY_ROLLY_RE.test(normalized);
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,6 +12,14 @@ import { HERMES_BASE_PATH } from "./lib/api";
 // can access React, components, etc. immediately.
 exposePluginSDK();
 
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    void navigator.serviceWorker.register("/sw.js").catch((error: unknown) => {
+      console.warn("Rolly service worker registration failed", error);
+    });
+  });
+}
+
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter basename={HERMES_BASE_PATH || undefined}>
     <I18nProvider>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -26,7 +26,8 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, X } from "lucide-react";
+import { ClipboardPaste, Copy, PanelRight, Send, X } from "lucide-react";
+import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -139,7 +140,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       : null,
   );
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+  const [composerDraft, setComposerDraft] = useState("");
+  const [pasteState, setPasteState] = useState<"idle" | "pasted" | "blocked">("idle");
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pasteResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Raw state for the mobile side-sheet + a derived value that force-
   // closes whenever the chat tab isn't active.  The *derived* value is
   // what side-effects (body-scroll lock, keydown listener, portal render)
@@ -177,6 +181,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const kanbanTitleParam = searchParams.get("kanban_title");
   const ptyModeParam = searchParams.get("pty_mode");
   const tmuxSessionParam = searchParams.get("tmux_session");
+  const isTmuxTerminal = ptyModeParam === "tmux" || !!tmuxSessionParam;
   const terminalParams = useMemo(() => {
     const params = new URLSearchParams();
     if (ptyModeParam) params.set("pty_mode", ptyModeParam);
@@ -297,6 +302,51 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     termRef.current?.focus();
   };
 
+  const sendTextToTerminal = useCallback((text: string, submit = true) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const term = termRef.current;
+    const ws = wsRef.current;
+    if (!term || !ws || ws.readyState !== WebSocket.OPEN) return;
+    // xterm.paste preserves terminal paste semantics, including bracketed
+    // paste when the TUI/shell has it enabled. A short delayed Return lets
+    // dictated/mobile text submit without making the user focus xterm first.
+    term.paste(trimmed);
+    if (submit) {
+      window.setTimeout(() => {
+        const s = wsRef.current;
+        if (s && s.readyState === WebSocket.OPEN) s.send("\r");
+      }, 80);
+    }
+    term.focus();
+  }, []);
+
+  const submitComposerDraft = useCallback((event?: FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
+    const text = composerDraft;
+    setComposerDraft("");
+    sendTextToTerminal(text);
+  }, [composerDraft, sendTextToTerminal]);
+
+  const pasteClipboardIntoComposer = useCallback(() => {
+    navigator.clipboard
+      .readText()
+      .then((text) => {
+        if (!text) return;
+        setComposerDraft((prev) => (prev ? `${prev}\n${text}` : text));
+        setPasteState("pasted");
+      })
+      .catch(() => setPasteState("blocked"));
+    if (pasteResetRef.current) clearTimeout(pasteResetRef.current);
+    pasteResetRef.current = setTimeout(() => setPasteState("idle"), 1500);
+  }, []);
+
+  const handleComposerKeyDown = useCallback((event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    submitComposerDraft();
+  }, [submitComposerDraft]);
+
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -335,7 +385,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       rightClickSelectsWord: true,
       // Browser-embedded chat runs the TUI in inline mode. Keep transcript
       // history in xterm.js so the browser wheel can scroll it directly.
-      scrollback: 5000,
+      // tmux sessions keep much more local scrollback too, while mouse-wheel
+      // events are passed through below so tmux copy-mode can handle panes.
+      scrollback: 100000,
+      scrollOnUserInput: false,
       theme: TERMINAL_THEME,
     });
     termRef.current = term;
@@ -439,20 +492,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.loadAddon(fit);
 
     // Dashboard chat should scroll the browser-side transcript, not send
-    // mouse-wheel protocol bytes through the PTY.
-    term.attachCustomWheelEventHandler((ev) => {
-      const delta = ev.deltaY;
-      if (!delta) {
+    // mouse-wheel protocol bytes through the PTY. Tmux sessions are the
+    // exception: Deniz's tmux config binds WheelUpPane/WheelDownPane, so let
+    // xterm emit mouse reports and let tmux enter/leave copy-mode itself.
+    if (!isTmuxTerminal) {
+      term.attachCustomWheelEventHandler((ev) => {
+        const delta = ev.deltaY;
+        if (!delta) {
+          return false;
+        }
+
+        const step = Math.max(1, Math.round(Math.abs(delta) / 50));
+        term.scrollLines(delta > 0 ? step : -step);
+
+        ev.preventDefault();
+        ev.stopPropagation();
         return false;
-      }
-
-      const step = Math.max(1, Math.round(Math.abs(delta) / 50));
-      term.scrollLines(delta > 0 ? step : -step);
-
-      ev.preventDefault();
-      ev.stopPropagation();
-      return false;
-    });
+      });
+    }
 
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
@@ -647,23 +704,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // Keystrokes → PTY.
     //
     // IMPORTANT:
-    // The embedded web chat has occasionally surfaced stray letters/digits
-    // in the input line after a turn completes. The most likely culprit is
-    // browser-side terminal control traffic being forwarded back into the
-    // PTY as if it were user text. SGR mouse tracking is the highest-risk
-    // path here: xterm.js emits raw CSI reports (`\x1b[<...`) that look like
-    // ordinary bytes to the backend.
-    //
-    // For the browser embed we prefer input stability over terminal-style
-    // mouse reporting, so we drop SGR mouse reports entirely instead of
-    // forwarding them into Hermes. Keyboard input, paste, and resize still
-    // behave normally.
+    // Plain embedded web chat can surface stray letters/digits if browser-side
+    // mouse control traffic is forwarded into the Hermes TUI. Keep dropping
+    // SGR mouse reports there. Tmux sessions need those reports for pane-local
+    // mouse scrolling/copy-mode, so forward all data when pty_mode=tmux.
       // eslint-disable-next-line no-control-regex -- intentional ESC byte in xterm SGR mouse report parser
       const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
       onDataDisposable = term.onData((data) => {
         if (ws.readyState !== WebSocket.OPEN) return;
 
-        if (SGR_MOUSE_RE.test(data)) {
+        if (!isTmuxTerminal && SGR_MOUSE_RE.test(data)) {
           return;
         }
 
@@ -708,8 +758,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         clearTimeout(copyResetRef.current);
         copyResetRef.current = null;
       }
+      if (pasteResetRef.current) {
+        clearTimeout(pasteResetRef.current);
+        pasteResetRef.current = null;
+      }
     };
-  }, [channel, resumeParam, terminalParams, initialKanbanPrompt]);
+  }, [channel, resumeParam, terminalParams, initialKanbanPrompt, isTmuxTerminal]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
@@ -871,6 +925,49 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             ref={hostRef}
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
+
+          <form
+            onSubmit={submitComposerDraft}
+            className="mt-2 flex shrink-0 items-end gap-1.5 rounded border border-current/20 bg-black/20 p-1.5"
+            style={{ color: TERMINAL_THEME.foreground }}
+          >
+            <textarea
+              value={composerDraft}
+              onChange={(event) => setComposerDraft(event.target.value)}
+              onKeyDown={handleComposerKeyDown}
+              placeholder="Dictate or paste text… Enter sends, Shift+Enter newline"
+              rows={1}
+              autoCapitalize="sentences"
+              className={cn(
+                "min-h-8 max-h-24 flex-1 resize-none rounded bg-black/20 px-2 py-1.5 text-sm leading-snug outline-none",
+                "placeholder:text-current/45 focus:ring-1 focus:ring-current/40",
+              )}
+            />
+            <Button
+              type="button"
+              ghost
+              onClick={pasteClipboardIntoComposer}
+              title="Paste clipboard into the dictation box"
+              aria-label="Paste clipboard into dictation box"
+              className="h-8 shrink-0 rounded border border-current/25 px-2 text-xs"
+            >
+              <ClipboardPaste className="h-3.5 w-3.5" />
+              <span className="sr-only">
+                {pasteState === "blocked" ? "paste blocked" : pasteState === "pasted" ? "pasted" : "paste"}
+              </span>
+            </Button>
+            <Button
+              type="submit"
+              ghost
+              disabled={!composerDraft.trim()}
+              title="Send dictated/pasted text to the terminal"
+              aria-label="Send dictated or pasted text"
+              className="h-8 shrink-0 rounded border border-current/25 px-2 text-xs disabled:opacity-40"
+            >
+              <Send className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">send</span>
+            </Button>
+          </form>
 
           <Button
             ghost

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -408,19 +408,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     //
     // Three independent paths all route to the system clipboard:
     //
-    //   1. **Selection → Ctrl+C (or Cmd+C on macOS).**  Ink's own handler
+    //   1. **Mouse selection.**  On mouseup, if xterm has a selection,
+    //      write it directly to the system clipboard. This matches the
+    //      browser terminal expectation that dragging over text copies it
+    //      without needing a second keyboard shortcut.
+    //
+    //   2. **Selection → Ctrl+C (or Cmd+C on macOS).**  Ink's own handler
     //      in useInputHandlers.ts turns Ctrl+C into a copy when the
     //      terminal has a selection, then emits an OSC 52 escape.  Our
     //      OSC 52 handler below decodes that escape and writes to the
     //      browser clipboard — so the flow works just like it does in
     //      `hermes --tui`.
     //
-    //   2. **Ctrl/Cmd+Shift+C.**  Belt-and-suspenders shortcut that
+    //   3. **Ctrl/Cmd+Shift+C.**  Belt-and-suspenders shortcut that
     //      operates directly on xterm's selection, useful if the TUI
     //      ever stops listening (e.g. overlays / pickers) or if the user
     //      has selected with the mouse outside of Ink's selection model.
     //
-    //   3. **Ctrl/Cmd+Shift+V.**  Reads the system clipboard and feeds
+    //   4. **Ctrl/Cmd+Shift+V.**  Reads the system clipboard and feeds
     //      it to the terminal as keyboard input.  xterm's paste() wraps
     //      it with bracketed-paste if the host has that mode enabled.
     //
@@ -529,6 +534,44 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     term.loadAddon(new WebLinksAddon());
 
     term.open(host);
+
+    // Make plain click-drag act like a browser terminal selection even when
+    // the child TUI/tmux has enabled xterm mouse tracking. xterm's public
+    // option only supports forcing this with Option/Alt; Deniz expects normal
+    // drag-select to copy text, so override the internal selection gate for
+    // primary-button drags in this embedded dashboard terminal.
+    const selectionService = (term as unknown as {
+      _core?: {
+        _selectionService?: {
+          shouldForceSelection?: (event: MouseEvent) => boolean;
+        };
+      };
+    })._core?._selectionService;
+    const originalShouldForceSelection = selectionService?.shouldForceSelection?.bind(selectionService);
+    if (selectionService && originalShouldForceSelection) {
+      selectionService.shouldForceSelection = (event: MouseEvent) => {
+        if (event.button === 0) return true;
+        return originalShouldForceSelection(event);
+      };
+    }
+
+    let lastMouseSelectionCopy = "";
+    const copyTerminalSelectionOnMouseUp = () => {
+      const selected = term.getSelection();
+      if (!selected || selected === lastMouseSelectionCopy) return;
+      lastMouseSelectionCopy = selected;
+      navigator.clipboard.writeText(selected).catch((err) => {
+        console.warn("[dashboard clipboard] mouse selection copy failed:", err.message);
+      });
+      setCopyState("copied");
+      if (copyResetRef.current) clearTimeout(copyResetRef.current);
+      copyResetRef.current = setTimeout(() => setCopyState("idle"), 1500);
+    };
+    const resetLastMouseSelectionCopy = () => {
+      if (!term.getSelection()) lastMouseSelectionCopy = "";
+    };
+    const selectionDisposable = term.onSelectionChange(resetLastMouseSelectionCopy);
+    host.addEventListener("mouseup", copyTerminalSelectionOnMouseUp);
 
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells
@@ -760,6 +803,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // effect's top level so it can't reach into that scope — close via
       // the ref instead. ``?.`` covers the race where unmount fires before
       // the ticket fetch resolves and ``wsRef.current`` was never assigned.
+      host.removeEventListener("mouseup", copyTerminalSelectionOnMouseUp);
+      selectionDisposable.dispose();
+      if (selectionService && originalShouldForceSelection) {
+        selectionService.shouldForceSelection = originalShouldForceSelection;
+      }
       wsRef.current?.close();
       wsRef.current = null;
       term.dispose();

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -284,6 +284,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   }, [isActive, narrow, mobilePanelOpen, modelToolsLabel, setEnd]);
 
   const handleCopyLast = () => {
+    const selected = termRef.current?.getSelection();
+    if (selected) {
+      navigator.clipboard.writeText(selected).catch((err) => {
+        console.warn("[dashboard clipboard] selected copy failed:", err.message);
+      });
+      termRef.current?.clearSelection();
+      setCopyState("copied");
+      if (copyResetRef.current) clearTimeout(copyResetRef.current);
+      copyResetRef.current = setTimeout(() => setCopyState("idle"), 1500);
+      termRef.current?.focus();
+      return;
+    }
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
     // Send the slash as a burst, wait long enough for Ink's tokenizer to
@@ -303,15 +315,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   };
 
   const sendTextToTerminal = useCallback((text: string, submit = true) => {
-    const trimmed = text.trim();
-    if (!trimmed) return;
+    if (!text.trim()) return;
     const term = termRef.current;
     const ws = wsRef.current;
     if (!term || !ws || ws.readyState !== WebSocket.OPEN) return;
     // xterm.paste preserves terminal paste semantics, including bracketed
-    // paste when the TUI/shell has it enabled. A short delayed Return lets
-    // dictated/mobile text submit without making the user focus xterm first.
-    term.paste(trimmed);
+    // paste when the TUI/shell has it enabled. Keep the user's pasted text
+    // byte-for-byte instead of trimming command whitespace.
+    term.paste(text);
     if (submit) {
       window.setTimeout(() => {
         const s = wsRef.current;
@@ -900,7 +911,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex min-h-0 flex-1 flex-col gap-1">
       <PluginSlot name="chat:top" />
       {mobileModelToolsPortal}
 
@@ -910,15 +921,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         </div>
       )}
 
-      <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
+      <div className="flex min-h-0 flex-1 flex-col gap-1 lg:flex-row lg:gap-2">
         <div
           className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
-            "p-2 sm:p-3",
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-sm",
+            "p-1",
           )}
           style={{
             backgroundColor: TERMINAL_THEME.background,
-            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
+            boxShadow: "none",
           }}
         >
           <div
@@ -928,19 +939,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
           <form
             onSubmit={submitComposerDraft}
-            className="mt-2 flex shrink-0 items-end gap-1.5 rounded border border-current/20 bg-black/20 p-1.5"
+            className="mt-1 flex shrink-0 items-end gap-1 rounded-sm border border-current/15 bg-black/15 p-1"
             style={{ color: TERMINAL_THEME.foreground }}
           >
             <textarea
               value={composerDraft}
               onChange={(event) => setComposerDraft(event.target.value)}
               onKeyDown={handleComposerKeyDown}
-              placeholder="Dictate or paste text… Enter sends, Shift+Enter newline"
+              placeholder="paste/dictate… Enter sends"
               rows={1}
               autoCapitalize="sentences"
               className={cn(
-                "min-h-8 max-h-24 flex-1 resize-none rounded bg-black/20 px-2 py-1.5 text-sm leading-snug outline-none",
-                "placeholder:text-current/45 focus:ring-1 focus:ring-current/40",
+                "min-h-6 max-h-20 flex-1 resize-none rounded-sm bg-black/15 px-1.5 py-1 text-xs leading-tight outline-none",
+                "placeholder:text-current/40 focus:ring-1 focus:ring-current/35",
               )}
             />
             <Button
@@ -949,7 +960,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               onClick={pasteClipboardIntoComposer}
               title="Paste clipboard into the dictation box"
               aria-label="Paste clipboard into dictation box"
-              className="h-8 shrink-0 rounded border border-current/25 px-2 text-xs"
+              className="h-6 shrink-0 rounded-sm border border-current/20 px-1.5 text-[11px]"
             >
               <ClipboardPaste className="h-3.5 w-3.5" />
               <span className="sr-only">
@@ -962,7 +973,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               disabled={!composerDraft.trim()}
               title="Send dictated/pasted text to the terminal"
               aria-label="Send dictated or pasted text"
-              className="h-8 shrink-0 rounded border border-current/25 px-2 text-xs disabled:opacity-40"
+              className="h-6 shrink-0 rounded-sm border border-current/20 px-1.5 text-[11px] disabled:opacity-40"
             >
               <Send className="h-3.5 w-3.5" />
               <span className="hidden sm:inline">send</span>
@@ -972,24 +983,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           <Button
             ghost
             onClick={handleCopyLast}
-            title="Copy last assistant response as raw markdown"
-            aria-label="Copy last assistant response"
+            title="Copy selection, or copy last assistant response"
+            aria-label="Copy selection or last assistant response"
             className={cn(
               "absolute z-10",
               "normal-case tracking-normal font-normal",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-70 hover:opacity-100 hover:border-current/60",
+              "rounded-sm border border-current/20",
+              "bg-black/10 backdrop-blur-sm",
+              "opacity-35 hover:opacity-100 hover:border-current/50",
               "transition-opacity duration-150",
-              "bottom-2 right-2 px-2 py-1 text-xs sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5",
-              "lg:bottom-4 lg:right-4",
+              "bottom-8 right-1 px-1.5 py-0.5 text-[11px] sm:right-1",
             )}
             style={{ color: TERMINAL_THEME.foreground }}
           >
             <span className="inline-flex items-center gap-1.5">
               <Copy className="h-3 w-3 shrink-0" />
-              <span className="hidden min-[400px]:inline tracking-wide">
-                {copyState === "copied" ? "copied" : "copy last response"}
+              <span className="hidden min-[520px]:inline tracking-wide">
+                {copyState === "copied" ? "copied" : "copy"}
               </span>
             </span>
           </Button>
@@ -1000,7 +1010,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             id="chat-side-panel"
             role="complementary"
             aria-label={modelToolsLabel}
-            className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
+            className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-72"
           >
             <div className="min-h-0 flex-1 overflow-hidden">
               <ChatSidebar channel={channel} />

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -41,6 +41,7 @@ function buildWsUrl(
   authParam: [string, string],
   resume: string | null,
   channel: string,
+  terminalParams?: URLSearchParams,
 ): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   // ``authParam`` is ``["token", <session>]`` in loopback mode and
@@ -48,7 +49,15 @@ function buildWsUrl(
   // ``_ws_auth_ok`` picks whichever shape matches the current gate state.
   const qs = new URLSearchParams({ [authParam[0]]: authParam[1], channel });
   if (resume) qs.set("resume", resume);
+  terminalParams?.forEach((value, key) => {
+    if (key === "pty_mode" || key === "tmux_session") qs.set(key, value);
+  });
   return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
+}
+
+function buildKanbanPrompt(taskId: string, title: string | null): string {
+  const titleLine = title ? `Title: ${title}` : "Title: (unknown)";
+  return `You are Rolly Chat inside Kanban card ${taskId}. ${titleLine}. This conversation is specifically about this card. Start by briefly orienting yourself to the card, then ask what Deniz wants to do next unless the next message already gives direction.`;
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
@@ -164,7 +173,22 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const kanbanTaskParam = searchParams.get("kanban_task");
+  const kanbanTitleParam = searchParams.get("kanban_title");
+  const ptyModeParam = searchParams.get("pty_mode");
+  const tmuxSessionParam = searchParams.get("tmux_session");
+  const terminalParams = useMemo(() => {
+    const params = new URLSearchParams();
+    if (ptyModeParam) params.set("pty_mode", ptyModeParam);
+    if (tmuxSessionParam) params.set("tmux_session", tmuxSessionParam);
+    return params;
+  }, [ptyModeParam, tmuxSessionParam]);
+  const initialKanbanPrompt = useMemo(
+    () => kanbanTaskParam ? buildKanbanPrompt(kanbanTaskParam, kanbanTitleParam) : null,
+    [kanbanTaskParam, kanbanTitleParam],
+  );
+  const initialPromptSentRef = useRef<string | null>(null);
+  const channel = useMemo(() => generateChannelId(), [resumeParam, kanbanTaskParam, kanbanTitleParam, ptyModeParam, tmuxSessionParam]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -567,7 +591,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     void (async () => {
       const authParam = await buildWsAuthParam();
       if (unmounting) return;
-      const url = buildWsUrl(authParam, resumeParam, channel);
+      const url = buildWsUrl(authParam, resumeParam, channel, terminalParams);
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
@@ -579,6 +603,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // follow up with the authoritative measurement — at worst Ink
       // reflows once after the PTY boots, which is imperceptible.
       ws.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
+      if (initialKanbanPrompt && initialPromptSentRef.current !== initialKanbanPrompt) {
+        initialPromptSentRef.current = initialKanbanPrompt;
+        window.setTimeout(() => {
+          if (!unmounting && ws.readyState === WebSocket.OPEN) {
+            ws.send(initialKanbanPrompt);
+            window.setTimeout(() => {
+              if (!unmounting && ws.readyState === WebSocket.OPEN) ws.send("\r");
+            }, 120);
+          }
+        }, 400);
+      }
     };
 
     ws.onmessage = (ev) => {
@@ -674,7 +709,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, resumeParam, terminalParams, initialKanbanPrompt]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -18,7 +18,7 @@ import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
 
-const FILES = ["agent", "errors", "gateway"] as const;
+const FILES = ["agent", "errors", "gateway", "dashboard-out", "dashboard-err"] as const;
 const LEVELS = ["ALL", "DEBUG", "INFO", "WARNING", "ERROR"] as const;
 const COMPONENTS = ["all", "gateway", "agent", "tools", "cli", "cron"] as const;
 const LINE_COUNTS = [50, 100, 200, 500] as const;

--- a/web/src/pages/UploadPage.tsx
+++ b/web/src/pages/UploadPage.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useState } from "react";
+import { Upload, CheckCircle2, Copy, FileAudio, Loader2, UserRound } from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { api, type AudioAnalysisResponse, type AudioUploadResponse } from "@/lib/api";
+
+const ACCEPTED_AUDIO = [
+  ".aac",
+  ".aif",
+  ".aiff",
+  ".flac",
+  ".m4a",
+  ".mp3",
+  ".mp4",
+  ".oga",
+  ".ogg",
+  ".opus",
+  ".wav",
+  ".webm",
+].join(",");
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let size = value;
+  let unit = 0;
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024;
+    unit += 1;
+  }
+  return `${size.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function speakerQuestion(analysis: AudioAnalysisResponse | null): string {
+  const speakers = analysis?.speakers ?? [];
+  if (speakers.length < 2) return "";
+  const lines = speakers.map((speaker) => `${speaker.speaker}: “${speaker.example}”`);
+  return `Who are these speakers in the uploaded phone call?\n\n${lines.join("\n\n")}`;
+}
+
+export default function UploadPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [result, setResult] = useState<AudioUploadResponse | null>(null);
+  const [analysis, setAnalysis] = useState<AudioAnalysisResponse | null>(null);
+  const [speakerNames, setSpeakerNames] = useState<Record<string, string>>({});
+  const [savingNames, setSavingNames] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const helper = useMemo(() => {
+    if (!file) return "Pick an audio recording from your phone.";
+    return `${file.name} · ${formatBytes(file.size)}`;
+  }, [file]);
+
+  useEffect(() => {
+    if (!result?.stored_name) return;
+    let cancelled = false;
+    let timer: number | undefined;
+
+    async function poll() {
+      try {
+        const next = await api.getAudioAnalysis(result!.stored_name);
+        if (cancelled) return;
+        setAnalysis(next);
+        if (next.speaker_names) setSpeakerNames(next.speaker_names);
+        if (["queued", "running", "not_started"].includes(next.status)) {
+          timer = window.setTimeout(poll, 2500);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [result?.stored_name]);
+
+  async function onUpload() {
+    if (!file || uploading) return;
+    setUploading(true);
+    setError(null);
+    setResult(null);
+    setAnalysis(null);
+    setSpeakerNames({});
+    setCopied(false);
+    try {
+      setResult(await api.uploadAudio(file));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function copyText(text: string) {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  async function saveSpeakerNames() {
+    if (!result) return;
+    setSavingNames(true);
+    setError(null);
+    try {
+      setAnalysis(await api.setAudioSpeakers(result.stored_name, speakerNames));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSavingNames(false);
+    }
+  }
+
+  const question = speakerQuestion(analysis);
+  const analysisBusy = analysis && ["queued", "running", "not_started"].includes(analysis.status);
+
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col gap-5 px-4 py-6 sm:px-6">
+      <div>
+        <Typography className="font-mondwest text-display text-2xl uppercase tracking-[0.12em]">
+          Upload audio
+        </Typography>
+        <p className="mt-2 text-sm text-text-secondary">
+          Upload a phone call recording. Rolly will transcribe it, diarize speakers, then ask who each speaker is.
+        </p>
+      </div>
+
+      <label className="flex min-h-52 cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-current/25 bg-background-muted/40 p-6 text-center transition hover:border-current/50">
+        <FileAudio className="h-10 w-10 text-text-secondary" />
+        <div className="space-y-1">
+          <div className="text-base font-medium">Choose audio file</div>
+          <div className="text-sm text-text-secondary">{helper}</div>
+        </div>
+        <input
+          className="sr-only"
+          type="file"
+          accept={`${ACCEPTED_AUDIO},audio/*,video/mp4,video/webm`}
+          onChange={(event) => {
+            setResult(null);
+            setAnalysis(null);
+            setError(null);
+            setSpeakerNames({});
+            setFile(event.target.files?.[0] ?? null);
+          }}
+        />
+      </label>
+
+      <Button
+        className="h-12 w-full justify-center text-base sm:w-fit sm:px-8"
+        disabled={!file || uploading}
+        onClick={onUpload}
+      >
+        {uploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+        {uploading ? "Uploading…" : "Upload + diarize"}
+      </Button>
+
+      {error ? (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+          {error}
+        </div>
+      ) : null}
+
+      {result ? (
+        <div className="rounded-xl border border-current/15 bg-background-muted/40 p-4 text-sm">
+          <div className="mb-3 flex items-center gap-2 text-green-300">
+            <CheckCircle2 className="h-4 w-4" />
+            Uploaded {formatBytes(result.size_bytes)}
+          </div>
+          <div className="break-all rounded bg-black/20 p-3 font-mono text-xs text-text-secondary">
+            {result.path}
+          </div>
+        </div>
+      ) : null}
+
+      {analysisBusy ? (
+        <div className="flex items-center gap-2 rounded-xl border border-current/15 bg-background-muted/40 p-4 text-sm text-text-secondary">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Diarizing/transcribing… longer calls can take a bit.
+        </div>
+      ) : null}
+
+      {analysis?.status === "failed" ? (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+          Diarization failed: {analysis.error}
+        </div>
+      ) : null}
+
+      {question ? (
+        <div className="rounded-xl border border-current/15 bg-background-muted/40 p-4 text-sm">
+          <div className="mb-3 flex items-center gap-2 font-medium">
+            <UserRound className="h-4 w-4" />
+            Who said what?
+          </div>
+          <div className="space-y-3">
+            {(analysis?.speakers ?? []).map((speaker) => (
+              <label key={speaker.speaker} className="block space-y-1">
+                <div className="text-xs uppercase tracking-wide text-text-tertiary">{speaker.speaker}</div>
+                <div className="rounded bg-black/20 p-3 text-xs text-text-secondary">“{speaker.example}”</div>
+                <input
+                  className="w-full rounded border border-current/15 bg-background px-3 py-2 text-sm outline-none focus:border-current/40"
+                  placeholder={`Name for ${speaker.speaker}`}
+                  value={speakerNames[speaker.speaker] ?? ""}
+                  onChange={(event) => setSpeakerNames((prev) => ({ ...prev, [speaker.speaker]: event.target.value }))}
+                />
+              </label>
+            ))}
+          </div>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+            <Button className="justify-center" disabled={savingNames} onClick={saveSpeakerNames}>
+              {savingNames ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Save speaker names
+            </Button>
+            <Button className="justify-center" onClick={() => copyText(question)}>
+              <Copy className="mr-2 h-4 w-4" />
+              {copied ? "Copied" : "Copy question for chat"}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {analysis?.named_transcript ? (
+        <div className="rounded-xl border border-current/15 bg-background-muted/40 p-4 text-sm">
+          <div className="mb-2 font-medium">Transcript</div>
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded bg-black/20 p-3 text-xs text-text-secondary">
+            {analysis.named_transcript}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/pages/UploadPage.tsx
+++ b/web/src/pages/UploadPage.tsx
@@ -33,7 +33,7 @@ function formatBytes(value: number): string {
 
 function speakerQuestion(analysis: AudioAnalysisResponse | null): string {
   const speakers = analysis?.speakers ?? [];
-  if (speakers.length < 2) return "";
+  if (speakers.length === 0) return "";
   const lines = speakers.map((speaker) => `${speaker.speaker}: “${speaker.example}”`);
   return `Who are these speakers in the uploaded phone call?\n\n${lines.join("\n\n")}`;
 }

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { api, type VoiceMeetSignal, type VoiceRoomEvent, type VoiceRoomParticipant, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
@@ -10,6 +10,9 @@ type CallStatus = "idle" | "requesting" | "connecting" | "live" | "ending" | "er
 type LogKind = "system" | "user" | "rolly" | "tool" | "error";
 
 const VOICE_ACTION_BUTTON_CLASS = "leading-tight text-sm tracking-[0.12em] sm:text-base sm:tracking-[0.2em]";
+const AUTO_SCROLL_NEAR_BOTTOM_PX = 64;
+
+type ScrollColumn = "transcript" | "events";
 
 type WakeLockSentinelLike = EventTarget & {
   release: () => Promise<void>;
@@ -48,6 +51,15 @@ function isRealtimeSpeechEvent(entry: LogEntry): boolean {
   return entry.text === "Realtime API heard speech start." || entry.text === "Realtime API heard speech stop." || entry.text === "Realtime API committed mic audio.";
 }
 
+function isNearScrollBottom(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= AUTO_SCROLL_NEAR_BOTTOM_PX;
+}
+
+function scrollColumnToBottom(element: HTMLElement | null): void {
+  if (!element) return;
+  element.scrollTop = element.scrollHeight;
+}
+
 function sharedRoomLog(event: VoiceRoomEvent, localUser: string): { kind: LogKind; text: string } | null {
   const eventUser = event.user || "unknown dashboard user";
   if (eventUser === localUser && event.event_type !== "call_start" && event.event_type !== "call_end") return null;
@@ -80,6 +92,10 @@ export default function VoiceCallPage() {
       elapsedMs: null,
     },
   ]);
+  const transcriptScrollRef = useRef<HTMLDivElement | null>(null);
+  const eventsScrollRef = useRef<HTMLDivElement | null>(null);
+  const [transcriptAtLatest, setTranscriptAtLatest] = useState(true);
+  const [eventsAtLatest, setEventsAtLatest] = useState(true);
   const peerRef = useRef<RTCPeerConnection | null>(null);
   const dataRef = useRef<RTCDataChannel | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -1211,6 +1227,35 @@ export default function VoiceCallPage() {
   const speakerLabel = getRollyUser(speaker)?.label ?? "No dashboard user selected";
   const transcriptLogs = logs.filter((entry) => entry.kind === "user" || entry.kind === "rolly");
   const eventLogs = logs.filter((entry) => entry.kind !== "user" && entry.kind !== "rolly" && (verboseEvents || !isRealtimeSpeechEvent(entry)));
+  const lastTranscriptLog = transcriptLogs[transcriptLogs.length - 1];
+  const lastEventLog = eventLogs[eventLogs.length - 1];
+  const lastVoiceTask = voiceTasks[voiceTasks.length - 1];
+  const transcriptLatestKey = lastTranscriptLog?.id ?? "empty-transcript";
+  const eventsLatestKey = `${lastEventLog?.id ?? "empty-events"}:${lastVoiceTask?.task_id ?? "no-task"}:${lastVoiceTask?.updated_at ?? ""}`;
+
+  const updateScrollLock = useCallback((column: ScrollColumn, element: HTMLDivElement | null) => {
+    if (!element) return;
+    const atLatest = isNearScrollBottom(element);
+    if (column === "transcript") setTranscriptAtLatest(atLatest);
+    else setEventsAtLatest(atLatest);
+  }, []);
+
+  const jumpToLatest = useCallback(
+    (column: ScrollColumn) => {
+      const element = column === "transcript" ? transcriptScrollRef.current : eventsScrollRef.current;
+      scrollColumnToBottom(element);
+      updateScrollLock(column, element);
+    },
+    [updateScrollLock],
+  );
+
+  useLayoutEffect(() => {
+    if (transcriptAtLatest) scrollColumnToBottom(transcriptScrollRef.current);
+  }, [transcriptLatestKey, transcriptAtLatest]);
+
+  useLayoutEffect(() => {
+    if (eventsAtLatest) scrollColumnToBottom(eventsScrollRef.current);
+  }, [eventsLatestKey, eventsAtLatest]);
 
   return (
     <main className="flex h-full min-h-0 flex-col gap-4 overflow-auto p-4 lg:p-6">
@@ -1299,10 +1344,17 @@ export default function VoiceCallPage() {
 
       <section className="grid min-h-[24rem] gap-3 xl:grid-cols-[1fr_1fr_20rem]">
         <div className="min-h-0 border border-current/20 bg-black/30 p-3">
-          <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
-            Live transcript
-          </Typography>
-          <div className="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1 text-sm">
+          <div className="flex items-center justify-between gap-2">
+            <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
+              Live transcript
+            </Typography>
+            {!transcriptAtLatest ? (
+              <button className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary underline underline-offset-4 hover:text-midground" onClick={() => jumpToLatest("transcript")} type="button">
+                Jump to latest
+              </button>
+            ) : null}
+          </div>
+          <div ref={transcriptScrollRef} onScroll={(event) => updateScrollLock("transcript", event.currentTarget)} className="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1 text-sm">
             {(transcriptLogs.length ? transcriptLogs : [{ id: "empty-transcript", kind: "system" as LogKind, text: "No spoken transcript yet.", timestamp: new Date().toISOString(), elapsedMs: null }]).map((entry) => (
               <div key={entry.id} className="border border-current/10 bg-background-base/50 px-2 py-1">
                 <div className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary">
@@ -1314,10 +1366,17 @@ export default function VoiceCallPage() {
           </div>
         </div>
         <div className="min-h-0 border border-current/20 bg-black/30 p-3">
-          <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
-            Events + work
-          </Typography>
-          <div className="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1 text-sm">
+          <div className="flex items-center justify-between gap-2">
+            <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
+              Events + work
+            </Typography>
+            {!eventsAtLatest ? (
+              <button className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary underline underline-offset-4 hover:text-midground" onClick={() => jumpToLatest("events")} type="button">
+                Jump to latest
+              </button>
+            ) : null}
+          </div>
+          <div ref={eventsScrollRef} onScroll={(event) => updateScrollLock("events", event.currentTarget)} className="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1 text-sm">
             {eventLogs.map((entry) => (
               <div key={entry.id} className="border border-current/10 bg-background-base/50 px-2 py-1">
                 <div className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary">

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -1,0 +1,292 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { api, type VoiceToolRequest } from "@/lib/api";
+
+type CallStatus = "idle" | "requesting" | "connecting" | "live" | "ending" | "error";
+
+type LogKind = "system" | "user" | "rolly" | "tool" | "error";
+
+interface LogEntry {
+  id: string;
+  kind: LogKind;
+  text: string;
+}
+
+function logId(): string {
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function eventText(event: unknown): string | null {
+  if (!event || typeof event !== "object") return null;
+  const obj = event as Record<string, unknown>;
+  const direct = obj.transcript ?? obj.text ?? obj.delta;
+  return typeof direct === "string" && direct.trim() ? direct.trim() : null;
+}
+
+export default function VoiceCallPage() {
+  const [status, setStatus] = useState<CallStatus>("idle");
+  const [muted, setMuted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [logs, setLogs] = useState<LogEntry[]>([
+    {
+      id: logId(),
+      kind: "system",
+      text: "Prototype: browser WebRTC to realtime voice, with backend tool bridge for research.",
+    },
+  ]);
+  const peerRef = useRef<RTCPeerConnection | null>(null);
+  const dataRef = useRef<RTCDataChannel | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const callSeqRef = useRef(0);
+
+  const addLog = useCallback((kind: LogKind, text: string) => {
+    setLogs((prev) => [...prev.slice(-80), { id: logId(), kind, text }]);
+  }, []);
+
+  const stopCall = useCallback(() => {
+    callSeqRef.current += 1;
+    setStatus((current) => (current === "idle" ? current : "ending"));
+    if (dataRef.current) {
+      dataRef.current.onmessage = null;
+      dataRef.current.onerror = null;
+      dataRef.current.onopen = null;
+    }
+    dataRef.current?.close();
+    peerRef.current?.close();
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    if (audioRef.current?.srcObject instanceof MediaStream) {
+      audioRef.current.srcObject.getTracks().forEach((track) => track.stop());
+      audioRef.current.srcObject = null;
+    }
+    dataRef.current = null;
+    peerRef.current = null;
+    streamRef.current = null;
+    setMuted(false);
+    setStatus("idle");
+    addLog("system", "Call ended; microphone released.");
+  }, [addLog]);
+
+  const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
+    const channel = dataRef.current;
+    if (!channel || channel.readyState !== "open") return;
+    channel.send(JSON.stringify(payload));
+  }, []);
+
+  const handleToolCall = useCallback(
+    async (event: Record<string, unknown>) => {
+      const name = typeof event.name === "string" ? event.name : "";
+      const callId = typeof event.call_id === "string" ? event.call_id : "";
+      const rawArgs = typeof event.arguments === "string" ? event.arguments : "{}";
+      if (!name || !callId) return;
+
+      let args: Record<string, unknown> = {};
+      try {
+        args = JSON.parse(rawArgs) as Record<string, unknown>;
+      } catch {
+        args = { raw: rawArgs };
+      }
+
+      addLog("tool", `Running ${name}…`);
+      try {
+        const result = await api.runVoiceTool({ name, arguments: args } satisfies VoiceToolRequest);
+        const output = result.ok ? result.result : `Tool failed: ${result.error ?? "unknown error"}`;
+        addLog(result.ok ? "tool" : "error", output.slice(0, 700));
+        sendRealtimeEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: callId,
+            output,
+          },
+        });
+        sendRealtimeEvent({ type: "response.create" });
+      } catch (exc) {
+        const message = exc instanceof Error ? exc.message : String(exc);
+        addLog("error", message);
+        sendRealtimeEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: callId,
+            output: `Tool failed: ${message}`,
+          },
+        });
+        sendRealtimeEvent({ type: "response.create" });
+      }
+    },
+    [addLog, sendRealtimeEvent],
+  );
+
+  const handleRealtimeEvent = useCallback(
+    (message: MessageEvent<string>) => {
+      let event: Record<string, unknown>;
+      try {
+        event = JSON.parse(message.data) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      const type = typeof event.type === "string" ? event.type : "";
+
+      if (type === "response.function_call_arguments.done") {
+        void handleToolCall(event);
+        return;
+      }
+      if (type === "conversation.item.input_audio_transcription.completed") {
+        const text = eventText(event);
+        if (text) addLog("user", text);
+        return;
+      }
+      if (type === "response.audio_transcript.done" || type === "response.output_text.done") {
+        const text = eventText(event);
+        if (text) addLog("rolly", text);
+        return;
+      }
+      if (type === "error") {
+        const messageText = JSON.stringify(event.error ?? event).slice(0, 700);
+        addLog("error", messageText);
+      }
+    },
+    [addLog, handleToolCall],
+  );
+
+  const startCall = useCallback(async () => {
+    const callSeq = callSeqRef.current + 1;
+    callSeqRef.current = callSeq;
+    const isCurrentCall = () => callSeqRef.current === callSeq;
+    setError(null);
+    setStatus("requesting");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      if (!isCurrentCall()) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      streamRef.current = stream;
+      setStatus("connecting");
+
+      const session = await api.createVoiceSession();
+      if (!isCurrentCall()) return;
+      const peer = new RTCPeerConnection();
+      peerRef.current = peer;
+      peer.onconnectionstatechange = () => {
+        if (["closed", "disconnected", "failed"].includes(peer.connectionState)) {
+          addLog("system", `Connection ${peer.connectionState}.`);
+        }
+      };
+
+      peer.ontrack = (event) => {
+        if (!audioRef.current) return;
+        audioRef.current.srcObject = event.streams[0];
+      };
+      stream.getAudioTracks().forEach((track) => peer.addTrack(track, stream));
+
+      const dataChannel = peer.createDataChannel("oai-events");
+      dataRef.current = dataChannel;
+      dataChannel.onopen = () => {
+        setStatus("live");
+        addLog("system", "Live. Talk normally; Rolly can answer by voice and call tools.");
+      };
+      dataChannel.onmessage = handleRealtimeEvent;
+      dataChannel.onerror = () => addLog("error", "Realtime data channel error.");
+
+      const offer = await peer.createOffer();
+      await peer.setLocalDescription(offer);
+
+      const realtimeUrl = `${session.endpoint}?model=${encodeURIComponent(session.model)}`;
+      const sdpResponse = await fetch(realtimeUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.client_secret}`,
+          "Content-Type": "application/sdp",
+        },
+        body: offer.sdp,
+      });
+      if (!sdpResponse.ok) {
+        throw new Error(`${sdpResponse.status}: ${await sdpResponse.text()}`);
+      }
+      if (!isCurrentCall()) return;
+      await peer.setRemoteDescription({ type: "answer", sdp: await sdpResponse.text() });
+    } catch (exc) {
+      const message = exc instanceof Error ? exc.message : String(exc);
+      setError(message);
+      setStatus("error");
+      addLog("error", message);
+      stopCall();
+    }
+  }, [addLog, handleRealtimeEvent, stopCall]);
+
+  const toggleMute = useCallback(() => {
+    const next = !muted;
+    streamRef.current?.getAudioTracks().forEach((track) => {
+      track.enabled = !next;
+    });
+    setMuted(next);
+  }, [muted]);
+
+  useEffect(() => stopCall, [stopCall]);
+
+  const live = status === "live";
+  const busy = status === "requesting" || status === "connecting" || status === "ending";
+
+  return (
+    <main className="flex h-full min-h-0 flex-col gap-4 overflow-auto p-4 lg:p-6">
+      <audio ref={audioRef} autoPlay />
+      <section className="border border-current/20 bg-background-base/70 p-5 text-midground shadow-xl">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <Typography className="font-mondwest text-display text-2xl uppercase tracking-[0.12em]">
+              Rolly Voice
+            </Typography>
+            <p className="mt-2 max-w-2xl text-sm text-text-secondary">
+              One-on-one call prototype: browser mic/audio, realtime speech, and a backend bridge for bounded research/tool calls.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {!live && !busy ? <Button onClick={startCall}>Start call</Button> : null}
+            {live ? <Button onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
+            {live || busy ? <Button onClick={stopCall}>End call</Button> : null}
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.12em] text-text-secondary">
+          <span className="border border-current/20 px-2 py-1">Status: {status}</span>
+          <span className="border border-current/20 px-2 py-1">Provider: OpenAI Realtime WebRTC</span>
+          <span className="border border-current/20 px-2 py-1">Tools: research</span>
+        </div>
+        {error ? <p className="mt-3 text-sm text-red-300">{error}</p> : null}
+      </section>
+
+      <section className="grid min-h-[24rem] gap-4 lg:grid-cols-[1fr_22rem]">
+        <div className="min-h-0 border border-current/20 bg-black/30 p-4">
+          <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
+            Transcript + events
+          </Typography>
+          <div className="mt-3 flex max-h-[60vh] flex-col gap-2 overflow-auto pr-1 text-sm">
+            {logs.map((entry) => (
+              <div key={entry.id} className="border border-current/10 bg-background-base/50 p-3">
+                <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
+                  {entry.kind}
+                </div>
+                <div className="whitespace-pre-wrap leading-relaxed">{entry.text}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <aside className="border border-current/20 bg-background-base/50 p-4 text-sm text-text-secondary">
+          <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em] text-midground">
+            Try saying
+          </Typography>
+          <ul className="mt-3 list-disc space-y-2 pl-4">
+            <li>“Rolly, research the best way to test this voice prototype.”</li>
+            <li>“Summarize what we’ve decided so far.”</li>
+            <li>“Use your research tool and keep the answer brief.”</li>
+          </ul>
+          <p className="mt-4">
+            V1 intentionally avoids Meet/Telegram call plumbing. If this feels good, the production upgrade path is LiveKit.
+          </p>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -436,7 +436,8 @@ export default function VoiceCallPage() {
       duration_ms: durationMs,
       pending_saves_at_end: pendingTranscriptSavesRef.current.length,
       log_entries: logs.length,
-      status_at_end: statusAtEnd,
+      status_before_end: statusAtEnd,
+      status_at_end: "ending",
       reason,
     });
     if (dataRef.current) {
@@ -533,19 +534,23 @@ export default function VoiceCallPage() {
         });
       }
       persistTranscript("tool", handoff.output, "delegation_handoff", { task_id: handoff.taskId });
-      requestResponseCreate("tool output", { queueIfActive: false });
+      requestResponseCreate(
+        handoff.toolCallId.startsWith("handoff:") ? "background handoff" : "tool output",
+        handoff.toolCallId.startsWith("handoff:") ? undefined : { queueIfActive: false },
+      );
     }
   }, [persistTranscript, requestResponseCreate, sendRealtimeEvent]);
 
   const queueOrSendToolOutput = useCallback(
     (toolCallId: string, output: string, taskId = "foreground") => {
+      const isBackgroundHandoff = toolCallId.startsWith("handoff:");
       if (userSpeakingRef.current) {
         pendingHandoffsRef.current.push({ toolCallId, taskId, output });
         setPendingHandoffs(pendingHandoffsRef.current.length);
         persistTranscript("system", "Queued Rolly result until user stops speaking.", "handoff_queued", { task_id: taskId });
         return;
       }
-      if (toolCallId.startsWith("handoff:")) {
+      if (isBackgroundHandoff) {
         sendRealtimeEvent({
           type: "conversation.item.create",
           item: {
@@ -564,7 +569,10 @@ export default function VoiceCallPage() {
           },
         });
       }
-      requestResponseCreate("tool output", { queueIfActive: false });
+      requestResponseCreate(
+        isBackgroundHandoff ? "background handoff" : "tool output",
+        isBackgroundHandoff ? undefined : { queueIfActive: false },
+      );
     },
     [persistTranscript, requestResponseCreate, sendRealtimeEvent],
   );
@@ -586,7 +594,7 @@ export default function VoiceCallPage() {
           if (task.status === "complete") {
             const output = task.result || "Background Rolly task completed.";
             addLog("tool", `${taskId} complete\n${output.slice(0, 700)}`);
-            persistTranscript("tool", output, "delegation_result", { task_id: taskId, session_id: task.session_id });
+            persistTranscript("tool", output, "delegation_handoff", { task_id: taskId, session_id: task.session_id });
             queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
             return;
           }

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -27,6 +27,11 @@ function eventText(event: unknown): string | null {
 export default function VoiceCallPage() {
   const [status, setStatus] = useState<CallStatus>("idle");
   const [muted, setMuted] = useState(false);
+  const [micInfo, setMicInfo] = useState("Mic: not connected");
+  const [micLevel, setMicLevel] = useState(0);
+  const [inputDevices, setInputDevices] = useState<MediaDeviceInfo[]>([]);
+  const [selectedInputId, setSelectedInputId] = useState("");
+  const [speaker, setSpeaker] = useState(() => window.localStorage.getItem("rolly.voice.user") || "deniz");
   const [error, setError] = useState<string | null>(null);
   const [logs, setLogs] = useState<LogEntry[]>([
     {
@@ -39,11 +44,106 @@ export default function VoiceCallPage() {
   const dataRef = useRef<RTCDataChannel | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const micMonitorRafRef = useRef<number | null>(null);
+  const callIdRef = useRef(`voice-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const callSeqRef = useRef(0);
 
   const addLog = useCallback((kind: LogKind, text: string) => {
     setLogs((prev) => [...prev.slice(-80), { id: logId(), kind, text }]);
   }, []);
+
+  const persistTranscript = useCallback(
+    (role: string, text: string, eventType = "transcript") => {
+      void api.saveVoiceTranscript(
+        {
+          call_id: callIdRef.current,
+          role,
+          text,
+          event_type: eventType,
+          user: speaker,
+          timestamp: new Date().toISOString(),
+        },
+        speaker,
+      ).catch((exc) => {
+        const message = exc instanceof Error ? exc.message : String(exc);
+        addLog("error", `Transcript save failed: ${message}`);
+      });
+    },
+    [addLog, speaker],
+  );
+
+  const refreshInputDevices = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) return;
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const inputs = devices.filter((device) => device.kind === "audioinput");
+    setInputDevices(inputs);
+    if (!selectedInputId && inputs.some((device) => device.deviceId === "default")) {
+      setSelectedInputId("default");
+    }
+  }, [selectedInputId]);
+
+  const stopMicMonitor = useCallback(() => {
+    if (micMonitorRafRef.current !== null) {
+      window.cancelAnimationFrame(micMonitorRafRef.current);
+    }
+    micMonitorRafRef.current = null;
+    void audioContextRef.current?.close().catch(() => undefined);
+    audioContextRef.current = null;
+    setMicLevel(0);
+    setMicInfo("Mic: not connected");
+  }, []);
+
+  const startMicMonitor = useCallback((stream: MediaStream) => {
+    stopMicMonitor();
+    const track = stream.getAudioTracks()[0];
+    const settings = track?.getSettings?.() ?? {};
+    setMicInfo(`Mic: ${track?.label || "unknown"} (${settings.sampleRate ?? "?"} Hz)`);
+
+    const AudioContextCtor = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextCtor) {
+      addLog("error", "Browser does not expose AudioContext; cannot meter microphone input.");
+      return;
+    }
+
+    const context = new AudioContextCtor();
+    audioContextRef.current = context;
+    const analyser = context.createAnalyser();
+    analyser.fftSize = 1024;
+    context.createMediaStreamSource(stream).connect(analyser);
+    const samples = new Uint8Array(analyser.fftSize);
+
+    const tick = () => {
+      analyser.getByteTimeDomainData(samples);
+      let sum = 0;
+      for (const sample of samples) {
+        const centered = sample - 128;
+        sum += centered * centered;
+      }
+      setMicLevel(Math.min(100, Math.round((Math.sqrt(sum / samples.length) / 128) * 160)));
+      micMonitorRafRef.current = window.requestAnimationFrame(tick);
+    };
+    tick();
+  }, [addLog, stopMicMonitor]);
+
+  const enableMicList = useCallback(async () => {
+    setError(null);
+    try {
+      if (!window.isSecureContext || !navigator.mediaDevices?.getUserMedia) {
+        throw new Error(
+          "Microphone access requires HTTPS. Open https://denizs-mac-mini.taildfdcc0.ts.net:9119/voice instead of the raw http:// Tailscale IP.",
+        );
+      }
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream.getTracks().forEach((track) => track.stop());
+      await refreshInputDevices();
+      addLog("system", "Microphone permission granted; input list refreshed.");
+    } catch (exc) {
+      const message = exc instanceof Error ? exc.message : String(exc);
+      setError(message);
+      addLog("error", message);
+    }
+  }, [addLog, refreshInputDevices]);
 
   const stopCall = useCallback(() => {
     callSeqRef.current += 1;
@@ -56,6 +156,7 @@ export default function VoiceCallPage() {
     dataRef.current?.close();
     peerRef.current?.close();
     streamRef.current?.getTracks().forEach((track) => track.stop());
+    stopMicMonitor();
     if (audioRef.current?.srcObject instanceof MediaStream) {
       audioRef.current.srcObject.getTracks().forEach((track) => track.stop());
       audioRef.current.srcObject = null;
@@ -66,7 +167,7 @@ export default function VoiceCallPage() {
     setMuted(false);
     setStatus("idle");
     addLog("system", "Call ended; microphone released.");
-  }, [addLog]);
+  }, [addLog, stopMicMonitor]);
 
   const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
     const channel = dataRef.current;
@@ -79,7 +180,10 @@ export default function VoiceCallPage() {
       const name = typeof event.name === "string" ? event.name : "";
       const callId = typeof event.call_id === "string" ? event.call_id : "";
       const rawArgs = typeof event.arguments === "string" ? event.arguments : "{}";
-      if (!name || !callId) return;
+      if (!name || !callId) {
+        addLog("error", `Malformed Realtime tool call: ${JSON.stringify(event).slice(0, 500)}`);
+        return;
+      }
 
       let args: Record<string, unknown> = {};
       try {
@@ -89,10 +193,12 @@ export default function VoiceCallPage() {
       }
 
       addLog("tool", `Running ${name}…`);
+      persistTranscript("tool", `Running ${name}: ${JSON.stringify(args)}`, "tool_call");
       try {
-        const result = await api.runVoiceTool({ name, arguments: args } satisfies VoiceToolRequest);
+        const result = await api.runVoiceTool({ name, arguments: args } satisfies VoiceToolRequest, speaker);
         const output = result.ok ? result.result : `Tool failed: ${result.error ?? "unknown error"}`;
         addLog(result.ok ? "tool" : "error", output.slice(0, 700));
+        persistTranscript("tool", output, result.ok ? "tool_result" : "tool_error");
         sendRealtimeEvent({
           type: "conversation.item.create",
           item: {
@@ -105,6 +211,7 @@ export default function VoiceCallPage() {
       } catch (exc) {
         const message = exc instanceof Error ? exc.message : String(exc);
         addLog("error", message);
+        persistTranscript("tool", message, "tool_error");
         sendRealtimeEvent({
           type: "conversation.item.create",
           item: {
@@ -116,7 +223,7 @@ export default function VoiceCallPage() {
         sendRealtimeEvent({ type: "response.create" });
       }
     },
-    [addLog, sendRealtimeEvent],
+    [addLog, persistTranscript, sendRealtimeEvent, speaker],
   );
 
   const handleRealtimeEvent = useCallback(
@@ -133,14 +240,39 @@ export default function VoiceCallPage() {
         void handleToolCall(event);
         return;
       }
-      if (type === "conversation.item.input_audio_transcription.completed") {
-        const text = eventText(event);
-        if (text) addLog("user", text);
+      if (type === "response.output_item.done") {
+        const item = event.item;
+        if (item && typeof item === "object" && (item as Record<string, unknown>).type === "function_call") {
+          void handleToolCall(item as Record<string, unknown>);
+        }
         return;
       }
-      if (type === "response.audio_transcript.done" || type === "response.output_text.done") {
+      if (type === "conversation.item.input_audio_transcription.completed") {
         const text = eventText(event);
-        if (text) addLog("rolly", text);
+        if (text) {
+          addLog("user", text);
+          persistTranscript("user", text);
+        }
+        return;
+      }
+      if (type === "input_audio_buffer.speech_started") {
+        addLog("system", "Realtime API heard speech start.");
+        return;
+      }
+      if (type === "input_audio_buffer.speech_stopped") {
+        addLog("system", "Realtime API heard speech stop.");
+        return;
+      }
+      if (type === "input_audio_buffer.committed") {
+        addLog("system", "Realtime API committed mic audio.");
+        return;
+      }
+      if (type === "response.output_audio_transcript.done" || type === "response.audio_transcript.done" || type === "response.output_text.done") {
+        const text = eventText(event);
+        if (text) {
+          addLog("rolly", text);
+          persistTranscript("rolly", text);
+        }
         return;
       }
       if (type === "error") {
@@ -148,26 +280,39 @@ export default function VoiceCallPage() {
         addLog("error", messageText);
       }
     },
-    [addLog, handleToolCall],
+    [addLog, handleToolCall, persistTranscript],
   );
 
   const startCall = useCallback(async () => {
     const callSeq = callSeqRef.current + 1;
     callSeqRef.current = callSeq;
+    callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    window.localStorage.setItem("rolly.voice.user", speaker);
     const isCurrentCall = () => callSeqRef.current === callSeq;
     setError(null);
     setStatus("requesting");
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      if (!window.isSecureContext || !navigator.mediaDevices?.getUserMedia) {
+        throw new Error(
+          "Microphone access requires HTTPS. Open https://denizs-mac-mini.taildfdcc0.ts.net:9119/voice instead of the raw http:// Tailscale IP.",
+        );
+      }
+      await refreshInputDevices();
+      const audio: boolean | MediaTrackConstraints = selectedInputId
+        ? { deviceId: { exact: selectedInputId } }
+        : true;
+      const stream = await navigator.mediaDevices.getUserMedia({ audio });
       if (!isCurrentCall()) {
         stream.getTracks().forEach((track) => track.stop());
         return;
       }
+      await refreshInputDevices();
       streamRef.current = stream;
+      startMicMonitor(stream);
+      const track = stream.getAudioTracks()[0];
+      addLog("system", `Browser mic opened: ${track?.label || "unknown device"}. Watch the mic level; it should move when you talk.`);
       setStatus("connecting");
 
-      const session = await api.createVoiceSession();
-      if (!isCurrentCall()) return;
       const peer = new RTCPeerConnection();
       peerRef.current = peer;
       peer.onconnectionstatechange = () => {
@@ -194,20 +339,9 @@ export default function VoiceCallPage() {
       const offer = await peer.createOffer();
       await peer.setLocalDescription(offer);
 
-      const realtimeUrl = `${session.endpoint}?model=${encodeURIComponent(session.model)}`;
-      const sdpResponse = await fetch(realtimeUrl, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${session.client_secret}`,
-          "Content-Type": "application/sdp",
-        },
-        body: offer.sdp,
-      });
-      if (!sdpResponse.ok) {
-        throw new Error(`${sdpResponse.status}: ${await sdpResponse.text()}`);
-      }
+      const answerSdp = await api.createVoiceCall(offer.sdp || "", speaker);
       if (!isCurrentCall()) return;
-      await peer.setRemoteDescription({ type: "answer", sdp: await sdpResponse.text() });
+      await peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
     } catch (exc) {
       const message = exc instanceof Error ? exc.message : String(exc);
       setError(message);
@@ -215,7 +349,7 @@ export default function VoiceCallPage() {
       addLog("error", message);
       stopCall();
     }
-  }, [addLog, handleRealtimeEvent, stopCall]);
+  }, [addLog, handleRealtimeEvent, refreshInputDevices, selectedInputId, speaker, startMicMonitor, stopCall]);
 
   const toggleMute = useCallback(() => {
     const next = !muted;
@@ -226,6 +360,11 @@ export default function VoiceCallPage() {
   }, [muted]);
 
   useEffect(() => stopCall, [stopCall]);
+  useEffect(() => {
+    void refreshInputDevices().catch(() => undefined);
+    navigator.mediaDevices?.addEventListener?.("devicechange", refreshInputDevices);
+    return () => navigator.mediaDevices?.removeEventListener?.("devicechange", refreshInputDevices);
+  }, [refreshInputDevices]);
 
   const live = status === "live";
   const busy = status === "requesting" || status === "connecting" || status === "ending";
@@ -244,6 +383,7 @@ export default function VoiceCallPage() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
+            {!live && !busy ? <Button onClick={enableMicList}>Enable mic list</Button> : null}
             {!live && !busy ? <Button onClick={startCall}>Start call</Button> : null}
             {live ? <Button onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
             {live || busy ? <Button onClick={stopCall}>End call</Button> : null}
@@ -252,7 +392,45 @@ export default function VoiceCallPage() {
         <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.12em] text-text-secondary">
           <span className="border border-current/20 px-2 py-1">Status: {status}</span>
           <span className="border border-current/20 px-2 py-1">Provider: OpenAI Realtime WebRTC</span>
-          <span className="border border-current/20 px-2 py-1">Tools: research</span>
+          <span className="border border-current/20 px-2 py-1">Tools: full Rolly</span>
+        </div>
+        <div className="mt-3 text-xs uppercase tracking-[0.12em] text-text-secondary">
+          <label className="mb-3 block">
+            SPEAKER
+            <select
+              className="mt-1 w-full border border-current/20 bg-black/40 p-2 text-midground"
+              value={speaker}
+              onChange={(event) => setSpeaker(event.target.value)}
+              disabled={live || busy}
+            >
+              <option value="deniz">Deniz</option>
+              <option value="arman">Arman</option>
+              <option value="buket">Buket</option>
+              <option value="metin">Metin</option>
+              <option value="guest">Guest</option>
+            </select>
+          </label>
+          <label className="block">
+            MIC INPUT
+            <select
+              className="mt-1 w-full border border-current/20 bg-black/40 p-2 text-midground"
+              value={selectedInputId}
+              onChange={(event) => setSelectedInputId(event.target.value)}
+              disabled={live || busy}
+            >
+              <option value="">Browser default</option>
+              {inputDevices.map((device, index) => (
+                <option key={device.deviceId || index} value={device.deviceId}>
+                  {device.label || `Microphone ${index + 1}`}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div>{micInfo}</div>
+          <div className="mt-1 h-2 overflow-hidden border border-current/20 bg-black/40">
+            <div className="h-full bg-current transition-[width]" style={{ width: `${micLevel}%` }} />
+          </div>
+          <div className="mt-1">Mic level: {micLevel}%</div>
         </div>
         {error ? <p className="mt-3 text-sm text-red-300">{error}</p> : null}
       </section>
@@ -278,12 +456,12 @@ export default function VoiceCallPage() {
             Try saying
           </Typography>
           <ul className="mt-3 list-disc space-y-2 pl-4">
-            <li>“Rolly, research the best way to test this voice prototype.”</li>
-            <li>“Summarize what we’ve decided so far.”</li>
-            <li>“Use your research tool and keep the answer brief.”</li>
+            <li>“Rolly, what were we trying to finish tonight?”</li>
+            <li>“Check current MIX review blockers and keep it brief.”</li>
+            <li>“Use your tools and tell me what to do next.”</li>
           </ul>
           <p className="mt-4">
-            V1 intentionally avoids Meet/Telegram call plumbing. If this feels good, the production upgrade path is LiveKit.
+            Realtime voice can call full Rolly when it needs project context, files, web, or actions.
           </p>
         </aside>
       </section>

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -3,6 +3,7 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { api, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
 import { getRollyUser, getRollyUserSlug } from "@/lib/rollyIdentity";
+import { isRollyWakePhrase } from "@/lib/voiceMeet";
 
 type CallStatus = "idle" | "requesting" | "connecting" | "live" | "ending" | "error";
 
@@ -41,16 +42,6 @@ function formatClock(timestamp: string): string {
 function formatElapsed(ms: number | null): string {
   if (ms === null) return "+0.0s";
   return `+${(ms / 1000).toFixed(1)}s`;
-}
-
-function isRollyWakePhrase(text: string): boolean {
-  const normalized = text
-    .toLowerCase()
-    .normalize("NFKD")
-    .replace(/[^a-z\s]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return /\bhey\s+(?:rolly|rollie|rowley|rowly|rowy|roley|rally)\b/.test(normalized);
 }
 
 export default function VoiceCallPage() {
@@ -104,6 +95,12 @@ export default function VoiceCallPage() {
   const meetInvokedRef = useRef(false);
   const userSpeakingRef = useRef(false);
   const responseActiveRef = useRef(false);
+
+  useEffect(() => {
+    if (status !== "idle") return;
+    meetInvokedRef.current = false;
+    setRollyListenState(mode === "meet" ? "Silent until “Hey Rolly”" : "Always on");
+  }, [mode, status]);
   const pendingResponseCreateRef = useRef(false);
   const activeWorkRef = useRef<Map<string, string>>(new Map());
   const pendingHandoffsRef = useRef<Array<{ toolCallId: string; taskId: string; output: string }>>([]);

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -92,6 +92,7 @@ export default function VoiceCallPage() {
   const [voiceTasks, setVoiceTasks] = useState<VoiceTaskResponse[]>([]);
   const [rollyListenState, setRollyListenState] = useState("Always on");
   const handledToolCallsRef = useRef<Set<string>>(new Set());
+  const activeCallModeRef = useRef<"solo" | "meet">("solo");
   const meetInvokedRef = useRef(false);
   const userSpeakingRef = useRef(false);
   const responseActiveRef = useRef(false);
@@ -721,7 +722,8 @@ export default function VoiceCallPage() {
       if (type === "conversation.item.input_audio_transcription.completed") {
         const text = eventText(event);
         if (text) {
-          if (mode === "meet") {
+          const currentMode = activeCallModeRef.current;
+          if (currentMode === "meet") {
             const invoked = isRollyWakePhrase(text);
             if (invoked) {
               meetInvokedRef.current = true;
@@ -733,10 +735,10 @@ export default function VoiceCallPage() {
             }
           }
           const meetMetadata =
-            mode === "meet"
-              ? { mode, invoked_rolly: meetInvokedRef.current, dashboard_user: speaker, speaker_attribution: "unknown_room_speaker" }
-              : { mode, invoked_rolly: meetInvokedRef.current };
-          addLog("user", mode === "meet" ? `[room mic / dashboard: ${speaker || "unknown"}] ${text}` : text);
+            currentMode === "meet"
+              ? { mode: currentMode, invoked_rolly: meetInvokedRef.current, dashboard_user: speaker, speaker_attribution: "unknown_room_speaker" }
+              : { mode: currentMode, invoked_rolly: meetInvokedRef.current };
+          addLog("user", currentMode === "meet" ? `[room mic / dashboard: ${speaker || "unknown"}] ${text}` : text);
           persistTranscript("user", text, "transcript", meetMetadata);
         }
         return;
@@ -766,7 +768,7 @@ export default function VoiceCallPage() {
       if (type === "response.done" || type === "response.cancelled") {
         finishResponse(type === "response.cancelled" ? "cancelled" : "done");
         stopWorkingCue(type === "response.cancelled" ? false : "done");
-        if (mode === "meet") {
+        if (activeCallModeRef.current === "meet") {
           meetInvokedRef.current = false;
           setRollyListenState("Silent until “Hey Rolly”");
         }
@@ -796,11 +798,12 @@ export default function VoiceCallPage() {
         persistTranscript("error", messageText, "realtime_error");
       }
     },
-    [addLog, finishResponse, flushPendingHandoffs, handleToolCall, mode, persistTranscript, requestResponseCreate, sendRealtimeEvent, speaker, startBoundedWorkingCue, startWorkingCue, stopWorkingCue],
+    [addLog, finishResponse, flushPendingHandoffs, handleToolCall, persistTranscript, requestResponseCreate, sendRealtimeEvent, speaker, startBoundedWorkingCue, startWorkingCue, stopWorkingCue],
   );
 
   const startCall = useCallback(async (overrideMode?: "solo" | "meet") => {
     const callMode = overrideMode ?? mode;
+    activeCallModeRef.current = callMode;
     if (!speaker) {
       setError("Pick a dashboard user first, then start the call.");
       addLog("error", "Pick a dashboard user first, then start the call.");

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -94,6 +94,7 @@ export default function VoiceCallPage() {
   const [mode, setMode] = useState<"solo" | "meet">("solo");
   const [callIdDisplay, setCallIdDisplay] = useState(callIdRef.current);
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [invitePending, setInvitePending] = useState(false);
   const [voiceTasks, setVoiceTasks] = useState<VoiceTaskResponse[]>([]);
   const [rollyListenState, setRollyListenState] = useState("Always on");
   const handledToolCallsRef = useRef<Set<string>>(new Set());
@@ -479,8 +480,12 @@ export default function VoiceCallPage() {
   }, []);
 
   const requestResponseCreate = useCallback(
-    (reason: string) => {
+    (reason: string, options?: { queueIfActive?: boolean }) => {
       if (responseActiveRef.current) {
+        if (options?.queueIfActive === false) {
+          addLog("system", `Skipped extra voice response while current response is active (${reason}).`);
+          return;
+        }
         pendingResponseCreateRef.current = true;
         addLog("system", `Queued voice response until current response finishes (${reason}).`);
         return;
@@ -528,7 +533,7 @@ export default function VoiceCallPage() {
         });
       }
       persistTranscript("tool", handoff.output, "delegation_handoff", { task_id: handoff.taskId });
-      requestResponseCreate("tool output");
+      requestResponseCreate("tool output", { queueIfActive: false });
     }
   }, [persistTranscript, requestResponseCreate, sendRealtimeEvent]);
 
@@ -559,7 +564,7 @@ export default function VoiceCallPage() {
           },
         });
       }
-      requestResponseCreate("tool output");
+      requestResponseCreate("tool output", { queueIfActive: false });
     },
     [persistTranscript, requestResponseCreate, sendRealtimeEvent],
   );
@@ -659,7 +664,7 @@ export default function VoiceCallPage() {
             output,
           },
         });
-        requestResponseCreate("tool output");
+        requestResponseCreate("tool output", { queueIfActive: false });
         const taskId = typeof result.data?.task_id === "string" ? result.data.task_id : "";
         if (name === "rolly_background" && taskId) {
           rememberVoiceTask(result.data as unknown as VoiceTaskResponse);
@@ -683,7 +688,7 @@ export default function VoiceCallPage() {
             output: `Tool failed: ${message}`,
           },
         });
-        requestResponseCreate("tool output");
+        requestResponseCreate("tool output", { queueIfActive: false });
       }
     },
     [addLog, markWorkFinished, markWorkStarted, persistTranscript, pollVoiceTask, rememberVoiceTask, requestResponseCreate, sendRealtimeEvent, speaker],
@@ -911,6 +916,12 @@ export default function VoiceCallPage() {
 
   const startMeetingInvite = useCallback(async () => {
     setError(null);
+    setInvitePending(true);
+    if (!new URLSearchParams(window.location.search).get("call_id")) {
+      callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      setCallIdDisplay(callIdRef.current);
+      setInviteUrl(null);
+    }
     try {
       const resp = await api.createVoiceMeetInvite({ call_id: callIdRef.current, user: speaker });
       setMode("meet");
@@ -922,6 +933,8 @@ export default function VoiceCallPage() {
       const message = exc instanceof Error ? exc.message : String(exc);
       setError(`Meet invite unavailable: ${message}`);
       addLog("error", `Meet invite unavailable: ${message}`);
+    } finally {
+      setInvitePending(false);
     }
   }, [addLog, persistTranscript, speaker, startCall]);
 
@@ -979,7 +992,7 @@ export default function VoiceCallPage() {
   }, [requestWakeLock, status]);
 
   const live = status === "live";
-  const busy = status === "requesting" || status === "connecting" || status === "ending";
+  const busy = invitePending || status === "requesting" || status === "connecting" || status === "ending";
   const speakerLabel = getRollyUser(speaker)?.label ?? "No dashboard user selected";
   const transcriptLogs = logs.filter((entry) => entry.kind === "user" || entry.kind === "rolly");
   const eventLogs = logs.filter((entry) => entry.kind !== "user" && entry.kind !== "rolly" && (verboseEvents || !isRealtimeSpeechEvent(entry)));

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
-import { api, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
+import { api, type VoiceRoomEvent, type VoiceRoomParticipant, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
 import { getRollyUser, getRollyUserSlug } from "@/lib/rollyIdentity";
 import { isRollyWakePhrase } from "@/lib/voiceMeet";
 
@@ -46,6 +46,19 @@ function formatElapsed(ms: number | null): string {
 
 function isRealtimeSpeechEvent(entry: LogEntry): boolean {
   return entry.text === "Realtime API heard speech start." || entry.text === "Realtime API heard speech stop." || entry.text === "Realtime API committed mic audio.";
+}
+
+function sharedRoomLog(event: VoiceRoomEvent, localUser: string): { kind: LogKind; text: string } | null {
+  const eventUser = event.user || "unknown dashboard user";
+  if (eventUser === localUser && event.event_type !== "call_start" && event.event_type !== "call_end") return null;
+  if (event.event_type === "call_start") return { kind: "system", text: `${eventUser} joined the room.` };
+  if (event.event_type === "call_end") return { kind: "system", text: `${eventUser} left the room.` };
+  if (eventUser === localUser) return null;
+  if (event.event_type === "transcript" && event.text.trim()) {
+    if (event.role === "user") return { kind: "user", text: `${eventUser}: ${event.text}` };
+    if (event.role === "rolly" || event.role === "assistant") return { kind: "rolly", text: `Rolly to ${eventUser}: ${event.text}` };
+  }
+  return null;
 }
 
 export default function VoiceCallPage() {
@@ -95,11 +108,14 @@ export default function VoiceCallPage() {
   const [callIdDisplay, setCallIdDisplay] = useState(callIdRef.current);
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
   const [invitePending, setInvitePending] = useState(false);
+  const [roomParticipants, setRoomParticipants] = useState<VoiceRoomParticipant[]>([]);
   const [voiceTasks, setVoiceTasks] = useState<VoiceTaskResponse[]>([]);
   const [rollyListenState, setRollyListenState] = useState("Always on");
   const handledToolCallsRef = useRef<Set<string>>(new Set());
   const activeCallModeRef = useRef<"solo" | "meet">("solo");
   const meetInvokedRef = useRef(false);
+  const voiceRoomCursorRef = useRef(0);
+  const seenVoiceRoomEventsRef = useRef<Set<string>>(new Set());
   const userSpeakingRef = useRef(false);
   const responseActiveRef = useRef(false);
 
@@ -832,7 +848,7 @@ export default function VoiceCallPage() {
     }
     setCallIdDisplay(callIdRef.current);
     callStartedAtRef.current = Date.now();
-    eventSeqRef.current = 0;
+    if (!preserveCallId) eventSeqRef.current = 0;
     pendingTranscriptSavesRef.current = [];
     setLastSavePath(null);
     setSaveStatus("Saving call events…");
@@ -1008,6 +1024,42 @@ export default function VoiceCallPage() {
     }
   }, []);
   useEffect(() => {
+    if (mode !== "meet") return;
+    let cancelled = false;
+    const pollRoom = async () => {
+      try {
+        const room = await api.getVoiceRoom(callIdRef.current, voiceRoomCursorRef.current, 200, speaker);
+        if (cancelled) return;
+        voiceRoomCursorRef.current = room.cursor;
+        setRoomParticipants(room.participants);
+        const additions: LogEntry[] = [];
+        for (const event of room.events) {
+          const key = `${event.index}:${event.user ?? ""}:${event.event_type ?? ""}:${event.sequence ?? ""}`;
+          if (seenVoiceRoomEventsRef.current.has(key)) continue;
+          seenVoiceRoomEventsRef.current.add(key);
+          const mapped = sharedRoomLog(event, speaker);
+          if (!mapped) continue;
+          additions.push({
+            id: `room-${key}`,
+            kind: mapped.kind,
+            text: mapped.text,
+            timestamp: event.timestamp || new Date().toISOString(),
+            elapsedMs: event.elapsed_ms ?? null,
+          });
+        }
+        if (additions.length) setLogs((prev) => [...prev, ...additions].slice(-300));
+      } catch {
+        // Keep voice interaction usable if room polling misses a beat.
+      }
+    };
+    void pollRoom();
+    const timer = window.setInterval(() => void pollRoom(), 1500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [mode, speaker]);
+  useEffect(() => {
     const handleVisibility = () => {
       if (document.visibilityState === "visible" && status === "live") {
         void requestWakeLock();
@@ -1020,6 +1072,7 @@ export default function VoiceCallPage() {
 
   const live = status === "live";
   const busy = invitePending || status === "requesting" || status === "connecting" || status === "ending";
+  const hasMeetInvite = mode === "meet" && Boolean(inviteUrl);
   const speakerLabel = getRollyUser(speaker)?.label ?? "No dashboard user selected";
   const transcriptLogs = logs.filter((entry) => entry.kind === "user" || entry.kind === "rolly");
   const eventLogs = logs.filter((entry) => entry.kind !== "user" && entry.kind !== "rolly" && (verboseEvents || !isRealtimeSpeechEvent(entry)));
@@ -1038,7 +1091,11 @@ export default function VoiceCallPage() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={startMeetingInvite} disabled={!speaker}>Start meeting / invite</Button> : null}
+            {!live && !busy ? (
+              <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={hasMeetInvite ? () => void startCall("meet", true) : startMeetingInvite} disabled={!speaker}>
+                {hasMeetInvite ? "Join meeting" : "Start meeting / invite"}
+              </Button>
+            ) : null}
             {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => void startCall()} disabled={!speaker}>Start call</Button> : null}
             {live ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
             <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => setVerboseEvents((value) => !value)}>
@@ -1151,6 +1208,9 @@ export default function VoiceCallPage() {
           <div className="mt-3 space-y-3">
             <div>Transcript: {lastSavePath || "not saved yet"}</div>
             <div>Queued tasks: {voiceTasks.length || "none"}</div>
+            <div>
+              Room: {roomParticipants.length ? roomParticipants.map((participant) => `${participant.user} ${participant.status}`).join(", ") : "solo / no peers"}
+            </div>
             <div>Speaking pace: slightly faster style instruction; explicit provider rate unsupported.</div>
           </div>
           <Typography className="mt-5 font-mondwest text-display text-lg uppercase tracking-[0.12em] text-midground">

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -8,6 +8,8 @@ type CallStatus = "idle" | "requesting" | "connecting" | "live" | "ending" | "er
 
 type LogKind = "system" | "user" | "rolly" | "tool" | "error";
 
+const VOICE_ACTION_BUTTON_CLASS = "leading-tight text-sm tracking-[0.12em] sm:text-base sm:tracking-[0.2em]";
+
 type WakeLockSentinelLike = EventTarget & {
   release: () => Promise<void>;
   released?: boolean;
@@ -444,21 +446,32 @@ export default function VoiceCallPage() {
     }
   }, [addLog, persistTranscript, speaker]);
 
-  const stopCall = useCallback(() => {
+  const stopCall = useCallback((reason = "user") => {
     const endStartedAt = Date.now();
     const durationMs = callStartedAtRef.current === null ? 0 : endStartedAt - callStartedAtRef.current;
     callSeqRef.current += 1;
+    const statusAtEnd = status;
     setStatus((current) => (current === "idle" ? current : "ending"));
     stopWorkingCue(false);
     stopBackgroundCallSupport();
-    persistTranscript("system", "Call ended by user; microphone released.", "call_end", {
+    const endText = reason === "setup_error"
+      ? "Call ended after setup error; microphone released."
+      : "Call ended by user; microphone released.";
+    persistTranscript("system", endText, "call_end", {
       duration_ms: durationMs,
       pending_saves_at_end: pendingTranscriptSavesRef.current.length,
       log_entries: logs.length,
+      status_at_end: statusAtEnd,
+      reason,
     });
     if (dataRef.current) {
       dataRef.current.onerror = null;
+      dataRef.current.onmessage = null;
       dataRef.current.onopen = null;
+    }
+    if (peerRef.current) {
+      peerRef.current.onconnectionstatechange = null;
+      peerRef.current.ontrack = null;
     }
     dataRef.current?.close();
     peerRef.current?.close();
@@ -483,7 +496,7 @@ export default function VoiceCallPage() {
     Promise.allSettled([...pendingTranscriptSavesRef.current]).then(() => setSaveStatus("Call saved"));
     setStatus("idle");
     addLog("system", `Call ended; saved end marker (${(durationMs / 1000).toFixed(1)}s).`);
-  }, [addLog, logs.length, persistTranscript, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue]);
+  }, [addLog, logs.length, persistTranscript, status, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue]);
 
   const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
     const channel = dataRef.current;
@@ -903,16 +916,19 @@ export default function VoiceCallPage() {
 
       const offer = await peer.createOffer();
       await peer.setLocalDescription(offer);
+      persistTranscript("system", "WebRTC offer created; requesting Realtime answer.", "webrtc_offer_created", { mode });
 
       const answerSdp = await api.createVoiceCall(offer.sdp || "", speaker, mode);
       if (!isCurrentCall()) return;
+      persistTranscript("system", "Realtime SDP answer received.", "realtime_answer_received", { mode });
       await peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
+      persistTranscript("system", "Realtime remote description applied.", "webrtc_remote_description_set", { mode });
     } catch (exc) {
       const message = exc instanceof Error ? exc.message : String(exc);
       setError(message);
       setStatus("error");
       addLog("error", message);
-      stopCall();
+      stopCall("setup_error");
     }
   }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMicMonitor, stopBackgroundCallSupport, stopCall, stopMicMonitor, playVoiceCue]);
 
@@ -989,11 +1005,11 @@ export default function VoiceCallPage() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            {!live && !busy ? <Button onClick={enableMicList}>Enable mic list</Button> : null}
-            {!live && !busy ? <Button onClick={createInvite}>Start meeting / invite</Button> : null}
-            {!live && !busy ? <Button onClick={startCall} disabled={!speaker}>Start call</Button> : null}
-            {live ? <Button onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
-            {live || busy ? <Button onClick={stopCall}>End call</Button> : null}
+            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={enableMicList}>Enable mic list</Button> : null}
+            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={createInvite}>Start meeting / invite</Button> : null}
+            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={startCall} disabled={!speaker}>Start call</Button> : null}
+            {live ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
+            {live || busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => stopCall()}>End call</Button> : null}
           </div>
         </div>
         <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.12em] text-text-secondary">
@@ -1018,10 +1034,10 @@ export default function VoiceCallPage() {
         <div className="mt-3 text-xs uppercase tracking-[0.12em] text-text-secondary">
           <div className="mb-3">USER: {speakerLabel}</div>
           <div className="mb-3 flex gap-2">
-            <Button disabled={live || busy} onClick={() => setMode("solo")}>
+            <Button className={VOICE_ACTION_BUTTON_CLASS} disabled={live || busy} onClick={() => setMode("solo")}>
               1:1 Rolly
             </Button>
-            <Button disabled={live || busy} onClick={() => setMode("meet")}>
+            <Button className={VOICE_ACTION_BUTTON_CLASS} disabled={live || busy} onClick={() => setMode("meet")}>
               Meet: Hey Rolly
             </Button>
           </div>

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -428,21 +428,6 @@ export default function VoiceCallPage() {
     [addLog, muted, persistTranscript, refreshInputDevices, startMicMonitor, status],
   );
 
-  const createInvite = useCallback(async () => {
-    setError(null);
-    try {
-      const resp = await api.createVoiceMeetInvite({ call_id: callIdRef.current, user: speaker });
-      setMode("meet");
-      setInviteUrl(resp.invite_url);
-      addLog("system", `Meet invite ready: ${resp.invite_url}`);
-      persistTranscript("system", `Meet invite created: ${resp.invite_url}`, "meet_invite_created", { mode: "meet" });
-    } catch (exc) {
-      const message = exc instanceof Error ? exc.message : String(exc);
-      setError(`Meet invite unavailable: ${message}`);
-      addLog("error", `Meet invite unavailable: ${message}`);
-    }
-  }, [addLog, persistTranscript, speaker]);
-
   const stopCall = useCallback((reason = "user") => {
     const endStartedAt = Date.now();
     const durationMs = callStartedAtRef.current === null ? 0 : endStartedAt - callStartedAtRef.current;
@@ -814,7 +799,8 @@ export default function VoiceCallPage() {
     [addLog, finishResponse, flushPendingHandoffs, handleToolCall, mode, persistTranscript, requestResponseCreate, sendRealtimeEvent, speaker, startBoundedWorkingCue, startWorkingCue, stopWorkingCue],
   );
 
-  const startCall = useCallback(async () => {
+  const startCall = useCallback(async (overrideMode?: "solo" | "meet") => {
+    const callMode = overrideMode ?? mode;
     if (!speaker) {
       setError("Pick a dashboard user first, then start the call.");
       addLog("error", "Pick a dashboard user first, then start the call.");
@@ -842,11 +828,11 @@ export default function VoiceCallPage() {
     setVoiceTasks([]);
     handledToolCallsRef.current = new Set();
     meetInvokedRef.current = false;
-    setRollyListenState(mode === "meet" ? "Silent until “Hey Rolly”" : "Always on");
+    setRollyListenState(callMode === "meet" ? "Silent until “Hey Rolly”" : "Always on");
     persistTranscript("system", "Call started.", "call_start", {
       user_agent: navigator.userAgent,
       selected_input_id: selectedInputId || "browser-default",
-      mode,
+      mode: callMode,
     });
     const isCurrentCall = () => callSeqRef.current === callSeq;
     setError(null);
@@ -902,24 +888,24 @@ export default function VoiceCallPage() {
       dataChannel.onopen = () => {
         setStatus("live");
         playVoiceCue("live");
-        const liveMessage = mode === "meet"
+        const liveMessage = callMode === "meet"
           ? "Meet mode live. Rolly is silent until someone says “Hey Rolly.”"
           : "Live. Talk normally; Rolly can answer by voice and call tools.";
         addLog("system", liveMessage);
-        persistTranscript("system", "Realtime data channel live.", "call_live", { mode });
+        persistTranscript("system", "Realtime data channel live.", "call_live", { mode: callMode });
       };
       dataChannel.onmessage = handleRealtimeEvent;
       dataChannel.onerror = () => addLog("error", "Realtime data channel error.");
 
       const offer = await peer.createOffer();
       await peer.setLocalDescription(offer);
-      persistTranscript("system", "WebRTC offer created; requesting Realtime answer.", "webrtc_offer_created", { mode });
+      persistTranscript("system", "WebRTC offer created; requesting Realtime answer.", "webrtc_offer_created", { mode: callMode });
 
-      const answerSdp = await api.createVoiceCall(offer.sdp || "", speaker, mode);
+      const answerSdp = await api.createVoiceCall(offer.sdp || "", speaker, callMode);
       if (!isCurrentCall()) return;
-      persistTranscript("system", "Realtime SDP answer received.", "realtime_answer_received", { mode });
+      persistTranscript("system", "Realtime SDP answer received.", "realtime_answer_received", { mode: callMode });
       await peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
-      persistTranscript("system", "Realtime remote description applied.", "webrtc_remote_description_set", { mode });
+      persistTranscript("system", "Realtime remote description applied.", "webrtc_remote_description_set", { mode: callMode });
     } catch (exc) {
       const message = exc instanceof Error ? exc.message : String(exc);
       setError(message);
@@ -928,6 +914,22 @@ export default function VoiceCallPage() {
       stopCall("setup_error");
     }
   }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMicMonitor, stopBackgroundCallSupport, stopCall, stopMicMonitor, playVoiceCue]);
+
+  const startMeetingInvite = useCallback(async () => {
+    setError(null);
+    try {
+      const resp = await api.createVoiceMeetInvite({ call_id: callIdRef.current, user: speaker });
+      setMode("meet");
+      setInviteUrl(resp.invite_url);
+      addLog("system", `Meet invite ready: ${resp.invite_url}`);
+      persistTranscript("system", `Meet invite created: ${resp.invite_url}`, "meet_invite_created", { mode: "meet" });
+      await startCall("meet");
+    } catch (exc) {
+      const message = exc instanceof Error ? exc.message : String(exc);
+      setError(`Meet invite unavailable: ${message}`);
+      addLog("error", `Meet invite unavailable: ${message}`);
+    }
+  }, [addLog, persistTranscript, speaker, startCall]);
 
   const toggleMute = useCallback(() => {
     const next = !muted;
@@ -1003,8 +1005,8 @@ export default function VoiceCallPage() {
           </div>
           <div className="flex flex-wrap gap-2">
             {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={enableMicList}>Enable mic list</Button> : null}
-            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={createInvite}>Start meeting / invite</Button> : null}
-            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={startCall} disabled={!speaker}>Start call</Button> : null}
+            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={startMeetingInvite} disabled={!speaker}>Start meeting / invite</Button> : null}
+            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => void startCall()} disabled={!speaker}>Start call</Button> : null}
             {live ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
             {live || busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => stopCall()}>End call</Button> : null}
           </div>

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -11,6 +11,8 @@ interface LogEntry {
   id: string;
   kind: LogKind;
   text: string;
+  timestamp: string;
+  elapsedMs: number | null;
 }
 
 function logId(): string {
@@ -22,6 +24,15 @@ function eventText(event: unknown): string | null {
   const obj = event as Record<string, unknown>;
   const direct = obj.transcript ?? obj.text ?? obj.delta;
   return typeof direct === "string" && direct.trim() ? direct.trim() : null;
+}
+
+function formatClock(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function formatElapsed(ms: number | null): string {
+  if (ms === null) return "+0.0s";
+  return `+${(ms / 1000).toFixed(1)}s`;
 }
 
 export default function VoiceCallPage() {
@@ -38,6 +49,8 @@ export default function VoiceCallPage() {
       id: logId(),
       kind: "system",
       text: "Prototype: browser WebRTC to realtime voice, with backend tool bridge for research.",
+      timestamp: new Date().toISOString(),
+      elapsedMs: null,
     },
   ]);
   const peerRef = useRef<RTCPeerConnection | null>(null);
@@ -47,28 +60,57 @@ export default function VoiceCallPage() {
   const audioContextRef = useRef<AudioContext | null>(null);
   const micMonitorRafRef = useRef<number | null>(null);
   const callIdRef = useRef(`voice-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const callStartedAtRef = useRef<number | null>(null);
+  const eventSeqRef = useRef(0);
+  const pendingTranscriptSavesRef = useRef<Promise<unknown>[]>([]);
   const callSeqRef = useRef(0);
+  const [saveStatus, setSaveStatus] = useState("Not saving yet");
+  const [lastSavePath, setLastSavePath] = useState<string | null>(null);
+  const [activeTool, setActiveTool] = useState<string | null>(null);
 
   const addLog = useCallback((kind: LogKind, text: string) => {
-    setLogs((prev) => [...prev.slice(-80), { id: logId(), kind, text }]);
+    const now = Date.now();
+    const startedAt = callStartedAtRef.current;
+    setLogs((prev) => [
+      ...prev.slice(-120),
+      { id: logId(), kind, text, timestamp: new Date(now).toISOString(), elapsedMs: startedAt === null ? null : now - startedAt },
+    ]);
   }, []);
 
   const persistTranscript = useCallback(
-    (role: string, text: string, eventType = "transcript") => {
-      void api.saveVoiceTranscript(
+    (role: string, text: string, eventType = "transcript", metadata: Record<string, unknown> = {}) => {
+      const now = Date.now();
+      const startedAt = callStartedAtRef.current;
+      const sequence = ++eventSeqRef.current;
+      const save = api.saveVoiceTranscript(
         {
           call_id: callIdRef.current,
           role,
           text,
           event_type: eventType,
           user: speaker,
-          timestamp: new Date().toISOString(),
+          timestamp: new Date(now).toISOString(),
+          sequence,
+          elapsed_ms: startedAt === null ? undefined : now - startedAt,
+          metadata,
         },
         speaker,
-      ).catch((exc) => {
-        const message = exc instanceof Error ? exc.message : String(exc);
-        addLog("error", `Transcript save failed: ${message}`);
-      });
+      )
+        .then((resp) => {
+          setLastSavePath(resp.path);
+          setSaveStatus(`Saved event #${sequence}`);
+          return resp;
+        })
+        .catch((exc) => {
+          const message = exc instanceof Error ? exc.message : String(exc);
+          setSaveStatus(`Save failed: ${message}`);
+          addLog("error", `Transcript save failed: ${message}`);
+        })
+        .finally(() => {
+          pendingTranscriptSavesRef.current = pendingTranscriptSavesRef.current.filter((item) => item !== save);
+        });
+      pendingTranscriptSavesRef.current.push(save);
+      return save;
     },
     [addLog, speaker],
   );
@@ -146,10 +188,16 @@ export default function VoiceCallPage() {
   }, [addLog, refreshInputDevices]);
 
   const stopCall = useCallback(() => {
+    const endStartedAt = Date.now();
+    const durationMs = callStartedAtRef.current === null ? 0 : endStartedAt - callStartedAtRef.current;
     callSeqRef.current += 1;
     setStatus((current) => (current === "idle" ? current : "ending"));
+    persistTranscript("system", "Call ended by user; microphone released.", "call_end", {
+      duration_ms: durationMs,
+      pending_saves_at_end: pendingTranscriptSavesRef.current.length,
+      log_entries: logs.length,
+    });
     if (dataRef.current) {
-      dataRef.current.onmessage = null;
       dataRef.current.onerror = null;
       dataRef.current.onopen = null;
     }
@@ -165,9 +213,11 @@ export default function VoiceCallPage() {
     peerRef.current = null;
     streamRef.current = null;
     setMuted(false);
+    setActiveTool(null);
+    Promise.allSettled([...pendingTranscriptSavesRef.current]).then(() => setSaveStatus("Call saved"));
     setStatus("idle");
-    addLog("system", "Call ended; microphone released.");
-  }, [addLog, stopMicMonitor]);
+    addLog("system", `Call ended; saved end marker (${(durationMs / 1000).toFixed(1)}s).`);
+  }, [addLog, logs.length, persistTranscript, stopMicMonitor]);
 
   const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
     const channel = dataRef.current;
@@ -192,13 +242,25 @@ export default function VoiceCallPage() {
         args = { raw: rawArgs };
       }
 
-      addLog("tool", `Running ${name}…`);
-      persistTranscript("tool", `Running ${name}: ${JSON.stringify(args)}`, "tool_call");
+      const startedAt = Date.now();
+      setActiveTool(`${name} running since ${formatClock(new Date(startedAt).toISOString())}`);
+      addLog("tool", `Running ${name}… ${JSON.stringify(args).slice(0, 300)}`);
+      persistTranscript("tool", `Running ${name}: ${JSON.stringify(args)}`, "tool_call", {
+        realtime_call_id: callId,
+        tool_name: name,
+        started_at: new Date(startedAt).toISOString(),
+      });
       try {
         const result = await api.runVoiceTool({ name, arguments: args } satisfies VoiceToolRequest, speaker);
+        const durationMs = Date.now() - startedAt;
         const output = result.ok ? result.result : `Tool failed: ${result.error ?? "unknown error"}`;
-        addLog(result.ok ? "tool" : "error", output.slice(0, 700));
-        persistTranscript("tool", output, result.ok ? "tool_result" : "tool_error");
+        setActiveTool(null);
+        addLog(result.ok ? "tool" : "error", `${name} finished in ${(durationMs / 1000).toFixed(1)}s\n${output.slice(0, 700)}`);
+        persistTranscript("tool", output, result.ok ? "tool_result" : "tool_error", {
+          realtime_call_id: callId,
+          tool_name: name,
+          duration_ms: durationMs,
+        });
         sendRealtimeEvent({
           type: "conversation.item.create",
           item: {
@@ -209,9 +271,15 @@ export default function VoiceCallPage() {
         });
         sendRealtimeEvent({ type: "response.create" });
       } catch (exc) {
+        const durationMs = Date.now() - startedAt;
         const message = exc instanceof Error ? exc.message : String(exc);
-        addLog("error", message);
-        persistTranscript("tool", message, "tool_error");
+        setActiveTool(null);
+        addLog("error", `${name} failed in ${(durationMs / 1000).toFixed(1)}s: ${message}`);
+        persistTranscript("tool", message, "tool_error", {
+          realtime_call_id: callId,
+          tool_name: name,
+          duration_ms: durationMs,
+        });
         sendRealtimeEvent({
           type: "conversation.item.create",
           item: {
@@ -257,14 +325,17 @@ export default function VoiceCallPage() {
       }
       if (type === "input_audio_buffer.speech_started") {
         addLog("system", "Realtime API heard speech start.");
+        persistTranscript("system", "Realtime API heard speech start.", "speech_started");
         return;
       }
       if (type === "input_audio_buffer.speech_stopped") {
         addLog("system", "Realtime API heard speech stop.");
+        persistTranscript("system", "Realtime API heard speech stop.", "speech_stopped");
         return;
       }
       if (type === "input_audio_buffer.committed") {
         addLog("system", "Realtime API committed mic audio.");
+        persistTranscript("system", "Realtime API committed mic audio.", "audio_committed");
         return;
       }
       if (type === "response.output_audio_transcript.done" || type === "response.audio_transcript.done" || type === "response.output_text.done") {
@@ -278,6 +349,7 @@ export default function VoiceCallPage() {
       if (type === "error") {
         const messageText = JSON.stringify(event.error ?? event).slice(0, 700);
         addLog("error", messageText);
+        persistTranscript("error", messageText, "realtime_error");
       }
     },
     [addLog, handleToolCall, persistTranscript],
@@ -287,7 +359,17 @@ export default function VoiceCallPage() {
     const callSeq = callSeqRef.current + 1;
     callSeqRef.current = callSeq;
     callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    callStartedAtRef.current = Date.now();
+    eventSeqRef.current = 0;
+    pendingTranscriptSavesRef.current = [];
+    setLastSavePath(null);
+    setSaveStatus("Saving call events…");
+    setActiveTool(null);
     window.localStorage.setItem("rolly.voice.user", speaker);
+    persistTranscript("system", "Call started.", "call_start", {
+      user_agent: navigator.userAgent,
+      selected_input_id: selectedInputId || "browser-default",
+    });
     const isCurrentCall = () => callSeqRef.current === callSeq;
     setError(null);
     setStatus("requesting");
@@ -311,6 +393,7 @@ export default function VoiceCallPage() {
       startMicMonitor(stream);
       const track = stream.getAudioTracks()[0];
       addLog("system", `Browser mic opened: ${track?.label || "unknown device"}. Watch the mic level; it should move when you talk.`);
+      persistTranscript("system", `Browser mic opened: ${track?.label || "unknown device"}.`, "mic_opened");
       setStatus("connecting");
 
       const peer = new RTCPeerConnection();
@@ -318,6 +401,7 @@ export default function VoiceCallPage() {
       peer.onconnectionstatechange = () => {
         if (["closed", "disconnected", "failed"].includes(peer.connectionState)) {
           addLog("system", `Connection ${peer.connectionState}.`);
+          persistTranscript("system", `Connection ${peer.connectionState}.`, "connection_state", { state: peer.connectionState });
         }
       };
 
@@ -332,6 +416,7 @@ export default function VoiceCallPage() {
       dataChannel.onopen = () => {
         setStatus("live");
         addLog("system", "Live. Talk normally; Rolly can answer by voice and call tools.");
+        persistTranscript("system", "Realtime data channel live.", "call_live");
       };
       dataChannel.onmessage = handleRealtimeEvent;
       dataChannel.onerror = () => addLog("error", "Realtime data channel error.");
@@ -349,7 +434,7 @@ export default function VoiceCallPage() {
       addLog("error", message);
       stopCall();
     }
-  }, [addLog, handleRealtimeEvent, refreshInputDevices, selectedInputId, speaker, startMicMonitor, stopCall]);
+  }, [addLog, handleRealtimeEvent, persistTranscript, refreshInputDevices, selectedInputId, speaker, startMicMonitor, stopCall]);
 
   const toggleMute = useCallback(() => {
     const next = !muted;
@@ -359,7 +444,14 @@ export default function VoiceCallPage() {
     setMuted(next);
   }, [muted]);
 
-  useEffect(() => stopCall, [stopCall]);
+  useEffect(() => {
+    return () => {
+      dataRef.current?.close();
+      peerRef.current?.close();
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      stopMicMonitor();
+    };
+  }, [stopMicMonitor]);
   useEffect(() => {
     void refreshInputDevices().catch(() => undefined);
     navigator.mediaDevices?.addEventListener?.("devicechange", refreshInputDevices);
@@ -391,8 +483,12 @@ export default function VoiceCallPage() {
         </div>
         <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.12em] text-text-secondary">
           <span className="border border-current/20 px-2 py-1">Status: {status}</span>
+          <span className="border border-current/20 px-2 py-1">Call: {callIdRef.current}</span>
+          <span className="border border-current/20 px-2 py-1">Save: {saveStatus}</span>
+          {activeTool ? <span className="border border-current/20 px-2 py-1">Tool: {activeTool}</span> : null}
           <span className="border border-current/20 px-2 py-1">Provider: OpenAI Realtime WebRTC</span>
           <span className="border border-current/20 px-2 py-1">Tools: full Rolly</span>
+          {lastSavePath ? <span className="border border-current/20 px-2 py-1 normal-case">Transcript: {lastSavePath}</span> : null}
         </div>
         <div className="mt-3 text-xs uppercase tracking-[0.12em] text-text-secondary">
           <label className="mb-3 block">
@@ -444,7 +540,7 @@ export default function VoiceCallPage() {
             {logs.map((entry) => (
               <div key={entry.id} className="border border-current/10 bg-background-base/50 p-3">
                 <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
-                  {entry.kind}
+                  {entry.kind} · {formatClock(entry.timestamp)} · {formatElapsed(entry.elapsedMs)}
                 </div>
                 <div className="whitespace-pre-wrap leading-relaxed">{entry.text}</div>
               </div>

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -817,7 +817,7 @@ export default function VoiceCallPage() {
     [addLog, finishResponse, flushPendingHandoffs, handleToolCall, persistTranscript, requestResponseCreate, sendRealtimeEvent, speaker, startBoundedWorkingCue, startWorkingCue, stopWorkingCue],
   );
 
-  const startCall = useCallback(async (overrideMode?: "solo" | "meet") => {
+  const startCall = useCallback(async (overrideMode?: "solo" | "meet", preserveCallId = false) => {
     const callMode = overrideMode ?? mode;
     activeCallModeRef.current = callMode;
     if (!speaker) {
@@ -827,7 +827,7 @@ export default function VoiceCallPage() {
     }
     const callSeq = callSeqRef.current + 1;
     callSeqRef.current = callSeq;
-    if (!new URLSearchParams(window.location.search).get("call_id")) {
+    if (!preserveCallId && !new URLSearchParams(window.location.search).get("call_id")) {
       callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     }
     setCallIdDisplay(callIdRef.current);
@@ -955,7 +955,7 @@ export default function VoiceCallPage() {
         participant_audio_routing: resp.participant_audio_routing,
         participant_audio_routing_detail: resp.participant_audio_routing_detail,
       });
-      await startCall("meet");
+      await startCall("meet", true);
     } catch (exc) {
       const message = exc instanceof Error ? exc.message : String(exc);
       setError(`Meet invite unavailable: ${message}`);

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
-import { api, type VoiceRoomEvent, type VoiceRoomParticipant, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
+import { api, type VoiceMeetSignal, type VoiceRoomEvent, type VoiceRoomParticipant, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
 import { getRollyUser, getRollyUserSlug } from "@/lib/rollyIdentity";
 import { isRollyWakePhrase } from "@/lib/voiceMeet";
 
@@ -116,6 +116,10 @@ export default function VoiceCallPage() {
   const meetInvokedRef = useRef(false);
   const voiceRoomCursorRef = useRef(0);
   const seenVoiceRoomEventsRef = useRef<Set<string>>(new Set());
+  const voiceSignalCursorRef = useRef(0);
+  const meetPeerConnectionsRef = useRef<Map<string, RTCPeerConnection>>(new Map());
+  const meetRemoteAudioRef = useRef<Map<string, HTMLAudioElement>>(new Map());
+  const meetSignalCancelRef = useRef<(() => void) | null>(null);
   const userSpeakingRef = useRef(false);
   const responseActiveRef = useRef(false);
 
@@ -459,6 +463,18 @@ export default function VoiceCallPage() {
       status_at_end: "ending",
       reason,
     });
+    if (activeCallModeRef.current === "meet" && speaker) {
+      void api.postVoiceMeetSignal({ call_id: callIdRef.current, type: "leave", user: speaker }, speaker).catch(() => undefined);
+    }
+    meetSignalCancelRef.current?.();
+    meetSignalCancelRef.current = null;
+    meetPeerConnectionsRef.current.forEach((connection) => connection.close());
+    meetPeerConnectionsRef.current.clear();
+    meetRemoteAudioRef.current.forEach((audio) => {
+      audio.srcObject = null;
+      audio.remove();
+    });
+    meetRemoteAudioRef.current.clear();
     if (dataRef.current) {
       dataRef.current.onerror = null;
       dataRef.current.onmessage = null;
@@ -491,7 +507,111 @@ export default function VoiceCallPage() {
     Promise.allSettled([...pendingTranscriptSavesRef.current]).then(() => setSaveStatus("Call saved"));
     setStatus("idle");
     addLog("system", `Call ended; saved end marker (${(durationMs / 1000).toFixed(1)}s).`);
-  }, [addLog, logs.length, persistTranscript, status, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue, voiceTasks]);
+  }, [addLog, logs.length, persistTranscript, speaker, status, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue, voiceTasks]);
+
+  const startMeetPeerAudio = useCallback(
+    (roomCallId: string, localStream: MediaStream) => {
+      meetSignalCancelRef.current?.();
+      let cancelled = false;
+      meetSignalCancelRef.current = () => {
+        cancelled = true;
+      };
+      const ensurePeerConnection = (remoteUser: string) => {
+        let connection = meetPeerConnectionsRef.current.get(remoteUser);
+        if (connection) return connection;
+        connection = new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] });
+        localStream.getAudioTracks().forEach((track) => connection?.addTrack(track, localStream));
+        connection.onicecandidate = (event) => {
+          if (!event.candidate) return;
+          void api.postVoiceMeetSignal(
+            { call_id: roomCallId, type: "ice", to_user: remoteUser, user: speaker, payload: event.candidate.toJSON() as Record<string, unknown> },
+            speaker,
+          ).catch(() => undefined);
+        };
+        connection.ontrack = (event) => {
+          const [remoteStream] = event.streams;
+          if (!remoteStream) return;
+          let audio = meetRemoteAudioRef.current.get(remoteUser);
+          if (!audio) {
+            audio = document.createElement("audio");
+            audio.autoplay = true;
+            audio.setAttribute("playsinline", "true");
+            audio.dataset.rollyMeetPeer = remoteUser;
+            document.body.appendChild(audio);
+            meetRemoteAudioRef.current.set(remoteUser, audio);
+          }
+          audio.srcObject = remoteStream;
+          void audio.play().catch(() => addLog("system", `Remote audio from ${remoteUser} is ready; browser blocked autoplay until the next click.`));
+          addLog("system", `Remote audio connected: ${remoteUser}.`);
+        };
+        connection.onconnectionstatechange = () => {
+          if (connection?.connectionState === "failed") addLog("system", `Remote audio connection failed: ${remoteUser}.`);
+          if (connection?.connectionState === "connected") addLog("system", `Remote audio live: ${remoteUser}.`);
+        };
+        meetPeerConnectionsRef.current.set(remoteUser, connection);
+        return connection;
+      };
+      const sendOffer = async (remoteUser: string) => {
+        const connection = ensurePeerConnection(remoteUser);
+        if (connection.signalingState !== "stable") return;
+        const offer = await connection.createOffer({ offerToReceiveAudio: true });
+        await connection.setLocalDescription(offer);
+        await api.postVoiceMeetSignal({ call_id: roomCallId, type: "offer", to_user: remoteUser, user: speaker, payload: offer as unknown as Record<string, unknown> }, speaker);
+      };
+      const handleSignal = async (signal: VoiceMeetSignal) => {
+        const remoteUser = signal.from_user;
+        if (!remoteUser || remoteUser === speaker) return;
+        if (signal.to_user && signal.to_user !== speaker) return;
+        if (signal.type === "join") {
+          addLog("system", `${remoteUser} is available for peer audio.`);
+          if (speaker < remoteUser) await sendOffer(remoteUser);
+          return;
+        }
+        if (signal.type === "leave") {
+          meetPeerConnectionsRef.current.get(remoteUser)?.close();
+          meetPeerConnectionsRef.current.delete(remoteUser);
+          const audio = meetRemoteAudioRef.current.get(remoteUser);
+          if (audio) {
+            audio.srcObject = null;
+            audio.remove();
+            meetRemoteAudioRef.current.delete(remoteUser);
+          }
+          return;
+        }
+        const connection = ensurePeerConnection(remoteUser);
+        if (signal.type === "offer") {
+          await connection.setRemoteDescription(signal.payload as unknown as RTCSessionDescriptionInit);
+          const answer = await connection.createAnswer();
+          await connection.setLocalDescription(answer);
+          await api.postVoiceMeetSignal({ call_id: roomCallId, type: "answer", to_user: remoteUser, user: speaker, payload: answer as unknown as Record<string, unknown> }, speaker);
+          return;
+        }
+        if (signal.type === "answer") {
+          await connection.setRemoteDescription(signal.payload as unknown as RTCSessionDescriptionInit);
+          return;
+        }
+        if (signal.type === "ice") {
+          await connection.addIceCandidate(signal.payload as RTCIceCandidateInit);
+        }
+      };
+      const pollSignals = async () => {
+        while (!cancelled) {
+          try {
+            const response = await api.getVoiceMeetSignals(roomCallId, voiceSignalCursorRef.current, 200, speaker, 10000);
+            voiceSignalCursorRef.current = response.cursor;
+            for (const signal of response.signals) await handleSignal(signal);
+          } catch (exc) {
+            addLog("system", `Meet peer audio signaling paused: ${exc instanceof Error ? exc.message : String(exc)}`);
+            await new Promise((resolve) => window.setTimeout(resolve, 1000));
+          }
+        }
+      };
+      voiceSignalCursorRef.current = 0;
+      void api.postVoiceMeetSignal({ call_id: roomCallId, type: "join", user: speaker }, speaker).catch(() => undefined);
+      void pollSignals();
+    },
+    [addLog, speaker],
+  );
 
   const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
     const channel = dataRef.current;
@@ -849,6 +969,9 @@ export default function VoiceCallPage() {
     setCallIdDisplay(callIdRef.current);
     callStartedAtRef.current = Date.now();
     if (!preserveCallId) eventSeqRef.current = 0;
+    voiceRoomCursorRef.current = 0;
+    seenVoiceRoomEventsRef.current = new Set();
+    voiceSignalCursorRef.current = 0;
     pendingTranscriptSavesRef.current = [];
     setLastSavePath(null);
     setSaveStatus("Saving call events…");
@@ -901,6 +1024,10 @@ export default function VoiceCallPage() {
       const track = stream.getAudioTracks()[0];
       addLog("system", `Browser mic opened: ${track?.label || "unknown device"}. Watch the mic level; it should move when you talk.`);
       persistTranscript("system", `Browser mic opened: ${track?.label || "unknown device"}.`, "mic_opened");
+      if (callMode === "meet") {
+        startMeetPeerAudio(callIdRef.current, stream);
+        addLog("system", "Meet peer audio signaling started.");
+      }
       setStatus("connecting");
 
       const peer = new RTCPeerConnection();
@@ -948,7 +1075,7 @@ export default function VoiceCallPage() {
       addLog("error", message);
       stopCall("setup_error");
     }
-  }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMicMonitor, stopBackgroundCallSupport, stopCall, stopMicMonitor, playVoiceCue]);
+  }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMeetPeerAudio, startMicMonitor, stopBackgroundCallSupport, stopCall, stopMicMonitor, playVoiceCue]);
 
   const startMeetingInvite = useCallback(async () => {
     setError(null);
@@ -993,6 +1120,14 @@ export default function VoiceCallPage() {
     return () => {
       dataRef.current?.close();
       peerRef.current?.close();
+      meetSignalCancelRef.current?.();
+      meetPeerConnectionsRef.current.forEach((connection) => connection.close());
+      meetPeerConnectionsRef.current.clear();
+      meetRemoteAudioRef.current.forEach((audio) => {
+        audio.srcObject = null;
+        audio.remove();
+      });
+      meetRemoteAudioRef.current.clear();
       streamRef.current?.getTracks().forEach((track) => track.stop());
       stopWorkingCue(false);
       stopBackgroundCallSupport();

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -579,7 +579,6 @@ export default function VoiceCallPage() {
 
   const pollVoiceTask = useCallback(
     async (taskId: string, toolCallId: string) => {
-      markWorkStarted(`task:${taskId}`, `Rolly background task ${taskId} running`);
       let lastProgress = "";
       try {
         for (;;) {
@@ -594,7 +593,6 @@ export default function VoiceCallPage() {
           }
           if (task.status === "complete") {
             const output = task.result || "Background Rolly task completed.";
-            markWorkFinished(`task:${taskId}`, false);
             addLog("tool", `${taskId} complete\n${output.slice(0, 700)}`);
             persistTranscript("tool", output, "delegation_result", { task_id: taskId, session_id: task.session_id });
             queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
@@ -602,7 +600,6 @@ export default function VoiceCallPage() {
           }
           if (task.status === "failed" || task.status === "cancelled") {
             const output = `Background Rolly task ${task.status}: ${task.error || "no error detail"}`;
-            markWorkFinished(`task:${taskId}`, "error");
             addLog("error", output);
             persistTranscript("tool", output, "delegation_error", { task_id: taskId, session_id: task.session_id });
             queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
@@ -611,13 +608,12 @@ export default function VoiceCallPage() {
         }
       } catch (exc) {
         const message = exc instanceof Error ? exc.message : String(exc);
-        markWorkFinished(`task:${taskId}`, "error");
         addLog("error", `${taskId} polling failed: ${message}`);
         persistTranscript("tool", message, "delegation_error", { task_id: taskId });
         queueOrSendToolOutput(toolCallId, `Background task status check failed: ${message}`, taskId);
       }
     },
-    [addLog, markWorkFinished, markWorkStarted, persistTranscript, queueOrSendToolOutput, rememberVoiceTask, speaker],
+    [addLog, persistTranscript, queueOrSendToolOutput, rememberVoiceTask, speaker],
   );
 
   const handleToolCall = useCallback(
@@ -764,7 +760,6 @@ export default function VoiceCallPage() {
         return;
       }
       if (type === "input_audio_buffer.committed") {
-        if (mode === "solo") startWorkingCue();
         addLog("system", "Realtime API committed mic audio.");
         persistTranscript("system", "Realtime API committed mic audio.", "audio_committed");
         return;
@@ -865,6 +860,13 @@ export default function VoiceCallPage() {
       streamRef.current = stream;
       startMicMonitor(stream);
       await startBackgroundCallSupport();
+      if (!isCurrentCall()) {
+        stopBackgroundCallSupport();
+        stopMicMonitor();
+        if (streamRef.current === stream) streamRef.current = null;
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
       const track = stream.getAudioTracks()[0];
       addLog("system", `Browser mic opened: ${track?.label || "unknown device"}. Watch the mic level; it should move when you talk.`);
       persistTranscript("system", `Browser mic opened: ${track?.label || "unknown device"}.`, "mic_opened");
@@ -912,7 +914,7 @@ export default function VoiceCallPage() {
       addLog("error", message);
       stopCall();
     }
-  }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMicMonitor, stopCall, playVoiceCue]);
+  }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMicMonitor, stopBackgroundCallSupport, stopCall, stopMicMonitor, playVoiceCue]);
 
   const toggleMute = useCallback(() => {
     const next = !muted;

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -432,9 +432,12 @@ export default function VoiceCallPage() {
     const endText = reason === "setup_error"
       ? "Call ended after setup error; microphone released."
       : "Call ended by user; microphone released.";
+    const voiceTasksAtEnd = voiceTasks.map((task) => ({ task_id: task.task_id, status: task.status, session_id: task.session_id }));
     persistTranscript("system", endText, "call_end", {
       duration_ms: durationMs,
       pending_saves_at_end: pendingTranscriptSavesRef.current.length,
+      active_work_count_at_end: activeWorkRef.current.size,
+      voice_tasks_at_end: voiceTasksAtEnd,
       log_entries: logs.length,
       status_before_end: statusAtEnd,
       status_at_end: "ending",
@@ -472,7 +475,7 @@ export default function VoiceCallPage() {
     Promise.allSettled([...pendingTranscriptSavesRef.current]).then(() => setSaveStatus("Call saved"));
     setStatus("idle");
     addLog("system", `Call ended; saved end marker (${(durationMs / 1000).toFixed(1)}s).`);
-  }, [addLog, logs.length, persistTranscript, status, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue]);
+  }, [addLog, logs.length, persistTranscript, status, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue, voiceTasks]);
 
   const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
     const channel = dataRef.current;
@@ -578,11 +581,16 @@ export default function VoiceCallPage() {
   );
 
   const pollVoiceTask = useCallback(
-    async (taskId: string, toolCallId: string) => {
+    async (taskId: string, toolCallId: string, callSeq: number) => {
       let lastProgress = "";
       try {
         for (;;) {
           await new Promise((resolve) => window.setTimeout(resolve, 2000));
+          if (callSeqRef.current !== callSeq || !dataRef.current || dataRef.current.readyState !== "open") {
+            addLog("system", `${taskId}: stopped live polling because the call is no longer active.`);
+            markWorkFinished(`task:${taskId}`, false);
+            return;
+          }
           const task: VoiceTaskResponse = await api.getVoiceTask(taskId, speaker);
           rememberVoiceTask(task);
           const latest = task.progress?.[task.progress.length - 1]?.message ?? task.status;
@@ -596,6 +604,7 @@ export default function VoiceCallPage() {
             addLog("tool", `${taskId} complete\n${output.slice(0, 700)}`);
             persistTranscript("tool", output, "delegation_handoff", { task_id: taskId, session_id: task.session_id });
             queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
+            markWorkFinished(`task:${taskId}`, "done");
             return;
           }
           if (task.status === "failed" || task.status === "cancelled") {
@@ -603,6 +612,7 @@ export default function VoiceCallPage() {
             addLog("error", output);
             persistTranscript("tool", output, "delegation_error", { task_id: taskId, session_id: task.session_id });
             queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
+            markWorkFinished(`task:${taskId}`, "error");
             return;
           }
         }
@@ -611,9 +621,10 @@ export default function VoiceCallPage() {
         addLog("error", `${taskId} polling failed: ${message}`);
         persistTranscript("tool", message, "delegation_error", { task_id: taskId });
         queueOrSendToolOutput(toolCallId, `Background task status check failed: ${message}`, taskId);
+        markWorkFinished(`task:${taskId}`, "error");
       }
     },
-    [addLog, persistTranscript, queueOrSendToolOutput, rememberVoiceTask, speaker],
+    [addLog, markWorkFinished, persistTranscript, queueOrSendToolOutput, rememberVoiceTask, speaker],
   );
 
   const handleToolCall = useCallback(
@@ -647,7 +658,7 @@ export default function VoiceCallPage() {
       const startedAt = Date.now();
       markWorkStarted(`tool:${toolKey}`, `${name} running since ${formatClock(new Date(startedAt).toISOString())}`);
       addLog("tool", `Running ${name}… ${JSON.stringify(args).slice(0, 300)}`);
-      persistTranscript("tool", `Running ${name}: ${JSON.stringify(args)}`, "tool_call", {
+      await persistTranscript("tool", `Running ${name}: ${JSON.stringify(args)}`, "tool_call", {
         realtime_call_id: callId,
         tool_name: name,
         started_at: new Date(startedAt).toISOString(),
@@ -676,7 +687,8 @@ export default function VoiceCallPage() {
         const taskId = typeof result.data?.task_id === "string" ? result.data.task_id : "";
         if (name === "rolly_background" && taskId) {
           rememberVoiceTask(result.data as unknown as VoiceTaskResponse);
-          void pollVoiceTask(taskId, callId);
+          markWorkStarted(`task:${taskId}`, `${taskId} running in background`);
+          void pollVoiceTask(taskId, callId, callSeqRef.current);
         }
       } catch (exc) {
         const durationMs = Date.now() - startedAt;

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -935,7 +935,14 @@ export default function VoiceCallPage() {
       setMode("meet");
       setInviteUrl(resp.invite_url);
       addLog("system", `Meet invite ready: ${resp.invite_url}`);
-      persistTranscript("system", `Meet invite created: ${resp.invite_url}`, "meet_invite_created", { mode: "meet" });
+      if (resp.participant_audio_routing === "not_supported") {
+        addLog("system", resp.participant_audio_routing_detail || "Participant-to-participant audio is not bridged yet.");
+      }
+      persistTranscript("system", `Meet invite created: ${resp.invite_url}`, "meet_invite_created", {
+        mode: "meet",
+        participant_audio_routing: resp.participant_audio_routing,
+        participant_audio_routing_detail: resp.participant_audio_routing_detail,
+      });
       await startCall("meet");
     } catch (exc) {
       const message = exc instanceof Error ? exc.message : String(exc);

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
-import { api, type VoiceToolRequest } from "@/lib/api";
+import { api, type VoiceTaskResponse, type VoiceToolRequest } from "@/lib/api";
+import { getRollyUser, getRollyUserSlug } from "@/lib/rollyIdentity";
 
 type CallStatus = "idle" | "requesting" | "connecting" | "live" | "ending" | "error";
 
 type LogKind = "system" | "user" | "rolly" | "tool" | "error";
+
+type WakeLockSentinelLike = EventTarget & {
+  release: () => Promise<void>;
+  released?: boolean;
+};
 
 interface LogEntry {
   id: string;
@@ -35,6 +41,16 @@ function formatElapsed(ms: number | null): string {
   return `+${(ms / 1000).toFixed(1)}s`;
 }
 
+function isRollyWakePhrase(text: string): boolean {
+  const normalized = text
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return /\bhey\s+(?:rolly|rollie|rowley|rowly|rowy|roley|rally)\b/.test(normalized);
+}
+
 export default function VoiceCallPage() {
   const [status, setStatus] = useState<CallStatus>("idle");
   const [muted, setMuted] = useState(false);
@@ -42,7 +58,7 @@ export default function VoiceCallPage() {
   const [micLevel, setMicLevel] = useState(0);
   const [inputDevices, setInputDevices] = useState<MediaDeviceInfo[]>([]);
   const [selectedInputId, setSelectedInputId] = useState("");
-  const [speaker, setSpeaker] = useState(() => window.localStorage.getItem("rolly.voice.user") || "deniz");
+  const [speaker, setSpeaker] = useState(() => getRollyUserSlug());
   const [error, setError] = useState<string | null>(null);
   const [logs, setLogs] = useState<LogEntry[]>([
     {
@@ -58,15 +74,207 @@ export default function VoiceCallPage() {
   const streamRef = useRef<MediaStream | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
+  const cueAudioContextRef = useRef<AudioContext | null>(null);
+  const backgroundAudioContextRef = useRef<AudioContext | null>(null);
+  const backgroundOscillatorRef = useRef<OscillatorNode | null>(null);
+  const wakeLockRef = useRef<WakeLockSentinelLike | null>(null);
+  const workingCueIntervalRef = useRef<number | null>(null);
+  const workingCueTimeoutRef = useRef<number | null>(null);
   const micMonitorRafRef = useRef<number | null>(null);
   const callIdRef = useRef(`voice-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const callStartedAtRef = useRef<number | null>(null);
   const eventSeqRef = useRef(0);
   const pendingTranscriptSavesRef = useRef<Promise<unknown>[]>([]);
+  const transcriptSaveChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const callSeqRef = useRef(0);
   const [saveStatus, setSaveStatus] = useState("Not saving yet");
   const [lastSavePath, setLastSavePath] = useState<string | null>(null);
   const [activeTool, setActiveTool] = useState<string | null>(null);
+  const [activeWorkCount, setActiveWorkCount] = useState(0);
+  const [pendingHandoffs, setPendingHandoffs] = useState(0);
+  const [backgroundSupport, setBackgroundSupport] = useState("Background call support: idle");
+  const [mode, setMode] = useState<"solo" | "meet">("solo");
+  const [callIdDisplay, setCallIdDisplay] = useState(callIdRef.current);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [voiceTasks, setVoiceTasks] = useState<VoiceTaskResponse[]>([]);
+  const [rollyListenState, setRollyListenState] = useState("Always on");
+  const handledToolCallsRef = useRef<Set<string>>(new Set());
+  const meetInvokedRef = useRef(false);
+  const userSpeakingRef = useRef(false);
+  const responseActiveRef = useRef(false);
+  const pendingResponseCreateRef = useRef(false);
+  const activeWorkRef = useRef<Map<string, string>>(new Map());
+  const pendingHandoffsRef = useRef<Array<{ toolCallId: string; taskId: string; output: string }>>([]);
+
+  const getCueAudioContext = useCallback(() => {
+    const AudioContextCtor = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextCtor) return null;
+    if (!cueAudioContextRef.current || cueAudioContextRef.current.state === "closed") {
+      cueAudioContextRef.current = new AudioContextCtor();
+    }
+    void cueAudioContextRef.current.resume().catch(() => undefined);
+    return cueAudioContextRef.current;
+  }, []);
+
+  const playTone = useCallback(
+    (frequency: number, delayMs = 0, durationMs = 90, volume = 0.035) => {
+      const context = getCueAudioContext();
+      if (!context) return;
+      const start = context.currentTime + delayMs / 1000;
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(frequency, start);
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(volume, start + 0.015);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + durationMs / 1000);
+      oscillator.connect(gain).connect(context.destination);
+      oscillator.start(start);
+      oscillator.stop(start + durationMs / 1000 + 0.03);
+    },
+    [getCueAudioContext],
+  );
+
+  const playVoiceCue = useCallback(
+    (kind: "live" | "working" | "done" | "error") => {
+      if (kind === "live") {
+        playTone(523, 0, 80);
+        playTone(784, 95, 110);
+      } else if (kind === "working") {
+        playTone(659, 0, 65, 0.025);
+        playTone(880, 95, 65, 0.022);
+      } else if (kind === "done") {
+        playTone(880, 0, 70, 0.026);
+        playTone(659, 90, 90, 0.022);
+      } else {
+        playTone(220, 0, 130, 0.035);
+      }
+    },
+    [playTone],
+  );
+
+  const releaseWakeLock = useCallback(() => {
+    const lock = wakeLockRef.current;
+    wakeLockRef.current = null;
+    if (lock && !lock.released) void lock.release().catch(() => undefined);
+  }, []);
+
+  const requestWakeLock = useCallback(async () => {
+    const wakeLock = (navigator as Navigator & { wakeLock?: { request: (type: "screen") => Promise<WakeLockSentinelLike> } }).wakeLock;
+    if (!wakeLock || document.visibilityState !== "visible") return false;
+    try {
+      wakeLockRef.current = await wakeLock.request("screen");
+      wakeLockRef.current.addEventListener("release", () => {
+        wakeLockRef.current = null;
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const startBackgroundCallSupport = useCallback(async () => {
+    const AudioContextCtor = window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (AudioContextCtor && (!backgroundAudioContextRef.current || backgroundAudioContextRef.current.state === "closed")) {
+      const context = new AudioContextCtor();
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+      oscillator.type = "sine";
+      oscillator.frequency.value = 20;
+      gain.gain.value = 0.00001;
+      oscillator.connect(gain).connect(context.destination);
+      oscillator.start();
+      backgroundAudioContextRef.current = context;
+      backgroundOscillatorRef.current = oscillator;
+      await context.resume().catch(() => undefined);
+    }
+
+    if ("mediaSession" in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: "Rolly Voice Call",
+        artist: "Rolly",
+        album: mode === "meet" ? "Meet mode" : "1:1 mode",
+      });
+      navigator.mediaSession.playbackState = "playing";
+    }
+
+    const wakeLocked = await requestWakeLock();
+    setBackgroundSupport(wakeLocked ? "Background call support: app registered + screen wake lock active" : "Background call support: app registered; install to Home Screen for best lock-screen behavior");
+  }, [mode, requestWakeLock]);
+
+  const stopBackgroundCallSupport = useCallback(() => {
+    releaseWakeLock();
+    backgroundOscillatorRef.current?.stop();
+    backgroundOscillatorRef.current?.disconnect();
+    backgroundOscillatorRef.current = null;
+    void backgroundAudioContextRef.current?.close().catch(() => undefined);
+    backgroundAudioContextRef.current = null;
+    if ("mediaSession" in navigator) navigator.mediaSession.playbackState = "none";
+    setBackgroundSupport("Background call support: idle");
+  }, [releaseWakeLock]);
+
+  const startWorkingCue = useCallback(() => {
+    if (workingCueIntervalRef.current !== null) return;
+    playVoiceCue("working");
+    workingCueIntervalRef.current = window.setInterval(() => playVoiceCue("working"), 6500);
+  }, [playVoiceCue]);
+
+  const stopWorkingCue = useCallback(
+    (finish: "done" | "error" | false = false) => {
+      if (workingCueTimeoutRef.current !== null) {
+        window.clearTimeout(workingCueTimeoutRef.current);
+        workingCueTimeoutRef.current = null;
+      }
+      if (workingCueIntervalRef.current !== null) {
+        window.clearInterval(workingCueIntervalRef.current);
+        workingCueIntervalRef.current = null;
+      }
+      if (finish) playVoiceCue(finish);
+    },
+    [playVoiceCue],
+  );
+
+  const startBoundedWorkingCue = useCallback(() => {
+    startWorkingCue();
+    if (workingCueTimeoutRef.current !== null) window.clearTimeout(workingCueTimeoutRef.current);
+    workingCueTimeoutRef.current = window.setTimeout(() => {
+      if (activeWorkRef.current.size === 0) stopWorkingCue(false);
+    }, 15000);
+  }, [startWorkingCue, stopWorkingCue]);
+
+  const refreshActiveWork = useCallback(() => {
+    const count = activeWorkRef.current.size;
+    setActiveWorkCount(count);
+    if (count > 0) startWorkingCue();
+    else stopWorkingCue(false);
+  }, [startWorkingCue, stopWorkingCue]);
+
+  const rememberVoiceTask = useCallback((task: VoiceTaskResponse) => {
+    setVoiceTasks((prev) => {
+      const without = prev.filter((item) => item.task_id !== task.task_id);
+      return [task, ...without].slice(0, 12);
+    });
+  }, []);
+
+  const markWorkStarted = useCallback(
+    (id: string, label: string) => {
+      activeWorkRef.current.set(id, label);
+      setActiveTool(label);
+      refreshActiveWork();
+    },
+    [refreshActiveWork],
+  );
+
+  const markWorkFinished = useCallback(
+    (id: string, finish: "done" | "error" | false = false) => {
+      activeWorkRef.current.delete(id);
+      const remaining = Array.from(activeWorkRef.current.values());
+      setActiveTool(remaining[remaining.length - 1] ?? null);
+      setActiveWorkCount(activeWorkRef.current.size);
+      if (activeWorkRef.current.size === 0) stopWorkingCue(finish);
+    },
+    [stopWorkingCue],
+  );
 
   const addLog = useCallback((kind: LogKind, text: string) => {
     const now = Date.now();
@@ -82,20 +290,20 @@ export default function VoiceCallPage() {
       const now = Date.now();
       const startedAt = callStartedAtRef.current;
       const sequence = ++eventSeqRef.current;
-      const save = api.saveVoiceTranscript(
-        {
-          call_id: callIdRef.current,
-          role,
-          text,
-          event_type: eventType,
-          user: speaker,
-          timestamp: new Date(now).toISOString(),
-          sequence,
-          elapsed_ms: startedAt === null ? undefined : now - startedAt,
-          metadata,
-        },
-        speaker,
-      )
+      const payload = {
+        call_id: callIdRef.current,
+        role,
+        text,
+        event_type: eventType,
+        user: speaker,
+        timestamp: new Date(now).toISOString(),
+        sequence,
+        elapsed_ms: startedAt === null ? undefined : now - startedAt,
+        metadata,
+      };
+      const save = transcriptSaveChainRef.current
+        .catch(() => undefined)
+        .then(() => api.saveVoiceTranscript(payload, speaker))
         .then((resp) => {
           setLastSavePath(resp.path);
           setSaveStatus(`Saved event #${sequence}`);
@@ -109,6 +317,7 @@ export default function VoiceCallPage() {
         .finally(() => {
           pendingTranscriptSavesRef.current = pendingTranscriptSavesRef.current.filter((item) => item !== save);
         });
+      transcriptSaveChainRef.current = save.catch(() => undefined);
       pendingTranscriptSavesRef.current.push(save);
       return save;
     },
@@ -187,11 +396,61 @@ export default function VoiceCallPage() {
     }
   }, [addLog, refreshInputDevices]);
 
+  const switchMicrophone = useCallback(
+    async (deviceId: string) => {
+      if (status !== "live" || !peerRef.current) return;
+      setError(null);
+      try {
+        const audio: MediaTrackConstraints = deviceId ? { deviceId: { exact: deviceId } } : {};
+        const nextStream = await navigator.mediaDevices.getUserMedia({ audio });
+        const nextTrack = nextStream.getAudioTracks()[0];
+        if (!nextTrack) throw new Error("Selected microphone produced no audio track.");
+        const sender = peerRef.current.getSenders().find((item) => item.track?.kind === "audio");
+        if (!sender) throw new Error("Active call has no microphone sender to replace.");
+        await sender.replaceTrack(nextTrack);
+        streamRef.current?.getTracks().forEach((track) => track.stop());
+        streamRef.current = nextStream;
+        nextTrack.enabled = !muted;
+        startMicMonitor(nextStream);
+        await refreshInputDevices();
+        addLog("system", `Switched microphone to ${nextTrack.label || "selected input"}.`);
+        persistTranscript("system", `Switched microphone to ${nextTrack.label || "selected input"}.`, "mic_switched", {
+          selected_input_id: deviceId || "browser-default",
+        });
+      } catch (exc) {
+        const message = exc instanceof Error ? exc.message : String(exc);
+        setError(`Microphone switch failed: ${message}`);
+        addLog("error", `Microphone switch failed: ${message}`);
+        persistTranscript("error", `Microphone switch failed: ${message}`, "mic_switch_failed", {
+          selected_input_id: deviceId || "browser-default",
+        });
+      }
+    },
+    [addLog, muted, persistTranscript, refreshInputDevices, startMicMonitor, status],
+  );
+
+  const createInvite = useCallback(async () => {
+    setError(null);
+    try {
+      const resp = await api.createVoiceMeetInvite({ call_id: callIdRef.current, user: speaker });
+      setMode("meet");
+      setInviteUrl(resp.invite_url);
+      addLog("system", `Meet invite ready: ${resp.invite_url}`);
+      persistTranscript("system", `Meet invite created: ${resp.invite_url}`, "meet_invite_created", { mode: "meet" });
+    } catch (exc) {
+      const message = exc instanceof Error ? exc.message : String(exc);
+      setError(`Meet invite unavailable: ${message}`);
+      addLog("error", `Meet invite unavailable: ${message}`);
+    }
+  }, [addLog, persistTranscript, speaker]);
+
   const stopCall = useCallback(() => {
     const endStartedAt = Date.now();
     const durationMs = callStartedAtRef.current === null ? 0 : endStartedAt - callStartedAtRef.current;
     callSeqRef.current += 1;
     setStatus((current) => (current === "idle" ? current : "ending"));
+    stopWorkingCue(false);
+    stopBackgroundCallSupport();
     persistTranscript("system", "Call ended by user; microphone released.", "call_end", {
       duration_ms: durationMs,
       pending_saves_at_end: pendingTranscriptSavesRef.current.length,
@@ -212,12 +471,19 @@ export default function VoiceCallPage() {
     dataRef.current = null;
     peerRef.current = null;
     streamRef.current = null;
+    activeWorkRef.current.clear();
+    pendingHandoffsRef.current = [];
+    userSpeakingRef.current = false;
+    responseActiveRef.current = false;
+    pendingResponseCreateRef.current = false;
+    setActiveWorkCount(0);
+    setPendingHandoffs(0);
     setMuted(false);
     setActiveTool(null);
     Promise.allSettled([...pendingTranscriptSavesRef.current]).then(() => setSaveStatus("Call saved"));
     setStatus("idle");
     addLog("system", `Call ended; saved end marker (${(durationMs / 1000).toFixed(1)}s).`);
-  }, [addLog, logs.length, persistTranscript, stopMicMonitor]);
+  }, [addLog, logs.length, persistTranscript, stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue]);
 
   const sendRealtimeEvent = useCallback((payload: Record<string, unknown>) => {
     const channel = dataRef.current;
@@ -225,13 +491,151 @@ export default function VoiceCallPage() {
     channel.send(JSON.stringify(payload));
   }, []);
 
+  const requestResponseCreate = useCallback(
+    (reason: string) => {
+      if (responseActiveRef.current) {
+        pendingResponseCreateRef.current = true;
+        addLog("system", `Queued voice response until current response finishes (${reason}).`);
+        return;
+      }
+      responseActiveRef.current = true;
+      sendRealtimeEvent({ type: "response.create" });
+    },
+    [addLog, sendRealtimeEvent],
+  );
+
+  const finishResponse = useCallback(
+    (status: "done" | "cancelled" | "error") => {
+      responseActiveRef.current = false;
+      if (!pendingResponseCreateRef.current) return;
+      pendingResponseCreateRef.current = false;
+      window.setTimeout(() => {
+        requestResponseCreate(`pending after ${status}`);
+      }, 100);
+    },
+    [requestResponseCreate],
+  );
+
+  const flushPendingHandoffs = useCallback(() => {
+    if (userSpeakingRef.current || pendingHandoffsRef.current.length === 0) return;
+    const handoffs = pendingHandoffsRef.current.splice(0);
+    setPendingHandoffs(0);
+    for (const handoff of handoffs) {
+      if (handoff.toolCallId.startsWith("handoff:")) {
+        sendRealtimeEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: `Background Rolly task result is ready. Summarize it to the user in no more than two short spoken sentences. Full result: ${handoff.output}` }],
+          },
+        });
+      } else {
+        sendRealtimeEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: handoff.toolCallId,
+            output: handoff.output,
+          },
+        });
+      }
+      persistTranscript("tool", handoff.output, "delegation_handoff", { task_id: handoff.taskId });
+      requestResponseCreate("tool output");
+    }
+  }, [persistTranscript, requestResponseCreate, sendRealtimeEvent]);
+
+  const queueOrSendToolOutput = useCallback(
+    (toolCallId: string, output: string, taskId = "foreground") => {
+      if (userSpeakingRef.current) {
+        pendingHandoffsRef.current.push({ toolCallId, taskId, output });
+        setPendingHandoffs(pendingHandoffsRef.current.length);
+        persistTranscript("system", "Queued Rolly result until user stops speaking.", "handoff_queued", { task_id: taskId });
+        return;
+      }
+      if (toolCallId.startsWith("handoff:")) {
+        sendRealtimeEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: `Background Rolly task result is ready. Summarize it to the user in no more than two short spoken sentences. Full result: ${output}` }],
+          },
+        });
+      } else {
+        sendRealtimeEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: toolCallId,
+            output,
+          },
+        });
+      }
+      requestResponseCreate("tool output");
+    },
+    [persistTranscript, requestResponseCreate, sendRealtimeEvent],
+  );
+
+  const pollVoiceTask = useCallback(
+    async (taskId: string, toolCallId: string) => {
+      markWorkStarted(`task:${taskId}`, `Rolly background task ${taskId} running`);
+      let lastProgress = "";
+      try {
+        for (;;) {
+          await new Promise((resolve) => window.setTimeout(resolve, 2000));
+          const task: VoiceTaskResponse = await api.getVoiceTask(taskId, speaker);
+          rememberVoiceTask(task);
+          const latest = task.progress?.[task.progress.length - 1]?.message ?? task.status;
+          if (latest && latest !== lastProgress) {
+            lastProgress = latest;
+            addLog("tool", `${taskId}: ${latest}`);
+            persistTranscript("tool", latest, "delegation_progress", { task_id: taskId, status: task.status });
+          }
+          if (task.status === "complete") {
+            const output = task.result || "Background Rolly task completed.";
+            markWorkFinished(`task:${taskId}`, false);
+            addLog("tool", `${taskId} complete\n${output.slice(0, 700)}`);
+            persistTranscript("tool", output, "delegation_result", { task_id: taskId, session_id: task.session_id });
+            queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
+            return;
+          }
+          if (task.status === "failed" || task.status === "cancelled") {
+            const output = `Background Rolly task ${task.status}: ${task.error || "no error detail"}`;
+            markWorkFinished(`task:${taskId}`, "error");
+            addLog("error", output);
+            persistTranscript("tool", output, "delegation_error", { task_id: taskId, session_id: task.session_id });
+            queueOrSendToolOutput(`handoff:${taskId}`, output, taskId);
+            return;
+          }
+        }
+      } catch (exc) {
+        const message = exc instanceof Error ? exc.message : String(exc);
+        markWorkFinished(`task:${taskId}`, "error");
+        addLog("error", `${taskId} polling failed: ${message}`);
+        persistTranscript("tool", message, "delegation_error", { task_id: taskId });
+        queueOrSendToolOutput(toolCallId, `Background task status check failed: ${message}`, taskId);
+      }
+    },
+    [addLog, markWorkFinished, markWorkStarted, persistTranscript, queueOrSendToolOutput, rememberVoiceTask, speaker],
+  );
+
   const handleToolCall = useCallback(
     async (event: Record<string, unknown>) => {
       const name = typeof event.name === "string" ? event.name : "";
       const callId = typeof event.call_id === "string" ? event.call_id : "";
-      const rawArgs = typeof event.arguments === "string" ? event.arguments : "{}";
+      const rawArgs = typeof event.arguments === "string" ? event.arguments : "";
       if (!name || !callId) {
         addLog("error", `Malformed Realtime tool call: ${JSON.stringify(event).slice(0, 500)}`);
+        return;
+      }
+      if (!rawArgs.trim()) {
+        addLog("system", `Waiting for Realtime function arguments for ${name}:${callId}.`);
+        return;
+      }
+      const toolKey = `${name}:${callId}`;
+      if (handledToolCallsRef.current.has(toolKey)) {
+        addLog("system", `Skipped duplicate Realtime tool call ${toolKey}.`);
         return;
       }
 
@@ -239,11 +643,13 @@ export default function VoiceCallPage() {
       try {
         args = JSON.parse(rawArgs) as Record<string, unknown>;
       } catch {
-        args = { raw: rawArgs };
+        addLog("error", `Invalid Realtime tool arguments for ${toolKey}: ${rawArgs.slice(0, 300)}`);
+        return;
       }
+      handledToolCallsRef.current.add(toolKey);
 
       const startedAt = Date.now();
-      setActiveTool(`${name} running since ${formatClock(new Date(startedAt).toISOString())}`);
+      markWorkStarted(`tool:${toolKey}`, `${name} running since ${formatClock(new Date(startedAt).toISOString())}`);
       addLog("tool", `Running ${name}… ${JSON.stringify(args).slice(0, 300)}`);
       persistTranscript("tool", `Running ${name}: ${JSON.stringify(args)}`, "tool_call", {
         realtime_call_id: callId,
@@ -251,10 +657,11 @@ export default function VoiceCallPage() {
         started_at: new Date(startedAt).toISOString(),
       });
       try {
-        const result = await api.runVoiceTool({ name, arguments: args } satisfies VoiceToolRequest, speaker);
+        const idempotencyKey = `${callIdRef.current}:${callId}`;
+        const result = await api.runVoiceTool({ name, arguments: args, call_id: callIdRef.current, realtime_call_id: callId, idempotency_key: idempotencyKey } satisfies VoiceToolRequest, speaker);
         const durationMs = Date.now() - startedAt;
         const output = result.ok ? result.result : `Tool failed: ${result.error ?? "unknown error"}`;
-        setActiveTool(null);
+        markWorkFinished(`tool:${toolKey}`, false);
         addLog(result.ok ? "tool" : "error", `${name} finished in ${(durationMs / 1000).toFixed(1)}s\n${output.slice(0, 700)}`);
         persistTranscript("tool", output, result.ok ? "tool_result" : "tool_error", {
           realtime_call_id: callId,
@@ -269,11 +676,16 @@ export default function VoiceCallPage() {
             output,
           },
         });
-        sendRealtimeEvent({ type: "response.create" });
+        requestResponseCreate("tool output");
+        const taskId = typeof result.data?.task_id === "string" ? result.data.task_id : "";
+        if (name === "rolly_background" && taskId) {
+          rememberVoiceTask(result.data as unknown as VoiceTaskResponse);
+          void pollVoiceTask(taskId, callId);
+        }
       } catch (exc) {
         const durationMs = Date.now() - startedAt;
         const message = exc instanceof Error ? exc.message : String(exc);
-        setActiveTool(null);
+        markWorkFinished(`tool:${toolKey}`, "error");
         addLog("error", `${name} failed in ${(durationMs / 1000).toFixed(1)}s: ${message}`);
         persistTranscript("tool", message, "tool_error", {
           realtime_call_id: callId,
@@ -288,10 +700,10 @@ export default function VoiceCallPage() {
             output: `Tool failed: ${message}`,
           },
         });
-        sendRealtimeEvent({ type: "response.create" });
+        requestResponseCreate("tool output");
       }
     },
-    [addLog, persistTranscript, sendRealtimeEvent, speaker],
+    [addLog, markWorkFinished, markWorkStarted, persistTranscript, pollVoiceTask, rememberVoiceTask, requestResponseCreate, sendRealtimeEvent, speaker],
   );
 
   const handleRealtimeEvent = useCallback(
@@ -318,27 +730,60 @@ export default function VoiceCallPage() {
       if (type === "conversation.item.input_audio_transcription.completed") {
         const text = eventText(event);
         if (text) {
-          addLog("user", text);
-          persistTranscript("user", text);
+          if (mode === "meet") {
+            const invoked = isRollyWakePhrase(text);
+            if (invoked) {
+              meetInvokedRef.current = true;
+              setRollyListenState("Invoked by “Hey Rolly”");
+              startBoundedWorkingCue();
+              requestResponseCreate("meet wake phrase");
+            } else if (!meetInvokedRef.current) {
+              setRollyListenState("Silent; no “Hey Rolly” heard");
+            }
+          }
+          const meetMetadata =
+            mode === "meet"
+              ? { mode, invoked_rolly: meetInvokedRef.current, dashboard_user: speaker, speaker_attribution: "unknown_room_speaker" }
+              : { mode, invoked_rolly: meetInvokedRef.current };
+          addLog("user", mode === "meet" ? `[room mic / dashboard: ${speaker || "unknown"}] ${text}` : text);
+          persistTranscript("user", text, "transcript", meetMetadata);
         }
         return;
       }
       if (type === "input_audio_buffer.speech_started") {
+        userSpeakingRef.current = true;
         addLog("system", "Realtime API heard speech start.");
         persistTranscript("system", "Realtime API heard speech start.", "speech_started");
         return;
       }
       if (type === "input_audio_buffer.speech_stopped") {
+        userSpeakingRef.current = false;
         addLog("system", "Realtime API heard speech stop.");
         persistTranscript("system", "Realtime API heard speech stop.", "speech_stopped");
+        window.setTimeout(flushPendingHandoffs, 250);
         return;
       }
       if (type === "input_audio_buffer.committed") {
+        if (mode === "solo") startWorkingCue();
         addLog("system", "Realtime API committed mic audio.");
         persistTranscript("system", "Realtime API committed mic audio.", "audio_committed");
         return;
       }
+      if (type === "response.created") {
+        responseActiveRef.current = true;
+        return;
+      }
+      if (type === "response.done" || type === "response.cancelled") {
+        finishResponse(type === "response.cancelled" ? "cancelled" : "done");
+        stopWorkingCue(type === "response.cancelled" ? false : "done");
+        if (mode === "meet") {
+          meetInvokedRef.current = false;
+          setRollyListenState("Silent until “Hey Rolly”");
+        }
+        return;
+      }
       if (type === "response.output_audio_transcript.done" || type === "response.audio_transcript.done" || type === "response.output_text.done") {
+        stopWorkingCue(false);
         const text = eventText(event);
         if (text) {
           addLog("rolly", text);
@@ -347,28 +792,56 @@ export default function VoiceCallPage() {
         return;
       }
       if (type === "error") {
+        const errorObj = event.error && typeof event.error === "object" ? (event.error as Record<string, unknown>) : {};
+        if (errorObj.code === "conversation_already_has_active_response") {
+          pendingResponseCreateRef.current = true;
+          addLog("system", "Realtime response was already active; queued another response after it finishes.");
+          persistTranscript("system", "Queued voice response after active-response conflict.", "realtime_response_queued");
+          return;
+        }
+        finishResponse("error");
+        stopWorkingCue("error");
         const messageText = JSON.stringify(event.error ?? event).slice(0, 700);
         addLog("error", messageText);
         persistTranscript("error", messageText, "realtime_error");
       }
     },
-    [addLog, handleToolCall, persistTranscript],
+    [addLog, finishResponse, flushPendingHandoffs, handleToolCall, mode, persistTranscript, requestResponseCreate, sendRealtimeEvent, speaker, startBoundedWorkingCue, startWorkingCue, stopWorkingCue],
   );
 
   const startCall = useCallback(async () => {
+    if (!speaker) {
+      setError("Pick a dashboard user first, then start the call.");
+      addLog("error", "Pick a dashboard user first, then start the call.");
+      return;
+    }
     const callSeq = callSeqRef.current + 1;
     callSeqRef.current = callSeq;
-    callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    if (!new URLSearchParams(window.location.search).get("call_id")) {
+      callIdRef.current = `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    }
+    setCallIdDisplay(callIdRef.current);
     callStartedAtRef.current = Date.now();
     eventSeqRef.current = 0;
     pendingTranscriptSavesRef.current = [];
     setLastSavePath(null);
     setSaveStatus("Saving call events…");
+    activeWorkRef.current.clear();
+    pendingHandoffsRef.current = [];
+    userSpeakingRef.current = false;
+    responseActiveRef.current = false;
+    pendingResponseCreateRef.current = false;
+    setActiveWorkCount(0);
+    setPendingHandoffs(0);
     setActiveTool(null);
-    window.localStorage.setItem("rolly.voice.user", speaker);
+    setVoiceTasks([]);
+    handledToolCallsRef.current = new Set();
+    meetInvokedRef.current = false;
+    setRollyListenState(mode === "meet" ? "Silent until “Hey Rolly”" : "Always on");
     persistTranscript("system", "Call started.", "call_start", {
       user_agent: navigator.userAgent,
       selected_input_id: selectedInputId || "browser-default",
+      mode,
     });
     const isCurrentCall = () => callSeqRef.current === callSeq;
     setError(null);
@@ -391,6 +864,7 @@ export default function VoiceCallPage() {
       await refreshInputDevices();
       streamRef.current = stream;
       startMicMonitor(stream);
+      await startBackgroundCallSupport();
       const track = stream.getAudioTracks()[0];
       addLog("system", `Browser mic opened: ${track?.label || "unknown device"}. Watch the mic level; it should move when you talk.`);
       persistTranscript("system", `Browser mic opened: ${track?.label || "unknown device"}.`, "mic_opened");
@@ -415,8 +889,12 @@ export default function VoiceCallPage() {
       dataRef.current = dataChannel;
       dataChannel.onopen = () => {
         setStatus("live");
-        addLog("system", "Live. Talk normally; Rolly can answer by voice and call tools.");
-        persistTranscript("system", "Realtime data channel live.", "call_live");
+        playVoiceCue("live");
+        const liveMessage = mode === "meet"
+          ? "Meet mode live. Rolly is silent until someone says “Hey Rolly.”"
+          : "Live. Talk normally; Rolly can answer by voice and call tools.";
+        addLog("system", liveMessage);
+        persistTranscript("system", "Realtime data channel live.", "call_live", { mode });
       };
       dataChannel.onmessage = handleRealtimeEvent;
       dataChannel.onerror = () => addLog("error", "Realtime data channel error.");
@@ -424,7 +902,7 @@ export default function VoiceCallPage() {
       const offer = await peer.createOffer();
       await peer.setLocalDescription(offer);
 
-      const answerSdp = await api.createVoiceCall(offer.sdp || "", speaker);
+      const answerSdp = await api.createVoiceCall(offer.sdp || "", speaker, mode);
       if (!isCurrentCall()) return;
       await peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
     } catch (exc) {
@@ -434,7 +912,7 @@ export default function VoiceCallPage() {
       addLog("error", message);
       stopCall();
     }
-  }, [addLog, handleRealtimeEvent, persistTranscript, refreshInputDevices, selectedInputId, speaker, startMicMonitor, stopCall]);
+  }, [addLog, handleRealtimeEvent, mode, persistTranscript, refreshInputDevices, selectedInputId, speaker, startBackgroundCallSupport, startMicMonitor, stopCall, playVoiceCue]);
 
   const toggleMute = useCallback(() => {
     const next = !muted;
@@ -449,17 +927,51 @@ export default function VoiceCallPage() {
       dataRef.current?.close();
       peerRef.current?.close();
       streamRef.current?.getTracks().forEach((track) => track.stop());
+      stopWorkingCue(false);
+      stopBackgroundCallSupport();
+      void cueAudioContextRef.current?.close().catch(() => undefined);
+      cueAudioContextRef.current = null;
       stopMicMonitor();
     };
-  }, [stopMicMonitor]);
+  }, [stopBackgroundCallSupport, stopMicMonitor, stopWorkingCue]);
   useEffect(() => {
     void refreshInputDevices().catch(() => undefined);
     navigator.mediaDevices?.addEventListener?.("devicechange", refreshInputDevices);
     return () => navigator.mediaDevices?.removeEventListener?.("devicechange", refreshInputDevices);
   }, [refreshInputDevices]);
+  useEffect(() => {
+    const updateUser = () => setSpeaker(getRollyUserSlug());
+    window.addEventListener("rolly-user-change", updateUser);
+    updateUser();
+    return () => window.removeEventListener("rolly-user-change", updateUser);
+  }, []);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const requestedMode = params.get("mode");
+    const requestedCallId = params.get("call_id");
+    if (requestedMode === "meet") setMode("meet");
+    if (requestedCallId) {
+      callIdRef.current = requestedCallId;
+      setCallIdDisplay(requestedCallId);
+      setInviteUrl(window.location.href);
+    }
+  }, []);
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible" && status === "live") {
+        void requestWakeLock();
+        void backgroundAudioContextRef.current?.resume().catch(() => undefined);
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [requestWakeLock, status]);
 
   const live = status === "live";
   const busy = status === "requesting" || status === "connecting" || status === "ending";
+  const speakerLabel = getRollyUser(speaker)?.label ?? "No dashboard user selected";
+  const transcriptLogs = logs.filter((entry) => entry.kind === "user" || entry.kind === "rolly");
+  const eventLogs = logs.filter((entry) => entry.kind !== "user" && entry.kind !== "rolly");
 
   return (
     <main className="flex h-full min-h-0 flex-col gap-4 overflow-auto p-4 lg:p-6">
@@ -471,48 +983,57 @@ export default function VoiceCallPage() {
               Rolly Voice
             </Typography>
             <p className="mt-2 max-w-2xl text-sm text-text-secondary">
-              One-on-one call prototype: browser mic/audio, realtime speech, and a backend bridge for bounded research/tool calls.
+              Realtime Rolly Voice with fast local context, durable transcripts, and optional Meet mode where Rolly only speaks after “Hey Rolly.”
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
             {!live && !busy ? <Button onClick={enableMicList}>Enable mic list</Button> : null}
-            {!live && !busy ? <Button onClick={startCall}>Start call</Button> : null}
+            {!live && !busy ? <Button onClick={createInvite}>Start meeting / invite</Button> : null}
+            {!live && !busy ? <Button onClick={startCall} disabled={!speaker}>Start call</Button> : null}
             {live ? <Button onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
             {live || busy ? <Button onClick={stopCall}>End call</Button> : null}
           </div>
         </div>
         <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.12em] text-text-secondary">
           <span className="border border-current/20 px-2 py-1">Status: {status}</span>
-          <span className="border border-current/20 px-2 py-1">Call: {callIdRef.current}</span>
+          <span className="border border-current/20 px-2 py-1">Call: {callIdDisplay}</span>
           <span className="border border-current/20 px-2 py-1">Save: {saveStatus}</span>
+          <span className="border border-current/20 px-2 py-1">Mode: {mode === "meet" ? "Meet" : "1:1"}</span>
+          <span className="border border-current/20 px-2 py-1 normal-case">Rolly: {rollyListenState}</span>
+          <span className="border border-current/20 px-2 py-1 normal-case">{backgroundSupport}</span>
           {activeTool ? <span className="border border-current/20 px-2 py-1">Tool: {activeTool}</span> : null}
+          {activeWorkCount > 0 ? <span className="border border-current/20 px-2 py-1">Working: {activeWorkCount}</span> : null}
+          {pendingHandoffs > 0 ? <span className="border border-current/20 px-2 py-1">Queued handoffs: {pendingHandoffs}</span> : null}
           <span className="border border-current/20 px-2 py-1">Provider: OpenAI Realtime WebRTC</span>
-          <span className="border border-current/20 px-2 py-1">Tools: full Rolly</span>
+          <span className="border border-current/20 px-2 py-1">Tools: fast context + full Rolly</span>
           {lastSavePath ? <span className="border border-current/20 px-2 py-1 normal-case">Transcript: {lastSavePath}</span> : null}
         </div>
+        {inviteUrl ? (
+          <div className="mt-3 border border-current/20 bg-black/30 p-2 text-xs text-text-secondary">
+            Invite: <span className="break-all normal-case text-midground">{inviteUrl}</span>
+          </div>
+        ) : null}
         <div className="mt-3 text-xs uppercase tracking-[0.12em] text-text-secondary">
-          <label className="mb-3 block">
-            SPEAKER
-            <select
-              className="mt-1 w-full border border-current/20 bg-black/40 p-2 text-midground"
-              value={speaker}
-              onChange={(event) => setSpeaker(event.target.value)}
-              disabled={live || busy}
-            >
-              <option value="deniz">Deniz</option>
-              <option value="arman">Arman</option>
-              <option value="buket">Buket</option>
-              <option value="metin">Metin</option>
-              <option value="guest">Guest</option>
-            </select>
-          </label>
+          <div className="mb-3">USER: {speakerLabel}</div>
+          <div className="mb-3 flex gap-2">
+            <Button disabled={live || busy} onClick={() => setMode("solo")}>
+              1:1 Rolly
+            </Button>
+            <Button disabled={live || busy} onClick={() => setMode("meet")}>
+              Meet: Hey Rolly
+            </Button>
+          </div>
           <label className="block">
             MIC INPUT
             <select
               className="mt-1 w-full border border-current/20 bg-black/40 p-2 text-midground"
               value={selectedInputId}
-              onChange={(event) => setSelectedInputId(event.target.value)}
-              disabled={live || busy}
+              onChange={(event) => {
+                const next = event.target.value;
+                setSelectedInputId(next);
+                if (live) void switchMicrophone(next);
+              }}
+              disabled={busy}
             >
               <option value="">Browser default</option>
               {inputDevices.map((device, index) => (
@@ -531,13 +1052,13 @@ export default function VoiceCallPage() {
         {error ? <p className="mt-3 text-sm text-red-300">{error}</p> : null}
       </section>
 
-      <section className="grid min-h-[24rem] gap-4 lg:grid-cols-[1fr_22rem]">
+      <section className="grid min-h-[24rem] gap-4 xl:grid-cols-[1fr_1fr_22rem]">
         <div className="min-h-0 border border-current/20 bg-black/30 p-4">
           <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
-            Transcript + events
+            Live transcript
           </Typography>
           <div className="mt-3 flex max-h-[60vh] flex-col gap-2 overflow-auto pr-1 text-sm">
-            {logs.map((entry) => (
+            {(transcriptLogs.length ? transcriptLogs : [{ id: "empty-transcript", kind: "system" as LogKind, text: "No spoken transcript yet.", timestamp: new Date().toISOString(), elapsedMs: null }]).map((entry) => (
               <div key={entry.id} className="border border-current/10 bg-background-base/50 p-3">
                 <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
                   {entry.kind} · {formatClock(entry.timestamp)} · {formatElapsed(entry.elapsedMs)}
@@ -547,8 +1068,39 @@ export default function VoiceCallPage() {
             ))}
           </div>
         </div>
+        <div className="min-h-0 border border-current/20 bg-black/30 p-4">
+          <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
+            Events + work
+          </Typography>
+          <div className="mt-3 flex max-h-[60vh] flex-col gap-2 overflow-auto pr-1 text-sm">
+            {eventLogs.map((entry) => (
+              <div key={entry.id} className="border border-current/10 bg-background-base/50 p-3">
+                <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
+                  {entry.kind} · {formatClock(entry.timestamp)} · {formatElapsed(entry.elapsedMs)}
+                </div>
+                <div className="whitespace-pre-wrap leading-relaxed">{entry.text}</div>
+              </div>
+            ))}
+            {voiceTasks.map((task) => (
+              <div key={task.task_id} className="border border-current/10 bg-background-base/50 p-3">
+                <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
+                  {task.task_id} · {task.status} · {formatClock(task.updated_at)}
+                </div>
+                <div className="whitespace-pre-wrap leading-relaxed">{task.progress?.[task.progress.length - 1]?.message || task.request}</div>
+              </div>
+            ))}
+          </div>
+        </div>
         <aside className="border border-current/20 bg-background-base/50 p-4 text-sm text-text-secondary">
           <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em] text-midground">
+            Pinned
+          </Typography>
+          <div className="mt-3 space-y-3">
+            <div>Transcript: {lastSavePath || "not saved yet"}</div>
+            <div>Queued tasks: {voiceTasks.length || "none"}</div>
+            <div>Speaking pace: slightly faster style instruction; explicit provider rate unsupported.</div>
+          </div>
+          <Typography className="mt-5 font-mondwest text-display text-lg uppercase tracking-[0.12em] text-midground">
             Try saying
           </Typography>
           <ul className="mt-3 list-disc space-y-2 pl-4">
@@ -556,9 +1108,6 @@ export default function VoiceCallPage() {
             <li>“Check current MIX review blockers and keep it brief.”</li>
             <li>“Use your tools and tell me what to do next.”</li>
           </ul>
-          <p className="mt-4">
-            Realtime voice can call full Rolly when it needs project context, files, web, or actions.
-          </p>
         </aside>
       </section>
     </main>

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -377,47 +377,33 @@ export default function VoiceCallPage() {
     tick();
   }, [addLog, stopMicMonitor]);
 
-  const enableMicList = useCallback(async () => {
-    setError(null);
-    try {
-      if (!window.isSecureContext || !navigator.mediaDevices?.getUserMedia) {
-        throw new Error(
-          "Microphone access requires HTTPS. Open https://denizs-mac-mini.taildfdcc0.ts.net:9119/voice instead of the raw http:// Tailscale IP.",
-        );
-      }
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      stream.getTracks().forEach((track) => track.stop());
-      await refreshInputDevices();
-      addLog("system", "Microphone permission granted; input list refreshed.");
-    } catch (exc) {
-      const message = exc instanceof Error ? exc.message : String(exc);
-      setError(message);
-      addLog("error", message);
-    }
-  }, [addLog, refreshInputDevices]);
-
   const switchMicrophone = useCallback(
     async (deviceId: string) => {
       if (status !== "live" || !peerRef.current) return;
       setError(null);
+      let nextStream: MediaStream | null = null;
       try {
         const audio: MediaTrackConstraints = deviceId ? { deviceId: { exact: deviceId } } : {};
-        const nextStream = await navigator.mediaDevices.getUserMedia({ audio });
+        nextStream = await navigator.mediaDevices.getUserMedia({ audio });
         const nextTrack = nextStream.getAudioTracks()[0];
         if (!nextTrack) throw new Error("Selected microphone produced no audio track.");
         const sender = peerRef.current.getSenders().find((item) => item.track?.kind === "audio");
         if (!sender) throw new Error("Active call has no microphone sender to replace.");
         await sender.replaceTrack(nextTrack);
         streamRef.current?.getTracks().forEach((track) => track.stop());
-        streamRef.current = nextStream;
+        const acceptedStream = nextStream;
+        if (!acceptedStream) throw new Error("Selected microphone stream was unavailable.");
+        streamRef.current = acceptedStream;
+        nextStream = null;
         nextTrack.enabled = !muted;
-        startMicMonitor(nextStream);
+        startMicMonitor(acceptedStream);
         await refreshInputDevices();
         addLog("system", `Switched microphone to ${nextTrack.label || "selected input"}.`);
         persistTranscript("system", `Switched microphone to ${nextTrack.label || "selected input"}.`, "mic_switched", {
           selected_input_id: deviceId || "browser-default",
         });
       } catch (exc) {
+        nextStream?.getTracks().forEach((track) => track.stop());
         const message = exc instanceof Error ? exc.message : String(exc);
         setError(`Microphone switch failed: ${message}`);
         addLog("error", `Microphone switch failed: ${message}`);
@@ -1007,7 +993,6 @@ export default function VoiceCallPage() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={enableMicList}>Enable mic list</Button> : null}
             {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={startMeetingInvite} disabled={!speaker}>Start meeting / invite</Button> : null}
             {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => void startCall()} disabled={!speaker}>Start call</Button> : null}
             {live ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}

--- a/web/src/pages/VoiceCallPage.tsx
+++ b/web/src/pages/VoiceCallPage.tsx
@@ -44,6 +44,10 @@ function formatElapsed(ms: number | null): string {
   return `+${(ms / 1000).toFixed(1)}s`;
 }
 
+function isRealtimeSpeechEvent(entry: LogEntry): boolean {
+  return entry.text === "Realtime API heard speech start." || entry.text === "Realtime API heard speech stop." || entry.text === "Realtime API committed mic audio.";
+}
+
 export default function VoiceCallPage() {
   const [status, setStatus] = useState<CallStatus>("idle");
   const [muted, setMuted] = useState(false);
@@ -53,6 +57,7 @@ export default function VoiceCallPage() {
   const [selectedInputId, setSelectedInputId] = useState("");
   const [speaker, setSpeaker] = useState(() => getRollyUserSlug());
   const [error, setError] = useState<string | null>(null);
+  const [verboseEvents, setVerboseEvents] = useState(false);
   const [logs, setLogs] = useState<LogEntry[]>([
     {
       id: logId(),
@@ -977,7 +982,7 @@ export default function VoiceCallPage() {
   const busy = status === "requesting" || status === "connecting" || status === "ending";
   const speakerLabel = getRollyUser(speaker)?.label ?? "No dashboard user selected";
   const transcriptLogs = logs.filter((entry) => entry.kind === "user" || entry.kind === "rolly");
-  const eventLogs = logs.filter((entry) => entry.kind !== "user" && entry.kind !== "rolly");
+  const eventLogs = logs.filter((entry) => entry.kind !== "user" && entry.kind !== "rolly" && (verboseEvents || !isRealtimeSpeechEvent(entry)));
 
   return (
     <main className="flex h-full min-h-0 flex-col gap-4 overflow-auto p-4 lg:p-6">
@@ -996,6 +1001,9 @@ export default function VoiceCallPage() {
             {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={startMeetingInvite} disabled={!speaker}>Start meeting / invite</Button> : null}
             {!live && !busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => void startCall()} disabled={!speaker}>Start call</Button> : null}
             {live ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={toggleMute}>{muted ? "Unmute" : "Mute"}</Button> : null}
+            <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => setVerboseEvents((value) => !value)}>
+              Verbose: {verboseEvents ? "on" : "off"}
+            </Button>
             {live || busy ? <Button className={VOICE_ACTION_BUTTON_CLASS} onClick={() => stopCall()}>End call</Button> : null}
           </div>
         </div>
@@ -1057,46 +1065,46 @@ export default function VoiceCallPage() {
         {error ? <p className="mt-3 text-sm text-red-300">{error}</p> : null}
       </section>
 
-      <section className="grid min-h-[24rem] gap-4 xl:grid-cols-[1fr_1fr_22rem]">
-        <div className="min-h-0 border border-current/20 bg-black/30 p-4">
+      <section className="grid min-h-[24rem] gap-3 xl:grid-cols-[1fr_1fr_20rem]">
+        <div className="min-h-0 border border-current/20 bg-black/30 p-3">
           <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
             Live transcript
           </Typography>
-          <div className="mt-3 flex max-h-[60vh] flex-col gap-2 overflow-auto pr-1 text-sm">
+          <div className="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1 text-sm">
             {(transcriptLogs.length ? transcriptLogs : [{ id: "empty-transcript", kind: "system" as LogKind, text: "No spoken transcript yet.", timestamp: new Date().toISOString(), elapsedMs: null }]).map((entry) => (
-              <div key={entry.id} className="border border-current/10 bg-background-base/50 p-3">
-                <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
+              <div key={entry.id} className="border border-current/10 bg-background-base/50 px-2 py-1">
+                <div className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary">
                   {entry.kind} · {formatClock(entry.timestamp)} · {formatElapsed(entry.elapsedMs)}
                 </div>
-                <div className="whitespace-pre-wrap leading-relaxed">{entry.text}</div>
+                <div className="whitespace-pre-wrap leading-snug">{entry.text}</div>
               </div>
             ))}
           </div>
         </div>
-        <div className="min-h-0 border border-current/20 bg-black/30 p-4">
+        <div className="min-h-0 border border-current/20 bg-black/30 p-3">
           <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em]">
             Events + work
           </Typography>
-          <div className="mt-3 flex max-h-[60vh] flex-col gap-2 overflow-auto pr-1 text-sm">
+          <div className="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-auto pr-1 text-sm">
             {eventLogs.map((entry) => (
-              <div key={entry.id} className="border border-current/10 bg-background-base/50 p-3">
-                <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
+              <div key={entry.id} className="border border-current/10 bg-background-base/50 px-2 py-1">
+                <div className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary">
                   {entry.kind} · {formatClock(entry.timestamp)} · {formatElapsed(entry.elapsedMs)}
                 </div>
-                <div className="whitespace-pre-wrap leading-relaxed">{entry.text}</div>
+                <div className="whitespace-pre-wrap leading-snug">{entry.text}</div>
               </div>
             ))}
             {voiceTasks.map((task) => (
-              <div key={task.task_id} className="border border-current/10 bg-background-base/50 p-3">
-                <div className="mb-1 text-[0.65rem] uppercase tracking-[0.14em] text-text-secondary">
+              <div key={task.task_id} className="border border-current/10 bg-background-base/50 px-2 py-1">
+                <div className="text-[0.62rem] uppercase tracking-[0.12em] text-text-secondary">
                   {task.task_id} · {task.status} · {formatClock(task.updated_at)}
                 </div>
-                <div className="whitespace-pre-wrap leading-relaxed">{task.progress?.[task.progress.length - 1]?.message || task.request}</div>
+                <div className="whitespace-pre-wrap leading-snug">{task.progress?.[task.progress.length - 1]?.message || task.request}</div>
               </div>
             ))}
           </div>
         </div>
-        <aside className="border border-current/20 bg-background-base/50 p-4 text-sm text-text-secondary">
+        <aside className="border border-current/20 bg-background-base/50 px-3 py-2 text-sm text-text-secondary">
           <Typography className="font-mondwest text-display text-lg uppercase tracking-[0.12em] text-midground">
             Pinned
           </Typography>

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -29,6 +29,7 @@ import { Label } from "@nous-research/ui/ui/components/label";
 import { Separator } from "@nous-research/ui/ui/components/separator";
 import { Tabs, TabsList, TabsTrigger } from "@nous-research/ui/ui/components/tabs";
 import { useI18n } from "@/i18n";
+import { PtyTerminalPane } from "@/components/PtyTerminalPane";
 import { registerSlot, PluginSlot } from "./slots";
 
 // ---------------------------------------------------------------------------
@@ -140,6 +141,7 @@ export function exposePluginSDK() {
       TabsList,
       TabsTrigger,
       PluginSlot,
+      PtyTerminalPane,
     },
 
     // Utilities


### PR DESCRIPTION
## Summary
- make Kanban card detail default to a compact terminal-first workspace
- move full metadata/editors into Details and keep lifecycle actions top-right
- move card prompt controls into Terminal / CC controls and collapse prompt context

## Test Plan
- node --check plugins/kanban/dashboard/dist/index.js
- scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py