### PR TITLE
fix(cua): scrub operator environment before launching cua-driver MCP

### DIFF
--- a/tests/tools/test_browser_secret_exfil.py
+++ b/tests/tools/test_browser_secret_exfil.py
@@ -1,6 +1,8 @@
 """Tests for secret exfiltration prevention in browser and web tools."""
 
 import json
+import sys
+import types
 from unittest.mock import patch, MagicMock
 import pytest
 
@@ -190,3 +192,64 @@ class TestCamofoxAnnotationRedaction:
         assert "ANTHROPICFAKEKEY123456789" not in result
         assert "OPENAIFAKEKEY99887766" not in result
         assert "PATH=/usr/local/bin" in result
+
+
+class TestCuaDriverSubprocessEnv:
+    """Verify cua-driver MCP subprocesses do not inherit provider secrets."""
+
+    @pytest.mark.asyncio
+    async def test_cua_driver_session_scrubs_provider_credentials(self, monkeypatch):
+        from tools.computer_use import cua_backend
+
+        captured = {}
+
+        class FakeStdioServerParameters:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        class FakeClientSession:
+            def __init__(self, read, write):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def initialize(self):
+                return None
+
+        class FakeStdioClient:
+            async def __aenter__(self):
+                return object(), object()
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        fake_mcp = types.ModuleType("mcp")
+        fake_mcp.ClientSession = FakeClientSession
+        fake_mcp.StdioServerParameters = FakeStdioServerParameters
+        fake_client = types.ModuleType("mcp.client")
+        fake_stdio = types.ModuleType("mcp.client.stdio")
+        fake_stdio.stdio_client = lambda params: FakeStdioClient()
+
+        monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+        monkeypatch.setitem(sys.modules, "mcp.client", fake_client)
+        monkeypatch.setitem(sys.modules, "mcp.client.stdio", fake_stdio)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-" + "x" * 30)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-" + "y" * 30)
+        monkeypatch.setenv("HERMES_CUA_DRIVER_CMD", "fake-cua-driver")
+        monkeypatch.setenv("HERMES_PROVIDER_SAFE_SETTING", "kept")
+        monkeypatch.setattr(cua_backend.shutil, "which", lambda command: f"/tmp/{command}")
+
+        session = cua_backend._CuaDriverSession(cua_backend._AsyncBridge())
+
+        await session._aenter()
+        try:
+            env = captured["env"]
+            assert "OPENAI_API_KEY" not in env
+            assert "ANTHROPIC_API_KEY" not in env
+            assert env["HERMES_PROVIDER_SAFE_SETTING"] == "kept"
+        finally:
+            await session._aexit()

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -73,6 +73,19 @@ class TestProviderEnvBlocklist:
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_anthropic_api_key_is_explicitly_blocklisted(self):
+        """ANTHROPIC_API_KEY must stay blocked even if provider imports change."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        result_env = _sanitize_subprocess_env({
+            "ANTHROPIC_API_KEY": "sk-ant-fake-key",
+            "HERMES_PROVIDER_SAFE_SETTING": "kept",
+        })
+
+        assert "ANTHROPIC_API_KEY" in _HERMES_PROVIDER_ENV_BLOCKLIST
+        assert "ANTHROPIC_API_KEY" not in result_env
+        assert result_env["HERMES_PROVIDER_SAFE_SETTING"] == "kept"
+
     def test_registry_derived_vars_are_stripped(self):
         """Vars from the provider registry (ANTHROPIC_TOKEN, ZAI_API_KEY, etc.)
         must also be blocked — not just the hand-written extras."""

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -34,6 +34,7 @@ from tools.computer_use.backend import (
     ComputerUseBackend,
     UIElement,
 )
+from tools.environments.local import _sanitize_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +239,7 @@ class _CuaDriverSession:
         params = StdioServerParameters(
             command=_CUA_DRIVER_CMD,
             args=_CUA_DRIVER_ARGS,
-            env={**os.environ},
+            env=_sanitize_subprocess_env(os.environ),
         )
         stack = AsyncExitStack()
         read, write = await stack.enter_async_context(stdio_client(params))

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -131,6 +131,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "OPENAI_ORGANIZATION",
         "OPENROUTER_API_KEY",
         "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
         "ANTHROPIC_TOKEN",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "LLM_MODEL",


### PR DESCRIPTION
## Summary
A malicious or compromised `cua-driver` binary can read the operator's Hermes-managed provider credentials, gateway authorization values, and platform tokens from its own process environment as soon as the computer-use backend starts.

This bypasses the documented subprocess trust boundary without any prompt injection, plugin review, or break-glass flag; Hermes core launches the MCP subprocess directly.

- The source call site passes the full parent environment to the MCP subprocess.
- The existing `_sanitize_subprocess_env` helper removes Hermes-managed credentials from subprocess environments.
- Browser-tool already uses that helper for the same subprocess credential boundary.
- No equivalent computer-use regression test asserts that `cua-driver` launch env excludes those credentials.

Build the `cua-driver` MCP launch environment through `tools.environments.local._sanitize_subprocess_env`, preserving only runtime-required variables and explicit passthroughs, then add a computer-use regression test mirroring the browser-tool subprocess environment test.

## Linked context
Closes #37878

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/tools/computer_use/cua_backend.py:232-242`
- `hermes-agent/tools/computer_use/cua_backend.py:47-48`
- `hermes-agent/tools/computer_use/cua_backend.py:80-95`
- `hermes-agent/tools/browser_tool.py:80-82`
- `hermes-agent/tools/environments/local.py:205-235`
- `hermes-agent/tests/tools/test_browser_secret_exfil.py:45-72`

### Files changed in this PR
- `tests/tools/test_browser_secret_exfil.py`
- `tests/tools/test_local_env_blocklist.py`
- `tools/computer_use/cua_backend.py`
- `tools/environments/local.py`

### Behavior reproduced or verified
1. Use Hermes Agent latest upstream `main` at source receipt commit `a92cbcac45d51fea0d241000df7d011da6064d24`.
2. Enable the `computer_use` toolset on macOS with `cua-driver` installed or set `HERMES_CUA_DRIVER_CMD` to a substitute binary.
3. Start a computer-use action so `_CuaDriverSession._aenter()` builds `StdioServerParameters`.
4. Observe the launch parameters pass `env={**os.environ}` to the MCP subprocess.
5. Expected result: call the existing subprocess sanitizer before launch so Hermes-managed credentials are absent unless explicitly passed through.

### Expected fixed behavior
Build the `cua-driver` MCP launch environment through `tools.environments.local._sanitize_subprocess_env`, preserving only runtime-required variables and explicit passthroughs, then add a computer-use regression test mirroring the browser-tool subprocess environment test.

## Tests and validation
- `bash scripts/run_tests.sh tests/tools/test_browser_secret_exfil.py`
- Result: 11 tests passed, 0 failed.
- The new regression test captures `StdioServerParameters` and verifies `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are absent from the cua-driver MCP subprocess environment while a non-blocklisted value remains.

## Environment
Hermes latest-main source receipt: `a92cbcac45d51fea0d241000df7d011da6064d24` on current `main`. Runtime prerequisite: macOS computer-use backend with `cua-driver` available. Redaction complete; no secrets, tokens, credentials, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness receipt: `source_ready` for `upstream-main` at `a92cbcac45d51fea0d241000df7d011da6064d24`; affected paths exist in the prepared latest-main checkout. Linked PR validation ran the upstream wrapper-backed regression file successfully.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.

