### PR TITLE
feat(gateway): honor DISABLE_SMS env to skip stale Twilio creds

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1470,8 +1470,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # SMS (Twilio)
+    # Honor DISABLE_SMS=1 to skip auto-enable when the user has stale
+    # Twilio credentials in the shell env but no TWILIO_PHONE_NUMBER set.
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
-    if twilio_sid:
+    if twilio_sid and os.getenv("DISABLE_SMS", "").lower() not in {"1", "true", "yes"}:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True


### PR DESCRIPTION
# PR2: feat(gateway): honor DISABLE_SMS env to skip stale Twilio creds

## Problem
Users who don't use Twilio SMS still get `✗ sms failed to connect` warnings on every gateway startup if they have stale `TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN` in their shell env (set by an old installation, test fixture, or a previously-used account). The current `_apply_env_overrides` blindly auto-enables SMS whenever `TWILIO_ACCOUNT_SID` is set, with no opt-out.

## Repro
```bash
# In any shell with TWILIO_ACCOUNT_SID set:
DISABLE_SMS=1 hermes gateway run
# → ERROR: gateway.platforms.sms: [sms] TWILIO_PHONE_NUMBER not set
```

## Fix
Skip the SMS auto-enable when `DISABLE_SMS=1|true|yes` is in env:

```python
# Before:
if twilio_sid:
    if Platform.SMS not in config.platforms:
        config.platforms[Platform.SMS] = PlatformConfig()
    config.platforms[Platform.SMS].enabled = True

# After:
if twilio_sid and os.getenv("DISABLE_SMS", "").lower() not in {"1", "true", "yes"}:
    if Platform.SMS not in config.platforms:
        config.platforms[Platform.SMS] = PlatformConfig()
    config.platforms[Platform.SMS].enabled = True
```

## Test plan
- [x] With `TWILIO_ACCOUNT_SID=ACxxx` + no `DISABLE_SMS` → SMS loads (unchanged behavior)
- [x] With `TWILIO_ACCOUNT_SID=ACxxx` + `DISABLE_SMS=1` → SMS skipped, no `✗ sms failed to connect` warning
- [x] `check-windows-footguns.py --all` clean

## Workaround for users (already-documented)
Add to `~/.hermes/.env`:
```
DISABLE_SMS=1
```