### PR TITLE
feat(desktop): custom zoom shortcuts at half default step

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2731,9 +2731,31 @@ function buildApplicationMenu() {
       { role: 'forceReload' },
       { role: 'toggleDevTools' },
       { type: 'separator' },
-      { role: 'resetZoom' },
-      { role: 'zoomIn' },
-      { role: 'zoomOut' },
+      {
+        label: 'Actual Size',
+        accelerator: 'CommandOrControl+0',
+        click: () => { if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.setZoomLevel(0) }
+      },
+      {
+        label: 'Zoom In',
+        accelerator: 'CommandOrControl+Plus',
+        click: () => {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            const next = Math.min(mainWindow.webContents.getZoomLevel() + 0.1, 9)
+            mainWindow.webContents.setZoomLevel(next)
+          }
+        }
+      },
+      {
+        label: 'Zoom Out',
+        accelerator: 'CommandOrControl+-',
+        click: () => {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            const next = Math.max(mainWindow.webContents.getZoomLevel() - 0.1, -9)
+            mainWindow.webContents.setZoomLevel(next)
+          }
+        }
+      },
       { type: 'separator' },
       { role: 'togglefullscreen' }
     ]
@@ -2789,6 +2811,32 @@ function installPreviewShortcut(window) {
 
     event.preventDefault()
     sendClosePreviewRequested()
+  })
+}
+
+function installZoomShortcuts(window) {
+  // Override Ctrl/Cmd + +/-/0 with half the default zoom step (0.1 vs 0.2).
+  // The menu items handle this on macOS (where the menu is always present),
+  // but on Linux/Windows the menu is null and Chromium's default handler
+  // would use the full 0.2 step, so we intercept here for consistency.
+  const ZOOM_STEP = 0.1
+  window.webContents.on('before-input-event', (event, input) => {
+    const mod = IS_MAC ? input.meta : input.control
+    if (!mod || input.alt || input.shift) return
+
+    const key = input.key
+    if (key === '0') {
+      event.preventDefault()
+      window.webContents.setZoomLevel(0)
+    } else if (key === '=' || key === '+') {
+      event.preventDefault()
+      const next = Math.min(window.webContents.getZoomLevel() + ZOOM_STEP, 9)
+      window.webContents.setZoomLevel(next)
+    } else if (key === '-') {
+      event.preventDefault()
+      const next = Math.max(window.webContents.getZoomLevel() - ZOOM_STEP, -9)
+      window.webContents.setZoomLevel(next)
+    }
   })
 }
 
@@ -3378,6 +3426,7 @@ function createWindow() {
 
   installPreviewShortcut(mainWindow)
   installDevToolsShortcut(mainWindow)
+  installZoomShortcuts(mainWindow)
   installContextMenu(mainWindow)
   mainWindow.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)


### PR DESCRIPTION
## What does this PR do?

Adds custom Ctrl/Cmd + +/-/0 zoom handling to the desktop Electron app that uses **half the default zoom step** (0.1 instead of Chromium's built-in 0.2 per keypress). This makes zooming feel more granular and less jumpy.

The default Electron `zoomIn`/`zoomOut`/`resetZoom` menu roles and Chromium's built-in keyboard handler both use a 0.2 zoom-level step. This PR replaces them with explicit `setZoomLevel()` calls that step by 0.1, giving users finer control.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/electron/main.cjs` — Replaced `{ role: 'resetZoom' }`, `{ role: 'zoomIn' }`, `{ role: 'zoomOut' }` View menu items with custom click handlers that use `webContents.setZoomLevel()` with a 0.1 step (clamped to ±9)
- `apps/desktop/electron/main.cjs` — Added `installZoomShortcuts(window)` that intercepts Ctrl/Cmd + `=`/`+`/`-`/`0` via `before-input-event` and applies the same 0.1 step. Required on Linux/Windows where the application menu is `null` and Chromium would otherwise handle the shortcut with its default 0.2 step.
- `apps/desktop/electron/main.cjs` — Wired `installZoomShortcuts(mainWindow)` into the window setup alongside the other `install*` calls.

## How to Test

1. Launch the desktop app (`hermes --desktop` or from the built electron package)
2. Press Ctrl+Plus (or Cmd+Plus on macOS) — observe the UI zooms in by a small increment
3. Press Ctrl+Minus — observe the UI zooms out by the same small increment
4. Press Ctrl+0 — observe the zoom resets to default (level 0)
5. On macOS, the View menu items (Actual Size / Zoom In / Zoom Out) should also use the same half-step increment
6. Verify that holding Ctrl+Plus several times gradually zooms in more smoothly than before (0.1 steps vs 0.2)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Linux (NixOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A