### PR TITLE
fix(disk-cleanup): dedup tracked paths by inode to handle hard links

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -173,18 +173,31 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"REJECT: {path} (outside HERMES_HOME)")
         return False
 
-    size = path.stat().st_size if path.is_file() else 0
+    st = path.stat()
+    size = st.st_size if path.is_file() else 0
     tracked = load_tracked()
 
-    # Deduplicate
-    if any(item["path"] == str(path) for item in tracked):
-        return False
+    # Deduplicate by physical identity (inode + device), falling back to the
+    # resolved path string. Hard links share one inode under multiple paths,
+    # so a pure path comparison would track the same physical file twice —
+    # double-counting its size and double-deleting it during cleanup. On
+    # platforms without real inode numbers (e.g. Windows, where st_ino may be
+    # 0) we rely on the path comparison alone.
+    new_path = str(path)
+    new_ino, new_dev = st.st_ino, st.st_dev
+    for item in tracked:
+        if item["path"] == new_path:
+            return False
+        if new_ino and item.get("ino") == new_ino and item.get("dev") == new_dev:
+            return False
 
     tracked.append({
-        "path": str(path),
+        "path": new_path,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "category": category,
         "size": size,
+        "ino": new_ino,
+        "dev": new_dev,
     })
     save_tracked(tracked)
     _log(f"TRACKED: {path} ({category}, {fmt_size(size)})")

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -188,6 +188,27 @@ class TestTrackForgetQuick:
         # Second call returns False (already tracked)
         assert dg.track(str(p), "test", silent=True) is False
 
+    def test_track_dedup_hard_link(self, _isolate_env):
+        """A hard link to an already-tracked file is the same physical file.
+
+        Tracking both paths would double-count the file's size and make
+        ``quick()`` try to delete it twice. Dedup must key on inode/device,
+        not just the path string.
+        """
+        import os
+
+        dg = _load_lib()
+        a = _isolate_env / "test_a.py"
+        a.write_text("payload")
+        b = _isolate_env / "test_b.py"
+        os.link(a, b)  # hard link: same inode, different path
+
+        assert a.stat().st_ino == b.stat().st_ino  # sanity: same physical file
+        assert dg.track(str(a), "test", silent=True) is True
+        # Second hard link points at the same inode → must not be re-tracked.
+        assert dg.track(str(b), "test", silent=True) is False
+        assert len(dg.load_tracked()) == 1
+
     def test_track_rejects_outside_home(self, _isolate_env):
         dg = _load_lib()
         # /etc/hostname exists on most Linux boxes; fall back if not.


### PR DESCRIPTION
## Summary

Fix hard link double-tracking bug in disk-cleanup plugin. Previously, `track()` deduplicated only by resolved path string, allowing hard links (multiple paths pointing to the same inode) to be registered as separate entries. This caused:
- Double-counted file size in status totals
- Attempted double-deletion during `quick()` cleanup (first succeeds, second fails with FileNotFoundError)

Now deduplicated by inode+device number (physical file identity), with path-string fallback for platforms without real inode numbers (Windows).

## Test Plan

- [x] New regression test `test_track_dedup_hard_link` verifies hard links are recognized as same physical file
- [x] All 42 existing tests pass (no regressions)
- [x] Ruff style checks pass
- [x] Backward compatible with old `tracked.json` records lacking ino/dev fields
- [x] Windows compatible (skips inode check when st_ino=0)
