### PR TITLE
fix(kanban): clean up task_links when archiving a task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4501,6 +4501,15 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
+        # Sever parent→child links so children of the archived task are
+        # no longer blocked.  Without this, ``recompute_ready`` promotes
+        # children (archived ≈ done), but the children's workers may
+        # still try to access the archived parent's scratch workspace,
+        # which was already cleaned up on completion — causing crashes.
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ?",
+            (task_id,),
+        )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting


### PR DESCRIPTION
When archive_task() archives a task, it does not remove task_links entries where the archived task is a parent. recompute_ready() treats archived parents as done, promoting child tasks to ready. The children's workers may then try to access the archived parent's scratch workspace, which was already cleaned up on task completion — causing worker crashes with 'File not found'.

## Fix
Add DELETE FROM task_links WHERE parent_id = ? inside the archive_task write transaction.

## Case study
In a 3-task kanban pipeline (T1 reviewer → T2 writer → T3 reviewer), T2 completed and was archived. T3 remained linked to the archived T2 via task_links. When recompute_ready promoted T3, its worker attempted to read T2's scratch workspace and crashed 3 times before the stale link was manually corrected.

## Files changed
- hermes_cli/kanban_db.py (+9 lines)