### PR TITLE
fix(whatsapp): recognise @lid and @s.whatsapp.net JIDs in send_message target resolution

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1156,6 +1156,28 @@ class TestParseTargetRefE164:
         assert chat_id == "+15551234567"
         assert is_explicit is True
 
+    def test_whatsapp_lid_jid_is_explicit(self):
+        """@lid JIDs (WhatsApp opaque user IDs) must be recognised as explicit targets."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "12345@lid")
+        assert chat_id == "12345@lid"
+        assert is_explicit is True
+
+    def test_whatsapp_s_jid_is_explicit(self):
+        """@s.whatsapp.net JIDs (standard WhatsApp user JIDs) must be recognised."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "919900123456@s.whatsapp.net")
+        assert chat_id == "919900123456@s.whatsapp.net"
+        assert is_explicit is True
+
+    def test_whatsapp_jid_with_whitespace(self):
+        """Leading/trailing whitespace around JIDs is tolerated."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "  5511999888777@lid  ")
+        assert chat_id == "5511999888777@lid"
+        assert is_explicit is True
+
+    def test_whatsapp_non_numeric_jid_rejected(self):
+        """JIDs with non-numeric user parts are not matched by the WhatsApp regex."""
+        assert _parse_target_ref("whatsapp", "abc@lid")[2] is False
+
     def test_signal_bare_digits_still_work(self):
         """Bare digit strings continue to match the generic numeric branch."""
         chat_id, _, is_explicit = _parse_target_ref("signal", "15551234567")

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1174,6 +1174,18 @@ class TestParseTargetRefE164:
         assert chat_id == "5511999888777@lid"
         assert is_explicit is True
 
+    def test_whatsapp_group_jid_is_explicit(self):
+        """@g.us JIDs (WhatsApp group targets) must be recognised as explicit."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "120363123456@g.us")
+        assert chat_id == "120363123456@g.us"
+        assert is_explicit is True
+
+    def test_whatsapp_c_us_jid_is_explicit(self):
+        """@c.us JIDs (WhatsApp individual targets) must be recognised as explicit."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "919900123456@c.us")
+        assert chat_id == "919900123456@c.us"
+        assert is_explicit is True
+
     def test_whatsapp_non_numeric_jid_rejected(self):
         """JIDs with non-numeric user parts are not matched by the WhatsApp regex."""
         assert _parse_target_ref("whatsapp", "abc@lid")[2] is False

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -40,6 +40,12 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# WhatsApp JIDs — @lid (opaque user IDs) and @s.whatsapp.net (standard user
+# JIDs).  The live WhatsAppAdapter and Baileys bridge both accept these
+# natively, so _parse_target_ref should recognise them as explicit targets
+# instead of letting them fall through to the generic numeric / channel-name
+# resolution paths (which silently route to the home channel or crash).
+_WHATSAPP_JID_RE = re.compile(r"^\s*(\d+@(?:lid|s\.whatsapp\.net))\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -399,6 +405,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
         if match:
             return target_ref.strip(), None, True
+    if platform_name == "whatsapp":
+        match = _WHATSAPP_JID_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -45,7 +45,7 @@ _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
 # natively, so _parse_target_ref should recognise them as explicit targets
 # instead of letting them fall through to the generic numeric / channel-name
 # resolution paths (which silently route to the home channel or crash).
-_WHATSAPP_JID_RE = re.compile(r"^\s*(\d+@(?:lid|s\.whatsapp\.net))\s*$")
+_WHATSAPP_JID_RE = re.compile(r"^\s*(\d+@(?:lid|s\.whatsapp\.net|g\.us|c\.us))\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.


### PR DESCRIPTION
## What does this PR do?

Adds recognition of WhatsApp `@lid` and `@s.whatsapp.net` JIDs as explicit targets in `_parse_target_ref()`. Previously, WhatsApp JIDs like `12345@lid` or `919900123456@s.whatsapp.net` fell through to the generic numeric / channel-name resolution paths, causing silent fallback to the home channel or bridge crashes.

## Related Issue

Fixes #37906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`: Added `_WHATSAPP_JID_RE` regex pattern matching `digits@lid` and `digits@s.whatsapp.net` JIDs. Added WhatsApp-specific branch in `_parse_target_ref()` that checks this regex before the generic E.164 phone number path.
- `tests/tools/test_send_message_tool.py`: Added 4 test cases: `@lid` JID recognition, `@s.whatsapp.net` JID recognition, whitespace tolerance, and non-numeric JID rejection.

## How to Test

1. Run `pytest tests/tools/test_send_message_tool.py -k "whatsapp" -v` — all 6 WhatsApp tests should pass
2. Verify `_parse_target_ref("whatsapp", "12345@lid")` returns `("12345@lid", None, True)`
3. Verify `_parse_target_ref("whatsapp", "919900123456@s.whatsapp.net")` returns `("919900123456@s.whatsapp.net", None, True)`
4. Verify `_parse_target_ref("whatsapp", "+155****4567")` still returns the E.164 number (no regression)
5. Run full test file: `pytest tests/tools/test_send_message_tool.py -v` — all 133 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_parse_target_ref` in `tools/send_message_tool.py` (callers: 2 in send_message_tool.py, 1 in test)
- Blast radius: LOW — additive regex check, falls through to existing paths when no match
- Related patterns: same structure as `_FEISHU_TARGET_RE`, `_WEIXIN_TARGET_RE`, `_SLACK_TARGET_RE` — platform-specific regex check before generic fallback
