### PR TITLE
fix(streaming): add mattermost.streaming=false default to match Discord/Slack

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1371,6 +1371,10 @@ DEFAULT_CONFIG = {
         "platforms": {
             "telegram": {"streaming": True},
             "discord": {"streaming": False},
+            # Mattermost uses repeated editMessage for streaming, which
+            # visibly flickers — same as Discord/Slack.  Disable by default
+            # so users get clean final replies.  Symmetric with discord/slack.
+            "mattermost": {"streaming": False},
         },
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders


### PR DESCRIPTION
## Summary

Mattermost uses repeated `editMessage` calls for streaming output — the
same edit-based path as Discord and Slack — which visibly flickers in
channel views.

PR #37303 shipped `telegram=true` and `discord=false` streaming defaults.
Slack received the same treatment (PR #37688).  Mattermost was overlooked.

## Root cause

`display_config._PLATFORM_DEFAULTS["mattermost"]` is `_TIER_MEDIUM` with
`streaming=None` (follows global).  Unlike `_TIER_LOW` platforms (Signal,
WeCom, …) which already have `streaming=False` baked into their tier,
`_TIER_MEDIUM` requires an explicit `DEFAULT_CONFIG` entry to override the
global — just as Discord needed one in #37303.

## Fix

Add `"mattermost": {"streaming": False}` to `DEFAULT_CONFIG`
`display.platforms`.  Config deep-merge means user-set values always win,
so operators who prefer streaming can opt back in via:

```yaml
display:
  platforms:
    mattermost:
      streaming: true
```

## Test plan

- [x] `tests/gateway/test_per_platform_streaming_defaults.py` — 4 tests pass
- [x] `tests/hermes_cli/test_config.py` — 87 tests pass
- [x] Symmetric with discord/slack streaming=false defaults