### PR TITLE
fix(memory): bridge all actions with result-aware success gating

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1756,17 +1756,27 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 store=agent._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes
-            if agent._memory_manager and next_args.get("action") in {"add", "replace"}:
+            action = next_args.get("action", "")
+            if agent._memory_manager and action in {"add", "replace", "remove"}:
                 try:
-                    agent._memory_manager.on_memory_write(
-                        next_args.get("action", ""),
-                        target,
-                        next_args.get("content", ""),
-                        metadata=agent._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=tool_call_id,
-                        ),
-                    )
+                    import json as _json
+                    parsed = _json.loads(result) if isinstance(result, str) else result
+                    if isinstance(parsed, dict) and parsed.get("success"):
+                        mutated = parsed.get("mutated", action != "remove")
+                        if mutated:
+                            if action == "remove":
+                                content = parsed.get("removed_content", "")
+                            else:
+                                content = parsed.get("bridge_content") or next_args.get("content", "")
+                            agent._memory_manager.on_memory_write(
+                                action,
+                                target,
+                                content,
+                                metadata=agent._build_memory_write_metadata(
+                                    task_id=effective_task_id,
+                                    tool_call_id=tool_call_id,
+                                ),
+                            )
                 except Exception:
                     pass
             return _finish_agent_tool(result, next_args)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1021,17 +1021,27 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     store=agent._memory_store,
                 )
                 # Bridge: notify external memory provider of built-in memory writes
-                if agent._memory_manager and next_args.get("action") in {"add", "replace"}:
+                action = next_args.get("action", "")
+                if agent._memory_manager and action in {"add", "replace", "remove"}:
                     try:
-                        agent._memory_manager.on_memory_write(
-                            next_args.get("action", ""),
-                            target,
-                            next_args.get("content", ""),
-                            metadata=agent._build_memory_write_metadata(
-                                task_id=effective_task_id,
-                                tool_call_id=getattr(tool_call, "id", None),
-                            ),
-                        )
+                        import json as _json
+                        parsed = _json.loads(result) if isinstance(result, str) else result
+                        if isinstance(parsed, dict) and parsed.get("success"):
+                            mutated = parsed.get("mutated", action != "remove")
+                            if mutated:
+                                if action == "remove":
+                                    content = parsed.get("removed_content", "")
+                                else:
+                                    content = parsed.get("bridge_content") or next_args.get("content", "")
+                                agent._memory_manager.on_memory_write(
+                                    action,
+                                    target,
+                                    content,
+                                    metadata=agent._build_memory_write_metadata(
+                                        task_id=effective_task_id,
+                                        tool_call_id=getattr(tool_call, "id", None),
+                                    ),
+                                )
                     except Exception:
                         pass
                 return result

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1510,6 +1510,70 @@ class HindsightMemoryProvider(MemoryProvider):
         self._register_atexit()
         self._retain_queue.put(_do_retain)
 
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Archive removed built-in memory entries to Hindsight.
+
+        Only handles ``action == "remove"`` — add/replace are the built-in
+        store's own concern and already populate Hindsight via normal
+        conversation retention.
+        """
+        if action != "remove":
+            return
+        content = (content or "").strip()
+        if not content:
+            return
+        if self._shutting_down.is_set():
+            return
+
+        # Snapshot state for the async writer
+        metadata_snapshot = self._build_metadata(
+            message_count=len(self._session_turns) * 2,
+            turn_index=self._turn_index,
+        )
+        if metadata:
+            metadata_snapshot.update(metadata)
+        metadata_snapshot.setdefault("memory_action", action)
+        metadata_snapshot.setdefault("memory_target", target)
+
+        context = f"archived Hermes built-in {target} memory removed from active store"
+        bank_id = self._bank_id
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        retain_async_flag = self._retain_async
+        tags = _normalize_retain_tags(
+            ["builtin-memory", "removed-entry", f"target:{target}"]
+        )
+
+        def _do_archival() -> None:
+            kwargs = self._build_retain_kwargs(
+                content,
+                context=context,
+                metadata=metadata_snapshot,
+                tags=tags,
+                retain_async=retain_async_flag,
+            )
+            kwargs.pop("bank_id", None)
+            kwargs.pop("retain_async", None)
+            if update_mode is not None:
+                kwargs["update_mode"] = update_mode
+            self._run_hindsight_operation(
+                lambda client: client.aretain_batch(
+                    bank_id=bank_id,
+                    items=[kwargs],
+                    document_id=document_id,
+                    retain_async=retain_async_flag,
+                )
+            )
+
+        self._ensure_writer()
+        self._register_atexit()
+        self._retain_queue.put(_do_archival)
+
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -319,7 +319,7 @@ class MemoryStore:
 
             # Reject exact duplicates
             if content in entries:
-                return self._success_response(target, "Entry already exists (no duplicate added).")
+                return self._success_response(target, "Entry already exists (no duplicate added).", mutated=False)
 
             # Calculate what the new total would be
             new_entries = entries + [content]
@@ -342,7 +342,7 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry added.")
+        return self._success_response(target, "Entry added.", mutated=True)
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
@@ -402,7 +402,7 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry replaced.")
+        return self._success_response(target, "Entry replaced.", mutated=True)
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
@@ -434,11 +434,11 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
-            entries.pop(idx)
+            removed_entry = entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry removed.")
+        return self._success_response(target, "Entry removed.", mutated=True, removed_content=removed_entry)
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """
@@ -455,7 +455,7 @@ class MemoryStore:
 
     # -- Internal helpers --
 
-    def _success_response(self, target: str, message: str = None) -> Dict[str, Any]:
+    def _success_response(self, target: str, message: str = None, **kwargs) -> Dict[str, Any]:
         entries = self._entries_for(target)
         current = self._char_count(target)
         limit = self._char_limit(target)
@@ -467,6 +467,7 @@ class MemoryStore:
             "entries": entries,
             "usage": f"{pct}% — {current:,}/{limit:,} chars",
             "entry_count": len(entries),
+            **kwargs,
         }
         if message:
             resp["message"] = message


### PR DESCRIPTION
## Problem
The on_memory_write bridge only forwards add/replace actions to memory providers. When the agent deletes memory entries (common under ~99% quota pressure), the deleted content is permanently lost.

## Fix (4 files, +111/-26)

### 1. memory_tool.py
- `remove()` captures removed content
- `mutated` flag on all success responses
- `_success_response()` accepts `**kwargs`

### 2. agent/tool_executor.py + agent_runtime_helpers.py
- Bridge expanded to {add,replace,remove}
- Result-aware: only bridge successful, state-mutating writes

### 3. plugins/memory/hindsight/__init__.py
- New `on_memory_write()` archives removed entries via aretain_batch
- Only handles remove (add/replace covered by normal retention)

## Testing
- 68 existing memory unit tests pass
- All 4 files import cleanly
- Codex reviewed and approved

## Related PRs
- #35473: Previous version (closed) — replaced by this
- #39508: Related but different approach

**Version**: Based on upstream/main at 136dae779 | **Rebased**: 2026-06-07