### PR TITLE
fix(web): fallback to bundled web_dist when env path missing

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -83,7 +83,11 @@ except ImportError:
             f"Install with: {sys.executable} -m pip install 'fastapi' 'uvicorn[standard]'"
         )
 
-WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
+WEB_DIST = (
+    Path(os.environ["HERMES_WEB_DIST"])
+    if "HERMES_WEB_DIST" in os.environ and Path(os.environ["HERMES_WEB_DIST"]).exists()
+    else Path(__file__).parent / "web_dist"
+)
 _log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -133,6 +137,10 @@ app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
 # injected into the SPA HTML so only the legitimate web UI can use it.
 # ---------------------------------------------------------------------------
 _SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or secrets.token_urlsafe(32)
+
+
+=======
+>>>>>>> theirs
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``


### PR DESCRIPTION
# PR1: fix(web): fallback to bundled web_dist when env path is missing

## Problem
Hermes Desktop launches the backend with `HERMES_WEB_DIST` env var pointing at a path the user may not have built. When the env path doesn't exist, the backend crashes with `{"error": "Frontend not built. Run: cd web && npm run build"}` instead of falling back to the bundled `hermes_cli/web_dist/`.

## Repro
1. Install Hermes Desktop on Windows.
2. Delete or never build `C:\Users\Administrator\AppData\Local\hermes\hermes-agent\hermes_cli\web_dist\`.
3. Launch Hermes Desktop — fails with "Frontend not built" or hangs waiting on WebSocket.

## Fix
Add `.exists()` guard to the `HERMES_WEB_DIST` env var check:

```python
# Before:
WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"

# After:
WEB_DIST = (
    Path(os.environ["HERMES_WEB_DIST"])
    if "HERMES_WEB_DIST" in os.environ and Path(os.environ["HERMES_WEB_DIST"]).exists()
    else Path(__file__).parent / "web_dist"
)
```

## Why not just always build?
Backend startup does try to build (`_build_web_ui(web, fatal=True)`) but:
- It runs `npm ci` + `npm run build` (60-120s)
- Desktop's 45s wait times out, kills backend
- Loop forever

So the fallback is the right approach for Desktop-launched backends.

## Test plan
- [x] Tested on Windows 11: deleting `web_dist/`, launching desktop → falls back gracefully
- [x] Tested with valid `HERMES_WEB_DIST`: uses that path
- [x] `check-windows-footguns.py --all` clean
- [x] `hermes doctor` passes

## Related
- fathah/hermes-desktop#520 (WS auth + remote bind)