### PR TITLE
fix(toolsets): resolve alias target when merging registry tools into a static toolset

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -46,6 +46,30 @@ class TestGetToolset:
         assert ts is not None
         assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
 
+    def test_merges_aliased_registry_tools_into_builtin_toolset(self, monkeypatch):
+        # An MCP server named identically to a static toolset (e.g. "browser")
+        # registers its tools under the canonical alias target ("mcp-browser")
+        # and records the alias "browser" -> "mcp-browser". get_toolset("browser")
+        # must resolve the alias and merge those tools, not just the ones whose
+        # toolset literally equals "browser".
+        reg = ToolRegistry()
+        reg.register(
+            name="browser_mcp_extra",
+            toolset="mcp-browser",
+            schema=_make_schema("browser_mcp_extra", "Aliased MCP browser tool"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("browser", "mcp-browser")
+
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        ts = get_toolset("browser")
+        assert ts is not None
+        # Static built-in browser tools are still present...
+        assert "browser_navigate" in ts["tools"]
+        # ...and the aliased MCP tool is now merged in.
+        assert "browser_mcp_extra" in ts["tools"]
+
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -571,9 +571,17 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         return toolset if toolset else None
 
     if toolset:
+        # Resolve ``name`` to its canonical registry toolset before querying
+        # for registry-owned tools. When a static toolset name collides with
+        # an MCP server name (e.g. an MCP server literally named "browser"),
+        # the registry records the tools under the canonical alias target
+        # (``mcp-browser``) and an alias ``browser -> mcp-browser``. Querying
+        # by the original name would miss those tools, so honour the alias.
+        registry_toolset = registry.get_toolset_alias_target(name) or name
         merged_tools = sorted(
             set(toolset.get("tools", []))
             | set(registry.get_tool_names_for_toolset(name))
+            | set(registry.get_tool_names_for_toolset(registry_toolset))
         )
         return {**toolset, "tools": merged_tools}
 


### PR DESCRIPTION
## Summary

Fixes a bug where `get_toolset()` silently dropped tools from aliased MCP servers. When a static toolset name collides with an MCP server name (e.g., an MCP server literally named "browser"), the registry stores those tools under the canonical alias target (e.g., "mcp-browser") and records an alias mapping ("browser" → "mcp-browser"). The function was querying by the original name only, missing aliased tools.

## Root Cause

- `get_toolset("browser")` merged registry tools by calling `registry.get_tool_names_for_toolset("browser")`
- Tools registered under the canonical alias target "mcp-browser" were not returned, since the registry query matched only the exact toolset name
- Result: aliased MCP tools were silently dropped from the merged toolset

## Fix

Resolve the input name to its canonical alias target (when one exists) and union tools from both:
1. Tools registered directly under the original name
2. Tools registered under the canonical alias target

When no alias exists, the resolved name equals the original, so behavior is unchanged. Uses `registry.get_toolset_alias_target()` API with a safe `or name` fallback.

## Testing

- **New regression test**: `tests/test_toolsets.py::TestGetToolset::test_merges_aliased_registry_tools_into_builtin_toolset`
  - Fails on unfixed code: AssertionError `'browser_mcp_extra' not in ts["tools"]`
  - Passes with fix
  - Verifies both static built-in tools and aliased MCP tools are present in the merged result
- **Full suite**: 28 tests in `tests/test_toolsets.py` + 38 tests in `tests/tools/test_mcp_dynamic_discovery.py` = 66 passed
