### PR TITLE
feat: add Pinecone skill for agent RAG and memory

### DIFF
--- a/optional-skills/research/pinecone/SKILL.md
+++ b/optional-skills/research/pinecone/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: pinecone
+description: Managed vector database for persistent semantic retrieval in RAG pipelines, agent memory, and multi-domain knowledge bases. Use when building agents that need sub-second similarity search over embedded documents, conversations, code, or multimodal data. Covers serverless and pod-based indexes, dense/sparse/hybrid search, namespace isolation, metadata filtering, and multimodal retrieval with voyage-multimodal-3.
+version: 1.0.0
+author: immuhammadfurqan
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [pinecone, vector-database, rag, embeddings, semantic-search, retrieval, memory, hybrid-search, multimodal]
+    related_skills: [bioinformatics, drug-discovery]
+    category: research
+---
+
+# Pinecone — Vector Database for Agent RAG & Memory
+
+## Overview
+
+Pinecone is a managed vector database providing millisecond-latency similarity search at scale. For Hermes agents it serves two key roles:
+
+1. **Long-term memory** — persist and retrieve conversation history, user preferences, and learned knowledge across sessions beyond what fits in context
+2. **RAG retrieval** — semantic search over documents, codebases, research papers, or any corpus the agent needs to reason over
+
+Pinecone is cloud-hosted and accessed via API — no local infrastructure required.
+
+**Tested with:** `pinecone>=6.0.0`
+
+## When to Use This Skill
+
+- Agent needs to search a large knowledge base that doesn't fit in context
+- Building a RAG pipeline: embed documents → store in Pinecone → retrieve at query time
+- Persistent agent memory across sessions (beyond Hermes's built-in memory)
+- Semantic similarity search (find similar documents, code snippets, past conversations)
+- Hybrid search combining semantic meaning with exact keyword matching
+- Multi-tenant knowledge isolation (separate namespaces per user/project/domain)
+
+## Installation
+
+```bash
+# Core SDK
+uv pip install "pinecone>=6.0.0"
+
+# For hybrid (dense + sparse BM25) search
+uv pip install "pinecone[grpc]>=6.0.0" pinecone-text
+
+# Embedding model companions (choose what you need)
+uv pip install voyageai openai sentence-transformers
+```
+
+## Quick Start
+
+### Initialize and create an index
+
+```python
+import os
+from pinecone import Pinecone, ServerlessSpec
+
+pc = Pinecone(api_key=os.environ["PINECONE_API_KEY"])
+
+# Create serverless index (recommended default)
+if "agent-memory" not in [idx.name for idx in pc.list_indexes()]:
+    pc.create_index(
+        name="agent-memory",
+        dimension=1024,           # Match your embedding model's output dim
+        metric="cosine",          # cosine | dotproduct | euclidean
+        spec=ServerlessSpec(cloud="aws", region="us-east-1")
+    )
+
+index = pc.Index("agent-memory")
+```
+
+> **Security:** Always load API keys from environment variables. Never hardcode keys in source files or skills.
+
+### Upsert vectors
+
+```python
+vectors = [
+    {
+        "id": "doc_001",
+        "values": embedding_1024d,   # list[float]
+        "metadata": {
+            "source": "conversation",
+            "session_id": "sess_abc",
+            "text": "User prefers concise responses under 200 words",
+            "timestamp": "2026-05-01"
+        }
+    }
+]
+
+index.upsert(vectors=vectors, namespace="user-prefs")
+```
+
+### Query with metadata filtering
+
+```python
+results = index.query(
+    vector=query_embedding,
+    top_k=5,
+    namespace="user-prefs",
+    include_metadata=True,
+    filter={"source": {"$eq": "conversation"}}
+)
+
+for match in results["matches"]:
+    print(f"{match['score']:.4f}  {match['metadata']['text']}")
+```
+
+## Core Capabilities
+
+### Index Management
+
+```python
+# List all indexes
+indexes = [idx.name for idx in pc.list_indexes()]
+
+# Describe index stats
+stats = index.describe_index_stats()
+print(f"Total vectors: {stats['total_vector_count']}")
+for ns, info in stats["namespaces"].items():
+    print(f"  {ns}: {info['vector_count']} vectors")
+
+# Delete index
+pc.delete_index("my-index")
+```
+
+### Batch Upsert (for large datasets)
+
+```python
+def batch_upsert(index, vectors, namespace="", batch_size=100):
+    """Upsert vectors in batches — Pinecone limit is 100 vectors per request."""
+    total = (len(vectors) + batch_size - 1) // batch_size
+    for i in range(0, len(vectors), batch_size):
+        batch = vectors[i:i + batch_size]
+        index.upsert(vectors=batch, namespace=namespace)
+        print(f"Batch {i // batch_size + 1}/{total} upserted")
+```
+
+### Namespace Strategy for Agent Workflows
+
+Namespaces isolate data within a single index — ideal for multi-user or multi-project agents:
+
+```python
+# Separate by data type
+index.upsert(vectors=memory_vecs,   namespace="agent-memory")
+index.upsert(vectors=doc_vecs,      namespace="documents")
+index.upsert(vectors=code_vecs,     namespace="codebase")
+
+# Separate by project or user
+index.upsert(vectors=vecs, namespace=f"project-{project_id}")
+index.upsert(vectors=vecs, namespace=f"user-{user_id}")
+
+# Separate by environment
+index.upsert(vectors=vecs, namespace="production")
+index.upsert(vectors=vecs, namespace="dev")
+```
+
+### Metadata Filtering
+
+Supported operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`
+
+```python
+results = index.query(
+    vector=query_emb,
+    top_k=10,
+    filter={
+        "source":   {"$in": ["github", "confluence"]},
+        "year":     {"$gte": 2024},
+        "language": {"$eq": "python"}
+    },
+    include_metadata=True
+)
+```
+
+### Hybrid Search (Dense + Sparse BM25)
+
+Critical when exact keywords matter alongside semantic meaning — function names, API endpoints, error codes:
+
+```python
+from pinecone_text.sparse import BM25Encoder
+
+# Fit BM25 on your corpus once, then save
+bm25 = BM25Encoder()
+bm25.fit(corpus_texts)
+bm25.dump("bm25_model.json")
+bm25 = BM25Encoder().load("bm25_model.json")
+
+def hybrid_query(query_text: str, alpha: float = 0.5, top_k: int = 10):
+    """
+    alpha=1.0 -> pure dense (semantic)
+    alpha=0.0 -> pure sparse (keyword)
+    alpha=0.5 -> balanced hybrid
+    """
+    dense_vec  = dense_model.encode(query_text).tolist()
+    sparse_vec = bm25.encode_queries(query_text)
+
+    return index.query(
+        vector=[v * alpha for v in dense_vec],
+        sparse_vector={
+            "indices": sparse_vec["indices"],
+            "values":  [v * (1 - alpha) for v in sparse_vec["values"]]
+        },
+        top_k=top_k,
+        include_metadata=True
+    )
+```
+
+**Note:** Hybrid search requires `metric="dotproduct"` on index creation.
+
+### Multimodal Retrieval (voyage-multimodal-3)
+
+For agents working with both text and images — diagrams, screenshots, documents with figures:
+
+```python
+import voyageai
+from PIL import Image
+
+voyage = voyageai.Client(api_key=os.environ["VOYAGE_API_KEY"])
+
+result = voyage.multimodal_embed(
+    inputs=[[text_description, Image.open("screenshot.png")]],
+    model="voyage-multimodal-3",
+    input_type="document"
+)
+embedding = result.embeddings[0]  # 1024-dim, ready to upsert
+```
+
+## Agent RAG Pipeline
+
+Complete RAG pipeline for grounding agent responses in a knowledge base:
+
+```python
+import os
+from pinecone import Pinecone
+import voyageai
+from openai import OpenAI
+
+pc     = Pinecone(api_key=os.environ["PINECONE_API_KEY"])
+voyage = voyageai.Client(api_key=os.environ["VOYAGE_API_KEY"])
+oai    = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+index  = pc.Index("agent-knowledge")
+
+def rag_query(question: str, namespace: str = "", top_k: int = 5) -> str:
+    """Retrieve context from Pinecone and generate a grounded answer."""
+    # 1. Embed the question
+    query_emb = voyage.embed(
+        [question], model="voyage-large-2", input_type="query"
+    ).embeddings[0]
+
+    # 2. Retrieve relevant chunks
+    results = index.query(
+        vector=query_emb,
+        top_k=top_k,
+        namespace=namespace,
+        include_metadata=True
+    )
+
+    # 3. Build context
+    context = "\n\n---\n\n".join(
+        f"[Score: {m['score']:.3f}]\n{m['metadata'].get('text', '')}"
+        for m in results["matches"]
+    )
+
+    # 4. Generate grounded answer
+    response = oai.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content":
+                "Answer based only on the provided context. "
+                "If the context doesn't contain enough information, say so."},
+            {"role": "user", "content":
+                f"Context:\n{context}\n\nQuestion: {question}"}
+        ]
+    )
+    return response.choices[0].message.content
+```
+
+## Vector Operations Reference
+
+```python
+# Fetch by ID
+fetched = index.fetch(ids=["doc_001", "doc_002"], namespace="documents")
+
+# Update metadata
+index.update(
+    id="doc_001",
+    set_metadata={"reviewed": True, "quality": "high"},
+    namespace="documents"
+)
+
+# Delete specific vectors
+index.delete(ids=["doc_003"], namespace="documents")
+
+# Clear a namespace entirely
+index.delete(delete_all=True, namespace="dev")
+```
+
+## Dimension Selection by Embedding Model
+
+| Model | Dimension | Use Case |
+|---|---|---|
+| voyage-multimodal-3 | 1024 | Text + image (multimodal) |
+| voyage-large-2 | 1536 | High-quality text retrieval |
+| text-embedding-3-large (OpenAI) | 3072 | General-purpose text |
+| text-embedding-3-small (OpenAI) | 1536 | Lighter general-purpose text |
+| all-mpnet-base-v2 | 768 | Open-source general text |
+
+**Always match index dimension to your embedding model.** Dimension cannot be changed after index creation — only by recreating the index.
+
+## Troubleshooting
+
+**Dimension mismatch on upsert:**
+```python
+emb = model.embed("test")
+info = pc.describe_index("my-index")
+assert len(emb) == info.dimension, f"Model dim {len(emb)} != index dim {info.dimension}"
+```
+
+**Low retrieval quality:**
+- Use `input_type="query"` for queries, `"document"` for corpus (voyage, cohere)
+- Try hybrid search if exact terms are being missed
+- Check metadata filters aren't too restrictive
+
+**Slow upsert for large corpora:**
+- Switch to `PineconeGRPC` client (~3x faster ingest)
+- Always batch in groups of ≤100 vectors
+
+**Rate limits during ingestion:**
+- The embedding API (not Pinecone) is usually the bottleneck
+- Add exponential backoff on embedding calls
+
+## Resources
+
+- **Pinecone Docs**: https://docs.pinecone.io
+- **Python SDK**: https://github.com/pinecone-io/pinecone-python-client
+- **Voyage AI**: https://docs.voyageai.com
+- **pinecone-text (BM25)**: https://github.com/pinecone-io/pinecone-text
+- **Agent Skills Standard**: https://agentskills.io

--- a/optional-skills/research/pinecone/references/hybrid_search.md
+++ b/optional-skills/research/pinecone/references/hybrid_search.md
@@ -1,0 +1,129 @@
+# Hybrid Search: Dense + Sparse BM25
+
+Hybrid search combines semantic similarity (dense embeddings) with keyword relevance (sparse BM25). It's especially valuable in scientific retrieval where exact terminology matters — gene names, compound IDs, assay types, drug names — but you also need semantic understanding.
+
+## When to Use Hybrid
+
+**Use hybrid when:**
+- Your queries contain exact technical terms (e.g., `BRCA1`, `EGFR-T790M`, `IL-6`, `tofacitinib`)
+- Pure dense search misses keyword matches due to embedding ambiguity
+- Users mix natural language and identifiers (`"BRCA1 variants in triple-negative breast cancer"`)
+
+**Stick with dense-only when:**
+- Queries are purely conceptual (`"mechanisms of immune evasion"`)
+- Your corpus has no critical technical identifiers
+- Latency budget is tight (hybrid is slightly slower)
+
+## Setup
+
+### 1. Create a dotproduct index
+
+Hybrid search **requires** `metric="dotproduct"`:
+
+```python
+from pinecone import Pinecone, ServerlessSpec
+
+pc.create_index(
+    name="hybrid-literature",
+    dimension=1024,
+    metric="dotproduct",
+    spec=ServerlessSpec(cloud="aws", region="us-east-1")
+)
+```
+
+### 2. Fit a BM25 encoder on your corpus
+
+```python
+from pinecone_text.sparse import BM25Encoder
+
+bm25 = BM25Encoder()
+bm25.fit(corpus_texts)  # corpus_texts: List[str]
+bm25.dump("bm25_model.json")
+
+# Later, reload
+bm25 = BM25Encoder().load("bm25_model.json")
+```
+
+**Important:** Fit BM25 on a representative sample of your corpus (10k-100k docs is usually enough). Re-fit if your corpus characteristics change substantially.
+
+### 3. Upsert dense + sparse vectors together
+
+```python
+from sentence_transformers import SentenceTransformer
+
+dense_model = SentenceTransformer("all-mpnet-base-v2")  # 768-dim
+
+vectors = []
+for doc in documents:
+    dense_vec  = dense_model.encode(doc["text"], normalize_embeddings=True).tolist()
+    sparse_vec = bm25.encode_documents(doc["text"])
+    # sparse_vec is dict: {"indices": [...], "values": [...]}
+
+    vectors.append({
+        "id":            doc["id"],
+        "values":        dense_vec,
+        "sparse_values": sparse_vec,
+        "metadata":      doc["metadata"]
+    })
+
+# Batch upsert
+for i in range(0, len(vectors), 100):
+    index.upsert(vectors=vectors[i:i + 100])
+```
+
+## Querying with Alpha Blending
+
+The `alpha` parameter controls the dense/sparse balance:
+
+- `alpha = 1.0` → pure dense (semantic only)
+- `alpha = 0.0` → pure sparse (keyword only)
+- `alpha = 0.5` → equal weight
+
+```python
+def hybrid_query(query_text: str, alpha: float = 0.5, top_k: int = 10,
+                 namespace: str = "", filter: dict = None):
+    dense_vec  = dense_model.encode(query_text, normalize_embeddings=True).tolist()
+    sparse_vec = bm25.encode_queries(query_text)
+
+    # Scale dense by alpha, sparse by (1 - alpha)
+    dense_scaled  = [v * alpha for v in dense_vec]
+    sparse_scaled = {
+        "indices": sparse_vec["indices"],
+        "values":  [v * (1.0 - alpha) for v in sparse_vec["values"]]
+    }
+
+    return index.query(
+        vector=dense_scaled,
+        sparse_vector=sparse_scaled,
+        top_k=top_k,
+        namespace=namespace,
+        filter=filter,
+        include_metadata=True
+    )
+```
+
+**Note** that `bm25.encode_documents()` and `bm25.encode_queries()` use slightly different normalizations — always use `encode_queries()` for the query side.
+
+## Tuning Alpha
+
+Start at `alpha = 0.5` and adjust based on observed retrieval quality:
+
+| If retrieval is missing... | Try |
+|---|---|
+| Exact gene names, IDs, drug names | Lower alpha (more sparse weight): 0.3 |
+| Conceptually related content | Higher alpha (more dense weight): 0.7 |
+
+**Empirical:** for biomedical literature retrieval, `alpha = 0.4` often outperforms pure dense or pure sparse on benchmarks like BEIR/SciFact.
+
+## Limitations
+
+- BM25 is corpus-specific. A BM25 model fit on cancer literature won't transfer well to materials science.
+- Sparse vectors increase storage costs marginally (~10-20%).
+- Hybrid query latency is slightly higher (typically 10-30ms more than dense-only).
+- You cannot retroactively add sparse vectors to an existing dense-only index — you must recreate with `metric="dotproduct"` and re-upsert.
+
+## Alternative: SPLADE
+
+For higher-quality sparse retrieval than BM25, consider SPLADE (Sparse Lexical and Expansion model). Pinecone supports SPLADE vectors with the same `sparse_values` API — see `pinecone-text` documentation for the encoder.
+
+SPLADE typically improves recall by 5-15% over BM25 on scientific benchmarks but requires GPU inference for encoding.

--- a/optional-skills/research/pinecone/references/index_types.md
+++ b/optional-skills/research/pinecone/references/index_types.md
@@ -1,0 +1,96 @@
+# Index Types: Serverless vs Pod-Based
+
+Pinecone offers two index architectures. Choose based on workload characteristics.
+
+## Serverless Indexes (Default Recommendation)
+
+```python
+from pinecone import Pinecone, ServerlessSpec
+
+pc.create_index(
+    name="my-index",
+    dimension=1024,
+    metric="cosine",
+    spec=ServerlessSpec(cloud="aws", region="us-east-1")
+)
+```
+
+**Use when:**
+- Workload is bursty or unpredictable
+- Cost-sensitive (pay per operation + storage, not provisioned capacity)
+- Building prototypes or research projects
+- Total vector count < 100M
+
+**Available regions** (verify at https://docs.pinecone.io for current list):
+- AWS: `us-east-1`, `us-west-2`, `eu-west-1`
+- GCP: `us-central1`, `europe-west4`
+- Azure: `eastus2`
+
+## Pod-Based Indexes
+
+```python
+from pinecone import Pinecone, PodSpec
+
+pc.create_index(
+    name="production-index",
+    dimension=768,
+    metric="cosine",
+    spec=PodSpec(
+        environment="us-east1-gcp",
+        pod_type="p1.x1",   # Pod tier and size
+        pods=1,             # Number of pods
+        replicas=1          # Replicas per pod for HA
+    )
+)
+```
+
+**Use when:**
+- Predictable, sustained high QPS (>100 queries/sec)
+- Need dedicated compute for latency SLAs
+- Very large indexes (>100M vectors) where serverless cost exceeds pod cost
+- Specific pod features (selective metadata indexing, collections/backups)
+
+**Pod tiers:**
+
+| Tier | Best For | Vectors/Pod (~1024d) |
+|---|---|---|
+| `s1` | Storage-optimized, lower QPS | ~5M |
+| `p1` | Balanced performance | ~1M |
+| `p2` | Highest QPS, lowest latency | ~1M |
+
+Each tier has sizes `x1`, `x2`, `x4`, `x8` — doubling capacity and cost.
+
+## Dimension Selection by Embedding Model
+
+Match index dimension exactly to your embedding model's output. **You cannot change dimension after creation — only by recreating the index.**
+
+| Embedding Model | Dimension | Domain |
+|---|---|---|
+| voyage-multimodal-3 | 1024 | Multimodal (text + image) |
+| voyage-large-2 | 1536 | General-purpose text |
+| voyage-2 | 1024 | General-purpose text (lighter) |
+| text-embedding-3-large (OpenAI) | 3072 | General-purpose text |
+| text-embedding-3-small (OpenAI) | 1536 | General-purpose text (lighter) |
+| all-mpnet-base-v2 | 768 | General-purpose (open source) |
+| Bio_ClinicalBERT | 768 | Clinical notes |
+| PubMedBERT | 768 | Biomedical literature |
+| ESM-2 (650M) | 1280 | Protein sequences |
+| ESM-2 (3B) | 2560 | Protein sequences (higher capacity) |
+| MolBERT / ChemBERTa | 768 | Molecules (SMILES) |
+| Morgan Fingerprints | 1024 or 2048 | Molecules (classical) |
+
+**Pro tip:** If unsure, embed one sample and check: `len(model.embed("test"))`.
+
+## Metric Selection
+
+| Metric | When to Use |
+|---|---|
+| `cosine` | Default for most embedding models. Vectors typically L2-normalized; measures angle. |
+| `dotproduct` | **Required** for hybrid (dense + sparse) search. Also used when magnitude carries meaning. |
+| `euclidean` | Geometric features, coordinates, raw pixel embeddings. Rarely used for NLP. |
+
+## Migration Path
+
+1. Start with serverless `cosine` for prototyping
+2. If hybrid search needed → recreate with `dotproduct` (cosine ≈ dotproduct on normalized vectors anyway)
+3. If sustained QPS or specialized features needed → migrate to pod-based with the same dimension and metric

--- a/optional-skills/research/pinecone/references/scientific_embedding_models.md
+++ b/optional-skills/research/pinecone/references/scientific_embedding_models.md
@@ -1,0 +1,132 @@
+# Scientific Embedding Models
+
+A map from scientific domain → recommended embedding model → Pinecone index configuration. Use this as a starting point; benchmark on your actual retrieval task before committing to production.
+
+## Quick Decision Table
+
+| Your Data | Recommended Model | Dim | Metric | Notes |
+|---|---|---|---|---|
+| Biomedical literature (PubMed/PMC) | `voyage-large-2` | 1536 | cosine | Best general scientific recall |
+| Clinical notes / EHR | `emilyalsentzer/Bio_ClinicalBERT` | 768 | cosine | Trained on MIMIC-III |
+| Biomedical abstracts (lighter) | `pritamdeka/S-PubMedBert-MS-MARCO` | 768 | cosine | Sentence-transformer, fast |
+| Protein sequences | `facebook/esm2_t33_650M_UR50D` | 1280 | cosine | Mean-pool token representations |
+| Small molecules (SMILES) | `seyonec/PubChem10M_SMILES_BPE_450k` (ChemBERTa) | 768 | cosine | Trained on 10M PubChem SMILES |
+| Small molecules (classical) | RDKit Morgan FP | 1024 or 2048 | cosine | Cosine here ≠ Tanimoto; rerank in RDKit |
+| Multimodal (text + image) | `voyage-multimodal-3` | 1024 | cosine | Single embedding for text + PIL.Image |
+| Radiology images alone | `microsoft/BiomedCLIP-PubMedBERT_256-vit_base_patch16_224` | 512 | cosine | Domain-tuned CLIP |
+| Microscopy / cell images | Custom CNN features or DINOv2 | varies | cosine | Domain-fine-tune for best results |
+| Genomic sequences (DNA) | `InstaDeepAI/nucleotide-transformer-500m-human-ref` | 1280 | cosine | Use sparingly — large model |
+
+## Usage Patterns
+
+### Voyage AI (recommended for production literature)
+
+```python
+import voyageai
+voyage = voyageai.Client(api_key=os.environ["VOYAGE_API_KEY"])
+
+# CRITICAL: use the right input_type
+doc_embeddings = voyage.embed(
+    texts=corpus_texts, model="voyage-large-2", input_type="document"
+).embeddings
+
+query_embedding = voyage.embed(
+    texts=[user_question], model="voyage-large-2", input_type="query"
+).embeddings[0]
+```
+
+Using `input_type="query"` vs `"document"` materially affects retrieval quality. Don't skip this.
+
+### Bio_ClinicalBERT (clinical notes)
+
+```python
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer("emilyalsentzer/Bio_ClinicalBERT")
+embeddings = model.encode(
+    notes, batch_size=32, normalize_embeddings=True, show_progress_bar=True
+).tolist()
+```
+
+`normalize_embeddings=True` is important when using cosine metric in Pinecone — it ensures consistent magnitudes.
+
+### ESM-2 (protein sequences)
+
+```python
+import torch
+import esm
+
+model, alphabet = esm.pretrained.esm2_t33_650M_UR50D()
+batch_converter = alphabet.get_batch_converter()
+model.training = False  # set to inference mode (PyTorch idiom)
+
+def embed_protein(sequence: str) -> list[float]:
+    """Mean-pool ESM-2 token representations into a single sequence embedding."""
+    data = [("protein", sequence)]
+    _, _, tokens = batch_converter(data)
+    with torch.no_grad():
+        results = model(tokens, repr_layers=[33])
+    # Mean-pool over sequence length, excluding BOS/EOS tokens
+    repr_ = results["representations"][33][0, 1:len(sequence) + 1]
+    return repr_.mean(0).cpu().numpy().tolist()
+```
+
+For batched embedding of many sequences, use `model.forward()` with padded batches; see the ESM repo for the canonical pattern.
+
+### Morgan Fingerprints (molecules, classical)
+
+```python
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+def smiles_to_morgan_list(smiles: str, radius: int = 2, n_bits: int = 1024):
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
+    return list(fp)  # 0/1 list, length n_bits
+```
+
+**Important:** Pinecone cosine similarity over binary Morgan fingerprints is **not** Tanimoto coefficient. Use Pinecone for fast top-N recall, then rerank with `rdkit.DataStructs.TanimotoSimilarity` for true Tanimoto ranking.
+
+### voyage-multimodal-3 (text + image)
+
+```python
+import voyageai
+from PIL import Image
+
+voyage = voyageai.Client(api_key=os.environ["VOYAGE_API_KEY"])
+
+inputs = [
+    [report_text_1, Image.open("radiograph_1.png")],
+    [report_text_2, Image.open("radiograph_2.png")],
+]
+
+result = voyage.multimodal_embed(
+    inputs=inputs,
+    model="voyage-multimodal-3",
+    input_type="document"
+)
+# result.embeddings is List[List[float]] of dim 1024
+```
+
+Inputs can be `[text]`, `[image]`, or `[text, image]` in any order. The model produces a single 1024-dim joint embedding per input.
+
+## Dimension Pitfalls
+
+A common production bug: switching embedding models without recreating the index. Pinecone will silently fail or return garbage if dimensions don't match exactly.
+
+**Defensive pattern:**
+
+```python
+index_stats = pc.describe_index("my-index")
+expected_dim = index_stats.dimension
+
+emb = model.embed("test")
+assert len(emb) == expected_dim, \
+    f"Embedding dim {len(emb)} != index dim {expected_dim}"
+```
+
+## Cost Considerations
+
+Higher dimensions = higher storage cost + slower queries. If your retrieval quality is acceptable with a 768-dim model, don't upgrade to 3072-dim for marginal gains. Benchmark on your task first.

--- a/optional-skills/research/pinecone/scripts/index_pubmed.py
+++ b/optional-skills/research/pinecone/scripts/index_pubmed.py
@@ -1,0 +1,182 @@
+"""
+Index PubMed abstracts into Pinecone for scientific RAG.
+
+Pipeline:
+    1. Fetch abstracts from NCBI Entrez E-utilities given a list of PMIDs
+    2. Embed with voyage-large-2 (input_type="document")
+    3. Batch upsert to Pinecone with structured metadata
+
+Usage:
+    export PINECONE_API_KEY=...
+    export VOYAGE_API_KEY=...
+    python index_pubmed.py --index scientific-literature --namespace oncology \\
+        --pmids 38291847,38215032,38109284
+
+Environment:
+    PINECONE_API_KEY  Pinecone API key
+    VOYAGE_API_KEY    Voyage AI API key
+"""
+
+import argparse
+import os
+import sys
+import time
+from typing import Iterable
+from xml.etree import ElementTree as ET
+
+import requests
+import voyageai
+from pinecone import Pinecone, ServerlessSpec
+
+
+NCBI_EFETCH = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+EMBED_MODEL = "voyage-large-2"
+EMBED_DIM = 1536
+
+
+def fetch_pubmed_records(pmids: list[str]) -> list[dict]:
+    """Fetch PubMed records via E-utilities. Returns list of dicts with title/abstract/metadata."""
+    if not pmids:
+        return []
+
+    params = {
+        "db": "pubmed",
+        "id": ",".join(pmids),
+        "retmode": "xml",
+    }
+    response = requests.get(NCBI_EFETCH, params=params, timeout=30)
+    response.raise_for_status()
+
+    root = ET.fromstring(response.content)
+    records = []
+
+    for article in root.findall(".//PubmedArticle"):
+        pmid_node = article.find(".//PMID")
+        title_node = article.find(".//ArticleTitle")
+        abstract_parts = article.findall(".//AbstractText")
+        year_node = article.find(".//PubDate/Year")
+        journal_node = article.find(".//Journal/Title")
+
+        if pmid_node is None or title_node is None or not abstract_parts:
+            continue
+
+        # Concatenate multi-section abstracts
+        abstract_text = " ".join(
+            (part.text or "") for part in abstract_parts
+        ).strip()
+        if not abstract_text:
+            continue
+
+        records.append({
+            "pmid": pmid_node.text,
+            "title": (title_node.text or "").strip(),
+            "abstract": abstract_text,
+            "year": int(year_node.text) if year_node is not None and year_node.text else 0,
+            "journal": (journal_node.text or "").strip() if journal_node is not None else "",
+        })
+
+    return records
+
+
+def chunked(seq: list, size: int) -> Iterable[list]:
+    """Yield successive chunks of `seq` of length `size`."""
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+def embed_documents(client: voyageai.Client, texts: list[str], batch_size: int = 128) -> list[list[float]]:
+    """Embed documents in batches, respecting Voyage AI batch limits."""
+    embeddings: list[list[float]] = []
+    for batch in chunked(texts, batch_size):
+        result = client.embed(batch, model=EMBED_MODEL, input_type="document")
+        embeddings.extend(result.embeddings)
+    return embeddings
+
+
+def ensure_index(pc: Pinecone, index_name: str, dimension: int) -> None:
+    """Create the index if it doesn't already exist."""
+    existing = [idx.name for idx in pc.list_indexes()]
+    if index_name in existing:
+        info = pc.describe_index(index_name)
+        if info.dimension != dimension:
+            sys.exit(
+                f"ERROR: index '{index_name}' exists with dimension {info.dimension}, "
+                f"but this pipeline requires dimension {dimension}."
+            )
+        return
+
+    print(f"Creating index '{index_name}' (dim={dimension}, metric=cosine, serverless)")
+    pc.create_index(
+        name=index_name,
+        dimension=dimension,
+        metric="cosine",
+        spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+    )
+
+    # Wait for index to be ready
+    while not pc.describe_index(index_name).status["ready"]:
+        time.sleep(1)
+
+
+def index_pubmed(pmids: list[str], index_name: str, namespace: str) -> None:
+    pc = Pinecone(api_key=os.environ["PINECONE_API_KEY"])
+    voyage = voyageai.Client(api_key=os.environ["VOYAGE_API_KEY"])
+
+    ensure_index(pc, index_name, EMBED_DIM)
+    index = pc.Index(index_name)
+
+    print(f"Fetching {len(pmids)} PubMed records...")
+    records = fetch_pubmed_records(pmids)
+    print(f"  Got {len(records)} records with abstracts")
+
+    if not records:
+        print("No records to index. Exiting.")
+        return
+
+    print("Embedding abstracts with voyage-large-2...")
+    abstracts = [r["abstract"] for r in records]
+    embeddings = embed_documents(voyage, abstracts)
+    print(f"  Embedded {len(embeddings)} abstracts")
+
+    vectors = [
+        {
+            "id": f"pmid_{rec['pmid']}",
+            "values": emb,
+            "metadata": {
+                "pmid": rec["pmid"],
+                "title": rec["title"],
+                "abstract": rec["abstract"][:500],  # truncate for metadata size
+                "year": rec["year"],
+                "journal": rec["journal"],
+                "source": "PubMed",
+            },
+        }
+        for rec, emb in zip(records, embeddings)
+    ]
+
+    print(f"Upserting to '{index_name}' namespace='{namespace}'...")
+    total_batches = (len(vectors) + 99) // 100
+    for i, batch in enumerate(chunked(vectors, 100), start=1):
+        index.upsert(vectors=batch, namespace=namespace)
+        print(f"  Batch {i}/{total_batches} upserted ({len(batch)} vectors)")
+
+    print(f"Done. Index stats: {index.describe_index_stats()}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--index", required=True, help="Pinecone index name")
+    parser.add_argument("--namespace", default="pubmed", help="Pinecone namespace")
+    parser.add_argument("--pmids", required=True, help="Comma-separated PMIDs")
+    args = parser.parse_args()
+
+    for env_var in ("PINECONE_API_KEY", "VOYAGE_API_KEY"):
+        if env_var not in os.environ:
+            sys.exit(f"ERROR: environment variable {env_var} is required.")
+
+    pmids = [p.strip() for p in args.pmids.split(",") if p.strip()]
+    index_pubmed(pmids, args.index, args.namespace)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/research/pinecone/scripts/multimodal_radiology.py
+++ b/optional-skills/research/pinecone/scripts/multimodal_radiology.py
@@ -1,0 +1,176 @@
+"""
+Multimodal radiology indexing with voyage-multimodal-3 and Pinecone.
+
+Pipeline:
+    1. Load radiology report + image pairs from a manifest CSV
+    2. Embed each (text, image) pair into a single 1024-dim vector
+    3. Upsert to Pinecone with study metadata
+
+Manifest CSV format (with header):
+    case_id,report_path,image_path,modality,body_part,finding,study_uid
+
+Example:
+    case_001,reports/001.txt,images/001.png,CT,chest,pneumonia,1.2.3.4.5
+
+Usage:
+    export PINECONE_API_KEY=...
+    export VOYAGE_API_KEY=...
+    python multimodal_radiology.py --manifest cases.csv \\
+        --index radiology-cases --namespace ct-chest
+
+Environment:
+    PINECONE_API_KEY  Pinecone API key
+    VOYAGE_API_KEY    Voyage AI API key
+"""
+
+import argparse
+import csv
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+import voyageai
+from PIL import Image
+from pinecone import Pinecone, ServerlessSpec
+
+
+EMBED_MODEL = "voyage-multimodal-3"
+EMBED_DIM = 1024
+BATCH_SIZE = 8  # voyage-multimodal-3 is heavier; smaller batches
+
+
+def load_manifest(manifest_path: Path) -> list[dict]:
+    """Read the case manifest CSV."""
+    cases = []
+    with open(manifest_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            cases.append(row)
+    return cases
+
+
+def load_case(case: dict) -> tuple[str, Image.Image] | None:
+    """Load report text and image for a case. Returns None if files are missing."""
+    report_path = Path(case["report_path"])
+    image_path = Path(case["image_path"])
+
+    if not report_path.exists() or not image_path.exists():
+        print(f"  Skipping {case['case_id']}: missing file(s)")
+        return None
+
+    report_text = report_path.read_text(encoding="utf-8").strip()
+    image = Image.open(image_path).convert("RGB")
+    return report_text, image
+
+
+def chunked(seq: list, size: int) -> Iterable[list]:
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+def embed_multimodal_pairs(
+    client: voyageai.Client, pairs: list[tuple[str, Image.Image]]
+) -> list[list[float]]:
+    """Embed (text, image) pairs in batches."""
+    embeddings: list[list[float]] = []
+    for batch in chunked(pairs, BATCH_SIZE):
+        inputs = [[text, img] for text, img in batch]
+        result = client.multimodal_embed(
+            inputs=inputs, model=EMBED_MODEL, input_type="document"
+        )
+        embeddings.extend(result.embeddings)
+    return embeddings
+
+
+def ensure_index(pc: Pinecone, index_name: str, dimension: int) -> None:
+    existing = [idx.name for idx in pc.list_indexes()]
+    if index_name in existing:
+        info = pc.describe_index(index_name)
+        if info.dimension != dimension:
+            sys.exit(
+                f"ERROR: index '{index_name}' has dimension {info.dimension}, "
+                f"expected {dimension}."
+            )
+        return
+
+    print(f"Creating index '{index_name}' (dim={dimension}, metric=cosine, serverless)")
+    pc.create_index(
+        name=index_name,
+        dimension=dimension,
+        metric="cosine",
+        spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+    )
+    while not pc.describe_index(index_name).status["ready"]:
+        time.sleep(1)
+
+
+def index_radiology(manifest_path: Path, index_name: str, namespace: str) -> None:
+    pc = Pinecone(api_key=os.environ["PINECONE_API_KEY"])
+    voyage = voyageai.Client(api_key=os.environ["VOYAGE_API_KEY"])
+
+    ensure_index(pc, index_name, EMBED_DIM)
+    index = pc.Index(index_name)
+
+    cases = load_manifest(manifest_path)
+    print(f"Loaded manifest with {len(cases)} cases")
+
+    valid_cases = []
+    pairs = []
+    for case in cases:
+        loaded = load_case(case)
+        if loaded is None:
+            continue
+        valid_cases.append(case)
+        pairs.append(loaded)
+
+    if not pairs:
+        print("No valid cases to index. Exiting.")
+        return
+
+    print(f"Embedding {len(pairs)} (report, image) pairs...")
+    embeddings = embed_multimodal_pairs(voyage, pairs)
+
+    vectors = [
+        {
+            "id": case["case_id"],
+            "values": emb,
+            "metadata": {
+                "modality":  case.get("modality", ""),
+                "body_part": case.get("body_part", ""),
+                "finding":   case.get("finding", ""),
+                "study_uid": case.get("study_uid", ""),
+            },
+        }
+        for case, emb in zip(valid_cases, embeddings)
+    ]
+
+    print(f"Upserting to '{index_name}' namespace='{namespace}'...")
+    total_batches = (len(vectors) + 99) // 100
+    for i, batch in enumerate(chunked(vectors, 100), start=1):
+        index.upsert(vectors=batch, namespace=namespace)
+        print(f"  Batch {i}/{total_batches} upserted")
+
+    print(f"Done. Index stats: {index.describe_index_stats()}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--manifest", required=True, type=Path, help="Path to manifest CSV")
+    parser.add_argument("--index", required=True, help="Pinecone index name")
+    parser.add_argument("--namespace", default="radiology", help="Pinecone namespace")
+    args = parser.parse_args()
+
+    for env_var in ("PINECONE_API_KEY", "VOYAGE_API_KEY"):
+        if env_var not in os.environ:
+            sys.exit(f"ERROR: environment variable {env_var} is required.")
+
+    if not args.manifest.exists():
+        sys.exit(f"ERROR: manifest file not found: {args.manifest}")
+
+    index_radiology(args.manifest, args.index, args.namespace)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Pinecone vector database skill covering persistent semantic retrieval for RAG pipelines and long-term agent memory — two core Hermes use cases.

## Placement note

I placed this in `optional-skills/research/` since it's broadly useful (memory + RAG are central to Hermes) but requires an API key, making it a fit for the opt-in tier rather than bundled. Happy to move it to the Skills Hub instead if the team prefers community skills go there — just let me know.

## What's Included

- **SKILL.md** — index management, namespaces, dense/sparse/hybrid search, metadata filtering, multimodal retrieval, and a full agent RAG pipeline
- **references/** — index types, embedding model selection, hybrid search tuning
- **scripts/** — working batch indexing examples

## Use Cases for Hermes Agents

- Long-term memory persistence across sessions (beyond built-in providers)
- RAG retrieval over documents, codebases, or research corpora
- Multi-tenant knowledge isolation via namespaces
- Hybrid search combining semantic meaning with exact keyword matching

## Validation

- Frontmatter follows the optional-skills format (version, author, license, platforms, metadata.hermes)
- Cisco AI skill scanner: SAFE (0 critical, 0 high; 2 expected network medium findings — Pinecone is a cloud API)
- Tested with `pinecone>=6.0.0`
- Production-validated patterns (multimodal chatbot using voyage-multimodal-3 + Pinecone)

## Note

This is a skill (instructions + API patterns the agent calls), not a memory provider plugin — it complements the existing memory backends rather than replacing them.