### PR TITLE
fix(profile): clone provider-owned memory configs

### DIFF
--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -151,6 +151,15 @@ class MemoryProvider(ABC):
     def shutdown(self) -> None:
         """Clean shutdown — flush queues, close connections."""
 
+    def get_profile_config_paths(self) -> List[str]:
+        """Return HERMES_HOME-relative provider config paths copied by profile clone.
+
+        Providers that persist native config files under the active profile
+        should return those file or directory paths here. Providers that use
+        only config.yaml or env vars can keep the default empty list.
+        """
+        return []
+
     # -- Optional hooks (override to opt in) ---------------------------------
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -163,6 +163,100 @@ def _clone_all_copytree_ignore(source_dir: Path):
     return _ignore
 
 
+def _safe_profile_config_relpath(raw_path: object) -> Optional[Path]:
+    """Return a safe HERMES_HOME-relative config path, or None."""
+    try:
+        raw = os.fspath(raw_path)
+    except TypeError:
+        return None
+
+    if not isinstance(raw, str):
+        return None
+
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    posix_path = PurePosixPath(raw)
+    windows_path = PureWindowsPath(raw)
+    if posix_path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
+        return None
+
+    relpath = Path(raw)
+    if relpath.is_absolute():
+        return None
+
+    parts = relpath.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        return None
+
+    return relpath
+
+
+def _iter_memory_provider_profile_config_paths() -> List[Path]:
+    """Ask discovered memory providers which profile-local config paths they own."""
+    try:
+        from plugins.memory import discover_memory_providers, load_memory_provider
+    except Exception:
+        return []
+
+    try:
+        discovered = discover_memory_providers()
+    except Exception:
+        return []
+
+    config_paths: list[Path] = []
+    seen: set[str] = set()
+    for provider_info in discovered:
+        if not provider_info:
+            continue
+        provider_name = provider_info[0]
+        try:
+            provider = load_memory_provider(provider_name)
+        except Exception:
+            continue
+        if provider is None:
+            continue
+
+        get_paths = getattr(provider, "get_profile_config_paths", None)
+        if not callable(get_paths):
+            continue
+
+        try:
+            raw_paths = get_paths()
+        except Exception:
+            continue
+
+        if isinstance(raw_paths, (str, os.PathLike)):
+            raw_paths = [raw_paths]
+
+        for raw_path in raw_paths or []:
+            relpath = _safe_profile_config_relpath(raw_path)
+            if relpath is None:
+                continue
+            key = relpath.as_posix()
+            if key in seen:
+                continue
+            seen.add(key)
+            config_paths.append(relpath)
+
+    return config_paths
+
+
+def _copy_profile_config_path(source_dir: Path, profile_dir: Path, relpath: Path) -> None:
+    """Copy one profile-relative provider config file or directory if present."""
+    src = source_dir / relpath
+    if not src.exists():
+        return
+
+    dst = profile_dir / relpath
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+    elif src.is_file() or src.is_symlink():
+        shutil.copy2(src, dst)
+
+
 # Directories/files to exclude when exporting the default (~/.hermes) profile.
 # The default profile contains infrastructure (repo checkout, worktrees, DBs,
 # caches, binaries) that named profiles don't have.  We exclude those so the
@@ -778,6 +872,13 @@ def create_profile(
                     dst = profile_dir / relpath
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, dst)
+
+            # Clone provider-owned native config files for every provider
+            # that has config present in the source profile, active or not.
+            # Values are copied verbatim: provider-scoped memory banks remain
+            # shared with the source profile until the clone is reconfigured.
+            for relpath in _iter_memory_provider_profile_config_paths():
+                _copy_profile_config_path(source_dir, profile_dir, relpath)
 
     # Seed a default SOUL.md so the user has a file to customize immediately.
     # Skipped when the profile already has one (from --clone / --clone-all).

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -600,6 +600,9 @@ class HindsightMemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "hindsight"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["hindsight/config.json"]
+
     def is_available(self) -> bool:
         try:
             cfg = _load_config()

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -239,6 +239,9 @@ class HonchoMemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "honcho"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["honcho.json"]
+
     def is_available(self) -> bool:
         """Check if Honcho is configured. No network calls."""
         try:

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -139,6 +139,9 @@ class Mem0MemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "mem0"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["mem0.json"]
+
     def is_available(self) -> bool:
         cfg = _load_config()
         return bool(cfg.get("api_key"))

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -452,6 +452,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
     def name(self) -> str:
         return "supermemory"
 
+    def get_profile_config_paths(self) -> List[str]:
+        return ["supermemory.json"]
+
     def is_available(self) -> bool:
         api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
         if not api_key:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -30,6 +30,7 @@ from hermes_cli.profiles import (
     import_profile,
     _get_profiles_root,
     _get_default_hermes_home,
+    _safe_profile_config_relpath,
     seed_profile_skills,
     has_bundled_skills_opt_out,
     NO_BUNDLED_SKILLS_MARKER,
@@ -201,6 +202,63 @@ class TestCreateProfile:
             / "installed-skill"
             / "SKILL.md"
         ).read_text() == "---\nname: installed-skill\n---\n"
+
+    def test_clone_config_copies_memory_provider_config_paths(
+        self, profile_env, monkeypatch
+    ):
+        import plugins.memory as memory_plugins
+
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text(
+            "memory:\n  provider: hindsight\n"
+        )
+        (default_home / "hindsight").mkdir()
+        (default_home / "hindsight" / "config.json").write_text(
+            '{"mode": "local_embedded", "bank_id": "hermes"}'
+        )
+        (default_home / "mem0.json").write_text('{"agent_id": "hermes"}')
+
+        class FakeProvider:
+            def __init__(self, paths):
+                self._paths = paths
+
+            def get_profile_config_paths(self):
+                return self._paths
+
+        providers = {
+            "hindsight": FakeProvider(["hindsight/config.json"]),
+            "mem0": FakeProvider(["mem0.json"]),
+            "honcho": FakeProvider(["honcho.json"]),
+        }
+        monkeypatch.setattr(
+            memory_plugins,
+            "discover_memory_providers",
+            lambda: [(name, "", True) for name in providers],
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "load_memory_provider",
+            lambda name: providers[name],
+        )
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        assert (
+            profile_dir / "hindsight" / "config.json"
+        ).read_text() == '{"mode": "local_embedded", "bank_id": "hermes"}'
+        assert (profile_dir / "mem0.json").read_text() == '{"agent_id": "hermes"}'
+        assert not (profile_dir / "honcho.json").exists()
+
+    def test_memory_provider_config_paths_must_be_profile_relative(self):
+        assert _safe_profile_config_relpath("hindsight/config.json") == Path(
+            "hindsight/config.json"
+        )
+
+        unsafe_paths = ["", ".", "..", "../outside.json", "/tmp/config.json"]
+        unsafe_paths.append(r"C:\tmp\config.json")
+        for raw_path in unsafe_paths:
+            assert _safe_profile_config_relpath(raw_path) is None
 
     def test_clone_all_copies_entire_tree(self, profile_env):
         tmp_path = profile_env


### PR DESCRIPTION
## What does this PR do?

Fixes profile cloning for memory providers that store provider-owned config files under `HERMES_HOME`.

Problem/repro:
- Configure a source profile with `memory.provider: hindsight`.
- Configure Hindsight for local mode, which writes provider config to `hindsight/config.json`.
- Clone the profile with `hermes profile create <name> --clone`.
- The cloned profile gets `config.yaml`, so it still says `memory.provider: hindsight`, but it does not get `hindsight/config.json`.
- Without that provider config, Hindsight loses `mode: local_embedded` and falls back to its default cloud-mode behavior.

Root cause: `--clone` copied only the central profile files (`config.yaml`, `.env`, `SOUL.md`) and selected memory files. It never asked memory providers whether they had profile-local native config files to copy.

Fix:
- Adds an optional `MemoryProvider.get_profile_config_paths()` hook.
- Hindsight, Mem0, Honcho, and Supermemory opt in with their provider-owned config paths.
- Profile clone now asks discovered providers for those paths and copies any config file or directory that is present in the source profile, active or not.
- Returned paths are sanitized so provider hooks cannot copy absolute paths, parent-directory escapes, or Windows drive paths.

Cloned profiles inherit provider config verbatim, so provider-scoped memory banks such as Hindsight `bank_id` remain shared with the source profile until reconfigured.

Duplicate-PR check: searched open PRs for profile-clone/provider-config/Hindsight-related fixes. The closest open PR is #12271, but that is Honcho-specific profile isolation and workspace behavior; this PR is the generic provider-owned config clone path and is not a duplicate.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/memory_provider.py`: add optional `get_profile_config_paths()` hook.
- `hermes_cli/profiles.py`: collect provider-owned profile config paths, sanitize them, and copy any present source config during `--clone`.
- `plugins/memory/hindsight/__init__.py`: declare `hindsight/config.json`.
- `plugins/memory/mem0/__init__.py`: declare `mem0.json`.
- `plugins/memory/honcho/__init__.py`: declare `honcho.json`.
- `plugins/memory/supermemory/__init__.py`: declare `supermemory.json`.
- `tests/hermes_cli/test_profiles.py`: add regression coverage for copying present provider configs, skipping absent configs, and rejecting unsafe provider paths.

## How to Test

1. Configure a source profile with `memory.provider: hindsight` and local Hindsight config in `hindsight/config.json`.
2. Run `hermes profile create <clone-name> --clone`.
3. Confirm the clone has `<clone-profile>/hindsight/config.json` and preserves `mode: local_embedded`.

Test run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_profiles.py
```

Result:

```text
119 tests passed, 0 failed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A.
