### PR TITLE
fix(desktop): stop background session messages bleeding into the active transcript

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -95,6 +95,19 @@ export function useSessionStateCache({
 
   const syncSessionStateToView = useCallback(
     (sessionId: string, state: ClientSessionState) => {
+      // Only the currently-viewed session may stage into the shared `$messages`
+      // view. A background session (e.g. one still busy and emitting stream /
+      // error updates after the user toggled away) must update its own cache
+      // entry but never the view — otherwise its messages clobber the
+      // foreground transcript and appear to "bleed" into every other session.
+      // The flush below also re-checks the active id, but staging here is what
+      // prevents a background write from overwriting an already-pending
+      // foreground write within the same animation frame (only one RAF is
+      // scheduled, so the last `pendingViewStateRef` writer would otherwise win).
+      if (sessionId !== activeSessionIdRef.current) {
+        return
+      }
+
       pendingViewStateRef.current = { sessionId, state }
 
       if (viewSyncRafRef.current !== null) {


### PR DESCRIPTION
## Summary

On the desktop app, a failed/queued turn from one session renders on top of **every other session you toggle to**. The screenshot symptom is stale user bubbles (e.g. `the code is in the repo itself in: /apps`, `test`) each followed by a red **"session busy"** error, persisting into unrelated sessions.

## Root cause

The messages are real, correctly-keyed transcript entries belonging to **one** session (verified against `Local Storage` + `state.db` — the data layer is *not* bleeding). The bleed is in the **render path**.

A still-busy background session (the one the user toggled away from) keeps emitting `updateSessionState()` heartbeats — stream deltas, and especially the `session busy` `prompt.submit` rejection errors produced when a queued turn auto-drains while the backend is still busy. Each `updateSessionState()` called `syncSessionStateToView()` **unconditionally**, staging that background session's messages into the shared `$messages` view.

`flushPendingViewState()` does guard against the wrong session reaching the view — **but** only one `requestAnimationFrame` is scheduled per frame and `pendingViewStateRef` holds just the latest writer. So within a single frame a background write can overwrite an already-pending **foreground** write, and the stale background transcript renders on top of whatever session the user switched to.

## Fix

Guard at the staging site (`syncSessionStateToView`): a session may only stage into `$messages` when it is the **currently-active** session. Background sessions still update their own cache entry (`sessionStateByRuntimeIdRef`); they just never touch the view. This mirrors the existing `flushPendingViewState` active-id check, moved earlier so a background write can't displace a pending foreground write within the same RAF window.

Pure render fix — **no behavior change** to queuing, interrupt/Stop (#37948), or drain. The active session's optimistic seeds and updates still reach the view because `activeSessionIdRef.current` is set to the runtime id before its `updateSessionState` calls run (create/resume paths).

## Test plan

- `tsc -b` clean.
- Manual repro: session A busy + a queued turn that errors with `session busy` → toggle to session B → before: A's rows render over B; after: B shows only its own transcript, A's rows stay in A.

Local vitest jsdom suite is environment-broken in this checkout (`window.localStorage.clear is not a function` on node 25, fails identically on clean main), so relying on CI for the suite.