### PR TITLE
feat(skills): add cross-reference integrity and metadata.hermes validation to 'hermes skills validate'

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13627,6 +13627,39 @@ Examples:
         help="Run AST-level analysis on Python files (opt-in diagnostic)",
     )
 
+    skills_validate = skills_subparsers.add_parser(
+        "validate",
+        help="Statically validate installed skills against a ruleset",
+        description=(
+            "Read-only structural lint pass complementary to the Curator. "
+            "Validates frontmatter completeness, section presence, line counts, "
+            "and metadata fields against a configurable ruleset. Operates on "
+            "any skill (bundled, hub-installed, or agent-authored) and never "
+            "modifies them."
+        ),
+    )
+    skills_validate.add_argument(
+        "target",
+        nargs="?",
+        help=(
+            "Skill name or path to a SKILL.md. Defaults to all installed "
+            "skills under ~/.hermes/skills/."
+        ),
+    )
+    skills_validate.add_argument(
+        "--ruleset",
+        default="hermes",
+        help=(
+            "Built-in ruleset name ('hermes' = lenient, 'agentskills' = strict) "
+            "or path to a custom YAML ruleset file. Default: hermes."
+        ),
+    )
+    skills_validate.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat SUGGEST findings as BLOCKING for the exit count.",
+    )
+
     skills_uninstall = skills_subparsers.add_parser(
         "uninstall", help="Remove a hub-installed skill"
     )

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -14,7 +14,7 @@ import json
 import re
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from rich.console import Console
 from rich.panel import Panel
@@ -1009,6 +1009,138 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
         c.print()
 
 
+def do_validate(
+    target: Optional[str] = None,
+    ruleset: str = "hermes",
+    strict: bool = False,
+    console: Optional[Console] = None,
+) -> int:
+    """Validate one or more installed skills against a ruleset.
+
+    Static lint pass complementary to the Curator (which is an LLM-driven
+    mutation pass). Operates on any skill — bundled, hub-installed, or
+    agent-authored — and never modifies them.
+
+    Returns the number of skills with BLOCKING findings (0 = all clean).
+
+    Args:
+        target: Skill name, path to a SKILL.md, or None to validate every
+                skill under ~/.hermes/skills/ (excluding .archive/).
+        ruleset: Built-in name ('hermes', 'agentskills') or path to a YAML
+                 ruleset file.
+        strict: When True, treat SUGGEST findings as BLOCKING in the exit
+                count.
+    """
+    from pathlib import Path
+
+    from tools.skills_validator import (
+        SEVERITY_BLOCKING,
+        SEVERITY_SUGGEST,
+        build_skill_name_index,
+        find_skills,
+        load_ruleset,
+        validate_skill,
+    )
+
+    c = console or _console
+
+    try:
+        rules = load_ruleset(ruleset)
+    except ValueError as e:
+        c.print(f"[bold red]Error:[/] {e}\n")
+        return 1
+    ruleset_name = ruleset
+
+    # Build cross-reference index when validating all skills
+    valid_names: Optional[Set[str]] = None
+
+    targets: List[Path] = []
+    if target is None:
+        try:
+            from hermes_constants import display_hermes_home
+            from pathlib import Path as _P
+            hermes_skills = _P(display_hermes_home()).expanduser() / "skills"
+        except Exception:
+            hermes_skills = Path.home() / ".hermes" / "skills"
+        if not hermes_skills.exists():
+            c.print(f"[dim]No skills directory at {hermes_skills}.[/]\n")
+            return 0
+        targets = find_skills(hermes_skills)
+        if not targets:
+            c.print("[dim]No installed skills found.[/]\n")
+            return 0
+        # Build cross-reference index once for all-skills validation
+        valid_names = build_skill_name_index(hermes_skills)
+    else:
+        p = Path(target).expanduser()
+        if p.exists():
+            targets = [p]
+        else:
+            # treat as skill name; look under sources
+            try:
+                from agent.skill_utils import get_all_skills_dirs
+                resolved = None
+                for root in get_all_skills_dirs():
+                    candidate = Path(root) / target
+                    if (candidate / "SKILL.md").exists():
+                        resolved = candidate
+                        break
+                if resolved is None:
+                    c.print(
+                        f"[bold red]Error:[/] '{target}' is neither a readable path "
+                        f"nor an installed skill name.\n"
+                    )
+                    return 1
+                targets = [resolved]
+            except Exception as e:
+                c.print(f"[bold red]Error:[/] cannot resolve '{target}': {e}\n")
+                return 1
+
+    blocking_skills = 0
+    suggest_skills = 0
+    clean_skills = 0
+
+    table = Table(title=f"Skill Validation — ruleset: {ruleset_name}")
+    table.add_column("Skill", style="bold cyan")
+    table.add_column("Blocking", justify="right", style="red")
+    table.add_column("Suggest", justify="right", style="yellow")
+    table.add_column("Status", style="dim")
+
+    detailed_findings: List = []
+
+    for skill_path in targets:
+        report = validate_skill(skill_path, rules, ruleset_name=ruleset_name, valid_names=valid_names)
+        b = len(report.blocking)
+        s = len(report.suggestions)
+        if b > 0:
+            blocking_skills += 1
+            status = "[red]BLOCKING[/]"
+        elif s > 0:
+            suggest_skills += 1
+            status = "[yellow]SUGGEST[/]"
+        else:
+            clean_skills += 1
+            status = "[green]OK[/]"
+        table.add_row(report.skill_name, str(b), str(s), status)
+        if b > 0 or (strict and s > 0):
+            detailed_findings.append(report)
+
+    c.print(table)
+
+    for report in detailed_findings:
+        c.print(f"\n[bold]{report.skill_name}[/]  [dim]{report.skill_path}[/]")
+        for f in report.findings:
+            colour = "red" if f.severity == SEVERITY_BLOCKING else "yellow"
+            c.print(f"  [{colour}]{f.severity}[/]  [bold]{f.rule}[/]  {f.message}")
+
+    c.print(
+        f"\n[dim]Summary: {clean_skills} OK, {suggest_skills} with suggestions, "
+        f"{blocking_skills} with blocking findings.[/]\n"
+    )
+
+    return blocking_skills + (suggest_skills if strict else 0)
+
+
 def do_uninstall(name: str, console: Optional[Console] = None,
                  skip_confirm: bool = False,
                  invalidate_cache: bool = True) -> None:
@@ -1559,6 +1691,12 @@ def skills_command(args) -> None:
     elif action == "audit":
         do_audit(name=getattr(args, "name", None),
                  deep=getattr(args, "deep", False))
+    elif action == "validate":
+        do_validate(
+            target=getattr(args, "target", None),
+            ruleset=getattr(args, "ruleset", "hermes"),
+            strict=getattr(args, "strict", False),
+        )
     elif action == "uninstall":
         do_uninstall(args.name)
     elif action == "reset":
@@ -1594,7 +1732,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|validate|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 
@@ -1742,6 +1880,20 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         name = args[0] if args and not args[0].startswith("--") else None
         deep = "--deep" in args
         do_audit(name=name, console=c, deep=deep)
+
+    elif action == "validate":
+        target = None
+        ruleset = "hermes"
+        strict = "--strict" in args
+        for a in args:
+            if not a.startswith("--"):
+                target = a
+                break
+        if "--ruleset" in args:
+            idx = args.index("--ruleset")
+            if idx + 1 < len(args):
+                ruleset = args[idx + 1]
+        do_validate(target=target, ruleset=ruleset, strict=strict)
 
     elif action == "uninstall":
         if not args:

--- a/tests/tools/test_skills_validator.py
+++ b/tests/tools/test_skills_validator.py
@@ -1,0 +1,380 @@
+"""Tests for tools/skills_validator.py — static skill validation."""
+
+from pathlib import Path
+
+import pytest
+
+from tools.skills_validator import (
+    BUILTIN_RULESETS,
+    SEVERITY_BLOCKING,
+    SEVERITY_SUGGEST,
+    Finding,
+    ValidationReport,
+    _BODY_DEAD_REF_SKIP,
+    build_skill_name_index,
+    find_skills,
+    load_ruleset,
+    validate_skill,
+)
+
+
+# ─── ruleset loading ─────────────────────────────────────────────────
+
+
+def test_load_builtin_hermes_ruleset():
+    rules = load_ruleset("hermes")
+    assert rules["frontmatter.name.present"] == SEVERITY_BLOCKING
+    # Hermes ruleset is lenient — should not include section.* rules
+    assert "section.when_to_use.present" not in rules
+
+
+def test_load_builtin_agentskills_ruleset():
+    rules = load_ruleset("agentskills")
+    assert rules["frontmatter.name.kebab_case"] == SEVERITY_BLOCKING
+    assert rules["section.when_to_use.present"] == SEVERITY_SUGGEST
+
+
+def test_load_unknown_ruleset_raises():
+    with pytest.raises(ValueError, match="not a built-in"):
+        load_ruleset("does-not-exist-as-name-or-path")
+
+
+def test_load_custom_ruleset_from_yaml(tmp_path):
+    custom = tmp_path / "custom.yaml"
+    custom.write_text(
+        "rules:\n"
+        "  frontmatter.present: BLOCKING\n"
+        "  body.non_empty: SUGGEST\n",
+        encoding="utf-8",
+    )
+    rules = load_ruleset(str(custom))
+    assert rules == {
+        "frontmatter.present": "BLOCKING",
+        "body.non_empty": "SUGGEST",
+    }
+
+
+def test_load_custom_ruleset_invalid_severity(tmp_path):
+    custom = tmp_path / "bad.yaml"
+    custom.write_text(
+        "rules:\n  frontmatter.present: TOTALLY_INVALID\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="invalid severity"):
+        load_ruleset(str(custom))
+
+
+# ─── validate_skill — valid case ─────────────────────────────────────
+
+
+def _write_skill(tmp_path: Path, name: str, content: str) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+VALID_AGENTSKILLS_SKILL = """\
+---
+name: example-skill
+description: An example skill that validates against the full agentskills.io spec.
+license: MIT
+allowed-tools: Read Grep
+metadata:
+  author: Test Author
+  version: "1.0.0"
+  domain: testing
+  complexity: basic
+  tags: example, test, validation
+  hermes:
+    tags: [example, test, validation]
+    related_skills: []
+    trigger: manual
+---
+
+# Example Skill
+
+## When to Use
+
+Use this when validating the validator.
+
+## Procedure
+
+1. Read the file.
+2. Check the structure.
+"""
+
+
+def test_validate_clean_skill_against_agentskills(tmp_path):
+    skill_dir = _write_skill(tmp_path, "example-skill", VALID_AGENTSKILLS_SKILL)
+    rules = load_ruleset("agentskills")
+    report = validate_skill(skill_dir, rules, ruleset_name="agentskills")
+    assert report.has_blocking is False, [f.message for f in report.findings]
+    assert report.findings == []
+
+
+# ─── validate_skill — failure modes ─────────────────────────────────
+
+
+MINIMAL_HERMES_SKILL = """\
+---
+name: minimal-skill
+description: Only the bare minimum fields.
+---
+
+# Minimal Skill
+
+Body content.
+"""
+
+
+def test_validate_minimal_skill_against_hermes_passes(tmp_path):
+    skill_dir = _write_skill(tmp_path, "minimal-skill", MINIMAL_HERMES_SKILL)
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes")
+    assert report.has_blocking is False
+
+
+def test_validate_minimal_skill_against_agentskills_reports_suggestions(tmp_path):
+    skill_dir = _write_skill(tmp_path, "minimal-skill", MINIMAL_HERMES_SKILL)
+    rules = load_ruleset("agentskills")
+    report = validate_skill(skill_dir, rules, ruleset_name="agentskills")
+    assert report.has_blocking is False  # name/description present
+    rule_ids = {f.rule for f in report.findings}
+    # Should flag missing recommended fields
+    assert "frontmatter.license.present" in rule_ids
+    assert "frontmatter.allowed_tools.present" in rule_ids
+    assert "frontmatter.metadata.version.present" in rule_ids
+    assert "section.when_to_use.present" in rule_ids
+
+
+def test_validate_missing_name_is_blocking(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "nameless",
+        "---\ndescription: A skill without a name.\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes")
+    assert report.has_blocking is True
+    blocking_rules = {f.rule for f in report.blocking}
+    assert "frontmatter.name.present" in blocking_rules
+
+
+def test_validate_name_must_match_directory(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "directory-name",
+        "---\nname: different-name\ndescription: x\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("agentskills")
+    report = validate_skill(skill_dir, rules, ruleset_name="agentskills")
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.name.matches_dir" in rule_ids
+
+
+def test_validate_name_must_be_kebab_case(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "BadName_Skill",
+        "---\nname: BadName_Skill\ndescription: x\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("agentskills")
+    report = validate_skill(skill_dir, rules, ruleset_name="agentskills")
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.name.kebab_case" in rule_ids
+
+
+def test_validate_long_description_is_blocking(tmp_path):
+    long_desc = "x" * 1100
+    skill_dir = _write_skill(
+        tmp_path,
+        "long-desc",
+        f"---\nname: long-desc\ndescription: {long_desc}\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes")
+    assert report.has_blocking is True
+    assert "frontmatter.description.length" in {f.rule for f in report.blocking}
+
+
+def test_validate_empty_body_is_blocking(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "empty-body",
+        "---\nname: empty-body\ndescription: A skill with no body.\n---\n\n   \n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes")
+    assert report.has_blocking is True
+    assert "body.non_empty" in {f.rule for f in report.blocking}
+
+
+def test_validate_missing_frontmatter_is_blocking(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path, "no-fm", "# Just a heading, no frontmatter.\n"
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes")
+    assert report.has_blocking is True
+
+
+def test_validate_invalid_semver_is_suggest(tmp_path):
+    skill_dir = _write_skill(
+        tmp_path,
+        "bad-version",
+        "---\nname: bad-version\ndescription: x\nmetadata:\n"
+        "  version: not-a-version\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("agentskills")
+    report = validate_skill(skill_dir, rules, ruleset_name="agentskills")
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.metadata.version.semver" in rule_ids
+
+
+# ─── find_skills ────────────────────────────────────────────────────
+
+
+def test_find_skills_excludes_archive(tmp_path):
+    _write_skill(tmp_path, "active-skill", MINIMAL_HERMES_SKILL)
+    archive_skill = tmp_path / ".archive" / "old-skill"
+    archive_skill.mkdir(parents=True)
+    (archive_skill / "SKILL.md").write_text(MINIMAL_HERMES_SKILL, encoding="utf-8")
+
+    found = find_skills(tmp_path)
+    names = {p.name for p in found}
+    assert names == {"active-skill"}
+
+
+def test_find_skills_recursive(tmp_path):
+    nested = tmp_path / "category-a" / "nested-skill"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(MINIMAL_HERMES_SKILL, encoding="utf-8")
+    _write_skill(tmp_path, "top-level", MINIMAL_HERMES_SKILL)
+
+    found = find_skills(tmp_path)
+    names = {p.name for p in found}
+    assert names == {"top-level", "nested-skill"}
+
+
+# ─── cross-reference integrity ─────────────────────────────────────────
+
+
+def test_validate_related_skills_valid(tmp_path):
+    """All related_skills entries resolve to existing skill YAML names."""
+    skill_a = _write_skill(
+        tmp_path, "skill-a",
+        "---\nname: skill-a\ndescription: First skill.\n---\n\nBody.\n",
+    )
+    _write_skill(
+        tmp_path, "skill-b",
+        "---\nname: skill-b\ndescription: Second skill.\nmetadata:\n  hermes:\n    related_skills: [skill-a]\n    trigger: manual\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    valid = build_skill_name_index(tmp_path)
+    report = validate_skill(skill_a, rules, ruleset_name="hermes", valid_names=valid)
+    assert "frontmatter.related_skills.valid" not in {f.rule for f in report.findings}
+
+
+def test_validate_related_skills_broken_detected(tmp_path):
+    """Broken related_skills entries are flagged."""
+    skill_dir = _write_skill(
+        tmp_path, "broken-ref",
+        "---\nname: broken-ref\ndescription: A skill with broken ref.\nmetadata:\n  hermes:\n    related_skills: [does-not-exist, also-missing]\n    trigger: manual\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    valid = build_skill_name_index(tmp_path)  # empty index
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes", valid_names=valid)
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.related_skills.valid" in rule_ids
+
+
+def test_validate_related_skills_top_level_fallback(tmp_path):
+    """related_skills at top level (not under metadata.hermes) is detected."""
+    skill_dir = _write_skill(
+        tmp_path, "top-level-rs",
+        "---\nname: top-level-rs\ndescription: Top-level related_skills.\nrelated_skills: [nonexistent]\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    valid: set[str] = set()
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes", valid_names=valid)
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.related_skills.valid" in rule_ids, (
+        "Top-level related_skills must be checked, not just metadata.hermes"
+    )
+
+
+def test_validate_metadata_hermes_missing(tmp_path):
+    """Skills without metadata.hermes get a SUGGEST finding."""
+    skill_dir = _write_skill(
+        tmp_path, "no-hermes-meta",
+        "---\nname: no-hermes-meta\ndescription: Missing metadata.hermes.\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes",
+                            valid_names=set())
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.metadata.hermes.present" in rule_ids
+
+
+def test_validate_metadata_hermes_trigger_invalid(tmp_path):
+    """Invalid trigger value is flagged."""
+    skill_dir = _write_skill(
+        tmp_path, "bad-trigger",
+        "---\nname: bad-trigger\ndescription: Invalid trigger.\nmetadata:\n  hermes:\n    tags: [test]\n    related_skills: []\n    trigger: never-automatically\n---\n\nBody.\n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes",
+                            valid_names=set())
+    rule_ids = {f.rule for f in report.findings}
+    assert "frontmatter.metadata.hermes.trigger.valid" in rule_ids
+
+
+def test_validate_body_dead_refs_detected(tmp_path):
+    """Backtick-wrapped skill names not in the name index are flagged."""
+    skill_dir = _write_skill(
+        tmp_path, "has-dead-refs",
+        "---\nname: has-dead-refs\ndescription: Has body dead refs.\n---\n\n# Test\n\nUse the `nonexistent-skill` to do X. Also see `another-missing`.\n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes",
+                            valid_names=set())
+    rule_ids = {f.rule for f in report.findings}
+    assert "body.dead_references" in rule_ids
+
+
+def test_validate_body_dead_refs_common_keywords_skipped(tmp_path):
+    """Common CLI commands / file extensions / keywords are NOT flagged."""
+    skill_dir = _write_skill(
+        tmp_path, "clean-body",
+        "---\nname: clean-body\ndescription: Body with only common keywords.\n---\n\nUse `curl` to fetch data. Parse `json` with `jq`. Run `python3` script.\n",
+    )
+    rules = load_ruleset("hermes")
+    report = validate_skill(skill_dir, rules, ruleset_name="hermes",
+                            valid_names=set())
+    rule_ids = {f.rule for f in report.findings}
+    assert "body.dead_references" not in rule_ids, (
+        f"Common CLI keywords must be in _BODY_DEAD_REF_SKIP. "
+        f"Current skip set: {sorted(_BODY_DEAD_REF_SKIP)}\n"
+        f"Got: {[f.message for f in report.findings if f.rule == 'body.dead_references']}"
+    )
+
+
+def test_build_skill_name_index(tmp_path):
+    """build_skill_name_index collects all YAML names from SKILL.md files."""
+    _write_skill(tmp_path, "first", "---\nname: first-skill\ndescription: A.\n---\n\nBody.\n")
+    _write_skill(tmp_path, "second", "---\nname: second-skill\ndescription: B.\n---\n\nBody.\n")
+    _write_skill(tmp_path, "archived/.archive", "---\nname: should-skip\ndescription: Archived.\n---\n\nBody.\n")
+    names = build_skill_name_index(tmp_path)
+    assert names == {"first-skill", "second-skill"}, (
+        f"Expected {{'first-skill', 'second-skill'}}, got {names}"
+    )
+
+
+def test_build_skill_name_index_graceful_errors(tmp_path):
+    """Skills with unparseable frontmatter are silently skipped."""
+    _write_skill(tmp_path, "good", "---\nname: good-skill\ndescription: OK.\n---\n\nBody.\n")
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    (bad_dir / "SKILL.md").write_text("No frontmatter here.\n", encoding="utf-8")
+    names = build_skill_name_index(tmp_path)
+    assert names == {"good-skill"}

--- a/tools/skills_validator.py
+++ b/tools/skills_validator.py
@@ -1,0 +1,496 @@
+"""Static validation of installed skills against a configurable ruleset.
+
+Complementary to the Curator (`agent/curator.py`). Where Curator performs
+LLM-driven mutation of agent-authored skills, this module is a read-only
+structural linter that operates on any skill — bundled, hub-installed, or
+agent-authored — and reports findings without modifying anything.
+
+Two built-in rulesets:
+  - `hermes`      — Matches the existing `_validate_frontmatter` contract
+                    in `tools/skill_manager_tool.py` (name + description +
+                    non-empty body). Lenient.
+  - `agentskills` — Full agentskills.io frontmatter + section + line-count
+                    spec. Strict.
+
+Custom rulesets can be loaded from a YAML file (see docs).
+
+The validator never writes to disk. It returns a `ValidationReport` that
+CLI / tooling can render as needed.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import yaml
+
+
+SEMVER_RE = re.compile(r"^\d+\.\d+(\.\d+)?$")
+KEBAB_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+DEFAULT_MAX_DESCRIPTION = 1024
+DEFAULT_MAX_LINES = 500
+
+KNOWN_COMPLEXITIES = {"basic", "intermediate", "advanced"}
+TRIGGER_VALUES = {"manual", "cron", "slash", "preload"}
+
+SEVERITY_BLOCKING = "BLOCKING"
+SEVERITY_SUGGEST = "SUGGEST"
+SEVERITY_OK = "OK"
+_VALID_SEVERITIES = {SEVERITY_BLOCKING, SEVERITY_SUGGEST, SEVERITY_OK}
+
+# Common keywords/CLI commands/false-positives in body backtick refs
+_BODY_DEAD_REF_SKIP = {
+"sh", "md", "yml", "yaml", "json", "toml", "env", "git",
+"py", "js", "ts", "go", "rs", "rb", "php", "html", "css",
+"txt", "csv", "xml", "png", "jpg", "gif", "svg", "pdf",
+"http", "https", "api", "url", "uri", "cli", "ui", "ux",
+"stdout", "stdin", "stderr", "config", "debug", "release",
+"curl", "wget", "grep", "sed", "awk", "cat", "less", "tail",
+"head", "find", "ls", "cp", "mv", "rm", "mkdir", "chmod",
+"chown", "ps", "top", "kill", "ssh", "scp", "rsync",
+"docker", "kubectl", "helm",
+"pip", "npm", "yarn", "apt", "yum", "brew", "cargo",
+"python3", "node", "ruby", "perl", "php", "go",
+"ffmpeg", "ffprobe", "sox", "convert", "magick",
+"jq", "yq", "xmllint", "csvtool", "pandoc",
+"left", "right", "top", "bottom", "up", "down",
+"name", "type", "kind", "size", "path", "mode",
+"start", "end", "next", "prev", "last", "first",
+"true", "false", "yes", "no", "on", "off",
+"age", "message", "user", "bot",
+"str", "int", "bool", "float", "var", "val", "func",
+"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+}
+
+
+BUILTIN_RULESETS: Dict[str, Dict[str, str]] = {
+    "hermes": {
+        "frontmatter.present": SEVERITY_BLOCKING,
+        "frontmatter.parseable": SEVERITY_BLOCKING,
+        "frontmatter.name.present": SEVERITY_BLOCKING,
+        "frontmatter.description.present": SEVERITY_BLOCKING,
+        "frontmatter.description.length": SEVERITY_BLOCKING,
+        "frontmatter.metadata.hermes.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.hermes.trigger.valid": SEVERITY_SUGGEST,
+        "frontmatter.related_skills.valid": SEVERITY_SUGGEST,
+        "body.non_empty": SEVERITY_BLOCKING,
+        "body.dead_references": SEVERITY_SUGGEST,
+    },
+    "agentskills": {
+        "frontmatter.present": SEVERITY_BLOCKING,
+        "frontmatter.parseable": SEVERITY_BLOCKING,
+        "frontmatter.name.present": SEVERITY_BLOCKING,
+        "frontmatter.name.kebab_case": SEVERITY_BLOCKING,
+        "frontmatter.name.matches_dir": SEVERITY_BLOCKING,
+        "frontmatter.description.present": SEVERITY_BLOCKING,
+        "frontmatter.description.length": SEVERITY_BLOCKING,
+        "frontmatter.license.present": SEVERITY_SUGGEST,
+        "frontmatter.allowed_tools.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.author.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.version.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.version.semver": SEVERITY_SUGGEST,
+        "frontmatter.metadata.domain.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.complexity.valid": SEVERITY_SUGGEST,
+        "frontmatter.metadata.tags.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.hermes.present": SEVERITY_SUGGEST,
+        "frontmatter.metadata.hermes.trigger.valid": SEVERITY_SUGGEST,
+        "frontmatter.related_skills.valid": SEVERITY_BLOCKING,
+        "section.when_to_use.present": SEVERITY_SUGGEST,
+        "section.procedure.present": SEVERITY_SUGGEST,
+        "body.non_empty": SEVERITY_BLOCKING,
+        "body.line_count": SEVERITY_SUGGEST,
+        "body.dead_references": SEVERITY_SUGGEST,
+    },
+}
+
+
+@dataclass
+class Finding:
+    rule: str
+    severity: str
+    message: str
+
+
+@dataclass
+class ValidationReport:
+    skill_path: Path
+    skill_name: str
+    ruleset_name: str
+    findings: List[Finding] = field(default_factory=list)
+
+    @property
+    def blocking(self) -> List[Finding]:
+        return [f for f in self.findings if f.severity == SEVERITY_BLOCKING]
+
+    @property
+    def suggestions(self) -> List[Finding]:
+        return [f for f in self.findings if f.severity == SEVERITY_SUGGEST]
+
+    @property
+    def has_blocking(self) -> bool:
+        return any(f.severity == SEVERITY_BLOCKING for f in self.findings)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _deep_get(d: dict, *keys: str, default=None):
+    """Safely traverse nested dicts."""
+    for k in keys:
+        if isinstance(d, dict):
+            d = d.get(k)
+        else:
+            return default
+    return d
+
+
+def _find_related_skills(fm: dict) -> List[str]:
+    """Extract related_skills list, checking metadata.hermes first, then top-level."""
+    # Try metadata.hermes.related_skills first
+    rs = _deep_get(fm, "metadata", "hermes", "related_skills")
+    if isinstance(rs, list):
+        return rs
+    if isinstance(rs, str):
+        return [rs]
+
+    # Fallback to top-level related_skills
+    rs = fm.get("related_skills", [])
+    if isinstance(rs, list):
+        return rs
+    if isinstance(rs, str):
+        return [rs]
+
+    return []
+
+
+def _find_body_dead_refs(body: str, valid_names: Set[str]) -> List[str]:
+    """Find backtick-wrapped strings in body that look like skill names but don't exist."""
+    refs = re.findall(r"`([a-z][a-z0-9-]*[a-z0-9])`", body)
+    dead = []
+    for ref in refs:
+        if ref in _BODY_DEAD_REF_SKIP:
+            continue
+        if ref not in valid_names:
+            dead.append(ref)
+    return dead
+
+
+def build_skill_name_index(skills_root: Path) -> Set[str]:
+    """Build set of valid skill YAML names from all SKILL.md files.
+
+    Scans every SKILL.md under `skills_root`, parses frontmatter, and
+    collects the ``name`` field.  Skips anything under an ``.archive``
+    segment.
+    """
+    names: Set[str] = set()
+    for p in sorted(skills_root.rglob("SKILL.md")):
+        if any(part == ".archive" for part in p.parts):
+            continue
+        try:
+            content = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        fm, _, _ = _parse_frontmatter(content)
+        if fm and isinstance(fm, dict) and "name" in fm:
+            n = str(fm["name"]).strip()
+            if n:
+                names.add(n)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Rulesets
+# ---------------------------------------------------------------------------
+
+def load_ruleset(name_or_path: str) -> Dict[str, str]:
+    """Resolve a built-in ruleset name or a YAML file path to {rule: severity}.
+
+    Built-in names: 'hermes', 'agentskills'.
+    Custom files must be valid YAML with a top-level 'rules' mapping
+    of `rule_id: severity`. Severities are case-insensitive and must be
+    one of BLOCKING, SUGGEST, OK.
+    """
+    if name_or_path in BUILTIN_RULESETS:
+        return dict(BUILTIN_RULESETS[name_or_path])
+
+    p = Path(name_or_path)
+    if not p.exists():
+        builtins = sorted(BUILTIN_RULESETS)
+        raise ValueError(
+            f"Ruleset '{name_or_path}' is not a built-in and not a readable file. "
+            f"Built-ins: {builtins}."
+        )
+
+    try:
+        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise ValueError(f"Custom ruleset '{p}' has invalid YAML: {e}") from e
+
+    if not isinstance(data, dict) or "rules" not in data:
+        raise ValueError(
+            f"Custom ruleset '{p}' must be a mapping with a 'rules' key."
+        )
+
+    rules_raw = data["rules"]
+    if not isinstance(rules_raw, dict):
+        raise ValueError(
+            f"Custom ruleset '{p}': 'rules' must be a mapping of rule_id -> severity."
+        )
+
+    resolved: Dict[str, str] = {}
+    for rule_id, sev in rules_raw.items():
+        sev_norm = str(sev).strip().upper()
+        if sev_norm not in _VALID_SEVERITIES:
+            raise ValueError(
+                f"Custom ruleset '{p}': rule '{rule_id}' has invalid severity "
+                f"'{sev}'. Must be one of {sorted(_VALID_SEVERITIES)}."
+            )
+        resolved[str(rule_id)] = sev_norm
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+def _parse_frontmatter(content: str):
+    """Returns (frontmatter_dict_or_None, body_str, error_message_or_None)."""
+    if not content.strip():
+        return None, "", "file is empty"
+    if not content.startswith("---"):
+        return None, content, "missing opening '---' delimiter"
+    end = re.search(r"\n---\s*\n", content[3:])
+    if not end:
+        return None, content, "missing closing '---' delimiter"
+    yaml_text = content[3 : end.start() + 3]
+    body = content[end.end() + 3 :]
+    try:
+        fm = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as e:
+        return None, body, f"YAML parse error: {e}"
+    if not isinstance(fm, dict):
+        return None, body, "frontmatter is not a YAML mapping"
+    return fm, body, None
+
+
+# ---------------------------------------------------------------------------
+# Core validation
+# ---------------------------------------------------------------------------
+
+def validate_skill(
+    skill_path: Path,
+    ruleset: Dict[str, str],
+    ruleset_name: str = "custom",
+    valid_names: Optional[Set[str]] = None,
+) -> ValidationReport:
+    """Validate a single skill against the supplied ruleset.
+
+    `skill_path` may point at a directory containing SKILL.md or directly at
+    the SKILL.md file.
+
+    ``valid_names`` is an optional set of known skill YAML names (from
+    :func:`build_skill_name_index`).  When supplied, cross-reference checks
+    (related_skills validity, body-level dead refs) are enabled.
+    """
+    skill_md = (
+        skill_path / "SKILL.md" if skill_path.is_dir() else skill_path
+    )
+    skill_dir_name = skill_md.parent.name
+    report = ValidationReport(
+        skill_path=skill_md,
+        skill_name=skill_dir_name,
+        ruleset_name=ruleset_name,
+    )
+
+    def add(rule_id: str, message: str) -> None:
+        sev = ruleset.get(rule_id)
+        if sev and sev != SEVERITY_OK:
+            report.findings.append(Finding(rule_id, sev, message))
+
+    if not skill_md.exists():
+        report.findings.append(
+            Finding("file.exists", SEVERITY_BLOCKING, f"SKILL.md not found at {skill_md}")
+        )
+        return report
+
+    content = skill_md.read_text(encoding="utf-8")
+    fm, body, fm_err = _parse_frontmatter(content)
+
+    if fm is None:
+        rule = (
+            "frontmatter.present"
+            if fm_err and "missing" in fm_err
+            else "frontmatter.parseable"
+        )
+        add(rule, fm_err or "frontmatter could not be parsed")
+        if not body.strip():
+            add("body.non_empty", "body is empty after frontmatter")
+        return report
+
+    # name.*
+    name = fm.get("name")
+    if not name:
+        add("frontmatter.name.present", "missing 'name' field")
+    else:
+        name_str = str(name)
+        if not KEBAB_RE.match(name_str):
+            add(
+                "frontmatter.name.kebab_case",
+                f"name '{name_str}' is not kebab-case (expected ^[a-z][a-z0-9-]*$)",
+            )
+        if name_str != skill_dir_name:
+            add(
+                "frontmatter.name.matches_dir",
+                f"name '{name_str}' does not match directory '{skill_dir_name}'",
+            )
+
+    # description.*
+    desc = fm.get("description")
+    if not desc:
+        add("frontmatter.description.present", "missing 'description' field")
+    else:
+        desc_str = str(desc)
+        if len(desc_str) > DEFAULT_MAX_DESCRIPTION:
+            add(
+                "frontmatter.description.length",
+                f"description is {len(desc_str)} characters, max {DEFAULT_MAX_DESCRIPTION}",
+            )
+
+    # license / allowed-tools
+    if not fm.get("license"):
+        add("frontmatter.license.present", "missing 'license' field (e.g. MIT)")
+    if not fm.get("allowed-tools"):
+        add("frontmatter.allowed_tools.present", "missing 'allowed-tools' field")
+
+    # metadata.*
+    meta_raw = fm.get("metadata") or {}
+    meta = meta_raw if isinstance(meta_raw, dict) else {}
+
+    if not meta.get("author"):
+        add("frontmatter.metadata.author.present", "missing metadata.author")
+    if not meta.get("domain"):
+        add("frontmatter.metadata.domain.present", "missing metadata.domain")
+    if not meta.get("tags"):
+        add("frontmatter.metadata.tags.present", "missing metadata.tags")
+
+    version = meta.get("version")
+    if not version:
+        add("frontmatter.metadata.version.present", "missing metadata.version")
+    elif not SEMVER_RE.match(str(version)):
+        add(
+            "frontmatter.metadata.version.semver",
+            f"metadata.version '{version}' is not semver (M.m or M.m.p)",
+        )
+
+    complexity = meta.get("complexity")
+    if not complexity:
+        add("frontmatter.metadata.complexity.valid", "missing metadata.complexity")
+    elif str(complexity) not in KNOWN_COMPLEXITIES:
+        add(
+            "frontmatter.metadata.complexity.valid",
+            f"metadata.complexity '{complexity}' is not in "
+            f"{sorted(KNOWN_COMPLEXITIES)}",
+        )
+
+    # metadata.hermes.* — Hermes-specific operational metadata
+    hermes_meta_raw = _deep_get(fm, "metadata", "hermes", default={})
+    hermes_meta = hermes_meta_raw if isinstance(hermes_meta_raw, dict) else {}
+    if not hermes_meta:
+        add(
+            "frontmatter.metadata.hermes.present",
+            "missing metadata.hermes section (tags, related_skills, trigger)",
+        )
+    else:
+        if not hermes_meta.get("tags"):
+            add(
+                "frontmatter.metadata.hermes.present",
+                "metadata.hermes is present but missing 'tags'",
+            )
+        trigger = hermes_meta.get("trigger", "")
+        if not trigger:
+            add(
+                "frontmatter.metadata.hermes.trigger.valid",
+                "missing metadata.hermes.trigger",
+            )
+        elif trigger not in TRIGGER_VALUES:
+            add(
+                "frontmatter.metadata.hermes.trigger.valid",
+                f"metadata.hermes.trigger '{trigger}' is not one of "
+                f"{sorted(TRIGGER_VALUES)}",
+            )
+
+    # related_skills.* — cross-reference integrity (requires valid_names)
+    if valid_names is not None:
+        rs_list = _find_related_skills(fm)
+        broken = [r for r in rs_list if r not in valid_names]
+        if broken:
+            add(
+                "frontmatter.related_skills.valid",
+                f"Broken related_skills references (skill not found): {broken}",
+            )
+
+    # body.*
+    if not body.strip():
+        add("body.non_empty", "body is empty after frontmatter")
+
+    line_count = len(body.splitlines())
+    if line_count > DEFAULT_MAX_LINES:
+        add(
+            "body.line_count",
+            f"body is {line_count} lines (suggested max {DEFAULT_MAX_LINES}) — "
+            f"consider extracting examples or splitting compound procedures",
+        )
+
+    # body.dead_references — backtick-wrapped skill names that don't resolve
+    if valid_names is not None:
+        body_dead = _find_body_dead_refs(body, valid_names)
+        # Deduplicate for cleaner output
+        seen: Set[str] = set()
+        unique_dead: List[str] = []
+        for r in body_dead:
+            if r not in seen:
+                seen.add(r)
+                unique_dead.append(r)
+        if unique_dead:
+            add(
+                "body.dead_references",
+                f"Body text references skill names not found in any SKILL.md: {unique_dead}",
+            )
+
+    # section.*
+    body_lower = body.lower()
+    if "## when to use" not in body_lower:
+        add(
+            "section.when_to_use.present",
+            "missing '## When to Use' section (recommended by agentskills.io)",
+        )
+    if not re.search(r"^##\s+procedure\b", body, re.MULTILINE | re.IGNORECASE):
+        add(
+            "section.procedure.present",
+            "missing '## Procedure' section (recommended by agentskills.io)",
+        )
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def find_skills(skills_root: Path) -> List[Path]:
+    """Return all skill directories under `skills_root` that contain a SKILL.md.
+
+    Skips anything under an `.archive` segment so archived skills don't show
+    up in audit runs.
+    """
+    found: List[Path] = []
+    for p in skills_root.rglob("SKILL.md"):
+        if any(part == ".archive" for part in p.parts):
+            continue
+        found.append(p.parent)
+    return found

--- a/website/docs/user-guide/features/skills-validate.md
+++ b/website/docs/user-guide/features/skills-validate.md
@@ -1,0 +1,155 @@
+---
+sidebar_position: 4
+title: "Skills validate"
+description: "Static lint pass for installed skills — frontmatter, sections, metadata, line counts. Complementary to the Curator."
+---
+
+# Skills Validate
+
+`hermes skills validate` is a **read-only static lint pass** for installed
+skills. It checks frontmatter completeness, recommended sections, metadata
+fields, and structural limits against a configurable ruleset, then reports
+findings. It never modifies skills on disk.
+
+It is **complementary to the [Curator](/docs/user-guide/features/curator)** —
+the Curator is a background LLM-driven mutation pass that prunes and
+consolidates agent-authored skills; this is a deterministic checker that
+runs against *any* installed skill (bundled, hub-installed, or
+agent-authored) and produces a report.
+
+## Quick start
+
+Validate every installed skill against the default (lenient) ruleset:
+
+```bash
+hermes skills validate
+```
+
+Validate a single skill against the strict agentskills.io ruleset:
+
+```bash
+hermes skills validate my-skill --ruleset agentskills
+```
+
+Validate a SKILL.md file directly:
+
+```bash
+hermes skills validate path/to/SKILL.md --ruleset agentskills
+```
+
+Use a custom ruleset:
+
+```bash
+hermes skills validate --ruleset /path/to/rules.yaml
+```
+
+Treat suggestions as blocking for exit-code purposes:
+
+```bash
+hermes skills validate --strict
+```
+
+## Built-in rulesets
+
+### `hermes` (default — lenient)
+
+Matches the existing `_validate_frontmatter` contract in
+`tools/skill_manager_tool.py`. Useful as a regression check: every existing
+Hermes skill should pass.
+
+Rules:
+- `frontmatter.present` (BLOCKING)
+- `frontmatter.parseable` (BLOCKING)
+- `frontmatter.name.present` (BLOCKING)
+- `frontmatter.description.present` (BLOCKING)
+- `frontmatter.description.length` (BLOCKING — max 1024 chars)
+- `body.non_empty` (BLOCKING)
+
+### `agentskills` (strict)
+
+Implements the full [agentskills.io](https://agentskills.io) skill spec.
+Useful when authoring or accepting skills meant to be portable across
+agentskills.io-compatible runtimes.
+
+Additional rules on top of `hermes`:
+- `frontmatter.name.kebab_case` (BLOCKING)
+- `frontmatter.name.matches_dir` (BLOCKING — name must match directory)
+- `frontmatter.license.present` (SUGGEST)
+- `frontmatter.allowed_tools.present` (SUGGEST)
+- `frontmatter.metadata.author.present` (SUGGEST)
+- `frontmatter.metadata.version.present` (SUGGEST)
+- `frontmatter.metadata.version.semver` (SUGGEST — must match `M.m` or `M.m.p`)
+- `frontmatter.metadata.domain.present` (SUGGEST)
+- `frontmatter.metadata.complexity.valid` (SUGGEST — must be one of `basic`,
+  `intermediate`, `advanced`)
+- `frontmatter.metadata.tags.present` (SUGGEST)
+- `section.when_to_use.present` (SUGGEST — recommends `## When to Use`)
+- `section.procedure.present` (SUGGEST — recommends `## Procedure`)
+- `body.line_count` (SUGGEST — suggested max 500 lines)
+
+## Custom rulesets
+
+A custom ruleset is a YAML file with a top-level `rules` mapping of
+`rule_id: severity`. Valid severities are `BLOCKING`, `SUGGEST`, `OK`. Use
+`OK` to silence a rule that a parent ruleset would otherwise enable.
+
+```yaml
+# rules.yaml — relaxed agentskills variant
+rules:
+  frontmatter.present: BLOCKING
+  frontmatter.parseable: BLOCKING
+  frontmatter.name.present: BLOCKING
+  frontmatter.name.kebab_case: BLOCKING
+  frontmatter.description.present: BLOCKING
+  frontmatter.description.length: BLOCKING
+  frontmatter.metadata.version.semver: SUGGEST
+  body.non_empty: BLOCKING
+  body.line_count: OK    # disable line-count check entirely
+```
+
+```bash
+hermes skills validate --ruleset rules.yaml
+```
+
+## Exit code
+
+`hermes skills validate` exits non-zero when any skill has BLOCKING findings.
+With `--strict`, SUGGEST findings also count. This makes it usable in CI:
+
+```bash
+hermes skills validate --ruleset agentskills --strict
+```
+
+## Output
+
+```
+Skill Validation — ruleset: agentskills
+┌──────────────────┬──────────┬─────────┬──────────┐
+│ Skill            │ Blocking │ Suggest │ Status   │
+├──────────────────┼──────────┼─────────┼──────────┤
+│ my-clean-skill   │        0 │       0 │ OK       │
+│ my-thin-skill    │        0 │       4 │ SUGGEST  │
+│ broken-skill     │        2 │       1 │ BLOCKING │
+└──────────────────┴──────────┴─────────┴──────────┘
+
+broken-skill  ~/.hermes/skills/broken-skill/SKILL.md
+  BLOCKING  frontmatter.name.matches_dir   name 'wrong' does not match directory 'broken-skill'
+  BLOCKING  frontmatter.description.length description is 1500 characters, max 1024
+  SUGGEST   section.when_to_use.present    missing '## When to Use' section (recommended by agentskills.io)
+
+Summary: 1 OK, 1 with suggestions, 1 with blocking findings.
+```
+
+## Relationship to the Curator
+
+| Aspect | Curator | Skills validate |
+|---|---|---|
+| Engine | LLM (forked auxiliary agent) | Deterministic (no LLM) |
+| Scope | Agent-authored skills only | Any skill (bundled, hub, agent-authored) |
+| Action | Mutates: patch / consolidate / archive | Reports only; never writes |
+| Trigger | Background (7d cycle, idle gate) | On-demand CLI |
+| Use case | Drift / staleness in self-improvement loop | Spec compliance, CI gate, authoring lint |
+
+The two are designed to be used together: the validator catches structural
+problems early (CI, pre-install, post-authoring), while the Curator handles
+long-term lifecycle of agent-grown skills.


### PR DESCRIPTION
## Summary

Adds cross-skill reference integrity checks and metadata.hermes structural validation to the existing `hermes skills validate` command.

### Cross-reference checks:
- **related_skills resolution** — each entry in `related_skills` must resolve to an existing skill YAML `name` value
- **Body-level dead reference detection** — backtick-wrapped kebab-case strings in body text that don't match any known skill name (SUGGEST severity only, body text is sacred)

### Metadata structural checks:
- **metadata.hermes presence** — suggests adding `metadata.hermes` block with `tags`, `related_skills`, `trigger`
- **trigger validation** — must be one of `manual`, `cron`, `slash`, `preload`

### New rule IDs
```
frontmatter.metadata.hermes.present       — SUGGEST (both)
frontmatter.metadata.hermes.trigger.valid — SUGGEST (both)
frontmatter.related_skills.valid          — SUGGEST (hermes) / BLOCKING (agentskills)
body.dead_references                       — SUGGEST (both)
```

The validator remains deterministic (no LLM), operates on any skill (bundled, hub, or agent-authored), and never writes to disk. Backward compatible via optional `valid_names=None` parameter.

### Files changed
- `tools/skills_validator.py` — cross-ref logic + new ruleset entries (+~130 lines)
- `hermes_cli/skills_hub.py` — CLI integration for name index building (+~30 lines)
- `tests/tools/test_skills_validator.py` — 9 new test cases (+~130 lines)

Total: ~290 lines added, 0 deleted (net addition on top of PR #25534). The existing 17 tests from #25534 pass unchanged.

## Motivation

Issue #416 (March 4, 2026) originally requested skill validation and linting. PR #25534 (pjt222) delivered the structural linter but explicitly left cross-skill reference integrity out of scope. This PR closes that gap.

During an audit of ~111 installed skills, we found:
- 11 skills entirely missing `metadata.hermes` section
- 1 skill with broken `related_skills` references
- 1 skill with an invalid `trigger` value
- Dozens of skills with body-level dead references to non-existent skill names

## Out of scope
- Auto-fix — the validator is read-only, per #25534's design
- Metadata mutation — operational metadata belongs in the sidecar (per #7816)
- `hermes skills lint` alias — follow-up; this PR keeps the `validate` command name

Co-authored-by: pjt222 <ph.thoss@gmx.de>