### PR TITLE
fix(qqbot): add env-var fallbacks for dm_policy, group_policy, and allowlists

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -207,14 +207,25 @@ class QQAdapter(BasePlatformAdapter):
         ).strip()
         self._markdown_support = bool(extra.get("markdown_support", True))
 
-        # Auth/ACL policies
-        self._dm_policy = str(extra.get("dm_policy", "open")).strip().lower()
+        # Auth/ACL policies — read from config extra first, then env vars so
+        # that env-only setups (e.g. written by the setup wizard) work without
+        # a config.yaml entry.  Mirrors the identical fallback pattern in WeCom
+        # (f7a3509b2), WhatsApp (PR #37452), and WeCom group (PR #37678).
+        self._dm_policy = str(
+            extra.get("dm_policy") or os.getenv("QQBOT_DM_POLICY", "open")
+        ).strip().lower()
         self._allow_from = _coerce_list(
-            extra.get("allow_from") or extra.get("allowFrom")
+            extra.get("allow_from")
+            or extra.get("allowFrom")
+            or os.getenv("QQBOT_ALLOWED_USERS", "")
         )
-        self._group_policy = str(extra.get("group_policy", "open")).strip().lower()
+        self._group_policy = str(
+            extra.get("group_policy") or os.getenv("QQBOT_GROUP_POLICY", "open")
+        ).strip().lower()
         self._group_allow_from = _coerce_list(
-            extra.get("group_allow_from") or extra.get("groupAllowFrom")
+            extra.get("group_allow_from")
+            or extra.get("groupAllowFrom")
+            or os.getenv("QQBOT_GROUP_ALLOWED_USERS", "")
         )
 
         # Connection state


### PR DESCRIPTION
## Summary

`QQBotAdapter` read `dm_policy` / `group_policy` / `allow_from` /
`group_allow_from` exclusively from `config.extra` (config.yaml).  When the
setup wizard writes these settings as `QQBOT_DM_POLICY` / `QQBOT_ALLOWED_USERS`
/ etc. env vars (the standard pattern for env-only deployments), the adapter
silently ran with the `"open"` default and an empty allowlist — dropping every
DM the operator intended to restrict.

## Root cause

Every other platform with `enforces_own_access_policy = True` already reads
its access-control config from **both** config.yaml and env vars:

| Platform | Fix |
|----------|-----|
| WeCom | f7a3509b2 — `WECOM_ALLOWED_USERS` |
| WhatsApp | PR #37452 — `WHATSAPP_ALLOWED_USERS` / `WHATSAPP_GROUP_ALLOWED_USERS` |
| WeCom group | PR #37678 — `WECOM_GROUP_ALLOWED_USERS` |

QQBot had no such fallback.

## Fix

Add the same env-var fallback chain, keeping `config.extra` as the
higher-priority source:

```
QQBOT_DM_POLICY            → dm_policy default
QQBOT_ALLOWED_USERS        → DM allow_from
QQBOT_GROUP_POLICY         → group_policy default
QQBOT_GROUP_ALLOWED_USERS  → group_allow_from
```

No behaviour change when config.yaml already carries the values.

## Test plan

- [x] All 165 `tests/gateway/test_qqbot.py` tests pass
- [x] Symmetric with WeCom / WhatsApp env-fallback fixes