### PR TITLE
fix(google_meet): use trusted Playwright click to enable captions

### DIFF
--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -571,9 +571,16 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             _click_join(page, state)
 
             # Install caption observer and attempt to enable captions.
+            # Try the synthetic 'c' keystroke first (cheap, fire-and-forget);
+            # then a real Playwright click on the 'Turn on captions' button
+            # (trusted event, ignores synthetic events in modern Meet).
             try:
                 page.evaluate(_enable_captions_js())
                 state.set(captions_enabled_attempted=True)
+            except Exception:
+                pass
+            try:
+                _click_enable_captions(page, state)
             except Exception:
                 pass
             try:
@@ -829,6 +836,28 @@ def _click_join(page, state: _BotState) -> None:
                 break
         except Exception:
             continue
+
+
+def _click_enable_captions(page, state: _BotState) -> bool:
+    """Click the 'Turn on captions' button via Playwright.
+
+    Polls for up to 30s. Meet's captions button only renders once the bot
+    is actually in the call (post-lobby, post-prejoin). We use a real click
+    via Playwright so the resulting event is trusted (isTrusted=true);
+    Meet ignores synthetic keystrokes for app-level shortcuts.
+    """
+    deadline = time.time() + 30.0
+    while time.time() < deadline:
+        for label in ("Turn on captions", "Captions"):
+            try:
+                btn = page.get_by_role("button", name=label, exact=False).first
+                if btn.count() and btn.is_visible():
+                    btn.click(timeout=3_000)
+                    return True
+            except Exception:
+                continue
+        time.sleep(0.5)
+    return False
 
 
 def _parse_duration(raw: str) -> Optional[float]:


### PR DESCRIPTION
## What

Add `_click_enable_captions(page, state)` — a helper that polls for
the **Turn on captions** button via Playwright for up to 30 s and
clicks it with a trusted event. Wire it into `run_bot()` immediately
after the existing synthetic keystroke attempt.

## Why

Modern Google Meet ignores synthetic `KeyboardEvent` dispatches
(`isTrusted: false`) for app-level shortcuts. The existing
`_enable_captions_js()` fires a synthetic `c` keystroke which Meet
silently drops, so captions were **never auto-enabled** in practice —
the transcript stayed empty for the entire call.

A click dispatched by Playwright is a real browser-trusted input event
(`isTrusted: true`) and Meet honours it.

The synthetic keystroke is kept as a cheap fire-and-forget fallback
(harmless on older Meet versions that do accept it) before the real
Playwright click is attempted.

## Fix

```python
def _click_enable_captions(page, state: _BotState) -> bool:
    deadline = time.time() + 30.0
    while time.time() < deadline:
        for label in ("Turn on captions", "Captions"):
            try:
                btn = page.get_by_role("button", name=label, exact=False).first
                if btn.count() and btn.is_visible():
                    btn.click(timeout=3_000)
                    return True
            except Exception:
                continue
        time.sleep(0.5)
    return False
```

Call site (after existing synthetic attempt):
```python
try:
    _click_enable_captions(page, state)
except Exception:
    pass
```

## Test plan

- Join a Meet call with the bot (`HERMES_MEET_HEADED=1`).
- Confirm the captions toolbar button is clicked within ~30 s of joining.
- Confirm `transcript.txt` begins accumulating lines once someone speaks
  (previously the file stayed empty).
- Older Meet versions: synthetic keystroke still fires first; if it
  works the Playwright click is a no-op (button already toggled off).

## Platforms tested

Linux (Ubuntu 22.04), Chromium via Playwright.