### PR TITLE
fix(gateway): preserve launchd user session

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2903,6 +2903,9 @@ def generate_launchd_plist() -> str:
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
     </dict>
+
+    <key>SessionCreate</key>
+    <true/>
     
     <key>RunAtLoad</key>
     <true/>

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -474,6 +475,11 @@ class TestLaunchdServiceRecovery:
             gateway_cli._get_restart_drain_timeout()
             == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
         )
+
+    def test_launchd_plist_creates_user_session_for_keychain_access(self):
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["SessionCreate"] is True
 
     def test_launchd_install_repairs_outdated_plist_without_force(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"


### PR DESCRIPTION
## Summary
- Add `SessionCreate=true` to the generated macOS launchd gateway plist.
- Cover the generated plist with a `plistlib` regression test.

## Why
`SessionCreate` lets a LaunchAgent create a user session so macOS keychain-backed tooling can work reliably under the gateway. Without this key, `hermes gateway start` can rewrite a locally-correct plist and remove the keychain/session fix.

## Test
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery -q` — 11 passed
- `git diff --check`
