### PR TITLE
fix(google_meet): kill spawned bot process if active-state write fails to avoid orphan

### DIFF
--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -183,7 +183,20 @@ def start(
         "log_path": str(log_path),
         "mode": mode,
     }
-    _write_active(record)
+    try:
+        _write_active(record)
+    except Exception:
+        # The active pointer is the only handle later status()/stop() calls
+        # have on this bot (we communicate via files only). If we fail to
+        # persist it — e.g. disk full or a permission error on the state
+        # file — the subprocess we just spawned would become an unreachable
+        # orphan that can't be monitored or torn down. Kill it before
+        # propagating so we don't leak a runaway Chromium-driving process.
+        try:
+            os.kill(proc.pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+        raise
     return {"ok": True, **record}
 
 

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -186,6 +186,41 @@ def test_start_spawns_subprocess_and_writes_active_pointer(tmp_path):
     assert active["meeting_id"] == "abc-defg-hij"
 
 
+def test_start_kills_spawned_process_when_active_write_fails(tmp_path):
+    """If _write_active() fails after Popen, the bot must not be orphaned.
+
+    The active pointer is the only handle later status()/stop() calls have
+    on the bot. When persisting it raises (e.g. disk full / permission), the
+    already-spawned subprocess would become an unreachable orphan — so start()
+    must kill it and re-raise instead of silently leaking the process.
+    """
+    from plugins.google_meet import process_manager as pm
+
+    class _FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+    def _fake_popen(argv, **kwargs):
+        return _FakeProc(99999)
+
+    killed = []
+
+    def _kill(pid, sig):
+        killed.append((pid, sig))
+
+    with patch.object(pm.subprocess, "Popen", side_effect=_fake_popen), \
+         patch.object(pm, "_pid_alive", return_value=False), \
+         patch.object(pm, "_write_active", side_effect=IOError("disk full")), \
+         patch.object(pm.os, "kill", side_effect=_kill):
+        with pytest.raises(IOError):
+            pm.start("https://meet.google.com/abc-defg-hij")
+
+    # The spawned bot was killed rather than leaked as an orphan...
+    assert (99999, signal.SIGKILL) in killed
+    # ...and no active pointer was left behind.
+    assert pm._read_active() is None
+
+
 def test_transcript_reads_last_n_lines(tmp_path):
     from plugins.google_meet import process_manager as pm
 


### PR DESCRIPTION
## What does this PR do?

When `start()` spawns the meet_bot subprocess via `Popen()` and the subsequent `_write_active()` call fails (e.g. disk full or a permission error on the state file), the bot process is left running but the active pointer is never persisted. Because `status()` / `stop()` locate the bot solely through `_read_active()`, the subprocess becomes an unreachable orphan that can't be monitored or torn down — a runaway Chromium-driving process leaks on every such failure.

This wraps `_write_active()` in a try/except that `SIGKILL`s the just-spawned process on failure before re-raising, so a failed state write can no longer leak an orphan.

## Related Issue

No pre-existing issue — discovered via code audit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/google_meet/process_manager.py`: wrap `_write_active(record)` in try/except; on failure kill the just-spawned process with `SIGKILL` (swallowing `ProcessLookupError` / `OSError` from the kill itself) and re-raise the original error.
- `tests/plugins/test_google_meet_plugin.py`: add `test_start_kills_spawned_process_when_active_write_fails()` verifying the spawned pid is killed and no active pointer is left behind when `_write_active()` raises.

## How to Test

```bash
bash scripts/run_tests.sh tests/plugins/test_google_meet_plugin.py -- -q
```

All google_meet plugin tests pass. The new test fails before the fix (the orphan is leaked, `os.kill` is never called) and passes after.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added a regression test for the fixed behavior
- [x] I've run the test suite and it passes
- [x] I've tested on my platform: Ubuntu 20.04 (Linux)
- [x] Cross-platform: `google_meet` is POSIX-only; `SIGKILL` is standard there
