### PR TITLE
fix(feishu): add enforces_own_access_policy so config-only allowlists are honoured

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4025,6 +4025,19 @@ class FeishuAdapter(BasePlatformAdapter):
     # Inbound admission
     # =========================================================================
 
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """Feishu gates group access at intake via group_policy / group_rules.
+
+        Messages that fail the policy are dropped inside _admit() before
+        reaching the gateway, so a message arriving at _is_user_authorized
+        has already been authorized by the adapter.  Without this flag the
+        gateway falls through to the env-allowlist default-deny, silently
+        breaking config-only group allowlists where FEISHU_ALLOWED_USERS
+        is not set.
+        """
+        return True
+
     def _admit(self, sender: Any, message: Any) -> Optional[RejectReason]:
         sender_ids = _sender_identity(sender)
         self_ids = frozenset(v for v in (self._bot_open_id, self._bot_user_id) if v)


### PR DESCRIPTION
## Summary

`FeishuAdapter._admit()` drops messages that fail `group_policy` / per-group
`group_rules` **before** they reach the gateway.  Without
`enforces_own_access_policy = True`, `_is_user_authorized()` falls through to
the env-based default-deny when `FEISHU_ALLOWED_USERS` is not set in the
environment — silently blocking every message that the adapter's own
config-driven policy had already allowed.

## Root cause

`_is_user_authorized()` (gateway/run.py) contains:

```python
if not platform_allowlist and … and not global_allowlist:
    if self._adapter_enforces_own_access_policy(source.platform):
        return True          # adapter already checked
    return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
```

Operators who configure Feishu access via `group_rules` in `config.yaml`
(not env vars) have no `FEISHU_ALLOWED_USERS` set, so `platform_allowlist` is
empty and the gateway denies the message even though `_admit()` passed it.

## Fix

Add `enforces_own_access_policy = True` to `FeishuAdapter`, identical to the
property already present on `WeCom` (f7a3509b2), `WhatsApp` (0cd5867bb),
`Yuanbao`, and `QQBot`.  No behaviour change for deployments that already set
`FEISHU_ALLOWED_USERS`.

## Test plan

- [x] All 160 `tests/gateway/test_feishu.py` tests pass
- [x] No behaviour change when `FEISHU_ALLOWED_USERS` is set (env path unchanged)
- [x] Config-only `group_policy: allowlist` + `group_rules` now lets messages through