### PR TITLE
fix(gateway): apply topic enabled_toolsets in background task dispatch too

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12482,6 +12482,28 @@ class GatewayRunner:
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+
+            # Telegram group_topics: narrow toolsets per topic (same as main dispatch).
+            if platform_key == "telegram" and source.thread_id and source.chat_id:
+                try:
+                    telegram_cfg = user_config.get("telegram") or {}
+                    if not isinstance(telegram_cfg, dict):
+                        telegram_cfg = {}
+                    for chat_entry in (telegram_cfg.get("group_topics") or []):
+                        if str(chat_entry.get("chat_id", "")) == str(source.chat_id):
+                            for topic in (chat_entry.get("topics") or []):
+                                if str(topic.get("thread_id", "")) == str(source.thread_id):
+                                    topic_ts = topic.get("enabled_toolsets")
+                                    if isinstance(topic_ts, list) and topic_ts:
+                                        allowed = set(str(t) for t in topic_ts)
+                                        enabled_toolsets = sorted(
+                                            t for t in enabled_toolsets if t in allowed
+                                        )
+                                    break
+                            break
+                except Exception:
+                    pass
+
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 


### PR DESCRIPTION
## Summary

PR #37922 fixed the main message-dispatch path (`_run_agent`) to intersect
platform toolsets with `telegram.group_topics[].topics[].enabled_toolsets`.
The **background-task path** (`_run_background_task`) had the same gap: when a
background agent is spawned from a group-topic message, it received the full
platform toolset instead of the narrowed per-topic set.

## Fix

Apply the identical `(chat_id, thread_id) → group_topics → enabled_toolsets`
intersection in `_run_background_task`, symmetric with the fix already landed
in the main dispatch loop.

```
telegram:
  group_topics:
    - chat_id: "-1001234567890"
      topics:
        - thread_id: 3
          enabled_toolsets: [homeassistant, web]  # ← now also honoured in bg tasks
```

## Test plan

- [x] All 44 `tests/gateway/test_telegram_group_gating.py` pass
- [x] No regression in related Telegram tests
- [x] Symmetric with PR #37922 (main dispatch path)