### PR TITLE
fix(kanban): route task model defaults

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -74,6 +74,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "model_override": t.model_override,
         "max_retries": t.max_retries,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
@@ -332,6 +333,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). Appended to the built-in "
                                "kanban-worker skill. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("-m", "--model", default=None, dest="model_override",
+                          help="Per-task model override passed to the worker "
+                               "as hermes -m/--model. Omit to use the "
+                               "assignee profile default or board-level "
+                               "assignee_defaults metadata.")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1355,6 +1361,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            model_override=getattr(args, "model_override", None),
             max_retries=max_retries,
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1992,6 +1992,89 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+
+
+def _normalize_task_skills(skills: Optional[Iterable[str]]) -> Optional[list[str]]:
+    """Normalize, validate, and dedupe task skill names preserving order."""
+    if skills is None:
+        return None
+    if isinstance(skills, str):
+        values: Iterable[str] = [skills]
+    else:
+        values = skills
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    # Collect all toolset-name confusions up front so the user sees the
+    # whole list at once. Agents that confuse skills with toolsets usually
+    # pass several at once (`skills=["web", "browser", "terminal"]`).
+    toolset_typos: list[str] = []
+    for s in values:
+        if not s:
+            continue
+        name = str(s).strip()
+        if not name:
+            continue
+        if "," in name:
+            raise ValueError(
+                f"skill name cannot contain comma: {name!r} "
+                f"(pass a list of separate names instead of a comma-joined string)"
+            )
+        if name.casefold() in KNOWN_TOOLSET_NAMES:
+            toolset_typos.append(name)
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        cleaned.append(name)
+    if toolset_typos:
+        quoted = ", ".join(repr(n) for n in toolset_typos)
+        noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+        raise ValueError(
+            f"{quoted} {noun}, not skill name(s). "
+            "Put toolsets in the assignee profile's `toolsets:` config "
+            "instead of per-task skills. Skills are named skill bundles "
+            "(e.g. `kanban-worker`, `blogwatcher`); toolsets are runtime "
+            "capabilities (e.g. `web`, `browser`, `terminal`)."
+        )
+    return cleaned
+
+
+def _merge_task_skills(
+    explicit: Optional[list[str]],
+    defaults: Optional[list[str]],
+) -> Optional[list[str]]:
+    if explicit is None and defaults is None:
+        return None
+    merged: list[str] = []
+    seen: set[str] = set()
+    for source in (explicit or []) + (defaults or []):
+        if source and source not in seen:
+            seen.add(source)
+            merged.append(source)
+    return merged
+
+
+def _board_assignee_defaults(
+    board_meta: dict[str, Any],
+    assignee: Optional[str],
+) -> dict[str, Any]:
+    if not assignee:
+        return {}
+    raw = board_meta.get("assignee_defaults")
+    if not isinstance(raw, dict):
+        return {}
+    direct = raw.get(assignee)
+    if isinstance(direct, dict):
+        return direct
+    for key, value in raw.items():
+        try:
+            normalized = _canonical_assignee(str(key))
+        except Exception:
+            continue
+        if normalized == assignee and isinstance(value, dict):
+            return value
+    return {}
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2009,6 +2092,7 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    model_override: Optional[str] = None,
     max_retries: Optional[int] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
@@ -2039,6 +2123,10 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``model_override`` is an optional per-task model route. If omitted,
+    board metadata may provide an assignee default via
+    ``assignee_defaults.<assignee>.model_override`` or ``.model``.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -2058,51 +2146,6 @@ def create_task(
         raise ValueError("branch_name is only valid for worktree workspaces")
     parents = tuple(p for p in parents if p)
 
-    # Normalise + validate skills: strip whitespace, drop empties, dedupe
-    # (preserving order). Refuse commas inside a single name so we don't
-    # invisibly splatter a comma-joined string into one argv slot — the
-    # `hermes --skills X,Y` comma syntax is handled in the dispatcher,
-    # not here.
-    skills_list: Optional[list[str]] = None
-    if skills is not None:
-        cleaned: list[str] = []
-        seen: set[str] = set()
-        # Collect all toolset-name confusions up front so the user sees the
-        # whole list at once. Raising on the first hit is friendly when the
-        # input has one mistake, but agents that confuse skills with toolsets
-        # usually pass several at once (`skills=["web", "browser", "terminal"]`)
-        # and serial-correcting one per failure round-trips wastes tokens.
-        toolset_typos: list[str] = []
-        for s in skills:
-            if not s:
-                continue
-            name = str(s).strip()
-            if not name:
-                continue
-            if "," in name:
-                raise ValueError(
-                    f"skill name cannot contain comma: {name!r} "
-                    f"(pass a list of separate names instead of a comma-joined string)"
-                )
-            if name.casefold() in KNOWN_TOOLSET_NAMES:
-                toolset_typos.append(name)
-                continue
-            if name in seen:
-                continue
-            seen.add(name)
-            cleaned.append(name)
-        if toolset_typos:
-            quoted = ", ".join(repr(n) for n in toolset_typos)
-            noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
-            raise ValueError(
-                f"{quoted} {noun}, not skill name(s). "
-                "Put toolsets in the assignee profile's `toolsets:` config "
-                "instead of per-task skills. Skills are named skill bundles "
-                "(e.g. `kanban-worker`, `blogwatcher`); toolsets are runtime "
-                "capabilities (e.g. `web`, `browser`, `terminal`)."
-            )
-        skills_list = cleaned
-
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -2118,6 +2161,26 @@ def create_task(
         if row:
             return row["id"]
 
+    board_slug = board if board else get_current_board()
+    board_meta = read_board_metadata(board_slug)
+    assignee_defaults = _board_assignee_defaults(board_meta, assignee)
+
+    default_model = (
+        assignee_defaults.get("model_override")
+        or assignee_defaults.get("model")
+    )
+    model_override = (
+        str(model_override).strip() or None
+        if model_override is not None
+        else None
+    )
+    if model_override is None and default_model:
+        model_override = str(default_model).strip() or None
+
+    explicit_skills = _normalize_task_skills(skills)
+    default_skills = _normalize_task_skills(assignee_defaults.get("skills"))
+    skills_list = _merge_task_skills(explicit_skills, default_skills)
+
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -2130,8 +2193,6 @@ def create_task(
     # containment guard in ``_cleanup_workspace`` is the safety rail, but
     # we also stop the bad state from being created in the first place.
     if workspace_path is None and workspace_kind in {"dir", "worktree"}:
-        board_slug = board if board else get_current_board()
-        board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
@@ -2179,8 +2240,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, model_override, max_retries, goal_mode, goal_max_turns, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2198,6 +2259,7 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        model_override,
                         int(max_retries) if max_retries is not None else None,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
@@ -2220,6 +2282,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "model_override": model_override,
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -166,6 +166,16 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_create_json_includes_model_override(kanban_home):
+    out = kc.run_slash(
+        "create 'routed task' --assignee builder "
+        "--model openrouter/qwen3 --skill github-pr-workflow --json"
+    )
+    payload = json.loads(out)
+    assert payload["model_override"] == "openrouter/qwen3"
+    assert payload["skills"] == ["github-pr-workflow"]
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import sys
@@ -202,6 +203,133 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.status == "ready"
     assert t.assignee == "alice"
     assert t.workspace_kind == "scratch"
+
+
+def test_create_task_persists_explicit_model_override(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="route to qwen",
+            assignee="builder",
+            model_override="openrouter/qwen3",
+        )
+        t = kb.get_task(conn, tid)
+
+    assert t is not None
+    assert t.model_override == "openrouter/qwen3"
+
+
+def test_create_task_inherits_board_assignee_defaults(kanban_home):
+    meta_path = kb.board_metadata_path("default")
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(
+        json.dumps({
+            "assignee_defaults": {
+                "builder": {
+                    "model_override": "openrouter/qwen3-default",
+                    "skills": ["kanban-builder", "github-pr-workflow"],
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="inherit routing",
+            assignee="builder",
+            skills=["test-driven-development", "kanban-builder"],
+        )
+        t = kb.get_task(conn, tid)
+
+    assert t is not None
+    assert t.model_override == "openrouter/qwen3-default"
+    assert t.skills == [
+        "test-driven-development",
+        "kanban-builder",
+        "github-pr-workflow",
+    ]
+
+
+def test_create_task_explicit_model_overrides_board_default(kanban_home):
+    meta_path = kb.board_metadata_path("default")
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(
+        json.dumps({
+            "assignee_defaults": {
+                "builder": {"model_override": "openrouter/qwen3-default"},
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="explicit route",
+            assignee="builder",
+            model_override="openrouter/qwen3-explicit",
+        )
+        t = kb.get_task(conn, tid)
+
+    assert t is not None
+    assert t.model_override == "openrouter/qwen3-explicit"
+
+
+def test_create_task_blank_model_falls_back_to_board_default(kanban_home):
+    meta_path = kb.board_metadata_path("default")
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(
+        json.dumps({
+            "assignee_defaults": {
+                "builder": {"model_override": "openrouter/qwen3-default"},
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="blank route",
+            assignee="builder",
+            model_override="   ",
+        )
+        t = kb.get_task(conn, tid)
+
+    assert t is not None
+    assert t.model_override == "openrouter/qwen3-default"
+
+
+def test_create_task_idempotency_fast_path_skips_new_default_validation(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="first routed task",
+            assignee="builder",
+            idempotency_key="same-task",
+        )
+
+        meta_path = kb.board_metadata_path("default")
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(
+            json.dumps({
+                "assignee_defaults": {
+                    "builder": {"skills": ["web"]},
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        retry_tid = kb.create_task(
+            conn,
+            title="retry routed task",
+            assignee="builder",
+            idempotency_key="same-task",
+        )
+
+    assert retry_tid == tid
 
 
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -768,6 +768,30 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_persists_model_override_and_skills(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "routed child",
+        "assignee": "peer",
+        "parents": [worker_env],
+        "model_override": "openrouter/qwen3",
+        "skills": ["github-code-review"],
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child is not None
+        assert child.model_override == "openrouter/qwen3"
+        assert child.skills == ["github-code-review"]
+    finally:
+        conn.close()
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen
@@ -1552,6 +1576,41 @@ def test_board_param_routes_create_to_alt_board(multi_board_env):
     # Does NOT land on default board.
     with kb.connect() as conn:
         assert kb.get_task(conn, new_tid) is None
+
+
+def test_board_param_create_uses_target_board_assignee_defaults(multi_board_env):
+    """A board-routed create must read defaults from the target board metadata."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    meta_path = kb.board_metadata_path("alt")
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(
+        json.dumps({
+            "assignee_defaults": {
+                "worker": {
+                    "model_override": "openrouter/alt-default",
+                    "skills": ["github-pr-workflow"],
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    out = kt._handle_create({
+        "title": "alt-defaulted",
+        "assignee": "worker",
+        "board": "alt",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, d
+
+    with kb.connect(board="alt") as conn:
+        child = kb.get_task(conn, d["task_id"])
+
+    assert child is not None
+    assert child.model_override == "openrouter/alt-default"
+    assert child.skills == ["github-pr-workflow"]
 
 
 def test_board_param_routes_list_to_alt_board(multi_board_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -769,6 +769,7 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"skills must be a list of skill names, got {type(skills).__name__}"
         )
+    model_override = args.get("model_override") or args.get("model")
     goal_mode, goal_bool_error = _parse_bool_arg(args, "goal_mode")
     if goal_bool_error:
         return tool_error(goal_bool_error)
@@ -809,6 +810,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                model_override=model_override,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -816,6 +818,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                board=board,
             )
             new_task = kb.get_task(conn, new_tid)
             return _ok(
@@ -1276,6 +1279,19 @@ KANBAN_CREATE_SCHEMA = {
                     "The names must match skills installed on the "
                     "assignee's profile."
                 ),
+            },
+            "model_override": {
+                "type": "string",
+                "description": (
+                    "Optional per-task model override. The dispatcher "
+                    "passes this to the worker as hermes -m/--model. "
+                    "Omit to use the assignee profile default or board "
+                    "assignee_defaults metadata."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": "Alias for model_override.",
             },
             "goal_mode": {
                 "type": "boolean",


### PR DESCRIPTION
## Approval brief

This PR centralizes Kanban worker model routing so task creators do not have to remember per-card `--model` details. It is scoped to Kanban task creation metadata/API surfaces and tests.

### What changed
- `create_task(..., model_override=...)` now persists a per-task model route.
- Board metadata can define assignee defaults:
  - `assignee_defaults.<assignee>.model_override`
  - `assignee_defaults.<assignee>.model` alias
  - `assignee_defaults.<assignee>.skills`
- Explicit task inputs behave predictably:
  - explicit non-blank `model_override` overrides board default model
  - blank model strings normalize to omitted and fall back to board defaults
  - explicit skills merge with default skills, deduped while preserving explicit order
- Idempotency behavior is preserved:
  - existing `idempotency_key` retries return the existing task before newly added board defaults are read/validated
- CLI support:
  - `/kanban create --model/-m <model>`
  - JSON output includes `model_override`
- Tool support:
  - `kanban_create` accepts `model_override`
  - `kanban_create` accepts `model` as an alias
  - board-routed tool calls pass `board=board` through to `create_task`, so target-board defaults are used

### Why this should merge
- Prevents silent worker misrouting in Kanban/decomposer flows.
- Moves routing policy from ad hoc per-card arguments into board/assignee config.
- Keeps existing behavior when no `model_override` or board defaults are configured.
- Preserves retry/idempotency semantics even if board defaults change after the original task is created.
- The dispatcher already honors `task.model_override` by passing `-m <model>`; this PR wires creation paths into that existing dispatch behavior.

### Reviewer checklist
- [ ] `hermes_cli/kanban_db.py`: idempotency fast path happens before default resolution/validation.
- [ ] `hermes_cli/kanban_db.py`: default resolution is board-scoped and explicit non-blank model override wins.
- [ ] `tools/kanban_tools.py`: `board` override is passed through to `create_task`, so target-board defaults are used.
- [ ] `hermes_cli/kanban.py`: CLI `--model/-m` reaches `create_task` and JSON exposes `model_override`.
- [ ] Tests cover DB, CLI, tool, explicit/default precedence, blank model fallback, skill merge, board-routed defaults, and idempotent retries.

## Verification

PR head commit: `900ba9796ebe1476af11cb1251cb0c474ba7bf14`  
Base tested against: `origin/main@f019a9c491b5f263d98c1966d54afff9914b15e8`

```bash
venv/bin/python -m py_compile \
  hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py
```

Passed.

```bash
venv/bin/python -m pytest \
  tests/hermes_cli/test_kanban_db.py::test_create_task_persists_explicit_model_override \
  tests/hermes_cli/test_kanban_db.py::test_create_task_inherits_board_assignee_defaults \
  tests/hermes_cli/test_kanban_db.py::test_create_task_explicit_model_overrides_board_default \
  tests/hermes_cli/test_kanban_db.py::test_create_task_blank_model_falls_back_to_board_default \
  tests/hermes_cli/test_kanban_db.py::test_create_task_idempotency_fast_path_skips_new_default_validation \
  tests/hermes_cli/test_kanban_cli.py::test_run_slash_create_json_includes_model_override \
  tests/tools/test_kanban_tools.py::test_create_persists_model_override_and_skills \
  tests/tools/test_kanban_tools.py::test_board_param_create_uses_target_board_assignee_defaults \
  -q -o 'addopts='
```

`8 passed`.

```bash
venv/bin/python -m pytest \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_cli.py \
  tests/tools/test_kanban_tools.py \
  -q -o 'addopts='
```

`343 passed, 1 warning`.

Warning was unrelated: `discord.player` imports deprecated stdlib `audioop`.

```bash
venv/bin/python -m ruff check \
  hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py \
  tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py
```

Passed.

```bash
git diff --check origin/main...HEAD
```

Passed.

## Independent review

- First review found a real blocker: board-routed `kanban_create` wrote to the target board DB but read assignee defaults from the current board.
  - Fixed by passing `board=board` from `kanban_create` into `kb.create_task`.
  - Covered by `test_board_param_create_uses_target_board_assignee_defaults`.
- Final review found a real blocker: new board default validation ran before idempotency lookup, so retries could fail if board defaults changed after the original task was created.
  - Fixed by moving the idempotency fast path before board metadata/default validation.
  - Covered by `test_create_task_idempotency_fast_path_skips_new_default_validation`.
- Follow-up independent review verdict: `PASS`; no blocking issues found.

## Current GitHub state

At last check, GitHub reported no PR checks for this branch. Branch protection is enabled on `main`, but no required status check contexts were returned by the API for `main`.
