### PR TITLE
feat: Claude Code session manager with tmux state awareness + persistence (v2)

### DIFF
--- a/skills/claude-session/SKILL.md
+++ b/skills/claude-session/SKILL.md
@@ -1,0 +1,446 @@
+---
+name: claude-session
+description: Guide for using claude_session tool to delegate coding tasks to Claude Code via tmux. Includes session persistence (auto-resume via .claude/claude-session.json) and list_persisted for cross-restart continuity.
+tags: ['claude-code', 'tmux', 'interactive', 'coding', 'delegation', 'persistence', 'auto-resume']
+triggers:
+  - "claude session"
+  - "coding task"
+  - "delegation"
+  - "interactive session"
+  - "resume session"
+  - "previous session"
+  - "persisted session"
+version: 4.5
+code_commit: see git history
+required_environment_variables:
+  - name: HERMES_STREAM_STALE_TIMEOUT
+    prompt: "Stream stale timeout (秒，推荐 300)"
+    help: "防止 claude_session 长任务时 Hermes API 流中断，默认 180s 不够用"
+    optional: true
+    required_for: "防止 Stream Stalled mid tool-call 错误"
+  - name: HERMES_CLAUDE_SESSION_PATROL_INTERVAL
+    prompt: "Patrol check interval (秒，推荐 300)"
+    help: "idle 状态检查输出增长的间隔，默认 300 秒（5 分钟）"
+    optional: true
+    required_for: "patrol checkpoint 轮询间隔"
+  - name: HERMES_CLAUDE_SESSION_STALL_THRESHOLD
+    prompt: "Stall threshold (秒，推荐 1800)"
+    help: "无输出增长判定为 stall 的时间，默认 1800 秒（30 分钟）"
+    optional: true
+    required_for: "长时间无响应检测"
+  - name: HERMES_CLAUDE_SESSION_OBSERVER_POLL_INTERVAL
+    prompt: "Observer poll interval (秒，推荐 5)"
+    help: "observer 后台轮询间隔，默认 5 秒（足够捕捉短工具调用，180秒会错过 2-3 秒的任务）"
+    optional: true
+    required_for: "状态变化检测频率"
+---
+
+# Claude Session — 任务委托核心框架
+
+## 架构原则（第一性原理）
+
+**claude_session 是 Hermes 与 Claude Code 之间唯一的通信通道。**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Hermes (AI)                                            │
+│       ↓                                                │
+│  claude_session API  ←  唯一的入口，所有操作必须通过这里 │
+│       ↓                                                │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │ observer (后台线程) + OutputBuffer (输出缓冲)    │   │
+│  │  - 后台追踪 tmux 状态                            │   │
+│  │  - 缓冲输出供 API 查询                           │   │
+│  └─────────────────────────────────────────────────┘   │
+│       ↓                                                │
+│  StateDetection (纯函数 detect_state)                   │
+│       ↓                                                │
+│  tmux_interface (终端控制)                             │
+│       ↓                                                │
+│  Claude Code CLI (执行者)                              │
+└─────────────────────────────────────────────────────────┘
+```
+
+**核心规则**：
+- 所有状态来自 API，不来自手动 tmux
+- observer 后台运行，不应被绕过
+- API 返回的数据已经过 buffer 整理
+
+---
+
+## ⚠️ 禁止行为（强制）
+
+### 1. 禁止手动 tmux 操作
+
+```python
+# ❌ 禁止：绕过 observer + buffer 体系
+terminal("tmux capture-pane -t session -p")
+terminal("tmux send-keys ...")
+
+# ✅ 正确：使用 API 获取状态和输出
+claude_session(action="status")      # 返回 state + output_tail
+claude_session(action="output")     # 获取完整输出
+```
+
+**原因**：手动 tmux 操作破坏状态追踪，导致：
+- 状态不一致（API 说 IDLE，手动读出 THINKING）
+- buffer 数据过时
+- 并发问题（observer 正在读时你也在读）
+
+### 2. 禁止直接 terminal 调用 claude
+
+```python
+# ❌ 禁止
+terminal("claude -p 'fix bug'")
+terminal("tmux send-keys -t session 'claude'")
+
+# ✅ 正确
+claude_session(action="send", message="fix bug")
+```
+
+### 3. 禁止反复轮询
+
+```python
+# ❌ 禁止：每30秒轮询一次
+send → wait_for_idle(30) → status → wait_for_idle(30) → output → ...
+
+# ✅ 正确：一次等到底
+send → wait_for_idle(300-600) → output → stop
+```
+
+---
+
+## 正确使用流程
+
+### 标准模式（3轮完成）
+
+```python
+# 第1轮：启动
+claude_session(action="start", name="task-name", workdir="/project", permission_mode="skip")
+claude_session(action="wait_for_idle", timeout=60)  # 等待就绪
+
+# 第2轮：执行任务
+claude_session(action="send", message="Your task here")
+claude_session(action="wait_for_idle", timeout=300)  # 一次等到底（工具默认900s）
+
+# 第3轮：获取结果
+result = claude_session(action="output", limit=100)
+claude_session(action="stop")
+```
+
+### 状态检查
+
+```python
+# ❌ 不要手动读 tmux
+terminal("tmux capture-pane -t session -p")
+
+# ✅ 用 status API
+status = claude_session(action="status")
+# 返回: {"state": "THINKING", "state_duration_seconds": 42.3, "output_tail": "..."}
+```
+
+### 进度监控
+
+```python
+# wait_for_idle 返回值包含 output_since_send，不需要单独调 output
+result = claude_session(action="wait_for_idle", timeout=300)
+# result["output_since_send"] 已包含增量输出
+```
+
+---
+
+## Named Sessions（多会话管理）
+
+v3.0+ 支持通过语义化名称管理多个会话。
+
+### 为什么 name 必须
+
+```python
+# ❌ 旧方式（自动生成 hash，不可读）
+claude_session(action="start", workdir="/project")  # 生成 hermes-7935c242
+
+# ✅ 新方式（语义化，一目了然）
+claude_session(action="start", name="frontend", workdir="/project")
+claude_session(action="start", name="backend", workdir="/project")
+```
+
+### 路由优先级
+
+| 优先级 | 参数 | 说明 |
+|--------|------|------|
+| 1 | `session_id` | 精确指定 |
+| 2 | `name` | 语义化路由 |
+| 3 | 活跃会话 | 最近交互 |
+| 4 | 最近创建 | 回退 |
+
+---
+
+## Permission Modes
+
+| Mode | 场景 | 说明 |
+|------|------|------|
+| `skip` | 自动化任务 | 自动批准所有操作 |
+| `normal` | 需要用户确认 | 手动响应权限 |
+
+**建议**：多步任务用 `skip`，避免频繁权限中断。
+
+---
+
+## State Awareness
+
+7个状态：`IDLE` `THINKING` `TOOL_CALL` `PERMISSION` `ERROR` `DISCONNECTED` `EXITED`
+
+```python
+# 检查状态
+status = claude_session(action="status")
+if status["state"] == "IDLE":
+    # 可以发送任务
+elif status["state"] == "PERMISSION":
+    # 需要响应权限
+```
+
+---
+
+## 常见错误（真实案例）
+
+### 错误1：手动读 tmux 绕过 observer
+
+**现象**：status 返回 IDLE，但 tmux pane 显示还在 thinking。
+
+**原因**：手动 `tmux capture-pane` 读到的和 observer buffer 不一样。
+
+**正确做法**：只用 API，用 `status["output_tail"]` 或 `output`。
+
+### 错误2：以为 Claude 卡住了
+
+**现象**：等待 2 分钟没有响应，判定"卡住"并重启。
+
+**真实情况**：Claude 正在读取多个文件、分析代码，GLM-5.1 处理大上下文需要时间。
+
+**正确做法**：
+- 给够 timeout（300-600秒）
+- 用 `status["state_duration_seconds"]` 判断是否真的停滞
+- 除非明确超时，否则不重启
+
+### 错误3：反复轮询 + 超时递减
+
+**现象**：
+```python
+# 每轮 timeout 递减，像是轮询而不是等待
+wait_for_idle(60) → 没完成 → wait_for_idle(300) → 没完成 → wait_for_idle(600)
+```
+
+**后果**：
+- 每次 `wait_for_idle` 调用都生成新的 output context，Claude 每次都要处理
+- Hermes 反复检查打断 Claude，Claude 丢失耐心无法完成复杂任务
+- 每轮累积上下文 → 最终 Stream Stalled
+
+**正确做法**：`wait_for_idle(900)` 一次给够 timeout，不中途打断
+
+### 错误4：动画鬼影导致提前返回 IDLE
+
+**现象**：`wait_for_idle` 返回 `status: idle`，但 `output_since_send` 显示的是动画（Forming/Unfurling/Jitterbugging/Stewing），命令实际结果未捕获。
+
+**原因**：Claude Code 动画结束后，tmux pane 先显示短暂的 `❯` 提示符（触发 IDLE 检测），随后动画恢复并持续显示。observer 的 2 秒 poll 间隔捕获的是动画状态。
+
+**正确做法**：
+```python
+# session.py wait_for_idle() 中，检测到 IDLE 后等待 0.5 秒再次确认
+if state == SessionState.IDLE:
+    time.sleep(0.5)
+    confirm_pane = self._tmux.capture_pane()
+    confirm_lines = clean_lines(confirm_pane)
+    confirm_result = detect_state(confirm_lines)
+    if confirm_result.state != SessionState.IDLE:
+        continue  # 仍在过渡中，继续等待
+    return {**self._build_idle_result(), "status": "idle"}
+```
+
+### 错误5：PATROL_INTERVAL 默认值过大（中低优）
+
+**现象**：`PATROL_INTERVAL=300`（5分钟）导致 THINKING/TOOL_CALL 状态轮询间隔过长。
+
+**现状**：代码中 THINKING 使用 `POLL_INTERVAL=180s`（3分钟），与 PATROL_INTERVAL 分离。
+
+**建议**：保持现状，observer 使用自适应轮询（THINKING=5s 已修复），wait_for_idle 使用 POLL_INTERVAL=180s。
+
+---
+
+## 轮询策略
+
+### 核心原则
+
+用最少 tool call 完成任务。
+
+### 错误模式（❌）
+
+```
+send → wait_for_idle(30) → output → wait_for_idle(30) → output → ... (10+轮)
+```
+
+每轮累积上下文 → 最终 Stream Stalled
+
+### 正确模式（✅）
+
+```
+1. start + wait_for_idle(60)     # 启动，等就绪
+2. send + wait_for_idle(300-600) # 发任务，一次等到底
+3. output + stop                 # 取结果，关闭
+```
+
+---
+
+## 陷阱与应对
+
+### 陷阱0：首次启动不稳定
+
+**现象**：wait_for_idle 超时，但实际 Claude 还在初始化。
+
+**应对**：首次启动 timeout 设为 300 秒。
+
+### 陷阱1：Permission 状态幽灵
+
+**现象**：status 返回 PERMISSION，但 Claude 实际在正常工作。
+
+**应对**：检查 `output_tail` 是否有权限提示文本，再决定是否 respond。
+
+### 陷阱2：多行文本粘贴后不发送
+
+**现象**：多行消息发送后 Claude 没收到。
+
+**应对**：代码已有 10 秒延迟保护（session.py:422），不要在发送后立即 wait_for_idle。
+
+### 陷阱3：tokens 不增长
+
+**现象**：Claude 卡在某个 token 数不动。
+
+**应对**：
+```python
+claude_session(action="cancel_input")
+claude_session(action="send", message="简化指令")
+```
+
+---
+
+## Error Recovery
+
+1. 检查 `status` 的 state 字段
+2. 检查 `output_tail` 或 `output_since_send` 的错误信息
+3. 发送修正指令（最多 2 次重试）
+4. 仍然失败 → 报告用户
+5. **绝不等得久就放弃当前方案**
+
+---
+
+## API Reference
+
+### start
+```
+claude_session(action="start", name="my-task", workdir="/path",
+               permission_mode="skip")
+```
+
+### send
+```
+claude_session(action="send", message="Fix the auth bug")
+claude_session(action="send", name="frontend", message="...")
+```
+
+### status
+```
+claude_session(action="status")
+# 返回: {"state": "IDLE", "state_duration_seconds": 12.4, "output_tail": "..."}
+```
+
+### wait_for_idle
+```
+claude_session(action="wait_for_idle", timeout=300)
+# 返回: {"status": "idle", "output_since_send": "...", "state": "IDLE"}
+```
+
+### output
+```
+claude_session(action="output", offset=0, limit=50)
+```
+
+### stop
+```
+claude_session(action="stop")
+claude_session(action="stop", name="frontend")
+```
+
+### list / switch
+```
+claude_session(action="list")
+claude_session(action="switch", name="frontend")
+```
+
+### diagnose
+```
+claude_session(action="diagnose")
+# 检查 tmux、Claude CLI、环境变量
+```
+
+### list_persisted（持久化会话）
+```
+claude_session(action="list_persisted", workdir="/project")
+# 返回该 workdir 下 .claude/claude-session.json 中所有持久化的会话
+# 每条记录含 status（持久化时状态）+ active_in_gateway（当前 gateway 是否活跃）
+```
+
+---
+
+## Session Persistence（自动 resume 机制）
+
+**核心目的**：跨进程重启保留会话上下文，避免每次新建会话都从零开始。
+
+### 存储位置
+```
+<workdir>/.claude/claude-session.json
+```
+
+格式示例：
+```json
+{
+  "task-name": {
+    "claude_session_uuid": "034271e5-...",
+    "workdir": "/path/to/project",
+    "model": "sonnet",
+    "permission_mode": "skip",
+    "resume_count": 3,
+    "last_resume_status": "auto_resumed",
+    "status": "active",
+    "last_active_at": "2026-06-02T11:24:41"
+  }
+}
+```
+
+### 写入时机
+- `start` 成功：写入/更新条目，`status: "active"`
+- `stop` 成功：更新 `status: "stopped"`
+- 自动 resume：增加 `resume_count`，`last_resume_status: "auto_resumed"`
+
+### 读取时机
+- `claude_session(action="list_persisted", workdir=...)`：列出 workdir 下所有持久化会话
+- 启动同 `name` 的会话时：若存在条目，自动用 `claude_session_uuid` resume
+
+### 何时应该主动调用 list_persisted
+- 接手新 workdir，先查有没有可恢复的会话
+- 用户提到"上次"、"之前的会话"、"继续上次"
+- 不确定当前 workdir 有哪些命名会话
+
+⚠️ 注意：`status` 字段是**持久化时的状态**（最后写入时），不代表**当前进程是否活跃**。判断当前活跃用 `active_in_gateway: true` 字段。
+
+---
+
+## 首次使用配置
+
+加载 skill 时检查 `HERMES_STREAM_STALE_TIMEOUT`：
+
+```bash
+bash ~/.hermes/skills/claude-session/scripts/configure.sh
+```
+
+未配置时可能遇到 `⚠ Stream stalled mid tool-call` 错误。
+
+配置后需重启 Gateway。

--- a/skills/claude-session/scripts/configure.sh
+++ b/skills/claude-session/scripts/configure.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# claude-session 安装配置钩子
+# 用途：检查依赖 + 自动配置环境变量 + 权限预设
+# 使用：bash ~/.hermes/skills/claude-session/scripts/configure.sh
+# 触发：首次启用 claude_session toolset 时由 tools_config.py 调用
+
+set -euo pipefail
+
+HERMES_ENV="${HERMES_HOME:-$HOME/.hermes}/.env"
+VAR_NAME="HERMES_STREAM_STALE_TIMEOUT"
+RECOMMENDED_VALUE="300"
+ISSUES=()
+ALL_OK=true
+
+echo "=== 🤖 Claude Code Session — 安装配置 ==="
+echo ""
+
+# ── 1. 依赖检查 ──────────────────────────────────────────────────────────────
+
+# tmux
+echo "Checking tmux..."
+if command -v tmux >/dev/null 2>&1; then
+    TMUX_VER=$(tmux -V 2>/dev/null || echo "unknown")
+    echo "  ✅ tmux: $TMUX_VER"
+else
+    echo "  ❌ tmux: 未安装"
+    ISSUES+=("tmux — Install: apt install tmux / brew install tmux")
+    ALL_OK=false
+fi
+
+# Claude Code CLI
+echo "Checking Claude Code CLI..."
+if command -v claude >/dev/null 2>&1; then
+    CLAUDE_VER=$(claude --version 2>/dev/null | head -1 || echo "unknown")
+    echo "  ✅ Claude Code: $CLAUDE_VER"
+else
+    echo "  ❌ Claude Code CLI: 未安装"
+    ISSUES+=("Claude Code CLI — Install: npm install -g @anthropic-ai/claude-code")
+    ALL_OK=false
+fi
+
+echo ""
+
+# ── 2. 环境变量配置 ──────────────────────────────────────────────────────────
+
+echo "Configuring environment variables..."
+
+if grep -q "^${VAR_NAME}=" "$HERMES_ENV" 2>/dev/null; then
+    current=$(grep "^${VAR_NAME}=" "$HERMES_ENV" | cut -d'=' -f2)
+    if [ "$current" -lt "$RECOMMENDED_VALUE" ] 2>/dev/null; then
+        echo "  ⚠️  ${VAR_NAME}=${current} (recommend ≥ ${RECOMMENDED_VALUE})"
+    else
+        echo "  ✅ ${VAR_NAME}=${current}"
+    fi
+else
+    echo "" >> "$HERMES_ENV"
+    echo "# Claude Session 优化 - 防止 Stream Stalled 中断" >> "$HERMES_ENV"
+    echo "${VAR_NAME}=${RECOMMENDED_VALUE}" >> "$HERMES_ENV"
+    echo "  ✅ Auto-configured ${VAR_NAME}=${RECOMMENDED_VALUE}"
+    echo "     (Prevents 'Stream Stalled' errors during long tasks)"
+fi
+
+echo ""
+
+# ── 3. Claude Code 权限预设（可选） ──────────────────────────────────────────
+
+CLAUDE_DIR="$HOME/.claude"
+if [ -d "$CLAUDE_DIR" ]; then
+    echo "Detected Claude Code config directory..."
+    SETTINGS="$CLAUDE_DIR/settings.json"
+
+    if [ ! -f "$SETTINGS" ]; then
+        echo "  ℹ️  No settings.json yet — will be created on first claude run"
+    else
+        echo "  ✅ Claude Code settings.json exists"
+    fi
+    echo ""
+fi
+
+# ── 4. 结果汇总 ──────────────────────────────────────────────────────────────
+
+if [ "$ALL_OK" = true ]; then
+    echo "✅ All dependencies met — claude_session is ready to use."
+else
+    echo "⚠️  Missing dependencies:"
+    for issue in "${ISSUES[@]}"; do
+        echo "    • $issue"
+    done
+    echo ""
+    echo "  claude_session will not work until these are installed."
+fi
+
+echo ""
+echo "⚠️  Important: Restart Hermes Gateway for env changes to take effect!"
+echo "   Ctrl+C the gateway, then run: hermes gateway run"
+echo ""
+echo "Configuration complete ✅"

--- a/tests/tools/test_claude_session_buffer.py
+++ b/tests/tools/test_claude_session_buffer.py
@@ -1,0 +1,129 @@
+"""Tests for tools/claude_session/output_buffer.py"""
+
+import time
+import pytest
+from tools.claude_session.output_buffer import OutputBuffer, OutputLine
+
+
+class TestOutputLine:
+    def test_creation(self):
+        ol = OutputLine(text="hello", timestamp=1.0)
+        assert ol.text == "hello"
+        assert ol.timestamp == 1.0
+
+    def test_content_hash(self):
+        ol1 = OutputLine(text="hello", timestamp=1.0)
+        ol2 = OutputLine(text="hello", timestamp=2.0)
+        assert ol1.content_hash() == ol2.content_hash()
+
+    def test_content_hash_differs(self):
+        ol1 = OutputLine(text="hello", timestamp=1.0)
+        ol2 = OutputLine(text="world", timestamp=1.0)
+        assert ol1.content_hash() != ol2.content_hash()
+
+
+class TestOutputBuffer:
+    def test_append_and_read(self):
+        buf = OutputBuffer(max_lines=10)
+        buf.append("line1")
+        buf.append("line2")
+        lines = buf.read(offset=0, limit=10)
+        assert len(lines) == 2
+        assert lines[0].text == "line1"
+        assert lines[1].text == "line2"
+
+    def test_ring_overflow(self):
+        buf = OutputBuffer(max_lines=3)
+        buf.append("line1")
+        buf.append("line2")
+        buf.append("line3")
+        buf.append("line4")
+        lines = buf.read(offset=0, limit=10)
+        assert len(lines) == 3
+        assert lines[0].text == "line2"
+        assert lines[2].text == "line4"
+
+    def test_offset_limit(self):
+        buf = OutputBuffer(max_lines=100)
+        for i in range(10):
+            buf.append(f"line{i}")
+        lines = buf.read(offset=5, limit=3)
+        assert len(lines) == 3
+        assert lines[0].text == "line5"
+
+    def test_total_count(self):
+        buf = OutputBuffer(max_lines=100)
+        for i in range(10):
+            buf.append(f"line{i}")
+        assert buf.total_count() == 10
+
+    def test_total_count_with_overflow(self):
+        buf = OutputBuffer(max_lines=5)
+        for i in range(10):
+            buf.append(f"line{i}")
+        assert buf.total_count() == 10
+
+    def test_since_marker(self):
+        buf = OutputBuffer(max_lines=100)
+        buf.append("before1")
+        buf.append("before2")
+        marker = buf.append("marker_line")
+        buf.append("after1")
+        buf.append("after2")
+        lines = buf.since(marker)
+        assert len(lines) == 2
+        assert lines[0].text == "after1"
+
+    def test_since_marker_overflow(self):
+        buf = OutputBuffer(max_lines=3)
+        m = buf.append("m")
+        buf.append("a")
+        buf.append("b")
+        buf.append("c")  # overflow, "m" evicted
+        lines = buf.since(m)
+        # marker was evicted, return all current content
+        assert len(lines) == 3
+
+    def test_last_n_chars(self):
+        buf = OutputBuffer(max_lines=100)
+        for i in range(20):
+            buf.append(f"line{i}")
+        tail = buf.last_n_chars(30)
+        assert len(tail) <= 30
+
+    def test_append_batch_dedup(self):
+        buf = OutputBuffer(max_lines=100)
+        buf.append("line1")
+        buf.append("line2")
+        # Simulate re-capturing same pane output
+        added = buf.append_batch(["line1", "line2", "line3"])
+        assert added == 1  # Only line3 is new
+
+    def test_clear(self):
+        buf = OutputBuffer(max_lines=100)
+        buf.append("line1")
+        buf.clear()
+        # Counter is preserved to keep markers valid
+        assert buf.total_count() == 1
+        assert buf.read() == []
+
+    def test_thread_safety(self):
+        import threading
+        buf = OutputBuffer(max_lines=100)
+        errors = []
+
+        def writer(start):
+            try:
+                for i in range(100):
+                    buf.append(f"thread{start}-{i}")
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=writer, args=(0,))
+        t2 = threading.Thread(target=writer, args=(100,))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        assert not errors
+        assert buf.total_count() == 200

--- a/tests/tools/test_claude_session_refactored.py
+++ b/tests/tools/test_claude_session_refactored.py
@@ -1,0 +1,523 @@
+"""Tests for refactored claude_session modules: task_context, idle, session."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from tools.claude_session.task_context import TaskContext, FileContext
+from tools.claude_session.idle import (
+    SessionState, clean_lines, detect_state, detect_activity,
+    detect_startup_scene, strip_ansi, is_permission_in_text,
+)
+from tools.claude_session.session import ClaudeSession, _StateView
+from tools.claude_session.errors import SessionNotActiveError
+
+
+# ---------------------------------------------------------------------------
+# TaskContext tests
+# ---------------------------------------------------------------------------
+
+class TestTaskContext:
+    def test_basic_prompt(self):
+        tc = TaskContext(task_description="Fix login bug")
+        prompt = tc.to_prompt()
+        assert "Fix login bug" in prompt
+        assert "## Task" in prompt
+
+    def test_full_prompt(self):
+        tc = TaskContext(
+            task_description="Implement auth",
+            file_contexts=[
+                FileContext(path="auth.py", content="def login(): pass", description="Auth module"),
+            ],
+            constraints=["Must not break existing tests"],
+            acceptance_criteria=["Login works with valid credentials"],
+            project_conventions="Use snake_case for functions",
+        )
+        prompt = tc.to_prompt()
+        assert "## Task" in prompt
+        assert "## Relevant Files" in prompt
+        assert "auth.py" in prompt
+        assert "def login(): pass" in prompt
+        assert "## Constraints" in prompt
+        assert "## Acceptance Criteria" in prompt
+        assert "## Project Conventions" in prompt
+
+    def test_empty_optional_fields(self):
+        tc = TaskContext(task_description="Simple task")
+        prompt = tc.to_prompt()
+        assert "Relevant Files" not in prompt
+        assert "Constraints" not in prompt
+        assert "Acceptance Criteria" not in prompt
+        assert "Project Conventions" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# idle.py tests
+# ---------------------------------------------------------------------------
+
+class TestIdleDetection:
+    def test_empty_input(self):
+        result = detect_state([])
+        assert result.state == SessionState.THINKING
+
+    def test_idle_with_welcome_screen(self):
+        lines = ["Welcome to Claude", "Tips for getting started", "❯"]
+        result = detect_state(lines)
+        assert result.state == SessionState.IDLE
+
+    def test_idle_with_done_marker(self):
+        lines = ["✻ Churned for 2m 57s", "─────────", "❯", "─────────", "⏵⏵"]
+        result = detect_state(lines)
+        assert result.state == SessionState.IDLE
+
+    def test_tool_call(self):
+        lines = ["● Read file.py"]
+        result = detect_state(lines)
+        assert result.state == SessionState.TOOL_CALL
+        assert result.tool_name == "Read"
+        assert result.tool_target == "file.py"
+
+    def test_tool_call_paren(self):
+        lines = ["● Bash(npm test)"]
+        result = detect_state(lines)
+        assert result.state == SessionState.TOOL_CALL
+        assert result.tool_name == "Bash"
+
+    def test_permission(self):
+        lines = ["Allow Bash command?", "❯ 1. Yes", "  2. No"]
+        result = detect_state(lines)
+        assert result.state == SessionState.PERMISSION
+
+    def test_shell_prompt_is_exited(self):
+        lines = ["some output", "❯"]
+        result = detect_state(lines)
+        assert result.state == SessionState.EXITED
+
+    def test_status_bar_prompt_is_idle(self):
+        """v2.1.126 renders ❯ + ── + status bar at IDLE — not phantom."""
+        lines = ["─────────", "❯", "─────────", "⏵⏵ bypass permissions on"]
+        result = detect_state(lines)
+        assert result.state == SessionState.IDLE
+
+    def test_phantom_prompt_without_status_bar(self):
+        """Separator + prompt + separator without status bar = phantom (THINKING)."""
+        lines = ["─────────", "❯", "─────────"]
+        result = detect_state(lines)
+        assert result.state == SessionState.THINKING
+
+    def test_compacting(self):
+        lines = ["Compacting conversation..."]
+        result = detect_state(lines)
+        assert result.state == SessionState.THINKING
+        assert result.is_compacting
+
+    def test_stale_tool_marker(self):
+        lines = ["● Read old.py", "✻ Churned for 1m", "Welcome to Claude", "❯"]
+        result = detect_state(lines)
+        assert result.state == SessionState.IDLE
+
+
+class TestActivityDetection:
+    def test_reading(self):
+        result = detect_activity(["● Read file.py"])
+        assert result["activity"] == "reading"
+
+    def test_writing(self):
+        result = detect_activity(["● Edit file.py"])
+        assert result["activity"] == "writing"
+
+    def test_executing(self):
+        result = detect_activity(["● Bash(npm test)"])
+        assert result["activity"] == "executing"
+
+    def test_searching(self):
+        result = detect_activity(["● Grep pattern"])
+        assert result["activity"] == "searching"
+
+    def test_idle_no_markers(self):
+        result = detect_activity(["some text", "more text"])
+        assert result["activity"] == "idle"
+
+    def test_empty(self):
+        result = detect_activity([])
+        assert result["activity"] == "idle"
+
+
+class TestCleanLines:
+    def test_strips_ansi(self):
+        raw = "\x1b[32mgreen text\x1b[0m\nnormal"
+        lines = clean_lines(raw)
+        assert lines == ["green text", "normal"]
+
+    def test_removes_empty(self):
+        lines = clean_lines("hello\n\nworld\n")
+        assert lines == ["hello", "world"]
+
+
+class TestPermissionDetection:
+    def test_real_permission(self):
+        assert is_permission_in_text("Allow Bash command?\n❯ 1. Yes")
+
+    def test_status_bar_not_permission(self):
+        assert not is_permission_in_text("⏵⏵ bypass permissions on\nshift+tab to cycle")
+
+
+class TestStartupScene:
+    def test_workspace_trust(self):
+        lines = ["Quick safety check", "Enter to confirm"]
+        scene = detect_startup_scene(lines)
+        assert scene is not None
+        assert scene.scene_type == "workspace_trust"
+
+    def test_no_scene(self):
+        assert detect_startup_scene(["normal output"]) is None
+
+
+# ---------------------------------------------------------------------------
+# ClaudeSession tests (unit tests, no tmux required)
+# ---------------------------------------------------------------------------
+
+class TestClaudeSessionBasic:
+    def test_initial_state(self):
+        s = ClaudeSession()
+        assert s._state == SessionState.DISCONNECTED
+        assert s._session_active is False
+
+    def test_sm_compat(self):
+        s = ClaudeSession()
+        sv = s._sm
+        assert sv.current_state == SessionState.DISCONNECTED
+        assert sv.state_duration() > 0
+
+    def test_backward_compat_alias(self):
+        from tools.claude_session import ClaudeSessionManager
+        assert ClaudeSessionManager is ClaudeSession
+
+    def test_status_no_session(self):
+        s = ClaudeSession()
+        result = s.status()
+        assert result["state"] == SessionState.DISCONNECTED
+
+    def test_send_no_session(self):
+        s = ClaudeSession()
+        with pytest.raises(SessionNotActiveError):
+            s.send("hello")
+
+    def test_send_task_context_no_session(self):
+        s = ClaudeSession()
+        tc = TaskContext(task_description="test")
+        with pytest.raises(SessionNotActiveError):
+            s.send(tc)
+
+    def test_stop_no_session(self):
+        s = ClaudeSession()
+        with pytest.raises(SessionNotActiveError):
+            s.stop()
+
+    def test_output_no_session(self):
+        s = ClaudeSession()
+        result = s.output()
+        assert result["lines"] == []
+
+    def test_history_simplified(self):
+        s = ClaudeSession()
+        result = s.history()
+        assert result["total_turns"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Interview state detection tests
+# ---------------------------------------------------------------------------
+
+class TestInterviewDetection:
+    """Tests for INTERVIEW state detection in idle.py."""
+
+    def test_interview_with_navigation_hints(self):
+        """Interview mode with navigation hints + numbered options."""
+        lines = [
+            "←  ☐ 运行环境  ☐ M1 范围  ✔ Submit  →",
+            "❯ 1. WSL 内运行",
+            "2. 混合环境",
+            "3. 都用 Windows",
+            "Enter to select · Tab/Arrow keys to navigate · Esc to cancel",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+
+    def test_interview_with_sections_only(self):
+        """Interview mode with checkbox sections and numbered options."""
+        lines = [
+            "←  ☐ 运行环境  ☐ M1 范围  ✔ Submit  →",
+            "Ready to submit your answers?",
+            "❯ 1. Submit answers",
+            "2. Cancel ⋯",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+
+    def test_interview_with_numbered_options_and_nav(self):
+        """Interview mode: numbered options + nav hints with ❯ cursor."""
+        lines = [
+            "❯ 1. WSL 内运行",
+            "2. 混合环境",
+            "3. 都用 Windows",
+            "4. Type something.",
+            "Enter to select · Tab/Arrow keys to navigate · Esc to cancel",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+
+    def test_interview_not_confused_with_permission(self):
+        """Permission selector should not be detected as INTERVIEW."""
+        lines = [
+            "Allow Bash command?",
+            "❯ 1. Yes",
+            "  2. No",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.PERMISSION
+
+    def test_interview_not_confused_with_idle(self):
+        """Interview mode should NOT return IDLE."""
+        lines = [
+            "❯ 1. WSL 内运行",
+            "2. 混合环境",
+            "Enter to select · Tab/Arrow keys to navigate · Esc to cancel",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+        assert result.state != SessionState.IDLE
+
+    def test_interview_not_triggered_without_nav_or_sections(self):
+        """Numbered options alone without nav hints or sections should not trigger INTERVIEW."""
+        lines = [
+            "Some output",
+            "❯ 1. First option",
+            "2. Second option",
+        ]
+        result = detect_state(lines)
+        # Should not be INTERVIEW (no nav hints, no section markers)
+        assert result.state != SessionState.INTERVIEW
+
+    def test_bare_type_something_not_false_positive(self):
+        """Bare 'Type something.' in prose should not trigger INTERVIEW."""
+        lines = [
+            "To fix this, type something. Then press Enter.",
+            "❯ 1. Option A",
+        ]
+        result = detect_state(lines)
+        assert result.state != SessionState.INTERVIEW
+
+    def test_numbered_explanations_not_false_positive(self):
+        """Claude's numbered explanations without ❯ cursor or nav hints should not trigger."""
+        lines = [
+            "Here are the steps:",
+            "1. First step",
+            "2. Second step",
+            "3. Third step",
+            "Enter to select · Tab/Arrow keys to navigate",
+        ]
+        result = detect_state(lines)
+        assert result.state != SessionState.INTERVIEW
+
+    def test_interview_with_ctrl_o_hint(self):
+        """Interview mode with ctrl+o hint."""
+        lines = [
+            "❯ 1. Option A",
+            "2. Option B",
+            "ctrl+o to expand",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+
+    def test_interview_with_type_something_hint(self):
+        """Interview mode with numbered 'Type something.' hint."""
+        lines = [
+            "❯ 1. Chat about this",
+            "2. Skip interview and plan immediately",
+            "4. Type something.",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+
+    def test_interview_has_higher_priority_than_tool_call(self):
+        """INTERVIEW should be detected before TOOL_CALL when both patterns exist."""
+        lines = [
+            "● Read some_file.py",
+            "←  ☐ Question  ✔ Submit  →",
+            "❯ 1. Option A",
+            "2. Option B",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.INTERVIEW
+
+    def test_permission_has_higher_priority_than_interview(self):
+        """PERMISSION should be detected before INTERVIEW."""
+        lines = [
+            "Allow Bash command?",
+            "❯ 1. Yes",
+            "  2. No",
+            "Enter to select · Tab/Arrow keys to navigate",
+        ]
+        result = detect_state(lines)
+        assert result.state == SessionState.PERMISSION
+
+
+# ---------------------------------------------------------------------------
+# Interview context building tests
+# ---------------------------------------------------------------------------
+
+class TestInterviewContext:
+    """Tests for _build_interview_context in session.py."""
+
+    def test_build_context_extracts_options(self):
+        s = ClaudeSession()
+        lines = [
+            "←  ☐ 运行环境  ☐ M1 范围  ✔ Submit  →",
+            "❯ 1. WSL 内运行",
+            "2. 混合环境",
+            "3. 都用 Windows",
+            "Enter to select · Tab/Arrow keys to navigate · Esc to cancel",
+        ]
+        ctx = s._build_interview_context(lines)
+        assert ctx["state"] == SessionState.INTERVIEW
+        assert ctx["needs_hermes_decision"] is True
+        assert len(ctx["options"]) == 3
+        assert ctx["options"][0]["number"] == 1
+        assert ctx["options"][0]["text"] == "WSL 内运行"
+        assert ctx["options"][0]["selected"] is True
+        assert ctx["options"][1]["selected"] is False
+
+    def test_build_context_extracts_sections(self):
+        s = ClaudeSession()
+        lines = [
+            "←  ☐ 运行环境  ☐ M1 范围  ✔ Submit  →",
+            "❯ 1. Submit answers",
+            "2. Cancel ⋯",
+        ]
+        ctx = s._build_interview_context(lines)
+        assert len(ctx["sections"]) >= 3  # at least 运行环境, M1 范围, Submit
+        checked = [sec for sec in ctx["sections"] if sec["checked"]]
+        unchecked = [sec for sec in ctx["sections"] if not sec["checked"]]
+        assert len(checked) >= 1  # Submit is ✔
+        assert len(unchecked) >= 1  # ☐ sections
+        # Verify multi-word labels are captured fully (not truncated)
+        labels = [sec["label"] for sec in ctx["sections"]]
+        assert any("M1 范围" in label for label in labels), f"Expected 'M1 范围' in {labels}"
+
+    def test_build_context_extracts_question(self):
+        s = ClaudeSession()
+        lines = [
+            "What is your environment?",
+            "❯ 1. WSL 内运行",
+            "2. 混合环境",
+            "Enter to select",
+        ]
+        ctx = s._build_interview_context(lines)
+        assert "What is your environment?" in ctx["question"]
+
+    def test_build_context_question_not_confused_with_numbered_option(self):
+        """Numbered options containing '?' should not be picked as the question."""
+        s = ClaudeSession()
+        lines = [
+            "What is your environment?",
+            "❯ 1. WSL 内运行",
+            "2. Use Windows?",
+            "Enter to select",
+        ]
+        ctx = s._build_interview_context(lines)
+        assert "What is your environment?" in ctx["question"]
+        assert "Use Windows?" not in ctx["question"]
+
+    def test_build_context_empty_lines(self):
+        s = ClaudeSession()
+        ctx = s._build_interview_context(None)
+        assert ctx["state"] == SessionState.INTERVIEW
+        assert ctx["options"] == []
+        assert ctx["sections"] == []
+
+    def test_build_context_no_question(self):
+        s = ClaudeSession()
+        lines = [
+            "←  ☐ Config  ✔ Submit  →",
+            "❯ 1. Submit",
+        ]
+        ctx = s._build_interview_context(lines)
+        assert ctx["question"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Interview response tests
+# ---------------------------------------------------------------------------
+
+class TestRespondInterview:
+    """Tests for respond_interview in session.py."""
+
+    def test_respond_no_session_raises(self):
+        s = ClaudeSession()
+        with pytest.raises(SessionNotActiveError):
+            s.respond_interview("1")
+
+    def test_respond_wrong_state_raises(self):
+        """respond_interview should reject when not in INTERVIEW state."""
+        s = ClaudeSession()
+        s._session_active = True
+        s._state = SessionState.THINKING
+        with pytest.raises(SessionNotActiveError, match="Not in INTERVIEW state"):
+            s.respond_interview("1")
+
+    def test_respond_enter(self):
+        s = ClaudeSession()
+        s._session_active = True
+        s._tmux = MagicMock()
+        s._state = SessionState.INTERVIEW
+        with patch.object(s, '_refresh_state'):
+            result = s.respond_interview("enter")
+        s._tmux.send_special_key.assert_called_once_with("Enter")
+        assert result["responded"] is True
+
+    def test_respond_escape(self):
+        s = ClaudeSession()
+        s._session_active = True
+        s._tmux = MagicMock()
+        s._state = SessionState.INTERVIEW
+        with patch.object(s, '_refresh_state'):
+            result = s.respond_interview("escape")
+        s._tmux.send_special_key.assert_called_once_with("Escape")
+        assert result["responded"] is True
+
+    def test_respond_number_direct_typing(self):
+        """Typing a number navigates via arrow keys to that option."""
+        s = ClaudeSession()
+        s._session_active = True
+        s._tmux = MagicMock()
+        s._state = SessionState.INTERVIEW
+
+        with patch.object(s, '_refresh_state'):
+            result = s.respond_interview("3")
+
+        # Should send Up 20 times (reset to top), then Down 2 times (to option 3), then Enter
+        assert s._tmux.send_special_key.call_count == 23  # 20 Up + 2 Down + 1 Enter
+        s._tmux.send_special_key.assert_called_with("Enter")
+        assert result["responded"] is True
+
+    def test_respond_option_zero_rejected(self):
+        """Option '0' should fall through to custom text path (not isdigit()>0)."""
+        s = ClaudeSession()
+        s._session_active = True
+        s._tmux = MagicMock()
+        s._state = SessionState.INTERVIEW
+        with patch.object(s, '_refresh_state'):
+            result = s.respond_interview("0")
+        # "0" is a digit but int("0") > 0 is False, so it falls to custom text
+        s._tmux.send_keys.assert_called_once_with("0", enter=True)
+        assert result["responded"] is True
+
+    def test_respond_custom_text(self):
+        s = ClaudeSession()
+        s._session_active = True
+        s._tmux = MagicMock()
+        s._state = SessionState.INTERVIEW
+        with patch.object(s, '_refresh_state'):
+            result = s.respond_interview("custom text input")
+        s._tmux.send_keys.assert_called_once_with("custom text input", enter=True)
+        assert result["responded"] is True

--- a/tests/tools/test_claude_session_tmux.py
+++ b/tests/tools/test_claude_session_tmux.py
@@ -1,0 +1,98 @@
+"""Tests for tools/claude_session/tmux_interface.py"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.claude_session.tmux_interface import TmuxInterface
+
+
+@pytest.fixture
+def tmux():
+    return TmuxInterface(session_name="test-claude")
+
+
+class TestTmuxInterface:
+    def test_session_exists_check(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert tmux.session_exists() is True
+
+    def test_session_not_exists(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert tmux.session_exists() is False
+
+    def test_create_session(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = tmux.create_session(workdir="/tmp/test")
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert "new-session" in args
+            assert "-d" in args
+
+    def test_capture_pane(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="line1\nline2\n❯ "
+            )
+            output = tmux.capture_pane()
+            assert "line1" in output
+            assert "❯" in output
+
+    def test_send_keys_uses_literal_flag(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            tmux.send_keys("hello world")
+            args = mock_run.call_args[0][0]
+            assert "send-keys" in args
+            assert "-l" in args
+            assert "hello world" in args
+
+    def test_send_keys_with_enter_sends_separately(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            tmux.send_keys("hello", enter=True)
+            # Should have two calls: one for text (-l), one for Enter
+            assert mock_run.call_count == 2
+            first_args = mock_run.call_args_list[0][0][0]
+            second_args = mock_run.call_args_list[1][0][0]
+            assert "-l" in first_args
+            assert "Enter" in second_args
+
+    def test_send_special_key(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            tmux.send_special_key("C-c")
+            args = mock_run.call_args[0][0]
+            assert "C-c" in args
+
+    def test_kill_session(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            tmux.kill_session()
+            args = mock_run.call_args[0][0]
+            assert "kill-session" in args
+
+    def test_send_keys_no_shell_escaping_needed(self, tmux):
+        """With -l flag and subprocess.run list args, special chars are safe."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            tmux.send_keys("it's $HOME `whoami`")
+            args = mock_run.call_args[0][0]
+            # Text should pass through unmodified
+            assert "it's $HOME `whoami`" in args
+
+    def test_create_session_with_env(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            tmux.create_session(workdir="/tmp", env={"FOO": "bar"})
+            args = mock_run.call_args[0][0]
+            assert "-e" in args
+            assert "FOO=bar" in args
+
+    def test_session_not_found_error(self, tmux):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("tmux not found")
+            with pytest.raises(RuntimeError, match="not installed"):
+                tmux.session_exists()

--- a/tests/tools/test_claude_session_tool.py
+++ b/tests/tools/test_claude_session_tool.py
@@ -1,0 +1,575 @@
+"""Tests for tools/claude_session_tool.py — Tool registration and dispatch."""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.claude_session_tool import (
+    CLAUDE_SESSION_SCHEMA, _handle_claude_session,
+    _check_claude_session, _diagnose_claude_session,
+    _extract_mcp_failure_count, _get_active_sessions_output,
+)
+
+
+class TestSchema:
+    def test_schema_has_name(self):
+        assert CLAUDE_SESSION_SCHEMA["name"] == "claude_session"
+
+    def test_schema_has_required_action(self):
+        assert "action" in CLAUDE_SESSION_SCHEMA["parameters"]["required"]
+
+    def test_schema_action_enum(self):
+        actions = CLAUDE_SESSION_SCHEMA["parameters"]["properties"]["action"]["enum"]
+        expected = [
+            "start", "send", "type", "submit", "send_text", "cancel_input",
+            "status", "wait_for_idle", "wait_for_state",
+            "output", "jsonl_output", "respond_permission", "respond_interview",
+            "stop", "history", "events",
+            "list", "switch",
+            "diagnose", "doctor_fix",
+        ]
+        assert set(actions) == set(expected)
+
+
+class TestHandlerDispatch:
+    def test_status_no_session(self):
+        result = _handle_claude_session({"action": "status"})
+        data = json.loads(result)
+        assert data["state"] == "DISCONNECTED"
+
+    def test_unknown_action(self):
+        result = _handle_claude_session({"action": "nonexistent"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_send_no_session(self):
+        result = _handle_claude_session({"action": "send", "message": "test"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_stop_no_session(self):
+        result = _handle_claude_session({"action": "stop"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_send_missing_message(self):
+        result = _handle_claude_session({"action": "send"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_type_missing_text(self):
+        result = _handle_claude_session({"action": "type"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_wait_for_state_missing_target(self):
+        result = _handle_claude_session({"action": "wait_for_state"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_respond_permission_missing_response(self):
+        result = _handle_claude_session({"action": "respond_permission"})
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_history_no_session(self):
+        result = _handle_claude_session({"action": "history"})
+        data = json.loads(result)
+        assert data["total_turns"] == 0
+
+    def test_events_no_session(self):
+        result = _handle_claude_session({"action": "events"})
+        data = json.loads(result)
+        assert data["events"] == []
+
+    def test_output_no_session(self):
+        result = _handle_claude_session({"action": "output"})
+        data = json.loads(result)
+        assert "lines" in data
+
+    def test_default_route_uses_active_session_not_last_created(self):
+        """switch/_active_session must control default routing when name/session_id omitted."""
+        from tools.claude_session_tool import (
+            _sessions, _workdir_index, _name_index, _active_session, _sessions_lock,
+        )
+        _sessions.clear()
+        _workdir_index.clear()
+        _name_index.clear()
+        _active_session.clear()
+
+        first = MagicMock(_session_id="sess-1", _gateway_session_key="", _session_active=True)
+        first.status.return_value = {"state": "IDLE", "session": "first"}
+        second = MagicMock(_session_id="sess-2", _gateway_session_key="", _session_active=True)
+        second.status.return_value = {"state": "THINKING", "session": "second"}
+
+        with _sessions_lock:
+            _sessions["sess-1"] = first
+            _sessions["sess-2"] = second
+            _name_index[("", "first")] = "sess-1"
+            _name_index[("", "second")] = "sess-2"
+            _active_session[""] = "sess-1"
+
+        data = json.loads(_handle_claude_session({"action": "status"}))
+        assert data["session"] == "first"
+        first.status.assert_called_once()
+        second.status.assert_not_called()
+
+
+class TestToolRegistration:
+    def test_tool_registered(self):
+        """Verify the tool is discoverable in the registry."""
+        from tools.registry import registry
+        entry = registry.get_entry("claude_session")
+        assert entry is not None
+        assert entry.toolset == "claude_session"
+        assert entry.emoji == "🤖"
+
+    def test_schema_matches_registry(self):
+        from tools.registry import registry
+        entry = registry.get_entry("claude_session")
+        assert entry is not None
+        assert entry.schema["name"] == "claude_session"
+
+
+class TestCheckFn:
+    """Tests for _check_claude_session availability check."""
+
+    def test_returns_true_when_tmux_available(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: "/usr/bin/tmux" if cmd == "tmux" else None
+            assert _check_claude_session() is True
+
+    def test_returns_false_when_tmux_missing(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which:
+            mock_which.return_value = None
+            assert _check_claude_session() is False
+
+    def test_logs_warning_when_claude_missing(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which:
+            with patch("tools.claude_session_tool.logger") as mock_logger:
+                mock_which.side_effect = lambda cmd: "/usr/bin/tmux" if cmd == "tmux" else None
+                _check_claude_session()
+                mock_logger.warning.assert_called_once()
+                assert "Claude Code CLI not found" in mock_logger.warning.call_args[0][0]
+
+    def test_returns_true_even_when_claude_missing(self):
+        """tmux is the hard dep; claude CLI is soft — still registers."""
+        with patch("tools.claude_session_tool.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: "/usr/bin/tmux" if cmd == "tmux" else None
+            assert _check_claude_session() is True
+
+
+class TestDiagnose:
+    """Tests for _diagnose_claude_session and the diagnose action."""
+
+    def setup_method(self):
+        """Reset module-level state before each test."""
+        from tools.claude_session_tool import _sessions, _workdir_index, _name_index, _active_session
+        _sessions.clear()
+        _workdir_index.clear()
+        _name_index.clear()
+        _active_session.clear()
+
+    def test_diagnose_function_all_ok(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            assert result["status"] == "ready"
+            assert len(result["checks"]) == 6
+
+    def test_diagnose_function_missing_deps(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {}, clear=True):
+            mock_which.return_value = None
+            result = _diagnose_claude_session()
+            assert result["status"] == "missing_deps"
+            dep_names = [c["dependency"] for c in result["checks"]]
+            assert "tmux" in dep_names
+            assert "Claude Code CLI" in dep_names
+
+    def test_diagnose_action_dispatch(self):
+        """diagnose action should return JSON via handler."""
+        with patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _handle_claude_session({"action": "diagnose"})
+            data = json.loads(result)
+            assert data["status"] == "ready"
+
+    def test_diagnose_timeout_too_low(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "120"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            timeout_check = next(c for c in result["checks"] if c["dependency"] == "HERMES_STREAM_STALE_TIMEOUT")
+            assert timeout_check["status"] == "too_low"
+
+    def test_diagnose_timeout_not_set(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {}, clear=True):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            timeout_check = next(c for c in result["checks"] if c["dependency"] == "HERMES_STREAM_STALE_TIMEOUT")
+            assert timeout_check["status"] == "not_set"
+
+    def test_diagnose_has_hints_for_missing(self):
+        with patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {}, clear=True):
+            mock_which.return_value = None
+            result = _diagnose_claude_session()
+            for check in result["checks"]:
+                if check["status"] == "missing":
+                    assert check.get("hint") is not None
+                    assert len(check["hint"]) > 0
+
+
+class TestExtractMcpFailureCount:
+    """Tests for _extract_mcp_failure_count pure function."""
+
+    def test_single_server_failure(self):
+        text = "2 MCP servers failed · /mcp"
+        assert _extract_mcp_failure_count(text) == 2
+
+    def test_single_server_singular(self):
+        text = "1 MCP server failed · /mcp"
+        assert _extract_mcp_failure_count(text) == 1
+
+    def test_no_failure(self):
+        text = "All systems operational"
+        assert _extract_mcp_failure_count(text) == 0
+
+    def test_empty_string(self):
+        assert _extract_mcp_failure_count("") == 0
+
+    def test_large_count(self):
+        text = "15 MCP servers failed · /mcp"
+        assert _extract_mcp_failure_count(text) == 15
+
+
+class TestWorkdirIndexCleanup:
+    """Tests for _workdir_index cleanup when stopping sessions."""
+
+    def setup_method(self):
+        """Reset module-level state before each test."""
+        from tools.claude_session_tool import _sessions, _workdir_index, _name_index, _active_session
+        _sessions.clear()
+        _workdir_index.clear()
+        _name_index.clear()
+        _active_session.clear()
+
+    def test_workdir_index_cleanup_single_session(self):
+        """Stop session with unique workdir removes entry entirely."""
+        from tools.claude_session_tool import (
+            _sessions, _workdir_index, _name_index,
+            _sessions_lock,
+        )
+        gw_key = ""
+        workdir = "/tmp/test"
+        session_id = "sess-1"
+        name = "task-1"
+
+        # 模拟启动后的状态
+        with _sessions_lock:
+            _name_index[(gw_key, name)] = session_id
+            _workdir_index[(gw_key, workdir)] = [session_id]
+            _sessions[session_id] = MagicMock(
+                _session_id=session_id,
+                _session_name=name,
+                _gateway_session_key=gw_key,
+                _session_active=True,
+            )
+
+        # 验证初始状态
+        with _sessions_lock:
+            assert (gw_key, workdir) in _workdir_index
+            assert _workdir_index[(gw_key, workdir)] == [session_id]
+
+        # 模拟 stop
+        with _sessions_lock:
+            # 执行清理逻辑
+            keys_to_remove = []
+            for k, v_list in _workdir_index.items():
+                if session_id in v_list:
+                    updated_list = [sid for sid in v_list if sid != session_id]
+                    if updated_list:
+                        _workdir_index[k] = updated_list
+                    else:
+                        keys_to_remove.append(k)
+            for k in keys_to_remove:
+                _workdir_index.pop(k, None)
+
+        # 验证清理结果
+        with _sessions_lock:
+            assert (gw_key, workdir) not in _workdir_index
+
+    def test_workdir_index_cleanup_multiple_sessions_same_workdir(self):
+        """Stop one of two sessions with same workdir keeps the other."""
+        from tools.claude_session_tool import (
+            _sessions, _workdir_index, _name_index,
+            _sessions_lock,
+        )
+        gw_key = ""
+        workdir = "/tmp/test"
+        sess1 = "sess-1"
+        sess2 = "sess-2"
+        name1 = "task-1"
+        name2 = "task-2"
+
+        # 模拟启动两个会话后的状态
+        with _sessions_lock:
+            _name_index[(gw_key, name1)] = sess1
+            _name_index[(gw_key, name2)] = sess2
+            _workdir_index[(gw_key, workdir)] = [sess1, sess2]
+            _sessions[sess1] = MagicMock(
+                _session_id=sess1,
+                _session_name=name1,
+                _gateway_session_key=gw_key,
+                _session_active=True,
+            )
+            _sessions[sess2] = MagicMock(
+                _session_id=sess2,
+                _session_name=name2,
+                _gateway_session_key=gw_key,
+                _session_active=True,
+            )
+
+        # 验证初始状态
+        with _sessions_lock:
+            assert _workdir_index[(gw_key, workdir)] == [sess1, sess2]
+
+        # 模拟停止 sess1
+        with _sessions_lock:
+            keys_to_remove = []
+            for k, v_list in _workdir_index.items():
+                if sess1 in v_list:
+                    updated_list = [sid for sid in v_list if sid != sess1]
+                    if updated_list:
+                        _workdir_index[k] = updated_list
+                    else:
+                        keys_to_remove.append(k)
+            for k in keys_to_remove:
+                _workdir_index.pop(k, None)
+
+        # 验证 sess2 仍在索引中
+        with _sessions_lock:
+            assert (gw_key, workdir) in _workdir_index
+            assert _workdir_index[(gw_key, workdir)] == [sess2]
+
+    def test_workdir_index_cleanup_both_sessions_same_workdir(self):
+        """Stop both sessions with same workdir removes entry entirely."""
+        from tools.claude_session_tool import (
+            _sessions, _workdir_index, _name_index,
+            _sessions_lock,
+        )
+        gw_key = ""
+        workdir = "/tmp/test"
+        sess1 = "sess-1"
+        sess2 = "sess-2"
+
+        # 模拟两个会话
+        with _sessions_lock:
+            _workdir_index[(gw_key, workdir)] = [sess1, sess2]
+            _sessions[sess1] = MagicMock(_session_id=sess1)
+            _sessions[sess2] = MagicMock(_session_id=sess2)
+
+        # 停止 sess1
+        with _sessions_lock:
+            keys_to_remove = []
+            for k, v_list in _workdir_index.items():
+                if sess1 in v_list:
+                    updated_list = [sid for sid in v_list if sid != sess1]
+                    if updated_list:
+                        _workdir_index[k] = updated_list
+                    else:
+                        keys_to_remove.append(k)
+            for k in keys_to_remove:
+                _workdir_index.pop(k, None)
+
+        # 验证只剩 sess2
+        with _sessions_lock:
+            assert _workdir_index[(gw_key, workdir)] == [sess2]
+
+        # 停止 sess2
+        with _sessions_lock:
+            keys_to_remove = []
+            for k, v_list in _workdir_index.items():
+                if sess2 in v_list:
+                    updated_list = [sid for sid in v_list if sid != sess2]
+                    if updated_list:
+                        _workdir_index[k] = updated_list
+                    else:
+                        keys_to_remove.append(k)
+            for k in keys_to_remove:
+                _workdir_index.pop(k, None)
+
+        # 验证 entry 被移除
+        with _sessions_lock:
+            assert (gw_key, workdir) not in _workdir_index
+
+
+class TestSessionDiagnoseChecks:
+    """Tests for session-level diagnose checks (THINKING, bypass, MCP)."""
+
+    def _mock_session(self, state, duration, output_tail=""):
+        """Build a mock session info dict for _get_active_sessions_output."""
+        return [{
+            "session_id": "abcd1234efgh5678",
+            "state": state,
+            "state_duration_seconds": duration,
+            "output_tail": output_tail,
+        }]
+
+    def test_thinking_critical(self):
+        """THINKING >300s → status='session_issues' with critical check."""
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = self._mock_session("THINKING", 350.0)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            assert result["status"] == "session_issues"
+            thinking_checks = [c for c in result["checks"]
+                               if "THINKING duration" in c.get("dependency", "")]
+            assert len(thinking_checks) == 1
+            assert thinking_checks[0]["status"] == "critical"
+
+    def test_thinking_warning(self):
+        """THINKING >120s but <300s → status='ready' with warning check."""
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = self._mock_session("THINKING", 150.0)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            assert result["status"] == "ready"
+            thinking_checks = [c for c in result["checks"]
+                               if "THINKING duration" in c.get("dependency", "")]
+            assert len(thinking_checks) == 1
+            assert thinking_checks[0]["status"] == "warning"
+
+    def test_bypass_permissions_hang(self):
+        """3+ 'bypass permissions on' → critical startup hang."""
+        bypass_text = (
+            "bypass permissions on (shift+tab to cycle)\n"
+            "bypass permissions on (shift+tab to cycle)\n"
+            "bypass permissions on (shift+tab to cycle)\n"
+        )
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = self._mock_session("READY", 5.0, bypass_text)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            assert result["status"] == "session_issues"
+            hang_checks = [c for c in result["checks"]
+                           if "startup hang" in c.get("dependency", "")]
+            assert len(hang_checks) == 1
+            assert hang_checks[0]["status"] == "critical"
+
+    def test_mcp_failure(self):
+        """MCP server failure text → warning check."""
+        mcp_text = "Some output\n2 MCP servers failed · /mcp\nMore output"
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = self._mock_session("READY", 5.0, mcp_text)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            mcp_checks = [c for c in result["checks"]
+                          if "MCP servers" in c.get("dependency", "")]
+            assert len(mcp_checks) == 1
+            assert mcp_checks[0]["status"] == "warning"
+
+    def test_no_sessions_ready_status(self):
+        """No active sessions → status='ready' (no session-level checks)."""
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = []
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+            assert result["status"] == "ready"
+
+    def test_cli_migration_prompt(self):
+        """CLI migration prompt → info check."""
+        migration_text = "switched from npm to native installer\nSome other output"
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = self._mock_session("READY", 5.0, migration_text)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+        cli_checks = [c for c in result["checks"]
+                      if "CLI migration" in c.get("dependency", "")]
+        assert len(cli_checks) == 1
+        assert cli_checks[0]["status"] == "info"
+
+    def test_tmux_focus_events_off(self):
+        """tmux focus-events off → info check."""
+        tmux_text = "tmux focus-events off · add 'set -g focus-events on'\nSome output"
+        with patch("tools.claude_session_tool._get_active_sessions_output") as mock_sessions, \
+             patch("tools.claude_session_tool.shutil.which") as mock_which, \
+             patch.dict(os.environ, {"HERMES_STREAM_STALE_TIMEOUT": "300"}):
+            mock_which.side_effect = lambda cmd: {
+                "tmux": "/usr/bin/tmux",
+                "claude": "/usr/local/bin/claude",
+            }.get(cmd)
+            mock_sessions.return_value = self._mock_session("READY", 5.0, tmux_text)
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="tmux 3.4")
+                result = _diagnose_claude_session()
+        tmux_checks = [c for c in result["checks"]
+                       if "tmux config" in c.get("dependency", "")]
+        assert len(tmux_checks) == 1
+        assert tmux_checks[0]["status"] == "info"

--- a/tools/claude_session/__init__.py
+++ b/tools/claude_session/__init__.py
@@ -1,0 +1,28 @@
+"""Claude Session — context pipeline for Claude Code."""
+
+from tools.claude_session.session import ClaudeSession
+from tools.claude_session.errors import (
+    SessionError, ErrorSeverity,
+    TmuxError, TmuxNotFoundError, TmuxTimeoutError,
+    SessionDisconnectedError, SessionNotActiveError,
+    StartupFailedError, SessionExitedError,
+    PermissionError, InvalidPermissionResponseError,
+    WaitTimeoutError, StallDetectedError, ValidationError,
+    StateDetectionError, wrap_tmux_error,
+)
+from tools.claude_session.stream_output import SessionOutputStreamer
+
+# Backward compatibility alias
+ClaudeSessionManager = ClaudeSession
+
+__all__ = [
+    "ClaudeSession", "ClaudeSessionManager",
+    "SessionError", "ErrorSeverity",
+    "TmuxError", "TmuxNotFoundError", "TmuxTimeoutError",
+    "SessionDisconnectedError", "SessionNotActiveError",
+    "StartupFailedError", "SessionExitedError",
+    "PermissionError", "InvalidPermissionResponseError",
+    "WaitTimeoutError", "StallDetectedError", "ValidationError",
+    "StateDetectionError", "wrap_tmux_error",
+    "SessionOutputStreamer",
+]

--- a/tools/claude_session/errors.py
+++ b/tools/claude_session/errors.py
@@ -1,0 +1,142 @@
+"""errors.py — Unified error taxonomy for claude_session.
+
+All session-layer errors are wrapped in SessionError subclasses so callers
+(gateway, tools) can branch on error type instead of parsing strings.
+
+Severity levels guide the gateway's response:
+  - TRANSIENT: auto-retry is reasonable (network blip, tmux hiccup)
+  - RECOVERABLE: user action or restart can fix (permission denied, startup fail)
+  - FATAL: cannot be recovered in-session (tmux not installed, auth revoked)
+"""
+
+from enum import Enum
+
+
+class ErrorSeverity(str, Enum):
+    TRANSIENT = "transient"
+    RECOVERABLE = "recoverable"
+    FATAL = "fatal"
+
+
+class SessionError(Exception):
+    """Base for all session errors."""
+
+    severity: ErrorSeverity = ErrorSeverity.RECOVERABLE
+    retryable: bool = False
+
+    def __init__(self, message: str, *, detail: str = ""):
+        self.detail = detail
+        super().__init__(message)
+
+    def to_dict(self) -> dict:
+        return {
+            "error": str(self),
+            "error_type": type(self).__name__,
+            "severity": self.severity.value,
+            "retryable": self.retryable,
+            "detail": self.detail,
+        }
+
+
+# --- Infrastructure errors (tmux / subprocess) ---
+
+class TmuxError(SessionError):
+    """Tmux command failed or session was lost."""
+    severity = ErrorSeverity.TRANSIENT
+    retryable = True
+
+
+class TmuxNotFoundError(SessionError):
+    """tmux binary is not installed."""
+    severity = ErrorSeverity.FATAL
+    retryable = False
+
+
+class TmuxTimeoutError(SessionError):
+    """Tmux command timed out."""
+    severity = ErrorSeverity.TRANSIENT
+    retryable = True
+
+
+class SessionDisconnectedError(SessionError):
+    """Tmux session disappeared (crashed / killed externally)."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = False
+
+
+# --- Session lifecycle errors ---
+
+class SessionNotActiveError(SessionError):
+    """Operation attempted on a session that isn't running."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = False
+
+
+class StartupFailedError(SessionError):
+    """Claude Code failed to become IDLE within the startup timeout."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = True
+
+
+class SessionExitedError(SessionError):
+    """Claude Code process has exited."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = False
+
+
+# --- Permission errors ---
+
+class PermissionError(SessionError):
+    """Permission prompt handling failed."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = False
+
+
+class InvalidPermissionResponseError(SessionError):
+    """Caller passed an invalid permission response value."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = False
+
+
+# --- Wait / timeout errors ---
+
+class WaitTimeoutError(SessionError):
+    """wait_for_idle exceeded its deadline."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = True
+
+
+class StallDetectedError(SessionError):
+    """No output growth for the stall threshold duration."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = True
+
+
+# --- Validation errors ---
+
+class ValidationError(SessionError):
+    """Invalid input parameter."""
+    severity = ErrorSeverity.RECOVERABLE
+    retryable = False
+
+
+# --- Detection / parsing errors ---
+
+class StateDetectionError(SessionError):
+    """Failed to parse Claude Code output state."""
+    severity = ErrorSeverity.TRANSIENT
+    retryable = True
+
+
+def wrap_tmux_error(exc: Exception) -> SessionError:
+    """Convert a raw tmux/subprocess exception into the appropriate SessionError."""
+    import subprocess
+
+    if isinstance(exc, FileNotFoundError):
+        return TmuxNotFoundError("tmux is not installed or not in PATH")
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return TmuxTimeoutError(f"tmux command timed out: {exc}", detail=str(exc))
+    msg = str(exc).lower()
+    if "session not found" in msg or "can't find session" in msg or "no session" in msg:
+        return SessionDisconnectedError(f"tmux session lost: {exc}", detail=str(exc))
+    return TmuxError(f"tmux error: {exc}", detail=str(exc))

--- a/tools/claude_session/idle.py
+++ b/tools/claude_session/idle.py
@@ -1,0 +1,383 @@
+"""idle.py — Minimal state detection for Claude Code TUI output.
+
+Extracted from the former output_parser.py. Only retains what's needed
+to answer "what state is Claude in?" and "is Claude done?".
+
+No state machine, no turn tracking, no user-prompt parsing.
+Just pure functions that inspect tmux output.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# State constants
+# ---------------------------------------------------------------------------
+
+class SessionState:
+    IDLE = "IDLE"
+    THINKING = "THINKING"
+    TOOL_CALL = "TOOL_CALL"
+    PERMISSION = "PERMISSION"
+    INTERVIEW = "INTERVIEW"
+    ERROR = "ERROR"
+    DISCONNECTED = "DISCONNECTED"
+    EXITED = "EXITED"
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\].*?\x07|\x1b\[.*?m")
+
+_TOOL_CALL_RE = re.compile(r"^●\s+(\w+)(?:\s+(.+))?$")
+_TOOL_CALL_PAREN_RE = re.compile(r"^●\s+(\w+)\((.+)\)$")
+_PROMPT_RE = re.compile(r"^❯")
+_PASTED_TEXT_RE = re.compile(r"^\❯\s*\[Pasted text")
+
+_PERMISSION_RE = re.compile(
+    r"(Allow\s+.*\?"
+    r"|.*permission\s+to.*"
+    r"|❯\s*(Allow|Yes)\b"
+    r"|❯\s*\d+\.\s*(Yes|Allow|Deny|No)\b"
+    r"|Do you want to proceed\?"
+    r"|.*Yes.*No\b)",
+    re.IGNORECASE,
+)
+
+_STATUS_BAR_RE = re.compile(
+    r"(bypass permissions (on|off)|shift\+tab to cycle|esc to interrupt|"
+    r"⏵⏵|/model|/mcp|/ide for Visual Studio Code|"
+    r"\d+\s+MCP\s+servers?\s+failed|"
+    r"tmux focus-events|"
+    r"[─━]{5,})",
+    re.IGNORECASE,
+)
+# Status bar without decoration lines — used to distinguish real IDLE from phantom prompt.
+# Decoration lines (───) are ambiguous: they appear in both phantom prompts and real IDLE.
+_STATUS_BAR_CONTENT_RE = re.compile(
+    r"(bypass permissions (on|off)|shift\+tab to cycle|esc to interrupt|"
+    r"⏵⏵|/model|/mcp|/ide for Visual Studio Code|"
+    r"\d+\s+MCP\s+servers?\s+failed|"
+    r"tmux focus-events)",
+    re.IGNORECASE,
+)
+_DECORATION_RE = re.compile(r"^[─━]{5,}$")
+_ERROR_RE = re.compile(r"(Error:.*|Failed:.*|error:.*)", re.IGNORECASE)
+_DONE_TIME_RE = re.compile(r"^✻\s+\S+.*\bfor\s+\d+[hms]", re.IGNORECASE)
+_COMPACT_RE = re.compile(
+    r"(Compacting|compressing\s+conversation|context\s+compression|"
+    r"condensing|summarizing\s+conversation|✓.*compact|"
+    r"concise.*summary|compact.*history)",
+    re.IGNORECASE,
+)
+# Spinner animation patterns — indicate Claude is actively thinking/working
+# These appear as animated characters at the start of lines during processing
+# NOTE: "Brewed for Xm" is a DONE marker, excluded here (handled by _DONE_TIME_RE)
+# Match ANY text after spinner char — Claude Code verbs are constantly changing
+_SPINNER_CHAR_RE = re.compile(
+    r"^[" + re.escape("✶✽✻✢·*") + r"]\s+\S",
+)
+# Legacy: specific verb matching (kept for backward compat with tests)
+_SPINNER_RE = re.compile(
+    r"^[" + re.escape("✶✽✻✢·*") + r"]\s+"
+    r"(Nebulizing|Zigzagging|Tomfoolering|thinking|"
+    r"still thinking|thinking more|thinking some more|almost done thinking|"
+    r"Deliberating|Meditating|Pondering|Reasoning|Analyzing|Processing|"
+    r"Photosynthesizing|Marinating|Percolating|"
+    r"Cogitating|Ruminating|Speculating|Computing|Evaluating)",
+    re.IGNORECASE,
+)
+_WELCOME_SCREEN_RE = re.compile(
+    r"(welcome to claude|welcome back|tips for getting started|recent activity)",
+    re.IGNORECASE,
+)
+_CLAUDE_TUI_SIGNATURE_RE = re.compile(
+    r"(claude|thinking|compacting|bypass permissions|"
+    r"shift\+tab to cycle|esc to interrupt|/model|/mcp|"
+    r"⏵⏵|welcome to claude)",
+    re.IGNORECASE,
+)
+_TRUST_WORKSPACE_RE = re.compile(r"quick\s+safety\s+check", re.IGNORECASE)
+_ENTER_TO_CONFIRM_RE = re.compile(r"enter\s+to\s+confirm", re.IGNORECASE)
+
+# Interview/Selector patterns — Claude Code interactive selection menus
+_INTERVIEW_NAV_RE = re.compile(
+    r"(Enter to select|Tab.*Arrow keys to navigate|Esc to cancel|"
+    r"ctrl\+o to expand|\d+\.\s+Type something\.)",
+    re.IGNORECASE,
+)
+_INTERVIEW_OPTION_RE = re.compile(r"^❯\s*\d+\.\s+\S", re.MULTILINE)
+_INTERVIEW_NUMBERED_RE = re.compile(r"^\s*\d+\.\s+\S", re.MULTILINE)
+_INTERVIEW_SECTION_RE = re.compile(r"[☐✔]\s+\S+", re.UNICODE)
+
+# Tool name → activity classification (for observer)
+_TOOL_ACTIVITY_MAP = {
+    "Read": "reading",
+    "Write": "writing",
+    "Edit": "writing",
+    "MultiEdit": "writing",
+    "Bash": "executing",
+    "Grep": "searching",
+    "Glob": "searching",
+    "Search": "searching",
+    "WebSearch": "searching",
+    "WebFetch": "searching",
+}
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StateResult:
+    """Result of detecting Claude Code state from tmux output."""
+    state: str
+    tool_name: Optional[str] = None
+    tool_target: Optional[str] = None
+    is_compacting: bool = False
+
+
+@dataclass
+class StartupScene:
+    """Detected startup scene requiring special handling."""
+    scene_type: str
+    description: str
+    action: str  # "press_enter" | "press_down_enter"
+
+
+# ---------------------------------------------------------------------------
+# Core detection functions
+# ---------------------------------------------------------------------------
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences."""
+    return _ANSI_RE.sub("", text)
+
+
+def clean_lines(raw_output: str) -> list:
+    """Split raw tmux output into cleaned, non-empty lines."""
+    text = strip_ansi(raw_output)
+    return [line for line in text.splitlines() if line.strip()]
+
+
+def detect_state(lines: list) -> StateResult:
+    """Detect current Claude Code state from cleaned output lines.
+
+    Priority: ERROR > PERMISSION > INTERVIEW > TOOL_CALL > IDLE > THINKING
+    """
+    if not lines:
+        return StateResult(state=SessionState.THINKING)
+
+    last_lines = lines[-15:] if len(lines) >= 15 else lines
+    all_text = "\n".join(last_lines[-5:])
+    recent_lines = lines[-10:] if len(lines) >= 10 else lines
+
+    # ERROR (suppressed when tool markers are active)
+    has_active_tool = any(_parse_tool_line(l) for l in recent_lines)
+    error_match = _ERROR_RE.search(all_text)
+    if error_match and not has_active_tool:
+        return StateResult(state=SessionState.ERROR)
+
+    # PERMISSION (exclude status bar noise)
+    non_status = [l for l in last_lines if not _STATUS_BAR_RE.search(l)]
+    if non_status:
+        if _PERMISSION_RE.search("\n".join(non_status)):
+            return StateResult(state=SessionState.PERMISSION)
+
+    # INTERVIEW — interactive selector menu (not permission, not regular prompt)
+    # Requires both: (1) nav/section indicators AND (2) ❯ cursor on a numbered option.
+    # The ❯ cursor is mandatory to distinguish from Claude's numbered explanations.
+    # Uses full line list (not windowed) because the ❯ cursor can be many lines
+    # above the nav hints when option descriptions span multiple lines.
+    full_text = "\n".join(lines)
+    if _INTERVIEW_NAV_RE.search(all_text) or _INTERVIEW_SECTION_RE.search(all_text):
+        if _INTERVIEW_OPTION_RE.search(full_text):
+            return StateResult(state=SessionState.INTERVIEW)
+
+    # TOOL_CALL — skip stale markers (❯ appears below ●)
+    rev = list(reversed(recent_lines))
+    for i, line in enumerate(rev):
+        tool_info = _parse_tool_line(line)
+        if tool_info:
+            has_prompt_below = any(_PROMPT_RE.search(l) for l in rev[:i])
+            if has_prompt_below:
+                break
+            return StateResult(
+                state=SessionState.TOOL_CALL,
+                tool_name=tool_info[0],
+                tool_target=tool_info[1],
+            )
+
+    # IDLE — bare ❯ prompt (not permission selector, not phantom)
+    # BUT: if spinner is active, Claude is actually THINKING, not idle
+    # Per-line exclusion: detect spinner on any line that is NOT a done marker
+    # (a done marker on line A should not suppress spinner on line B)
+    has_spinner = any(
+        _SPINNER_CHAR_RE.search(l) and not _DONE_TIME_RE.search(l)
+        for l in recent_lines
+    )
+    if has_spinner:
+        return StateResult(state=SessionState.THINKING)
+
+    idle_lines = [l for l in last_lines if not _STATUS_BAR_RE.search(l)]
+    for line in reversed(idle_lines):
+        stripped = line.strip()
+        if _PROMPT_RE.search(line):
+            if re.match(r"^❯\s*(Allow|Yes|Deny|No|\d+\.)", stripped, re.IGNORECASE):
+                continue
+            if _PASTED_TEXT_RE.search(stripped):
+                return StateResult(state=SessionState.THINKING)
+            # Phantom prompt check
+            if _is_phantom_prompt(lines, last_lines):
+                continue
+            # Shell prompt check
+            if _is_shell_prompt(lines):
+                return StateResult(state=SessionState.EXITED)
+            return StateResult(state=SessionState.IDLE)
+
+    # COMPACT
+    if _COMPACT_RE.search(all_text):
+        return StateResult(state=SessionState.THINKING, is_compacting=True)
+
+    return StateResult(state=SessionState.THINKING)
+
+
+def detect_activity(lines: list) -> dict:
+    """Detect Claude's current activity from output lines.
+
+    Returns dict with: activity, detail, raw
+    """
+    if not lines:
+        return {"activity": "idle", "detail": "", "raw": ""}
+
+    recent = lines[-20:] if len(lines) >= 20 else lines
+    rev = list(reversed(recent))
+
+    for i, line in enumerate(rev):
+        stripped = line.strip()
+        m = _TOOL_CALL_PAREN_RE.match(stripped)
+        if m:
+            tool_name, target = m.group(1), m.group(2)
+        else:
+            m = _TOOL_CALL_RE.match(stripped)
+            if not m:
+                continue
+            tool_name, target = m.group(1), m.group(2) or ""
+
+        # Stale marker check: if ✻ completion or ❯ prompt appears AFTER
+        # this ● marker in the original output (= before it in rev), the marker is stale.
+        # rev[:i] = lines more recent than the marker (below on screen).
+        # When i=0, marker is the last line — nothing comes after it, so it can't be stale.
+        if i > 0:
+            after_in_original = rev[:i]
+            if any("✻" in l for l in after_in_original) or any("❯" in l for l in after_in_original):
+                continue
+
+        activity = _TOOL_ACTIVITY_MAP.get(tool_name, "tool_call")
+        return {"activity": activity, "detail": target, "raw": stripped}
+
+    # Thinking fallback
+    for line in reversed(recent):
+        for pattern in ("Thinking", "Processing", "Shenaniganing", "Churned"):
+            if pattern in line:
+                return {"activity": "thinking", "detail": line.strip(), "raw": line.strip()}
+
+    return {"activity": "idle", "detail": "", "raw": ""}
+
+
+def detect_startup_scene(lines: list) -> Optional[StartupScene]:
+    """Detect startup scenes requiring special handling."""
+    if not lines:
+        return None
+    all_text = "\n".join(lines)
+    if _TRUST_WORKSPACE_RE.search(all_text) and _ENTER_TO_CONFIRM_RE.search(all_text):
+        return StartupScene(
+            scene_type="workspace_trust",
+            description="Workspace trust confirmation prompt",
+            action="press_enter",
+        )
+    return None
+
+
+def is_permission_in_text(text: str) -> bool:
+    """Check if text contains a real permission prompt (not status bar)."""
+    lines = clean_lines(text)
+    last = lines[-5:] if len(lines) >= 5 else lines
+    non_status = [l for l in last if not _STATUS_BAR_RE.search(l)]
+    return bool(_PERMISSION_RE.search("\n".join(non_status)))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _parse_tool_line(line: str) -> Optional[tuple]:
+    """Parse '● ToolName target'. Returns (name, target) or None."""
+    stripped = line.strip()
+    m = _TOOL_CALL_PAREN_RE.match(stripped)
+    if m:
+        return (m.group(1), m.group(2))
+    m = _TOOL_CALL_RE.match(stripped)
+    if m:
+        return (m.group(1), m.group(2) or "")
+    return None
+
+
+def _is_phantom_prompt(lines: list, last_lines: list) -> bool:
+    """Check if ❯ is a phantom prompt (TUI renders it while working)."""
+    for i, raw_line in enumerate(last_lines):
+        if _PROMPT_RE.search(raw_line):
+            nearby_separators = 0
+            for j in range(max(0, i - 2), min(len(last_lines), i + 3)):
+                if j == i:
+                    continue
+                if _DECORATION_RE.search(last_lines[j].strip()):
+                    nearby_separators += 1
+            if nearby_separators >= 2:
+                has_welcome = any(_WELCOME_SCREEN_RE.search(l) for l in lines)
+                global_idx = len(lines) - len(last_lines) + i
+                has_done = any(_DONE_TIME_RE.search(l) for l in lines[:global_idx])
+                if has_welcome or has_done:
+                    break
+                # Status bar content near the prompt means real IDLE (not phantom).
+                # Claude Code v2.1.126 renders: ❯ + ── + "bypass permissions on"
+                # This looks like phantom (2 separators) but is actually IDLE.
+                # Use _STATUS_BAR_CONTENT_RE (excludes decoration lines) to avoid
+                # false positives when the only "status bar" lines are ─── separators.
+                status_bar_window = last_lines[-3:] if len(last_lines) >= 3 else last_lines
+                if any(_STATUS_BAR_CONTENT_RE.search(l) for l in status_bar_window):
+                    break
+                return True
+            # Fewer than 2 separators — normally means real prompt (not phantom).
+            # But during animation, a phantom ❯ may appear without the typical
+            # 2-separator layout. Only treat as phantom if the broader output
+            # contains Claude TUI elements (otherwise it's a bare shell prompt).
+            has_claude_tui = any(_CLAUDE_TUI_SIGNATURE_RE.search(l) for l in lines)
+            if has_claude_tui:
+                status_bar_window = last_lines[-3:] if len(last_lines) >= 3 else last_lines
+                if (not any(_STATUS_BAR_CONTENT_RE.search(l) for l in status_bar_window)
+                        and not any(_CLAUDE_TUI_SIGNATURE_RE.search(l) for l in status_bar_window)):
+                    return True
+            break
+    return False
+
+
+def _is_shell_prompt(lines: list) -> bool:
+    """Check if output is a bare shell prompt (Claude has exited)."""
+    window = lines[-5:] if len(lines) >= 5 else lines
+    if not any("❯" in l for l in window):
+        return False
+    window_text = "\n".join(window)
+    if (any(_DECORATION_RE.search(l.strip()) for l in window)
+            or any(_STATUS_BAR_RE.search(l) for l in window)
+            or any("●" in l for l in window)
+            or any(_DONE_TIME_RE.search(l) for l in window)
+            or _CLAUDE_TUI_SIGNATURE_RE.search(window_text)
+            or _WELCOME_SCREEN_RE.search(window_text)):
+        return False
+    return True

--- a/tools/claude_session/observer.py
+++ b/tools/claude_session/observer.py
@@ -1,0 +1,144 @@
+"""observer.py — Optional observability side-channel for Claude sessions.
+
+Runs in a background thread, polls tmux output, and reports activity
+to logs or callbacks. Completely independent from the core pipeline —
+does not block send/wait_for_idle, and can be disabled without
+affecting functionality.
+
+Uses adaptive polling: interval varies by detected session state to
+balance responsiveness with resource efficiency.
+"""
+
+import logging
+import threading
+import time
+from typing import Callable, Optional
+
+from tools.claude_session.idle import (
+    SessionState, clean_lines, detect_state, detect_activity,
+)
+from tools.claude_session.tmux_interface import TmuxInterface
+from tools.claude_session.output_buffer import OutputBuffer
+
+logger = logging.getLogger(__name__)
+
+# Adaptive polling intervals (seconds) keyed by session state.
+# THINKING: Claude is generating — output changes slowly, low frequency ok.
+# TOOL_CALL: Tools executing — state changes fast, need timely updates.
+# PERMISSION: Waiting for user — moderate frequency.
+# IDLE: Session quiet — minimal polling.
+# UNKNOWN / fallback: Use default interval from constructor.
+_STATE_INTERVALS = {
+    "THINKING": 5.0,
+    "TOOL_CALL": 2.0,
+    "PERMISSION": 3.0,
+    "INTERVIEW": 3.0,
+    "IDLE": 15.0,
+}
+
+
+class SessionObserver:
+    """Background observer for Claude Code session activity.
+
+    Non-blocking, non-essential. Use for:
+    - Progress monitoring / logging
+    - Status callbacks to external systems (e.g. Telegram)
+    - Stalled-session detection
+
+    Polling is adaptive: interval adjusts based on detected session state.
+    TOOL_CALL → 2s (fast feedback), THINKING → 180s (slow changes),
+    IDLE → 15s (minimal), PERMISSION → 3s (moderate).
+
+    Usage:
+        observer = SessionObserver(tmux, buffer, on_update=my_callback)
+        observer.start()
+        # ... session runs ...
+        observer.stop()
+    """
+
+    def __init__(
+        self,
+        tmux: TmuxInterface,
+        buffer: OutputBuffer,
+        on_update: Optional[Callable[[dict], None]] = None,
+        poll_interval: float = 5.0,
+    ):
+        self._tmux = tmux
+        self._buf = buffer
+        self._on_update = on_update
+        self._default_interval = poll_interval
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._wake_event = threading.Event()  # signaled by poll_now()
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._stop_event.clear()
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._loop,
+            name="session-observer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+
+    def poll_now(self) -> None:
+        """Force an immediate poll (also updates buffer).
+
+        Signals the loop thread to wake up and poll immediately,
+        rather than calling _poll_once directly (avoids concurrent
+        buffer writes from two threads).
+        """
+        self._wake_event.set()
+
+    def _get_interval(self, state_name: str) -> float:
+        """Return adaptive poll interval for the given session state."""
+        return _STATE_INTERVALS.get(state_name, self._default_interval)
+
+    def _loop(self) -> None:
+        current_interval = self._default_interval
+        while not self._stop_event.is_set():
+            state_name = None
+            try:
+                state_name = self._poll_once()
+            except Exception as e:
+                logger.warning("Observer poll error: %s", e)
+            current_interval = self._get_interval(state_name) if state_name else self._default_interval
+            # Wait for either timeout or wake signal from poll_now()
+            self._wake_event.clear()
+            self._wake_event.wait(timeout=current_interval)
+
+    def _poll_once(self) -> Optional[str]:
+        """Poll tmux once. Returns the detected state name, or None."""
+        if not self._tmux.session_exists():
+            return None
+
+        raw = self._tmux.capture_pane()
+        lines = clean_lines(raw)
+
+        if lines:
+            self._buf.append_batch(lines)
+
+        # Always detect state (needed for adaptive polling even without callback)
+        state_result = detect_state(lines)
+        state_name = state_result.state
+
+        if self._on_update:
+            activity = detect_activity(lines)
+            self._on_update({
+                "state": state_result.state,
+                "tool_name": state_result.tool_name,
+                "tool_target": state_result.tool_target,
+                "current_activity": activity["activity"],
+                "activity_detail": activity["detail"],
+                "output_lines": len(lines),
+            })
+        return state_name

--- a/tools/claude_session/output_buffer.py
+++ b/tools/claude_session/output_buffer.py
@@ -1,0 +1,124 @@
+"""tools/claude_session/output_buffer.py — Ring buffer for tmux output."""
+
+import hashlib
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class OutputLine:
+    """A single line of captured output."""
+    text: str
+    timestamp: float
+    index: int = 0  # Global monotonic index
+
+    def content_hash(self) -> str:
+        return hashlib.md5(self.text.encode()).hexdigest()
+
+
+class OutputBuffer:
+    """Thread-safe ring buffer that stores deduplicated tmux output lines.
+
+    Features:
+      - Fixed capacity with automatic eviction of oldest lines
+      - Content-hash deduplication for repeated capture-pane output
+      - Marker-based range queries (for output_since_send)
+      - Pagination via offset/limit
+    """
+
+    _HASH_GC_THRESHOLD = 100  # rebuild hash set every N appends to prevent unbounded growth
+
+    def __init__(self, max_lines: int = 1000):
+        self._max_lines = max_lines
+        self._lines: deque = deque(maxlen=max_lines)
+        self._counter = 0
+        self._lock = threading.Lock()
+        self._last_seen_hashes: set = set()
+        self._append_since_gc = 0
+
+    def _maybe_gc_hashes(self) -> None:
+        """Rebuild hash set from current deque contents if threshold exceeded."""
+        if self._append_since_gc < self._HASH_GC_THRESHOLD:
+            return
+        self._last_seen_hashes = {line.content_hash() for line in self._lines}
+        self._append_since_gc = 0
+
+    def append(self, text: str) -> int:
+        """Append a single line. Returns its global index (marker)."""
+        with self._lock:
+            self._counter += 1
+            ol = OutputLine(
+                text=text,
+                timestamp=time.monotonic(),
+                index=self._counter,
+            )
+            self._lines.append(ol)
+            # Incremental: track hash of new line only
+            self._last_seen_hashes.add(ol.content_hash())
+            self._append_since_gc += 1
+            self._maybe_gc_hashes()
+            return self._counter
+
+    def append_batch(self, texts: List[str]) -> int:
+        """Append multiple lines, skipping duplicates. Returns count of new lines added."""
+        added = 0
+        with self._lock:
+            for text in texts:
+                h = hashlib.md5(text.encode()).hexdigest()
+                if h not in self._last_seen_hashes:
+                    self._counter += 1
+                    self._lines.append(OutputLine(
+                        text=text,
+                        timestamp=time.monotonic(),
+                        index=self._counter,
+                    ))
+                    self._last_seen_hashes.add(h)
+                    added += 1
+                    self._append_since_gc += 1
+                    # Inline GC check during large batches to prevent unbounded growth
+                    if self._append_since_gc >= self._HASH_GC_THRESHOLD:
+                        self._maybe_gc_hashes()
+        return added
+
+    def read(self, offset: int = 0, limit: Optional[int] = None) -> List[OutputLine]:
+        """Read lines with offset/limit pagination."""
+        with self._lock:
+            total = len(self._lines)
+            if total == 0:
+                return []
+            start = min(offset, total)
+            end = total if limit is None else min(start + limit, total)
+            return list(self._lines)[start:end]
+
+    def total_count(self) -> int:
+        """Total lines ever appended (may exceed current buffer size)."""
+        with self._lock:
+            return self._counter
+
+    def since(self, marker: int) -> List[OutputLine]:
+        """Return all lines appended after the given marker index.
+
+        If the marker has been evicted from the ring, returns all current lines.
+        """
+        with self._lock:
+            result = [line for line in self._lines if line.index > marker]
+            if not result and any(line.index <= marker for line in self._lines):
+                # Marker was evicted, return everything we have
+                return list(self._lines)
+            return result
+
+    def last_n_chars(self, n: int) -> str:
+        """Return up to n characters from the tail of the buffer."""
+        with self._lock:
+            text = "\n".join(line.text for line in self._lines)
+            return text[-n:] if len(text) > n else text
+
+    def clear(self) -> None:
+        """Clear all stored lines. Counter is preserved to keep markers valid."""
+        with self._lock:
+            self._lines.clear()
+            self._last_seen_hashes.clear()
+            self._append_since_gc = 0

--- a/tools/claude_session/session.py
+++ b/tools/claude_session/session.py
@@ -1,0 +1,1731 @@
+"""session.py — Simplified Claude Code session as a context pipeline.
+
+Replaces the former manager.py. Key simplifications:
+- No state machine object — state detected fresh each poll
+- No turn/tool-call tracking — just "output since last send"
+- No auto-responder — that's a separate concern
+- wait_for_idle uses inline polling
+
+Core flow:
+    TaskContext → format prompt → write to tmux → wait for idle → return result
+"""
+
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+import threading
+import time
+import uuid
+from typing import Optional
+
+from tools.claude_session.idle import (
+    SessionState, clean_lines, detect_state, detect_startup_scene,
+    detect_activity, is_permission_in_text,
+    _STATUS_BAR_RE, _PERMISSION_RE, _DONE_TIME_RE,
+    _INTERVIEW_NAV_RE, _INTERVIEW_OPTION_RE, _INTERVIEW_SECTION_RE,
+)
+from tools.claude_session.output_buffer import OutputBuffer
+from tools.claude_session.tmux_interface import TmuxInterface
+from tools.claude_session.task_context import TaskContext
+from tools.claude_session.observer import SessionObserver
+from tools.claude_session.status_card import StatusCard
+from tools.claude_session.errors import (
+    SessionError, TmuxError, TmuxNotFoundError, TmuxTimeoutError,
+    SessionDisconnectedError, SessionNotActiveError, StartupFailedError,
+    SessionExitedError, PermissionError, InvalidPermissionResponseError,
+    WaitTimeoutError, StallDetectedError, ValidationError,
+    wrap_tmux_error,
+)
+
+logger = logging.getLogger(__name__)
+
+PASTE_SUBMIT_DELAY_SECONDS = 2.0
+_PASTE_POLL_INTERVAL = 0.1
+JSONL_RESUME_SIZE_LIMIT = 20 * 1024 * 1024  # 20MB — skip auto-resume for oversized JSONL
+
+
+class _StateView:
+    """Lightweight shim for backward compatibility with mgr._sm.current_state."""
+
+    __slots__ = ("_session",)
+
+    def __init__(self, session: "ClaudeSession"):
+        self._session = session
+
+    @property
+    def current_state(self) -> str:
+        return self._session._state
+
+    def state_duration(self) -> float:
+        return time.monotonic() - self._session._state_entered
+
+
+class ClaudeSession:
+    """Context pipeline: TaskContext → Claude Code → Result.
+
+    All instance state, naturally supports parallel sessions.
+    """
+
+    _PERMISSION_PROMPT_RE = re.compile(
+        r"(Allow\?|Yes.*No|permission to|wants to|proceed\?|"
+        r"❯\s*\d+\.\s*(Yes|Allow))",
+        re.IGNORECASE,
+    )
+
+    def __init__(self):
+        self._session_id: Optional[str] = None
+        self._tmux: Optional[TmuxInterface] = None
+        self._buf = OutputBuffer(max_lines=1000)
+        self._session_active = False
+        self._permission_mode = "normal"
+        self._claude_session_uuid: Optional[str] = None
+        self._session_start_time: Optional[float] = None
+        self._workdir: Optional[str] = None
+
+        # Simplified state tracking (no StateMachine object)
+        self._state: str = SessionState.DISCONNECTED
+        self._state_entered: float = time.monotonic()
+
+        # Output tracking (replaces Turn tracking)
+        self._send_marker: int = 0
+
+        # Threading
+        self._lock = threading.RLock()  # RLock: allows reentrant locking from same thread
+        self._state_event = threading.Event()
+        self._initializing = False
+
+        # Gateway session isolation
+        self._gateway_session_key: str = ""
+        self._session_name: Optional[str] = None
+        self._model: Optional[str] = None
+
+        # Prevent double permission response
+        self._permission_responded = False
+        self._permission_auto_allow_low_risk = True  # auto-allow low-risk in normal mode
+        self._in_auto_approve = False  # guard against recursive _auto_approve_permission
+        self._startup_error_count = 0  # Track ERROR/EXITED detections during startup
+
+        # Initialization grace period — don't trust observer non-IDLE states during startup
+        self._session_ready_time: Optional[float] = None  # None until fully initialized
+        self._startup_grace_period: float = 5.0  # seconds
+
+        # Status callback
+        self._status_callback = None
+
+        # Send receipt tracking (Layer 1: echo, Layer 2: wait_for_idle receipt)
+        self._send_time: Optional[float] = None
+        self._send_seq: int = 0
+        self._send_needs_receipt: bool = False
+
+        # Observer (optional side-channel)
+        self._observer: Optional[SessionObserver] = None
+        # Observer poll interval (default 5s — tight enough to catch short tool calls
+        # like Bash/Read/Write which complete in 1-10s; 180s would miss them entirely)
+        self._observer_poll_interval: float = float(os.environ.get("HERMES_CLAUDE_SESSION_OBSERVER_POLL_INTERVAL", "5"))
+
+        # Status card (optional Telegram real-time status)
+        self._status_card: Optional[StatusCard] = None
+
+        # Output streamer (optional real-time output to chat)
+        self._output_streamer = None
+
+    # ------------------------------------------------------------------
+    # Backward compatibility shim
+    # ------------------------------------------------------------------
+
+    @property
+    def _sm(self) -> _StateView:
+        return _StateView(self)
+
+    def _update_state(self, new_state: str) -> None:
+        changed = False
+        with self._lock:
+            if new_state != self._state:
+                old = self._state
+                self._state = new_state
+                self._state_entered = time.monotonic()
+                self._state_event.set()
+                changed = True
+        if changed:
+            logger.debug("State: %s → %s", old, new_state)
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def start(
+        self,
+        workdir: str,
+        session_name: str = "hermes-default",
+        model: Optional[str] = None,
+        permission_mode: str = "normal",
+        on_event: str = "notify",
+        completion_queue=None,
+        resume_uuid: Optional[str] = None,
+        force_new: bool = False,
+        auto_responder: bool = False,  # Accepted for API compat, no-op in pipeline architecture
+        auto_responder_config: Optional[dict] = None,  # Accepted for API compat, no-op
+        status_card_config: Optional[dict] = None,
+    ) -> dict:
+        """Start a Claude Code session in tmux."""
+        # Phase 0: fast validation (under lock, no I/O)
+        with self._lock:
+            if self._session_active or self._initializing:
+                return {
+                    "session_id": self._session_id,
+                    "tmux_session": session_name,
+                    "state": self._state,
+                    "permission_mode": self._permission_mode,
+                    "claude_session_uuid": self._claude_session_uuid,
+                    "note": "Session already active",
+                }
+
+            if permission_mode not in ("normal", "skip"):
+                raise ValidationError(f"Invalid permission_mode: {permission_mode}")
+
+            self._claude_session_uuid = str(uuid.uuid5(
+                uuid.NAMESPACE_DNS,
+                f"hermes-session:{self._gateway_session_key}:{self._session_name}:{os.path.abspath(workdir)}"
+            ))
+
+            # Auto-detect resume: if same name+workdir had a previous session, resume it.
+            auto_resume_uuid = None
+            if not resume_uuid and not force_new:
+                jsonl_path = self._find_session_jsonl(workdir, self._claude_session_uuid)
+                if jsonl_path:
+                    jsonl_size = os.path.getsize(jsonl_path)
+                    if jsonl_size <= JSONL_RESUME_SIZE_LIMIT:
+                        auto_resume_uuid = self._claude_session_uuid
+                    else:
+                        logger.info(
+                            "JSONL too large (%d MB) for session %s, starting fresh",
+                            jsonl_size // 1024 // 1024, self._claude_session_uuid[:8],
+                        )
+
+            actually_resuming = False
+            effective_resume = resume_uuid or auto_resume_uuid
+            if effective_resume:
+                jsonl_path = self._find_session_jsonl(workdir, effective_resume)
+                if jsonl_path:
+                    actually_resuming = True
+                else:
+                    logger.warning("resume_uuid=%s history not found, starting new", effective_resume)
+
+            if actually_resuming:
+                self._state = SessionState.DISCONNECTED
+                self._buf.clear()
+                self._send_marker = 0
+
+            self._session_id = f"cs_{uuid.uuid4().hex[:8]}"
+            if self._session_name is None:
+                self._session_name = session_name
+            self._permission_mode = permission_mode
+            self._workdir = os.path.abspath(workdir)
+            self._tmux = TmuxInterface(session_name)
+            self._initializing = True
+
+        # Phase 1: tmux I/O (no lock, don't block other threads)
+        try:
+            needs_init = False
+
+            if not self._tmux.session_exists():
+                self._tmux.create_session(workdir=workdir)
+                needs_init = True
+            else:
+                pane = self._tmux.capture_pane(lines=50)
+                pane_lower = pane.lower()
+
+                cwd_check = subprocess.run(
+                    ["tmux", "display-message", "-t", session_name,
+                     "-p", "#{pane_current_path}"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                tmux_cwd = cwd_check.stdout.strip() if cwd_check.returncode == 0 else ""
+
+                needs_rebuild = False
+                if tmux_cwd and workdir not in tmux_cwd and tmux_cwd not in workdir:
+                    needs_rebuild = True
+                elif "claude code" in pane_lower or "claude-" in pane_lower:
+                    if workdir.lower() not in pane_lower:
+                        needs_rebuild = True
+
+                if needs_rebuild:
+                    logger.warning("tmux session %s needs rebuild", session_name)
+                    self._tmux.kill_session()
+                    time.sleep(0.5)
+                    self._tmux.create_session(workdir=workdir)
+                    needs_init = True
+                else:
+                    pane_lines = clean_lines(pane)
+                    result = detect_state(pane_lines)
+                    if result.state == SessionState.IDLE:
+                        logger.info("Reusing existing IDLE session %s", session_name)
+                    elif result.state == SessionState.EXITED:
+                        logger.info("Session %s EXITED (Claude gone), reinitializing", session_name)
+                        needs_init = True
+                    else:
+                        # Wait for busy session to become IDLE before rebuilding
+                        _BUSY_WAIT_TIMEOUT = 30  # seconds
+                        _BUSY_WAIT_INTERVAL = 3
+                        logger.warning("Session %s in %s state, waiting up to %ds to settle",
+                                       session_name, result.state, _BUSY_WAIT_TIMEOUT)
+                        _waited = 0
+                        _settled = False
+                        while _waited < _BUSY_WAIT_TIMEOUT:
+                            time.sleep(_BUSY_WAIT_INTERVAL)
+                            _waited += _BUSY_WAIT_INTERVAL
+                            pane = self._tmux.capture_pane(lines=50)
+                            pane_lines = clean_lines(pane)
+                            check = detect_state(pane_lines)
+                            if check.state == SessionState.IDLE:
+                                logger.info("Session %s settled to IDLE after %ds", session_name, _waited)
+                                _settled = True
+                                break
+                            elif check.state == SessionState.EXITED:
+                                logger.info("Session %s EXITED while waiting", session_name)
+                                needs_init = True
+                                _settled = True
+                                break
+                        if not _settled:
+                            logger.warning("Session %s still %s after %ds, forcing rebuild",
+                                           session_name, result.state, _BUSY_WAIT_TIMEOUT)
+                            self._tmux.kill_session()
+                            time.sleep(0.5)
+                            self._tmux.create_session(workdir=workdir)
+                            needs_init = True
+
+            if needs_init:
+                current_uid = os.getuid()
+                if current_uid == 0:
+                    non_root_user = os.environ.get("SUDO_USER") or os.environ.get("USER", "user")
+                    self._tmux.send_keys(f"su - {shlex.quote(non_root_user)}", enter=True)
+                    time.sleep(1.5)
+                    self._tmux.send_keys(f"cd {shlex.quote(workdir)}", enter=True)
+                    time.sleep(0.5)
+                    user_bin = f"/home/{non_root_user}/bin"
+                    self._tmux.send_keys(f"export PATH={shlex.quote(user_bin)}:$PATH", enter=True)
+                    time.sleep(0.5)
+
+                claude_cmd = "claude"
+                if actually_resuming:
+                    claude_cmd += f" --resume {shlex.quote(effective_resume)}"
+                else:
+                    claude_cmd += f" --session-id {shlex.quote(self._claude_session_uuid)}"
+                if permission_mode == "skip":
+                    claude_cmd += " --permission-mode bypassPermissions"
+                    claude_cmd = "CLAUDE_CODE_TRUST_WORKSPACE=1 " + claude_cmd
+                if model:
+                    claude_cmd += f" --model {shlex.quote(model)}"
+                self._tmux.send_keys(claude_cmd, enter=True)
+                time.sleep(2)
+
+                if permission_mode == "skip":
+                    time.sleep(1)
+                    pane = self._tmux.capture_pane()
+                    # Only match the actual permission prompt, NOT the welcome screen
+                    # or status bar which also contain "bypass permissions" text.
+                    # The prompt asks "Do you want to proceed?" or shows permission choices.
+                    is_permission_prompt = (
+                        ("permission" in pane.lower() and ("proceed" in pane.lower() or "allow" in pane.lower() or "yes" in pane.lower()))
+                        or ("Do you want to proceed" in pane)
+                    )
+                    if is_permission_prompt:
+                        self._tmux.send_special_key("Down")
+                        time.sleep(0.3)
+                        self._tmux.send_special_key("Enter")
+                        time.sleep(1)
+
+                STARTUP_HEALTH_TIMEOUT = 60
+                if not self._wait_for_claude_startup(STARTUP_HEALTH_TIMEOUT, is_resume=actually_resuming):
+                    logger.error("Claude Code failed to start in %s", session_name)
+                    try:
+                        self._tmux.kill_session()
+                    except Exception:
+                        pass
+                    with self._lock:
+                        self._initializing = False
+                    raise StartupFailedError(
+                        f"Claude Code did not start within {STARTUP_HEALTH_TIMEOUT}s.",
+                        detail=f"session={session_name}",
+                    )
+
+        except SessionError:
+            with self._lock:
+                self._initializing = False
+            if self._tmux:
+                try:
+                    self._tmux.kill_session()
+                except Exception:
+                    pass
+            raise
+        except Exception as e:
+            with self._lock:
+                self._initializing = False
+            if self._tmux:
+                try:
+                    self._tmux.kill_session()
+                except Exception:
+                    pass
+            raise wrap_tmux_error(e) from e
+
+        # Phase 2: finalize (under lock)
+        with self._lock:
+            self._initializing = False
+            self._session_active = True
+            self._session_start_time = time.monotonic()
+            self._session_ready_time = time.monotonic()  # Mark session as fully initialized
+            self._model = model  # Persist for restart detection
+            self._update_state(SessionState.IDLE)
+
+            # Start status card first (sets self._status_callback for observer)
+            if status_card_config:
+                self._start_status_card(status_card_config)
+
+            # Start observer (uses self._status_callback set above)
+            self._observer = SessionObserver(
+                tmux=self._tmux,
+                buffer=self._buf,
+                on_update=self._on_observer_update if self._status_callback else None,
+                poll_interval=self._observer_poll_interval,
+            )
+            self._observer.start()
+
+        # Synchronous initial poll
+        try:
+            if self._observer:
+                self._observer.poll_now()
+                # Refresh state from buffer
+                pane = self._tmux.capture_pane()
+                lines = clean_lines(pane)
+                result = detect_state(lines)
+                self._update_state(result.state)
+        except Exception as e:
+            logger.warning("Initial poll failed: %s", e)
+
+        with self._lock:
+            result = {
+                "session_id": self._session_id,
+                "tmux_session": session_name,
+                "state": self._state,
+                "permission_mode": self._permission_mode,
+                "claude_session_uuid": self._claude_session_uuid,
+            }
+            if actually_resuming:
+                result["resumed_from"] = effective_resume
+                if auto_resume_uuid:
+                    result["auto_resumed"] = True
+            elif resume_uuid:
+                result["fallback_note"] = f"resume_uuid={resume_uuid} history not found"
+            return result
+
+    def stop(self) -> dict:
+        """Stop the session and clean up."""
+        with self._lock:
+            if not self._session_active:
+                raise SessionNotActiveError("No active session")
+
+            if self._observer:
+                self._observer.stop()
+
+            if self._status_card:
+                self._status_card.stop()
+                self._status_card = None
+
+            if self._tmux:
+                try:
+                    self._tmux.kill_session()
+                except Exception as e:
+                    logger.warning("Failed to kill tmux: %s", e)
+
+            sid = self._session_id
+            uuid_to_return = self._claude_session_uuid
+            self._session_active = False
+            self._session_id = None
+            self._claude_session_uuid = None
+            self._session_start_time = None
+            self._observer = None
+            self._update_state(SessionState.DISCONNECTED)
+
+            return {
+                "stopped": True,
+                "session_id": sid,
+                "claude_session_uuid": uuid_to_return,
+            }
+
+    # ------------------------------------------------------------------
+    # Send operations
+    # ------------------------------------------------------------------
+
+    def send(self, message_or_task) -> dict:
+        """Send a message or TaskContext to Claude.
+
+        Args:
+            message_or_task: str (raw message) or TaskContext (structured)
+        """
+        if isinstance(message_or_task, TaskContext):
+            message = message_or_task.to_prompt()
+        else:
+            message = str(message_or_task)
+
+        return self._send_text(message)
+
+    def send_text(self, text: str) -> dict:
+        """Type text and submit atomically."""
+        return self._send_text(text)
+
+    def type_text(self, text: str) -> dict:
+        """Type text without pressing Enter."""
+        with self._lock:
+            if not self._session_active:
+                raise SessionNotActiveError("No active session")
+            if self._state in (SessionState.EXITED, SessionState.DISCONNECTED):
+                raise SessionExitedError("Claude Code has exited.")
+            self._tmux.send_keys(text)
+            return {"typed": True, "state": self._state}
+
+    def submit(self) -> dict:
+        """Submit typed text by pressing Enter."""
+        with self._lock:
+            if not self._session_active:
+                raise SessionNotActiveError("No active session")
+            if self._state in (SessionState.EXITED, SessionState.DISCONNECTED):
+                raise SessionExitedError("Claude Code has exited.")
+            self._tmux.send_special_key("Enter")
+        return {"submitted": True, "state": self._state}
+
+    def cancel_input(self) -> dict:
+        """Cancel current input (Ctrl+C)."""
+        logger.warning("cancel_input for session %s", self._session_id)
+        with self._lock:
+            if not self._session_active:
+                raise SessionNotActiveError("No active session")
+            self._tmux.send_special_key("C-c")
+            return {"cancelled": True, "state": self._state}
+
+    def _send_text(self, text: str) -> dict:
+        """Internal: send text to tmux, handling multi-line.
+
+        Layer 1 verification: lightweight echo check (pane content changed).
+        Does NOT retry. Claude-level receipt verification happens in
+        wait_for_idle's send receipt phase (Layer 2).
+        """
+        is_multiline = "\n" in text
+
+        with self._lock:
+            if not self._session_active:
+                raise SessionNotActiveError("No active session")
+            if not self._tmux:
+                raise TmuxError("No tmux interface")
+            if self._state in (SessionState.EXITED, SessionState.DISCONNECTED):
+                raise SessionExitedError("Claude Code has exited.")
+
+            self._send_marker = self._buf.total_count()
+            self._send_seq += 1
+            self._send_time = time.monotonic()
+            self._send_needs_receipt = True
+
+            if is_multiline:
+                self._tmux.send_keys(text, enter=False)
+            else:
+                self._tmux.send_keys(text, enter=True)
+
+        # Multi-line: wait for bracketed paste to land, then submit
+        if is_multiline:
+            self._wait_for_paste_then_submit()
+
+        # Layer 1: echo check — did tmux pane content change?
+        echo_ok = self._verify_echo(timeout=1.5)
+
+        # Refresh state
+        self._refresh_state()
+        result = {
+            "sent": True,
+            "state": self._state,
+            "send_seq": self._send_seq,
+        }
+        if not echo_ok:
+            result["echo_status"] = "no_echo"
+            result["echo_hint"] = "Paste may not have reached tmux pane"
+        else:
+            result["echo_status"] = "echo_detected"
+        return result
+
+    def _verify_echo(self, timeout: float = 1.5) -> bool:
+        """Check that tmux pane content changed after send.
+
+        Only verifies tmux-level delivery (text appeared in pane).
+        Does NOT verify Claude received or processed the message.
+        """
+        baseline = self._send_marker
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            pane = self._tmux.capture_pane()
+            lines = clean_lines(pane)
+            if lines:
+                self._buf.append_batch(lines)
+            if self._buf.total_count() > baseline:
+                return True
+            time.sleep(0.15)
+        return False
+
+    def _send_receipt_check(self, timeout: float = 10.0) -> Optional[dict]:
+        """Layer 2: verify Claude received the message by checking state transition.
+
+        Called at the start of wait_for_idle. Polls for up to `timeout` seconds.
+        Returns None if Claude left IDLE (message received).
+        Returns a send_unconfirmed dict if Claude stayed IDLE.
+
+        Note: Uses short-interval polling (0.5s) instead of _state_event because
+        observer only sets _state_event for terminal states, not THINKING/TOOL_CALL.
+        """
+        initial_state = self._state
+        receipt_deadline = time.monotonic() + timeout
+
+        while time.monotonic() < receipt_deadline:
+            pane = self._tmux.capture_pane()
+            lines = clean_lines(pane)
+            if lines:
+                self._buf.append_batch(lines)
+            result = detect_state(lines)
+            self._update_state(result.state)
+
+            if self._state != SessionState.IDLE:
+                # Claude left IDLE → message received
+                self._send_needs_receipt = False
+                logger.info("Send receipt confirmed: state=%s (seq=%d)", self._state, self._send_seq)
+                return None  # Continue to normal wait_for_idle
+
+            # Short poll — THINKING doesn't trigger _state_event
+            time.sleep(0.5)
+
+        # Timeout: Claude stayed IDLE
+        if initial_state == SessionState.IDLE:
+            self._send_needs_receipt = False
+            logger.warning("Send unconfirmed: Claude stayed IDLE for %.0fs (seq=%d)", timeout, self._send_seq)
+            return {
+                "status": "send_unconfirmed",
+                "state": self._state,
+                "send_seq": self._send_seq,
+                "elapsed_since_send": round(time.monotonic() - self._send_time, 1) if self._send_time else 0,
+                "hint": "Claude did not leave IDLE after send. Try: submit() to retry Enter, or cancel_input() + send() to resend.",
+            }
+
+        # Non-IDLE initial state → can't do receipt check, proceed normally
+        return None
+
+    def _wait_for_paste_then_submit(self) -> None:
+        """Wait for bracketed paste to land in tmux, then send Enter."""
+        baseline = self._send_marker
+        deadline = time.monotonic() + PASTE_SUBMIT_DELAY_SECONDS
+        settled = False
+
+        while time.monotonic() < deadline:
+            time.sleep(_PASTE_POLL_INTERVAL)
+            if self._buf.total_count() > baseline:
+                # Pane received new content — paste has landed
+                settled = True
+                break
+
+        if settled:
+            logger.info("Multi-line send: paste landed, submitting")
+        else:
+            logger.warning("Multi-line send: no pane change after %.1fs, submitting anyway", PASTE_SUBMIT_DELAY_SECONDS)
+
+        self._tmux.send_special_key("Enter")
+
+    # ------------------------------------------------------------------
+    # Status and wait
+    # ------------------------------------------------------------------
+
+    def status(self) -> dict:
+        """Return current session state."""
+        if not self._session_active:
+            return {"state": SessionState.DISCONNECTED}
+
+        self._refresh_state()
+        # Detect current activity from buffer
+        buf_lines = self._buf.read()
+        activity = detect_activity([l.text for l in buf_lines]) if buf_lines else {"activity": "idle", "detail": ""}
+
+        return {
+            "state": self._state,
+            "state_duration_seconds": round(time.monotonic() - self._state_entered, 1),
+            "output_tail": self._buf.last_n_chars(200),
+            "current_activity": activity.get("activity", "idle"),
+            "activity_detail": activity.get("detail", ""),
+            "session_ready": self._session_ready_time is not None,
+        }
+
+    def wait_for_idle(self, timeout: int = 1800) -> dict:
+        """Wait for Claude to return to IDLE state.
+
+        Simplified from the original: inline polling, no adaptive intervals,
+        no turn tracking. Just poll → check state → return when done.
+
+        Returns dict with status: "idle" | "permission" | "error" |
+        "disconnected" | "exited" | "timeout" | "send_unconfirmed"
+        """
+        if not self._session_active:
+            raise SessionNotActiveError("No active session")
+
+        # Timeout & patrol intervals (all in seconds)
+        # PATROL_INTERVAL: how often to check for output growth when idle (default 300s = 5 min)
+        PATROL_INTERVAL = int(os.environ.get("HERMES_CLAUDE_SESSION_PATROL_INTERVAL", "300"))
+        # STALL_THRESHOLD: consecutive seconds with no buffer growth → consider stalled
+        STALL_THRESHOLD = float(os.environ.get("HERMES_CLAUDE_SESSION_STALL_THRESHOLD", "1800"))
+        # STATE_STALL_THRESHOLD: seconds in same non-terminal state with no growth → state stall
+        STATE_STALL_THRESHOLD = float(os.environ.get("HERMES_CLAUDE_SESSION_STATE_STALL_THRESHOLD", "600"))
+        # THINKING_TIMEOUT: max seconds in THINKING state before considering it stalled
+        # Catches cases where the model API never responds (e.g. GLM-5 timeout)
+        THINKING_TIMEOUT = float(os.environ.get("HERMES_CLAUDE_SESSION_THINKING_TIMEOUT", "300"))
+        COMPACT_MIN_WAIT = 3600  # 1 hour minimum for compaction
+        COMPACT_MAX_WAIT = 7200  # 2 hours maximum for compaction
+        POLL_INTERVAL = 180  # 3 minutes - poll for state changes when thinking/calling
+
+        deadline = time.monotonic() + timeout
+        last_patrol_tokens = self._buf.total_count()
+        last_growth_time = time.monotonic()
+        last_state_change_time = time.monotonic()
+        last_state_for_stall = self._state
+        compact_detected = False
+        compact_start = None
+
+        # ===== Layer 2: Send Receipt Check =====
+        # If a recent send hasn't been confirmed yet, verify Claude received it.
+        # Claude typically leaves IDLE within 1-2s of receiving a message.
+        # If still IDLE after 10s, the message likely wasn't delivered.
+        if self._send_needs_receipt and self._send_time is not None:
+            receipt_result = self._send_receipt_check()
+            if receipt_result is not None:
+                return receipt_result
+        # ===== End Layer 2 =====
+
+        while time.monotonic() < deadline:
+            pane = self._tmux.capture_pane()
+            lines = clean_lines(pane)
+            if lines:
+                self._buf.append_batch(lines)
+
+            result = detect_state(lines)
+            self._update_state(result.state)
+            state = self._state
+
+            # Push incremental output to streamer
+            if self._output_streamer:
+                try:
+                    self._output_streamer.poll_increment()
+                except Exception:
+                    pass
+
+            # Terminal states
+            if state == SessionState.IDLE:
+                # Guard against animation ghost (Forming/Unfurling etc. 3-8s).
+                # Confirm IDLE with 3 successive stable checks over 2 seconds.
+                idle_confirmed = self._confirm_idle_stable(checks=3, interval=0.7)
+                if not idle_confirmed:
+                    continue
+                self._send_needs_receipt = False
+                return {**self._build_idle_result(), "status": "idle"}
+
+            if state == SessionState.PERMISSION:
+                perm_context = self._build_permission_context(lines)
+
+                if self._permission_mode == "skip":
+                    logger.info("Auto-allowing permission in skip mode: %s",
+                                perm_context.get("permission_request", ""))
+                    self.respond_permission("allow")
+                    self._state_event.clear()
+                    self._state_event.wait(timeout=1)
+                    continue  # 继续等待 IDLE
+
+                # normal模式：low风险自动批准，medium/high交给Hermes决策
+                risk = perm_context.get("risk_level", "medium")
+                if risk == "low":
+                    logger.info("Auto-allowing low-risk permission: %s %s",
+                                perm_context.get("operation", ""),
+                                perm_context.get("target", ""))
+                    self.respond_permission("allow")
+                    self._state_event.clear()
+                    self._state_event.wait(timeout=1)
+                    continue  # 继续等待 IDLE
+
+                # medium/high风险：返回上下文让Hermes决策
+                return {**perm_context, "status": "permission"}
+
+            if state == SessionState.INTERVIEW:
+                interview_context = self._build_interview_context(lines)
+                return {**interview_context, "status": "interview"}
+
+            if state == SessionState.ERROR:
+                return {
+                    "state": state,
+                    "error_output": self._buf.last_n_chars(500),
+                    "status": "error",
+                    "error_type": "StateDetectionError",
+                    "severity": "transient",
+                    "retryable": True,
+                }
+
+            if state == SessionState.DISCONNECTED:
+                return {"error": "Session disconnected", "state": state, "status": "disconnected"}
+
+            if state == SessionState.EXITED:
+                return {"error": "Claude Code has exited", "state": state, "status": "exited"}
+
+            # Compact detection
+            if result.is_compacting and not compact_detected:
+                compact_detected = True
+                compact_start = time.monotonic()
+                logger.info("Compact detected, extending wait")
+
+            now = time.monotonic()
+
+            # Update growth tracking
+            current_tokens = self._buf.total_count()
+            if current_tokens > last_patrol_tokens:
+                last_growth_time = now
+                last_patrol_tokens = current_tokens
+
+            # Track state changes for state-stall detection
+            if state != last_state_for_stall:
+                last_state_for_stall = state
+                last_state_change_time = now
+
+            # State stall detection: same non-terminal state for too long with no output growth
+            # This catches cases where Claude appears stuck (e.g. THINKING for 10+ minutes with no progress)
+            non_terminal = state in (SessionState.THINKING, SessionState.TOOL_CALL)
+            if non_terminal and (now - last_state_change_time) > STATE_STALL_THRESHOLD:
+                # Only trigger if also no output growth
+                if (now - last_growth_time) > STATE_STALL_THRESHOLD:
+                    logger.warning(
+                        "State stall: %s for %.0fs, no output growth for %.0fs",
+                        state, now - last_state_change_time, now - last_growth_time,
+                    )
+                    return {
+                        "status": "stalled",
+                        "state": state,
+                        "stalled_seconds": round(now - last_state_change_time, 1),
+                        "no_growth_seconds": round(now - last_growth_time, 1),
+                        "progress_info": self._check_progress(deadline - timeout),
+                        "hint": f"State {state} unchanged for {round((now - last_state_change_time) / 60, 1)} min with no output. Consider sending a follow-up or cancelling.",
+                    }
+
+            # THINKING timeout: model API may not respond (e.g. GLM-5 hangs)
+            # Uses _state_entered (set by _update_state) which tracks when THINKING first appeared
+            if state == SessionState.THINKING and self._state_entered:
+                thinking_duration = now - self._state_entered
+                if thinking_duration > THINKING_TIMEOUT:
+                    logger.warning(
+                        "Thinking timeout: THINKING for %.0fs (limit=%ds), model may be unresponsive",
+                        thinking_duration, int(THINKING_TIMEOUT),
+                    )
+                    return {
+                        "status": "stalled",
+                        "state": state,
+                        "stalled_seconds": round(thinking_duration, 1),
+                        "stall_type": "thinking_timeout",
+                        "model": getattr(self, "_model", None),
+                        "progress_info": self._check_progress(deadline - timeout),
+                        "hint": f"Model has been THINKING for {round(thinking_duration / 60, 1)} min with no response. The model API may be unresponsive. Consider stopping and retrying with a different model.",
+                    }
+
+            # Fast poll: just check state and wait
+            remaining = deadline - now
+            if remaining <= 0:
+                if compact_detected and compact_start and (now - compact_start) < COMPACT_MAX_WAIT:
+                    deadline = now + COMPACT_MIN_WAIT
+                    continue
+                break
+
+            # Stall detection: no output growth for STALL_THRESHOLD seconds
+            compact_active = (
+                compact_detected and compact_start is not None
+                and (now - compact_start) < COMPACT_MAX_WAIT
+            )
+            if not compact_active and (now - last_growth_time) > STALL_THRESHOLD:
+                return StallDetectedError(
+                    f"No output growth for {STALL_THRESHOLD}s",
+                    detail=f"state={state}, stalled={round(now - last_growth_time, 1)}s",
+                ).to_dict() | {
+                    "status": "stalled",
+                    "state": state,
+                    "stalled_seconds": round(now - last_growth_time, 1),
+                    "progress_info": self._check_progress(deadline - timeout),
+                }
+
+            # State-aware wait: fast poll when active, respect patrol interval when idle/waiting
+            if state in (SessionState.THINKING, SessionState.TOOL_CALL):
+                wait_time = min(POLL_INTERVAL, remaining)
+            else:
+                wait_time = min(PATROL_INTERVAL, remaining)
+            self._state_event.clear()
+            self._state_event.wait(timeout=wait_time)
+
+        # Timeout
+        elapsed = time.monotonic() - (deadline - timeout)
+        err = WaitTimeoutError(
+            f"wait_for_idle timed out after {timeout}s",
+            detail=f"state={self._state}, elapsed={round(elapsed, 1)}s",
+        )
+        full_output = self._get_output_since_send()
+        truncated = len(full_output) > self._OUTPUT_SINCE_SEND_MAX
+        timeout_result = err.to_dict() | {
+            "status": "timeout",
+            "state": self._state,
+            "timeout_reached": True,
+            "elapsed_seconds": round(elapsed, 1),
+            "hint": "Timeout is normal for long tasks. Call wait_for_idle again with a larger timeout.",
+            "output_since_send": full_output[:self._OUTPUT_SINCE_SEND_MAX],
+        }
+        if truncated:
+            timeout_result["output_since_send_truncated"] = True
+        return timeout_result
+
+    def wait_for_state(self, target_state: str, timeout: int = 60) -> dict:
+        """Wait for a specific state."""
+        if not self._session_active:
+            raise SessionNotActiveError("No active session")
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._refresh_state()
+            if self._state == target_state:
+                return {"state": target_state}
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            self._state_event.clear()
+            self._state_event.wait(timeout=min(0.3, remaining))
+
+        return {"state": self._state, "timeout_reached": True}
+
+    # ------------------------------------------------------------------
+    # Output
+    # ------------------------------------------------------------------
+
+    def output(self, offset: int = 0, limit: int = 50) -> dict:
+        """Get output lines with pagination."""
+        lines = self._buf.read(offset=offset, limit=limit)
+        return {
+            "lines": [{"text": l.text, "index": l.index} for l in lines],
+            "total": self._buf.total_count(),
+            "has_more": (offset + limit) < self._buf.total_count(),
+        }
+
+    def jsonl_output(self, last_reply: bool = False, last_n: int = 0,
+                     max_length: int = 15000) -> dict:
+        """Extract Claude's replies from the JSONL session file.
+
+        Use this when tmux output is truncated (long Claude responses).
+        The JSONL file contains the complete conversation history.
+
+        Args:
+            last_reply: If True, return only the last assistant text reply.
+            last_n: If > 0, return the last N assistant text replies.
+                    If both are 0/False, returns a summary.
+            max_length: Max chars per reply (default 15000). Truncated with
+                        a notice if exceeded.
+        """
+        if not self._claude_session_uuid:
+            return {"error": "No session UUID", "replies": []}
+
+        jsonl_path = self._find_session_jsonl(self._workdir or ".", self._claude_session_uuid)
+        if not jsonl_path or not os.path.exists(jsonl_path):
+            return {"error": "JSONL file not found", "path": str(jsonl_path), "replies": []}
+
+        # Determine how many replies to keep
+        if last_reply:
+            keep = 1
+        elif last_n > 0:
+            keep = last_n
+        else:
+            keep = 0  # summary only
+
+        try:
+            assistant_texts = []
+            total_tools = 0
+            total_entries = 0
+
+            with open(jsonl_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    total_entries += 1
+
+                    # Fast path: skip non-assistant lines without parsing
+                    if not line.startswith('{"type":"assistant"'):
+                        # Still need to check — type might not be first key
+                        try:
+                            entry = json.loads(line)
+                        except (json.JSONDecodeError, ValueError):
+                            continue
+                        if entry.get("type") != "assistant":
+                            continue
+                    else:
+                        try:
+                            entry = json.loads(line)
+                        except (json.JSONDecodeError, ValueError):
+                            continue
+
+                    msg = entry.get("message", {})
+                    for item in msg.get("content", []):
+                        if not isinstance(item, dict):
+                            continue
+                        if item.get("type") == "tool_use":
+                            total_tools += 1
+                        if item.get("type") == "text" and item.get("text", "").strip():
+                            text = item["text"]
+                            if keep > 0:
+                                # Sliding window: only keep last N
+                                assistant_texts.append(text)
+                                if len(assistant_texts) > keep:
+                                    assistant_texts.pop(0)
+                            else:
+                                # Summary mode: just count
+                                assistant_texts.append(text)
+
+            if total_entries == 0:
+                return {"status": "empty", "replies": []}
+
+            # Summary mode
+            if keep == 0:
+                return {
+                    "status": "active",
+                    "total_entries": total_entries,
+                    "assistant_text_count": len(assistant_texts),
+                    "tool_call_count": total_tools,
+                    "last_reply_length": len(assistant_texts[-1]) if assistant_texts else 0,
+                }
+
+            # Truncate oversized replies
+            result_texts = []
+            for text in assistant_texts:
+                if len(text) > max_length:
+                    text = text[:max_length] + f"\n... [truncated, {len(text)} total chars]"
+                result_texts.append(text)
+
+            return {
+                "replies": result_texts,
+                "count": len(result_texts),
+                "total_assistant_texts": len(assistant_texts) + (keep - len(assistant_texts)) if keep > 0 else len(assistant_texts),
+            }
+
+        except Exception as e:
+            return {"error": str(e), "replies": []}
+
+    # ------------------------------------------------------------------
+    # Permission handling
+    # ------------------------------------------------------------------
+
+    def respond_permission(self, response: str) -> dict:
+        """Respond to a permission request."""
+        if response not in ("allow", "deny"):
+            raise InvalidPermissionResponseError(f"Invalid response: {response}")
+
+        self._permission_responded = True
+        max_retries = 3
+        for attempt in range(max_retries):
+            with self._lock:
+                pane = self._tmux.capture_pane()
+                lines = clean_lines(pane)
+                result = detect_state(lines)
+
+                if result.state != SessionState.PERMISSION:
+                    if is_permission_in_text(pane):
+                        self._update_state(SessionState.PERMISSION)
+                    else:
+                        if attempt < max_retries - 1:
+                            continue
+                        raise PermissionError(
+                            "Not in PERMISSION state",
+                            detail="Permission may have been auto-handled.",
+                        )
+
+                is_numbered = self._detect_numbered_selector(pane)
+                if response == "allow":
+                    if is_numbered:
+                        self._tmux.send_special_key("Enter")
+                    else:
+                        self._tmux.send_keys("y", enter=True)
+                else:
+                    if is_numbered:
+                        deny_num = self._find_deny_option_number()
+                        if deny_num:
+                            self._tmux.send_keys(str(deny_num), enter=True)
+                        else:
+                            self._tmux.send_special_key("Enter")
+                    else:
+                        self._tmux.send_keys("n", enter=True)
+
+            time.sleep(0.5)  # 等待 Claude 处理权限
+            self._refresh_state()
+            return {"responded": True, "state": self._state}
+
+        raise PermissionError("Not in PERMISSION state after retries")
+
+    # ------------------------------------------------------------------
+    # Interview handling
+    # ------------------------------------------------------------------
+
+    def respond_interview(self, option: str) -> dict:
+        """Respond to an interview selector by selecting an option.
+
+        Args:
+            option: The option to select. Can be:
+                - A number string (e.g. "1") to select that numbered option
+                - A text string to type as custom input
+                - "enter" to confirm the currently selected option
+                - "escape" to cancel
+        """
+        if not self._session_active:
+            raise SessionNotActiveError("No active session")
+
+        # Refresh state before checking — observer cache may be stale
+        # (interview menus with multi-line options can evade observer detection)
+        self._refresh_state()
+
+        if self._state != SessionState.INTERVIEW:
+            raise SessionNotActiveError(
+                f"Not in INTERVIEW state (current: {self._state})"
+            )
+
+        # Validate state and read current selection under lock, then act outside lock
+        if option == "enter":
+            with self._lock:
+                self._tmux.send_special_key("Enter")
+        elif option == "escape":
+            with self._lock:
+                self._tmux.send_special_key("Escape")
+        elif option.isdigit() and int(option) > 0:
+            target_num = int(option)
+            # Navigate to the target option using arrow keys.
+            # Claude Code's Ink select may not support number-key shortcuts in all versions,
+            # so we use Up/Down navigation: press Up many times to reach the top, then Down.
+            with self._lock:
+                # Press Up enough times to guarantee we're at the first option
+                # (assumes max ~20 options in a menu — generous upper bound)
+                for _ in range(20):
+                    self._tmux.send_special_key("Up")
+                time.sleep(0.1)
+                # Move down (target_num - 1) times to reach the target
+                for _ in range(target_num - 1):
+                    self._tmux.send_special_key("Down")
+                    time.sleep(0.05)
+                # Confirm selection
+                time.sleep(0.1)
+                self._tmux.send_special_key("Enter")
+        else:
+            # Type custom text
+            with self._lock:
+                self._tmux.send_keys(option, enter=True)
+
+        time.sleep(0.5)
+        self._refresh_state()
+        return {"responded": True, "state": self._state}
+
+    # ------------------------------------------------------------------
+    # History / Events (simplified — no turn tracking)
+    # ------------------------------------------------------------------
+
+    def history(self) -> dict:
+        """Return simplified session history."""
+        return {
+            "turns": [],
+            "total_turns": 0,
+            "total_tools_called": 0,
+            "deprecated": True,
+            "note": "Turn tracking removed in context-pipeline refactor",
+        }
+
+    def events(self, since_turn: int = 0) -> dict:
+        """Return queued events (no-op in simplified version)."""
+        return {"events": [], "deprecated": True}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _refresh_state(self) -> None:
+        """Poll tmux and update internal state."""
+        if not self._tmux or not self._session_active:
+            return
+        try:
+            pane = self._tmux.capture_pane()
+            lines = clean_lines(pane)
+            if lines:
+                self._buf.append_batch(lines)
+            result = detect_state(lines)
+            self._update_state(result.state)
+
+            # Auto-approve in skip mode or low-risk in normal mode
+            # Guard: skip if already inside _auto_approve_permission to prevent recursion
+            if result.state == SessionState.PERMISSION and not self._in_auto_approve:
+                if self._permission_mode == "skip":
+                    self._auto_approve_permission()
+                elif self._permission_auto_allow_low_risk:
+                    self._try_auto_approve_low_risk(pane)
+        except Exception as e:
+            session_err = wrap_tmux_error(e)
+            logger.warning("State refresh failed: %s [%s]", session_err, session_err.severity.value)
+            if isinstance(session_err, SessionDisconnectedError):
+                self._update_state(SessionState.DISCONNECTED)
+
+    def _on_observer_update(self, info: dict) -> None:
+        """Called by observer thread with activity updates."""
+        # Signal wait_for_idle when observer detects a terminal state,
+        # so it wakes immediately instead of sleeping through POLL_INTERVAL.
+        observed_state = info.get("state")
+        if observed_state in (
+            SessionState.IDLE, SessionState.PERMISSION, SessionState.INTERVIEW,
+            SessionState.ERROR, SessionState.DISCONNECTED, SessionState.EXITED,
+        ):
+            self._state_event.set()
+
+        if self._status_callback:
+            try:
+                now = time.monotonic()
+                status_info = {
+                    "state": info.get("state", self._state),
+                    "turn_id": None,
+                    "elapsed_seconds": round(now - self._state_entered, 1),
+                    "tool_calls": [],
+                    "recent_output": self._buf.last_n_chars(200),
+                    "tool_name": info.get("tool_name"),
+                    "tool_target": info.get("tool_target"),
+                }
+                current_activity = info.get("current_activity", "idle")
+                if current_activity != "idle":
+                    status_info["current_activity"] = current_activity
+                    status_info["activity_detail"] = info.get("activity_detail", "")
+                self._status_callback(status_info)
+            except Exception as e:
+                logger.warning("Status callback error: %s", e)
+
+    def _start_status_card(self, config: dict) -> None:
+        """Create and start a StatusCard for Telegram real-time status.
+
+        config keys:
+            chat_id (str): Telegram chat ID
+            loop: asyncio event loop from Gateway
+            send_func: async callable(chat_id, content) -> SendResult
+            edit_func: async callable(chat_id, message_id, content) -> SendResult
+            delete_func: async callable(chat_id, message_id) -> bool
+            poll_interval (float, optional): polling interval in seconds (default 3.0)
+            max_card_length (int, optional): max characters in status card (default 500)
+            bump_threshold (int, optional): consecutive failed edits before bumping (default 3)
+        """
+        chat_id = config.get("chat_id")
+        loop = config.get("loop")
+        send_func = config.get("send_func")
+        edit_func = config.get("edit_func")
+        delete_func = config.get("delete_func")
+
+        if not chat_id or not loop or not send_func or not edit_func or not delete_func:
+            logger.warning(
+                "Status card disabled: missing gateway adapter config "
+                "(chat_id=%s, loop=%s, send=%s)",
+                chat_id or "missing",
+                "set" if loop else "missing",
+                "set" if send_func else "missing",
+            )
+            return
+        try:
+            self._status_card = StatusCard(
+                session_uuid=self._claude_session_uuid,
+                loop=loop,
+                send_func=send_func,
+                edit_func=edit_func,
+                delete_func=delete_func,
+                chat_id=chat_id,
+                poll_interval=config.get("poll_interval", 3.0),
+                max_card_length=config.get("max_card_length", 500),
+                bump_threshold=config.get("bump_threshold", 3),
+                session_name=self._session_name or "",
+                session_id=self._session_id or "",
+                tmux_session=self._tmux.session_name if self._tmux else "",
+            )
+            self._status_card.start()
+
+            # Wire observer updates to StatusCard for real-time Telegram updates
+            def _observer_to_status_card(info: dict) -> None:
+                if self._status_card:
+                    self._status_card.update_from_observer(info)
+
+            self._status_callback = _observer_to_status_card
+
+            logger.info("Status card started for session %s", self._claude_session_uuid[:8])
+        except Exception as e:
+            logger.warning("Status card start failed: %s", e)
+            self._status_card = None
+
+    def _auto_approve_permission(self) -> None:
+        """Auto-approve permission in skip mode."""
+        with self._lock:
+            if self._permission_responded:
+                self._permission_responded = False
+                return
+        self._in_auto_approve = True
+        try:
+            for _ in range(3):
+                time.sleep(0.3)
+                pane = self._tmux.capture_pane()
+                if not is_permission_in_text(pane):
+                    self._update_state(SessionState.THINKING)
+                    self._permission_responded = False
+                    return
+
+                is_numbered = self._detect_numbered_selector(pane)
+                if is_numbered:
+                    self._tmux.send_special_key("Enter")
+                else:
+                    self._tmux.send_keys("y", enter=True)
+
+                time.sleep(0.5)
+                self._refresh_state()
+                if self._state != SessionState.PERMISSION:
+                    self._permission_responded = False
+                    return
+        finally:
+            self._in_auto_approve = False
+
+    def _try_auto_approve_low_risk(self, pane_text: str) -> None:
+        """Auto-approve low-risk permissions even in normal mode.
+
+        Called from _refresh_state when permission is detected and mode is 'normal'.
+        Builds permission context, checks risk level, and auto-allows if low risk.
+        Uses _lock to prevent race with wait_for_idle's permission handling.
+        """
+        with self._lock:
+            if self._permission_responded:
+                return
+            # Claim immediately to prevent concurrent paths
+            self._permission_responded = True
+
+        lines = clean_lines(pane_text)
+        perm_context = self._build_permission_context(lines)
+        risk = perm_context.get("risk_level", "medium")
+        if risk == "low":
+            logger.info("Auto-allowing low-risk permission (observer path): %s %s",
+                        perm_context.get("operation", ""),
+                        perm_context.get("target", ""))
+            self._auto_approve_permission()
+        else:
+            # Not low-risk, release the flag so wait_for_idle can handle it
+            self._permission_responded = False
+
+    def _confirm_idle_stable(self, checks: int = 3, interval: float = 0.7) -> bool:
+        """Confirm IDLE is stable across multiple checks (defeats animation ghosts).
+
+        Claude Code animations (Forming, Unfurling, etc.) can produce transient
+        ❯ prompts that last 3-8 seconds. A single 0.5s confirmation is insufficient.
+        This method polls `checks` times over `checks * interval` seconds and
+        only returns True if ALL checks agree on IDLE.
+        """
+        for check_idx in range(checks):
+            time.sleep(interval)
+            pane = self._tmux.capture_pane()
+            lines = clean_lines(pane)
+            result = detect_state(lines)
+            tail = [l[:80] for l in lines[-5:]] if lines else ["(empty)"]
+            logger.debug("confirm_idle_stable check %d/%d: state=%s tail=%s",
+                         check_idx + 1, checks, result.state, tail)
+            if result.state != SessionState.IDLE:
+                self._update_state(result.state)
+                return False
+        return True
+
+    _OUTPUT_SINCE_SEND_MAX = 500
+
+    def _build_idle_result(self) -> dict:
+        full_output = self._get_output_since_send()
+        truncated = len(full_output) > self._OUTPUT_SINCE_SEND_MAX
+        result = {
+            "state": SessionState.IDLE,
+            "output_since_send": full_output[:self._OUTPUT_SINCE_SEND_MAX],
+        }
+        if truncated:
+            result["output_since_send_truncated"] = True
+        return result
+
+    def _build_permission_result(self, lines: list = None) -> dict:
+        result = {"state": SessionState.PERMISSION}
+        if lines:
+            for line in reversed(lines[-10:]):
+                lower = line.lower()
+                if "allow" in lower or "permission" in lower or "proceed?" in lower:
+                    result["permission_request"] = line
+                    break
+        return result
+
+    def _build_permission_context(self, lines: list = None) -> dict:
+        """构建权限上下文，供Hermes智能决策使用"""
+        context = {
+            "state": SessionState.PERMISSION,
+            "needs_hermes_decision": True,
+            "permission_request": "",
+            "operation": "",
+            "target": "",
+            "risk_level": "medium",
+        }
+
+        if not lines:
+            return context
+
+        # 从输出中提取权限请求详情
+        for line in reversed(lines[-15:]):
+            lower = line.lower()
+            if "allow" in lower or "permission" in lower or "proceed?" in lower:
+                context["permission_request"] = line.strip()
+                break
+
+        # 识别操作类型和目标
+        for line in lines:
+            stripped = line.strip()
+            # Edit/Write/MultiEdit 操作
+            m = re.match(r"●\s*(Edit|Write|MultiEdit)\s+(.+)", stripped)
+            if m:
+                context["operation"] = m.group(1)
+                context["target"] = m.group(2).strip()
+                context["risk_level"] = self._assess_risk(m.group(1), m.group(2))
+                break
+            # Create 操作（创建文件/目录）
+            m = re.match(r"●\s*Create\s+(.+)", stripped)
+            if m:
+                context["operation"] = "Create"
+                context["target"] = m.group(1).strip()
+                context["risk_level"] = self._assess_risk("Create", m.group(1))
+                break
+            # Bash 操作
+            m = re.match(r"●\s*Bash\s*\((.+)\)", stripped)
+            if m:
+                context["operation"] = "Bash"
+                context["target"] = m.group(1).strip()
+                context["risk_level"] = self._assess_risk("Bash", m.group(1))
+                break
+            # 只读操作（低风险）
+            m = re.match(r"●\s*(Grep|Search|WebFetch|Read|LS|List|Glob)\s*\((.+)\)", stripped)
+            if m:
+                context["operation"] = m.group(1)
+                context["target"] = m.group(2).strip()
+                context["risk_level"] = "low"
+                break
+            # TodoWrite — 元数据操作，低风险
+            m = re.match(r"●\s*TodoWrite\s*\((.+)\)", stripped)
+            if m:
+                context["operation"] = "TodoWrite"
+                context["target"] = m.group(1).strip()
+                context["risk_level"] = "low"
+                break
+            # Task — 子任务委派
+            m = re.match(r"●\s*Task\s*\((.+)\)", stripped)
+            if m:
+                context["operation"] = "Task"
+                context["target"] = m.group(1).strip()
+                context["risk_level"] = self._assess_risk("Task", m.group(1))
+                break
+            # NotebookEdit — notebook 单元格编辑
+            m = re.match(r"●\s*NotebookEdit\s*\((.+)\)", stripped)
+            if m:
+                context["operation"] = "NotebookEdit"
+                context["target"] = m.group(1).strip()
+                context["risk_level"] = self._assess_risk("NotebookEdit", m.group(1))
+                break
+            # MCP 工具调用 (MCP::server::tool 格式)
+            m = re.match(r"●\s*MCP::(\S+?)::(\S+)\s*\((.+)\)", stripped)
+            if m:
+                context["operation"] = f"MCP::{m.group(1)}::{m.group(2)}"
+                context["target"] = m.group(3).strip()
+                context["risk_level"] = self._assess_risk("MCP", m.group(3))
+                break
+
+        # 如果没有检测到具体操作，从权限文本推断
+        if not context["operation"] and context["permission_request"]:
+            req_lower = context["permission_request"].lower()
+            if "edit" in req_lower or "write" in req_lower:
+                context["operation"] = "Edit"
+            elif "delete" in req_lower or "remove" in req_lower:
+                context["operation"] = "Delete"
+                context["risk_level"] = "high"
+            elif "run" in req_lower or "execute" in req_lower:
+                context["operation"] = "Bash"
+                context["risk_level"] = "high"
+
+        return context
+
+    def _build_interview_context(self, lines: list = None) -> dict:
+        """构建 interview 上下文，供 Hermes 智能选择"""
+        context = {
+            "state": SessionState.INTERVIEW,
+            "needs_hermes_decision": True,
+            "question": "",
+            "options": [],
+            "sections": [],
+        }
+
+        if not lines:
+            return context
+
+        # 提取问题（排除编号选项行）
+        for line in reversed(lines[-20:]):
+            stripped = line.strip()
+            if (stripped
+                    and not stripped.startswith("❯")
+                    and not stripped.startswith("←")
+                    and "?" in stripped
+                    and not re.match(r"\s*\d+\.\s+", stripped)):
+                context["question"] = stripped
+                break
+
+        # 提取选项列表
+        for line in lines[-20:]:
+            m = re.match(r"\s*❯?\s*(\d+)\.\s+(.+)", line.strip())
+            if m:
+                num = int(m.group(1))
+                text = m.group(2).strip()
+                selected = line.strip().startswith("❯")
+                context["options"].append({
+                    "number": num,
+                    "text": text,
+                    "selected": selected,
+                })
+
+        # 提取 section 标记（如 ☐ 运行环境  ✔ Submit）
+        for line in lines[-20:]:
+            for m_sec in re.finditer(r"([☐✔])\s+([^☐✔←→]+?)\s*(?=[☐✔←→]|$)", line):
+                label = m_sec.group(2).strip()
+                if label:
+                    context["sections"].append({
+                        "checked": m_sec.group(1) == "✔",
+                        "label": label,
+                    })
+
+        return context
+
+    # 系统目录 — 始终高风险
+    _SYSTEM_DIRS = ("/etc", "/usr", "/bin", "/sbin", "/lib", "/boot", "/System", "/Windows")
+    # 敏感用户目录 — 始终高风险
+    _SENSITIVE_DIRS = ("~/.ssh", "~/.gnupg", "~/.kube", "~/.aws")
+    # 非破坏性 Bash 命令 — 低风险
+    _SAFE_BASH_PREFIXES = (
+        "cat ", "ls ", "head ", "tail ", "wc ", "grep ", "find ", "echo ",
+        "test ", "mkdir -p ", "which ", "type ", "file ", "stat ",
+        "du ", "df ", "pwd", "whoami", "hostname", "uname ",
+        "python -c \"import", "python3 -c \"import",  # read-only python
+        "git status", "git log", "git diff", "git branch", "git remote",
+    )
+
+    def _assess_risk(self, operation: str, target: str) -> str:
+        """评估操作风险等级，考虑 workdir 上下文。"""
+        target_lower = target.lower()
+        op_lower = operation.lower()
+
+        # 1. 绝对高风险模式（无论什么操作）
+        high_risk_patterns = [
+            r"rm\s+-rf\b", r"\bdelete\b.*\bforce\b", r"\bdrop\b",
+            r"chmod\s+0?[0-7]{3}",
+            r"\bsudo\b", r"\bsu\b\s",
+            r"\.\./", r"\.\.\\",
+        ]
+        for pattern in high_risk_patterns:
+            if re.search(pattern, target_lower, re.IGNORECASE):
+                return "high"
+
+        # 2. 系统目录和敏感目录 — 始终 high（路径前缀匹配，避免子字符串误报）
+        norm_target = os.path.normpath(target)
+        for sys_dir in self._SYSTEM_DIRS:
+            if norm_target == sys_dir or norm_target.startswith(sys_dir + os.sep):
+                return "high"
+        for sens_dir in self._SENSITIVE_DIRS:
+            if sens_dir in target or os.path.expanduser(sens_dir) in target:
+                return "high"
+
+        # 3. 操作类型 + workdir 感知
+        is_in_workdir = self._is_in_workdir(target)
+
+        # 只读操作 — 始终 low
+        if op_lower in ("grep", "search", "webfetch", "read", "ls", "list", "glob", "todowrite"):
+            return "low"
+
+        # Bash — 根据命令内容判断
+        if op_lower == "bash":
+            return self._assess_bash_risk(target)
+
+        # Edit/Write/Create/MultiEdit/NotebookEdit — workdir 内 low，否则 medium
+        if op_lower in ("edit", "write", "multiedit", "create", "notebookedit"):
+            if is_in_workdir:
+                return "low"
+            return "medium"
+
+        # Task/MCP — 默认 medium
+        if op_lower in ("task", "mcp"):
+            if is_in_workdir:
+                return "low"
+            return "medium"
+
+        # 未识别操作 — 默认 medium
+        return "medium"
+
+    def _is_in_workdir(self, target: str) -> bool:
+        """检查目标路径是否在 session 的 workdir 内。"""
+        if not self._workdir or not target:
+            return False
+        # 展开相对路径
+        target_expanded = target
+        if not os.path.isabs(target):
+            target_expanded = os.path.join(self._workdir, target)
+        target_expanded = os.path.abspath(target_expanded)
+        return target_expanded.startswith(self._workdir + os.sep) or target_expanded == self._workdir
+
+    def _assess_bash_risk(self, command: str) -> str:
+        """评估 Bash 命令的风险等级。"""
+        cmd = command.strip().lower()
+
+        # 高风险命令
+        high_patterns = [
+            r"rm\s+-rf\b", r"\bsudo\b", r"dd\s+if=", r"mkfs\b",
+            r"curl\s+.*\|\s*sh", r"wget\s+.*\|\s*sh",
+            r">\s*/dev/sd", r"chmod\s+[0-7]{3,4}\s",
+        ]
+        for p in high_patterns:
+            if re.search(p, cmd, re.IGNORECASE):
+                return "high"
+
+        # 非破坏性命令 — low
+        for safe_prefix in self._SAFE_BASH_PREFIXES:
+            if cmd.startswith(safe_prefix.lower()):
+                return "low"
+
+        # workdir 内操作 — medium（如 pytest, npm test 等）
+        return "medium"
+
+    def _get_output_since_send(self) -> str:
+        lines = self._buf.since(self._send_marker)
+        return "\n".join(l.text for l in lines)
+
+    def _check_progress(self, start_time: float) -> dict:
+        now = time.monotonic()
+        current = self._buf.total_count()
+        return {
+            "elapsed_seconds": round(now - start_time, 1),
+            "token_count": current,
+            "current_state": self._state,
+            "state_duration_seconds": round(now - self._state_entered, 1),
+        }
+
+    def _detect_numbered_selector(self, pane_text: Optional[str] = None) -> bool:
+        try:
+            if pane_text is None:
+                pane_text = self._tmux.capture_pane()
+            lines = clean_lines(pane_text)
+            last_lines = lines[-8:] if len(lines) >= 8 else lines
+            for line in last_lines:
+                if re.match(r"\s*❯\s*\d+\.", line):
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def _find_deny_option_number(self) -> Optional[int]:
+        try:
+            pane = self._tmux.capture_pane()
+            lines = clean_lines(pane)
+            for line in lines[-8:]:
+                m = re.match(r"\s*(?:❯\s*)?(\d+)\.\s*(No|Deny)\b", line, re.IGNORECASE)
+                if m:
+                    return int(m.group(1))
+        except Exception:
+            pass
+        return None
+
+    def _wait_for_claude_startup(self, timeout: int = 30, is_resume: bool = False) -> bool:
+        """Wait for Claude Code to become usable."""
+        deadline = time.monotonic() + timeout
+        EMPTY_THRESHOLD = 3
+        startup_attempts = 0
+        self._startup_error_count = 0  # Reset for this startup attempt
+        # For resume: allow non-IDLE states after settling (session may continue mid-task)
+        resume_settle_deadline = time.monotonic() + 5 if is_resume else None
+
+        while time.monotonic() < deadline:
+            try:
+                pane = self._tmux.capture_pane(lines=100)
+                lines = clean_lines(pane)
+
+                if not lines or len(lines) < EMPTY_THRESHOLD:
+                    time.sleep(1.0)
+                    continue
+
+                scene = detect_startup_scene(lines)
+                if scene and startup_attempts < 3:
+                    startup_attempts += 1
+                    if scene.action == "press_enter":
+                        self._tmux.send_special_key("Enter")
+                    elif scene.action == "press_down_enter":
+                        self._tmux.send_special_key("Down")
+                        time.sleep(0.3)
+                        self._tmux.send_special_key("Enter")
+                    time.sleep(2.0)
+                    continue
+
+                result = detect_state(lines)
+
+                if result.state == SessionState.IDLE:
+                    logger.info("Claude Code startup OK: IDLE")
+                    return True
+
+                # During startup, THINKING/TOOL_CALL/PERMISSION may appear from
+                # the welcome screen spinner or animation — do NOT treat as ready.
+                # Only accept these states if we've already seen an IDLE (prompt).
+                # Skip and keep polling until the welcome screen clears.
+                if result.state in ("THINKING", "TOOL_CALL", "PERMISSION", "INTERVIEW"):
+                    # For resume: after 5s settling, accept non-IDLE states
+                    # (session may have been interrupted mid-task and continues executing)
+                    if resume_settle_deadline and time.monotonic() >= resume_settle_deadline:
+                        logger.info("Claude Code startup OK (resume): %s", result.state)
+                        return True
+                    # Wait longer — welcome screen animation takes several seconds
+                    time.sleep(1.0)
+                    continue
+
+                if result.state in (SessionState.ERROR, SessionState.EXITED):
+                    error_count = getattr(self, "_startup_error_count", 0) + 1
+                    self._startup_error_count = error_count
+                    logger.warning(
+                        "Claude startup detected %s (attempt %d/3) — pane tail: %s",
+                        result.state, error_count,
+                        " | ".join(l.strip() for l in lines[-8:] if l.strip()),
+                    )
+                    if error_count >= 3:
+                        logger.error("Claude Code startup failed after %d ERROR/EXITED detections", error_count)
+                        return False
+                    # Transient errors (API timeout, network blip) may clear — wait and retry
+                    time.sleep(3.0)
+                    continue
+
+            except Exception as e:
+                logger.warning("Startup poll error: %s", e)
+
+            time.sleep(1.0)
+
+        logger.warning("Claude Code startup timed out after %ds", timeout)
+        return False
+
+    @staticmethod
+    def _find_session_jsonl(workdir: str, session_uuid: str) -> Optional[str]:
+        if not re.match(
+            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+            session_uuid,
+        ):
+            return None
+
+        workdir = os.path.abspath(workdir).rstrip("/")
+        claude_dir = os.path.expanduser("~/.claude/projects")
+        dir_name = workdir.replace("/", "-")
+        jsonl_path = os.path.join(claude_dir, dir_name, f"{session_uuid}.jsonl")
+        if os.path.exists(jsonl_path):
+            return jsonl_path
+        return None

--- a/tools/claude_session/status_card.py
+++ b/tools/claude_session/status_card.py
@@ -1,0 +1,736 @@
+"""status_card.py — Real-time Claude session status card via Gateway adapter.
+
+Monitors the session JSONL file and continuously updates a Telegram message
+with the latest session state. Runs in a background thread, non-blocking.
+Uses Gateway adapter callbacks for sending — no independent Bot instance needed.
+
+Lifecycle:
+    card = StatusCard(session_uuid, send_func=adapter.send, edit_func=adapter.edit_message, ...)
+    card.start()                                   # sends initial message
+    # ... Claude runs ...
+    card.stop(summary="Done. 5 tools, 2m 30s")     # final update
+"""
+
+import asyncio
+import json
+import logging
+import re
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+def get_jsonl_path(session_uuid: str) -> Path:
+    """Get the JSONL file path for a Claude session UUID.
+    
+    Searches ~/.claude/projects/ subdirectories for the matching file,
+    avoiding hardcoded project directory names.
+    """
+    if not re.match(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+        session_uuid,
+    ):
+        return Path(f"/nonexistent/{session_uuid}.jsonl")
+
+    projects_dir = Path.home() / ".claude" / "projects"
+    if not projects_dir.exists():
+        return projects_dir / f"{session_uuid}.jsonl"
+
+    target = f"{session_uuid}.jsonl"
+    for subdir in sorted(projects_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        candidate = subdir / target
+        if candidate.exists():
+            return candidate
+
+    # Fallback: return path even if it doesn't exist yet (first poll)
+    # Use the most recently modified project dir as best guess
+    subdirs = list(projects_dir.iterdir())
+    if subdirs:
+        most_recent = max(subdirs, key=lambda p: p.stat().st_mtime)
+        return most_recent / target
+    return projects_dir / target
+
+
+# ------------------------------------------------------------------
+# JSONL Parsing
+# ------------------------------------------------------------------
+
+def parse_jsonl(jsonl_path: Path) -> dict:
+    """Parse JSONL and return structured session state."""
+    if not jsonl_path.exists():
+        return {"status": "no_session"}
+
+    entries = []
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    if not entries:
+        return {"status": "empty"}
+
+    result = {
+        "status": "active",
+        "total_entries": len(entries),
+        "assistant_count": sum(1 for e in entries if e.get("type") == "assistant"),
+        "user_count": sum(1 for e in entries if e.get("type") == "user"),
+    }
+
+    # Walk backwards to find the latest meaningful entry
+    for entry in reversed(entries):
+        entry_type = entry.get("type", "")
+        if entry_type not in ("assistant", "user"):
+            continue
+
+        result["entry_type"] = entry_type
+        result["timestamp"] = entry.get("timestamp", "")
+
+        msg = entry.get("message", {})
+        content = msg.get("content", [])
+
+        if entry_type == "assistant":
+            result["model"] = msg.get("model", "")
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "tool_use":
+                    result["tool"] = item.get("name", "")
+                    result["tool_input"] = item.get("input", {})
+                elif item.get("type") == "text" and "text" not in result:
+                    result["text"] = item.get("text", "")[:200]
+        else:
+            # user content
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "tool_result":
+                    result["tool_result"] = str(item.get("content", ""))[:200]
+                elif item.get("type") == "text" and "text" not in result:
+                    result["text"] = item.get("text", "")[:200]
+        break
+
+    return result
+
+
+# ------------------------------------------------------------------
+# Formatting
+# ------------------------------------------------------------------
+
+# Spinner line extraction — finds the most recent spinner line from tmux output
+_SPINNER_LINE_RE = re.compile(
+    r"^[" + re.escape("✶✽✻✢·*") + r"]\s+(.+)$",
+)
+
+
+def _extract_spinner_text(raw_output: str, max_len: int = 80) -> str:
+    """Extract the most recent spinner text from raw tmux output.
+
+    Returns e.g. "Boogieing… (12s · ↓ 88 tokens · thinking with xhigh effort)"
+    """
+    if not raw_output:
+        return ""
+    lines = raw_output.split("\n")
+    for line in reversed(lines):
+        line = line.strip()
+        m = _SPINNER_LINE_RE.match(line)
+        if m:
+            text = m.group(1).strip()
+            return text[:max_len]
+    return ""
+
+
+_TOOL_ICONS = {
+    "Write": "✏️",
+    "Edit": "📝",
+    "Read": "📖",
+    "Bash": "⚡",
+    "Agent": "🤖",
+    "TaskUpdate": "📋",
+    "TaskCreate": "📋",
+    "Grep": "🔍",
+}
+
+
+def _build_header(session_name: str, session_id: str, tmux_session: str = "") -> str:
+    """Build status card header with optional session identification."""
+    header = "📊 Claude Status"
+    if session_name or session_id or tmux_session:
+        parts = []
+        if session_name:
+            parts.append(session_name[:30])
+        if tmux_session:
+            parts.append(tmux_session)
+        if session_id:
+            parts.append(session_id)
+        header += f" [{' · '.join(parts)}]"
+    return header
+
+
+def format_status_card(state: dict, observer_state: dict = None, max_length: int = 500,
+                       session_name: str = "", session_id: str = "", tmux_session: str = "") -> str:
+    """Format session state as a compact Telegram status card."""
+    real_time = observer_state or {}
+    # When observer reports a live state, prefer it over stale JSONL status.
+    # This prevents "Starting session..." from sticking when the JSONL file
+    # hasn't been written yet but the observer already detects IDLE/THINKING.
+    observer_state_name = real_time.get("state")
+    if observer_state_name and state["status"] in ("no_session", "empty"):
+        # Observer has real data — build card using observer state instead
+        header = _build_header(session_name, session_id, tmux_session)
+        lines = [header]
+
+        if observer_state_name == "THINKING":
+            lines.append("🤔 Thinking...")
+        elif observer_state_name == "TOOL_CALL":
+            lines.append("🔧 Working...")
+        elif observer_state_name == "PERMISSION":
+            lines.append("⏸️ Waiting for permission")
+        else:
+            lines.append("✅ Idle")
+
+        activity = real_time.get("current_activity", "")
+        activity_detail = real_time.get("activity_detail", "")
+        if activity and activity != "idle":
+            if activity_detail:
+                lines.append(f"⚡ {activity}: {activity_detail}")
+            else:
+                lines.append(f"⚡ {activity}")
+
+        result = "\n".join(lines)
+        if len(result) > max_length:
+            result = result[:max_length - 3] + "..."
+        return result
+
+    if state["status"] == "no_session":
+        h = _build_header(session_name, session_id, tmux_session)
+        return f"{h}\n⏳ Starting session..."
+    if state["status"] == "empty":
+        h = _build_header(session_name, session_id, tmux_session)
+        return f"{h}\n⏳ Waiting for activity..."
+
+    header = _build_header(session_name, session_id, tmux_session)
+    lines = [header]
+
+    # State indicator — trust session state over observer when session is IDLE
+    # Observer polls every 5s and may report stale THINKING while Claude is actually idle
+    session_state = state.get("state", "IDLE")
+    
+    # During startup grace period (5s), trust session state over observer
+    session_ready = state.get("session_ready", True)
+    if not session_ready:
+        # Startup phase: trust session state directly
+        current_state = session_state
+    elif session_state == "IDLE":
+        # Trust session's IDLE — it's more accurate than stale observer state
+        current_state = "IDLE"
+    else:
+        current_state = real_time.get("state") or session_state
+
+    if current_state == "THINKING":
+        lines.append("🤔 Thinking...")
+    elif current_state == "TOOL_CALL":
+        lines.append("🔧 Working...")
+    elif current_state == "PERMISSION":
+        perm_tool = real_time.get("tool_name") or state.get("tool")
+        perm_target = real_time.get("tool_target") or state.get("tool_input", {})
+        perm_detail = ""
+        if perm_tool:
+            icon = _TOOL_ICONS.get(perm_tool, "🔧")
+            if isinstance(perm_target, dict):
+                perm_detail = _format_tool_detail(perm_tool, perm_target)
+            elif perm_target:
+                perm_detail = str(perm_target)[:50]
+            if perm_detail:
+                lines.append(f"⏸️ {icon} {perm_tool}: {perm_detail}")
+            else:
+                lines.append(f"⏸️ {icon} {perm_tool}")
+        else:
+            lines.append("⏸️ Waiting for permission")
+    else:
+        lines.append("✅ Idle")
+
+    # Current activity (from observer)
+    activity = real_time.get("current_activity", "")
+    activity_detail = real_time.get("activity_detail", "")
+    if activity and activity != "idle":
+        if activity_detail:
+            lines.append(f"⚡ {activity}: {activity_detail}")
+        else:
+            lines.append(f"⚡ {activity}")
+
+    # Message counts
+    ac = real_time.get("assistant_count") or state.get("assistant_count", 0)
+    uc = real_time.get("user_count") or state.get("user_count", 0)
+    lines.append(f"💬 {ac} / {uc}")
+
+    # Tool call - prefer observer's tool info
+    tool = real_time.get("tool_name") or state.get("tool")
+    if tool:
+        icon = _TOOL_ICONS.get(tool, "🔧")
+        detail = real_time.get("activity_detail") or state.get("tool_input", {})
+        if isinstance(detail, dict):
+            detail = _format_tool_detail(tool, detail)
+        if detail:
+            lines.append(f"{icon} {tool}: {detail}")
+        else:
+            lines.append(f"{icon} {tool}")
+
+    # Text preview — only for THINKING (show spinner verb) and TOOL_CALL (show detail)
+    if current_state == "THINKING":
+        # Extract spinner verb from recent_output (e.g. "✻ Boogieing… (12s)")
+        raw_output = real_time.get("recent_output", "")
+        spinner_text = _extract_spinner_text(raw_output)
+        if spinner_text:
+            lines.append(f"💭 {spinner_text}")
+    elif current_state == "TOOL_CALL":
+        text = real_time.get("recent_output") or state.get("text") or state.get("recent_output")
+        if text:
+            preview = text[:80] + "..." if len(text) > 80 else text
+            first_line = preview.split("\n", 1)[0].strip()
+            if first_line:
+                lines.append(f"💭 {first_line}")
+
+    result = "\n".join(lines)
+
+    if len(result) > max_length:
+        result = result[:max_length - 3] + "..."
+
+    return result
+
+
+def _format_tool_detail(tool: str, tool_input: dict) -> str:
+    """Extract a short detail string from tool input."""
+    if tool in ("Write", "Edit", "Read"):
+        path = tool_input.get("file_path", "")
+        if "/" in path:
+            path = path.rsplit("/", 2)[-1] if len(path.split("/")) > 3 else path
+        return path
+    if tool == "Bash":
+        cmd = tool_input.get("command", "")
+        return (cmd[:50] + "...") if len(cmd) > 50 else cmd
+    if tool in ("TaskUpdate", "TaskCreate"):
+        return f"#{tool_input.get('taskId', '?')} {tool_input.get('status', '')}"
+    if tool == "Agent":
+        return tool_input.get("description", "")
+    return ""
+
+
+# ------------------------------------------------------------------
+# StatusCard — Gateway adapter-based message lifecycle
+# ------------------------------------------------------------------
+
+class StatusCard:
+    """Manages a persistent Telegram status message via Gateway adapter.
+
+    Uses async callbacks (send/edit/delete) from the Gateway's platform
+    adapter instead of creating its own Bot instance. This ensures the
+    status card uses the same proxy/auth config as the main message flow.
+
+    Usage::
+
+        card = StatusCard(
+            session_uuid,
+            loop=gateway_loop,
+            send_func=adapter.send,
+            edit_func=adapter.edit_message,
+            delete_func=adapter.delete_message,
+            chat_id=chat_id,
+        )
+        card.start()
+        # ... Claude runs ...
+        card.stop(summary="Done. 5 tools, 2m")
+    """
+
+    _POLL_INTERVAL = 3.0
+    _MIN_EDIT_INTERVAL = 2.0
+    _MAX_MSG_LEN = 4096
+    _INIT_RETRIES = 3
+    _RETRY_DELAY = 2.0
+    _BUMP_INTERVAL = 60.0  # re-send card at bottom every 60s even if state unchanged
+
+    def __init__(
+        self,
+        session_uuid: str,
+        loop: asyncio.AbstractEventLoop,
+        send_func: Callable,
+        edit_func: Callable,
+        delete_func: Callable,
+        chat_id: str,
+        poll_interval: float = 3.0,
+        max_card_length: int = 500,
+        bump_threshold: int = 3,
+        session_name: str = "",
+        session_id: str = "",
+        tmux_session: str = "",
+    ):
+        self._session_uuid = session_uuid
+        self._session_name = session_name
+        self._session_id = session_id
+        self._tmux_session = tmux_session
+        self._loop = loop
+        self._send_func = send_func
+        self._edit_func = edit_func
+        self._delete_func = delete_func
+        self._chat_id = str(chat_id)
+        self._jsonl_path = get_jsonl_path(session_uuid)
+        self._poll_interval = poll_interval
+        self._max_card_length = max_card_length
+        self._bump_threshold = bump_threshold
+
+        self._message_id: Optional[str] = None
+        self._last_card_text: Optional[str] = None
+        self._last_edit_time: float = 0.0
+        self._bump_count: int = 0
+        self._running = False
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # Cached observer data for real-time status
+        self._observer_state: dict = {}
+        # State transition tracking (protected by _state_lock)
+        self._state_lock = threading.Lock()
+        self._send_lock = threading.Lock()  # protects _sending flag + message state
+        self._sending = False  # True while an async message operation is in flight
+        self._prev_state: Optional[str] = None
+        self._pending_bump: bool = False
+        self._prev_activity: Optional[str] = None
+        self._STATE_TRANSITIONS = {
+            ("IDLE", "THINKING"),
+            ("THINKING", "TOOL_CALL"),
+            ("TOOL_CALL", "THINKING"),
+            ("THINKING", "IDLE"),
+            ("TOOL_CALL", "IDLE"),
+            ("IDLE", "TOOL_CALL"),
+            ("PERMISSION", "IDLE"),
+            ("PERMISSION", "THINKING"),
+            ("PERMISSION", "TOOL_CALL"),
+            ("TOOL_CALL", "PERMISSION"),
+            ("THINKING", "PERMISSION"),
+        }
+
+    def _should_bump(self, new_state: str) -> bool:
+        """Check if state transition warrants a bump (new message at bottom).
+
+        When a valid transition is detected, sets ``_pending_bump`` so the bump
+        survives across polls until it is actually performed.
+        """
+        with self._state_lock:
+            if self._prev_state is None:
+                self._prev_state = new_state
+                return False
+            transition = (self._prev_state, new_state)
+            self._prev_state = new_state
+            if transition in self._STATE_TRANSITIONS:
+                self._pending_bump = True
+                return True
+            return False
+
+    def _clear_pending_bump(self) -> None:
+        """Clear the pending-bump flag after a bump has been performed."""
+        with self._state_lock:
+            self._pending_bump = False
+
+    def update_from_observer(self, info: dict) -> None:
+        """Update cached observer state from real-time session monitoring."""
+        self._observer_state = {
+            "status": "active",
+            "state": info.get("state", "IDLE"),
+            "current_activity": info.get("current_activity", ""),
+            "activity_detail": info.get("activity_detail", ""),
+            "recent_output": info.get("recent_output", ""),
+            "tool_name": info.get("tool_name", ""),
+            "tool_target": info.get("tool_target", ""),
+            "assistant_count": info.get("assistant_count", 0),
+            "user_count": info.get("user_count", 0),
+        }
+
+        # Trigger immediate update via Gateway adapter
+        if self._running and self._loop and self._loop.is_running():
+            try:
+                now = time.monotonic()
+                if (now - self._last_edit_time) < self._MIN_EDIT_INTERVAL:
+                    return
+
+                new_state = info.get("state", "IDLE")
+                do_bump = self._should_bump(new_state)
+
+                # Claim the sending slot (non-blocking)
+                with self._send_lock:
+                    if self._sending:
+                        return  # _run_loop is already sending
+                    self._sending = True
+
+                async def _immediate_send():
+                    try:
+                        # Guard: don't send before initial message is sent
+                        if self._message_id is None:
+                            return
+                        # Re-check: _run_loop may have already updated
+                        state = parse_jsonl(self._jsonl_path)
+                        card_text = format_status_card(state, observer_state=self._observer_state, max_length=self._max_card_length, session_name=self._session_name, session_id=self._session_id, tmux_session=self._tmux_session)
+                        if card_text == self._last_card_text and not do_bump:
+                            return
+                        try:
+                            if do_bump and self._message_id:
+                                await self._bump_message(card_text)
+                            else:
+                                success = await self._edit_telegram(card_text)
+                                if not success:
+                                    await self._send_new_message(card_text)
+                        except Exception as e:
+                            logger.warning("Immediate status send failed: %s", e)
+                        self._last_card_text = card_text
+                        self._last_edit_time = time.monotonic()
+                        self._bump_count = 0
+                    finally:
+                        with self._send_lock:
+                            self._sending = False
+
+                asyncio.run_coroutine_threadsafe(_immediate_send(), self._loop)
+            except Exception as e:
+                with self._send_lock:
+                    self._sending = False
+                logger.warning("Immediate status send failed: %s", e)
+
+    @property
+    def message_id(self) -> Optional[str]:
+        return self._message_id
+
+    def start(self) -> Optional[str]:
+        """Send initial message and start background polling."""
+        if self._running:
+            return self._message_id
+
+        self._running = True
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name=f"status-card-{self._session_uuid[:8]}",
+            daemon=True,
+        )
+        self._thread.start()
+        return None
+
+    def stop(self, summary: Optional[str] = None) -> None:
+        """Stop polling and optionally replace message with final summary."""
+        self._running = False
+        self._stop_event.set()
+
+        if summary and self._message_id and self._loop and self._loop.is_running():
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self._send_or_edit(summary), self._loop
+                )
+                future.result(timeout=5.0)
+            except Exception as e:
+                logger.warning("Final status card update failed: %s", e)
+
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+
+    # ------------------------------------------------------------------
+    # Background loop
+    # ------------------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        """Background thread: polls JSONL and updates via Gateway adapter."""
+        # Send initial message (with retries)
+        initial_text = format_status_card(parse_jsonl(self._jsonl_path), max_length=self._max_card_length, session_name=self._session_name, session_id=self._session_id, tmux_session=self._tmux_session)
+        sent = False
+        for attempt in range(1, self._INIT_RETRIES + 1):
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self._send_new_message(initial_text), self._loop
+                )
+                sent = future.result(timeout=10.0)
+                if sent:
+                    break
+            except Exception as e:
+                logger.warning(
+                    "Status card: initial send attempt %d/%d failed: %s",
+                    attempt, self._INIT_RETRIES, e,
+                )
+                if attempt < self._INIT_RETRIES:
+                    self._stop_event.wait(timeout=self._RETRY_DELAY)
+
+        if not sent:
+            logger.error(
+                "Status card: all %d initial send attempts failed, running without status card",
+                self._INIT_RETRIES,
+            )
+            self._running = False
+            return
+
+        self._last_card_text = initial_text
+        self._last_edit_time = time.monotonic()
+        self._prev_state = None
+        self._pending_bump = False
+        self._prev_activity = None
+
+        # Poll loop
+        _poll_count = 0
+        while self._running and not self._stop_event.is_set():
+            try:
+                state = parse_jsonl(self._jsonl_path)
+                card_text = format_status_card(state, observer_state=self._observer_state, max_length=self._max_card_length, session_name=self._session_name, session_id=self._session_id, tmux_session=self._tmux_session)
+
+                _poll_count += 1
+                if _poll_count <= 5 or _poll_count % 20 == 0:
+                    logger.debug(
+                        "StatusCard poll #%d: jsonl=%s status=%s card_len=%d last=%s msg_id=%s running=%s",
+                        _poll_count, self._jsonl_path.name, state.get("status"),
+                        len(card_text), self._last_card_text[:30] if self._last_card_text else None,
+                        self._message_id, self._running,
+                    )
+
+                current_state = (self._observer_state or {}).get("state", "IDLE")
+                should_bump = self._should_bump(current_state) or self._pending_bump
+
+                # Claim the sending slot (non-blocking)
+                with self._send_lock:
+                    if self._sending:
+                        # Observer path is already sending — skip this poll
+                        self._stop_event.wait(timeout=self._poll_interval)
+                        continue
+                    self._sending = True
+
+                try:
+                    if card_text != self._last_card_text:
+                        logger.info(
+                            "StatusCard poll: text changed (msg_id=%s, state=%s, observer=%s, bump=%s)",
+                            self._message_id, state.get("status"), current_state, should_bump,
+                        )
+                        now = time.monotonic()
+                        if (now - self._last_edit_time) >= self._MIN_EDIT_INTERVAL or should_bump:
+                            if should_bump and self._message_id:
+                                try:
+                                    future = asyncio.run_coroutine_threadsafe(
+                                        self._delete_func(self._chat_id, self._message_id), self._loop
+                                    )
+                                    future.result(timeout=5.0)
+                                except Exception:
+                                    pass
+                                self._message_id = None
+                                future = asyncio.run_coroutine_threadsafe(
+                                    self._send_new_message(card_text), self._loop
+                                )
+                                sent_new = future.result(timeout=10.0)
+                                if sent_new:
+                                    self._last_card_text = card_text
+                                    self._last_edit_time = time.monotonic()
+                                    self._bump_count = 0
+                                self._clear_pending_bump()
+                            else:
+                                future = asyncio.run_coroutine_threadsafe(
+                                    self._edit_telegram(card_text), self._loop
+                                )
+                                success = future.result(timeout=10.0)
+                                if success:
+                                    self._last_card_text = card_text
+                                    self._last_edit_time = time.monotonic()
+                                    self._bump_count = 0
+                                    self._clear_pending_bump()
+                                else:
+                                    logger.warning("StatusCard edit failed (bump_count=%d)", self._bump_count)
+                                    self._bump_count += 1
+                                    if self._bump_count >= self._bump_threshold:
+                                        future = asyncio.run_coroutine_threadsafe(
+                                            self._send_new_message(card_text), self._loop
+                                        )
+                                        future.result(timeout=10.0)
+                                        self._last_card_text = card_text
+                                        self._last_edit_time = time.monotonic()
+                                        self._bump_count = 0
+                                        self._clear_pending_bump()
+                    else:
+                        now = time.monotonic()
+                        if self._message_id and (now - self._last_edit_time) >= self._BUMP_INTERVAL:
+                            should_bump = True
+
+                    # Periodic bump (text unchanged)
+                    if should_bump and self._message_id and card_text == self._last_card_text:
+                        try:
+                            future = asyncio.run_coroutine_threadsafe(
+                                self._delete_func(self._chat_id, self._message_id), self._loop
+                            )
+                            future.result(timeout=5.0)
+                        except Exception:
+                            pass
+                        self._message_id = None
+                        future = asyncio.run_coroutine_threadsafe(
+                            self._send_new_message(card_text), self._loop
+                        )
+                        sent_new = future.result(timeout=10.0)
+                        if sent_new:
+                            self._last_card_text = card_text
+                            self._last_edit_time = time.monotonic()
+                            self._bump_count = 0
+                        self._clear_pending_bump()
+                finally:
+                    with self._send_lock:
+                        self._sending = False
+            except Exception as e:
+                logger.warning("Status card poll error: %s", e)
+
+            self._stop_event.wait(timeout=self._poll_interval)
+
+    async def _edit_telegram(self, text: str) -> bool:
+        """Edit the status message via Gateway adapter. Returns True on success."""
+        if not self._message_id:
+            return False
+        try:
+            result = await self._edit_func(
+                chat_id=self._chat_id,
+                message_id=self._message_id,
+                content=text[:self._MAX_MSG_LEN],
+            )
+            return getattr(result, "success", False)
+        except Exception as e:
+            logger.warning("Status card edit error: %s", e)
+            return False
+
+    async def _send_new_message(self, text: str) -> bool:
+        """Send a new status message via Gateway adapter. Returns True on success."""
+        try:
+            result = await self._send_func(
+                chat_id=self._chat_id,
+                content=text[:self._MAX_MSG_LEN],
+            )
+            if getattr(result, "success", False) and getattr(result, "message_id", None):
+                old_id = self._message_id
+                self._message_id = str(result.message_id)
+                logger.info("Status card sent: %s -> %s", old_id, self._message_id)
+                return True
+            return False
+        except Exception as e:
+            logger.warning("Status card send failed: %s", e)
+            return False
+
+    async def _bump_message(self, text: str) -> bool:
+        """Delete old message and send new one at bottom."""
+        if self._message_id:
+            try:
+                await self._delete_func(self._chat_id, self._message_id)
+            except Exception as e:
+                logger.warning("Status card delete old msg failed: %s", e)
+        result = await self._send_new_message(text)
+        return result
+
+    async def _send_or_edit(self, text: str) -> None:
+        """Used for the final summary — edit existing message."""
+        if self._message_id:
+            try:
+                await self._edit_func(
+                    chat_id=self._chat_id,
+                    message_id=self._message_id,
+                    content=text[:self._MAX_MSG_LEN],
+                )
+            except Exception as e:
+                logger.warning("Status card final update error: %s", e)

--- a/tools/claude_session/stream_output.py
+++ b/tools/claude_session/stream_output.py
@@ -1,0 +1,186 @@
+"""stream_output.py — Stream Claude Code tmux output to gateway in real-time.
+
+Bridges the gap between the polling-based wait_for_idle and the gateway's
+message editing capabilities.  Uses the session observer's callback path
+to receive incremental output updates, then schedules async edits via the
+gateway's event loop.
+
+Usage (from claude_session_tool.py):
+    streamer = SessionOutputStreamer(session, adapter_info)
+    # Wire into observer callback chain
+    old_cb = session._status_callback
+    def chained(info):
+        old_cb(info) if old_cb else None
+        streamer.on_observer_update(info)
+    session._status_callback = chained
+    # ... wait_for_idle runs ...
+    streamer.finish()  # final edit, removes cursor
+"""
+
+import asyncio
+import logging
+import time
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SessionOutputStreamer:
+    """Streams incremental Claude Code output to a chat via gateway adapter.
+
+    Thread-safe: receives updates from the observer thread, schedules
+    async edits on the gateway's event loop via loop.call_soon_threadsafe.
+    """
+
+    # Output noise to strip
+    _NOISE_PATTERNS = [
+        re.compile(r"^─{5,}$"),
+        re.compile(r"bypass permissions (on|off)", re.IGNORECASE),
+        re.compile(r"shift\+tab to cycle", re.IGNORECASE),
+        re.compile(r"esc to interrupt", re.IGNORECASE),
+        re.compile(r"/model|/mcp|/ide for Visual Studio Code", re.IGNORECASE),
+    ]
+    _SPINNER_RE = re.compile(
+        r"^[" + re.escape("✶✽✻✢·*●") + r"]\s+\S",
+    )
+
+    def __init__(self, session, adapter_info: dict, config: Optional[dict] = None):
+        self._session = session
+        self._adapter_info = adapter_info
+        self._loop = adapter_info.get("loop")
+        self._chat_id = adapter_info.get("chat_id", "")
+        self._send_func = adapter_info.get("send_func")
+        self._edit_func = adapter_info.get("edit_func")
+
+        # Config
+        cfg = config or {}
+        self._edit_interval = cfg.get("edit_interval", 3.0)
+        self._max_length = cfg.get("max_length", 3800)
+        self._cursor = cfg.get("cursor", " ⋯")
+        self._min_delta_chars = cfg.get("min_delta_chars", 30)
+
+        # State
+        self._last_marker = session._send_marker
+        self._message_id: Optional[str] = None
+        self._last_sent_text = ""
+        self._last_edit_time = 0.0
+        self._accumulated = ""
+        self._already_sent = False
+        self._finished = False
+
+    @property
+    def already_sent(self) -> bool:
+        return self._already_sent
+
+    def on_observer_update(self, info: dict) -> None:
+        """Called from observer thread. Reads incremental output and schedules edit."""
+        if self._finished:
+            return
+        try:
+            buf = self._session._buf
+            current_marker = buf.total_count()
+            if current_marker <= self._last_marker:
+                return
+            lines = buf.since(self._last_marker)
+            self._last_marker = current_marker
+            if not lines:
+                return
+            text = "\n".join(l.text for l in lines)
+            cleaned = self._clean_output(text)
+            if not cleaned.strip():
+                return
+            self._accumulated += ("\n" if self._accumulated else "") + cleaned
+
+            # Check if enough time/new content to edit
+            now = time.monotonic()
+            elapsed = now - self._last_edit_time
+            delta_chars = len(self._accumulated) - len(self._last_sent_text)
+            if elapsed >= self._edit_interval or delta_chars >= self._min_delta_chars * 2:
+                self._schedule_edit()
+        except Exception as e:
+            logger.debug("on_observer_update error: %s", e)
+
+    def finish(self) -> None:
+        """Final edit: send accumulated output without cursor."""
+        self._finished = True
+        if not self._accumulated or not self._loop or not self._loop.is_running():
+            return
+        display = self._truncate(self._accumulated)
+        if display.strip():
+            self._schedule_async(self._do_send_or_edit, display)
+
+    def _schedule_edit(self) -> None:
+        """Schedule an edit on the event loop."""
+        if not self._loop or not self._loop.is_running():
+            return
+        display = self._truncate(self._accumulated) + self._cursor
+        self._schedule_async(self._do_send_or_edit, display)
+
+    def _truncate(self, text: str) -> str:
+        if len(text) > self._max_length:
+            return text[-self._max_length:]
+        return text
+
+    def _schedule_async(self, coro_fn, *args) -> None:
+        """Schedule an async function on the gateway event loop (thread-safe)."""
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro_fn(*args), self._loop)
+            future.add_done_callback(self._on_edit_done)
+        except Exception as e:
+            logger.debug("schedule_async error: %s", e)
+
+    def _on_edit_done(self, future) -> None:
+        """Callback after async edit completes."""
+        try:
+            ok = future.result()
+            if ok:
+                self._last_sent_text = self._accumulated
+                self._last_edit_time = time.monotonic()
+        except Exception as e:
+            logger.debug("edit done error: %s", e)
+
+    async def _do_send_or_edit(self, text: str) -> bool:
+        """Send or edit message. Returns True on success."""
+        text = text.strip()
+        if not text:
+            return True
+        try:
+            if self._message_id and self._edit_func:
+                result = await self._edit_func(
+                    chat_id=self._chat_id,
+                    message_id=self._message_id,
+                    content=text,
+                )
+                if getattr(result, "success", False):
+                    self._already_sent = True
+                    return True
+
+            # Send new message
+            if self._send_func:
+                result = await self._send_func(
+                    chat_id=self._chat_id,
+                    content=text,
+                )
+                if getattr(result, "success", False) and getattr(result, "message_id", None):
+                    self._message_id = str(result.message_id)
+                    self._already_sent = True
+                    return True
+            return False
+        except Exception as e:
+            logger.error("Stream send/edit error: %s", e)
+            return False
+
+    def _clean_output(self, text: str) -> str:
+        """Strip tmux noise from output."""
+        for pat in self._NOISE_PATTERNS:
+            text = pat.sub("", text)
+        lines = text.splitlines()
+        cleaned = []
+        for line in lines:
+            if self._SPINNER_RE.match(line.strip()):
+                continue
+            stripped = line.strip()
+            if stripped:
+                cleaned.append(stripped)
+        return "\n".join(cleaned)

--- a/tools/claude_session/task_context.py
+++ b/tools/claude_session/task_context.py
@@ -1,0 +1,61 @@
+"""task_context.py — Structured input for Claude Code sessions.
+
+The core data structure for the context pipeline:
+Hermes fills TaskContext → ClaudeSession formats it → Claude executes.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class FileContext:
+    """A file relevant to the task."""
+    path: str
+    content: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass
+class TaskContext:
+    """Structured task description for Claude Code execution.
+
+    Designed to capture what Claude needs without requiring
+    exploration: clear goal, relevant code, constraints, and
+    acceptance criteria.
+    """
+
+    task_description: str
+    file_contexts: list[FileContext] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    acceptance_criteria: list[str] = field(default_factory=list)
+    project_conventions: Optional[str] = None
+
+    def to_prompt(self) -> str:
+        """Format into a high-density prompt for Claude Code."""
+        parts = [f"## Task\n{self.task_description}"]
+
+        if self.file_contexts:
+            parts.append("\n## Relevant Files")
+            for fc in self.file_contexts:
+                header = f"### {fc.path}"
+                if fc.description:
+                    header += f" — {fc.description}"
+                parts.append(header)
+                if fc.content:
+                    parts.append(f"```\n{fc.content}\n```")
+
+        if self.constraints:
+            parts.append("\n## Constraints")
+            for c in self.constraints:
+                parts.append(f"- {c}")
+
+        if self.acceptance_criteria:
+            parts.append("\n## Acceptance Criteria")
+            for ac in self.acceptance_criteria:
+                parts.append(f"- {ac}")
+
+        if self.project_conventions:
+            parts.append(f"\n## Project Conventions\n{self.project_conventions}")
+
+        return "\n".join(parts)

--- a/tools/claude_session/tmux_interface.py
+++ b/tools/claude_session/tmux_interface.py
@@ -1,0 +1,113 @@
+"""tools/claude_session/tmux_interface.py — Low-level tmux operations."""
+
+import logging
+import os
+import signal
+import subprocess
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class TmuxInterface:
+    """Encapsulates all tmux CLI interactions for a single session."""
+
+    def __init__(self, session_name: str):
+        self.session_name = session_name
+
+    def _run(self, args: list, timeout: int = 10) -> subprocess.CompletedProcess:
+        """Run a tmux command."""
+        cmd = ["tmux"] + args
+        try:
+            return subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error("tmux command timed out: %s", " ".join(args))
+            raise
+        except FileNotFoundError:
+            raise RuntimeError("tmux is not installed or not in PATH")
+
+    def session_exists(self) -> bool:
+        """Check if the tmux session exists."""
+        r = self._run(["has-session", "-t", self.session_name])
+        return r.returncode == 0
+
+    def create_session(self, workdir: str, env: Optional[dict] = None) -> str:
+        """Create a new detached tmux session. Returns session name."""
+        cmd = [
+            "new-session",
+            "-d",
+            "-s", self.session_name,
+            "-c", workdir,
+        ]
+        if env:
+            for k, v in env.items():
+                cmd.extend(["-e", f"{k}={v}"])
+        r = self._run(cmd)
+        if r.returncode != 0:
+            raise RuntimeError(f"Failed to create tmux session: {r.stderr}")
+        return self.session_name
+
+    def capture_pane(self, lines: int = 200) -> str:
+        """Capture visible pane output. Returns raw text with ANSI codes."""
+        r = self._run([
+            "capture-pane",
+            "-t", self.session_name,
+            "-p",
+            "-S", f"-{lines}",
+        ])
+        return r.stdout if r.returncode == 0 else ""
+
+    def send_keys(self, text: str, enter: bool = False) -> None:
+        """Send text to the tmux session, optionally pressing Enter.
+
+        Uses send-keys -l for literal text (no special key name interpretation).
+        This avoids the need for manual escaping since subprocess.run passes
+        arguments directly without shell interpretation.
+
+        IMPORTANT: This method performs NO delays. The caller is responsible
+        for timing — multi-line text needs a delay before Enter to allow
+        bracketed paste to complete, but that delay must NOT be inside a lock.
+        """
+        cmd = ["send-keys", "-t", self.session_name, "-l", text]
+        self._run(cmd)
+        if enter:
+            self.send_special_key("Enter")
+
+    def send_special_key(self, key: str) -> None:
+        """Send a special key sequence (e.g., C-c, C-d, Enter)."""
+        self._run(["send-keys", "-t", self.session_name, key])
+
+    def kill_session(self) -> None:
+        """Kill the tmux session.
+
+        tmux kill-session closes the pty and sends SIGHUP to child processes.
+        However, Claude Code may setsid and escape the SIGHUP — fall back to
+        SIGTERM the pane PID if the session leader is gone.
+        """
+        try:
+            self._run(["kill-session", "-t", self.session_name], timeout=5)
+            logger.info("Tmux session %s killed", self.session_name)
+        except Exception as e:
+            logger.warning("tmux kill-session failed for %s: %s", self.session_name, e)
+            # Fallback: find the pane PID and SIGTERM it
+            try:
+                result = self._run(
+                    ["list-panes", "-t", self.session_name, "-F", "#{pane_pid}"], timeout=5
+                )
+                for line in result.stdout.strip().split("\n"):
+                    line = line.strip()
+                    if line.lstrip("-").isdigit():
+                        pid = int(line)
+                        try:
+                            os.kill(pid, signal.SIGTERM)
+                            logger.info("Sent SIGTERM to pane PID %d", pid)
+                        except ProcessLookupError:
+                            pass
+            except Exception as sig_e:
+                logger.warning("SIGTERM fallback also failed for %s: %s", self.session_name, sig_e)

--- a/tools/claude_session_tool.py
+++ b/tools/claude_session_tool.py
@@ -1,0 +1,2215 @@
+"""tools/claude_session_tool.py — Hermes tool for Claude Code session management."""
+
+import filecmp
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from tools.registry import registry, tool_error, tool_result
+from tools.claude_session.errors import SessionError
+
+# Module-level import of gateway session context — avoids repeated import on hot path.
+try:
+    from gateway.session_context import get_session_env
+except ImportError:
+    get_session_env = None
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Session Registry（支持并行运行多个独立会话 + gateway session 隔离）
+# ---------------------------------------------------------------------------
+_sessions: dict = {}   # session_id → ClaudeSession 实例
+_workdir_index: dict[tuple[str, str], list[str]] = {}  # (gateway_key, workdir) → list[session_id] (一对多，同一 workdir 支持多个会话)
+_name_index: dict[tuple[str, str], str] = {}  # (gateway_key, name) → session_id (主索引)
+_active_session: dict[str, str] = {}  # gateway_key → session_id (最近活跃)
+_sessions_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Session Persistence — claude-session.json in project .claude/ directory
+# ---------------------------------------------------------------------------
+_CLAUDE_DIR = ".claude"
+_SESSION_FILE = "claude-session.json"
+_GLOBAL_INDEX_FILE = os.path.expanduser("~/.hermes/claude-session-dirs.json")
+_global_index_lock = threading.Lock()
+
+
+def _register_workdir(workdir: str) -> None:
+    """Register a workdir in the global index for cross-session discovery."""
+    try:
+        with _global_index_lock:
+            dirs = set()
+            if os.path.isfile(_GLOBAL_INDEX_FILE):
+                try:
+                    with open(_GLOBAL_INDEX_FILE, "r") as f:
+                        dirs = set(json.load(f))
+                except Exception:
+                    pass
+            if workdir in dirs:
+                return
+            dirs.add(workdir)
+            os.makedirs(os.path.dirname(_GLOBAL_INDEX_FILE), exist_ok=True)
+            tmp = _GLOBAL_INDEX_FILE + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(sorted(dirs), f)
+                f.write("\n")
+            os.replace(tmp, _GLOBAL_INDEX_FILE)
+            try:
+                os.chmod(_GLOBAL_INDEX_FILE, 0o600)
+            except Exception:
+                pass
+    except Exception as e:
+        logger.debug("Failed to register workdir %s: %s", workdir, e)
+
+
+def _get_known_workdirs() -> list:
+    """Return all workdirs that have ever hosted a persisted session.
+    Filters out paths that no longer exist on disk."""
+    try:
+        if not os.path.isfile(_GLOBAL_INDEX_FILE):
+            return []
+        with _global_index_lock:
+            with open(_GLOBAL_INDEX_FILE, "r") as f:
+                dirs = json.load(f)
+        return [d for d in dirs if os.path.isdir(d)]
+    except Exception:
+        return []
+
+
+def _validate_workdir(workdir: str) -> str:
+    """Validate and normalize workdir. Returns realpath. Raises on unsafe paths."""
+    # Resolve to absolute, real path (follows symlinks, eliminates ..)
+    real = os.path.realpath(workdir)
+    # Must exist and be a directory
+    if not os.path.isdir(real):
+        raise ValueError(f"workdir does not exist or is not a directory: {real}")
+    # Block sensitive system directories
+    blocked = ("/etc", "/proc", "/sys", "/dev", "/boot", "/root", "/usr", "/var")
+    if any(real == b or real.startswith(b + "/") for b in blocked):
+        raise ValueError(f"workdir in blocked system directory: {real}")
+    return real
+
+
+def _session_file_path(workdir: str) -> str:
+    """Return the path to claude-session.json for a given workdir."""
+    return os.path.join(workdir, _CLAUDE_DIR, _SESSION_FILE)
+
+
+def _load_session_registry(workdir: str) -> dict:
+    """Load session registry from .claude/claude-session.json. Returns {} if not found."""
+    try:
+        workdir = _validate_workdir(workdir)
+    except ValueError as e:
+        logger.warning("Workdir validation failed for load: %s", e)
+        return {}
+    path = _session_file_path(workdir)
+    if not os.path.isfile(path):
+        return {}
+    # Verify no symlink tricks on the file itself
+    if os.path.islink(path):
+        logger.warning("Session file is a symlink, ignoring: %s", path)
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        # Sanity: top-level must be a dict of session entries
+        if not isinstance(data, dict):
+            logger.warning("Session file root is not a dict, ignoring: %s", path)
+            return {}
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load session registry from %s: %s", path, e)
+        return {}
+
+
+def _save_session_registry(workdir: str, data: dict) -> None:
+    """Save session registry to .claude/claude-session.json. Creates .claude/ if needed."""
+    try:
+        workdir = _validate_workdir(workdir)
+    except ValueError as e:
+        logger.warning("Workdir validation failed for save: %s", e)
+        return
+    path = _session_file_path(workdir)
+    claude_dir = os.path.dirname(path)
+    try:
+        # Create .claude dir if needed — check for existing symlink
+        if os.path.islink(claude_dir) and not os.path.isdir(claude_dir):
+            logger.warning(".claude is a dangling symlink, refusing: %s", claude_dir)
+            return
+        os.makedirs(claude_dir, exist_ok=True)
+        # Write with restricted permissions (owner-only: 600)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except OSError as e:
+        logger.warning("Failed to save session registry to %s: %s", path, e)
+    else:
+        _register_workdir(workdir)
+
+
+def _persist_session(workdir: str, name: str, claude_uuid: str, **kwargs) -> None:
+    """Persist a name→uuid mapping to the project's .claude/claude-session.json.
+    
+    Enriched fields: model, permission_mode, resume_count, last_resume_status,
+    jsonl_size, tmux_session, status.
+    """
+    data = _load_session_registry(workdir)
+    now = datetime.now().isoformat()
+    existing = data.get(name, {})
+    
+    # Increment resume_count if this is an auto-resume
+    resume_count = existing.get("resume_count", 0)
+    if kwargs.get("auto_resumed"):
+        resume_count += 1
+    
+    data[name] = {
+        "claude_session_uuid": claude_uuid,
+        "workdir": workdir,
+        "name": name,
+        # Time tracking
+        "created_at": existing.get("created_at", now),
+        "updated_at": now,
+        "last_active_at": now,
+        # Usage tracking
+        "resume_count": resume_count,
+        "total_starts": existing.get("total_starts", 0) + 1,
+        # Session config
+        "model": kwargs.get("model", existing.get("model")),
+        "permission_mode": kwargs.get("permission_mode", existing.get("permission_mode")),
+        "tmux_session": kwargs.get("tmux_session", existing.get("tmux_session")),
+        # Resume metadata
+        "last_resume_status": (
+            "auto_resumed" if kwargs.get("auto_resumed")
+            else kwargs.get("resume_status", existing.get("last_resume_status"))
+        ),
+        "jsonl_size": kwargs.get("jsonl_size", existing.get("jsonl_size")),
+        # Status
+        "status": "active",
+    }
+    _save_session_registry(workdir, data)
+
+
+def _update_session_status(workdir: str, name: str, status: str) -> None:
+    """Update session status in persistence (e.g. 'stopped', 'active')."""
+    data = _load_session_registry(workdir)
+    if name in data and isinstance(data[name], dict):
+        data[name]["status"] = status
+        data[name]["last_active_at"] = datetime.now().isoformat()
+        _save_session_registry(workdir, data)
+
+
+def _load_persisted_session(workdir: str, name: str) -> Optional[str]:
+    """Load a persisted claude_session_uuid for a given name. Returns None if not found."""
+    data = _load_session_registry(workdir)
+    entry = data.get(name)
+    if entry and isinstance(entry, dict):
+        return entry.get("claude_session_uuid")
+    return None
+
+
+def _load_persisted_sessions(workdir: str) -> dict:
+    """Load all persisted sessions for a workdir. Returns the full registry dict."""
+    return _load_session_registry(workdir)
+
+# Per-gateway-session status observers — bridges session status to Telegram.
+# Keyed by gateway_session_key so concurrent sessions route to the correct chat.
+from typing import Callable
+_status_observers: dict[str, Callable[[str, dict], None]] = {}  # gw_key → callback(session_id, info)
+_status_observers_lock = threading.Lock()
+# Gateway adapter registry: gw_key → {loop, send_func, edit_func, delete_func, chat_id, timestamp}
+_gateway_adapters: dict[str, dict] = {}
+_gateway_adapters_lock = threading.Lock()
+_gateway_adapters_ttl = 300  # seconds — clean up stale entries after 5 minutes
+
+
+def register_status_observer(callback, gateway_session_key: str = ""):
+    """Register a status observer for a specific gateway session.
+
+    Called by gateway/run.py to bridge ClaudeSession status updates
+    to Telegram status messages. The callback receives (session_id, status_info).
+
+    Uses per-gateway-session-key isolation so concurrent sessions (e.g. a DM
+    and a group chat running in parallel) each route status updates to the
+    correct chat instead of overwriting each other.
+    """
+    with _status_observers_lock:
+        _status_observers[gateway_session_key] = callback
+
+
+def unregister_status_observer(gateway_session_key: str = ""):
+    """Remove the status observer for a specific gateway session."""
+    with _status_observers_lock:
+        _status_observers.pop(gateway_session_key, None)
+
+
+def register_gateway_adapter(
+    gateway_session_key: str,
+    loop,
+    send_func,
+    edit_func,
+    delete_func,
+    chat_id: str,
+):
+    """Register Gateway adapter callbacks for StatusCard to use.
+
+    Called by gateway/run.py when setting up the status bridge.
+    StatusCard reads these to send/edit/delete messages via the Gateway's
+    platform adapter (instead of creating its own Bot instance).
+    """
+    with _gateway_adapters_lock:
+        _gateway_adapters[gateway_session_key] = {
+            "loop": loop,
+            "send_func": send_func,
+            "edit_func": edit_func,
+            "delete_func": delete_func,
+            "chat_id": chat_id,
+            "timestamp": time.time(),
+        }
+
+
+def _cleanup_stale_adapters():
+    """Remove adapter entries older than TTL to prevent memory leaks."""
+    cutoff = time.time() - _gateway_adapters_ttl
+    with _gateway_adapters_lock:
+        stale = [k for k, v in _gateway_adapters.items() if v.get("timestamp", 0) < cutoff]
+        for k in stale:
+            _gateway_adapters.pop(k, None)
+        return stale
+
+
+def unregister_gateway_adapter(gateway_session_key: str = ""):
+    """Remove the adapter registration for a specific gateway session."""
+    with _gateway_adapters_lock:
+        _gateway_adapters.pop(gateway_session_key, None)
+        # Also clean up any stale entries while we're here
+        cutoff = time.time() - _gateway_adapters_ttl
+        stale = [k for k, v in _gateway_adapters.items() if v.get("timestamp", 0) < cutoff]
+        for k in stale:
+            _gateway_adapters.pop(k, None)
+
+
+def _get_gateway_session_key() -> str:
+    """读取当前 gateway session_key（并发安全）。
+
+    优先从 contextvars 读取（gateway 模式，每个 Telegram 群聊独立），
+    回退到 os.environ（CLI/cron 模式），都为空则返回空串（无隔离）。
+    """
+    if get_session_env is not None:
+        try:
+            key = get_session_env("HERMES_SESSION_KEY", "")
+            if key:
+                return key
+        except Exception:
+            pass
+    return os.environ.get("HERMES_SESSION_KEY", "")
+
+
+def _safe_call_observer(observer: Callable[[str, dict], None], session_id: str, status_info: dict) -> None:
+    """Safely call an observer with exception handling.
+
+    Wraps observer callbacks to prevent crashes when the underlying resources
+    (e.g., gateway session, event loop) have been cleaned up. Silently logs
+    errors rather than propagating them to the Claude Code session manager.
+
+    Args:
+        observer: The observer callback to call
+        session_id: Claude session ID
+        status_info: Status information dictionary
+    """
+    try:
+        observer(session_id, status_info)
+    except Exception as e:
+        logger.debug(
+            "Observer callback error (session=%s, gateway_key=%s): %s",
+            session_id,
+            _get_gateway_session_key(),
+            e,
+        )
+
+
+def _derive_session_name(workdir: str, gateway_session_key: str = "", name: Optional[str] = None) -> str:
+    """基于 workdir + gateway session_key 生成确定性 tmux session 名。
+
+    gateway 模式下，同一 workdir 的不同 Telegram 群聊会得到不同的 tmux 名。
+    CLI/cron 模式下（gateway_session_key 为空），退化为纯 workdir 哈希。
+    格式：hermes-{sha256前8位}
+
+    如果提供了 name，将其纳入哈希计算，使同一 workdir 下不同命名的会话
+    得到不同的 tmux session 名。
+    """
+    abs_path = os.path.abspath(workdir)
+    parts = [abs_path]
+    if gateway_session_key:
+        parts.append(gateway_session_key)
+    if name:
+        parts.append(name)
+    combined = ":".join(parts)
+    h = hashlib.sha256(combined.encode()).hexdigest()[:8]
+    return f"hermes-{h}"
+
+
+def _validate_session_name(name: str, gw_key: str) -> Optional[str]:
+    """验证 session name，返回错误信息或 None。
+
+    规则：
+      - 非空，1-64 字符
+      - 只允许 [a-zA-Z0-9_-]
+      - 同一 gateway_key 下不能重复
+    """
+    if not name:
+        return "session name cannot be empty"
+    if len(name) > 64:
+        return f"session name too long ({len(name)} > 64)"
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", name):
+        return "session name must contain only letters, digits, underscores, and hyphens"
+    with _sessions_lock:
+        existing_id = _name_index.get((gw_key, name))
+        if existing_id and existing_id in _sessions:
+            return f"name '{name}' already in use by session {existing_id[:8]}"
+    return None
+
+
+def _touch_active(gw_key: str, session_id: str, already_locked: bool = False):
+    """更新活跃 session 记录（gateway_key → 最新 session_id）。
+
+    在 start / send / interact 时调用，确保 _active_session 始终指向
+    该 gateway 下最近交互的会话。
+
+    Args:
+        already_locked: 为 True 时跳过加锁（调用方已持有 _sessions_lock）。
+    """
+    if already_locked:
+        _active_session[gw_key] = session_id
+    else:
+        with _sessions_lock:
+            _active_session[gw_key] = session_id
+
+
+def _get_session(session_id: str = None, gateway_session_key: str = "", strict: bool = False):
+    """获取指定会话，无 session_id 时返回当前 gateway session 的最近会话。
+
+    Args:
+        session_id: 目标会话 ID。None 时按 gateway_session_key 过滤后返回最近的会话。
+        gateway_session_key: 当前 gateway session key，用于隔离不同 Telegram 群聊。
+        strict: 为 True 时，指定了 session_id 但找不到则返回 None（不回退），
+                用于 stop/操作类 action 防止操作错误会话。
+    """
+    with _sessions_lock:
+        if session_id:
+            if session_id in _sessions:
+                return _sessions[session_id]
+            # session_id 已明确指定但找不到
+            if strict:
+                logger.warning(
+                    "session_id=%s not found in registry (known: %s). "
+                    "Possible gateway restart lost in-memory state.",
+                    session_id, list(_sessions.keys()),
+                )
+                return None
+        # 优先使用 _active_session 记录（由 start/send/switch 更新）。
+        # 注意：CLI/部分 gateway 路径的 key 可能是空串，空串也是有效作用域。
+        active_id = _active_session.get(gateway_session_key)
+        if active_id and active_id in _sessions:
+            return _sessions[active_id]
+
+        # 回退：按 gateway session-key 过滤后返回最后创建的会话。
+        sessions_for_gateway = [
+            mgr for mgr in _sessions.values()
+            if getattr(mgr, "_gateway_session_key", "") == gateway_session_key
+        ]
+        if sessions_for_gateway:
+            return sessions_for_gateway[-1]
+
+        # 最后兜底：跨作用域返回全局最后一个（主要兼容旧 CLI/cron 行为）。
+        if _sessions:
+            return list(_sessions.values())[-1]
+    return None
+
+
+def _get_session_by_workdir(workdir: str, gateway_session_key: str = ""):
+    """通过 (gateway_session_key, workdir) 查找已注册的会话。
+
+    无锁，调用方需持有 _sessions_lock。
+    """
+    abs_path = os.path.abspath(workdir)
+    idx_key = (gateway_session_key, abs_path)
+    sid = _workdir_index.get(idx_key)
+    if sid and sid != "__starting__" and sid in _sessions:
+        return _sessions[sid]
+    return None
+
+
+def _resolve_target_session(args: dict, gw_key: str):
+    """根据 args 中的 session_id / name 解析目标会话。
+
+    优先级：session_id > name > _active_session[gw_key] > 最近会话。
+    返回 (mgr, error_json) 元组，mgr 为 None 时 error_json 非空。
+    """
+    sid = args.get("session_id")
+    name = args.get("name")
+
+    if sid:
+        mgr = _get_session(sid, gateway_session_key=gw_key, strict=True)
+        if mgr is None:
+            return None, tool_error(f"Session '{sid}' not found in registry.")
+        return mgr, None
+
+    if name:
+        with _sessions_lock:
+            resolved_id = _name_index.get((gw_key, name))
+            # Cross-gateway fallback: search all gateway contexts for the name
+            if not resolved_id:
+                for (gk, n), sid in _name_index.items():
+                    if n == name and sid and sid != "__starting__":
+                        resolved_id = sid
+                        break
+        if not resolved_id:
+            return None, tool_error(f"No session named '{name}' in current gateway context.")
+        mgr = _get_session(resolved_id, gateway_session_key=gw_key, strict=True)
+        if mgr is None:
+            return None, tool_error(f"Session '{name}' (id={resolved_id[:8]}) no longer exists.")
+        return mgr, None
+
+    # 无指定时回退到 _active_session 或最近会话
+    mgr = _get_session(None, gateway_session_key=gw_key)
+    if mgr is None:
+        return None, tool_error("No active session. Use 'start' first.")
+    return mgr, None
+
+
+def _list_sessions(gateway_key: str) -> dict:
+    """列出当前 gateway 下的所有 session，包含名称、workdir 和状态。"""
+    sessions = []
+    with _sessions_lock:
+        for sid, mgr in _sessions.items():
+            if getattr(mgr, "_gateway_session_key", "") != gateway_key:
+                continue
+            # 优先从 mgr 属性读取 name，回退到 _name_index 反查
+            session_name = getattr(mgr, "_session_name", None)
+            if not session_name:
+                for (gk, n), mapped_sid in _name_index.items():
+                    if gk == gateway_key and mapped_sid == sid:
+                        session_name = n
+                        break
+            sessions.append({
+                "session_id": sid,
+                "name": session_name,
+                "workdir": getattr(mgr, "_workdir", None),
+                "state": mgr._sm.current_state if hasattr(mgr, "_sm") else "UNKNOWN",
+                "active": getattr(mgr, "_session_active", False),
+            })
+        active_id = _active_session.get(gateway_key)
+    return {
+        "sessions": sessions,
+        "active_session_id": active_id,
+        "total": len(sessions),
+    }
+
+
+def _switch_session(name: str, gateway_key: str) -> dict:
+    """切换活跃 session 到指定 name。"""
+    with _sessions_lock:
+        target_id = _name_index.get((gateway_key, name))
+        if not target_id:
+            return {"error": f"No session named '{name}' in current gateway context."}
+        target_mgr = _sessions.get(target_id)
+        if not target_mgr or not getattr(target_mgr, "_session_active", False):
+            return {"error": f"Session '{name}' exists but is not active (may have been stopped)."}
+        _active_session[gateway_key] = target_id
+    return {
+        "switched_to": name,
+        "session_id": target_id,
+        "state": target_mgr._sm.current_state if hasattr(target_mgr, "_sm") else "UNKNOWN",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+CLAUDE_SESSION_SCHEMA = {
+    "name": "claude_session",
+    "description": (
+        "Interactive Claude Code session via tmux — PREFERRED way to delegate coding tasks.\n"
+        "Actions: start|send|type|submit|status|wait_for_idle|output|respond_permission|"
+        "respond_interview|stop|history|events|list|switch|diagnose|doctor_fix\n\n"
+        "WHEN TO USE: Complex multi-file coding tasks, tasks needing real-time monitoring, "
+        "long-running sessions with state tracking, parallel named sessions (name REQUIRED for start).\n\n"
+        "WHEN NOT TO USE: Simple shell commands (-> terminal), non-Claude reasoning (-> delegate_task), "
+        "one-shot questions (-> terminal with 'claude -p').\n\n"
+        "Provides real-time state awareness (IDLE/THINKING/TOOL_CALL/PERMISSION/INTERVIEW), "
+        "atomic send, and permission handling.\n"
+        "Load 'claude-session' skill for detailed workflows, collaboration principles, and troubleshooting."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "start", "send", "type", "submit", "send_text", "cancel_input",
+                    "status", "wait_for_idle", "wait_for_state",
+                    "output", "jsonl_output", "respond_permission", "respond_interview", "stop", "history", "events",
+                    "list", "switch",
+                    "diagnose", "doctor_fix",
+                ],
+                "description": "Action to perform on the Claude session",
+            },
+            # 多会话路由
+            "session_id": {
+                "type": "string",
+                "description": "目标会话ID（可选，默认最近活跃的会话）",
+            },
+            "name": {
+                "type": "string",
+                "description": "Named session identifier — REQUIRED. Used with start/list/switch/stop for multi-session management. Must be 1-64 chars, [a-zA-Z0-9_-].",
+            },
+            # start
+            "workdir": {
+                "type": "string",
+                "description": "Working directory for 'start' action",
+            },
+            "session_name": {
+                "type": "string",
+                "description": "tmux session name (default: hermes-{sha256[:8]} based on workdir)",
+            },
+            "model": {
+                "type": "string",
+                "description": "Claude model to use (e.g. 'sonnet', 'opus')",
+            },
+            "permission_mode": {
+                "type": "string",
+                "enum": ["normal", "skip"],
+                "description": "Permission mode: 'normal' (Claude asks) or 'skip' (auto-approve)",
+            },
+            "on_event": {
+                "type": "string",
+                "enum": ["notify", "queue", "none"],
+                "description": "Event delivery mode (default: 'notify')",
+            },
+            "resume_uuid": {
+                "type": "string",
+                "description": "Claude Code session UUID to resume (optional). If provided, starts with --resume to restore history.",
+            },
+            "force_new": {
+                "type": "boolean",
+                "description": "For 'start': force creating a new session instead of auto-resuming an existing one with the same name.",
+            },
+            # send / type / start
+            "message": {
+                "type": "string",
+                "description": "Message text for 'send' action. For 'start' action, if provided, automatically sends this message after session starts successfully.",
+            },
+            "text": {
+                "type": "string",
+                "description": "Text for 'type' action (no Enter)",
+            },
+            # wait_for_idle / wait_for_state
+            "timeout": {
+                "type": "integer",
+                "description": "Max seconds to wait (default: 900 for wait_for_idle, 60 for wait_for_state). Claude Code tasks typically take 3-30 minutes. Use 900 for normal tasks, 1800 for heavy analysis.",
+                "minimum": 1,
+            },
+            "target_state": {
+                "type": "string",
+                "description": "Target state for 'wait_for_state' action",
+            },
+            # output
+            "offset": {
+                "type": "integer",
+                "description": "Line offset for 'output' action",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max lines for 'output' action. Default: 50. Use 100-500 for detailed review.",
+                "minimum": 1,
+            },
+            # jsonl_output
+            "last_reply": {
+                "type": "boolean",
+                "description": "For 'jsonl_output': return the last assistant text reply (use when tmux output is truncated)",
+            },
+            "last_n": {
+                "type": "integer",
+                "description": "For 'jsonl_output': return the last N assistant text replies. Omit for summary only.",
+                "minimum": 1,
+            },
+            "max_length": {
+                "type": "integer",
+                "description": "For 'jsonl_output': max character length for each reply. Replies exceeding this are truncated. Default: 15000.",
+                "minimum": 1000,
+            },
+            # respond_permission
+            "response": {
+                "type": "string",
+                "enum": ["allow", "deny"],
+                "description": "Permission response for 'respond_permission' action",
+            },
+            # respond_interview
+            "option": {
+                "type": "string",
+                "description": "Option for 'respond_interview' action. IMPORTANT: analyze the interview context (question + options) from wait_for_idle result and choose the best answer for the task. A number (e.g. '1') to select that numbered option, 'enter' to confirm current selection, 'escape' to cancel, or text to type as custom input.",
+            },
+            # events
+            "since_turn": {
+                "type": "integer",
+                "description": "Filter events since turn ID for 'events' action",
+            },
+            # doctor_fix
+            "apply": {
+                "type": "boolean",
+                "description": "For 'doctor_fix': False=analyze only (default), True=execute fixes",
+            },
+            "strategy": {
+                "type": "string",
+                "enum": ["project", "user", "merge"],
+                "description": "For 'doctor_fix': merge strategy — 'project' (default), 'user', or 'merge'",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Output streaming helper
+# ---------------------------------------------------------------------------
+
+def _setup_output_streamer(mgr, gw_key: str):
+    """Create a SessionOutputStreamer if a gateway adapter is available.
+
+    Wires the streamer into the session's observer callback chain so
+    incremental output is pushed to the user's chat in real-time.
+    """
+    from tools.claude_session.stream_output import SessionOutputStreamer
+    try:
+        with _gateway_adapters_lock:
+            adapter_info = _gateway_adapters.get(gw_key)
+        if not adapter_info or not adapter_info.get("loop"):
+            return None
+        chat_id = adapter_info.get("chat_id", "")
+        if not chat_id:
+            return None
+
+        streamer = SessionOutputStreamer(mgr, adapter_info)
+
+        # Chain into existing status callback (preserves StatusCard updates)
+        existing_cb = mgr._status_callback
+
+        def _chained(info: dict) -> None:
+            if existing_cb:
+                try:
+                    existing_cb(info)
+                except Exception:
+                    pass
+            streamer.on_observer_update(info)
+
+        mgr._status_callback = _chained
+        mgr._output_streamer = streamer
+        return streamer
+    except Exception as e:
+        logger.debug("Output streamer setup failed: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def _handle_claude_session(args, **kw):
+    """Dispatch claude_session tool calls (支持多会话路由 + gateway session 隔离 + named sessions)."""
+    action = args.get("action", "")
+    gw_key = _get_gateway_session_key()
+
+    # ── start：创建新实例并注册（name 必填 + workdir 可选）──
+    if action == "start":
+        # 每次 start 时清理过期 adapter，防止断开时未正确注销导致内存泄漏
+        _cleanup_stale_adapters()
+
+        from tools.claude_session.session import ClaudeSession
+
+        # name 必须提供（第一性原理：明确会话用途，避免自动命名的混淆）
+        session_name_arg = args.get("name")
+        if not session_name_arg:
+            return json.dumps({"error": "name is required for 'start' action. Provide a meaningful name to identify the session."}, ensure_ascii=False)
+
+        # 验证 name
+        err = _validate_session_name(session_name_arg, gw_key)
+        if err:
+            return json.dumps({"error": err}, ensure_ascii=False)
+
+        workdir = args.get("workdir", ".")
+        abs_workdir = os.path.abspath(workdir)
+        idx_key = (gw_key, session_name_arg)  # 改为基于 name 的索引键
+
+        # 生成确定性 tmux session 名（基于 name，不再依赖 workdir）
+        sn = _derive_session_name(abs_workdir, gw_key, name=session_name_arg)
+
+        # 查找已有会话（锁内仅读取注册表，不执行耗时操作）
+        # check-and-set: name 查找 + 占位符注册在同一锁内，防止并发 start
+        # 双重创建（TOCTOU fix）。
+        _existing_resp = None
+        _old_mgr_to_stop = None  # 需要在锁外 stop 的旧 session
+        _old_sid_to_cleanup = None  # 需要在锁外清理注册表的旧 session_id
+        with _sessions_lock:
+            existing_sid = _name_index.get((gw_key, session_name_arg))
+            if existing_sid == "__starting__":
+                # 另一个线程正在创建同名会话 — 拒绝本次请求
+                return json.dumps(
+                    {"error": f"Session '{session_name_arg}' is currently being created by another request. Retry in a moment."},
+                    ensure_ascii=False,
+                )
+            if existing_sid and existing_sid in _sessions and _sessions[existing_sid]._session_active:
+                existing_mgr = _sessions[existing_sid]
+                # 检查关键参数是否变化：workdir/model/permission_mode/resume_uuid
+                old_workdir = getattr(existing_mgr, "_workdir", "")
+                old_model = getattr(existing_mgr, "_model", None)  # may not exist
+                old_perm = getattr(existing_mgr, "_permission_mode", "normal")
+                new_model = args.get("model")
+                new_perm = args.get("permission_mode", "normal")
+                has_resume = bool(args.get("resume_uuid"))
+
+                params_changed = (
+                    old_workdir != abs_workdir
+                    or old_perm != new_perm
+                    or has_resume
+                    or (new_model is not None and new_model != (old_model or None))
+                )
+
+                if params_changed:
+                    # 参数变化：需要 stop 旧 session 再 start 新的
+                    logger.info(
+                        "Session '%s' params changed (workdir=%s→%s, perm=%s→%s, resume=%s), auto-stopping old session",
+                        session_name_arg, old_workdir, abs_workdir, old_perm, new_perm, has_resume,
+                    )
+                    # 锁内只做轻量操作：清理注册表 + 预占，耗时 stop 延迟到锁外
+                    existing_mgr._status_callback = None
+                    # 立即清理注册表，释放 name 槽位
+                    _sessions.pop(existing_sid, None)
+                    keys_to_remove = []
+                    for k, v_list in _workdir_index.items():
+                        if existing_sid in v_list:
+                            updated_list = [sid for sid in v_list if sid != existing_sid]
+                            if updated_list:
+                                _workdir_index[k] = updated_list
+                            else:
+                                keys_to_remove.append(k)
+                    for k in keys_to_remove:
+                        _workdir_index.pop(k, None)
+                    name_keys = [k for k, v in _name_index.items() if v == existing_sid]
+                    for k in name_keys:
+                        _name_index.pop(k, None)
+                    if _active_session.get(gw_key) == existing_sid:
+                        _active_session.pop(gw_key, None)
+                    # 预占新槽位
+                    _name_index[(gw_key, session_name_arg)] = "__starting__"
+                    workdir_idx_key = (gw_key, abs_workdir)
+                    existing_list = _workdir_index.get(workdir_idx_key, [])
+                    _workdir_index[workdir_idx_key] = existing_list + ["__starting__"]
+                    # 记录待 stop 的实例（锁外执行）
+                    _old_mgr_to_stop = existing_mgr
+                    _old_sid_to_cleanup = existing_sid
+                else:
+                    # 参数没变：复用已有 session
+                    _touch_active(gw_key, existing_sid, already_locked=True)
+                    _existing_resp = {
+                        "session_id": existing_sid,
+                        "tmux_session": existing_mgr._tmux.session_name if existing_mgr._tmux else None,
+                        "state": existing_mgr._sm.current_state,
+                        "permission_mode": existing_mgr._permission_mode,
+                        "claude_session_uuid": existing_mgr._claude_session_uuid,
+                        "note": f"Session '{session_name_arg}' already active",
+                        "name": session_name_arg,
+                    }
+            else:
+                # 预占槽位，防止并发 start 时双重创建
+                _name_index[(gw_key, session_name_arg)] = "__starting__"
+                workdir_idx_key = (gw_key, abs_workdir)
+                existing_list = _workdir_index.get(workdir_idx_key, [])
+                _workdir_index[workdir_idx_key] = existing_list + ["__starting__"]
+
+        # 锁外执行耗时操作：stop 旧 session（tmux kill + observer stop）
+        if _old_mgr_to_stop is not None:
+            try:
+                _old_mgr_to_stop.stop()
+            except Exception as e:
+                logger.warning("Auto-stop old session '%s' (sid=%s) failed: %s", session_name_arg, _old_sid_to_cleanup[:8] if _old_sid_to_cleanup else "?", e)
+
+        # 已有活跃会话（参数未变）：在锁外处理 message
+        if _existing_resp is not None:
+            if args.get("message"):
+                try:
+                    send_result = existing_mgr.send(args["message"])
+                    if "error" in send_result:
+                        _existing_resp["send_error"] = send_result["error"]
+                    else:
+                        _existing_resp["message_sent"] = True
+                        _existing_resp["send_state"] = send_result.get("state")
+                except Exception as e:
+                    logger.warning("Auto-send on existing session failed (session=%s): %s", existing_sid[:8], e)
+                    _existing_resp["send_error"] = str(e)
+            return json.dumps(_existing_resp, ensure_ascii=False)
+
+        try:
+            # Build status_card_config from gateway adapter registry
+            _status_card_config = None
+            if get_session_env is not None:
+                try:
+                    _sc_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+                    _sc_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+                    logger.debug(
+                        "StatusCard config: platform=%s chat_id=%s gw_key=%s adapters=%s",
+                        _sc_platform, _sc_chat_id, gw_key, list(_gateway_adapters.keys()),
+                    )
+                    if _sc_platform == "telegram" and _sc_chat_id:
+                        # Read adapter from gateway registry (set by gateway/run.py)
+                        with _gateway_adapters_lock:
+                            _adapter_info = _gateway_adapters.get(gw_key)
+                        if _adapter_info:
+                            _status_card_config = {
+                                "chat_id": _sc_chat_id,
+                                "loop": _adapter_info["loop"],
+                                "send_func": _adapter_info["send_func"],
+                                "edit_func": _adapter_info["edit_func"],
+                                "delete_func": _adapter_info["delete_func"],
+                            }
+                            logger.info("StatusCard config built for gw_key=%s", gw_key)
+                        else:
+                            logger.warning("StatusCard: no adapter registered for gw_key=%s (registered: %s)", gw_key, list(_gateway_adapters.keys()))
+                except Exception as _sce:
+                    logger.warning("StatusCard config build error: %s", _sce)
+
+            mgr = ClaudeSession()
+            mgr._gateway_session_key = gw_key
+            mgr._session_name = session_name_arg
+            result = mgr.start(
+                workdir=abs_workdir,
+                session_name=sn,
+                model=args.get("model"),
+                permission_mode=args.get("permission_mode", "normal"),
+                on_event=args.get("on_event", "notify"),
+                completion_queue=kw.get("completion_queue"),
+                resume_uuid=args.get("resume_uuid"),
+                force_new=args.get("force_new", False),
+                status_card_config=_status_card_config,
+            )
+
+        except SessionError as e:
+            # 启动异常时清理占位
+            with _sessions_lock:
+                _name_index.pop((gw_key, session_name_arg), None)
+                workdir_idx_key = (gw_key, abs_workdir)
+                session_list = _workdir_index.get(workdir_idx_key, [])
+                if "__starting__" in session_list:
+                    updated_list = session_list.copy()
+                    updated_list.remove("__starting__")
+                    _workdir_index[workdir_idx_key] = updated_list
+            return json.dumps(e.to_dict() | {"name": session_name_arg}, ensure_ascii=False)
+        except Exception as e:
+            # 启动异常时清理占位
+            with _sessions_lock:
+                _name_index.pop((gw_key, session_name_arg), None)
+                workdir_idx_key = (gw_key, abs_workdir)
+                session_list = _workdir_index.get(workdir_idx_key, [])
+                if "__starting__" in session_list:
+                    updated_list = session_list.copy()
+                    updated_list.remove("__starting__")
+                    _workdir_index[workdir_idx_key] = updated_list
+            return json.dumps({"error": f"Failed to create session: {e}"}, ensure_ascii=False)
+
+        # 仅启动成功时注册到会话表和索引
+        if "error" not in result:
+            sid = result.get("session_id")
+            if sid:
+                with _sessions_lock:
+                    _sessions[sid] = mgr
+                    _name_index[(gw_key, session_name_arg)] = sid  # 基于 name 的主索引
+                    workdir_idx_key = (gw_key, abs_workdir)
+                    session_list = _workdir_index.get(workdir_idx_key, [])
+                    # 将占位符替换为实际的 session_id，或添加到列表
+                    if "__starting__" in session_list:
+                        updated_list = [sid if x == "__starting__" else x for x in session_list]
+                        _workdir_index[workdir_idx_key] = updated_list
+                    else:
+                        _workdir_index[workdir_idx_key] = session_list + [sid]
+                _touch_active(gw_key, sid)
+                # Persist name→uuid mapping to .claude/claude-session.json
+                claude_uuid = result.get("claude_session_uuid")
+                if claude_uuid and session_name_arg:
+                    _persist_session(
+                        abs_workdir, session_name_arg, claude_uuid,
+                        model=args.get("model"),
+                        permission_mode=args.get("permission_mode", "normal"),
+                        tmux_session=result.get("tmux_session"),
+                        auto_resumed=result.get("auto_resumed", False),
+                        resume_status=(
+                            "auto_resumed" if result.get("auto_resumed")
+                            else ("manual_resume" if result.get("resumed_from") else "new")
+                        ),
+                    )
+                # Attach status observer for this gateway session (per-key isolation).
+                # Only set the bridge callback if StatusCard hasn't already set one.
+                # StatusCard's _status_callback sends real-time Telegram updates;
+                # the bridge callback routes to gateway's StatusMessageManager (now removed).
+                # Co-existence: if both exist, chain them.
+
+                with _status_observers_lock:
+                    _observer = _status_observers.get(gw_key)
+                if _observer:
+                    _existing = mgr._status_callback
+                    _bridge = lambda info, _sid=sid, _obs=_observer: _safe_call_observer(_obs, _sid, info)
+                    if _existing:
+                        # Chain: call both sequentially, each with its own exception handling
+                        def _chained(info, _ex=_existing, _br=_bridge):
+                            for fn in (_ex, _br):
+                                try:
+                                    fn(info)
+                                except Exception as e:
+                                    logger.warning("Chained callback error: %s", e)
+                        mgr._status_callback = _chained
+                    else:
+                        mgr._status_callback = _bridge
+                # 返回结果中附带 name
+                if session_name_arg:
+                    result["name"] = session_name_arg
+                # Auto-inject persistence context: top-5 recently active peers
+                try:
+                    _all_persisted = _load_session_registry(abs_workdir)
+                    _peers = {
+                        k: v for k, v in _all_persisted.items()
+                        if k != session_name_arg and isinstance(v, dict)
+                    }
+                    if _peers:
+                        # Partition: valid entries have last_active_at; rest go to end
+                        _valid = [(k, v) for k, v in _peers.items() if v.get("last_active_at")]
+                        _no_ts = [(k, v) for k, v in _peers.items() if not v.get("last_active_at")]
+                        _valid.sort(key=lambda x: x[1]["last_active_at"], reverse=True)
+                        _top5 = (_valid + _no_ts)[:5]
+                        result["persistence_context"] = {
+                            "total_peers": len(_peers),
+                            "recent_sessions": {
+                                k: {
+                                    "status": v.get("status"),
+                                    "last_resume_status": v.get("last_resume_status"),
+                                    "last_active_at": v.get("last_active_at"),
+                                }
+                                for k, v in _top5
+                            },
+                            "hint": (
+                                f"Top {len(_top5)} of {len(_peers)} persisted peers "
+                                "sorted by last_active_at. Use list_persisted for full list."
+                            ),
+                        }
+                except Exception:
+                    pass  # non-critical enrichment
+                # send 逻辑在 try/except 之外，避免 send 异常触发 start 清理
+                if args.get("message"):
+                    try:
+                        send_result = mgr.send(args["message"])
+                        if "error" in send_result:
+                            result["send_error"] = send_result["error"]
+                        else:
+                            result["message_sent"] = True
+                            result["send_state"] = send_result.get("state")
+                    except Exception as e:
+                        logger.warning("Auto-send after start failed (session=%s): %s", sid[:8], e)
+                        result["send_error"] = str(e)
+        else:
+            # 启动失败时清理占位
+            with _sessions_lock:
+                workdir_idx_key = (gw_key, abs_workdir)
+                session_list = _workdir_index.get(workdir_idx_key, [])
+                if "__starting__" in session_list:
+                    updated_list = [sid for sid in session_list if sid != "__starting__"]
+                    if updated_list:
+                        _workdir_index[workdir_idx_key] = updated_list
+                    else:
+                        _workdir_index.pop(workdir_idx_key, None)
+        return json.dumps(result, ensure_ascii=False)
+
+    # ── list：列出当前 gateway 下的所有会话 + 可恢复的持久化会话 ──
+    if action == "list":
+        result = _list_sessions(gw_key)
+        # Enrich with resumable persisted sessions not currently in gateway
+        try:
+            _active_names = {s.get("name") for s in result.get("sessions", []) if s.get("name")}
+            _resumable = {}
+            _scanned_workdirs = set()
+            # Collect all stopped sessions with (name, workdir) pairs first
+            _raw_entries = []
+            for s in result.get("sessions", []):
+                wd = s.get("workdir")
+                if wd and wd not in _scanned_workdirs:
+                    _scanned_workdirs.add(wd)
+                    try:
+                        _persisted = _load_session_registry(wd)
+                        for _name, _entry in _persisted.items():
+                            if (isinstance(_entry, dict)
+                                    and _name not in _active_names
+                                    and _entry.get("status") == "stopped"):
+                                _raw_entries.append((_name, wd, _entry))
+                    except Exception:
+                        pass
+            # Also scan globally known workdirs (for gateway restart scenario)
+            for wd in _get_known_workdirs():
+                if wd not in _scanned_workdirs:
+                    _scanned_workdirs.add(wd)
+                    try:
+                        _persisted = _load_session_registry(wd)
+                        for _name, _entry in _persisted.items():
+                            if (isinstance(_entry, dict)
+                                    and _name not in _active_names
+                                    and _entry.get("status") == "stopped"):
+                                _raw_entries.append((_name, wd, _entry))
+                    except Exception:
+                        pass
+            # Build deduped dict — use @basename suffix for same-name collisions
+            _name_counts = {}
+            for _name, _wd, _ in _raw_entries:
+                _name_counts[_name] = _name_counts.get(_name, 0) + 1
+            for _name, _wd, _entry in _raw_entries:
+                _key = _name if _name_counts[_name] == 1 else f"{_name}@{os.path.basename(_wd)}"
+                _resumable[_key] = {
+                    "name": _name,
+                    "workdir": _wd,
+                    "last_active_at": _entry.get("last_active_at"),
+                    "resume_count": _entry.get("resume_count", 0),
+                    "model": _entry.get("model"),
+                }
+            if _resumable:
+                # Partition: valid entries have last_active_at; rest go to end
+                _valid_r = [(k, v) for k, v in _resumable.items() if v.get("last_active_at")]
+                _no_ts_r = [(k, v) for k, v in _resumable.items() if not v.get("last_active_at")]
+                _valid_r.sort(key=lambda x: x[1]["last_active_at"], reverse=True)
+                _top10 = (_valid_r + _no_ts_r)[:10]
+                result["resumable"] = {
+                    "total": len(_resumable),
+                    "sessions": dict(_top10),
+                    "hint": "These stopped sessions can be resumed with: "
+                            "claude_session(action='start', name='<name>', workdir='<workdir>')",
+                }
+        except Exception:
+            pass  # non-critical enrichment
+        return json.dumps(result, ensure_ascii=False)
+
+    # ── list_persisted：列出 workdir 下持久化的会话（v4.4+）──
+    if action == "list_persisted":
+        workdir = args.get("workdir", ".")
+        abs_workdir = os.path.abspath(workdir)
+        try:
+            validated_wd = _validate_workdir(abs_workdir)
+        except ValueError as e:
+            return json.dumps({"error": str(e), "workdir": abs_workdir}, ensure_ascii=False)
+        persisted = _load_persisted_sessions(validated_wd)
+        # Cross-reference with active sessions in current gateway
+        active_names = set()
+        with _sessions_lock:
+            for (g, n), sid in _name_index.items():
+                if g == gw_key and sid in _sessions and _sessions[sid]._session_active:
+                    active_names.add(n)
+        # Enrich with active marker. NOTE: 'status' reflects the persisted
+        # state at last write (active / stopped), NOT the current process
+        # state. Use 'active_in_gateway' for current liveness — a session
+        # with status='active' may not be running (e.g. after process restart
+        # or stop without the persistence write succeeding).
+        for name, entry in persisted.items():
+            if isinstance(entry, dict):
+                entry["active_in_gateway"] = name in active_names
+        return json.dumps({
+            "workdir": validated_wd,
+            "count": len(persisted),
+            "field_legend": {
+                "status": "Persisted status at last write (active|stopped). "
+                          "NOT a live process indicator.",
+                "active_in_gateway": "True if this session is currently "
+                                     "running in the active gateway context. "
+                                     "Use this for liveness checks.",
+                "last_active_at": "ISO timestamp of the most recent persistence write.",
+                "resume_count": "Number of times this session has been auto-resumed.",
+            },
+            "sessions": persisted,
+        }, ensure_ascii=False)
+
+    # ── switch：切换活跃会话 ──
+    if action == "switch":
+        name = args.get("name")
+        if not name:
+            return tool_error("name is required for switch action")
+        result = _switch_session(name, gw_key)
+        return json.dumps(result, ensure_ascii=False)
+
+    # ── stop：停止并从注册表和索引移除 ──
+    if action == "stop":
+        specified_id = args.get("session_id")
+        name = args.get("name")
+
+        # name → 解析 session_id
+        if name and not specified_id:
+            with _sessions_lock:
+                specified_id = _name_index.get((gw_key, name))
+            if not specified_id:
+                return tool_error(f"No session named '{name}' in current gateway context.")
+
+        mgr = _get_session(specified_id, gateway_session_key=gw_key, strict=bool(specified_id))
+        if mgr is None:
+            return tool_error(
+                f"Session '{specified_id or name}' not found in registry. "
+                "It may have been lost after a gateway restart. "
+                "Use tmux directly to clean up orphaned sessions."
+            )
+        # Clear callback before stop to prevent late callbacks to cleaned-up resources.
+        mgr._status_callback = None
+        try:
+            result = mgr.stop()
+        except SessionError as e:
+            result = e.to_dict()
+        if result.get("stopped"):
+            stopped_id = result.get("session_id")
+            with _sessions_lock:
+                _sessions.pop(stopped_id, None)
+                # 清理 _workdir_index（值是列表，需要从列表中移除 session_id）
+                keys_to_remove = []
+                for k, v_list in _workdir_index.items():
+                    if stopped_id in v_list:
+                        updated_list = [sid for sid in v_list if sid != stopped_id]
+                        if updated_list:
+                            _workdir_index[k] = updated_list
+                        else:
+                            keys_to_remove.append(k)
+                for k in keys_to_remove:
+                    _workdir_index.pop(k, None)
+                # 清理 _name_index
+                name_keys = [k for k, v in _name_index.items() if v == stopped_id]
+                for k in name_keys:
+                    _name_index.pop(k, None)
+                # 清理 _active_session（如果指向刚停止的会话）
+                if _active_session.get(gw_key) == stopped_id:
+                    _active_session.pop(gw_key, None)
+            # Update persistence: mark session as stopped in .claude/claude-session.json
+            # so future list_persisted runs show accurate status.
+            stopped_name = getattr(mgr, "_session_name", None) or name
+            stopped_workdir = getattr(mgr, "_workdir", None)
+            if stopped_name and stopped_workdir:
+                try:
+                    _update_session_status(stopped_workdir, stopped_name, "stopped")
+                except Exception as e:
+                    logger.debug("Failed to update persistence status for stopped session %s: %s", stopped_name, e)
+        return json.dumps(result, ensure_ascii=False)
+
+    # ── diagnose：不需要会话实例 ──
+    if action == "diagnose":
+        result = _diagnose_claude_session()
+        return json.dumps(result, ensure_ascii=False)
+
+    # ── doctor_fix：诊断并修复技能文件同步 ──
+    if action == "doctor_fix":
+        result = _doctor_fix_skills(
+            apply=args.get("apply", False),
+            strategy=args.get("strategy", "project"),
+        )
+        return json.dumps(result, ensure_ascii=False)
+
+    # ── 其他动作：通过 _resolve_target_session 路由（支持 session_id / name / 活跃回退）──
+    mgr, resolve_err = _resolve_target_session(args, gw_key)
+    if mgr is None:
+        # 只读查询 action：无会话时返回优雅默认值
+        if action == "status":
+            return json.dumps({"state": "DISCONNECTED"}, ensure_ascii=False)
+        if action == "output":
+            return json.dumps({"lines": [], "offset": 0, "total": 0}, ensure_ascii=False)
+        if action == "jsonl_output":
+            return json.dumps({"error": "No active session", "replies": []}, ensure_ascii=False)
+        if action == "events":
+            return json.dumps({"events": []}, ensure_ascii=False)
+        if action == "history":
+            return json.dumps({"total_turns": 0, "turns": []}, ensure_ascii=False)
+        return resolve_err or tool_error("No active session. Use 'start' first.")
+
+    # 交互类 action 更新 _active_session
+    if action in ("send", "type", "submit", "send_text", "respond_permission", "respond_interview", "cancel_input"):
+        _touch_active(gw_key, mgr._session_id)
+
+    if action == "send":
+        message = args.get("message")
+        if not message:
+            return tool_error("message is required for send action")
+        try:
+            result = mgr.send(message)
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "type":
+        text = args.get("text")
+        if not text:
+            return tool_error("text is required for type action")
+        try:
+            result = mgr.type_text(text)
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "submit":
+        try:
+            result = mgr.submit()
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "send_text":
+        text = args.get("text")
+        if not text:
+            return tool_error("text is required for send_text action")
+        try:
+            result = mgr.send_text(text)
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "cancel_input":
+        try:
+            result = mgr.cancel_input()
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "status":
+        result = mgr.status()
+    elif action == "wait_for_idle":
+        try:
+            # Set up output streamer if gateway adapter is available
+            _streamer = _setup_output_streamer(mgr, gw_key)
+
+            result = mgr.wait_for_idle(timeout=args.get("timeout", 900))
+
+            # Finalize streamer (sends final edit without cursor)
+            if _streamer:
+                _streamer.finish()
+                mgr._output_streamer = None
+                if _streamer.already_sent:
+                    result["output_streamed"] = True
+
+        except SessionError as e:
+            if mgr._output_streamer:
+                mgr._output_streamer.finish()
+                mgr._output_streamer = None
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "wait_for_state":
+        target = args.get("target_state")
+        if not target:
+            return tool_error("target_state is required for wait_for_state action")
+        try:
+            result = mgr.wait_for_state(target_state=target, timeout=args.get("timeout", 60))
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "output":
+        result = mgr.output(
+            offset=args.get("offset", 0),
+            limit=args.get("limit", 50),
+        )
+    elif action == "jsonl_output":
+        result = mgr.jsonl_output(
+            last_reply=args.get("last_reply", False),
+            last_n=args.get("last_n", 0),
+            max_length=args.get("max_length", 15000),
+        )
+    elif action == "respond_permission":
+        response = args.get("response")
+        if not response:
+            return tool_error("response is required for respond_permission action")
+        try:
+            result = mgr.respond_permission(response)
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "respond_interview":
+        option = args.get("option")
+        if not option:
+            return tool_error("option is required for respond_interview action")
+        try:
+            result = mgr.respond_interview(option)
+        except SessionError as e:
+            return json.dumps(e.to_dict(), ensure_ascii=False)
+    elif action == "history":
+        result = mgr.history()
+    elif action == "events":
+        result = mgr.events(since_turn=args.get("since_turn", 0))
+    else:
+        return tool_error(
+            f"Unknown action: {action}. "
+            "Valid: start, send, type, submit, cancel_input, status, "
+            "wait_for_idle, wait_for_state, output, respond_permission, "
+            "respond_interview, stop, history, events, list, switch, "
+            "diagnose, doctor_fix"
+        )
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def _check_claude_session():
+    """Check if tmux (hard dep) and claude CLI (soft dep) are available.
+    
+    Only tmux is required for the tool to register. Claude CLI availability
+    is logged as a warning but does not prevent registration, because the
+    user might install it later.
+    """
+    tmux_ok = shutil.which("tmux") is not None
+    claude_ok = shutil.which("claude") is not None
+    
+    if not claude_ok:
+        logger.warning(
+            "claude_session: Claude Code CLI not found in PATH. "
+            "Install with: npm install -g @anthropic-ai/claude-code"
+        )
+    
+    if not tmux_ok:
+        logger.warning(
+            "claude_session: tmux not found in PATH. "
+            "Install with: apt install tmux / brew install tmux"
+        )
+    
+    return tmux_ok
+
+
+def _get_active_sessions_output() -> list:
+    """Gather output and state info from all active sessions for diagnose.
+
+    Returns a list of dicts, each with session metadata, recent output,
+    and state duration — used by session-level diagnose checks.
+    """
+    # Phase 1: collect references under lock (fast, no nested locks)
+    with _sessions_lock:
+        snapshot = [
+            (sid, mgr) for sid, mgr in _sessions.items()
+            if getattr(mgr, '_session_active', False)
+        ]
+
+    # Phase 2: read state/output outside _sessions_lock
+    # (each mgr has its own internal locks)
+    sessions_info = []
+    for sid, mgr in snapshot:
+        try:
+            state = mgr._sm.current_state
+            duration = mgr._sm.state_duration()
+            output_tail = mgr._buf.last_n_chars(2000)
+            sessions_info.append({
+                "session_id": sid,
+                "state": state,
+                "state_duration_seconds": round(duration, 1),
+                "output_tail": output_tail,
+            })
+        except Exception:
+            logger.warning("Failed to gather session %s info for diagnose", sid[:8], exc_info=True)
+    return sessions_info
+
+
+def _extract_mcp_failure_count(text: str) -> int:
+    """Extract MCP server failure count from output text.
+
+    Matches patterns like "3 MCP servers failed · /mcp".
+    """
+    m = re.search(r"(\d+)\s+MCP\s+servers?\s+failed", text)
+    return int(m.group(1)) if m else 0
+
+
+def _diagnose_claude_session() -> dict:
+    """Diagnose claude_session dependencies and configuration.
+
+    Returns a structured report of all dependencies, their status,
+    and remediation hints. Used by the 'diagnose' action.
+    """
+    import os
+
+    checks = []
+    all_ok = True
+    
+    # 1. tmux
+    tmux_path = shutil.which("tmux")
+    checks.append({
+        "dependency": "tmux",
+        "status": "ok" if tmux_path else "missing",
+        "path": tmux_path,
+        "hint": "Install: apt install tmux / brew install tmux" if not tmux_path else None,
+        "required": True,
+    })
+    if not tmux_path:
+        all_ok = False
+    
+    # 2. claude CLI
+    claude_path = shutil.which("claude")
+    checks.append({
+        "dependency": "Claude Code CLI",
+        "status": "ok" if claude_path else "missing",
+        "path": claude_path,
+        "hint": "Install: npm install -g @anthropic-ai/claude-code" if not claude_path else None,
+        "required": True,
+    })
+    if not claude_path:
+        all_ok = False
+    
+    # 3. HERMES_STREAM_STALE_TIMEOUT
+    timeout_val = os.environ.get("HERMES_STREAM_STALE_TIMEOUT", "")
+    timeout_ok = timeout_val.isdigit() and int(timeout_val) >= 300
+    checks.append({
+        "dependency": "HERMES_STREAM_STALE_TIMEOUT",
+        "status": "ok" if timeout_ok else ("not_set" if not timeout_val else "too_low"),
+        "value": timeout_val or "(not set)",
+        "hint": (
+            "Set to >= 300 in ~/.hermes/.env to prevent Stream Stalled errors"
+            if not timeout_ok else None
+        ),
+        "required": False,
+    })
+    
+    # 4. tmux version
+    tmux_version = ""
+    if tmux_path:
+        try:
+            import subprocess
+            result = subprocess.run(
+                [tmux_path, "-V"], capture_output=True, text=True, timeout=5
+            )
+            tmux_version = result.stdout.strip()
+        except Exception:
+            tmux_version = "unknown"
+    checks.append({
+        "dependency": "tmux version",
+        "status": "ok" if tmux_version else "unknown",
+        "value": tmux_version or "unknown",
+        "required": False,
+    })
+    
+    # 5. Claude Code version
+    claude_version = ""
+    if claude_path:
+        try:
+            import subprocess
+            result = subprocess.run(
+                [claude_path, "--version"], capture_output=True, text=True, timeout=10
+            )
+            claude_version = result.stdout.strip()
+        except Exception:
+            claude_version = "unknown"
+    checks.append({
+        "dependency": "Claude Code version",
+        "status": "ok" if claude_version else "unknown",
+        "value": claude_version or "unknown",
+        "required": False,
+    })
+
+    # 6. 残留 tmux session 检测
+    orphaned_sessions = []
+    if tmux_path:
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["tmux", "list-sessions"], capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                with _sessions_lock:
+                    known_tmux_names = set()
+                    for mgr in _sessions.values():
+                        if mgr._tmux:
+                            known_tmux_names.add(mgr._tmux.session_name)
+
+                for line in result.stdout.strip().splitlines():
+                    name = line.split(":")[0].strip()
+                    if name.startswith("hermes-") and name not in known_tmux_names:
+                        orphaned_sessions.append(name)
+
+            orphan_count = len(orphaned_sessions)
+            checks.append({
+                "dependency": "orphaned tmux sessions",
+                "status": "ok" if orphan_count == 0 else "warning",
+                "value": f"{orphan_count} orphaned session(s)" if orphan_count else "none",
+                "sessions": orphaned_sessions[:10],  # 最多显示 10 个
+                "hint": (
+                    "Orphaned hermes-* sessions detected. These may cause startup hangs. "
+                    "Clean up with: tmux kill-session -t <name>  "
+                    "or kill all: for s in $(tmux list-sessions 2>/dev/null | grep '^hermes-' | cut -d: -f1); do tmux kill-session -t \"$s\"; done"
+                    if orphan_count > 0 else None
+                ),
+                "required": False,
+            })
+        except Exception:
+            pass
+
+    # ── Session-level checks: detect hung/stuck sessions ──
+
+    active_sessions = _get_active_sessions_output()
+    session_critical = False
+
+    for sinfo in active_sessions:
+        sid_short = sinfo["session_id"][:8]
+        state = sinfo["state"]
+        duration = sinfo["state_duration_seconds"]
+        output_tail = sinfo["output_tail"]
+
+        # P0-1: THINKING state duration check
+        if state == "THINKING":
+            if duration > 300:
+                checks.append({
+                    "dependency": f"session {sid_short} THINKING duration",
+                    "status": "critical",
+                    "value": f"{duration}s (>300s threshold)",
+                    "session_id": sinfo["session_id"],
+                    "hint": "THINKING state too long, likely hung. Try cancel_input or stop+restart.",
+                    "required": False,
+                })
+                session_critical = True
+            elif duration > 120:
+                checks.append({
+                    "dependency": f"session {sid_short} THINKING duration",
+                    "status": "warning",
+                    "value": f"{duration}s (>120s threshold)",
+                    "session_id": sinfo["session_id"],
+                    "hint": "THINKING state running long. Monitor or consider cancel_input.",
+                    "required": False,
+                })
+
+        # P0-2: Repeated permission prompt fingerprint (bypass permissions on)
+        # Match 3+ occurrences of the "bypass permissions on" line
+        perm_matches = re.findall(
+            r"bypass permissions on \(shift\+tab to cycle\)", output_tail
+        )
+        if len(perm_matches) >= 3:
+            checks.append({
+                "dependency": f"session {sid_short} startup hang",
+                "status": "critical",
+                "value": f"'bypass permissions on' repeated {len(perm_matches)} times",
+                "session_id": sinfo["session_id"],
+                "hint": "New version startup hang detected. Try cancel_input to unblock.",
+                "required": False,
+            })
+            session_critical = True
+
+        # P1-3: MCP server failures
+        mcp_count = _extract_mcp_failure_count(output_tail)
+        if mcp_count > 0:
+            checks.append({
+                "dependency": f"session {sid_short} MCP servers",
+                "status": "warning",
+                "value": f"{mcp_count} MCP server(s) failed",
+                "session_id": sinfo["session_id"],
+                "hint": "MCP initialization may block startup. Run /mcp in Claude to check.",
+                "required": False,
+            })
+
+        # P1-4: CLI migration prompt
+        if re.search(r"switched from npm to native installer", output_tail):
+            checks.append({
+                "dependency": f"session {sid_short} CLI migration",
+                "status": "info",
+                "value": "npm → native installer migration detected",
+                "session_id": sinfo["session_id"],
+                "hint": "Run 'claude install' to complete migration.",
+                "required": False,
+            })
+
+        # P1-5: tmux focus-events warning
+        if re.search(r"tmux focus-events off", output_tail):
+            checks.append({
+                "dependency": f"session {sid_short} tmux config",
+                "status": "info",
+                "value": "tmux focus-events is off",
+                "session_id": sinfo["session_id"],
+                "hint": "Add 'set -g focus-events on' to ~/.tmux.conf for better experience.",
+                "required": False,
+            })
+
+    # Build status and summary
+    # Three distinct states: ready / session_issues / missing_deps
+    critical_count = sum(1 for c in checks if c.get("status") == "critical")
+    warning_count = sum(1 for c in checks if c.get("status") == "warning")
+
+    if not all_ok:
+        top_status = "missing_deps"
+        summary = "Missing required dependencies. See hints above."
+    elif session_critical:
+        top_status = "session_issues"
+        summary = f"{critical_count} critical issue(s) in active sessions. See hints above."
+    else:
+        top_status = "ready"
+        summary = "All dependencies met — claude_session is ready to use."
+        if warning_count > 0:
+            summary += f" ({warning_count} warning(s) from active sessions)"
+
+    return {
+        "status": top_status,
+        "checks": checks,
+        "summary": summary,
+    }
+
+
+def _doctor_fix_skills(apply: bool = False, strategy: str = "project") -> dict:
+    """诊断并修复 claude-session 技能文件同步问题。
+
+    两阶段操作：
+      - apply=False（默认）：仅分析，不执行任何修改
+      - apply=True：根据 strategy 执行修复
+
+    Args:
+        apply: False=仅分析返回报告，True=执行修复操作
+        strategy: 合并策略，仅在 apply=True 且有差异时生效
+            - "project": 优先项目版本（备份用户目录后创建软链接）
+            - "user": 保留用户版本（将用户修改复制到项目目录）
+            - "merge": 逐文件合并，项目独有的文件从项目复制，其余保留用户版本
+    """
+    # 定位两个目录
+    user_skill_dir = os.path.expanduser("~/.hermes/skills/claude-session")
+    # 项目目录：基于当前文件位置推导
+    _this_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(_this_dir)  # tools/ → project root
+    project_skill_dir = os.path.join(project_root, "skills", "claude-session")
+
+    report = {
+        "user_dir": user_skill_dir,
+        "project_dir": project_skill_dir,
+        "apply": apply,
+        "strategy": strategy,
+        "steps": [],
+        "actions_taken": [],
+        "status": "ok",
+    }
+
+    # ── Step 1: 项目目录必须存在 ──
+    if not os.path.isdir(project_skill_dir):
+        report["status"] = "error"
+        report["steps"].append({
+            "step": "check_project_dir",
+            "result": "missing",
+            "message": f"Project skill directory not found: {project_skill_dir}",
+        })
+        logger.error("doctor_fix: project skill dir missing: %s", project_skill_dir)
+        return report
+
+    report["steps"].append({
+        "step": "check_project_dir",
+        "result": "ok",
+        "path": project_skill_dir,
+        "files": _list_skill_files(project_skill_dir),
+    })
+
+    # ── Step 2: 用户目录状态检测 ──
+    if not os.path.exists(user_skill_dir):
+        report["steps"].append({"step": "check_user_dir", "result": "missing"})
+        if not apply:
+            report["status"] = "needs_fix"
+            report["actions_available"] = [_action_create_symlink()]
+            return report
+        action_result = _create_symlink(user_skill_dir, project_skill_dir)
+        report["actions_taken"].append(action_result)
+        report["status"] = "fixed" if action_result["success"] else "error"
+        logger.info("doctor_fix: created symlink %s -> %s", user_skill_dir, project_skill_dir)
+        return report
+
+    # 用户目录存在，判断类型
+    is_link = os.path.islink(user_skill_dir)
+    if is_link:
+        link_target = os.readlink(user_skill_dir)
+        resolved = os.path.realpath(user_skill_dir)
+        project_resolved = os.path.realpath(project_skill_dir)
+
+        # 断链检测
+        if not os.path.exists(resolved):
+            report["steps"].append({
+                "step": "check_user_dir",
+                "result": "symlink_broken",
+                "target": link_target,
+                "resolved": resolved,
+            })
+            logger.warning("Broken symlink: %s -> %s", user_skill_dir, link_target)
+            if not apply:
+                report["status"] = "needs_fix"
+                report["actions_available"] = [_action_fix_broken_symlink(link_target)]
+                return report
+            return _do_fix_broken_symlink(report, user_skill_dir, project_skill_dir)
+
+        if resolved == project_resolved:
+            report["steps"].append({
+                "step": "check_user_dir",
+                "result": "symlink_ok",
+                "target": link_target,
+                "resolved": resolved,
+            })
+            report["status"] = "ok"
+            return report
+        else:
+            report["steps"].append({
+                "step": "check_user_dir",
+                "result": "symlink_wrong",
+                "current_target": link_target,
+                "resolved": resolved,
+                "expected": project_resolved,
+            })
+            if not apply:
+                report["status"] = "needs_fix"
+                report["actions_available"] = [_action_fix_wrong_symlink(link_target, project_resolved)]
+                return report
+            return _do_fix_wrong_symlink(report, user_skill_dir, project_skill_dir)
+
+    # ── Step 3: 硬拷贝 — 比较差异 ──
+    report["steps"].append({"step": "check_user_dir", "result": "hardcopy"})
+
+    diff_result = _compare_skill_dirs(user_skill_dir, project_skill_dir)
+    report["steps"].append({
+        "step": "compare_content",
+        "result": diff_result["summary"],
+        "details": diff_result["details"],
+        "summary_human": _format_diff_summary_human(diff_result),
+    })
+
+    # 顶层 diff_summary
+    user_files = _list_skill_files(user_skill_dir)
+    project_files = _list_skill_files(project_skill_dir)
+    report["diff_summary"] = {
+        "total_files": len(set(user_files) | set(project_files)),
+        "differing_files": len(diff_result["details"]),
+        "newer_in_project": [d["file"] for d in diff_result["details"]
+                             if d["status"] in ("project_newer", "missing_in_user")],
+        "newer_in_user": [d["file"] for d in diff_result["details"]
+                          if d["status"] in ("user_newer", "missing_in_project")],
+    }
+
+    if diff_result["identical"]:
+        if not apply:
+            report["status"] = "needs_fix"
+            report["actions_available"] = [_action_replace_hardcopy()]
+            return report
+        return _do_replace_hardcopy(report, user_skill_dir, project_skill_dir)
+
+    # 有差异 → 根据分类和 strategy 决定
+    diff_class = _classify_diff_status(diff_result["details"])
+
+    # project_newer 且 strategy=project → 自动修复（安全操作）
+    if diff_class == "project_newer" and strategy in ("project", "merge"):
+        if not apply:
+            report["status"] = "needs_fix"
+            report["actions_available"] = [_action_backup_and_symlink()]
+            return report
+        return _do_backup_and_symlink(report, user_skill_dir, project_skill_dir)
+
+    # user_newer 且 strategy=user → 同步用户修改到项目
+    if diff_class == "user_newer" and strategy == "user":
+        if not apply:
+            report["status"] = "needs_fix"
+            report["actions_available"] = [_action_sync_user_to_project(diff_result["details"])]
+            return report
+        return _do_sync_user_to_project(report, user_skill_dir, project_skill_dir, diff_result["details"])
+
+    # merge 策略：逐文件合并
+    if strategy == "merge":
+        if not apply:
+            report["status"] = "needs_fix"
+            report["actions_available"] = [_action_merge_files(diff_result["details"])]
+            return report
+        return _do_merge_files(report, user_skill_dir, project_skill_dir, diff_result["details"])
+
+    # 所有其他情况（user_newer+project / both_modified / 策略不匹配）
+    report["status"] = "needs_user_decision"
+    logger.warning("doctor_fix: diff_class=%s, needs user decision", diff_class)
+    report["actions_available"] = _build_actions_for_decision(diff_class, diff_result["details"])
+    return report
+
+
+# ---------------------------------------------------------------------------
+# doctor_fix: execute helpers (only run when apply=True)
+# ---------------------------------------------------------------------------
+
+def _do_fix_broken_symlink(report, user_dir, project_dir):
+    try:
+        os.remove(user_dir)
+    except OSError as e:
+        report["actions_taken"].append({"action": "remove_broken_symlink", "success": False, "error": str(e)})
+        report["status"] = "error"
+        return report
+    r = _create_symlink(user_dir, project_dir)
+    r["action"] = "fix_broken_symlink"
+    report["actions_taken"].append(r)
+    report["status"] = "fixed" if r["success"] else "error"
+    return report
+
+
+def _do_fix_wrong_symlink(report, user_dir, project_dir):
+    try:
+        os.remove(user_dir)
+    except OSError as e:
+        report["actions_taken"].append({"action": "remove_wrong_symlink", "success": False, "error": str(e)})
+        report["status"] = "error"
+        return report
+    r = _create_symlink(user_dir, project_dir)
+    r["action"] = "fix_symlink"
+    report["actions_taken"].append(r)
+    report["status"] = "fixed" if r["success"] else "error"
+    return report
+
+
+def _do_replace_hardcopy(report, user_dir, project_dir):
+    try:
+        shutil.rmtree(user_dir)
+    except OSError as e:
+        report["actions_taken"].append({"action": "remove_hardcopy", "success": False, "error": str(e)})
+        report["status"] = "error"
+        return report
+    r = _create_symlink(user_dir, project_dir)
+    r["action"] = "replace_hardcopy_with_symlink"
+    r["reason"] = "files_identical"
+    report["actions_taken"].append(r)
+    report["status"] = "fixed" if r["success"] else "error"
+    logger.info("doctor_fix: replaced identical hardcopy with symlink: %s", user_dir)
+    return report
+
+
+def _do_backup_and_symlink(report, user_dir, project_dir):
+    backup_dir = user_dir + f".bak.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    try:
+        os.rename(user_dir, backup_dir)
+    except OSError as e:
+        report["actions_taken"].append({"action": "backup_user_dir", "success": False, "error": str(e)})
+        report["status"] = "error"
+        return report
+    report["actions_taken"].append({"action": "backup_user_dir", "success": True, "backup_path": backup_dir})
+    r = _create_symlink(user_dir, project_dir)
+    r["action"] = "replace_with_symlink_after_backup"
+    report["actions_taken"].append(r)
+    report["status"] = "fixed" if r["success"] else "error"
+    logger.info("doctor_fix: backed up to %s, created symlink", backup_dir)
+    return report
+
+
+def _do_sync_user_to_project(report, user_dir, project_dir, details):
+    """将用户修改的文件复制到项目目录，然后替换用户目录为软链接。"""
+    for d in details:
+        if d["status"] in ("user_newer", "missing_in_project"):
+            src = os.path.join(user_dir, d["file"])
+            dst = os.path.join(project_dir, d["file"])
+            try:
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                shutil.copy2(src, dst)
+                report["actions_taken"].append({"action": "sync_file_to_project", "file": d["file"], "success": True})
+            except OSError as e:
+                report["actions_taken"].append({"action": "sync_file_to_project", "file": d["file"], "success": False, "error": str(e)})
+                report["status"] = "error"
+                return report
+    # 同步完成后替换用户目录为软链接
+    try:
+        shutil.rmtree(user_dir)
+    except OSError as e:
+        report["actions_taken"].append({"action": "remove_user_dir", "success": False, "error": str(e)})
+        report["status"] = "error"
+        return report
+    r = _create_symlink(user_dir, project_dir)
+    r["action"] = "sync_user_to_project_then_symlink"
+    report["actions_taken"].append(r)
+    report["status"] = "fixed" if r["success"] else "error"
+    logger.info("doctor_fix: synced user changes to project, created symlink")
+    return report
+
+
+def _do_merge_files(report, user_dir, project_dir, details):
+    """逐文件合并：项目独有的从项目复制，其余保留用户版本，然后创建软链接。"""
+    for d in details:
+        if d["status"] in ("missing_in_user",):
+            # 项目独有的文件 → 复制到用户目录
+            src = os.path.join(project_dir, d["file"])
+            dst = os.path.join(user_dir, d["file"])
+            try:
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                shutil.copy2(src, dst)
+                report["actions_taken"].append({"action": "copy_project_file", "file": d["file"], "success": True})
+            except OSError as e:
+                report["actions_taken"].append({"action": "copy_project_file", "file": d["file"], "success": False, "error": str(e)})
+        # user_newer / missing_in_project → 保留用户版本（不动）
+        # project_newer / both_modified → 保留用户版本（用户优先）
+    # 合并完成后替换用户目录为软链接
+    try:
+        shutil.rmtree(user_dir)
+    except OSError as e:
+        report["actions_taken"].append({"action": "remove_user_dir", "success": False, "error": str(e)})
+        report["status"] = "error"
+        return report
+    r = _create_symlink(user_dir, project_dir)
+    r["action"] = "merge_then_symlink"
+    report["actions_taken"].append(r)
+    report["status"] = "fixed" if r["success"] else "error"
+    logger.info("doctor_fix: merged files, created symlink")
+    return report
+
+
+# ---------------------------------------------------------------------------
+# doctor_fix: actions_available builders (for apply=False reports)
+# ---------------------------------------------------------------------------
+
+def _action_create_symlink():
+    return {
+        "action": "create_symlink",
+        "description": "Create symlink to project directory",
+        "command": "claude_session(action='doctor_fix', apply=True)",
+    }
+
+
+def _action_fix_broken_symlink(broken_target):
+    return {
+        "action": "fix_broken_symlink",
+        "description": f"Remove broken symlink (points to {broken_target}) and recreate",
+        "command": "claude_session(action='doctor_fix', apply=True)",
+    }
+
+
+def _action_fix_wrong_symlink(current, expected):
+    return {
+        "action": "fix_wrong_symlink",
+        "description": f"Redirect symlink from {current} to {expected}",
+        "command": "claude_session(action='doctor_fix', apply=True)",
+    }
+
+
+def _action_replace_hardcopy():
+    return {
+        "action": "replace_hardcopy_with_symlink",
+        "description": "User directory is identical to project — replace with symlink",
+        "command": "claude_session(action='doctor_fix', apply=True)",
+    }
+
+
+def _action_backup_and_symlink():
+    return {
+        "action": "backup_and_symlink",
+        "description": "Backup user directory, then create symlink to project version",
+        "command": "claude_session(action='doctor_fix', apply=True)",
+    }
+
+
+def _action_sync_user_to_project(details):
+    files = [d["file"] for d in details if d["status"] in ("user_newer", "missing_in_project")]
+    return {
+        "action": "sync_user_to_project",
+        "description": f"Copy {len(files)} user-modified file(s) to project, then create symlink",
+        "files": files,
+        "command": "claude_session(action='doctor_fix', apply=True, strategy='user')",
+    }
+
+
+def _action_merge_files(details):
+    project_only = [d["file"] for d in details if d["status"] == "missing_in_user"]
+    return {
+        "action": "merge_files",
+        "description": (
+            f"Copy {len(project_only)} project-only file(s) to user dir, "
+            "keep user versions for rest, then create symlink"
+        ),
+        "project_only_files": project_only,
+        "command": "claude_session(action='doctor_fix', apply=True, strategy='merge')",
+    }
+
+
+def _build_actions_for_decision(diff_class, details):
+    """构建 needs_user_decision 状态下的可用操作列表。"""
+    actions = []
+
+    # 始终提供"使用项目版本"选项
+    actions.append({
+        "action": "use_project_version",
+        "description": "Backup user directory and create symlink to project version",
+        "command": "claude_session(action='doctor_fix', apply=True, strategy='project')",
+    })
+
+    # 如果用户有更新，提供"同步用户修改"选项
+    user_files = [d["file"] for d in details if d["status"] in ("user_newer", "missing_in_project")]
+    if user_files:
+        actions.append({
+            "action": "sync_user_changes",
+            "description": f"Sync {len(user_files)} user-modified file(s) to project, then symlink",
+            "files": user_files,
+            "command": "claude_session(action='doctor_fix', apply=True, strategy='user')",
+        })
+
+    # merge 选项
+    actions.append({
+        "action": "merge",
+        "description": "Copy project-only files to user dir, keep user versions for rest, then symlink",
+        "command": "claude_session(action='doctor_fix', apply=True, strategy='merge')",
+    })
+
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# doctor_fix: pure utility helpers
+# ---------------------------------------------------------------------------
+
+def _list_skill_files(directory: str) -> list:
+    """列出技能目录中的所有文件（相对路径）。"""
+    files = []
+    for root, _dirs, filenames in os.walk(directory):
+        for fn in filenames:
+            full = os.path.join(root, fn)
+            rel = os.path.relpath(full, directory)
+            files.append(rel)
+    return sorted(files)
+
+
+def _create_symlink(link_path: str, target_path: str) -> dict:
+    """创建软链接，确保父目录存在。"""
+    parent = os.path.dirname(link_path)
+    try:
+        os.makedirs(parent, exist_ok=True)
+        os.symlink(target_path, link_path)
+        return {
+            "action": "create_symlink",
+            "success": True,
+            "link": link_path,
+            "target": target_path,
+        }
+    except OSError as e:
+        return {
+            "action": "create_symlink",
+            "success": False,
+            "error": str(e),
+        }
+
+
+def _compare_skill_dirs(user_dir: str, project_dir: str) -> dict:
+    """比较两个技能目录的内容差异。
+
+    Returns:
+        dict with keys:
+            identical: bool
+            summary: str  ("identical" | "project_newer" | "user_newer" | "both_modified")
+            details: list of per-file comparison dicts
+    """
+    user_files = set(_list_skill_files(user_dir))
+    project_files = set(_list_skill_files(project_dir))
+
+    all_files = sorted(user_files | project_files)
+    details = []
+    project_newer_count = 0
+    user_newer_count = 0
+    both_modified_count = 0
+
+    for rel in all_files:
+        user_path = os.path.join(user_dir, rel)
+        proj_path = os.path.join(project_dir, rel)
+
+        entry = {"file": rel}
+
+        if not os.path.exists(user_path):
+            entry["status"] = "missing_in_user"
+            project_newer_count += 1
+        elif not os.path.exists(proj_path):
+            entry["status"] = "missing_in_project"
+            user_newer_count += 1
+        else:
+            # 比较内容
+            if filecmp.cmp(user_path, proj_path, shallow=False):
+                entry["status"] = "identical"
+            else:
+                user_mtime = os.path.getmtime(user_path)
+                proj_mtime = os.path.getmtime(proj_path)
+                entry["user_mtime"] = datetime.fromtimestamp(user_mtime).isoformat()
+                entry["project_mtime"] = datetime.fromtimestamp(proj_mtime).isoformat()
+
+                if proj_mtime > user_mtime:
+                    entry["status"] = "project_newer"
+                    project_newer_count += 1
+                elif user_mtime > proj_mtime:
+                    entry["status"] = "user_newer"
+                    user_newer_count += 1
+                else:
+                    # 同一秒修改但内容不同
+                    entry["status"] = "both_modified"
+                    both_modified_count += 1
+
+                # 生成 diff 摘要
+                entry["diff_summary"] = _diff_summary(user_path, proj_path)
+
+        if entry["status"] != "identical":
+            details.append(entry)
+
+    identical = len(details) == 0
+    if identical:
+        summary = "identical"
+    elif both_modified_count > 0 or (user_newer_count > 0 and project_newer_count > 0):
+        summary = "both_modified"
+    elif user_newer_count == 0 and project_newer_count > 0:
+        summary = "project_newer"
+    elif project_newer_count == 0 and user_newer_count > 0:
+        summary = "user_newer"
+    else:
+        summary = "both_modified"
+
+    return {"identical": identical, "summary": summary, "details": details}
+
+
+def _classify_diff_status(details: list) -> str:
+    """根据差异详情分类状态。"""
+    has_user_newer = any(
+        d["status"] in ("user_newer", "missing_in_project") for d in details
+    )
+    has_project_newer = any(
+        d["status"] in ("project_newer", "missing_in_user") for d in details
+    )
+    has_both_modified = any(d["status"] == "both_modified" for d in details)
+
+    if has_both_modified or (has_user_newer and has_project_newer):
+        return "both_modified"
+    if has_project_newer:
+        return "project_newer"
+    if has_user_newer:
+        return "user_newer"
+    return "identical"
+
+
+def _diff_summary(file_a: str, file_b: str) -> str:
+    """生成两个文件的简要 diff 摘要。"""
+    if not shutil.which("diff"):
+        return "files differ (diff not available)"
+
+    try:
+        result_stat = subprocess.run(
+            ["diff", file_a, file_b],
+            capture_output=True, text=True, timeout=5,
+        )
+        diff_lines = [l for l in result_stat.stdout.splitlines()
+                      if l.startswith(("<", ">"))]
+        return f"{len(diff_lines)} lines differ"
+    except (subprocess.TimeoutExpired, FileNotFoundError,
+            subprocess.SubprocessError):
+        return "files differ"
+
+
+def _format_diff_summary_human(diff_result: dict) -> str:
+    """生成人类可读的差异摘要。"""
+    if diff_result["identical"]:
+        return "All files identical"
+
+    parts = []
+    for d in diff_result["details"]:
+        if d["status"] == "project_newer":
+            parts.append(f"[project_newer] {d['file']} ({d['project_mtime']}, {d.get('diff_summary', '')})")
+        elif d["status"] == "user_newer":
+            parts.append(f"[user_newer] {d['file']} ({d['user_mtime']}, {d.get('diff_summary', '')})")
+        elif d["status"] == "missing_in_user":
+            parts.append(f"[project_only] {d['file']}")
+        elif d["status"] == "missing_in_project":
+            parts.append(f"[user_only] {d['file']}")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="claude_session",
+    toolset="claude_session",
+    schema=CLAUDE_SESSION_SCHEMA,
+    handler=_handle_claude_session,
+    check_fn=_check_claude_session,
+    emoji="🤖",
+    max_result_size_chars=200_000,
+)


### PR DESCRIPTION
## Claude Code Session Manager — Rebased v2

Replaces #12210. Rebased onto latest `main` (includes 142 upstream commits since original PR).

### What This Adds

A `claude_session` tool for managing Claude Code CLI sessions via tmux, enabling Hermes to delegate coding tasks to Claude Code with full lifecycle control.

### Core Features

- tmux-based session lifecycle: `start` / `stop` / `send` / `output` / `status` / `wait_for_idle`
- Real-time state detection: IDLE / THINKING / TOOL_CALL / PERMISSION / INTERVIEW / EXITED
- UUID5 deterministic session IDs + auto-resume from JSONL conversation files
- Session persistence to `.claude/claude-session.json` per workdir
- Global workdir index (`~/.hermes/claude-session-dirs.json`)
- Auto-inject top-5 recent peer sessions context on `start`
- Resumable session discovery on `list` (across all workdirs, with name collision dedup)
- Orphan tmux handling: EXITED detection, 30s busy-wait before force rebuild
- Security: realpath + system dir blacklist + symlink detection + 0o600 file permissions

### Actions

`start`, `send`, `type`, `submit`, `cancel_input`, `status`, `wait_for_idle`, `wait_for_state`, `output`, `jsonl_output`, `respond_permission`, `respond_interview`, `stop`, `history`, `events`, `list`, `switch`, `diagnose`, `doctor_fix`

### Files Changed

17 new files, 7,735 lines

- `tools/claude_session_tool.py` — Main tool implementation
- `tools/claude_session/` — Session management, state detection, tmux interface, observer, output buffer
- `skills/claude-session/` — SKILL.md v4.5 + configure script
- `tests/tools/test_claude_session_*.py` — 116 tests

### Quality

- 116 tests, all passing
- PEP 8 compliant, no hardcoded paths
- Security-hardened (path validation, symlink checks, restricted file permissions)
- Review cycle completed (0 P0, 0 P1 remaining)