### PR TITLE
fix(delegate-task): preserve approval context in executor submissions

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -351,6 +351,42 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("total_duration_seconds", result)
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_propagates_approval_session_contextvar(self, mock_run):
+        """Each batch worker keeps the initiating gateway approval session."""
+        from tools.approval import (
+            get_current_session_key,
+            reset_current_session_key,
+            set_current_session_key,
+        )
+
+        seen_session_keys = []
+
+        def run_child(**kwargs):
+            seen_session_keys.append(get_current_session_key(default="missing"))
+            return {
+                "task_index": kwargs["task_index"],
+                "status": "completed",
+                "summary": "done",
+                "api_calls": 0,
+                "duration_seconds": 0.0,
+            }
+
+        mock_run.side_effect = run_child
+        token = set_current_session_key("gateway-session-A")
+        try:
+            delegate_task(
+                tasks=[{"goal": "A"}, {"goal": "B"}],
+                parent_agent=_make_mock_parent(),
+            )
+        finally:
+            reset_current_session_key(token)
+
+        self.assertEqual(
+            seen_session_keys,
+            ["gateway-session-A", "gateway-session-A"],
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):
         mock_run.side_effect = [
             {
@@ -3200,6 +3236,45 @@ class TestSubagentApprovalCallback(unittest.TestCase):
         self.assertEqual(seen, [_subagent_auto_deny])
         # Parent's callback slot is still empty (TLS isolates threads).
         self.assertIsNone(_get_approval_callback())
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_run_single_child_preserves_session_context_and_callback(self, _mock_cfg):
+        """The timeout worker keeps gateway context and its own callback policy."""
+        from tools.approval import (
+            get_current_session_key,
+            reset_current_session_key,
+            set_current_session_key,
+        )
+        from tools.delegate_tool import _run_single_child, _subagent_auto_deny
+        from tools.terminal_tool import _get_approval_callback
+
+        seen = {}
+
+        class Child:
+            _current_task_id = "child-task"
+
+            def run_conversation(self, user_message, task_id, stream_callback=None):
+                seen["session_key"] = get_current_session_key(default="missing")
+                seen["approval_callback"] = _get_approval_callback()
+                return {
+                    "completed": True,
+                    "final_response": "done",
+                    "message": user_message,
+                    "task_id": task_id,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+        parent = _make_mock_parent()
+        token = set_current_session_key("gateway-session-A")
+        try:
+            result = _run_single_child(0, "needs approval", Child(), parent)
+        finally:
+            reset_current_session_key(token)
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(seen["session_key"], "gateway-session-A")
+        self.assertIs(seen["approval_callback"], _subagent_auto_deny)
 
 
 class TestFallbackModelInheritance(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -17,6 +17,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import contextvars
 import enum
 import json
 import logging
@@ -25,11 +26,8 @@ logger = logging.getLogger(__name__)
 import os
 import threading
 import time
-from concurrent.futures import (
-    ThreadPoolExecutor,
-    TimeoutError as FuturesTimeoutError,
-)
-from typing import Any, Dict, List, Optional
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any, Callable, Dict, List, Optional
 
 from toolsets import TOOLSETS
 
@@ -111,6 +109,25 @@ def _get_subagent_approval_callback():
     if is_truthy_value(val):
         return _subagent_auto_approve
     return _subagent_auto_deny
+
+
+def _propagate_contextvars_to_thread(
+    target: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Capture the caller's ContextVars without replacing worker TLS state.
+
+    Delegated approval routing depends on the gateway session ContextVars, but
+    the delegate executors deliberately install their own terminal approval
+    callbacks with an initializer.  The general thread-context helper also
+    copies those callbacks, so it is not appropriate at this boundary.
+    """
+    ctx = contextvars.copy_context()
+
+    def _runner(*args, **kwargs):
+        return ctx.run(target, *args, **kwargs)
+
+    return _runner
+
 
 # NOTE: nested delegation is granted by role='orchestrator' (which re-adds the
 # "delegation" toolset in _build_child_agent), NOT by the model naming toolsets
@@ -2008,7 +2025,9 @@ def _run_single_child(
                 stream_callback=_relay_child_text,
             )
 
-        _child_future = _timeout_executor.submit(_run_with_thread_capture)
+        _child_future = _timeout_executor.submit(
+            _propagate_contextvars_to_thread(_run_with_thread_capture)
+        )
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
@@ -2649,11 +2668,12 @@ def delegate_task(
             # normally, but if the parent is interrupted while a child is
             # wedged, the abandoned worker must not block interpreter exit.
             from tools.daemon_pool import DaemonThreadPoolExecutor
+
             with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
                 futures = {}
                 for i, t, child in children:
                     future = executor.submit(
-                        _run_single_child,
+                        _propagate_contextvars_to_thread(_run_single_child),
                         task_index=i,
                         goal=t["goal"],
                         child=child,


### PR DESCRIPTION
## Summary
`delegate_task` submits subagent work to `ThreadPoolExecutor` without propagating the parent thread's ContextVars. When the child reaches an approval check, the approval session key can fall back to gateway session context instead of the initiating user's session, allowing a subagent action to be approved or routed under a different active external session.

- `delegate_tool.py` uses bare `executor.submit(...)` on the subagent path.
- Other Hermes concurrent paths already use ContextVar propagation helpers, showing the intended boundary-preserving pattern.

Capture `contextvars.Context` at both `delegate_tool.py` executor boundaries without copying the parent thread's terminal approval callback, preserving each subagent worker's configured auto-deny/auto-approve policy. Add functional regression coverage for both the batch and inner timeout workers.

## Linked context
Closes #37935

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/tools/delegate_tool.py`
- `hermes-agent/gateway/run.py`
- `hermes-agent/tools/approval.py`
- `tools/delegate_tool.py`

### Files changed in this PR
- `tests/tools/test_delegate.py`
- `tools/delegate_tool.py`

### Behavior reproduced or verified
1. Rebased onto Hermes Agent `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`.
2. Verified both delegation executor boundaries previously used bare submissions that lost the initiating gateway approval ContextVars.
3. Verified the general `propagate_context_to_thread(...)` helper is unsuitable here because it also copies the parent's terminal approval callback, overriding the subagent executor's configured callback policy.
4. Added functional tests proving batch and timeout workers retain `gateway-session-A`, while the timeout worker still sees `_subagent_auto_deny`.
5. Expected result: delegated worker approvals remain bound to the initiating session without weakening the configured subagent callback policy.

### Expected fixed behavior
Both delegate executor boundaries propagate only the initiating `ContextVars`; the inner worker retains its explicitly initialized terminal approval callback.

## Tests and validation
- `scripts/run_tests.sh tests/tools/test_delegate.py -q`
- Result: 1 file, 160 tests passed, 0 failed (100% complete) in 17.6s (20 workers)
- `.venv/bin/ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
- Result: all checks passed

## Environment
Hermes latest-main source receipt: `477c08b44766ace8b890faa72bf82ecbcf2b3ba8` on current `main`. Runtime prerequisite: two concurrent gateway sessions and an approval-gated delegated action. Redaction complete; no secrets, tokens, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness: rebased head `61c04c8c834ba8429ac2537ff196900dc3736b29` has current `main` commit `477c08b44766ace8b890faa72bf82ecbcf2b3ba8` as its sole parent; affected paths were verified in an isolated checkout.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
