### PR TITLE
fix(gateway): make NO_REPLY a first-class silence token; don't re-inflate intentional silence (#13248)

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+LIVE_GATEWAY_SILENT_MARKERS = frozenset(
+    {
+        "[silent]",
+        "silent",
+        "no message",
+        "no reply",
+        "no response",
+        "no response generated",
+        "empty",
+    }
+)
+
+
+def _unwrap_live_gateway_response_text(text: str) -> str:
+    normalized = text
+    for _ in range(6):
+        updated = normalized.strip()
+        changed = False
+
+        for wrapper in ("**", "__", "~~", "`"):
+            if updated.startswith(wrapper) and updated.endswith(wrapper):
+                inner = updated[len(wrapper) : -len(wrapper)].strip()
+                if inner:
+                    normalized = inner
+                    changed = True
+                    break
+        if changed:
+            continue
+
+        for left, right in (("(", ")"), ("[", "]"), ("{", "}"), ('"', '"'), ("'", "'")):
+            if updated.startswith(left) and updated.endswith(right):
+                inner = updated[len(left) : -len(right)].strip()
+                if inner:
+                    normalized = inner
+                    changed = True
+                    break
+
+        if not changed:
+            normalized = updated
+            break
+
+    return normalized
+
+
+def _canonicalize_live_gateway_response(text: str) -> str:
+    normalized = _unwrap_live_gateway_response_text(text)
+    return re.sub(r"[\s\-_]+", " ", normalized).strip(" .!?:;").casefold()
+
+
+def normalize_live_gateway_response(
+    response: Optional[str], *, failed: bool = False
+) -> str:
+    """Suppress placeholder silence markers before live message delivery."""
+    if response is None:
+        return ""
+
+    text = str(response).strip()
+    if not text or failed:
+        return text
+
+    if _canonicalize_live_gateway_response(text) in LIVE_GATEWAY_SILENT_MARKERS:
+        return ""
+
+    return text

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -3,12 +3,27 @@ from __future__ import annotations
 import re
 from typing import Optional
 
+# Canonical, harness-emitted silence token. The agent emits this verbatim to
+# mean "this turn was processed, deliver nothing". It is a first-class control
+# token (cf. OpenClaw's SILENT_REPLY_TOKEN), NOT just a placeholder the model
+# stumbled into. Kept here as the single source of truth so prompt guidance,
+# the agent loop, and delivery suppression all agree on the same string.
+SILENT_REPLY_TOKEN = "NO_REPLY"
+
 LIVE_GATEWAY_SILENT_MARKERS = frozenset(
     {
+        # Explicit canonical silence token (and its underscore/space-folded
+        # form). Listed verbatim so the contract is self-documenting and does
+        # not depend on _canonicalize_live_gateway_response() happening to map
+        # "NO_REPLY" -> "no reply". If the canonicalizer ever changes, the
+        # canonical token must still be suppressed — that invariant is locked
+        # by tests/gateway/test_live_silent_responses.py.
+        "no reply",
+        # Placeholder markers a model may emit when it decides to stay silent
+        # but still produces visible filler instead of the canonical token.
         "[silent]",
         "silent",
         "no message",
-        "no reply",
         "no response",
         "no response generated",
         "empty",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8517,9 +8517,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
                 return None
 
+            _raw_final_response = agent_result.get("final_response")
             response = normalize_live_gateway_response(
-                agent_result.get("final_response"),
+                _raw_final_response,
                 failed=bool(agent_result.get("failed")),
+            )
+
+            # Distinguish an INTENTIONAL silent turn from an empty-generation
+            # FAILURE. When the model emits a recognized silence marker
+            # (canonical NO_REPLY, [SILENT], etc.) on a non-failed turn,
+            # normalize_live_gateway_response() collapses it to "". That empty
+            # string must NOT be re-inflated by _normalize_empty_agent_response()
+            # below into "Processing completed but no response was generated" —
+            # doing so turns a deliberate "stay silent" decision into chat noise
+            # (root cause of #13248). Detect the suppression here so the empty
+            # normalizer is skipped for intentional silence only.
+            _intentional_silence = bool(
+                str(_raw_final_response or "").strip()
+                and not response
+                and not agent_result.get("failed")
             )
 
             # Convert the agent's internal "(empty)" sentinel into a
@@ -8569,9 +8585,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
-            response = _normalize_empty_agent_response(
-                agent_result, response, history_len=len(history),
-            )
+            # Skip for intentional silence (#13248): a deliberate NO_REPLY turn
+            # already normalized to "" above and must stay empty, not be rewritten
+            # into a "no response was generated" notice.
+            if not _intentional_silence:
+                response = _normalize_empty_agent_response(
+                    agent_result, response, history_len=len(history),
+                )
             response = _sanitize_gateway_final_response(source.platform, response)
 
             # Ordering contract: the agent thread already updated the contextvar

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -850,6 +850,8 @@ def _collect_auto_append_media_tags(
 
     return media_tags, has_voice_directive
 
+from gateway.response_filters import normalize_live_gateway_response
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -8515,13 +8517,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
                 return None
 
-            response = agent_result.get("final_response") or ""
+            response = normalize_live_gateway_response(
+                agent_result.get("final_response"),
+                failed=bool(agent_result.get("failed")),
+            )
 
             # Convert the agent's internal "(empty)" sentinel into a
             # user-friendly message.  "(empty)" means the model failed to
             # produce visible content after exhausting all retries (nudge,
             # prefill, empty-retry, fallback).  Sending the raw sentinel
             # looks like a bug; a short explanation is more helpful.
+            #
+            # NOTE: normalize_live_gateway_response() canonicalizes "(empty)"
+            # into the silent-marker set and would return "" for it — but only
+            # when failed=False. A genuine empty-generation failure arrives with
+            # failed=True, so the sentinel survives normalization and is
+            # rewritten into the explanation below.
             if response == "(empty)":
                 response = (
                     "⚠️ The model returned no response after processing tool "
@@ -13840,6 +13851,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else:
                         _stream_consumer.on_commentary(text)
                     return
+                text = normalize_live_gateway_response(text)
                 if already_streamed or not _status_adapter or not str(text or "").strip():
                     return
                 safe_schedule_threadsafe(
@@ -15171,7 +15183,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         or _previewed
                         or (_sc and getattr(_sc, "final_content_delivered", False))
                     )
-                    first_response = result.get("final_response", "")
+                    first_response = normalize_live_gateway_response(
+                        result.get("final_response"),
+                        failed=bool(result.get("failed")),
+                    )
                     if first_response and not _already_streamed:
                         try:
                             logger.info(

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -33,6 +33,8 @@ from gateway.config import (
     DEFAULT_STREAMING_CURSOR as _DEFAULT_STREAMING_CURSOR,
 )
 
+from gateway.response_filters import normalize_live_gateway_response
+
 logger = logging.getLogger("gateway.stream_consumer")
 
 # Sentinel to signal the stream is complete
@@ -719,12 +721,31 @@ class GatewayStreamConsumer:
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
 
+    def _prepare_for_delivery(self, text: str) -> str:
+        cleaned = self._clean_for_display(text)
+        if not cleaned:
+            return cleaned
+
+        cursor = self.cfg.cursor or ""
+        if cursor and cleaned.strip() == cursor.strip():
+            return cleaned
+
+        if cursor and cleaned.endswith(cursor):
+            body = cleaned[: -len(cursor)].rstrip()
+            if body and not normalize_live_gateway_response(body):
+                return ""
+
+        if not normalize_live_gateway_response(cleaned):
+            return ""
+
+        return cleaned
+
     async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
         """Send a new message chunk, optionally threaded to a previous message.
 
         Returns the message_id so callers can thread subsequent chunks.
         """
-        text = self._clean_for_display(text)
+        text = self._prepare_for_delivery(text)
         if not text.strip():
             return reply_to_id
         try:
@@ -790,7 +811,7 @@ class GatewayStreamConsumer:
 
         Retries each chunk once on flood-control failures with a short delay.
         """
-        final_text = self._clean_for_display(text)
+        final_text = self._prepare_for_delivery(text)
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
         if not continuation.strip():
@@ -1068,7 +1089,7 @@ class GatewayStreamConsumer:
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
-        text = self._clean_for_display(text)
+        text = self._prepare_for_delivery(text)
         if not text.strip():
             return False
         try:
@@ -1188,7 +1209,7 @@ class GatewayStreamConsumer:
         # Strip MEDIA: directives so they don't appear as visible text.
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
-        text = self._clean_for_display(text)
+        text = self._prepare_for_delivery(text)
         # A bare streaming cursor is not meaningful user-visible content and
         # can render as a stray tofu/white-box message on some clients.
         visible_without_cursor = text

--- a/tests/gateway/test_live_silent_responses.py
+++ b/tests/gateway/test_live_silent_responses.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.response_filters import normalize_live_gateway_response
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+@pytest.mark.parametrize(
+    ("raw_text", "expected"),
+    [
+        ("(No message)", ""),
+        ("[SILENT]", ""),
+        ("`(No reply)`", ""),
+        ("**(No response generated)**", ""),
+        ("(empty)", ""),
+        ("[SILENT] means stay quiet", "[SILENT] means stay quiet"),
+        ("No message received from Discord", "No message received from Discord"),
+    ],
+)
+def test_normalize_live_gateway_response(raw_text, expected):
+    assert normalize_live_gateway_response(raw_text) == expected
+
+
+def test_normalize_live_gateway_response_preserves_failed_output():
+    assert normalize_live_gateway_response("[SILENT]", failed=True) == "[SILENT]"
+
+
+def _make_runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner.adapters = {}
+    runner._show_reasoning = False
+    runner._session_db = None
+    runner._set_session_env = MagicMock(return_value=[])
+    runner._clear_session_env = MagicMock()
+    runner._should_send_voice_reply = MagicMock(return_value=False)
+    runner._deliver_media_from_response = AsyncMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_suppresses_placeholder(monkeypatch):
+    runner = _make_runner()
+
+    session_entry = SimpleNamespace(
+        session_id="sess-1",
+        session_key="key-1",
+        created_at=1,
+        updated_at=2,
+        was_auto_reset=False,
+        last_prompt_tokens=0,
+    )
+    history = [{"role": "assistant", "content": "Earlier reply"}]
+
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "(No message)",
+            "messages": history,
+            "api_calls": 1,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr("gateway.run.build_session_context", lambda *_a, **_kw: {})
+    monkeypatch.setattr("gateway.run.build_session_context_prompt", lambda *_a, **_kw: "")
+
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="chat-1",
+        user_id="user-1",
+        user_name="tester",
+    )
+    event = MessageEvent(text="test", message_type=MessageType.TEXT, source=source)
+
+    result = await runner._handle_message_with_agent(event, source, "key-1")
+
+    assert result == ""
+    appended = [call.args[1] for call in runner.session_store.append_to_transcript.call_args_list]
+    assert any(entry["role"] == "user" for entry in appended)
+    assert not any(entry.get("content") == "(No message)" for entry in appended)

--- a/tests/gateway/test_live_silent_responses.py
+++ b/tests/gateway/test_live_silent_responses.py
@@ -5,7 +5,10 @@ import pytest
 
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
-from gateway.response_filters import normalize_live_gateway_response
+from gateway.response_filters import (
+    SILENT_REPLY_TOKEN,
+    normalize_live_gateway_response,
+)
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -28,6 +31,44 @@ def test_normalize_live_gateway_response(raw_text, expected):
 
 def test_normalize_live_gateway_response_preserves_failed_output():
     assert normalize_live_gateway_response("[SILENT]", failed=True) == "[SILENT]"
+
+
+@pytest.mark.parametrize(
+    "raw_text",
+    [
+        SILENT_REPLY_TOKEN,
+        f"  {SILENT_REPLY_TOKEN}\n",
+        SILENT_REPLY_TOKEN.lower(),
+        f"**{SILENT_REPLY_TOKEN}**",
+        f"({SILENT_REPLY_TOKEN})",
+        f"`{SILENT_REPLY_TOKEN}`",
+    ],
+)
+def test_canonical_silent_token_is_suppressed(raw_text):
+    """The canonical NO_REPLY token must always be suppressed.
+
+    Locks the control-token contract independently of how
+    _canonicalize_live_gateway_response normalizes punctuation/case, so a
+    future tweak to the canonicalizer can't silently start leaking the token
+    into live chats.
+    """
+    assert normalize_live_gateway_response(raw_text) == ""
+
+
+def test_canonical_silent_token_survives_when_failed():
+    """A real generation failure must never be silently swallowed.
+
+    failed=True means the empty output is a model/transport failure, not an
+    intentional silent turn, so the gateway keeps the sentinel for the
+    user-facing error path rather than suppressing it.
+    """
+    assert normalize_live_gateway_response(SILENT_REPLY_TOKEN, failed=True) == SILENT_REPLY_TOKEN
+
+
+def test_prose_mentioning_canonical_token_is_delivered():
+    """Ordinary prose that merely mentions NO_REPLY must still be delivered."""
+    text = f"Return {SILENT_REPLY_TOKEN} when you have nothing to add."
+    assert normalize_live_gateway_response(text) == text
 
 
 def _make_runner():
@@ -73,6 +114,9 @@ async def test_handle_message_with_agent_suppresses_placeholder(monkeypatch):
             "last_prompt_tokens": 0,
         }
     )
+    # _handle_message_with_agent now guards against stale runs via
+    # _is_session_run_current(session_key, generation); treat this run as current.
+    runner._is_session_run_current = MagicMock(return_value=True)
 
     monkeypatch.setattr("gateway.run.build_session_context", lambda *_a, **_kw: {})
     monkeypatch.setattr("gateway.run.build_session_context_prompt", lambda *_a, **_kw: "")
@@ -85,9 +129,65 @@ async def test_handle_message_with_agent_suppresses_placeholder(monkeypatch):
     )
     event = MessageEvent(text="test", message_type=MessageType.TEXT, source=source)
 
-    result = await runner._handle_message_with_agent(event, source, "key-1")
+    result = await runner._handle_message_with_agent(event, source, "key-1", 1)
 
     assert result == ""
     appended = [call.args[1] for call in runner.session_store.append_to_transcript.call_args_list]
     assert any(entry["role"] == "user" for entry in appended)
     assert not any(entry.get("content") == "(No message)" for entry in appended)
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_empty_failure_surfaces_notice(monkeypatch):
+    """A genuine empty-generation FAILURE must still surface a user notice.
+
+    Regression guard for #13248: intentional silence is suppressed, but a real
+    failure (api_calls>0, no text, not a silence marker) must NOT be silently
+    swallowed by the intentional-silence bypass — the user needs to know the
+    turn produced nothing so they can retry.
+    """
+    runner = _make_runner()
+
+    session_entry = SimpleNamespace(
+        session_id="sess-2",
+        session_key="key-2",
+        created_at=1,
+        updated_at=2,
+        was_auto_reset=False,
+        last_prompt_tokens=0,
+    )
+    history = [{"role": "assistant", "content": "Earlier reply"}]
+
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    # Empty final_response with api_calls>0 and no silence marker == failure.
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "",
+            "messages": history,
+            "api_calls": 1,
+            "last_prompt_tokens": 0,
+        }
+    )
+    runner._is_session_run_current = MagicMock(return_value=True)
+
+    monkeypatch.setattr("gateway.run.build_session_context", lambda *_a, **_kw: {})
+    monkeypatch.setattr("gateway.run.build_session_context_prompt", lambda *_a, **_kw: "")
+
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="chat-2",
+        user_id="user-2",
+        user_name="tester",
+    )
+    event = MessageEvent(text="test", message_type=MessageType.TEXT, source=source)
+
+    result = await runner._handle_message_with_agent(event, source, "key-2", 1)
+
+    # An empty failure is NOT intentional silence — the notice must be returned.
+    assert result
+    assert "no response was generated" in result

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -9,6 +9,16 @@ import pytest
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
+async def _wait_for_mock_call_count(mock, count: int, *, timeout: float = 0.5) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while mock.call_count < count and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    assert mock.call_count >= count, (
+        f"Timed out waiting for {mock!r} to reach {count} calls; got {mock.call_count}"
+    )
+
+
 # ── _clean_for_display unit tests ────────────────────────────────────────
 
 
@@ -321,6 +331,47 @@ class TestSendOrEditMediaStripping:
         assert result is True
         adapter.edit_message.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_silent_placeholder_skips_send(self):
+        """Silent placeholder text should not be streamed to the platform."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("(No message)")
+
+        adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_silent_placeholder_with_cursor_skips_send(self):
+        """Cursor updates should still suppress exact silence markers."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(cursor=" ..."),
+        )
+        await consumer._send_or_edit("(No message) ...")
+
+        adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_commentary_silent_placeholder_skips_send(self):
+        """Completed commentary placeholders should also stay hidden."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        sent = await consumer._send_commentary("[SILENT]")
+
+        assert sent is False
+        adapter.send.assert_not_called()
+
 
 # ── Integration: full stream run ─────────────────────────────────────────
 
@@ -359,6 +410,27 @@ class TestStreamRunMediaStripping:
             assert "MEDIA:" not in sent_text, f"MEDIA: leaked into display: {sent_text!r}"
 
         assert consumer.already_sent
+
+    @pytest.mark.asyncio
+    async def test_stream_with_silent_placeholder_sends_nothing(self):
+        """A final streamed silence marker should produce no visible message."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.edit_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("(No message)")
+        consumer.finish()
+
+        await consumer.run()
+
+        adapter.send.assert_not_called()
+        adapter.edit_message.assert_not_called()
+        assert consumer.already_sent is False
+        assert consumer.final_response_sent is True
 
 
 # ── Segment break (tool boundary) tests ──────────────────────────────────
@@ -521,10 +593,11 @@ class TestSegmentBreakOnToolBoundary:
 
         config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
         consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        consumer._MAX_FLOOD_STRIKES = 1
 
         consumer.on_delta("Hello")
         task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.08)
+        await _wait_for_mock_call_count(adapter.send, 1)
         consumer.on_delta(" world")
         await asyncio.sleep(0.08)
         consumer.finish()
@@ -553,10 +626,11 @@ class TestSegmentBreakOnToolBoundary:
 
         config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
         consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        consumer._MAX_FLOOD_STRIKES = 1
 
         consumer.on_delta("Hello")
         task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.08)
+        await _wait_for_mock_call_count(adapter.send, 1)
         consumer.on_delta(" world")
         await asyncio.sleep(0.08)
         consumer.on_delta(None)
@@ -639,7 +713,7 @@ class TestSegmentBreakOnToolBoundary:
 
         consumer.on_delta("Hello")
         task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.08)
+        await _wait_for_mock_call_count(adapter.send, 1)
         consumer.on_delta(" world, this is a longer response.")
         await asyncio.sleep(0.08)
         consumer.finish()
@@ -727,12 +801,13 @@ class TestSegmentBreakOnToolBoundary:
 
         config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
         consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        consumer._MAX_FLOOD_STRIKES = 1
 
         prefix = "Hello world"
         tail = "x" * 620
         consumer.on_delta(prefix)
         task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.08)
+        await _wait_for_mock_call_count(adapter.send, 1)
         consumer.on_delta(tail)
         await asyncio.sleep(0.08)
         consumer.finish()
@@ -1219,7 +1294,7 @@ class TestInterimCommentaryMessages:
 
         consumer.on_delta("Hello")
         task = asyncio.create_task(consumer.run())
-        await asyncio.sleep(0.08)
+        await _wait_for_mock_call_count(adapter.send, 1)
         consumer.on_delta(" world")
         await asyncio.sleep(0.08)
         consumer.finish()


### PR DESCRIPTION
## What this PR does

Makes `NO_REPLY` a first-class, harness-emitted silence token and stops the gateway from re-inflating an **intentional** silent turn into a "no response was generated" notice. Root-cause fix for the empty-vs-silent ambiguity behind #13248.

**This PR is stacked on top of #9956** — it keeps that PR's `gateway/response_filters.py` boundary and `normalize_live_gateway_response()` exactly as-is, and only adds the missing pieces. The first commit here is #9956's commit (author preserved); please review only the second commit.

## Why

#9956 centralizes *delivery* suppression of silent placeholders, which is great. But two gaps remain:

1. **The canonical token is suppressed only by accident.** `NO_REPLY` is suppressed today purely because `_canonicalize_live_gateway_response()` happens to fold it to `"no reply"`, which is in the marker set. There is no explicit contract; a future tweak to the canonicalizer could silently start leaking the literal token into live chats.

2. **Intentional silence is re-inflated downstream (the #13248 root).** Even after `normalize_live_gateway_response()` collapses an intentional silent turn to `""`, the live path then calls `_normalize_empty_agent_response()`, which rewrites `""` (when `api_calls > 0`) into:

   > ⚠️ Processing completed but no response was generated. This may be a transient error — try sending your message again.

   So a deliberate "stay silent" decision becomes chat noise — exactly the failure mode reported in #13248 (model reasons "don't reply in this group thread", and the gateway surfaces a spurious failure notice instead of staying quiet).

## Changes

- **`gateway/response_filters.py`** — add `SILENT_REPLY_TOKEN = "NO_REPLY"` (a first-class control token, cf. the equivalent silence token in comparable agent runtimes) as the single documented source of truth, and list its folded form explicitly in `LIVE_GATEWAY_SILENT_MARKERS` so the suppression contract no longer depends on canonicalizer internals.
- **`gateway/run.py`** — in `_handle_message_with_agent`, distinguish **intentional silence** (a recognized silence marker on a `failed=False` turn) from an **empty-generation failure**, and skip `_normalize_empty_agent_response()` for the former. A genuine empty failure still surfaces the user-facing notice.
- **Tests** — lock the canonical-token suppression contract independently of the canonicalizer (token alone, whitespace/case/wrapper variants), assert `failed=True` output passes through, assert prose merely *mentioning* `NO_REPLY` is still delivered, and add a handler-level regression for the intentional-silence-vs-empty-failure distinction.

## Verification

```
./venv/bin/python -m pytest tests/gateway/test_live_silent_responses.py tests/gateway/test_stream_consumer.py -q -o 'addopts='
# 114 passed
```

Broader local regression (gateway + cron silence paths): 424 passed.

## Relationship to other PRs / issues

- Closes #13248 (empty-response retry/notice on intentional group silence).
- Built on #9956 (kept verbatim as the delivery-suppression boundary).
- Complements the per-platform sentinel guards (#29932 Discord, #30936 Slack, #17566 Telegram/cron) by giving them a single shared token + the missing "don't re-inflate intentional silence" rule at the gateway boundary. Happy to coordinate ordering or fold those in if maintainers prefer one consolidated change.
