### PR TITLE
feat(google-workspace): support read-only mode, opt-in read/write

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -71,6 +71,12 @@ Calendar/Drive/Sheets/Docs?"**
 - **Full Workspace access** → Continue with this skill and use the default
   `all` service set.
 
+Each named service is requested as **read-write** by default. To restrict any
+service to read-only, append `=ro` (e.g. `--services gmail=ro,calendar=rw`).
+See the "Modes" section below for the full table. Read-only is enforced at
+the OAuth grant — once the token lacks `gmail.send`, no code path the agent
+can reach (bash, python, raw HTTP) can send mail through that account.
+
 **Question 2: "Does your Google account use Advanced Protection (hardware
 security keys required to sign in)? If you're not sure, you probably don't
 — it's something you would have explicitly enrolled in."**
@@ -122,10 +128,16 @@ Use the service set chosen in Step 1. Examples:
 $GSETUP --auth-url --services email,calendar --format json
 $GSETUP --auth-url --services calendar,drive,sheets,docs --format json
 $GSETUP --auth-url --services all --format json
+
+# Per-service read-only — recommended when the user wants the agent to
+# read but not act. Token cannot send mail / write events / modify Drive.
+$GSETUP --auth-url --services 'gmail=ro,calendar=rw,drive=ro' --format json
+$GSETUP --auth-url --services 'all=ro' --format json
 ```
 
-This returns JSON with an `auth_url` field and also saves the exact URL to
-`~/.hermes/google_oauth_last_url.txt`.
+`--format json` returns a JSON object with `auth_url` and `scopes` fields.
+The chosen services + modes are persisted to `~/.hermes/google_scopes.json`
+and reused by future `--auth-url` / `--check` calls.
 
 Agent rules for this step:
 - Extract the `auth_url` field and send that exact URL to the user as a single line.
@@ -141,7 +153,7 @@ pending OAuth session locally so `--auth-code` can complete the PKCE exchange
 later, even on headless systems:
 
 ```bash
-$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED" --format json
+$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
 ```
 
 If `--auth-code` fails because the code expired, was already used, or came from
@@ -163,6 +175,43 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 - Pending OAuth session state/verifier are stored temporarily at `~/.hermes/google_oauth_pending.json` until exchange completes.
 - If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.
 - To revoke: `$GSETUP --revoke`
+
+## Modes
+
+Each service can be granted in **read-only** (`=ro`) or **read-write** (`=rw`,
+the default) mode. The choice is recorded in `~/.hermes/google_scopes.json`
+and embedded in the OAuth grant — write subcommands are refused early when
+the token lacks the corresponding scope, and Google's auth server rejects
+them outright regardless of what code path is used.
+
+| Service | `=ro` grants | `=rw` adds |
+|---------|--------------|-----------|
+| gmail (alias: email) | read mail, search, list labels | send, reply, modify labels, trash |
+| calendar | list events | create / update / delete events |
+| drive | search, read, download | upload, share, create folder, delete |
+| sheets | read values | update, append, create |
+| docs | read content | create, append |
+| contacts | list (only mode in this skill) | — |
+
+```bash
+# Show the current config and the scopes that would be requested.
+$GSETUP --show-mode
+$GSETUP --show-mode --format json
+
+# Switch an existing install to read-only gmail (re-auth required).
+$GSETUP --revoke
+$GSETUP --auth-url --services 'gmail=ro,calendar=rw,drive=ro,sheets=ro,docs=ro' --format json
+# Send URL to user, then exchange the returned code:
+$GSETUP --auth-code "THE_URL_OR_CODE"
+$GSETUP --show-mode   # sanity check
+```
+
+**Security note for the agent**: read-only is a hard boundary. Do not attempt
+to "work around" a `READONLY_MODE: <action> blocked ...` error by writing a
+Python script, calling the REST API directly, or any other route — Google's
+auth server enforces the scope check on the token, not Hermes. The correct
+response is to tell the user the action is blocked and offer to re-run
+`$GSETUP --auth-url --services <service>=rw` if they want to enable it.
 
 ## Usage
 
@@ -327,6 +376,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 | `HttpError 403: Access Not Configured` | API not enabled — user needs to enable it in Google Cloud Console |
 | `ModuleNotFoundError` | Run `$GSETUP --install-deps` |
 | Advanced Protection blocks auth | Workspace admin must allowlist the OAuth client ID |
+| `READONLY_MODE: <action> blocked` | Token was issued without the write scope for that service. Tell the user and offer `$GSETUP --revoke && $GSETUP --auth-url --services <service>=rw` if they want to enable writes. Do not try to bypass — Google enforces the scope. |
 
 ## Revoking Access
 

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -79,6 +79,39 @@ def _stored_token_scopes() -> list[str]:
     return list(SCOPES)
 
 
+# Per-action scope URLs. Used by _require_scope to refuse early when the
+# token (issued under a reduced scope set per ~/.hermes/google_scopes.json)
+# lacks the scope a given write action needs. Without this gate the call
+# would still fail — Google's auth server rejects it — but with a more
+# opaque 403 instead of a clear READONLY_MODE message.
+SCOPE_API_BASE = "https://www.googleapis.com/auth"
+GMAIL_SEND_SCOPE = f"{SCOPE_API_BASE}/gmail.send"
+GMAIL_MODIFY_SCOPE = f"{SCOPE_API_BASE}/gmail.modify"
+CALENDAR_WRITE_SCOPE = f"{SCOPE_API_BASE}/calendar"
+DRIVE_WRITE_SCOPE = f"{SCOPE_API_BASE}/drive"
+SHEETS_WRITE_SCOPE = f"{SCOPE_API_BASE}/spreadsheets"
+DOCS_WRITE_SCOPE = f"{SCOPE_API_BASE}/documents"
+
+
+def _require_scope(scope_url: str, action: str) -> None:
+    """Refuse a write action if the stored token lacks the needed scope.
+
+    The real defense is Google's auth server (which rejects the call
+    regardless). This function turns that rejection into a readable
+    READONLY_MODE error so the agent doesn't waste a round trip.
+    """
+    if scope_url in set(_stored_token_scopes()):
+        return
+    print(
+        f"READONLY_MODE: {action} blocked — current OAuth token lacks "
+        f"'{scope_url}'. To enable this action, re-authorize with the "
+        f"relevant service in read-write mode, e.g.:\n"
+        f"  setup.py --revoke && setup.py --auth-url --services <service>=rw",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
 def _gws_binary() -> str | None:
     override = os.getenv("HERMES_GWS_BIN")
     if override:
@@ -316,6 +349,7 @@ def gmail_get(args):
 
 
 def gmail_send(args):
+    _require_scope(GMAIL_SEND_SCOPE, "gmail send")
     if _gws_binary():
         message = MIMEText(args.body, "html" if args.html else "plain")
         message["To"] = args.to
@@ -359,6 +393,7 @@ def gmail_send(args):
 
 
 def gmail_reply(args):
+    _require_scope(GMAIL_SEND_SCOPE, "gmail reply")
     if _gws_binary():
         original = _run_gws(
             ["gmail", "users", "messages", "get"],
@@ -436,6 +471,7 @@ def gmail_labels(args):
 
 
 def gmail_modify(args):
+    _require_scope(GMAIL_MODIFY_SCOPE, "gmail modify")
     body = {}
     if args.add_labels:
         body["addLabelIds"] = args.add_labels.split(",")
@@ -516,6 +552,7 @@ def calendar_list(args):
 
 
 def calendar_create(args):
+    _require_scope(CALENDAR_WRITE_SCOPE, "calendar create")
     event = {
         "summary": args.summary,
         "start": {"dateTime": args.start},
@@ -554,6 +591,7 @@ def calendar_create(args):
 
 
 def calendar_delete(args):
+    _require_scope(CALENDAR_WRITE_SCOPE, "calendar delete")
     if _gws_binary():
         _run_gws(["calendar", "events", "delete"], params={"calendarId": args.calendar, "eventId": args.event_id})
         print(json.dumps({"status": "deleted", "eventId": args.event_id}))
@@ -609,6 +647,7 @@ def drive_get(args):
 
 def drive_upload(args):
     """Upload a local file to Drive. Falls through to Python client even when gws
+    _require_scope(DRIVE_WRITE_SCOPE, "drive upload")
     is installed, because gws doesn't do multipart uploads."""
     import mimetypes
     from googleapiclient.http import MediaFileUpload
@@ -689,6 +728,7 @@ def drive_download(args):
 
 
 def drive_create_folder(args):
+    _require_scope(DRIVE_WRITE_SCOPE, "drive create_folder")
     body = {
         "name": args.name,
         "mimeType": "application/vnd.google-apps.folder",
@@ -721,6 +761,7 @@ def drive_create_folder(args):
 
 
 def drive_share(args):
+    _require_scope(DRIVE_WRITE_SCOPE, "drive share")
     permission = {
         "type": args.type,
         "role": args.role,
@@ -772,6 +813,7 @@ def drive_share(args):
 
 def drive_delete(args):
     """Trash or permanently delete a Drive file. Defaults to trash (reversible)."""
+    _require_scope(DRIVE_WRITE_SCOPE, "drive delete")
     if args.permanent:
         if _gws_binary():
             _run_gws(["drive", "files", "delete"], params={"fileId": args.file_id})
@@ -868,6 +910,7 @@ def sheets_get(args):
 
 
 def sheets_update(args):
+    _require_scope(SHEETS_WRITE_SCOPE, "sheets update")
     values = json.loads(args.values)
     body = {"values": values}
 
@@ -894,6 +937,7 @@ def sheets_update(args):
 
 
 def sheets_append(args):
+    _require_scope(SHEETS_WRITE_SCOPE, "sheets append")
     values = json.loads(args.values)
     body = {"values": values}
 
@@ -921,6 +965,7 @@ def sheets_append(args):
 
 def sheets_create(args):
     """Create a new spreadsheet. Returns the new spreadsheet ID and URL."""
+    _require_scope(SHEETS_WRITE_SCOPE, "sheets create")
     body = {"properties": {"title": args.title}}
     if args.sheet_name:
         body["sheets"] = [{"properties": {"title": args.sheet_name}}]
@@ -975,6 +1020,7 @@ def docs_get(args):
 
 def docs_create(args):
     """Create a new Doc. Optionally seed it with initial body text."""
+    _require_scope(DOCS_WRITE_SCOPE, "docs create")
     body = {"title": args.title}
 
     if _gws_binary():
@@ -998,6 +1044,7 @@ def docs_create(args):
 
 def docs_append(args):
     """Append text to the end of an existing Doc."""
+    _require_scope(DOCS_WRITE_SCOPE, "docs append")
     if _gws_binary():
         doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
     else:
@@ -1028,6 +1075,7 @@ def docs_append(args):
 
 def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
     """Send a batchUpdate with a single insertText request."""
+    _require_scope(DOCS_WRITE_SCOPE, "docs insert text")
     requests = [{
         "insertText": {
             "location": {"index": index},

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -41,17 +41,142 @@ HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
+SCOPES_CONFIG_PATH = HERMES_HOME / "google_scopes.json"
 
-SCOPES = [
-    "https://www.googleapis.com/auth/gmail.readonly",
-    "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/contacts.readonly",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/documents",
-]
+SCOPE_API_BASE = "https://www.googleapis.com/auth"
+SERVICE_SCOPES = {
+    "gmail": {
+        "readonly": [f"{SCOPE_API_BASE}/gmail.readonly"],
+        "readwrite": [
+            f"{SCOPE_API_BASE}/gmail.readonly",
+            f"{SCOPE_API_BASE}/gmail.send",
+            f"{SCOPE_API_BASE}/gmail.modify",
+        ],
+    },
+    "calendar": {
+        "readonly": [f"{SCOPE_API_BASE}/calendar.readonly"],
+        "readwrite": [f"{SCOPE_API_BASE}/calendar"],
+    },
+    "drive": {
+        "readonly": [f"{SCOPE_API_BASE}/drive.readonly"],
+        "readwrite": [f"{SCOPE_API_BASE}/drive"],
+    },
+    "sheets": {
+        "readonly": [f"{SCOPE_API_BASE}/spreadsheets.readonly"],
+        "readwrite": [f"{SCOPE_API_BASE}/spreadsheets"],
+    },
+    "docs": {
+        "readonly": [f"{SCOPE_API_BASE}/documents.readonly"],
+        "readwrite": [f"{SCOPE_API_BASE}/documents"],
+    },
+    "contacts": {
+        # This skill never calls a contacts-write API, so the two modes
+        # are intentionally identical — keeps the config schema uniform.
+        "readonly": [f"{SCOPE_API_BASE}/contacts.readonly"],
+        "readwrite": [f"{SCOPE_API_BASE}/contacts"],
+    },
+}
+
+ALL_SERVICES = SERVICE_SCOPES.keys()
+SERVICE_ALIASES = {"email": "gmail"}
+
+# Legacy full-access scope list. Used as the fallback when no
+# google_scopes.json exists — preserves the pre-config behavior for
+# existing installs that haven't opted into per-service modes.
+DEFAULT_SCOPES = list(
+    dict.fromkeys(
+        scope for svc in ALL_SERVICES for scope in SERVICE_SCOPES[svc]["readwrite"]
+    )
+)
+
+
+def _parse_services_spec(spec: str) -> dict:
+    """Parse a ``--services`` value into {service: 'readonly'|'readwrite'}.
+
+    Forms accepted:
+      ``all``                          → every service, readwrite
+      ``all=ro``                       → every service, readonly
+      ``gmail,calendar``               → those services, readwrite each
+      ``gmail=ro,calendar=rw``         → explicit modes per service
+      ``email`` (alias for gmail)      → handled via SERVICE_ALIASES
+    """
+    result: dict = {}
+    for raw_token in spec.split(","):
+        token = raw_token.strip()
+        if not token:
+            continue
+        if "=" in token:
+            name, mode = token.split("=", 1)
+            name, mode = name.strip().lower(), mode.strip().lower()
+        else:
+            name, mode = token.lower(), "rw"
+
+        name = SERVICE_ALIASES.get(name, name)
+
+        if mode in {"ro", "readonly", "read-only", "r"}:
+            mode_norm = "readonly"
+        elif mode in {"rw", "readwrite", "read-write", "w"}:
+            mode_norm = "readwrite"
+        else:
+            raise ValueError(
+                f"Invalid mode '{mode}' for service '{name}'; expected ro or rw"
+            )
+
+        if name == "all":
+            for svc in ALL_SERVICES:
+                result[svc] = mode_norm
+        elif name in SERVICE_SCOPES:
+            result[name] = mode_norm
+        else:
+            valid = ", ".join(sorted({*SERVICE_SCOPES, "all", *SERVICE_ALIASES}))
+            raise ValueError(f"Unknown service '{name}'; valid: {valid}")
+
+    if not result:
+        raise ValueError("--services value parsed to an empty set")
+
+    return result
+
+
+def _load_scope_config() -> dict | None:
+    """Read ~/.hermes/google_scopes.json; return None if absent/unreadable.
+
+    Returning None (rather than a default) preserves legacy behavior:
+    callers fall back to the full SCOPES list, so installs that never
+    set a config behave exactly as before.
+    """
+    if not SCOPES_CONFIG_PATH.exists():
+        return None
+    try:
+        raw = json.loads(SCOPES_CONFIG_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    cleaned = {
+        k: v
+        for k, v in raw.items()
+        if k in SERVICE_SCOPES and v in {"readonly", "readwrite"}
+    }
+    return cleaned or None
+
+
+def _save_scope_config(config: dict) -> None:
+    SCOPES_CONFIG_PATH.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+
+
+def _active_scopes() -> list:
+    """OAuth scopes to request, derived from google_scopes.json.
+
+    If no config exists, returns the full legacy SCOPES list so behavior
+    matches the pre-config code path.
+    """
+    config = _load_scope_config()
+    if config is None:
+        return list(DEFAULT_SCOPES)
+    scopes: list = []
+    for svc, mode in config.items():
+        scopes.extend(SERVICE_SCOPES[svc][mode])
+    return list(dict.fromkeys(scopes))
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
 
@@ -80,7 +205,8 @@ def _missing_scopes_from_payload(payload: dict) -> list[str]:
     if not raw:
         return []
     granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
-    return sorted(scope for scope in SCOPES if scope not in granted)
+    expected = _active_scopes()
+    return sorted(scope for scope in expected if scope not in granted)
 
 
 def _format_missing_scopes(missing_scopes: list[str]) -> str:
@@ -300,7 +426,7 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def get_auth_url():
+def get_auth_url(format_json: bool = False):
     """Print the OAuth authorization URL. User visits this in a browser."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
@@ -309,9 +435,10 @@ def get_auth_url():
     _ensure_deps()
     from google_auth_oauthlib.flow import Flow
 
+    scopes = _active_scopes()
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
+        scopes=scopes,
         redirect_uri=REDIRECT_URI,
         autogenerate_code_verifier=True,
     )
@@ -320,8 +447,11 @@ def get_auth_url():
         prompt="consent",
     )
     _save_pending_auth(state=state, code_verifier=flow.code_verifier)
-    # Print just the URL so the agent can extract it cleanly
-    print(auth_url)
+    if format_json:
+        print(json.dumps({"auth_url": auth_url, "scopes": scopes}))
+    else:
+        # Print just the URL so the agent can extract it cleanly
+        print(auth_url)
 
 
 def exchange_auth_code(code: str):
@@ -341,8 +471,9 @@ def exchange_auth_code(code: str):
     from google_auth_oauthlib.flow import Flow
     from urllib.parse import parse_qs, urlparse
 
+    requested_scopes = _active_scopes()
     # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
-    granted_scopes = list(SCOPES)
+    granted_scopes = list(requested_scopes)
     if isinstance(raw_callback, str) and raw_callback.startswith("http"):
         params = parse_qs(urlparse(raw_callback).query)
         scope_val = (params.get("scope") or [""])[0].strip()
@@ -375,7 +506,7 @@ def exchange_auth_code(code: str):
     actually_granted = list(creds.granted_scopes or []) if hasattr(creds, "granted_scopes") and creds.granted_scopes else []
     if actually_granted:
         token_payload["scopes"] = actually_granted
-    elif granted_scopes != SCOPES:
+    elif granted_scopes != requested_scopes:
         # granted_scopes was extracted from the callback URL
         token_payload["scopes"] = granted_scopes
 
@@ -401,7 +532,7 @@ def revoke():
     from google.auth.transport.requests import Request
 
     try:
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), _active_scopes())
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())
 
@@ -423,6 +554,31 @@ def revoke():
     print(f"Deleted {TOKEN_PATH}")
 
 
+def show_mode(format_json: bool = False):
+    """Print the current scope config and the scopes that would be requested."""
+    config = _load_scope_config()
+    scopes = _active_scopes()
+    if format_json:
+        print(json.dumps({
+            "config": config,
+            "config_path": str(SCOPES_CONFIG_PATH),
+            "config_present": SCOPES_CONFIG_PATH.exists(),
+            "scopes": scopes,
+        }, indent=2))
+        return
+
+    if config is None:
+        print(f"No scope config at {SCOPES_CONFIG_PATH} — falling back to legacy full-access defaults.")
+    else:
+        print(f"Current scope config ({SCOPES_CONFIG_PATH}):")
+        for svc in ALL_SERVICES:
+            if svc in config:
+                print(f"  {svc:9s} {config[svc]}")
+    print(f"\nScopes that would be requested ({len(scopes)}):")
+    for scope in scopes:
+        print(f"  {scope}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Hermes")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -433,7 +589,34 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    group.add_argument("--show-mode", action="store_true", help="Print current per-service scope config")
+    # Modifiers — used with --auth-url or --show-mode.
+    parser.add_argument(
+        "--services",
+        metavar="SPEC",
+        help=(
+            "Per-service scope spec, e.g. 'gmail=ro,calendar=rw,drive=ro'. "
+            "Bare names default to rw ('all' means every service). "
+            "Saved to ~/.hermes/google_scopes.json and used for --auth-url. "
+            "Examples: 'all', 'all=ro', 'gmail,calendar', 'gmail=ro,calendar=rw'."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for --auth-url and --show-mode (default: text)",
+    )
     args = parser.parse_args()
+
+    # Process --services modifier before any action that reads scope config.
+    if args.services:
+        try:
+            parsed = _parse_services_spec(args.services)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        _save_scope_config(parsed)
 
     if args.check:
         sys.exit(0 if check_auth() else 1)
@@ -442,13 +625,15 @@ def main():
     elif args.client_secret:
         store_client_secret(args.client_secret)
     elif args.auth_url:
-        get_auth_url()
+        get_auth_url(format_json=(args.format == "json"))
     elif args.auth_code:
         exchange_auth_code(args.auth_code)
     elif args.revoke:
         revoke()
     elif args.install_deps:
         sys.exit(0 if install_deps() else 1)
+    elif getattr(args, "show_mode", False):
+        show_mode(format_json=(args.format == "json"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Add read-only mode to `google-workspace` skill to prevent agent from doing dangerous actions.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #37900

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Update google-workspace SKILL.md to include read-only mode.
- Update google-workspace apis to request right OAuth scopes.
- Update tool calls to reject if OAuth scopes are not found.

## How to Test


1. Setup the skill with an agent on a fresh install.
2. Ask agent to perform write email action (should fail).
3. Ask agent to read some emails (should succeed).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

