### PR TITLE
feat: Add i18n / language selector support for TUI

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -597,6 +597,7 @@ DEFAULT_CONFIG = {
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
+        "language": "",  # UI language: "" (auto-detect), "en", "zh", "ja", "ko", "de", "es", "fr"
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1029,6 +1029,16 @@ def _launch_tui(resume_session_id: Optional[str] = None, tui_dev: bool = False):
     if resume_session_id:
         env["HERMES_TUI_RESUME"] = resume_session_id
 
+    # Set UI language from config
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        language = cfg.get("display", {}).get("language", "")
+        if language and language in ("en", "zh", "ja", "ko", "de", "es", "fr"):
+            env["HERMES_TUI_LANGUAGE"] = language
+    except Exception:
+        pass  # Fallback to auto-detection in TUI
+
     argv, cwd = _make_tui_argv(tui_dir, tui_dev)
     try:
         code = subprocess.call(argv, cwd=str(cwd), env=env)

--- a/ui-tui/locales/de.yaml
+++ b/ui-tui/locales/de.yaml
@@ -1,0 +1,37 @@
+# Deutsche Übersetzung for Hermes Agent TUI
+# German translations
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "Geben Sie Ihre Nachricht ein oder /help für Befehle."
+  goodbye: "Auf Wiedersehen！⚕"
+  help_header: "(^_^)? Befehle"
+
+# UI placeholders
+placeholders:
+  - "Fragen Sie mich Anything…"
+  - "Versuchen Sie \"Erklären Sie diese Codebasis\""
+  - "Versuchen Sie \"Schreiben Sie einen Test für…\""
+  - "Versuchen Sie \"Refactoring des Auth-Moduls\""
+  - "Versuchen Sie \"/help\" für Befehle"
+  - "Versuchen Sie \"Beheben Sie die Lint-Fehler\""
+  - "Versuchen Sie \"Wie funktioniert der Config-Loader?\""
+
+# Status messages
+status:
+  background_task_singular: "Hintergrundtask läuft"
+  background_task_plural: "Hintergroundtasks laufen"
+  interrupt: "Strg+C zum Unterbrechen…"
+
+# Language names (for language selector)
+language:
+  name: "Deutsch"
+  native_name: "Deutsch"
+  auto: "Systemsprache folgen"
+
+# Settings
+settings:
+  language: "Sprache"
+  appearance: "Erscheinungsbild"
+  theme: "Design"

--- a/ui-tui/locales/en.yaml
+++ b/ui-tui/locales/en.yaml
@@ -1,0 +1,37 @@
+# English translations for Hermes Agent TUI
+# This is the default language file
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "Type your message or /help for commands."
+  goodbye: "Goodbye! ⚕"
+  help_header: "(^_^)? Commands"
+
+# UI placeholders
+placeholders:
+  - "Ask me anything…"
+  - "Try \"explain this codebase\""
+  - "Try \"write a test for…\""
+  - "Try \"refactor the auth module\""
+  - "Try \"/help\" for commands"
+  - "Try \"fix the lint errors\""
+  - "Try \"how does the config loader work?\""
+
+# Status messages
+status:
+  background_task_singular: "background task running"
+  background_task_plural: "background tasks running"
+  interrupt: "Ctrl+C to interrupt…"
+
+# Language names (for language selector)
+language:
+  name: "English"
+  native_name: "English"
+  auto: "Follow system language"
+
+# Settings
+settings:
+  language: "Language"
+  appearance: "Appearance"
+  theme: "Theme"

--- a/ui-tui/locales/es.yaml
+++ b/ui-tui/locales/es.yaml
@@ -1,0 +1,37 @@
+# Traducción al español for Hermes Agent TUI
+# Spanish translations
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "Escribe tu mensaje o /help para ver comandos."
+  goodbye: "¡Adiós！⚕"
+  help_header: "(^_^)? Comandos"
+
+# UI placeholders
+placeholders:
+  - "Pregúntame cualquier cosa…"
+  - "Prueba \"explica este código\""
+  - "Prueba \"escribe una prueba para…\""
+  - "Prueba \"refactorizar el módulo de autenticación\""
+  - "Prueba \"/help\" para comandos"
+  - "Prueba \"corrige los errores de lint\""
+  - "Prueba \"¿cómo funciona el cargador de configuración?\""
+
+# Status messages
+status:
+  background_task_singular: "tarea en segundo plano ejecutándose"
+  background_task_plural: "tareas en segundo plano ejecutándose"
+  interrupt: "Ctrl+C para interrumpir…"
+
+# Language names (for language selector)
+language:
+  name: "Español"
+  native_name: "Español"
+  auto: "Seguir idioma del sistema"
+
+# Settings
+settings:
+  language: "Idioma"
+  appearance: "Apariencia"
+  theme: "Tema"

--- a/ui-tui/locales/fr.yaml
+++ b/ui-tui/locales/fr.yaml
@@ -1,0 +1,37 @@
+# Traduction française for Hermes Agent TUI
+# French translations
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "Tapez votre message ou /help pour les commandes."
+  goodbye: "Au revoir！⚕"
+  help_header: "(^_^)? Commandes"
+
+# UI placeholders
+placeholders:
+  - "Posez-moi n'importe quelle question…"
+  - "Essayez \"expliquer ce code\""
+  - "Essayez \"écrire un test pour…\""
+  - "Essayez \"refactoriser le module d'authentification\""
+  - "Essayez \"/help\" pour les commandes"
+  - "Essayez \"corriger les erreurs de lint\""
+  - "Essayez \"comment fonctionne le chargeur de configuration ?\""
+
+# Status messages
+status:
+  background_task_singular: "tâche en arrière-plan en cours d'exécution"
+  background_task_plural: "tâches en arrière-plan en cours d'exécution"
+  interrupt: "Ctrl+C pour interrompre…"
+
+# Language names (for language selector)
+language:
+  name: "Français"
+  native_name: "Français"
+  auto: "Suivre la langue du système"
+
+# Settings
+settings:
+  language: "Langue"
+  appearance: "Apparence"
+  theme: "Thème"

--- a/ui-tui/locales/ja.yaml
+++ b/ui-tui/locales/ja.yaml
@@ -1,0 +1,37 @@
+# 日本語翻訳 for Hermes Agent TUI
+# Japanese translations
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "メッセージを入力するか /help でコマンドを表示"
+  goodbye: "さようなら！⚕"
+  help_header: "(^_^)? コマンド"
+
+# UI placeholders
+placeholders:
+  - "何でも聞いて…"
+  - "「このコードベースを説明」と入力してみて"
+  - "「…のテストを書く」と入力してみて"
+  - "「認証モジュールをリファクタリング」と入力してみて"
+  - "「/help」でコマンドを表示"
+  - "「lint エラーを修正」と入力してみて"
+  - "「設定ローダーはどのように動作しますか？」と入力してみて"
+
+# Status messages
+status:
+  background_task_singular: "つのバックグラウンドタスクが実行中"
+  background_task_plural: "つのバックグラウンドタスクが実行中"
+  interrupt: "Ctrl+C で中断…"
+
+# Language names (for language selector)
+language:
+  name: "日本語"
+  native_name: "日本語"
+  auto: "システム言語に従う"
+
+# Settings
+settings:
+  language: "言語"
+  appearance: "外観"
+  theme: "テーマ"

--- a/ui-tui/locales/ko.yaml
+++ b/ui-tui/locales/ko.yaml
@@ -1,0 +1,37 @@
+# 한국어 번역 for Hermes Agent TUI
+# Korean translations
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "메시지를 입력하거나 /help로 명령어를 확인하세요."
+  goodbye: "안녕히 가세요！⚕"
+  help_header: "(^_^)? 명령어"
+
+# UI placeholders
+placeholders:
+  - "무엇이든 물어보세요…"
+  - "\"이 코드베이스를 설명해\" 시도"
+  - "\"…에 대한 테스트 작성\" 시도"
+  - "\"인증 모듈 리팩토링\" 시도"
+  - "명령어는 \"/help\" 시도"
+  - "\"lint 오류 수정\" 시도"
+  - "\"구성 로더는 어떻게 작동하나요?\" 시도"
+
+# Status messages
+status:
+  background_task_singular: "개의 백그라운드 작업 실행 중"
+  background_task_plural: "개의 백그라운드 작업 실행 중"
+  interrupt: "중단하려면 Ctrl+C…"
+
+# Language names (for language selector)
+language:
+  name: "한국어"
+  native_name: "한국어"
+  auto: "시스템 언어 따르기"
+
+# Settings
+settings:
+  language: "언어"
+  appearance: "모양"
+  theme: "테마"

--- a/ui-tui/locales/zh.yaml
+++ b/ui-tui/locales/zh.yaml
@@ -1,0 +1,37 @@
+# 简体中文翻译 for Hermes Agent TUI
+# Simplified Chinese translations
+
+# Brand strings
+brand:
+  name: "Hermes Agent"
+  welcome: "输入您的消息或输入 /help 查看命令。"
+  goodbye: "再见！⚕"
+  help_header: "(^_^)? 命令"
+
+# UI placeholders
+placeholders:
+  - "问我任何问题…"
+  - "试试 \"解释这个代码库\""
+  - "试试 \"为…编写测试\""
+  - "试试 \"重构认证模块\""
+  - "试试 \"/help\" 查看命令"
+  - "试试 \"修复 lint 错误\""
+  - "试试 \"配置加载器是如何工作的？\""
+
+# Status messages
+status:
+  background_task_singular: "个后台任务正在运行"
+  background_task_plural: "个后台任务正在运行"
+  interrupt: "按 Ctrl+C 中断…"
+
+# Language names (for language selector)
+language:
+  name: "简体中文"
+  native_name: "简体中文"
+  auto: "跟随系统语言"
+
+# Settings
+settings:
+  language: "语言"
+  appearance: "外观"
+  theme: "主题"

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -9,6 +9,7 @@ import { $uiState } from '../app/uiStore.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import type { Theme } from '../theme.js'
 import type { DetailsMode } from '../types.js'
+import { t, getBackgroundTaskText } from '../lib/i18n.js'
 
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
@@ -169,7 +170,7 @@ const ComposerPane = memo(function ComposerPane({
 
       {ui.bgTasks.size > 0 && (
         <Text color={ui.theme.color.dim}>
-          {ui.bgTasks.size} background {ui.bgTasks.size === 1 ? 'task' : 'tasks'} running
+          {getBackgroundTaskText(ui.bgTasks.size)}
         </Text>
       )}
 
@@ -224,7 +225,7 @@ const ComposerPane = memo(function ComposerPane({
                 onChange={composer.updateInput}
                 onPaste={composer.handleTextPaste}
                 onSubmit={composer.submit}
-                placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                placeholder={composer.empty ? PLACEHOLDER : ui.busy ? t('status.interrupt', 'Ctrl+C to interrupt…') : ''}
                 value={composer.input}
               />
 

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,3 +1,4 @@
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
 export const MOUSE_TRACKING = !/^(?:1|true|yes|on)$/i.test((process.env.HERMES_TUI_DISABLE_MOUSE ?? '').trim())
 export const NO_CONFIRM_DESTRUCTIVE = /^(?:1|true|yes|on)$/i.test((process.env.HERMES_TUI_NO_CONFIRM ?? '').trim())
+export const UI_LANGUAGE = (process.env.HERMES_TUI_LANGUAGE ?? '').trim()

--- a/ui-tui/src/content/placeholders.ts
+++ b/ui-tui/src/content/placeholders.ts
@@ -1,13 +1,3 @@
-import { pick } from '../lib/text.js'
+import { getPlaceholder } from '../lib/i18n.js'
 
-export const PLACEHOLDERS = [
-  'Ask me anything…',
-  'Try "explain this codebase"',
-  'Try "write a test for…"',
-  'Try "refactor the auth module"',
-  'Try "/help" for commands',
-  'Try "fix the lint errors"',
-  'Try "how does the config loader work?"'
-]
-
-export const PLACEHOLDER = pick(PLACEHOLDERS)
+export const PLACEHOLDER = getPlaceholder()

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -3,6 +3,18 @@ import { GatewayClient } from './gatewayClient.js'
 import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
 import { type MemorySnapshot, startMemoryMonitor } from './lib/memoryMonitor.js'
+import { UI_LANGUAGE } from './config/env.js'
+
+// Initialize i18n and branding system early
+import { initI18nAndBranding, type LanguageCode } from './lib/branding.js'
+
+// Determine language: env var > auto-detect
+const language: LanguageCode = (
+  UI_LANGUAGE && ['en', 'zh', 'ja', 'ko', 'de', 'es', 'fr'].includes(UI_LANGUAGE)
+    ? UI_LANGUAGE as LanguageCode
+    : undefined
+)
+initI18nAndBranding(language)
 
 if (!process.stdin.isTTY) {
   console.log('hermes-tui: no TTY')

--- a/ui-tui/src/lib/branding.ts
+++ b/ui-tui/src/lib/branding.ts
@@ -1,0 +1,77 @@
+/**
+ * Branding module that integrates with i18n
+ * This module must be imported after i18n is initialized
+ */
+
+import { initLocalizedBrand, type ThemeBrand } from '../theme.js'
+import { t, getCurrentLocale, setLocale, type LanguageCode, initI18n } from './i18n.js'
+import { getSystemLocaleLanguage } from '@hermes/ink/utils/intl'
+
+/**
+ * Get localized brand information
+ */
+export function getLocalizedBrand(): ThemeBrand {
+  return {
+    name: t('brand.name', 'Hermes Agent'),
+    icon: '⚕',
+    prompt: '❯',
+    welcome: t('brand.welcome', 'Type your message or /help for commands.'),
+    goodbye: t('brand.goodbye', 'Goodbye! ⚕'),
+    tool: '┊',
+    helpHeader: t('brand.help_header', '(^_^)? Commands')
+  }
+}
+
+/**
+ * Initialize i18n and branding system
+ * @param locale Optional locale code to force (auto-detects if not provided)
+ */
+export function initI18nAndBranding(locale?: LanguageCode): void {
+  // Initialize i18n
+  initI18n(locale)
+
+  // Register localized brand getter with theme system
+  initLocalizedBrand(getLocalizedBrand)
+}
+
+/**
+ * Set language and reload branding
+ */
+export function setLanguage(locale: LanguageCode): void {
+  setLocale(locale)
+  initLocalizedBrand(getLocalizedBrand)
+}
+
+/**
+ * Get current language code
+ */
+export function getCurrentLanguage(): LanguageCode {
+  return getCurrentLocale()
+}
+
+/**
+ * Detect system language
+ */
+export function detectSystemLanguage(): LanguageCode {
+  const systemLang = getSystemLocaleLanguage()
+
+  if (!systemLang) {
+    return 'en'
+  }
+
+  // Map common locale codes to our supported languages
+  const localeMap: Record<string, LanguageCode> = {
+    'zh': 'zh',
+    'ja': 'ja',
+    'ko': 'ko',
+    'de': 'de',
+    'es': 'es',
+    'fr': 'fr',
+  }
+
+  // Extract the language code (e.g., 'zh' from 'zh-Hans-CN')
+  const langCode = systemLang.split('-')[0]!
+  return localeMap[langCode] || 'en'
+}
+
+export * from './i18n.js'

--- a/ui-tui/src/lib/i18n.ts
+++ b/ui-tui/src/lib/i18n.ts
@@ -1,0 +1,319 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+import { getSystemLocaleLanguage } from '@hermes/ink/utils/intl'
+
+// Type definitions for translation structure
+export interface Translations {
+  brand: {
+    name: string
+    welcome: string
+    goodbye: string
+    help_header: string
+  }
+  placeholders: string[]
+  status: {
+    background_task_singular: string
+    background_task_plural: string
+    interrupt: string
+  }
+  language: {
+    name: string
+    native_name: string
+    auto: string
+  }
+  settings: {
+    language: string
+    appearance: string
+    theme: string
+  }
+}
+
+// Supported languages
+export const SUPPORTED_LANGUAGES = [
+  { code: 'en', name: 'English', native_name: 'English' },
+  { code: 'zh', name: 'Simplified Chinese', native_name: '简体中文' },
+  { code: 'ja', name: 'Japanese', native_name: '日本語' },
+  { code: 'ko', name: 'Korean', native_name: '한국어' },
+  { code: 'de', name: 'German', native_name: 'Deutsch' },
+  { code: 'es', name: 'Spanish', native_name: 'Español' },
+  { code: 'fr', name: 'French', native_name: 'Français' },
+] as const
+
+export type LanguageCode = typeof SUPPORTED_LANGUAGES[number]['code']
+
+// Locale cache
+let currentLocale: LanguageCode = 'en'
+let translations: Translations | null = null
+
+/**
+ * Get the locales directory path
+ */
+function getLocalesDir(): string {
+  // In development/build context, locales are in ui-tui/locales
+  // In production, they might be bundled elsewhere
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = join(__filename, '..')
+  return join(__dirname, '..', '..', 'locales')
+}
+
+/**
+ * Load translations from a YAML file
+ */
+function loadTranslations(locale: LanguageCode): Translations {
+  const localesDir = getLocalesDir()
+  const filePath = join(localesDir, `${locale}.yaml`)
+
+  try {
+    const content = readFileSync(filePath, 'utf-8')
+    return parseYaml(content)
+  } catch (error) {
+    console.warn(`Failed to load translations for ${locale}, falling back to en`)
+    // Fallback to English if the requested locale is not available
+    if (locale !== 'en') {
+      return loadTranslations('en')
+    }
+    // Return minimal translations if even English fails
+    return {
+      brand: {
+        name: 'Hermes Agent',
+        welcome: 'Type your message or /help for commands.',
+        goodbye: 'Goodbye! ⚕',
+        help_header: '(^_^)? Commands',
+      },
+      placeholders: [
+        'Ask me anything…',
+        'Try "explain this codebase"',
+        'Try "write a test for…"',
+        'Try "refactor the auth module"',
+        'Try "/help" for commands',
+        'Try "fix the lint errors"',
+        'Try "how does the config loader work?"',
+      ],
+      status: {
+        background_task_singular: 'background task running',
+        background_task_plural: 'background tasks running',
+        interrupt: 'Ctrl+C to interrupt…',
+      },
+      language: {
+        name: 'English',
+        native_name: 'English',
+        auto: 'Follow system language',
+      },
+      settings: {
+        language: 'Language',
+        appearance: 'Appearance',
+        theme: 'Theme',
+      },
+    }
+  }
+}
+
+/**
+ * Simple YAML parser for our translation files
+ * This is a minimal parser that handles the structure we need
+ */
+function parseYaml(content: string): Translations {
+  const result: any = {}
+  const lines = content.split('\n')
+  let stack: Array<{ obj: any; indent: number }> = [{ obj: result, indent: -1 }]
+
+  for (const line of lines) {
+    // Skip comments and empty lines
+    if (line.trim().startsWith('#') || line.trim() === '') {
+      continue
+    }
+
+    const indent = line.search(/\S/)
+    const trimmed = line.trim()
+
+    // Pop stack to the correct level
+    while (stack.length > 1 && stack[stack.length - 1]!.indent >= indent) {
+      stack.pop()
+    }
+
+    const current = stack[stack.length - 1]!.obj
+
+    // Check for array items
+    const arrayMatch = trimmed.match(/^-\s*(.+)$/)
+    if (arrayMatch) {
+      if (!Array.isArray(current)) {
+        // Parent should have been an array
+        const parent = stack[stack.length - 2]!.obj
+        const lastKey = Object.keys(parent).pop()
+        if (lastKey) {
+          parent[lastKey] = []
+          stack[stack.length - 1]!.obj = parent[lastKey]
+        }
+      }
+      if (Array.isArray(current)) {
+        const value = parseValue(arrayMatch[1]!)
+        current.push(value)
+      }
+      continue
+    }
+
+    // Check for key-value pair
+    const kvMatch = trimmed.match(/^([^:]+):\s*(.*)$/)
+    if (kvMatch) {
+      const key = kvMatch[1]!
+      const valueStr = kvMatch[2]!
+      const value = valueStr === '' ? {} : parseValue(valueStr)
+
+      // If current is an array, we're setting properties on array items
+      // which shouldn't happen in our format
+      if (Array.isArray(current)) {
+        continue
+      }
+
+      current[key] = value
+
+      // If the value is an object (empty string), push to stack for nested properties
+      if (valueStr === '') {
+        stack.push({ obj: current[key], indent })
+      }
+    }
+  }
+
+  return result as Translations
+}
+
+/**
+ * Parse a YAML value (string, number, boolean)
+ */
+function parseValue(str: string): string | number | boolean {
+  str = str.trim()
+
+  // Remove quotes if present
+  if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
+    return str.slice(1, -1)
+  }
+
+  // Check for boolean
+  if (str === 'true') return true
+  if (str === 'false') return false
+
+  // Check for number
+  const num = Number(str)
+  if (!isNaN(num)) {
+    return num
+  }
+
+  // Return as string
+  return str
+}
+
+/**
+ * Detect system locale and map to supported language code
+ */
+function detectSystemLocale(): LanguageCode {
+  const systemLang = getSystemLocaleLanguage()
+
+  if (!systemLang) {
+    return 'en'
+  }
+
+  // Map common locale codes to our supported languages
+  const localeMap: Record<string, LanguageCode> = {
+    'zh': 'zh',
+    'ja': 'ja',
+    'ko': 'ko',
+    'de': 'de',
+    'es': 'es',
+    'fr': 'fr',
+  }
+
+  // Extract the language code (e.g., 'zh' from 'zh-Hans-CN')
+  const langCode = systemLang.split('-')[0]!
+  return localeMap[langCode] || 'en'
+}
+
+/**
+ * Initialize the i18n system with the given locale or auto-detect
+ */
+export function initI18n(locale?: LanguageCode): void {
+  const resolvedLocale = locale || detectSystemLocale()
+  currentLocale = resolvedLocale
+  translations = loadTranslations(currentLocale)
+}
+
+/**
+ * Get the current locale code
+ */
+export function getCurrentLocale(): LanguageCode {
+  return currentLocale
+}
+
+/**
+ * Set the current locale and reload translations
+ */
+export function setLocale(locale: LanguageCode): void {
+  if (!SUPPORTED_LANGUAGES.some(lang => lang.code === locale)) {
+    console.warn(`Unsupported locale: ${locale}, falling back to en`)
+    locale = 'en'
+  }
+  currentLocale = locale
+  translations = loadTranslations(currentLocale)
+}
+
+/**
+ * Get a translation value by path
+ * @example t('brand.welcome')
+ */
+export function t(path: string, fallback?: string): string {
+  if (!translations) {
+    initI18n()
+  }
+
+  const keys = path.split('.')
+  let value: any = translations
+
+  for (const key of keys) {
+    if (value && typeof value === 'object' && key in value) {
+      value = value[key]
+    } else {
+      return fallback || path
+    }
+  }
+
+  return typeof value === 'string' ? value : fallback || path
+}
+
+/**
+ * Get a random placeholder from the placeholders list
+ */
+export function getPlaceholder(): string {
+  if (!translations) {
+    initI18n()
+  }
+
+  const placeholders = translations?.placeholders || []
+  return placeholders[Math.floor(Math.random() * placeholders.length)] || 'Ask me anything…'
+}
+
+/**
+ * Get pluralized text for background tasks
+ */
+export function getBackgroundTaskText(count: number): string {
+  if (!translations) {
+    initI18n()
+  }
+
+  if (count === 1) {
+    return `${count} ${t('status.background_task_singular')}`
+  } else {
+    return `${count} ${t('status.background_task_plural')}`
+  }
+}
+
+/**
+ * Get all supported languages
+ */
+export function getSupportedLanguages(): typeof SUPPORTED_LANGUAGES {
+  return SUPPORTED_LANGUAGES
+}
+
+/**
+ * Export initialization for use in app
+ */
+export { getSystemLocaleLanguage }

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -78,7 +78,7 @@ function mix(a: string, b: string, t: number) {
 
 // ── Defaults ─────────────────────────────────────────────────────────
 
-const BRAND: ThemeBrand = {
+const DEFAULT_BRAND: ThemeBrand = {
   name: 'Hermes Agent',
   icon: '⚕',
   prompt: '❯',
@@ -87,6 +87,20 @@ const BRAND: ThemeBrand = {
   tool: '┊',
   helpHeader: '(^_^)? Commands'
 }
+
+// Get localized brand information (imported dynamically to avoid circular deps)
+let getLocalizedBrand: (() => ThemeBrand) | null = null
+
+export function initLocalizedBrand(getter: () => ThemeBrand) {
+  getLocalizedBrand = getter
+}
+
+function getBrand(): ThemeBrand {
+  return getLocalizedBrand ? getLocalizedBrand() : DEFAULT_BRAND
+}
+
+// Backwards compatible export
+export const BRAND = DEFAULT_BRAND
 
 export const DARK_THEME: Theme = {
   color: {
@@ -130,7 +144,7 @@ export const DARK_THEME: Theme = {
     shellDollar: '#4dabf7'
   },
 
-  brand: BRAND,
+  brand: getBrand(),
 
   bannerLogo: '',
   bannerHero: ''
@@ -173,7 +187,7 @@ export const LIGHT_THEME: Theme = {
     shellDollar: '#1565C0'
   },
 
-  brand: BRAND,
+  brand: getBrand(),
 
   bannerLogo: '',
   bannerHero: ''
@@ -255,10 +269,10 @@ export function fromSkin(
       name: branding.agent_name ?? d.brand.name,
       icon: d.brand.icon,
       prompt: branding.prompt_symbol ?? d.brand.prompt,
-      welcome: branding.welcome ?? d.brand.welcome,
-      goodbye: branding.goodbye ?? d.brand.goodbye,
+      welcome: branding.welcome ?? getBrand().welcome,
+      goodbye: branding.goodbye ?? getBrand().goodbye,
       tool: toolPrefix || d.brand.tool,
-      helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader)
+      helpHeader: branding.help_header ?? (helpHeader || getBrand().helpHeader)
     },
 
     bannerLogo,


### PR DESCRIPTION
## What does this PR do?

This PR adds internationalization (i18n) support to the Hermes Agent TUI, addressing issue #37897. The TUI currently has hardcoded English text, but now supports multiple languages with automatic system language detection and manual override options.

## Related Issue

Fixes #37897

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

### Core i18n System
- ui-tui/src/lib/i18n.ts: New i18n module with translation loading, language detection, and utility functions
- ui-tui/src/lib/branding.ts: Integration module that connects i18n with the theme system
- ui-tui/locales/*.yaml: Translation files for 7 languages (en, zh, ja, ko, de, es, fr)

### Configuration
- hermes_cli/config.py: Added display.language config option
- hermes_cli/main.py: Read language config and pass to TUI via HERMES_TUI_LANGUAGE env var
- ui-tui/src/config/env.ts: Read HERMES_TUI_LANGUAGE environment variable

### UI Components
- ui-tui/src/theme.ts: Modified to support localized brand strings
- ui-tui/src/content/placeholders.ts: Use i18n for placeholder text
- ui-tui/src/components/appLayout.tsx: Use localized status messages
- ui-tui/src/entry.tsx: Initialize i18n system on startup

## How to Test

1. Auto-detection: Run TUI without config
2. Manual selection: Set display.language in config.yaml
3. Environment override: HERMES_TUI_LANGUAGE=ja hermes --tui
