### PR TITLE
fix(profile): strip reserved runtime vars when cloning .env

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -58,6 +58,8 @@ _CLONE_CONFIG_FILES = [
     "SOUL.md",
 ]
 
+_ENV_ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
+
 # Subdirectory files copied during --clone (path relative to profile root).
 # Memory files are part of the agent's curated identity — just as important
 # as SOUL.md for continuity when cloning a profile.
@@ -114,6 +116,27 @@ def has_bundled_skills_opt_out(profile_dir: Path) -> bool:
         return (profile_dir / NO_BUNDLED_SKILLS_MARKER).exists()
     except OSError:
         return False
+
+
+def _runtime_location_env_names() -> frozenset[str]:
+    """Return denylisted HERMES_* runtime-location env names."""
+    from hermes_cli.config import _ENV_VAR_NAME_DENYLIST
+
+    return frozenset(
+        name for name in _ENV_VAR_NAME_DENYLIST if name.startswith("HERMES_")
+    )
+
+
+def _copy_clone_env_file(src: Path, dst: Path) -> None:
+    """Copy .env for profile clone, dropping runtime profile-routing vars."""
+    denied_names = _runtime_location_env_names()
+    filtered_lines = []
+    for line in src.read_text(encoding="utf-8").splitlines(keepends=True):
+        match = _ENV_ASSIGNMENT_RE.match(line)
+        if match and match.group(1) in denied_names:
+            continue
+        filtered_lines.append(line)
+    dst.write_text("".join(filtered_lines), encoding="utf-8")
 
 
 def _clone_all_copytree_ignore(source_dir: Path):
@@ -737,7 +760,11 @@ def create_profile(
             profile_dir,
             ignore=_clone_all_copytree_ignore(source_dir),
         )
-        # Strip runtime files
+        # Strip runtime files and profile-routing env vars that should not
+        # carry over to the cloned HERMES_HOME.
+        env_file = profile_dir / ".env"
+        if env_file.exists():
+            _copy_clone_env_file(env_file, env_file)
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
     else:
@@ -752,11 +779,15 @@ def create_profile(
                 src = source_dir / filename
                 if src.exists():
                     dst = profile_dir / filename
-                    shutil.copy2(src, dst)
+                    if filename == ".env":
+                        _copy_clone_env_file(src, dst)
+                    else:
+                        shutil.copy2(src, dst)
                     # Tighten .env to owner-only after copy. shutil.copy2
-                    # preserves source mode bits, but if the source's .env
-                    # was loose (host umask 0o022 leaving 0o644), tighten
-                    # explicitly so the clone doesn't inherit weak perms.
+                    # preserves source mode bits for regular copies, but if
+                    # the source's .env was loose (host umask 0o022 leaving
+                    # 0o644), tighten explicitly so the clone doesn't inherit
+                    # weak perms.
                     if filename == ".env":
                         try:
                             os.chmod(str(dst), 0o600)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -185,6 +185,31 @@ class TestCreateProfile:
         assert (profile_dir / ".env").read_text() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
+    def test_clone_config_strips_reserved_runtime_env_vars(self, profile_env):
+        source_profile = create_profile("source", no_alias=True)
+        (source_profile / "config.yaml").write_text("model: test")
+        (source_profile / ".env").write_text(
+            "# keep comments\n"
+            "OPENAI_API_KEY=x\n"
+            f"HERMES_HOME={source_profile}\n"
+            "export HERMES_PROFILE=source\n"
+            "HERMES_CONFIG=/tmp/source-config.yaml\n"
+            "export HERMES_ENV=/tmp/source.env\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+            "export OPENROUTER_API_KEY=y\n"
+        )
+
+        profile_dir = create_profile(
+            "coder", clone_from="source", clone_config=True, no_alias=True
+        )
+
+        assert (profile_dir / ".env").read_text() == (
+            "# keep comments\n"
+            "OPENAI_API_KEY=x\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+            "export OPENROUTER_API_KEY=y\n"
+        )
+
     def test_clone_config_copies_source_skills(self, profile_env):
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
@@ -209,6 +234,11 @@ class TestCreateProfile:
         (default_home / "memories").mkdir(exist_ok=True)
         (default_home / "memories" / "note.md").write_text("remember this")
         (default_home / "config.yaml").write_text("model: gpt-4")
+        (default_home / ".env").write_text(
+            "OPENAI_API_KEY=x\n"
+            f"HERMES_HOME={default_home}\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+        )
         # Runtime files that should be stripped
         (default_home / "gateway.pid").write_text("12345")
         (default_home / "gateway_state.json").write_text("{}")
@@ -219,6 +249,10 @@ class TestCreateProfile:
         # Content should be copied
         assert (profile_dir / "memories" / "note.md").read_text() == "remember this"
         assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
+        assert (profile_dir / ".env").read_text() == (
+            "OPENAI_API_KEY=x\n"
+            "HERMES_GEMINI_CLIENT_ID=keep\n"
+        )
         # Runtime files should be stripped
         assert not (profile_dir / "gateway.pid").exists()
         assert not (profile_dir / "gateway_state.json").exists()


### PR DESCRIPTION
## What does this PR do?

Prevents cloned profiles from inheriting source-profile runtime routing through `.env`.

Problem/repro:
- A source profile `.env` can contain runtime-location vars such as `HERMES_HOME`, `HERMES_PROFILE`, `HERMES_CONFIG`, or `HERMES_ENV`.
- `hermes profile create <name> --clone` copies `.env` from the source profile.
- `hermes profile create <name> --clone-all` copies the whole source profile tree, including `.env`.
- `env_loader` loads profile `.env` with `override=True`, so a stale `HERMES_HOME=<source-profile>` value can route commands for the clone back to the source profile.

Root cause: Hermes already treats these vars as non-persistable runtime-location vars in `_ENV_VAR_NAME_DENYLIST`, but the profile clone paths copied existing `.env` files verbatim.

Fix:
- Adds a small `.env` clone filter in `hermes_cli/profiles.py`.
- Reuses `_ENV_VAR_NAME_DENYLIST` from `hermes_cli.config`.
- Filters the denylisted `HERMES_*` runtime-location subset during both `--clone` and `--clone-all`.
- Preserves comments, formatting, normal API keys, and allowed `HERMES_*` integration vars such as `HERMES_GEMINI_CLIENT_ID`.
- Keeps the existing owner-only chmod behavior for cloned `.env` files.

Out of scope: this does not change `env_loader` behavior for hand-edited `.env` files at runtime. It only prevents profile cloning from propagating stale runtime-routing vars.

Duplicate-PR check: searched open PRs for HERMES_HOME/profile-clone/env-related fixes. The open provider-config PR #37920 is adjacent but separate; this PR covers cloned `.env` runtime-location hygiene.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py`: filter denylisted Hermes runtime-location vars from cloned `.env` files.
- `hermes_cli/profiles.py`: apply the same `.env` filter to both `--clone` and `--clone-all`.
- `tests/hermes_cli/test_profiles.py`: assert `--clone` strips `HERMES_HOME`, `HERMES_PROFILE`, `HERMES_CONFIG`, and `HERMES_ENV` while preserving comments, API keys, and allowed `HERMES_*` integration vars.
- `tests/hermes_cli/test_profiles.py`: assert `--clone-all` strips stale `HERMES_HOME` while preserving normal and allowed integration env vars.

## How to Test

1. Create a source profile whose `.env` contains `HERMES_HOME=<source-profile>` and a normal API key.
2. Clone it with `hermes profile create <clone-name> --clone` or `--clone-all`.
3. Confirm the cloned `.env` keeps normal env vars but does not contain the runtime-location vars.

Test run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_profiles.py
```

Result:

```text
118 tests passed, 0 failed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A.
