### PR TITLE
fix(cron): isolate gateway approvals from environment pollution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2914,11 +2914,6 @@ def run_job(
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
-
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
@@ -3003,6 +2998,12 @@ def run_job(
     # acquire) and is a no-op for workdir-less jobs (they never mutate the env).
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
 
+    # Bind cron approval policy to this job's ContextVar scope. Keep the token
+    # so cleanup restores the true prior state (_UNSET for normal callers),
+    # preserving the legacy os.environ fallback used by standalone entrypoints.
+    _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
+    _cron_session_token = None
+
     _holds_cwd_write = _job_workdir is not None
     if _holds_cwd_write:
         _terminal_cwd_lock.acquire_write()
@@ -3015,6 +3016,7 @@ def run_job(
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        _cron_session_token = _cron_session_var.set("1")
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -3624,6 +3626,8 @@ def run_job(
             _terminal_cwd_lock.release_read()
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
+        if _cron_session_token is not None:
+            _cron_session_var.reset(_cron_session_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -173,6 +173,7 @@ def set_session_vars(
     cwd: str = "",
     async_delivery: bool = True,
     ui_session_id: str = "",
+    cron_session: Any = _UNSET,
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -188,6 +189,11 @@ def set_session_vars(
     background completion back to the agent after the turn ends (see
     ``_SESSION_ASYNC_DELIVERY`` / ``async_delivery_supported``). Stateless
     request/response adapters (the API server) pass ``False``.
+
+    ``cron_session`` is intentionally separate from ordinary session cleanup:
+    ``_UNSET`` leaves cron scope untouched, while ``"1"`` binds cron policy
+    for a nested context and returns a token that ``clear_session_vars`` resets.
+    This preserves the legacy process-environment fallback after cleanup.
     """
     # Mark the session-context machinery engaged for this process. The
     # subprocess-env bridge uses this to switch from "os.environ fallback" to
@@ -209,6 +215,8 @@ def set_session_vars(
         _SESSION_PROFILE.set(profile),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
+    if cron_session is not _UNSET:
+        tokens.append(_CRON_SESSION.set(cron_session))
     try:
         from agent.runtime_cwd import set_session_cwd
 
@@ -221,13 +229,10 @@ def set_session_vars(
 def clear_session_vars(tokens: list) -> None:
     """Mark session context variables as explicitly cleared.
 
-    Sets all variables to ``""`` so that ``get_session_env`` returns an empty
-    string instead of falling back to (potentially stale) ``os.environ``
-    values.  The *tokens* argument is accepted for API compatibility with
-    callers that saved the return value of ``set_session_vars``, but the
-    actual clearing uses ``var.set("")`` rather than ``var.reset(token)``
-    to ensure the "explicitly cleared" state is distinguishable from
-    "never set" (which holds the ``_UNSET`` sentinel).
+    Sets ordinary session variables to ``""`` so that ``get_session_env``
+    does not fall back to stale ``os.environ`` values. Dedicated nested scope
+    variables such as ``HERMES_CRON_SESSION`` instead reset their saved token,
+    preserving the pre-scope state and legacy fallback semantics.
     """
     for var in (
         _SESSION_PLATFORM,
@@ -244,6 +249,9 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_PROFILE,
     ):
         var.set("")
+    for token in tokens:
+        if getattr(token, "var", None) is _CRON_SESSION:
+            _CRON_SESSION.reset(token)
     # Reset async-delivery capability to the "never set" sentinel rather than a
     # falsy value: a cleared context should fall back to the default-supported
     # behavior (CLI / unaware paths), not be mistaken for an opted-out

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -90,6 +90,9 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
+# Approval routing: cron state must be context-local so a scheduler tick in the
+# gateway process cannot leak into unrelated live turns.
+_CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
 
@@ -133,6 +136,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_CRON_SESSION": _CRON_SESSION,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -249,7 +249,9 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_PROFILE,
     ):
         var.set("")
-    for token in tokens:
+    # Some legacy/mock gateway paths pass ``None`` because the old cleanup
+    # implementation ignored this argument entirely. Preserve that contract.
+    for token in tokens or ():
         if getattr(token, "var", None) is _CRON_SESSION:
             _CRON_SESSION.reset(token)
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1821,7 +1821,7 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         assert fake_db.close.call_count == 2
 
-    def test_run_job_restores_cron_session_env_after_completion(self, tmp_path, monkeypatch):
+    def test_run_job_keeps_cron_session_env_unchanged(self, tmp_path, monkeypatch):
         job = {
             "id": "cron-env-job",
             "name": "cron env test",
@@ -1867,9 +1867,9 @@ class TestRunJobSessionPersistence:
         assert error is None
         assert final_response == "ok"
         assert "ok" in output
-        assert seen == {"env": "1", "ctx": "1"}
+        assert seen == {"env": "legacy", "ctx": "1"}
         assert os.getenv("HERMES_CRON_SESSION") == "legacy"
-        assert get_session_env("HERMES_CRON_SESSION") == ""
+        assert get_session_env("HERMES_CRON_SESSION") == "legacy"
 
 
 class TestRunJobConfigLogging:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1821,6 +1821,56 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         assert fake_db.close.call_count == 2
 
+    def test_run_job_restores_cron_session_env_after_completion(self, tmp_path, monkeypatch):
+        job = {
+            "id": "cron-env-job",
+            "name": "cron env test",
+            "prompt": "hello",
+            "deliver": "local",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        monkeypatch.setenv("HERMES_CRON_SESSION", "legacy")
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+
+                seen["env"] = os.getenv("HERMES_CRON_SESSION")
+                seen["ctx"] = get_session_env("HERMES_CRON_SESSION")
+                return {"final_response": "ok"}
+
+            def close(self):
+                pass
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, output, final_response, error = run_job(job)
+
+        from gateway.session_context import get_session_env
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert seen == {"env": "1", "ctx": "1"}
+        assert os.getenv("HERMES_CRON_SESSION") == "legacy"
+        assert get_session_env("HERMES_CRON_SESSION") == ""
+
 
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -139,6 +139,19 @@ def test_get_session_env_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
 
 
+def test_cron_session_context_overrides_stale_os_environ(monkeypatch):
+    """Gateway session context must suppress leaked cron env state."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    assert get_session_env("HERMES_CRON_SESSION") == "1"
+
+    tokens = set_session_vars(platform="telegram")
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+    clear_session_vars(tokens)
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+
 def test_get_session_env_default_when_nothing_set(monkeypatch):
     """get_session_env returns default when neither contextvar nor env is set."""
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -139,17 +139,17 @@ def test_get_session_env_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
 
 
-def test_cron_session_context_overrides_stale_os_environ(monkeypatch):
-    """Gateway session context must suppress leaked cron env state."""
+def test_scoped_cron_session_restores_env_fallback(monkeypatch):
+    """Cron scope cleanup must restore, not permanently mask, env fallback."""
     monkeypatch.setenv("HERMES_CRON_SESSION", "1")
 
     assert get_session_env("HERMES_CRON_SESSION") == "1"
 
-    tokens = set_session_vars(platform="telegram")
+    tokens = set_session_vars(platform="telegram", cron_session="")
     assert get_session_env("HERMES_CRON_SESSION") == ""
 
     clear_session_vars(tokens)
-    assert get_session_env("HERMES_CRON_SESSION") == ""
+    assert get_session_env("HERMES_CRON_SESSION") == "1"
 
 
 def test_get_session_env_default_when_nothing_set(monkeypatch):
@@ -406,4 +406,3 @@ async def test_gateway_executor_refuses_resurrection_after_shutdown():
             await runner._run_in_executor_with_context(lambda: "second")
     finally:
         runner._shutdown_executor()
-

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -152,6 +152,13 @@ def test_scoped_cron_session_restores_env_fallback(monkeypatch):
     assert get_session_env("HERMES_CRON_SESSION") == "1"
 
 
+def test_clear_session_vars_accepts_legacy_none_tokens():
+    """Mock/legacy callers may have no saved token list to provide."""
+    clear_session_vars(None)
+
+    assert get_session_env("HERMES_SESSION_PLATFORM") == ""
+
+
 def test_get_session_env_default_when_nothing_set(monkeypatch):
     """get_session_env returns default when neither contextvar nor env is set."""
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -7,6 +7,7 @@ from tools.approval import (
     _get_cron_approval_mode,
     check_all_command_guards,
     check_dangerous_command,
+    check_execute_code_guard,
     detect_dangerous_command,
 )
 
@@ -380,7 +381,7 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="123")
+        tokens = set_session_vars(platform="telegram", chat_id="123", cron_session="1")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
@@ -402,7 +403,7 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="discord", chat_id="456")
+        tokens = set_session_vars(platform="discord", chat_id="456", cron_session="1")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
@@ -422,7 +423,7 @@ class TestCronWithGatewayOrigin:
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="789")
+        tokens = set_session_vars(platform="telegram", chat_id="789", cron_session="1")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
@@ -463,3 +464,59 @@ class TestGatewayAfterCronSession:
         assert result.get("status") == "pending_approval"
         assert result.get("approval_pending") is True
         assert "cron_mode" not in result["message"]
+
+    def test_gateway_context_session_takes_precedence_over_cron_marker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        tokens = set_session_vars(platform="telegram", session_key="ctx-session")
+        try:
+            result = check_dangerous_command("rm -rf /tmp/stuff", "local")
+        finally:
+            clear_session_vars(tokens)
+
+        assert not result["approved"]
+        assert result.get("status") == "approval_required"
+        assert "cron_mode" not in result["message"]
+
+    def test_combined_guard_gateway_context_session_takes_precedence_over_cron_marker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        tokens = set_session_vars(platform="telegram", session_key="ctx-session")
+        try:
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+        finally:
+            clear_session_vars(tokens)
+
+        assert not result["approved"]
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+        assert "cron_mode" not in result["message"]
+
+    def test_execute_code_gateway_context_session_takes_precedence_over_cron_marker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        tokens = set_session_vars(platform="telegram", session_key="ctx-session")
+        try:
+            result = check_execute_code_guard("import os", "local")
+        finally:
+            clear_session_vars(tokens)
+
+        assert not result["approved"]
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+        assert "cron profile is intentionally trusted" not in result["message"]

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -189,6 +189,22 @@ class TestCronDenyModeAllGuards:
             assert not result["approved"]
             assert "BLOCKED" in result["message"]
 
+    def test_exec_ask_does_not_bypass_cron_deny(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert not result["approved"]
+        assert "BLOCKED" in result["message"]
+        assert result.get("status") != "pending_approval"
+
     def test_safe_command_allowed_in_combined_guard(self, monkeypatch):
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
@@ -465,6 +481,27 @@ class TestGatewayAfterCronSession:
         assert result.get("approval_pending") is True
         assert "cron_mode" not in result["message"]
 
+    def test_context_cron_session_takes_precedence_over_gateway_env_marker(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        tokens = set_session_vars(cron_session="1")
+        try:
+            from unittest.mock import patch as mock_patch
+            with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+                result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+        finally:
+            clear_session_vars(tokens)
+
+        assert not result["approved"]
+        assert "BLOCKED" in result["message"]
+        assert "cron_mode" in result["message"]
+        assert result.get("status") != "pending_approval"
+
     def test_gateway_context_session_takes_precedence_over_cron_marker(self, monkeypatch):
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
@@ -520,3 +557,24 @@ class TestGatewayAfterCronSession:
         assert result.get("status") == "pending_approval"
         assert result.get("approval_pending") is True
         assert "cron profile is intentionally trusted" not in result["message"]
+
+    def test_execute_code_exec_ask_does_not_bypass_context_cron_deny(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from unittest.mock import patch as mock_patch
+
+        tokens = set_session_vars(cron_session="1")
+        try:
+            with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+                result = check_execute_code_guard("import os", "local")
+        finally:
+            clear_session_vars(tokens)
+
+        assert not result["approved"]
+        assert result.get("outcome") == "blocked"
+        assert "cron profile is intentionally trusted" in result["message"]

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -432,3 +432,34 @@ class TestCronWithGatewayOrigin:
                 assert result.get("status") != "approval_required"
         finally:
             clear_session_vars(tokens)
+
+
+class TestGatewayAfterCronSession:
+    """A cron marker left in process env must not disable live gateway approvals."""
+
+    def test_gateway_env_session_takes_precedence_over_cron_marker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        result = check_dangerous_command("rm -rf /tmp/stuff", "local")
+
+        assert not result["approved"]
+        assert result.get("status") == "approval_required"
+        assert "cron_mode" not in result["message"]
+
+    def test_combined_guard_gateway_env_session_takes_precedence_over_cron_marker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert not result["approved"]
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+        assert "cron_mode" not in result["message"]

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -351,6 +351,55 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("total_duration_seconds", result)
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_propagates_cron_context_to_worker(self, mock_run):
+        parent = _make_mock_parent()
+        observed = []
+        old_cron_env = os.environ.pop("HERMES_CRON_SESSION", None)
+
+        def _fake_run(**kwargs):
+            from gateway.session_context import get_session_env
+
+            observed.append(
+                {
+                    "ctx": get_session_env("HERMES_CRON_SESSION"),
+                    "env": os.getenv("HERMES_CRON_SESSION"),
+                    "goal": kwargs["goal"],
+                }
+            )
+            return {
+                "task_index": kwargs["task_index"],
+                "status": "completed",
+                "summary": kwargs["goal"],
+                "api_calls": 1,
+                "duration_seconds": 0.1,
+            }
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(cron_session="1")
+        try:
+            mock_run.side_effect = _fake_run
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "A"}, {"goal": "B"}],
+                    parent_agent=parent,
+                )
+            )
+        finally:
+            clear_session_vars(tokens)
+            if old_cron_env is not None:
+                os.environ["HERMES_CRON_SESSION"] = old_cron_env
+
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(
+            sorted(observed, key=lambda item: item["goal"]),
+            [
+                {"ctx": "1", "env": None, "goal": "A"},
+                {"ctx": "1", "env": None, "goal": "B"},
+            ],
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):
         mock_run.side_effect = [
             {
@@ -2041,6 +2090,92 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
 
 class TestChildCredentialLeasing(unittest.TestCase):
+    def test_run_single_child_propagates_cron_context_to_conversation_thread(self):
+        from tools.delegate_tool import _run_single_child
+
+        observed = {}
+        old_cron_env = os.environ.pop("HERMES_CRON_SESSION", None)
+
+        child = MagicMock()
+        child._credential_pool = None
+
+        def _run_conversation(*args, **kwargs):
+            from gateway.session_context import get_session_env
+
+            observed["ctx"] = get_session_env("HERMES_CRON_SESSION")
+            observed["env"] = os.getenv("HERMES_CRON_SESSION")
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = _run_conversation
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars(cron_session="1")
+        try:
+            result = _run_single_child(
+                task_index=0,
+                goal="Investigate delegated cron work",
+                child=child,
+                parent_agent=_make_mock_parent(),
+            )
+        finally:
+            clear_session_vars(tokens)
+            if old_cron_env is not None:
+                os.environ["HERMES_CRON_SESSION"] = old_cron_env
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(observed, {"ctx": "1", "env": None})
+
+    def test_run_single_child_keeps_subagent_approval_callback(self):
+        from tools.delegate_tool import _run_single_child
+        from tools.terminal_tool import _get_approval_callback, set_approval_callback
+
+        def parent_callback(*args, **kwargs):
+            return "parent"
+
+        def subagent_callback(*args, **kwargs):
+            return "subagent"
+
+        observed = {}
+        child = MagicMock()
+        child._credential_pool = None
+
+        def _run_conversation(*args, **kwargs):
+            observed["callback"] = _get_approval_callback()
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = _run_conversation
+
+        set_approval_callback(parent_callback)
+        try:
+            with patch(
+                "tools.delegate_tool._get_subagent_approval_callback",
+                return_value=subagent_callback,
+            ):
+                result = _run_single_child(
+                    task_index=0,
+                    goal="Keep subagent approval callback",
+                    child=child,
+                    parent_agent=_make_mock_parent(),
+                )
+        finally:
+            set_approval_callback(None)
+
+        self.assertEqual(result["status"], "completed")
+        self.assertIs(observed["callback"], subagent_callback)
+
     def test_run_single_child_acquires_and_releases_lease(self):
         from tools.delegate_tool import _run_single_child
 

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -103,8 +103,7 @@ class TestRequestToolApproval:
     def test_cron_deny_mode_blocks(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "env_var_enabled",
-                            lambda v: v == "HERMES_CRON_SESSION")
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "deny")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is False
@@ -113,8 +112,7 @@ class TestRequestToolApproval:
     def test_cron_approve_mode_allows(self, monkeypatch):
         monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
-        monkeypatch.setattr(approval, "env_var_enabled",
-                            lambda v: v == "HERMES_CRON_SESSION")
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.setattr(approval, "_get_cron_approval_mode", lambda: "approve")
         res = request_tool_approval("terminal", "smtp send")
         assert res["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -238,10 +238,10 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
-        return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
+    if env_var_enabled("HERMES_CRON_SESSION"):
+        return False
     return bool(_get_session_platform())
 
 # Sensitive write targets that should trigger approval even when referenced

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -224,6 +224,16 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_session() -> bool:
+    """Return True when the current context is running under cron rules."""
+    try:
+        from gateway.session_context import get_session_env
+
+        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+    except Exception:
+        return env_var_enabled("HERMES_CRON_SESSION")
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -231,16 +241,13 @@ def _is_gateway_approval_context() -> bool:
     Newer concurrent gateway paths bind HERMES_SESSION_PLATFORM via
     contextvars so approval mode does not depend on process-global flags.
 
-    Cron jobs are NEVER gateway-approval contexts even when they originate
-    from a gateway platform (cron binds HERMES_SESSION_PLATFORM via
-    contextvars for delivery routing). Cron approvals are governed by
-    ``approvals.cron_mode`` config, not interactive resolve — letting cron
-    fall through to the gateway branch would submit a pending approval
-    with no listener and block the job indefinitely.
+    Cron jobs are NEVER gateway-approval contexts. The scheduler binds a
+    context-local cron flag so a leaked process-global env var cannot
+    override a live gateway turn in the same process.
     """
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         return False
     return bool(_get_session_platform())
 
@@ -2708,7 +2715,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -3235,7 +3242,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3654,9 +3661,11 @@ def check_execute_code_guard(code: str, env_type: str,
 
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_cron = _is_cron_session()
 
-    # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    # Cron with no live approval surface: no user is present to approve
+    # arbitrary code. If a gateway/ask surface is active, let that win.
+    if is_cron and not is_gateway and not is_ask:
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -234,6 +234,19 @@ def _is_cron_session() -> bool:
         return env_var_enabled("HERMES_CRON_SESSION")
 
 
+def _is_context_cron_session() -> bool:
+    """Return True only when cron state is bound to the current ContextVar scope."""
+    try:
+        from gateway.session_context import _UNSET, _VAR_MAP
+
+        value = _VAR_MAP["HERMES_CRON_SESSION"].get()
+        if value is _UNSET:
+            return False
+        return is_truthy_value(value)
+    except Exception:
+        return False
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -241,15 +254,17 @@ def _is_gateway_approval_context() -> bool:
     Newer concurrent gateway paths bind HERMES_SESSION_PLATFORM via
     contextvars so approval mode does not depend on process-global flags.
 
-    Cron jobs are NEVER gateway-approval contexts. The scheduler binds a
-    context-local cron flag so a leaked process-global env var cannot
-    override a live gateway turn in the same process.
+    Cron jobs are NEVER gateway-approval contexts. A context-local cron flag is
+    authoritative over stale process-global gateway markers, while live gateway
+    contextvars still suppress a leaked process-global cron marker.
     """
+    if _is_context_cron_session():
+        return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
-    if _is_cron_session():
-        return False
-    return bool(_get_session_platform())
+    if _get_session_platform():
+        return True
+    return False
 
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME, or by the resolved absolute
@@ -3237,12 +3252,13 @@ def check_all_command_guards(command: str, env_type: str,
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_cron = _is_cron_session()
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
-    if not is_cli and not is_gateway and not is_ask:
+    if not is_cli and not is_gateway and (is_cron or not is_ask):
         # Cron sessions: respect cron_mode config
-        if _is_cron_session():
+        if is_cron:
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3663,9 +3679,9 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
     is_cron = _is_cron_session()
 
-    # Cron with no live approval surface: no user is present to approve
-    # arbitrary code. If a gateway/ask surface is active, let that win.
-    if is_cron and not is_gateway and not is_ask:
+    # Cron with no live gateway surface: no user is present to approve
+    # arbitrary code. An inherited ask-mode flag must not weaken cron policy.
+    if is_cron and not is_gateway:
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -18,6 +18,7 @@ never the child's intermediate tool calls or reasoning.
 """
 
 import enum
+import contextvars
 import json
 import logging
 
@@ -26,7 +27,6 @@ import os
 import threading
 import time
 from concurrent.futures import (
-    ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
 from typing import Any, Dict, List, Optional
@@ -115,6 +115,16 @@ def _get_subagent_approval_callback():
 # NOTE: nested delegation is granted by role='orchestrator' (which re-adds the
 # "delegation" toolset in _build_child_agent), NOT by the model naming toolsets
 # — the model has no toolsets argument. Subagents inherit the parent's toolsets.
+
+
+def _propagate_contextvars_to_thread(target):
+    """Propagate ContextVars without overriding subagent thread-local callbacks."""
+    ctx = contextvars.copy_context()
+
+    def _runner(*args, **kwargs):
+        return ctx.run(target, *args, **kwargs)
+
+    return _runner
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 # One-shot guard: the high-concurrency cost advisory is emitted at most once
@@ -2008,7 +2018,9 @@ def _run_single_child(
                 stream_callback=_relay_child_text,
             )
 
-        _child_future = _timeout_executor.submit(_run_with_thread_capture)
+        _child_future = _timeout_executor.submit(
+            _propagate_contextvars_to_thread(_run_with_thread_capture)
+        )
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
@@ -2653,7 +2665,7 @@ def delegate_task(
                 futures = {}
                 for i, t, child in children:
                     future = executor.submit(
-                        _run_single_child,
+                        _propagate_contextvars_to_thread(_run_single_child),
                         task_index=i,
                         goal=t["goal"],
                         child=child,


### PR DESCRIPTION
## Summary

The in-process cron scheduler must not place approval policy in process-global state. A persistent `HERMES_CRON_SESSION=1` causes later interactive gateway turns to use `approvals.cron_mode`; deny mode blocks a live user's command, while approve mode can bypass the expected gateway approval prompt.

This PR now:

- moves the cron marker into a per-job `ContextVar` and restores its exact prior state with its token
- leaves the legacy `os.environ` fallback intact for standalone and compatibility entrypoints
- makes context-local cron state authoritative over stale gateway markers
- lets a live gateway ContextVar/platform beat only a stale process-global cron marker
- keeps cron policy authoritative over an inherited `HERMES_EXEC_ASK` flag
- propagates approval ContextVars through delegated worker threads, preserving cron policy for child work
- covers success, cleanup, gateway, execute-code, ask-mode, and delegated-worker paths

Closes #37968

## Root cause

`cron/scheduler.py` set `HERMES_CRON_SESSION` in `os.environ`, even though the default gateway hosts the cron ticker and interactive sessions in the same process. Approval readers in `tools/approval.py` therefore could not distinguish the job that set the marker from unrelated live turns.

## Verification

Rebased onto current `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`.

- `scripts/run_tests.sh tests/gateway/test_session_env.py tests/tools/test_cron_approval_mode.py tests/tools/test_delegate.py -q` — 214 passed
- CI slice regression set (`test_session_env`, `test_incomplete_gateway_turns`, `test_stacked_skill_platform_disabled`, `test_telegram_topic_mode`) — 69 passed
- `scripts/run_tests.sh tests/cron/test_scheduler.py -q -k run_job_keeps_cron_session_env_unchanged` — 1 passed
- `.venv/bin/ruff check` on all eight changed files — passed
- `.venv/bin/python scripts/check-windows-footguns.py` on all eight changed files — passed
- `git diff --check origin/main...HEAD` — passed

The full `tests/cron/test_scheduler.py` file also reached 213 passing tests, but ten unrelated tick tests currently fail while opening the executions SQLite path in the isolated test environment; the changed scheduler regression passes independently as shown above.

## Risk

This changes approval-context routing. The marker remains visible inside each cron job and its delegated workers, but is no longer written into process-global environment state. Cleanup uses token reset rather than an empty-string sentinel so later env-only cron detection continues to work.
