### PR TITLE
fix(gateway): normalize SessionResetPolicy.mode to lowercase to stop silent reset skips

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -148,6 +148,22 @@ def _normalize_notice_delivery(value: Any, default: str = "public") -> str:
     return default
 
 
+def _normalize_session_reset_mode(value: Any, default: str = "none") -> str:
+    """Normalize a session-reset mode to a supported lowercase value.
+
+    Config files may supply ``mode`` with surrounding whitespace or mixed
+    case (e.g. YAML ``"BOTH"``).  ``SessionResetPolicy`` consumers compare
+    ``mode`` against the lowercase tokens ``daily``/``idle``/``both``/``none``
+    with exact matches, so any un-normalized value would silently skip every
+    reset check.  Fall back to ``default`` on unrecognized input.
+    """
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"daily", "idle", "both", "none"}:
+            return normalized
+    return default
+
+
 def _ensure_platform_extra_dict(platforms_data: dict, name: str) -> tuple[dict, dict]:
     """Get-or-create ``platforms_data[name]`` and its nested ``extra`` dict.
 
@@ -391,7 +407,7 @@ class SessionResetPolicy:
         exclude = data.get("notify_exclude_platforms")
         bg_max_age = data.get("bg_process_max_age_hours")
         return cls(
-            mode=mode if mode is not None else "none",
+            mode=_normalize_session_reset_mode(mode),
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -238,6 +238,28 @@ class TestSessionResetPolicy:
         restored = SessionResetPolicy.from_dict({"notify": "false"})
         assert restored.notify is False
 
+    def test_from_dict_normalizes_uppercase_mode(self):
+        for raw, expected in (
+            ("BOTH", "both"),
+            ("IDLE", "idle"),
+            ("DAILY", "daily"),
+            ("NONE", "none"),
+        ):
+            restored = SessionResetPolicy.from_dict({"mode": raw})
+            assert restored.mode == expected
+
+    def test_from_dict_normalizes_mixed_case_and_whitespace_mode(self):
+        restored = SessionResetPolicy.from_dict({"mode": "  Both "})
+        assert restored.mode == "both"
+
+    def test_from_dict_falls_back_to_default_on_invalid_mode(self):
+        restored = SessionResetPolicy.from_dict({"mode": "bogus"})
+        assert restored.mode == "none"
+
+    def test_from_dict_falls_back_to_default_on_non_string_mode(self):
+        restored = SessionResetPolicy.from_dict({"mode": 5})
+        assert restored.mode == "none"
+
 
 class TestStreamingConfig:
     def test_defaults_to_auto_transport(self):

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -71,6 +71,23 @@ class TestShouldResetReason:
         source = _make_source()
         assert store._should_reset(entry, source) == "idle"
 
+    def test_uppercase_mode_from_config_still_triggers_reset(self, tmp_path):
+        # Regression: an uppercase ``mode`` (e.g. YAML ``IDLE``) used to be
+        # stored verbatim and silently skip every reset check, leaving the
+        # session to grow unbounded.  from_dict() now normalizes it.
+        store = _make_store(
+            SessionResetPolicy.from_dict({"mode": "IDLE", "idle_minutes": 30}),
+            tmp_path,
+        )
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now() - timedelta(hours=2),
+            updated_at=datetime.now() - timedelta(hours=1),  # 60min ago > 30min threshold
+        )
+        source = _make_source()
+        assert store._should_reset(entry, source) == "idle"
+
     def test_returns_daily_when_daily_boundary_crossed(self, tmp_path):
         now = datetime.now()
         store = _make_store(


### PR DESCRIPTION
SessionResetPolicy.from_dict() stored the config-supplied mode verbatim, so a YAML value like "BOTH"/"IDLE"/"DAILY" kept its original casing. The reset checks in session.py (_should_reset / _is_session_expired) compare policy.mode against the lowercase tokens daily/idle/both/none with exact matches, so an un-normalized mode matched none of them and silently skipped every reset check, leaving the session to never auto-reset and its context to grow unbounded.

Add _normalize_session_reset_mode(), following the existing _normalize_unauthorized_dm_behavior / _normalize_notice_delivery helpers (strip + lower + validate, fall back to the default on unrecognized input), and call it from from_dict(). Non-string and null inputs fall back to the existing "both" default, preserving prior behavior.

Fixes: sessions with uppercase reset modes never auto-reset, context grows unbounded
Tests: added unit tests for uppercase/mixed-case/whitespace normalization, non-string fallback, and regression test verifying uppercase mode from config triggers reset correctly
