### PR TITLE
fix(gateway): enforce per-topic enabled_toolsets for Telegram group_topics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16825,6 +16825,29 @@ class GatewayRunner:
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+
+        # Telegram group_topics: per-topic enabled_toolsets narrows the
+        # platform set so each forum topic gets only its declared tools.
+        if platform_key == "telegram" and source.thread_id and source.chat_id:
+            try:
+                telegram_cfg = user_config.get("telegram") or {}
+                if not isinstance(telegram_cfg, dict):
+                    telegram_cfg = {}
+                for chat_entry in (telegram_cfg.get("group_topics") or []):
+                    if str(chat_entry.get("chat_id", "")) == str(source.chat_id):
+                        for topic in (chat_entry.get("topics") or []):
+                            if str(topic.get("thread_id", "")) == str(source.thread_id):
+                                topic_ts = topic.get("enabled_toolsets")
+                                if isinstance(topic_ts, list) and topic_ts:
+                                    allowed = set(str(t) for t in topic_ts)
+                                    enabled_toolsets = sorted(
+                                        t for t in enabled_toolsets if t in allowed
+                                    )
+                                break
+                        break
+            except Exception:
+                pass
+
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 


### PR DESCRIPTION
## Summary

`telegram.group_topics[].topics[].enabled_toolsets` was parsed from `config.yaml`
but silently ignored at runtime — every topic loaded the full
`platform_toolsets.telegram` set regardless of what was declared.

## Root cause

`_run_agent()` resolved `enabled_toolsets` via `_get_platform_tools(user_config, "telegram")`
without consulting the active topic's `enabled_toolsets` field.
The field existed in the YAML schema and was documented-looking, but no
downstream code ever read it (confirmed in issue #37743).

## Fix

After computing the platform-wide toolset, check whether `source.platform == "telegram"`,
`source.thread_id` and `source.chat_id` match a configured `group_topics` entry.
If the matching topic declares `enabled_toolsets`, the platform set is intersected
with the declared list.

```yaml
telegram:
  group_topics:
    - chat_id: "-1001234567890"
      topics:
        - thread_id: 3
          name: HomeAssistant
          skill: topic-homeassistant
          enabled_toolsets: [homeassistant, web, file]   # ← now enforced
```

- Sessions without `group_topics` config: **no change** (full platform toolset preserved)
- Topics without `enabled_toolsets`: **no change** (full platform toolset preserved)
- Topics with `enabled_toolsets`: toolset is now correctly narrowed

## Test plan

- [x] All `tests/gateway/test_telegram_group_gating.py` pass (44 tests)
- [x] `tests/gateway/test_reasoning_command.py` passes
- [x] No regression in telegram approval / model-picker / slash-confirm tests

Closes #37743