### PR TITLE
fix(profile-dist): restrict USER_OWNED_EXCLUDE copytree ignore to root level

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -557,6 +557,20 @@ def _copy_dist_payload(
     """
     target.mkdir(parents=True, exist_ok=True)
 
+    # Build an ignore function that only excludes USER_OWNED_EXCLUDE entries
+    # at the root of the staged tree — same two-tier pattern used by
+    # ``_clone_all_copytree_ignore`` and ``_default_export_ignore``.
+    # Nested directories named ``bin`` (e.g. ``control-plane/bin/``) must
+    # NOT be filtered; only the top-level ``bin/`` of a default Hermes
+    # installation (which contains host-specific binaries like tirith) is
+    # infrastructure, not distribution content.
+    staged_resolved = staged.resolve()
+
+    def _copytree_ignore(directory: str, names: list[str]) -> list[str]:
+        if Path(directory).resolve() == staged_resolved:
+            return [n for n in names if n in USER_OWNED_EXCLUDE]
+        return []
+
     for entry in staged.iterdir():
         name = entry.name
 
@@ -573,11 +587,7 @@ def _copy_dist_payload(
         if entry.is_dir():
             if dest.exists():
                 shutil.rmtree(dest)
-            shutil.copytree(
-                entry,
-                dest,
-                ignore=lambda d, names: [n for n in names if n in USER_OWNED_EXCLUDE],
-            )
+            shutil.copytree(entry, dest, ignore=_copytree_ignore)
         else:
             shutil.copy2(entry, dest)
 

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -354,6 +354,31 @@ class TestInstall:
 # ===========================================================================
 
 
+    @pytest.mark.parametrize(
+        "exclude_name",
+        ["bin", "logs", "cache", "sessions", "memories"],
+        ids=lambda n: f"nested_{n}",
+    )
+    def test_install_preserves_nested_exclude_named_dirs(
+        self, profile_env, exclude_name: str
+    ):
+        """Directories whose names appear in ``USER_OWNED_EXCLUDE`` (e.g.
+        ``bin``, ``logs``, ``cache``) must only be filtered at the **root** of
+        the staged tree.  Nested paths like ``tools/bin/`` or ``scripts/logs/``
+        are distribution content and must be copied verbatim."""
+        staged = _make_staging_dir(profile_env, "src")
+        parent = staged / "tools"
+        nested = parent / exclude_name
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "helper.py").write_text("# helper\n")
+
+        plan = install_distribution(str(staged), name=f"nested_{exclude_name}")
+
+        result = plan.target_dir / "tools" / exclude_name
+        assert result.is_dir(), f"tools/{exclude_name} must be copied, not filtered"
+        assert (result / "helper.py").read_text() == "# helper\n"
+
+
 class TestUpdate:
 
     def test_update_preserves_user_data(self, profile_env):
@@ -410,6 +435,39 @@ class TestUpdate:
         update_distribution("t3", force_config=True)
         assert "claude" in (plan.target_dir / "config.yaml").read_text()
         assert "gpt-5" not in (plan.target_dir / "config.yaml").read_text()
+
+    @pytest.mark.parametrize(
+        "exclude_name",
+        ["bin", "logs", "cache", "sessions", "memories"],
+        ids=lambda n: f"nested_{n}",
+    )
+    def test_update_preserves_nested_exclude_named_dirs(
+        self, profile_env, exclude_name: str
+    ):
+        """Update must not strip nested directories whose names happen to
+        appear in ``USER_OWNED_EXCLUDE``.  The root-level exclusion is only
+        for the host Hermes installation infrastructure."""
+        staged = _make_staging_dir(profile_env, "src")
+        nested = staged / "tools" / exclude_name
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "file.py").write_text("v1\n")
+
+        dist_name = f"up_nested_{exclude_name}"
+        plan = install_distribution(str(staged), name=dist_name)
+
+        result = plan.target_dir / "tools" / exclude_name
+        assert result.is_dir()
+        assert (result / "file.py").read_text() == "v1\n"
+
+        # Bump the source: update existing file, add a new one
+        (nested / "file.py").write_text("v2\n")
+        (nested / "extra.py").write_text("new\n")
+
+        update_distribution(dist_name, force_config=False)
+
+        assert result.is_dir(), f"tools/{exclude_name} must survive update"
+        assert (result / "file.py").read_text() == "v2\n"
+        assert (result / "extra.py").read_text() == "new\n"
 
     def test_update_missing_manifest_errors(self, profile_env):
         # Make a profile without a manifest; update must refuse


### PR DESCRIPTION
## What does this PR do?

`_copy_dist_payload` used an inline lambda as the `shutil.copytree` ignore callback that checked `USER_OWNED_EXCLUDE` at **every directory depth**. Because `USER_OWNED_EXCLUDE` contains common directory names like `bin`, `logs`, `cache`, `sessions`, and `memories`, any nested directory sharing one of those names (e.g. `tools/bin/`, `scripts/logs/`) was silently dropped during install and update.

The fix replaces the lambda with a closure (`_copytree_ignore`) that applies `USER_OWNED_EXCLUDE` filtering **only at the root of the staged tree**, matching the two-tier pattern already used by `_clone_all_copytree_ignore` and `_default_export_ignore` in `profiles.py`.

## Related Issue

Fixes #37954

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/profile_distribution.py`: replaced the depth-unaware `ignore` lambda in `_copy_dist_payload` with a `_copytree_ignore` closure that only filters at the staged-tree root
- `tests/hermes_cli/test_profile_distribution.py`: added parametrized tests (`bin`, `logs`, `cache`, `sessions`, `memories`) for both install and update paths

## How to Test

1. Run the test suite: `pytest tests/hermes_cli/test_profile_distribution.py -v`
2. All 74 tests should pass, including the 10 new parametrized cases (`test_install_preserves_nested_exclude_named_dirs[nested_*]` and `test_update_preserves_nested_exclude_named_dirs[nested_*]`)
3. To reproduce the original bug: revert the `_copytree_ignore` change, re-run — the nested directory tests will fail

## Checklist

### Code

- [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.14

### Documentation & Housekeeping

- [x] N/A — no documentation, config, or tool description changes needed