### PR TITLE
fix(desktop): slash command keyboard selection snaps back + scroll into view

### DIFF
--- a/apps/desktop/src/app/chat/composer/completion-drawer.tsx
+++ b/apps/desktop/src/app/chat/composer/completion-drawer.tsx
@@ -24,7 +24,12 @@ export const COMPLETION_DRAWER_BELOW_CLASS = [
 
 export const COMPLETION_DRAWER_ROW_CLASS = [
   'relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1',
-  'w-full min-w-0 text-left text-xs outline-hidden transition-colors',
+  'w-full min-w-0 text-left text-xs outline-hidden',
+  // Keyboard selection (data-highlighted / activeIndex) should feel instant —
+  // no transition on background so the highlight snaps to the new row.
+  // Mouse hover keeps a smooth 200ms color transition for that buttery feel.
+  'transition-[color,border-color,text-decoration-color] duration-0',
+  'hover:transition-colors hover:duration-200',
   'hover:bg-(--ui-bg-tertiary)',
   'data-[highlighted]:bg-(--ui-bg-tertiary) data-[highlighted]:text-foreground'
 ].join(' ')

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -65,7 +65,7 @@ import {
 } from './rich-editor'
 import { SkinSlashPopover } from './skin-slash-popover'
 import { detectTrigger, extractClipboardImageBlobs, textBeforeCaret, type TriggerState } from './text-utils'
-import { ComposerTriggerPopover } from './trigger-popover'
+import { ComposerTriggerPopover, type ComposerTriggerPopoverHandle } from './trigger-popover'
 import type { ChatBarProps } from './types'
 import { UrlDialog } from './url-dialog'
 import { VoiceActivity, VoicePlaybackActivity } from './voice-activity'
@@ -125,6 +125,7 @@ export function ChatBar({
   const previousBusyRef = useRef(busy)
   const drainingQueueRef = useRef(false)
   const urlInputRef = useRef<HTMLInputElement | null>(null)
+  const triggerPopoverRef = useRef<ComposerTriggerPopoverHandle>(null)
 
   const [urlOpen, setUrlOpen] = useState(false)
   const [urlValue, setUrlValue] = useState('')
@@ -441,8 +442,19 @@ export function ChatBar({
     const before = textBeforeCaret(editor)
     const detected = detectTrigger(before ?? composerPlainText(editor))
 
+    // Only reset the active index when the trigger state actually changed
+    // (new trigger opened, trigger closed, or query text changed). When the
+    // kind + query are the same (e.g. the user just pressed ArrowUp/Down),
+    // preserve the selection so keyboard navigation isn't wiped out by the
+    // keyup→refreshTrigger round-trip.
+    const queryChanged =
+      trigger?.kind !== detected?.kind || trigger?.query !== detected?.query
+
     setTrigger(detected)
-    setTriggerActive(0)
+
+    if (queryChanged) {
+      setTriggerActive(0)
+    }
   }, [trigger])
 
   const handleEditorInput = (event: FormEvent<HTMLDivElement>) => {
@@ -559,6 +571,7 @@ export function ChatBar({
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         setTriggerActive(idx => (idx + 1) % triggerItems.length)
+        requestAnimationFrame(() => triggerPopoverRef.current?.scrollActiveIntoView())
 
         return
       }
@@ -566,6 +579,7 @@ export function ChatBar({
       if (event.key === 'ArrowUp') {
         event.preventDefault()
         setTriggerActive(idx => (idx - 1 + triggerItems.length) % triggerItems.length)
+        requestAnimationFrame(() => triggerPopoverRef.current?.scrollActiveIntoView())
 
         return
       }
@@ -1092,6 +1106,7 @@ export function ChatBar({
           {showHelpHint && <HelpHint />}
           {trigger && (
             <ComposerTriggerPopover
+              ref={triggerPopoverRef}
               activeIndex={triggerActive}
               items={triggerItems}
               kind={trigger.kind}

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -1,4 +1,5 @@
 import type { Unstable_TriggerItem } from '@assistant-ui/core'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { cn } from '@/lib/utils'
@@ -51,21 +52,47 @@ interface ComposerTriggerPopoverProps {
   placement?: 'bottom' | 'top'
 }
 
-export function ComposerTriggerPopover({
-  activeIndex,
-  items,
-  kind,
-  loading,
-  onHover,
-  onPick,
-  placement = 'top'
-}: ComposerTriggerPopoverProps) {
+export interface ComposerTriggerPopoverHandle {
+  scrollActiveIntoView: () => void
+}
+
+export const ComposerTriggerPopover = forwardRef<
+  ComposerTriggerPopoverHandle,
+  ComposerTriggerPopoverProps
+>(function ComposerTriggerPopover(
+  { activeIndex, items, kind, loading, onHover, onPick, placement = 'top' },
+  ref
+) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // Expose scrollActiveIntoView so the keyboard handler in the parent can
+  // trigger a scroll only on arrow-key events — mouse hover never calls this.
+  useImperativeHandle(ref, () => ({
+    scrollActiveIntoView() {
+      const container = containerRef.current
+      if (!container) return
+
+      const highlighted = container.querySelector<HTMLElement>('[data-highlighted]')
+      if (!highlighted) return
+
+      const buttonRect = highlighted.getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+
+      if (buttonRect.top < containerRect.top) {
+        container.scrollTop -= containerRect.top - buttonRect.top
+      } else if (buttonRect.bottom > containerRect.bottom) {
+        container.scrollTop += buttonRect.bottom - containerRect.bottom
+      }
+    }
+  }))
+
   return (
     <div
       className={placement === 'bottom' ? COMPLETION_DRAWER_BELOW_CLASS : COMPLETION_DRAWER_CLASS}
       data-slot="composer-completion-drawer"
       data-state="open"
       onMouseDown={event => event.preventDefault()}
+      ref={containerRef}
       role="listbox"
     >
       {items.length === 0 ? (
@@ -86,11 +113,12 @@ export function ComposerTriggerPopover({
           const meta = item.metadata as { display?: string; meta?: string } | undefined
           const display = meta?.display ?? (kind === '/' ? `/${item.label}` : item.label)
           const description = meta?.meta || item.description
+          const isActive = index === activeIndex
 
           return (
             <button
-              className={cn(COMPLETION_DRAWER_ROW_CLASS, index === activeIndex && 'bg-(--ui-bg-tertiary)')}
-              data-highlighted={index === activeIndex ? '' : undefined}
+              className={cn(COMPLETION_DRAWER_ROW_CLASS, isActive && 'bg-(--ui-bg-tertiary)')}
+              data-highlighted={isActive ? '' : undefined}
               key={item.id}
               onClick={() => onPick(item)}
               onMouseEnter={() => onHover(index)}
@@ -109,4 +137,4 @@ export function ComposerTriggerPopover({
       )}
     </div>
   )
-}
+})


### PR DESCRIPTION
## What does this PR do?

Fixes three issues with the `/` command popover in the desktop app:

1. **Keyboard selection snaps back to first item**: Pressing ArrowDown/Up to navigate the slash command menu would instantly reset the highlight back to the first item. The root cause was `refreshTrigger()` unconditionally calling `setTriggerActive(0)` on every keyup — the ArrowDown handler would set the index to 1, then keyup would fire `refreshTrigger` and reset it to 0 before the user ever saw the change. Now `setTriggerActive(0)` only runs when the trigger kind or query string actually changed.

2. **No scroll-into-view on keyboard navigation**: When the command list overflowed the popover, arrow-keying past the visible area would highlight items that were off-screen. Added `scrollActiveIntoView()` via `useImperativeHandle` — called only from the keyboard ArrowDown/Up handlers, never on mouse hover.

3. **Keyboard highlight animation too slow**: The row used blanket `transition-colors` which made keyboard selection feel sluggish. Split into instant background snap for keyboard highlight (`transition-[color,border-color,text-decoration-color] duration-0`) and smooth 200ms transition only on mouse hover (`hover:transition-colors hover:duration-200`).

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`: `refreshTrigger()` now only resets `triggerActive` when trigger kind/query changed; ArrowDown/Up handlers call `requestAnimationFrame(() => triggerPopoverRef.current?.scrollActiveIntoView())`
- `apps/desktop/src/app/chat/composer/trigger-popover.tsx`: Converted to `forwardRef` + `useImperativeHandle` exposing `scrollActiveIntoView()`; added `containerRef` for rect-based scroll math
- `apps/desktop/src/app/chat/composer/completion-drawer.tsx`: Split `transition-colors` into instant keyboard + slow hover

## How to Test

1. Open the desktop app, focus the composer input
2. Type `/` to open the slash command popover
3. Press ArrowDown / ArrowUp — selection should move and stay on the chosen item (not snap back to the first)
4. If the list is long enough to overflow, arrow-key past the visible area — the popover should scroll to keep the highlighted item in view
5. Move the mouse over items — the hover highlight should still feel smooth (200ms transition)
6. Keyboard highlight should snap instantly (no transition on background)

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture, or tool behavior changed