### PR TITLE
fix(streaming): add matrix.streaming=false default to match Discord/Slack

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1371,6 +1371,10 @@ DEFAULT_CONFIG = {
         "platforms": {
             "telegram": {"streaming": True},
             "discord": {"streaming": False},
+            # Matrix uses m.replace events for streaming (edit-based), which
+            # shows rapid edits in clients like Element — same flickering
+            # behaviour as Discord/Slack.  Disable by default.
+            "matrix": {"streaming": False},
         },
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders


### PR DESCRIPTION
## Summary

Matrix streams via repeated `m.replace` (edit) events.  In Element Web,
Element iOS/Android, and most other Matrix clients this causes the message
text to flicker with every delta — the same edit-based path that led to
`discord=false` in #37303 and `slack=false` in #37688.

## Root cause

`display_config._PLATFORM_DEFAULTS["matrix"]` is `_TIER_MEDIUM` with
`streaming=None` (follows global).  Unlike `_TIER_LOW` platforms which
bake in `streaming=False`, `_TIER_MEDIUM` platforms require an explicit
`DEFAULT_CONFIG` entry — just like Discord needed in #37303.

## Fix

Add `"matrix": {"streaming": False}` to `DEFAULT_CONFIG`
`display.platforms`.  Config deep-merge means user-set values always win:

```yaml
display:
  platforms:
    matrix:
      streaming: true  # opt back in if you prefer live edits
```

## Test plan

- [x] `tests/gateway/test_per_platform_streaming_defaults.py` — 4 tests pass
- [x] `tests/hermes_cli/test_config.py` — 87 tests pass
- [x] Symmetric with discord/slack/mattermost streaming=false defaults