### PR TITLE
fix(gateway): omit raw process output from notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2759,6 +2759,49 @@ def _drain_gateway_watch_events(completion_queue) -> "list[dict]":
     return watch_events
 
 
+def _format_process_completion_notice(
+    *,
+    session_id: str,
+    command: object,
+    exit_code: object,
+    completion_reason: object = None,
+    termination_source: object = None,
+) -> str:
+    """Chat-facing completion notice: status retained, raw output omitted.
+
+    Shares the status phrase and the redacting command shortener with the
+    synthetic [IMPORTANT: ...] injection so killed/lost/SIGTERM outcomes and
+    the command-redaction boundary can never diverge between the two surfaces.
+    """
+    from tools.process_registry import (
+        _process_log_hint,
+        _short_process_command,
+        process_status_phrase,
+    )
+
+    status, signal = process_status_phrase(
+        exit_code, completion_reason, termination_source
+    )
+    return (
+        f"[Background process {session_id} {status} "
+        f"(exit code {exit_code}{signal}).\n"
+        f"Command: {_short_process_command(command)}\n"
+        f"{_process_log_hint(session_id)}]"
+    )
+
+
+def _format_process_running_notice(*, session_id: str, command: object) -> str:
+    """Chat-facing still-running notice without the raw output tail."""
+    from tools.process_registry import _process_log_hint, _short_process_command
+
+    return (
+        f"[Background process {session_id} is still running.\n"
+        f"Command: {_short_process_command(command)}\n"
+        f"New output is available in the process log.\n"
+        f"{_process_log_hint(session_id)}]"
+    )
+
+
 # Module-level weak reference to the active GatewayRunner instance.
 # Used by tools (e.g. send_message) that need to route through a live
 # adapter for plugin platforms.  Set in GatewayRunner.__init__().
@@ -16856,24 +16899,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # (#10156) — a status check must not suppress this delivery turn.
                 from tools.process_registry import format_process_notification, process_registry as _pr_check
                 if agent_notify and not _pr_check.is_completion_consumed(session_id):
-                    from agent.redact import redact_terminal_output
-                    from tools.ansi_strip import strip_ansi
-                    _command = getattr(session, "command", "") or ""
-                    _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
-                    _raw = redact_terminal_output(_raw, _command)
-                    _command = _redact_gateway_user_facing_secrets(_command)
-                    # Truncate at line boundaries so notifications never start
-                    # mid-line (fixes #23284). Keep the last ~2000 chars but
-                    # snap to the nearest preceding newline, then prepend a
-                    # truncation marker when output was cut.
-                    _LIMIT = 2000
-                    if len(_raw) > _LIMIT:
-                        _tail = _raw[-_LIMIT:]
-                        _nl = _tail.find("\n")
-                        _tail = _tail[_nl + 1:] if _nl != -1 else _tail
-                        _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
-                    else:
-                        _out = _raw
+                    _command = _redact_gateway_user_facing_secrets(
+                        getattr(session, "command", "") or ""
+                    )
+                    # Raw output is deliberately not embedded (the formatter
+                    # points at process(action="log") instead) — multi-KB
+                    # tails made these synthetic turns unreadable and pushed
+                    # terminal noise into the transcript.
                     completion_evt = {
                         "type": "completion",
                         "session_id": session_id,
@@ -16890,7 +16922,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "exit_code": session.exit_code,
                         "completion_reason": getattr(session, "completion_reason", "exited"),
                         "termination_source": getattr(session, "termination_source", ""),
-                        "output": _out,
+                        "output": "",
                     }
                     synth_text = format_process_notification(completion_evt)
                     if not synth_text:
@@ -16911,15 +16943,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
-                    if new_output:
-                        from agent.redact import redact_terminal_output
-                        new_output = redact_terminal_output(
-                            new_output, getattr(session, "command", "") or ""
-                        )
-                    message_text = (
-                        f"[Background process {session_id} finished with exit code {session.exit_code}~ "
-                        f"Here's the final output:\n{new_output}]"
+                    message_text = _format_process_completion_notice(
+                        session_id=session_id,
+                        command=getattr(session, "command", "unknown"),
+                        exit_code=session.exit_code,
+                        completion_reason=getattr(session, "completion_reason", None),
+                        termination_source=getattr(session, "termination_source", None),
                     )
                     adapter = None
                     for p, a in self.adapters.items():
@@ -16941,15 +16970,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             elif has_new_output and notify_mode == "all" and not agent_notify:
                 # New output available -- deliver status update (only in "all" mode)
                 # Skip periodic updates for agent_notify watchers (they only care about completion)
-                new_output = session.output_buffer[-500:] if session.output_buffer else ""
-                if new_output:
-                    from agent.redact import redact_terminal_output
-                    new_output = redact_terminal_output(
-                        new_output, getattr(session, "command", "") or ""
-                    )
-                message_text = (
-                    f"[Background process {session_id} is still running~ "
-                    f"New output:\n{new_output}]"
+                message_text = _format_process_running_notice(
+                    session_id=session_id,
+                    command=getattr(session, "command", "unknown"),
                 )
                 adapter = None
                 for p, a in self.adapters.items():

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -154,7 +154,7 @@ class TestLoadBackgroundNotificationsMode:
             "result",
             [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
             1,
-            "finished with exit code 0",
+            "completed normally (exit code 0)",
         ),
         # error mode: exit 0 → no notification
         (
@@ -168,14 +168,14 @@ class TestLoadBackgroundNotificationsMode:
             "error",
             [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1)],
             1,
-            "finished with exit code 1",
+            "exited (exit code 1)",
         ),
         # all mode: exited → notifies
         (
             "all",
             [SimpleNamespace(output_buffer="ok\n", exited=True, exit_code=0)],
             1,
-            "finished with exit code 0",
+            "completed normally (exit code 0)",
         ),
     ],
 )
@@ -556,3 +556,71 @@ def test_parse_session_key_too_short():
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
     assert _parse_session_key("agent:cron:telegram:dm:123") is None
+
+
+# ---------------------------------------------------------------------------
+# Chat-facing notice content: output omitted, states retained, commands redacted
+# ---------------------------------------------------------------------------
+
+from gateway.run import (  # noqa: E402
+    _format_process_completion_notice,
+    _format_process_running_notice,
+)
+
+_SECRET = "sk-abc123456789012345678901234567890123"
+_SECRET_CMD = f'curl -H "Authorization: Bearer {_SECRET}" https://api.example.com/v1'
+
+
+class TestProcessNoticeContent:
+
+    def test_completion_notice_omits_output_and_points_at_log(self):
+        notice = _format_process_completion_notice(
+            session_id="proc_1", command="npm run build", exit_code=0
+        )
+        assert "proc_1 completed normally (exit code 0)" in notice
+        assert "Command: npm run build" in notice
+        assert 'process(action="log", session_id="proc_1")' in notice
+
+    def test_completion_notice_retains_kill_diagnostics(self):
+        notice = _format_process_completion_notice(
+            session_id="proc_2",
+            command="sleep 600",
+            exit_code=-15,
+            completion_reason="killed",
+            termination_source="process.kill",
+        )
+        assert "terminated by process.kill" in notice
+        assert "exit code -15, SIGTERM" in notice
+
+    def test_completion_notice_reports_lost_backend(self):
+        notice = _format_process_completion_notice(
+            session_id="proc_3",
+            command="sleep 600",
+            exit_code=None,
+            completion_reason="lost",
+        )
+        assert "marked lost because the process backend disappeared" in notice
+
+    def test_completion_notice_redacts_command_credentials(self):
+        notice = _format_process_completion_notice(
+            session_id="proc_4", command=_SECRET_CMD, exit_code=1
+        )
+        assert _SECRET not in notice
+        assert "proc_4" in notice
+
+    def test_running_notice_redacts_and_omits_output(self):
+        notice = _format_process_running_notice(
+            session_id="proc_5", command=_SECRET_CMD
+        )
+        assert _SECRET not in notice
+        assert "proc_5 is still running" in notice
+        assert 'process(action="log", session_id="proc_5")' in notice
+
+    def test_long_commands_are_shortened_after_redaction(self):
+        long_cmd = "echo " + "x" * 600
+        notice = _format_process_running_notice(session_id="proc_6", command=long_cmd)
+        command_line = next(
+            line for line in notice.splitlines() if line.startswith("Command: ")
+        )
+        assert len(command_line) <= 310
+        assert command_line.endswith("…")

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -452,7 +452,7 @@ def test_unobserved_normal_completion_still_notifies(monkeypatch):
     adapter.handle_message.assert_awaited_once()
 
 
-def test_autonomous_completion_redacts_real_command_and_output_secrets(monkeypatch):
+def test_autonomous_completion_omits_output_and_redacts_command_secret(monkeypatch):
     import agent.redact as redact_module
     import tools.process_registry as pr_module
 
@@ -491,4 +491,8 @@ def test_autonomous_completion_redacts_real_command_and_output_secrets(monkeypat
 
     delivered = adapter.handle_message.await_args.args[0]
     assert secret not in delivered.text
-    assert "HOME=/home/user" in delivered.text
+    assert "HOME=/home/user" not in delivered.text
+    assert (
+        'process(action="log", session_id="proc_autonomous_redaction")'
+        in delivered.text
+    )

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1201,7 +1201,23 @@ def test_format_completion_event():
     assert "[IMPORTANT: Background process proc_abc completed normally" in result
     assert "exit code 0" in result
     assert "Command: sleep 5" in result
-    assert "Output:\ndone]" in result
+    # Raw output is omitted from the injection; the notice points at the
+    # process log instead.
+    assert "done" not in result.replace("completed normally", "")
+    assert 'process(action="log", session_id="proc_abc")' in result
+
+
+def test_format_completion_event_redacts_command_credentials():
+    evt = {
+        "type": "completion",
+        "session_id": "proc_secret",
+        "command": 'curl -H "Authorization: Bearer sk-abc123456789012345678901234567890123" https://api.example.com',
+        "exit_code": 0,
+        "output": "",
+    }
+    result = format_process_notification(evt)
+    assert "sk-abc123456789012345678901234567890123" not in result
+    assert "proc_secret" in result
 
 
 def test_format_killed_completion_event_names_source_and_signal():

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2165,6 +2165,58 @@ def _format_async_delegation(evt: dict) -> str:
     return "\n".join(lines)
 
 
+def _short_process_command(command: object, *, limit: int = 300) -> str:
+    """Single-line, redacted command snippet safe for chat-sized notices.
+
+    Redaction runs BEFORE shortening so the truncation boundary can never
+    bisect a secret into a surviving prefix. Same policy as
+    _redact_process_result: commands routinely carry inline credentials
+    (curl -H "Authorization: ...", DATABASE_URL=..., etc.).
+    """
+    from agent.redact import redact_sensitive_text
+
+    text = str(command or "unknown").replace("\r", " ").replace("\n", " ").strip()
+    text = redact_sensitive_text(text, code_file=True)
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(0, limit - 1)]}…"
+
+
+def _process_log_hint(session_id: object) -> str:
+    sid = str(session_id or "unknown")
+    return (
+        "Output omitted to keep the transcript readable; read it with "
+        f'process(action="log", session_id="{sid}").'
+    )
+
+
+def process_status_phrase(
+    exit_code: object,
+    completion_reason: object = None,
+    termination_source: object = None,
+) -> "tuple[str, str]":
+    """(human status, signal suffix) for a finished background process.
+
+    Shared by the synthetic [IMPORTANT: ...] injection and the chat-facing
+    notices in gateway/run.py so killed/lost/SIGTERM outcomes can never be
+    collapsed into a generic "completed" in one surface but not the other.
+    """
+    signal = ", SIGTERM" if exit_code in {-15, 143, "-15", "143"} else ""
+    reason = completion_reason or "exited"
+    source = termination_source or ""
+    if reason == "killed":
+        status = f"terminated by {source or 'Hermes'}"
+    elif reason == "lost":
+        status = "marked lost because the process backend disappeared"
+    elif reason == "failed_start":
+        status = "failed to start"
+    elif exit_code == 0:
+        status = "completed normally"
+    else:
+        status = "exited"
+    return status, signal
+
+
 def format_process_notification(evt: dict) -> "str | None":
     """Format a process notification event into a [IMPORTANT: ...] message.
 
@@ -2173,7 +2225,7 @@ def format_process_notification(evt: dict) -> "str | None":
     """
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
-    _cmd = evt.get("command", "unknown")
+    _cmd = _short_process_command(evt.get("command", "unknown"))
 
     if evt_type == "watch_disabled":
         return f"[IMPORTANT: {evt.get('message', '')}]"
@@ -2197,27 +2249,20 @@ def format_process_notification(evt: dict) -> "str | None":
         return _format_async_delegation(evt)
 
     _exit = evt.get("exit_code", "?")
-    _out = evt.get("output", "")
-    _reason = evt.get("completion_reason") or "exited"
-    _source = evt.get("termination_source") or ""
-    _signal = ""
-    if _exit in {-15, 143, "-15", "143"}:
-        _signal = ", SIGTERM"
-    if _reason == "killed":
-        _status = f"terminated by {_source or 'Hermes'}"
-    elif _reason == "lost":
-        _status = "marked lost because the process backend disappeared"
-    elif _reason == "failed_start":
-        _status = "failed to start"
-    elif _exit == 0:
-        _status = "completed normally"
-    else:
-        _status = "exited"
+    _status, _signal = process_status_phrase(
+        _exit,
+        evt.get("completion_reason"),
+        evt.get("termination_source"),
+    )
+    # Raw stdout/stderr is deliberately NOT embedded: multi-KB tails made
+    # these injections unreadable and leaked terminal noise into transcripts.
+    # The status/reason/signal diagnostics above are retained in full; the
+    # output itself stays one process(action="log") away.
     return (
         f"[IMPORTANT: Background process {_sid} {_status} "
         f"(exit code {_exit}{_signal}).\n"
         f"Command: {_cmd}\n"
-        f"Output:\n{_out}]"
+        f"{_process_log_hint(_sid)}]"
     )
 
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -434,10 +434,14 @@ display:
 
 | Mode | What you receive |
 |------|-----------------|
-| `all` | Running-output updates **and** the final completion message (default) |
+| `all` | New-output notices **and** the final completion message (default) |
 | `result` | Only the final completion message (regardless of exit code) |
 | `error` | Only the final message when the exit code is non-zero |
 | `off` | No process watcher messages at all |
+
+Notices carry the process status (including kills and signals) and a
+shortened, redacted command line — never the raw stdout/stderr, which stays
+available in full via `process(action="log", session_id=...)`.
 
 You can also set this via environment variable:
 


### PR DESCRIPTION
## Summary

Stops background process watcher notifications from pasting raw stdout and stderr into chat and persisted Desktop or TUI transcripts.

Completion and running notices now include:

- Process ID
- Exit code for completion notices
- A single-line command snippet
- A process log retrieval hint

Full output remains available through the process tool. Watch-pattern match notifications still include the matched snippet and remain out of scope.

## Verification

- Completion delivery, background notification, and process registry suites passed with 166 tests.
- Ruff and git diff check passed.
- The reviewed production and documentation patch rebased onto current main without alteration.
- A test-only follow-up aligned the older completion-delivery expectation with the reviewed output-omission contract.
