### PR TITLE
fix(mcp): reconnect stale server entries in register_mcp_servers (#37768)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3844,6 +3844,47 @@ class TestRegisterMcpServers:
 
         _servers.pop("srv", None)
 
+    def test_mixed_stale_and_healthy_servers(self):
+        """Only the stale server (session=None) should be reconnected;
+        the healthy one (active session) must be left untouched."""
+        from tools.mcp_tool import register_mcp_servers, _servers, _ensure_mcp_loop
+
+        active_session = MagicMock(name="active-session")
+        healthy = _make_mock_server("healthy", session=active_session)
+        healthy._registered_tool_names = ["mcp_healthy_tool"]
+        _servers["healthy"] = healthy
+
+        stale = _make_mock_server("stale", session=None)
+        stale._registered_tool_names = ["mcp_stale_tool"]
+        _servers["stale"] = stale
+
+        async def fake_register(name, cfg):
+            if name != "stale":
+                pytest.fail(f"unexpected reconnect for {name!r}")
+            server = _make_mock_server(name)
+            server._registered_tool_names = ["mcp_stale_tool"]
+            _servers[name] = server
+            return ["mcp_stale_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server",
+                       side_effect=fake_register) as mock_register, \
+                 patch("tools.mcp_tool._existing_tool_names",
+                       return_value=["mcp_healthy_tool", "mcp_stale_tool"]):
+                _ensure_mcp_loop()
+                result = register_mcp_servers({
+                    "healthy": {"command": "test-healthy"},
+                    "stale": {"command": "test-stale"},
+                })
+            assert sorted(result) == ["mcp_healthy_tool", "mcp_stale_tool"]
+            mock_register.assert_called_once_with(
+                "stale", {"command": "test-stale"}
+            )
+        finally:
+            _servers.pop("healthy", None)
+            _servers.pop("stale", None)
+
 
 # ---------------------------------------------------------------------------
 # Tests for parallel tool call support (port from openai/codex#17667)

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3713,7 +3713,8 @@ class TestRegisterMcpServers:
     def test_skips_already_connected_servers(self):
         from tools.mcp_tool import register_mcp_servers, _servers
 
-        mock_server = _make_mock_server("existing")
+        active_session = MagicMock(name="active-session")
+        mock_server = _make_mock_server("existing", session=active_session)
         _servers["existing"] = mock_server
 
         try:
@@ -3723,6 +3724,68 @@ class TestRegisterMcpServers:
             assert result == ["mcp_existing_tool"]
         finally:
             _servers.pop("existing", None)
+
+    def test_reconnects_stale_server_with_null_session(self):
+        """A server present in ``_servers`` but with ``session=None``
+        must be reconnected rather than skipped — otherwise tool
+        handlers return \"not connected\" forever.  Regression for
+        #37768."""
+        from tools.mcp_tool import register_mcp_servers, _servers, _ensure_mcp_loop
+
+        stale_server = _make_mock_server("stale", session=None)
+        stale_server._registered_tool_names = ["mcp_stale_tool"]
+        _servers["stale"] = stale_server
+
+        async def fake_register(name, cfg):
+            server = _make_mock_server(name)
+            server._registered_tool_names = ["mcp_stale_tool"]
+            _servers[name] = server
+            return ["mcp_stale_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server",
+                       side_effect=fake_register) as mock_register, \
+                 patch("tools.mcp_tool._existing_tool_names",
+                       return_value=["mcp_stale_tool"]):
+                _ensure_mcp_loop()
+                result = register_mcp_servers(
+                    {"stale": {"command": "test"}}
+                )
+            assert result == ["mcp_stale_tool"]
+            mock_register.assert_called_once_with(
+                "stale", {"command": "test"}
+            )
+        finally:
+            _servers.pop("stale", None)
+
+    def test_skips_healthy_server_with_active_session(self):
+        """A server with a live ``session`` must NOT be reconnected
+        — it's already healthy."""
+        from tools.mcp_tool import register_mcp_servers, _servers, _ensure_mcp_loop
+
+        active_session = MagicMock(name="active-session")
+        healthy = _make_mock_server("healthy", session=active_session)
+        healthy._registered_tool_names = ["mcp_healthy_tool"]
+        _servers["healthy"] = healthy
+
+        async def fake_register(name, cfg):
+            pytest.fail("should not attempt to reconnect a healthy server")
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server",
+                       side_effect=fake_register) as mock_register, \
+                 patch("tools.mcp_tool._existing_tool_names",
+                       return_value=["mcp_healthy_tool"]):
+                _ensure_mcp_loop()
+                result = register_mcp_servers(
+                    {"healthy": {"command": "test"}}
+                )
+            assert result == ["mcp_healthy_tool"]
+            mock_register.assert_not_called()
+        finally:
+            _servers.pop("healthy", None)
 
     def test_skips_disabled_servers(self):
         from tools.mcp_tool import register_mcp_servers, _servers

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3513,6 +3513,21 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     #
     # Enabled: false servers are skipped without removing existing sessions.
     with _lock:
+        # Cancel lingering background tasks for stale entries BEFORE building
+        # new_servers.  Otherwise a stale MCPServerTask may still be parked
+        # in its reconnect backoff loop (or waiting on _reconnect_event).  If
+        # we launch a new _discover_and_register_server for the same name
+        # while the old task later finishes its reconnection, two sessions
+        # race for the same server name (TOCTOU on _servers[<name>]) and the
+        # old task is orphaned, leaking an asyncio Task (#37899 review).
+        for k in list(_servers.keys()):
+            srv = _servers[k]
+            if getattr(srv, "session", None) is None:
+                old_task = getattr(srv, "_task", None)
+                if old_task is not None and not old_task.done():
+                    old_task.cancel()
+                del _servers[k]
+
         new_servers = {
             k: v
             for k, v in servers.items()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3506,13 +3506,21 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
-    # Only attempt servers that aren't already connected and are enabled
-    # (enabled: false skips the server entirely without removing its config)
+    # Only skip servers that are both already in ``_servers`` AND have an
+    # active session.  A stale entry (``session is None``, e.g. after a
+    # transport disconnect) must be reconnected so that tool handlers don't
+    # permanently return "not connected" (#37768).
+    #
+    # Enabled: false servers are skipped without removing existing sessions.
     with _lock:
         new_servers = {
             k: v
             for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
+            if _parse_boolish(v.get("enabled", True), default=True)
+            and (
+                k not in _servers
+                or getattr(_servers[k], "session", None) is None
+            )
         }
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():


### PR DESCRIPTION
## What does this PR do?

`register_mcp_servers()` skips servers that already exist in the `_servers` dict. After a transport disconnect, MCP servers remain in `_servers` with `session=None`. The stale entry blocks reconnection, so tool handlers permanently return "not connected" until the agent restarts.

This PR changes the skip condition to allow reconnection when `session is None` (stale entry) while still skipping servers with an active session.

**Note:** An existing PR (#37772) also addresses this issue. This PR differs by:
- Guarding the reconnect path with an explicit `session is None` check rather than unconditionally reconnecting all known servers
- Including a negative test that verifies healthy servers are NOT unnecessarily reconnected
- Providing 8 focused tests covering reconnect, healthy-skip, disabled-skip, empty input, MCP-unavailable, new-server connection, already-connected, and log summary

## Related Issue

Fixes #37768

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` — Changed the server-skip condition in `register_mcp_servers()`: now allows reconnection when `getattr(_servers[k], "session", None) is None` (stale entry), while still honoring `enabled: false` and skipping servers with active sessions
- `tests/tools/test_mcp_tool.py` — Added 2 new tests (`test_reconnects_stale_server_with_null_session`, `test_skips_healthy_server_with_active_session`) and updated existing `test_skips_already_connected_servers` to use a mock session object

## How to Test

1. Run `python3 -m pytest tests/tools/test_mcp_tool.py::TestRegisterMcpServers -v -o 'addopts='`
2. Verify stale server (session=None) is reconnected
3. Verify healthy server (active session) is NOT reconnected
4. Verify disabled servers are still skipped
5. Verify new servers are still connected

All 8 tests pass in TestRegisterMcpServers. Fail-without-fix verified: reverting the condition change in `tools/mcp_tool.py` causes `test_reconnects_stale_server_with_null_session` to fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64, Python 3.11)

### Documentation & Housekeeping

- [x] N/A
