### PR TITLE
fix(tools): send listItemId instead of sessionKey in Camofox tab creation

### DIFF
--- a/tests/tools/test_browser_camofox_ensure_tab.py
+++ b/tests/tools/test_browser_camofox_ensure_tab.py
@@ -1,0 +1,66 @@
+"""Regression test: _ensure_tab must send ``listItemId`` (not ``sessionKey``).
+
+The Camoufox REST API server requires ``listItemId`` in the ``POST /tabs``
+body.  A previous version sent ``sessionKey`` which caused a 400 Bad Request
+on every ``browser_navigate`` call.  See issue #37960.
+"""
+
+from unittest.mock import patch, MagicMock
+
+
+def test_ensure_tab_sends_list_item_id():
+    """POST /tabs body must contain ``listItemId``, not ``sessionKey``."""
+    # Import the module under test
+    from tools import browser_camofox as mod
+
+    fake_session = {
+        "user_id": "hermes_test123",
+        "tab_id": None,
+        "session_key": "task_my-session",
+        "managed": False,
+        "adopt_existing_tab": False,
+    }
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"tabId": "tab-42"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(mod, "_get_session", return_value=fake_session), \
+         patch.object(mod, "get_camofox_url", return_value="http://localhost:9377"), \
+         patch("tools.browser_camofox.requests.post", return_value=mock_response) as mock_post:
+        result = mod._ensure_tab("test-task", url="https://example.com")
+
+    # Verify the POST was called
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+
+    # Core assertion: listItemId present, sessionKey absent
+    assert "listItemId" in body, f"Expected 'listItemId' in POST body, got: {body}"
+    assert "sessionKey" not in body, f"'sessionKey' should not be in POST body: {body}"
+    assert body["listItemId"] == "task_my-session"
+    assert body["userId"] == "hermes_test123"
+    assert body["url"] == "https://example.com"
+
+    # Verify tab_id was set from response
+    assert result["tab_id"] == "tab-42"
+
+
+def test_ensure_tab_skips_creation_when_tab_exists():
+    """If session already has a tab_id, no POST should be made."""
+    from tools import browser_camofox as mod
+
+    fake_session = {
+        "user_id": "hermes_test123",
+        "tab_id": "existing-tab",
+        "session_key": "task_my-session",
+        "managed": False,
+    }
+
+    with patch.object(mod, "_get_session", return_value=fake_session), \
+         patch("tools.browser_camofox.requests.post") as mock_post:
+        result = mod._ensure_tab("test-task")
+
+    # No POST should be made — tab already exists
+    mock_post.assert_not_called()
+    assert result["tab_id"] == "existing-tab"

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -345,7 +345,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
         f"{base}/tabs",
         json={
             "userId": session["user_id"],
-            "sessionKey": session["session_key"],
+            "listItemId": session["session_key"],
             "url": url,
         },
         timeout=_DEFAULT_TIMEOUT,


### PR DESCRIPTION
## What does this PR do?

Fixes the Camoufox tab creation endpoint parameter name: `_ensure_tab` was sending `sessionKey` in the `POST /tabs` body, but the Camoufox REST API server expects `listItemId`. This caused a 400 Bad Request on every `browser_navigate` call when no existing tab was found.

## Related Issue

Fixes #37960

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_camofox.py`: Changed `sessionKey` to `listItemId` in `_ensure_tab()` POST body (line 348). The server-side field name is confirmed by the same file's `_adopt_existing_tab()` which reads `tab.get("listItemId")` at line 283.
- `tests/tools/test_browser_camofox_ensure_tab.py`: Added regression test verifying `_ensure_tab` sends `listItemId` (not `sessionKey`) and correctly skips POST when a tab already exists.

## How to Test

1. Start a Camofox server: `npm start` in the camofox-browser repo
2. Set `CAMOFOX_URL=http://localhost:9377` in `~/.hermes/.env`
3. Run `browser_navigate` — should create a tab successfully (no 400 error)
4. Run `pytest tests/tools/test_browser_camofox_ensure_tab.py -v` — both tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/browser_camofox.py:_ensure_tab` (single POST call site, no upstream callers outside browser module)
- Blast radius: LOW — single parameter rename in one function, no API/schema change
- Related patterns: `_adopt_existing_tab` at line 283 already uses `listItemId` for tab matching, confirming the server-side convention
