### PR TITLE
fix(plugins): prevent disabled dashboard plugin API imports

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7513,6 +7513,29 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     return api_field
 
 
+def _dashboard_plugin_enabled(name: str, directory_name: str, *, source: str) -> bool:
+    """Return whether a dashboard plugin may load executable assets."""
+
+    if source != "user":
+        return True
+    try:
+        from hermes_cli.plugins_cmd import _get_disabled_set, _get_enabled_set
+
+        disabled = _get_disabled_set()
+        if name in disabled or directory_name in disabled:
+            return False
+        enabled = _get_enabled_set()
+        return name in enabled or directory_name in enabled
+    except Exception:
+        _log.warning(
+            "Plugin %s: could not read plugin enablement config; "
+            "dashboard extension will stay inactive",
+            name,
+            exc_info=True,
+        )
+        return False
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -7556,6 +7579,8 @@ def _discover_dashboard_plugins() -> list:
                 data = json.loads(manifest_file.read_text(encoding="utf-8"))
                 name = data.get("name", child.name)
                 if name in seen_names:
+                    continue
+                if not _dashboard_plugin_enabled(str(name), child.name, source=source):
                     continue
                 seen_names.add(name)
                 # Tab options: ``path`` + ``position`` for a new tab, optional

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -189,6 +189,11 @@ class TestDiscoveryScrubsApiField:
 
         def _make(name: str, manifest: dict) -> None:
             _write_plugin_manifest(tmp_path / "plugins", name, manifest)
+            (tmp_path / "config.yaml").write_text(
+                "plugins:\n"
+                "  enabled:\n"
+                f"    - {name}\n"
+            )
 
         return _make
 
@@ -232,6 +237,91 @@ class TestDiscoveryScrubsApiField:
         entry = next(p for p in plugins if p["name"] == "safe")
         assert entry["_api_file"] == "api.py"
         assert entry["has_api"] is True
+
+
+class TestUserDashboardPluginEnablement:
+    """User-installed dashboard extensions must honor plugins.enabled."""
+
+    @pytest.fixture
+    def isolated_user_plugins(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "home"
+        plugins_root = hermes_home / "plugins"
+        bundled_root = tmp_path / "empty-bundled"
+        bundled_root.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_bundled_plugins_dir",
+            lambda: bundled_root,
+        )
+        return hermes_home, plugins_root
+
+    def _write_dashboard_plugin(self, plugins_root: Path, name: str) -> Path:
+        dashboard_dir = _write_plugin_manifest(
+            plugins_root,
+            name,
+            {
+                "name": name,
+                "label": name,
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        (dashboard_dir / "api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        return dashboard_dir
+
+    def test_user_dashboard_plugin_api_stays_inactive_until_enabled(
+        self,
+        isolated_user_plugins,
+    ):
+        _hermes_home, plugins_root = isolated_user_plugins
+        self._write_dashboard_plugin(plugins_root, "disabled-dashboard")
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert "disabled-dashboard" not in {p["name"] for p in plugins}
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 0
+
+    def test_user_dashboard_plugin_api_imports_after_explicit_enable(
+        self,
+        isolated_user_plugins,
+    ):
+        hermes_home, plugins_root = isolated_user_plugins
+        self._write_dashboard_plugin(plugins_root, "trusted-dashboard")
+        (hermes_home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - trusted-dashboard\n"
+        )
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        trusted = next(p for p in plugins if p["name"] == "trusted-dashboard")
+        assert trusted["has_api"] is True
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 1
+        assert Path(spec.call_args.args[1]).name == "api.py"
+
+    def test_disabled_list_wins_over_enabled_for_dashboard_plugin(
+        self,
+        isolated_user_plugins,
+    ):
+        hermes_home, plugins_root = isolated_user_plugins
+        self._write_dashboard_plugin(plugins_root, "blocked-dashboard")
+        (hermes_home / "config.yaml").write_text(
+            "plugins:\n"
+            "  enabled:\n"
+            "    - blocked-dashboard\n"
+            "  disabled:\n"
+            "    - blocked-dashboard\n"
+        )
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert "blocked-dashboard" not in {p["name"] for p in plugins}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A third-party plugin repository can include `dashboard/manifest.json` and `dashboard/api.py`. If the operator installs the plugin but keeps the documented default disabled state, launching `hermes dashboard` still imports the Python backend module and can execute import-time code.

- Dashboard discovery scans user plugins independently of the main plugin enablement contract.
- API mounting imports discovered user plugin backend code despite disabled plugin state.

Make dashboard plugin discovery and API mounting honor the same explicit enabled/disabled state as the main plugin loader, or add a separate documented dashboard-plugin activation gate before importing user plugin Python code.

## Linked context
Closes #37942

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes_cli/web_server.py`
- `hermes_cli/plugins_cmd.py`
- `website/docs/user-guide/features/plugins.md`

### Files changed in this PR
- `hermes_cli/web_server.py`
- `tests/hermes_cli/test_project_plugin_rce_bypass.py`

### Behavior reproduced or verified
1. Use Hermes Agent latest upstream `main` at source receipt commit `5005b79bc31802690f8c06ab2a08d74e92a96af5`.
2. Install a local proof plugin whose dashboard folder contains `manifest.json` and an `api.py` that writes a marker at import time.
3. Leave the plugin disabled, matching the documented default install choice.
4. Launch the dashboard plugin discovery and API mounting path from `web_server.py`.
5. Observe the disabled plugin's `api.py` imports and writes the marker; expected result is no import or route registration until explicit enablement.

### Expected fixed behavior
Make dashboard plugin discovery and API mounting honor the same explicit enabled/disabled state as the main plugin loader, or add a separate documented dashboard-plugin activation gate before importing user plugin Python code.

## Tests and validation
- `bash scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py`
- Result: 1 files, 38 tests passed, 0 failed (100% complete) in 1.3s (20 workers) ===

## Environment
Hermes latest-main source receipt: `5005b79bc31802690f8c06ab2a08d74e92a96af5` on current `main`. Runtime prerequisite: user-installed dashboard plugin left disabled after install. Redaction complete; no secrets, tokens, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness receipt: `source_ready` for `upstream-main` at `5005b79bc31802690f8c06ab2a08d74e92a96af5` via `/tmp/hermes-source-receipt.json`; affected paths exist in the prepared latest-main checkout.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
