### PR TITLE
fix(dashboard): redact audio provider errors before HTTP replies

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -52,6 +52,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from agent.redact import redact_sensitive_text
 from hermes_cli import __version__, __release_date__
 from hermes_cli.config import (
     cfg_get,
@@ -1132,6 +1133,10 @@ _AUDIO_MIME_EXTENSIONS: Dict[str, str] = {
     "video/webm": ".webm",
 }
 _MAX_TRANSCRIPTION_UPLOAD_BYTES = 25 * 1024 * 1024
+
+
+def _redact_audio_error(error: Any, fallback: str) -> str:
+    return redact_sensitive_text(str(error or fallback), force=True)
 
 
 def _audio_extension_for_mime(mime_type: str) -> str:
@@ -3971,7 +3976,10 @@ async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
         raise
     except Exception as exc:
         _log.exception("Desktop voice transcription failed")
-        raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}")
+        raise HTTPException(
+            status_code=500,
+            detail=_redact_audio_error(exc, "Transcription failed"),
+        )
     finally:
         if temp_path:
             try:
@@ -3982,7 +3990,7 @@ async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
     if not result.get("success"):
         raise HTTPException(
             status_code=400,
-            detail=result.get("error") or "Transcription failed",
+            detail=_redact_audio_error(result.get("error"), "Transcription failed"),
         )
 
     return {
@@ -4112,7 +4120,10 @@ async def speak_text(payload: TTSSpeakRequest):
         result_json = await loop.run_in_executor(None, text_to_speech_tool, text)
     except Exception as exc:
         _log.exception("Desktop voice TTS failed")
-        raise HTTPException(status_code=500, detail=f"Speech synthesis failed: {exc}")
+        raise HTTPException(
+            status_code=500,
+            detail=_redact_audio_error(exc, "Speech synthesis failed"),
+        )
 
     try:
         result = json.loads(result_json) if isinstance(result_json, str) else result_json
@@ -4122,7 +4133,7 @@ async def speak_text(payload: TTSSpeakRequest):
     if not result.get("success"):
         raise HTTPException(
             status_code=400,
-            detail=result.get("error") or "Speech synthesis failed",
+            detail=_redact_audio_error(result.get("error"), "Speech synthesis failed"),
         )
 
     file_path = result.get("file_path")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2230,6 +2230,55 @@ class TestWebServerEndpoints:
         assert resp.status_code == 400
         assert "base64" in resp.json()["detail"]
 
+    def test_audio_transcription_redacts_provider_error_detail(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+
+        raw_key = "sk-proj-audio-transcribe-secret1234567890"
+
+        def fake_transcribe_audio(_path):
+            return {
+                "success": False,
+                "error": f"provider rejected request with key {raw_key}",
+            }
+
+        monkeypatch.setattr(transcription_tools, "transcribe_audio", fake_transcribe_audio)
+
+        resp = self.client.post(
+            "/api/audio/transcribe",
+            json={
+                "data_url": "data:audio/webm;base64,aGVsbG8=",
+                "mime_type": "audio/webm",
+            },
+        )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert raw_key not in detail
+        assert "..." in detail
+
+    def test_audio_transcription_redacts_provider_exception_detail(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+
+        raw_key = "sk-proj-audio-exception-secret1234567890"
+
+        def fake_transcribe_audio(_path):
+            raise RuntimeError(f"provider rejected request with key {raw_key}")
+
+        monkeypatch.setattr(transcription_tools, "transcribe_audio", fake_transcribe_audio)
+
+        resp = self.client.post(
+            "/api/audio/transcribe",
+            json={
+                "data_url": "data:audio/webm;base64,aGVsbG8=",
+                "mime_type": "audio/webm",
+            },
+        )
+
+        assert resp.status_code == 500
+        detail = resp.json()["detail"]
+        assert raw_key not in detail
+        assert "..." in detail
+
     def test_desktop_audio_routes_registered(self):
         """All three desktop voice endpoints must exist.
 
@@ -2279,6 +2328,43 @@ class TestWebServerEndpoints:
         assert body["provider"] == "test"
         # The handler streams the bytes back and removes the temp file.
         assert not audio_file.exists()
+
+    def test_speak_text_redacts_provider_error_detail(self, monkeypatch):
+        import tools.tts_tool as tts_tool
+
+        raw_key = "sk-proj-tts-secret1234567890abcdef"
+
+        def fake_tts(_text):
+            return json.dumps({
+                "success": False,
+                "error": f"provider failed with api_key={raw_key}",
+            })
+
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", fake_tts)
+
+        resp = self.client.post("/api/audio/speak", json={"text": "hello there"})
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert raw_key not in detail
+        assert "..." in detail
+
+    def test_speak_text_redacts_provider_exception_detail(self, monkeypatch):
+        import tools.tts_tool as tts_tool
+
+        raw_key = "sk-proj-tts-exception-secret1234567890"
+
+        def fake_tts(_text):
+            raise RuntimeError(f"provider failed with api_key={raw_key}")
+
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", fake_tts)
+
+        resp = self.client.post("/api/audio/speak", json={"text": "hello there"})
+
+        assert resp.status_code == 500
+        detail = resp.json()["detail"]
+        assert raw_key not in detail
+        assert "..." in detail
 
     def test_speak_text_requires_nonempty_text(self):
         resp = self.client.post("/api/audio/speak", json={"text": "   "})


### PR DESCRIPTION
## Summary
An authenticated dashboard caller, or a caller on a non-loopback dashboard bind allowed by the operator, can trigger STT/TTS provider failures and receive unredacted provider error text in the JSON response body. If the upstream provider error includes the submitted API key or bearer material, Hermes sends that operator credential outside the agent process.

- Local venv proof showed the transcription HTTP `detail` field preserved the synthetic credential-bearing provider error.
- Local venv proof showed the TTS HTTP `detail` field preserved the synthetic credential-bearing provider error.
- `web_server.py` puts `result.get("error")` directly into `HTTPException.detail`.
- The same endpoint file does not apply `agent.redact.redact_sensitive_text` to these audio error paths.
- The protected resource is the operator's STT/TTS or LLM provider credential.

Sanitize every provider-derived audio error string with `agent.redact.redact_sensitive_text(..., force=True)` before constructing dashboard `HTTPException.detail`, including both success-dict failures and outer exception paths.

## Linked context
Closes #37889

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/hermes_cli/web_server.py:1130-1195`
- `hermes-agent/hermes_cli/web_server.py:1265-1295`
- `hermes-agent/tools/transcription_tools.py:1310-1311,1367-1368,1410-1412,1519,1605`
- `hermes-agent/tools/tts_tool.py:2142-2146`
- `hermes-agent/agent/redact.py:326-427`

### Files changed in this PR
- `hermes_cli/web_server.py`
- `tests/hermes_cli/test_web_server.py`

### Behavior reproduced or verified
1. Use Hermes Agent latest upstream `main` at source receipt commit `2f0ee664670bb308c44ef969628a998c7e13cb86`.
2. Patch `tools.transcription_tools.transcribe_audio` to return a failure dict whose error text contains a credential-shaped bearer token, then call `transcribe_audio_upload()` with a valid base64 audio payload.
3. Observe HTTP status `400` with `detail` equal to the unredacted provider error.
4. Patch `tools.tts_tool.text_to_speech_tool` to return a failure JSON object whose error text contains a credential-shaped API key, then call `speak_text()`.
5. Observe HTTP status `400` with unredacted `detail`; expected result is redacted provider-error text before any dashboard response.

### Expected fixed behavior
Sanitize every provider-derived audio error string with `agent.redact.redact_sensitive_text(..., force=True)` before constructing dashboard `HTTPException.detail`, including both success-dict failures and outer exception paths.

## Tests and validation
- `scripts/run_tests.sh -j 1 tests/hermes_cli/test_web_server.py -k 'redacts_provider' -q` — 4 passed, 0 failed.
- `scripts/run_tests.sh -j 1 tests/hermes_cli/test_web_server.py -q` — 467 passed, 0 failed.
- Coverage includes provider failure dictionaries and provider-raised exceptions for both transcription and TTS.

## Current branch status
- Rebased onto upstream `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`.
- Review feedback covering the two outer exception paths is implemented in `a341d6a7575967ae58c3c183f240b1228dc2d309`.

## Environment
Hermes latest-main source receipt: `2f0ee664670bb308c44ef969628a998c7e13cb86`, detached local checkout. Reproduction used the upstream `.venv` and provider-free mocks, so no real secrets, provider transcripts, unrelated private paths, or private execution artifacts are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness receipt: `source_ready` for `upstream-main` at `2f0ee664670bb308c44ef969628a998c7e13cb86` via `/tmp/hermes-source-receipt.json`; affected paths exist in the prepared latest-main checkout.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
