### PR TITLE
fix(gateway): prepend queued notes safely to multimodal messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -644,6 +644,32 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
     return message
 
 
+def _prepend_note_to_message(message: Any, note: str) -> Any:
+    """Prepend a one-shot system-style note to a user message.
+
+    ``message`` is normally a plain string, but gateway code can convert it
+    into a list of OpenAI-style content parts when native image attachments
+    are present.  Naively doing ``note + "\\n\\n" + message`` raises
+    ``TypeError: can only concatenate str (not "list") to str`` in that case.
+
+    Mirrors ``_prepend_note_to_message`` in ``cli.py`` (commit 043350dfd).
+    """
+    if not note:
+        return message
+    if isinstance(message, str):
+        return f"{note}\n\n{message}"
+    if isinstance(message, list):
+        parts = list(message)
+        for i, part in enumerate(parts):
+            if isinstance(part, dict) and part.get("type") == "text":
+                merged = dict(part)
+                merged["text"] = f"{note}\n\n{part.get('text', '')}"
+                parts[i] = merged
+                return parts
+        return [{"type": "text", "text": note}, *parts]
+    return message
+
+
 def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
@@ -17973,7 +17999,7 @@ class GatewayRunner:
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                message = _prepend_note_to_message(message, _msn)
 
             # Auto-continue: if the loaded history ends with a tool result,
             # the previous agent turn was interrupted mid-work (gateway
@@ -18056,7 +18082,7 @@ class GatewayRunner:
             if _pending_notes and session_key and session_key in _pending_notes:
                 _srn = _pending_notes.pop(session_key, None)
                 if _srn:
-                    message = _srn + "\n\n" + message
+                    message = _prepend_note_to_message(message, _srn)
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)


### PR DESCRIPTION
## Root cause

When a user sends an image to a vision-capable model, the gateway converts the
user message from a plain string into a list of OpenAI-style content parts
(`[{"type": "text", ...}, {"type": "image_url", ...}]`).

If a `/model` switch or `/reload-skills` note was queued for the same turn, the
gateway prepended it with:

```python
message = _msn + "\n\n" + message   # TypeError if message is a list
message = _srn + "\n\n" + message   # same
```

This crashes the agent thread with:

```
TypeError: can only concatenate str (not "list") to str
```

The identical bug was fixed in `cli.py` by commit `043350dfd`
(`fix(cli): prepend queued notes safely to multimodal messages`), but the two
parallel sites in `gateway/run.py` were not updated.

## Fix

Add `_prepend_note_to_message(message, note)` to `gateway/run.py`, mirroring
the helper added to `cli.py`:

- `str` message → `f"{note}\n\n{message}"` (unchanged behaviour)
- `list` message → note folded into the first `{"type": "text"}` part, or
  inserted as a new leading text block for image-only messages
- Unknown shape → returned unchanged (fail-open)

Replace both bare string concatenations with calls to this helper.

## Testing

- All 5 unit-level assertions on the new helper pass (str, empty-note, list-with-text, image-only-list, unknown-type).
- Full test suite passes (pre-existing unrelated failure in `test_anthropic_adapter` excluded).