### PR TITLE
fix(bedrock): skip temperature/top_p for Opus 4.7+ on Converse API

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -353,6 +353,25 @@ def bedrock_model_ids_or_none() -> Optional[List[str]]:
 
 
 # ---------------------------------------------------------------------------
+# Sampling parameter restrictions
+# ---------------------------------------------------------------------------
+# Opus 4.7+ rejects any non-default temperature/top_p/top_k with a 400
+# ValidationException ("temperature is deprecated"). Must omit these fields
+# entirely from inferenceConfig. Matches anthropic_adapter._forbids_sampling_params().
+
+_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7", "4-8", "4.8")
+
+
+def _forbids_sampling_params(model: str) -> bool:
+    """Return True for Bedrock models that reject temperature/top_p.
+
+    Opus 4.7+ on Bedrock Converse returns ValidationException when any
+    sampling parameter is included in inferenceConfig.
+    """
+    return any(v in model for v in _NO_SAMPLING_PARAMS_SUBSTRINGS)
+
+
+# ---------------------------------------------------------------------------
 # Tool-calling capability detection
 # ---------------------------------------------------------------------------
 # Some Bedrock models don't support tool/function calling. Sending toolConfig
@@ -900,11 +919,15 @@ def build_converse_kwargs(
     if system_prompt:
         kwargs["system"] = system_prompt
 
-    if temperature is not None:
-        kwargs["inferenceConfig"]["temperature"] = temperature
+    # Opus 4.7+ rejects sampling parameters entirely — omit them to avoid 400.
+    if not _forbids_sampling_params(model):
+        if temperature is not None:
+            kwargs["inferenceConfig"]["temperature"] = temperature
 
-    if top_p is not None:
-        kwargs["inferenceConfig"]["topP"] = top_p
+        if top_p is not None:
+            kwargs["inferenceConfig"]["topP"] = top_p
+    else:
+        logger.debug("Skipping temperature/top_p for %s (forbids sampling params)", model)
 
     if stop_sequences:
         kwargs["inferenceConfig"]["stopSequences"] = stop_sequences

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1474,3 +1474,50 @@ class TestCallConverseInvalidatesOnStaleError:
         )
 
         assert _bedrock_runtime_client_cache.get("us-east-1") is live_client
+
+
+class TestOpusTemperatureSkip:
+    """Opus 4.7+ rejects temperature/top_p — must be omitted from inferenceConfig.
+
+    Ref: #36151.
+    """
+
+    def test_opus_47_skips_temperature(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7,
+            top_p=0.9,
+        )
+        assert "temperature" not in kwargs["inferenceConfig"]
+        assert "topP" not in kwargs["inferenceConfig"]
+
+    def test_opus_48_skips_temperature(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="global.anthropic.claude-opus-4-8",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.5,
+        )
+        assert "temperature" not in kwargs["inferenceConfig"]
+
+    def test_sonnet_46_keeps_temperature(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7,
+        )
+        assert kwargs["inferenceConfig"]["temperature"] == 0.7
+
+    def test_nova_keeps_temperature(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="us.amazon.nova-pro-v1:0",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.8,
+            top_p=0.95,
+        )
+        assert kwargs["inferenceConfig"]["temperature"] == 0.8
+        assert kwargs["inferenceConfig"]["topP"] == 0.95


### PR DESCRIPTION
Opus 4.7 and 4.8 reject any sampling parameters (temperature, top_p, top_k) with `ValidationException: temperature is deprecated`. The `anthropic_messages` path already guards this via `_forbids_sampling_params()`, but the `bedrock_converse` path passed them through unconditionally.

## Fix

Add `_forbids_sampling_params()` to `bedrock_adapter.py` — models matching `4-7`, `4.7`, `4-8`, `4.8` substrings skip temperature/top_p in `inferenceConfig`. Logs a debug message when skipped.

## E2E verification

Tested on EC2 (us-east-2) with `us.anthropic.claude-opus-4-8`:
- Before fix: `ValidationException: temperature is deprecated`
- After fix: successful response ("Hi there, friend!")

4 new tests. Closes #36151.