### PR TITLE
fix(google_meet): poll 30s for Join button after page navigation

### DIFF
--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -816,19 +816,23 @@ def _looks_like_human_speaker(speaker: str, bot_guest_name: str) -> bool:
 def _click_join(page, state: _BotState) -> None:
     """Click 'Join now' or 'Ask to join' if either button is visible.
 
+    Polls for up to 30s waiting for the button to render after navigation.
     Flags ``lobby_waiting`` when we hit the "waiting for host to admit you"
     state so the agent can surface that in status.
     """
-    for label in ("Join now", "Ask to join"):
-        try:
-            btn = page.get_by_role("button", name=label, exact=False).first
-            if btn.count() and btn.is_visible():
-                btn.click(timeout=3_000)
-                if label == "Ask to join":
-                    state.set(lobby_waiting=True)
-                break
-        except Exception:
-            continue
+    deadline = time.time() + 30.0
+    while time.time() < deadline:
+        for label in ("Join now", "Ask to join"):
+            try:
+                btn = page.get_by_role("button", name=label, exact=False).first
+                if btn.count() and btn.is_visible():
+                    btn.click(timeout=3_000)
+                    if label == "Ask to join":
+                        state.set(lobby_waiting=True)
+                    return
+            except Exception:
+                continue
+        time.sleep(0.5)
 
 
 def _parse_duration(raw: str) -> Optional[float]:

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -817,8 +817,9 @@ def _click_join(page, state: _BotState) -> None:
     """Click 'Join now' or 'Ask to join' if either button is visible.
 
     Polls for up to 30s waiting for the button to render after navigation.
-    Flags ``lobby_waiting`` when we hit the "waiting for host to admit you"
-    state so the agent can surface that in status.
+    Sets ``lobby_waiting=True`` immediately after clicking 'Ask to join' —
+    indicating the bot has entered the admission lobby and is waiting for
+    the host. Actual admission is detected later by ``_detect_admission``.
     """
     deadline = time.time() + 30.0
     while time.time() < deadline:


### PR DESCRIPTION
## What

`_click_join` was called once immediately after `page.goto()`. If the
**Join now** / **Ask to join** button hadn't rendered yet the function
returned silently, leaving `--headed` Chromium parked on the pre-join
screen indefinitely — the bot never entered the call.

## Why

Meet's pre-join UI renders asynchronously; on slower connections or
machines the button can take several seconds to appear after the page
loads. A single fire-and-forget call races against that render and
loses most of the time in real-world usage.

## Fix

Wrap the button-click loop in a **30-second polling loop** (0.5 s
sleep between attempts). The function returns immediately on the first
successful click, so the happy path adds no latency. Only genuinely
slow loads pay the wait cost.

```python
deadline = time.time() + 30.0
while time.time() < deadline:
    for label in ("Join now", "Ask to join"):
        ...
        if visible: btn.click(); return
    time.sleep(0.5)
```

## Test plan

- Start the bot against a real Meet URL with `HERMES_MEET_HEADED=1`
  on a connection where the pre-join UI takes >1 s to render.
- Confirm `status.json` transitions to `joinAttemptedAt` set within
  ~1 s of the button appearing (previously it would never transition).
- Fast-render case: button appears immediately → bot joins without
  delay, same as before.

## Platforms tested

Linux (Ubuntu 22.04), Chromium via Playwright.