### PR TITLE
fix(mcp): resolve ${VAR} header placeholders before the discovery probe

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -354,8 +354,18 @@ def cmd_mcp_add(args):
     print()
     print(color(f"  Connecting to '{name}'...", Colors.CYAN))
 
+    # Resolve ${VAR} placeholders for the probe so that header auth
+    # credentials are sent as real values.  The on-disk config keeps the
+    # template strings (e.g. "Bearer ${MCP_FOO_API_KEY}") so that the
+    # saved config remains portable across machines and profiles.
     try:
-        tools = _probe_single_server(name, server_config)
+        from tools.mcp_tool import _interpolate_env_vars
+        probe_config = _interpolate_env_vars(dict(server_config))
+    except Exception:
+        probe_config = server_config
+
+    try:
+        tools = _probe_single_server(name, probe_config)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
         if _confirm("Save config anyway (you can test later)?", default=False):


### PR DESCRIPTION
## Summary

`hermes mcp add` sets `server_config["headers"]` to a template string:

```python
{"Authorization": "Bearer ${MCP_FOO_API_KEY}"}
```

This keeps the saved config portable (the env-var placeholder is preserved
on disk).  But the discovery probe received the raw template, sent the
literal string `"Bearer ${MCP_FOO_API_KEY}"` as the Authorization header,
and got **401 Unauthorized** — even though `hermes mcp test` (which loads
from disk and calls `_interpolate_env_vars`) succeeded.

## Root cause

`_probe_single_server(name, server_config)` was called with the
unresolved template.  `_interpolate_env_vars` is only called when loading
the saved config from disk, not when the config is built in-memory.

## Fix

Resolve `${VAR}` placeholders into a shallow copy of `server_config`
immediately before the probe.  The on-disk config is written **after** the
probe and keeps the original template strings.  Only the transient probe
copy is resolved.

```python
probe_config = _interpolate_env_vars(dict(server_config))
tools = _probe_single_server(name, probe_config)
```

- `hermes mcp add --auth header` → probe now uses the real token → 200 ✓
- Saved config still stores `"Bearer ${MCP_FOO_API_KEY}"` → portable ✓
- `hermes mcp test` unaffected (already resolves env vars from disk) ✓

## Test plan

- [x] All 34 `tests/hermes_cli/test_mcp_config.py` tests pass
- [x] `_interpolate_env_vars` import is guarded with `except Exception` for resilience

Fixes #37792