### PR TITLE
fix(telegram): attach media from replied messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1106,6 +1106,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ini": "text/plain",
     ".cfg": "text/plain",
     ".zip": "application/zip",
+    ".epub": "application/epub+zip",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5198,6 +5198,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        await self._attach_replied_document_if_present(event, msg)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
 
@@ -5212,8 +5213,121 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        await self._attach_replied_document_if_present(event, msg)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
+
+    async def _attach_replied_document_if_present(self, event: MessageEvent, message: Message) -> None:
+        """Expose media from the message being replied to.
+
+        Telegram only puts the current message in the update handler. If a user
+        replies to a photo/PDF/document and tags the bot, the current text
+        message has no media of its own; without this bridge the agent only sees
+        the quote text and says no attachment was present.
+        """
+        if event.media_urls:
+            return
+        replied = getattr(message, "reply_to_message", None)
+        if replied is None:
+            return
+
+        def append_reply_note(note: str) -> None:
+            event.reply_to_text = f"{event.reply_to_text}\n{note}" if event.reply_to_text else note
+
+        photo_sizes = getattr(replied, "photo", None)
+        if photo_sizes:
+            try:
+                photo = photo_sizes[-1]
+                file_obj = await photo.get_file()
+                image_bytes = await file_obj.download_as_bytearray()
+                ext = ".jpg"
+                file_path = getattr(file_obj, "file_path", None)
+                if file_path:
+                    for candidate in [".png", ".webp", ".gif", ".jpeg", ".jpg"]:
+                        if file_path.lower().endswith(candidate):
+                            ext = candidate
+                            break
+                cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+            except Exception as exc:
+                logger.warning("[Telegram] Failed to cache replied-to photo: %s", exc, exc_info=True)
+                append_reply_note("[Replied-to photo could not be downloaded.]")
+                return
+
+            event.message_type = MessageType.PHOTO
+            event.media_urls = [cached_path]
+            event.media_types = [_TELEGRAM_IMAGE_EXT_TO_MIME.get(ext, f"image/{ext.lstrip('.')}")]
+            append_reply_note(f"[Replied-to photo attached: saved at {cached_path}]")
+            logger.info("[Telegram] Cached replied-to user photo at %s", cached_path)
+            return
+
+        doc = getattr(replied, "document", None)
+        if doc is None:
+            return
+
+        original_filename = doc.file_name or ""
+        ext = ""
+        if original_filename:
+            _, ext = os.path.splitext(original_filename)
+            ext = ext.lower()
+
+        doc_mime = (doc.mime_type or "").lower()
+        if not ext and doc_mime:
+            ext = _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, "")
+            if not ext:
+                mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                ext = mime_to_ext.get(doc_mime, "")
+
+        display_name = original_filename or f"document{ext or ''}" or "document"
+        if not doc.file_size or doc.file_size > self._max_doc_bytes:
+            limit_mb = self._max_doc_bytes // (1024 * 1024)
+            note = (
+                f"[Replied-to document '{display_name}' was not downloaded: "
+                f"too large or size unknown. Maximum: {limit_mb} MB.]"
+            )
+            append_reply_note(note)
+            return
+
+        if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
+            try:
+                file_obj = await doc.get_file()
+                image_bytes = await file_obj.download_as_bytearray()
+                image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
+            except Exception as exc:
+                logger.warning("[Telegram] Failed to cache replied-to image document: %s", exc, exc_info=True)
+                note = f"[Replied-to image document '{display_name}' could not be downloaded.]"
+                append_reply_note(note)
+                return
+
+            event.message_type = MessageType.PHOTO
+            event.media_urls = [cached_path]
+            event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
+            note = f"[Replied-to image document attached: '{display_name}' saved at {cached_path}]"
+            append_reply_note(note)
+            logger.info("[Telegram] Cached replied-to user image-document at %s", cached_path)
+            return
+
+        if ext not in SUPPORTED_DOCUMENT_TYPES:
+            note = f"[Replied-to document '{display_name}' has unsupported type '{ext or 'unknown'}'.]"
+            append_reply_note(note)
+            return
+
+        try:
+            file_obj = await doc.get_file()
+            raw_bytes = bytes(await file_obj.download_as_bytearray())
+            cached_path = cache_document_from_bytes(raw_bytes, display_name)
+        except Exception as exc:
+            logger.warning("[Telegram] Failed to cache replied-to document: %s", exc, exc_info=True)
+            note = f"[Replied-to document '{display_name}' could not be downloaded.]"
+            append_reply_note(note)
+            return
+
+        event.message_type = MessageType.DOCUMENT
+        event.media_urls = [cached_path]
+        event.media_types = [SUPPORTED_DOCUMENT_TYPES[ext]]
+        note = f"[Replied-to document attached: '{display_name}' saved at {cached_path}]"
+        append_reply_note(note)
+        logger.info("[Telegram] Cached replied-to user document at %s", cached_path)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -21,6 +21,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_VIDEO_TYPES,
 )
 
@@ -81,7 +82,7 @@ def _make_document(
     return doc
 
 
-def _make_message(document=None, caption=None, media_group_id=None, photo=None):
+def _make_message(document=None, caption=None, media_group_id=None, photo=None, reply_to_message=None):
     """Build a mock Telegram Message with the given document/photo."""
     msg = MagicMock()
     msg.message_id = 42
@@ -106,6 +107,8 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     msg.from_user.id = 1
     msg.from_user.full_name = "Test User"
     msg.message_thread_id = None
+    msg.reply_to_message = reply_to_message
+    msg.quote = None
     return msg
 
 
@@ -259,6 +262,19 @@ class TestDocumentDownloadBlock:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls and event.media_urls[0].endswith("archive.zip")
         assert event.media_types == ["application/zip"]
+
+    @pytest.mark.asyncio
+    async def test_epub_document_cached(self, adapter):
+        """An .epub upload should be cached as a supported document."""
+        file_obj = _make_file_obj(b"epub-bytes")
+        doc = _make_document(file_name="book.epub", mime_type="application/epub+zip", file_size=10, file_obj=file_obj)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls and event.media_urls[0].endswith("book.epub")
+        assert event.media_types == ["application/epub+zip"]
 
     @pytest.mark.asyncio
     async def test_png_document_is_routed_as_image(self, adapter):
@@ -427,6 +443,76 @@ class TestVideoDownloadBlock:
         assert len(event.media_urls) == 1
         assert os.path.exists(event.media_urls[0])
         assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+
+class TestRepliedMediaBridge:
+    @pytest.mark.asyncio
+    async def test_text_reply_to_photo_attaches_replied_image(self, adapter):
+        file_obj = _make_file_obj(b"reply-photo-bytes")
+        file_obj.file_path = "photos/replied.jpeg"
+        replied = _make_message(photo=[_make_photo(file_obj)])
+        msg = _make_message(caption="@bot what is this", reply_to_message=replied)
+        event = adapter._build_message_event(msg, MessageType.TEXT)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/replied.jpeg") as cache_mock:
+            await adapter._attach_replied_document_if_present(event, msg)
+
+        cache_mock.assert_called_once_with(b"reply-photo-bytes", ext=".jpeg")
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/replied.jpeg"]
+        assert event.media_types == ["image/jpeg"]
+        assert "Replied-to photo attached" in event.reply_to_text
+
+    @pytest.mark.asyncio
+    async def test_text_reply_to_image_document_attaches_replied_image(self, adapter):
+        file_obj = _make_file_obj(b"reply-image-document")
+        doc = _make_document(file_name="screenshot.png", mime_type="image/png", file_size=21, file_obj=file_obj)
+        replied = _make_message(document=doc)
+        msg = _make_message(caption="@bot whats in this", reply_to_message=replied)
+        event = adapter._build_message_event(msg, MessageType.TEXT)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/replied.png") as cache_mock:
+            await adapter._attach_replied_document_if_present(event, msg)
+
+        cache_mock.assert_called_once_with(b"reply-image-document", ext=".png")
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/replied.png"]
+        assert event.media_types == ["image/png"]
+        assert "Replied-to image document attached" in event.reply_to_text
+
+    @pytest.mark.asyncio
+    async def test_text_reply_to_pdf_still_attaches_replied_document(self, adapter):
+        file_obj = _make_file_obj(b"%PDF-1.4 reply")
+        doc = _make_document(file_name="report.pdf", mime_type="application/pdf", file_size=14, file_obj=file_obj)
+        replied = _make_message(document=doc)
+        msg = _make_message(caption="@bot summarize", reply_to_message=replied)
+        event = adapter._build_message_event(msg, MessageType.TEXT)
+
+        with patch("gateway.platforms.telegram.cache_document_from_bytes", return_value="/tmp/report.pdf") as cache_mock:
+            await adapter._attach_replied_document_if_present(event, msg)
+
+        cache_mock.assert_called_once_with(b"%PDF-1.4 reply", "report.pdf")
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_urls == ["/tmp/report.pdf"]
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".pdf"]]
+        assert "Replied-to document attached" in event.reply_to_text
+
+    @pytest.mark.asyncio
+    async def test_text_reply_to_epub_attaches_replied_document(self, adapter):
+        file_obj = _make_file_obj(b"epub reply")
+        doc = _make_document(file_name="book.epub", mime_type="application/epub+zip", file_size=10, file_obj=file_obj)
+        replied = _make_message(document=doc)
+        msg = _make_message(caption="@bot summarize", reply_to_message=replied)
+        event = adapter._build_message_event(msg, MessageType.TEXT)
+
+        with patch("gateway.platforms.telegram.cache_document_from_bytes", return_value="/tmp/book.epub") as cache_mock:
+            await adapter._attach_replied_document_if_present(event, msg)
+
+        cache_mock.assert_called_once_with(b"epub reply", "book.epub")
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_urls == ["/tmp/book.epub"]
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".epub"]]
+        assert "Replied-to document attached" in event.reply_to_text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- attach media from Telegram `reply_to_message` when handling text and command replies
- support replied photos and image documents by caching them as photo media
- preserve the existing replied-document flow for supported files such as PDFs

Closes #37970

## Testing
- `uv run --extra dev pytest tests/gateway/test_telegram_documents.py`
- `uv run --extra dev ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_documents.py`

## Privacy
This PR uses only generic reproduction details and test fixtures. It does not include logs, tokens, chat IDs from real chats, bot names, provider details, or local configuration paths.