### PR TITLE
docs(contributing): correct gif-search skill example path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,7 +473,7 @@ Gateway and messaging sessions never collect secrets in-band; they instruct the 
 - The skill relies on a CLI tool that may not be installed (e.g., `himalaya`, `openhue`, `ddgs`)
 - Treat command checks as guidance, not discovery-time hiding
 
-See `skills/gifs/gif-search/` and `skills/email/himalaya/` for examples.
+See `skills/media/gif-search/` and `skills/email/himalaya/` for examples.
 
 ### Skill authoring standards (HARDLINE)
 

--- a/tests/test_contributing_skill_path_references.py
+++ b/tests/test_contributing_skill_path_references.py
@@ -1,0 +1,55 @@
+"""Regression test for the skill-path example references in CONTRIBUTING.md.
+
+CONTRIBUTING.md points new skill authors at concrete bundled skills as
+copyable examples:
+
+    See `skills/gifs/gif-search/` and `skills/email/himalaya/` for examples.
+
+The gif example pointed at ``skills/gifs/gif-search/``, which does not exist:
+``skills/gifs/`` is only a category folder holding a ``DESCRIPTION.md``. The
+actual skill lives at ``skills/media/gif-search/`` (the path used everywhere
+else in the docs, e.g. the skills catalog). A contributor following the
+CONTRIBUTING guide would ``ls`` a missing directory.
+
+This test extracts every backtick-quoted ``skills/...`` path referenced in
+CONTRIBUTING.md and asserts each one exists on disk, so a stale example path
+fails here instead of confusing a contributor.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+# Matches `skills/...` (optionally trailing slash) inside backticks.
+_SKILL_PATH_RE = re.compile(r"`(skills/[^`]+?)/?`")
+
+
+def _referenced_skill_paths():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    # De-dupe while preserving order for a readable failure message.
+    seen = {}
+    for match in _SKILL_PATH_RE.finditer(text):
+        seen.setdefault(match.group(1).rstrip("/"), None)
+    return list(seen)
+
+
+def test_contributing_has_skill_path_references():
+    """Guard against the regex silently matching nothing (e.g. a refactor)."""
+    assert _referenced_skill_paths(), (
+        "Expected at least one `skills/...` example path in CONTRIBUTING.md"
+    )
+
+
+def test_contributing_skill_example_paths_exist_on_disk():
+    missing = [
+        rel
+        for rel in _referenced_skill_paths()
+        if not (REPO_ROOT / rel).exists()
+    ]
+    assert not missing, (
+        "CONTRIBUTING.md references skill example paths that do not exist on "
+        f"disk: {missing}. Update the reference to the skill's real location "
+        "(e.g. skills/media/gif-search)."
+    )


### PR DESCRIPTION
## What does this PR do?

`CONTRIBUTING.md` points new skill authors at `skills/gifs/gif-search/` as a copyable example, but that path does not exist — `skills/gifs/` is only a category folder containing a `DESCRIPTION.md`. The actual skill lives at `skills/media/gif-search/` (the path used everywhere else, e.g. the skills catalog). A contributor following the guide would `ls` a missing directory.

This corrects the example path and adds a regression test that asserts every backtick-quoted `skills/...` path referenced in `CONTRIBUTING.md` exists on disk, so a stale example path fails CI instead of confusing a contributor.

## Related Issue

No pre-existing issue — discovered via documentation/code audit.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `CONTRIBUTING.md`: corrected `skills/gifs/gif-search/` → `skills/media/gif-search/`
- `tests/test_contributing_skill_path_references.py`: new regression test extracting and validating all backtick-quoted `skills/...` example paths in CONTRIBUTING.md

## How to Test

```bash
bash scripts/run_tests.sh tests/test_contributing_skill_path_references.py -- -q
```

The test fails on the old `skills/gifs/gif-search/` path and passes after the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and it passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 20.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this IS the docs fix
- [x] I've considered cross-platform impact — pure-text path reference, no platform-specific behavior
