### PR TITLE
fix(plugins): require renewed review before plugin updates

### DIFF
--- a/contributors/emails/local-reporter@example.com
+++ b/contributors/emails/local-reporter@example.com
@@ -1,0 +1,2 @@
+coygeek
+# PR #37977 contributor attribution

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,11 +34,13 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.metadata
 import importlib.util
 import inspect
 import logging
 import os
+import subprocess
 import sys
 import threading
 import types
@@ -77,6 +79,53 @@ class PluginToolOverrideError(PermissionError):
 
 
 logger = logging.getLogger(__name__)
+
+
+def plugin_content_revision(path: Path) -> str:
+    """Return a stable revision for capability grants on a plugin tree.
+
+    Git plugins are bound to their exact commit.  Non-Git plugins fall back to
+    a deterministic hash of their executable/content files.  Mutable runtime
+    directories are excluded so caches cannot revoke an otherwise valid
+    operator grant.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        revision = result.stdout.strip()
+        if result.returncode == 0 and len(revision) == 40:
+            return revision
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    digest = hashlib.sha256()
+    ignored = {".git", "__pycache__", ".venv", "venv", "node_modules"}
+    for file_path in sorted(path.rglob("*")):
+        if any(part in ignored for part in file_path.parts):
+            continue
+        if file_path.is_symlink():
+            relative = file_path.relative_to(path).as_posix()
+            digest.update(relative.encode("utf-8"))
+            digest.update(b"\0link\0")
+            digest.update(os.readlink(file_path).encode("utf-8", errors="replace"))
+            digest.update(b"\0")
+            continue
+        if not file_path.is_file():
+            continue
+        relative = file_path.relative_to(path).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        try:
+            digest.update(file_path.read_bytes())
+        except OSError:
+            continue
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
 
 
 # ---------------------------------------------------------------------------
@@ -469,7 +518,21 @@ class PluginContext:
         plugin_id = self.manifest.key or self.manifest.name
         entries = (cfg.get("plugins") or {}).get("entries") or {}
         entry = entries.get(plugin_id) or {}
-        return bool(entry.get("allow_tool_override", False))
+        if not bool(entry.get("allow_tool_override", False)):
+            return False
+        approved_revision = entry.get("allow_tool_override_revision")
+        if not approved_revision or not self.manifest.path:
+            return False
+        current_revision = plugin_content_revision(Path(self.manifest.path))
+        if approved_revision != current_revision:
+            logger.warning(
+                "Plugin %s tool-override grant is stale: approved %s, current %s",
+                plugin_id,
+                approved_revision,
+                current_revision,
+            )
+            return False
+        return True
 
     # -- message injection --------------------------------------------------
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -10,6 +10,7 @@ rendered with Rich Markdown.  Otherwise a default confirmation is shown.
 from __future__ import annotations
 
 import functools
+import hashlib
 import importlib.metadata
 import json
 import logging
@@ -17,6 +18,8 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -633,54 +636,359 @@ def cmd_install(
     console.print()
 
 
+def _plugin_update_root() -> Path:
+    """Return the private quarantine root for staged plugin updates."""
+    root = get_hermes_home() / ".plugin-updates"
+    root.mkdir(parents=True, exist_ok=True)
+    try:
+        root.chmod(0o700)
+    except OSError:
+        pass
+    return root
+
+
+def _append_plugin_update_audit(action: str, fields: dict[str, Any]) -> None:
+    """Append one best-effort JSON audit event for a plugin update."""
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "action": action,
+        **fields,
+    }
+    try:
+        with (_plugin_update_root() / "audit.jsonl").open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")
+    except OSError as exc:
+        logger.warning("Could not append plugin update audit event: %s", exc)
+
+
+def _git_revision(path: Path) -> str:
+    """Read the exact Git commit checked out at *path*."""
+    git_exe = _resolve_git_executable()
+    if not git_exe:
+        raise PluginOperationError("git is not installed or not in PATH.")
+    result = subprocess.run(
+        [git_exe, "rev-parse", "HEAD"],
+        cwd=str(path),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    revision = result.stdout.strip()
+    if result.returncode != 0 or len(revision) != 40:
+        raise PluginOperationError((result.stderr or "Could not read plugin revision.").strip())
+    return revision
+
+
+def _git_changed_files(path: Path, old_revision: str, new_revision: str) -> list[str]:
+    git_exe = _resolve_git_executable()
+    if not git_exe:
+        return []
+    result = subprocess.run(
+        [git_exe, "diff", "--name-status", old_revision, new_revision],
+        cwd=str(path),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()][:200]
+
+
+def _plugin_update_scan(path: Path) -> list[dict[str, Any]]:
+    """Return diagnostic AST findings for changed plugin code review."""
+    try:
+        from tools.skills_ast_audit import ast_scan_path
+
+        return [
+            {"file": file_name, "line": line, "pattern": pattern, "description": description}
+            for file_name, line, pattern, description in ast_scan_path(path)[:100]
+        ]
+    except Exception as exc:
+        logger.warning("Plugin update diagnostic scan failed: %s", exc)
+        return [{"file": "", "line": 0, "pattern": "scan_error", "description": str(exc)}]
+
+
+def _plugin_override_granted(plugin_key: str) -> bool:
+    try:
+        from hermes_cli.config import load_config
+
+        entries = ((load_config().get("plugins") or {}).get("entries") or {})
+        return bool((entries.get(plugin_key) or {}).get("allow_tool_override", False))
+    except Exception:
+        return False
+
+
+def _plugin_tree_hash(path: Path) -> str:
+    """Hash the exact staged content, excluding Git/runtime cache internals."""
+    digest = hashlib.sha256()
+    ignored = {".git", "__pycache__", ".venv", "venv", "node_modules"}
+    for file_path in sorted(path.rglob("*")):
+        if any(part in ignored for part in file_path.parts):
+            continue
+        if file_path.is_symlink():
+            relative = file_path.relative_to(path).as_posix()
+            digest.update(relative.encode("utf-8"))
+            digest.update(b"\0link\0")
+            digest.update(os.readlink(file_path).encode("utf-8", errors="replace"))
+            digest.update(b"\0")
+            continue
+        if not file_path.is_file():
+            continue
+        relative = file_path.relative_to(path).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _stage_plugin_update(name: str, target: Path) -> dict[str, Any]:
+    """Fetch an update into quarantine without changing the live plugin tree."""
+    if not (target / ".git").exists():
+        raise PluginOperationError(
+            f"Plugin '{name}' was not installed from git (no .git directory). Cannot update."
+        )
+
+    old_revision = _git_revision(target)
+    root = _plugin_update_root()
+    work_dir = Path(tempfile.mkdtemp(prefix="stage-", dir=str(root)))
+    candidate = work_dir / "candidate"
+    try:
+        shutil.copytree(target, candidate, symlinks=True)
+        ok, output = _git_pull_plugin_dir(candidate)
+        if not ok:
+            raise PluginOperationError(output)
+        new_revision = _git_revision(candidate)
+        if new_revision == old_revision:
+            shutil.rmtree(work_dir)
+            return {
+                "ok": True,
+                "name": name,
+                "output": output,
+                "unchanged": True,
+                "review_required": False,
+            }
+
+        old_manifest = _read_manifest(target)
+        new_manifest = _read_manifest(candidate)
+        old_name = str(old_manifest.get("name") or target.name)
+        new_name = str(new_manifest.get("name") or target.name)
+        if old_name != new_name:
+            raise PluginOperationError(
+                f"Plugin manifest name changed from '{old_name}' to '{new_name}'; refusing staged update."
+            )
+        manifest_version = new_manifest.get("manifest_version")
+        if manifest_version is not None:
+            try:
+                if int(manifest_version) > _SUPPORTED_MANIFEST_VERSION:
+                    raise PluginOperationError(
+                        f"Plugin '{new_name}' requires unsupported manifest_version {manifest_version}."
+                    )
+            except (TypeError, ValueError):
+                raise PluginOperationError(
+                    f"Plugin '{new_name}' has invalid manifest_version '{manifest_version}'."
+                ) from None
+
+        content_hash = _plugin_tree_hash(candidate)
+        live_hash = _plugin_tree_hash(target)
+        changed_files = _git_changed_files(candidate, old_revision, new_revision)
+        scan_findings = _plugin_update_scan(candidate)
+        canonical_key = _resolve_plugin_key(name) or name
+        enabled = canonical_key in _get_enabled_set() and canonical_key not in _get_disabled_set()
+        override_granted = _plugin_override_granted(canonical_key)
+        token = hashlib.sha256(
+            f"{canonical_key}\0{old_revision}\0{new_revision}\0{content_hash}".encode("utf-8")
+        ).hexdigest()
+        staged_path = root / token
+        metadata_path = root / f"{token}.json"
+        if staged_path.exists():
+            shutil.rmtree(staged_path)
+        candidate.rename(staged_path)
+        shutil.rmtree(work_dir)
+        metadata = {
+            "name": name,
+            "canonical_key": canonical_key,
+            "target": str(target.resolve()),
+            "old_revision": old_revision,
+            "old_hash": live_hash,
+            "candidate_revision": new_revision,
+            "candidate_hash": content_hash,
+            "changed_files": changed_files,
+            "scan_findings": scan_findings,
+            "was_enabled": enabled,
+            "tool_override_was_granted": override_granted,
+        }
+        metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+        _append_plugin_update_audit(
+            "STAGED",
+            {"plugin": canonical_key, "from": old_revision, "to": new_revision, "hash": content_hash},
+        )
+        return {
+            "ok": True,
+            "name": name,
+            "output": output,
+            "unchanged": False,
+            "review_required": True,
+            "review_token": token,
+            **{key: metadata[key] for key in (
+                "candidate_revision",
+                "candidate_hash",
+                "changed_files",
+                "scan_findings",
+                "was_enabled",
+                "tool_override_was_granted",
+            )},
+        }
+    except Exception:
+        if work_dir.exists():
+            shutil.rmtree(work_dir)
+        raise
+
+
+def _activate_staged_plugin_update(
+    name: str,
+    target: Path,
+    review_token: str,
+    *,
+    renew_tool_override: bool,
+) -> dict[str, Any]:
+    """Atomically promote a reviewed staged update into the live plugin path."""
+    if len(review_token) != 64 or any(ch not in "0123456789abcdef" for ch in review_token):
+        raise PluginOperationError("Invalid plugin update review token.")
+    root = _plugin_update_root()
+    staged_path = root / review_token
+    metadata_path = root / f"{review_token}.json"
+    if not staged_path.is_dir() or not metadata_path.is_file():
+        raise PluginOperationError("The staged plugin update no longer exists; review it again.")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if metadata.get("name") != name or metadata.get("target") != str(target.resolve()):
+        raise PluginOperationError("The staged plugin update does not match this plugin.")
+    if (
+        _git_revision(target) != metadata.get("old_revision")
+        or _plugin_tree_hash(target) != metadata.get("old_hash")
+    ):
+        raise PluginOperationError("The live plugin changed after review; review a fresh update.")
+    if _git_revision(staged_path) != metadata.get("candidate_revision"):
+        raise PluginOperationError("The staged plugin revision changed after review.")
+    if _plugin_tree_hash(staged_path) != metadata.get("candidate_hash"):
+        raise PluginOperationError("The staged plugin content changed after review.")
+
+    backup = root / f"backup-{review_token}"
+    if backup.exists():
+        shutil.rmtree(backup)
+    try:
+        target.rename(backup)
+        staged_path.rename(target)
+    except Exception:
+        if not target.exists() and backup.exists():
+            backup.rename(target)
+        raise
+
+    try:
+        from rich.console import Console
+
+        _copy_example_files(target, Console())
+        canonical_key = str(metadata.get("canonical_key") or name)
+        if metadata.get("tool_override_was_granted"):
+            _set_plugin_entry_flag(
+                canonical_key,
+                "allow_tool_override",
+                bool(renew_tool_override),
+            )
+        _append_plugin_update_audit(
+            "ACCEPTED",
+            {
+                "plugin": canonical_key,
+                "from": metadata["old_revision"],
+                "to": metadata["candidate_revision"],
+                "hash": metadata["candidate_hash"],
+                "tool_override_renewed": bool(
+                    metadata.get("tool_override_was_granted") and renew_tool_override
+                ),
+            },
+        )
+    except Exception:
+        if target.exists():
+            shutil.rmtree(target)
+        backup.rename(target)
+        raise
+    else:
+        shutil.rmtree(backup)
+        metadata_path.unlink(missing_ok=True)
+
+    return {
+        "ok": True,
+        "name": name,
+        "unchanged": False,
+        "review_required": False,
+        "accepted": True,
+        "candidate_revision": metadata["candidate_revision"],
+        "enabled_after_update": bool(metadata.get("was_enabled")),
+        "tool_override_renewed": bool(
+            metadata.get("tool_override_was_granted") and renew_tool_override
+        ),
+    }
+
+
 def cmd_update(name: str) -> None:
-    """Update an installed plugin by pulling latest from its git remote."""
+    """Stage, review, and explicitly accept a Git plugin update."""
     from rich.console import Console
 
     console = Console()
-    plugins_dir = _plugins_dir()
-
     try:
-        target = _require_installed_plugin(name, plugins_dir, console)
-    except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        target = _require_installed_plugin(name, _plugins_dir(), console)
+        result = _stage_plugin_update(name, target)
+    except (ValueError, PluginOperationError) as exc:
+        console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
-    if not (target / ".git").exists():
-        console.print(
-            f"[red]Error:[/red] Plugin '{name}' was not installed from git "
-            f"(no .git directory). Cannot update."
-        )
-        sys.exit(1)
+    if result.get("unchanged"):
+        console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date.")
+        return
 
-    console.print(f"[dim]Updating {name}...[/dim]")
-
-    ok, output = _git_pull_plugin_dir(target)
-    if not ok:
-        console.print(f"[red]Error:[/red] {output}")
-        sys.exit(1)
-
-    # Copy any new .example files
-    _copy_example_files(target, console)
-
-    out = output.strip()
-    if "Already up to date" in out:
-        console.print(
-            f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date."
-        )
-    else:
-        manifest = _read_manifest(target)
-        review_names = _plugin_review_names(name, target, manifest)
-        _prompt_plugin_env_vars(manifest, console)
-        _display_after_install(target, name)
-        disabled_for_review = _disable_enabled_plugin_names(review_names)
-        console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] updated.")
-        console.print(f"[dim]{out}[/dim]")
-        if disabled_for_review:
+    console.print(f"[yellow]Review required before updating {name}.[/yellow]")
+    console.print(f"  Candidate revision: [bold]{result['candidate_revision']}[/bold]")
+    console.print(f"  Content revision: [dim]{result['candidate_hash']}[/dim]")
+    for changed in result.get("changed_files") or []:
+        console.print(f"  {changed}")
+    findings = result.get("scan_findings") or []
+    if findings:
+        console.print(f"[yellow]Diagnostic scan findings: {len(findings)}[/yellow]")
+        for finding in findings:
             console.print(
-                "[yellow]Review required:[/yellow] Updated plugin content was "
-                "disabled until you explicitly enable it again."
+                f"  {finding['file']}:{finding['line']} {finding['pattern']} — "
+                f"{finding['description']}"
             )
+    _display_after_install(_plugin_update_root() / result["review_token"], name)
+    try:
+        answer = console.input("Accept and install this reviewed update? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        answer = ""
+    if answer not in {"y", "yes"}:
+        console.print("[dim]Update remains quarantined; the live plugin was not changed.[/dim]")
+        return
+
+    renew_override = False
+    if result.get("tool_override_was_granted"):
+        try:
+            answer = console.input(
+                "Renew permission for this revision to replace built-in tools? [y/N] "
+            ).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        renew_override = answer in {"y", "yes"}
+    accepted = _activate_staged_plugin_update(
+        name,
+        target,
+        result["review_token"],
+        renew_tool_override=renew_override,
+    )
+    _prompt_plugin_env_vars(_read_manifest(target), console)
+    console.print(
+        f"[green]✓[/green] Plugin [bold]{name}[/bold] updated to "
+        f"[bold]{accepted['candidate_revision']}[/bold]. Restart Hermes to load it."
+    )
 
 
 def cmd_remove(name: str) -> None:
@@ -845,7 +1153,25 @@ def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
         entry = {}
         entries[plugin_id] = entry
     entry[key] = bool(value)
+    if key == "allow_tool_override":
+        if value:
+            revision = _installed_plugin_revision(plugin_id)
+            if revision:
+                entry["allow_tool_override_revision"] = revision
+        else:
+            entry.pop("allow_tool_override_revision", None)
     save_config(config)
+
+
+def _installed_plugin_revision(plugin_id: str) -> Optional[str]:
+    """Return the content revision for a discovered plugin key/name."""
+    from hermes_cli.plugins import plugin_content_revision
+
+    for entry in _discover_all_plugins():
+        # entry = (name, version, description, source, dir_path, key)
+        if plugin_id in {entry[0], entry[5]}:
+            return plugin_content_revision(Path(entry[4]))
+    return None
 
 
 def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
@@ -1945,8 +2271,13 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
     return target if target.is_dir() else None
 
 
-def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
-    """``git pull`` inside ``~/.hermes/plugins/<name>``."""
+def dashboard_update_user_plugin(
+    name: str,
+    *,
+    review_token: Optional[str] = None,
+    renew_tool_override: bool = False,
+) -> dict[str, Any]:
+    """Stage an update, or accept an exact revision after dashboard review."""
     target = _user_installed_plugin_dir(name)
     if target is None:
         return {
@@ -1960,29 +2291,17 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
         }
 
-    ok, msg = _git_pull_plugin_dir(target)
-    if not ok:
-        return {"ok": False, "error": msg}
-
-    from rich.console import Console
-
-    _copy_example_files(target, Console())
-    unchanged = "Already up to date" in msg
-    review_required = False
-    enabled_after_update = name in _get_enabled_set() and name not in _get_disabled_set()
-    if not unchanged:
-        manifest = _read_manifest(target)
-        review_names = _plugin_review_names(name, target, manifest)
-        review_required = _disable_enabled_plugin_names(review_names)
-        enabled_after_update = not review_required
-    return {
-        "ok": True,
-        "name": name,
-        "output": msg,
-        "unchanged": unchanged,
-        "review_required": review_required,
-        "enabled_after_update": enabled_after_update,
-    }
+    try:
+        if review_token:
+            return _activate_staged_plugin_update(
+                name,
+                target,
+                review_token,
+                renew_tool_override=renew_tool_override,
+            )
+        return _stage_plugin_update(name, target)
+    except (PluginOperationError, OSError, ValueError, json.JSONDecodeError) as exc:
+        return {"ok": False, "error": str(exc)}
 
 
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -669,8 +669,18 @@ def cmd_update(name: str) -> None:
             f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date."
         )
     else:
+        manifest = _read_manifest(target)
+        review_names = _plugin_review_names(name, target, manifest)
+        _prompt_plugin_env_vars(manifest, console)
+        _display_after_install(target, name)
+        disabled_for_review = _disable_enabled_plugin_names(review_names)
         console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] updated.")
         console.print(f"[dim]{out}[/dim]")
+        if disabled_for_review:
+            console.print(
+                "[yellow]Review required:[/yellow] Updated plugin content was "
+                "disabled until you explicitly enable it again."
+            )
 
 
 def cmd_remove(name: str) -> None:
@@ -1958,7 +1968,21 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
 
     _copy_example_files(target, Console())
     unchanged = "Already up to date" in msg
-    return {"ok": True, "name": name, "output": msg, "unchanged": unchanged}
+    review_required = False
+    enabled_after_update = name in _get_enabled_set() and name not in _get_disabled_set()
+    if not unchanged:
+        manifest = _read_manifest(target)
+        review_names = _plugin_review_names(name, target, manifest)
+        review_required = _disable_enabled_plugin_names(review_names)
+        enabled_after_update = not review_required
+    return {
+        "ok": True,
+        "name": name,
+        "output": msg,
+        "unchanged": unchanged,
+        "review_required": review_required,
+        "enabled_after_update": enabled_after_update,
+    }
 
 
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18569,6 +18569,11 @@ class _AgentPluginInstallBody(BaseModel):
     enable: bool = True
 
 
+class _AgentPluginUpdateBody(BaseModel):
+    review_token: Optional[str] = None
+    renew_tool_override: bool = False
+
+
 def _strip_dashboard_manifest(p: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in p.items() if not k.startswith("_")}
 
@@ -18753,12 +18758,20 @@ async def post_agent_plugin_disable(request: Request, name: str):
 
 
 @app.post("/api/dashboard/agent-plugins/{name:path}/update")
-async def post_agent_plugin_update(request: Request, name: str):
+async def post_agent_plugin_update(
+    request: Request,
+    name: str,
+    body: Optional[_AgentPluginUpdateBody] = None,
+):
     _require_token(request)
     name = _validate_plugin_name(name)
     from hermes_cli.plugins_cmd import dashboard_update_user_plugin
 
-    result = dashboard_update_user_plugin(name)
+    result = dashboard_update_user_plugin(
+        name,
+        review_token=body.review_token if body else None,
+        renew_tool_override=body.renew_tool_override if body else False,
+    )
     if not result.get("ok"):
         raise HTTPException(status_code=400, detail=result.get("error") or "Update failed.")
     _get_dashboard_plugins(force_rescan=True)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1262,6 +1262,7 @@ class TestPluginContext:
     def test_register_tool_override_replaces_existing(self, tmp_path, monkeypatch, caplog):
         """override=True lets a plugin replace an existing built-in tool."""
         from tools.registry import registry
+        from hermes_cli.plugins import plugin_content_revision
 
         registry.register(
             name="override_target",
@@ -1290,7 +1291,10 @@ class TestPluginContext:
                     "plugins": {
                         "enabled": ["override_plugin"],
                         "entries": {
-                            "override_plugin": {"allow_tool_override": True}
+                            "override_plugin": {
+                                "allow_tool_override": True,
+                                "allow_tool_override_revision": plugin_content_revision(plugin_dir),
+                            }
                         },
                     }
                 })
@@ -1317,6 +1321,7 @@ class TestPluginContext:
     def test_register_tool_override_on_new_name_is_noop_path(self, tmp_path, monkeypatch):
         """override=True on a brand-new name still registers cleanly (no existing entry to replace)."""
         from tools.registry import registry
+        from hermes_cli.plugins import plugin_content_revision
 
         plugins_dir = tmp_path / "hermes_test" / "plugins"
         plugin_dir = plugins_dir / "new_override_plugin"
@@ -1338,7 +1343,10 @@ class TestPluginContext:
                 "plugins": {
                     "enabled": ["new_override_plugin"],
                     "entries": {
-                        "new_override_plugin": {"allow_tool_override": True}
+                        "new_override_plugin": {
+                            "allow_tool_override": True,
+                            "allow_tool_override_revision": plugin_content_revision(plugin_dir),
+                        }
                     },
                 }
             })
@@ -1351,6 +1359,49 @@ class TestPluginContext:
             assert "brand_new_override_tool" in registry._tools
         finally:
             registry.deregister("brand_new_override_tool")
+
+    def test_tool_override_grant_is_bound_to_reviewed_plugin_revision(
+        self, tmp_path, monkeypatch
+    ):
+        """Changing plugin content invalidates an earlier privileged grant."""
+        from hermes_cli.plugins import (
+            PluginContext,
+            PluginManifest,
+            plugin_content_revision,
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        plugin_dir = hermes_home / "plugins" / "revision_bound"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text("name: revision_bound\n")
+        (plugin_dir / "__init__.py").write_text("def register(ctx):\n    return None\n")
+        approved_revision = plugin_content_revision(plugin_dir)
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "plugins": {
+                        "entries": {
+                            "revision_bound": {
+                                "allow_tool_override": True,
+                                "allow_tool_override_revision": approved_revision,
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        manifest = PluginManifest(
+            name="revision_bound",
+            key="revision_bound",
+            source="user",
+            path=str(plugin_dir),
+        )
+        context = PluginContext(manifest, MagicMock())
+
+        assert context._tool_override_allowed("write_file") is True
+        (plugin_dir / "__init__.py").write_text("def register(ctx):\n    ctx.changed = True\n")
+        assert context._tool_override_allowed("write_file") is False
 
     def test_register_tool_override_blocked_without_operator_opt_in(self, tmp_path, monkeypatch):
         """override=True must be rejected when the operator hasn't opted in.

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -452,34 +453,82 @@ class TestCmdInstall:
 class TestCmdUpdate:
     """Test the update command."""
 
-    @patch("hermes_cli.plugins_cmd._display_after_install")
-    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
-    @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(
-        self,
-        mock_run,
-        mock_plugins_dir,
-        mock_sanitize,
-        mock_display_after_install,
-    ):
-        from hermes_cli.plugins_cmd import cmd_update
-
-        mock_plugins_dir_val = MagicMock()
-        mock_plugins_dir.return_value = mock_plugins_dir_val
-        mock_target = MagicMock()
-        mock_target.exists.return_value = True
-        mock_target.__truediv__ = lambda self, x: MagicMock(
-            exists=MagicMock(return_value=True)
+    @staticmethod
+    def _git(path: Path, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
         )
-        mock_sanitize.return_value = mock_target
+        return result.stdout.strip()
 
-        mock_run.return_value = MagicMock(returncode=0, stdout="Updated", stderr="")
+    def _git_plugin(self, tmp_path: Path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        plugins_dir = hermes_home / "plugins"
+        remote = tmp_path / "remote"
+        remote.mkdir()
+        self._git(remote, "init", "-b", "main")
+        (remote / "plugin.yaml").write_text("name: review_me\nversion: 1\n")
+        (remote / "__init__.py").write_text("def register(ctx):\n    return None\n")
+        self._git(remote, "add", "plugin.yaml", "__init__.py")
+        self._git(
+            remote,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "initial",
+        )
+        plugins_dir.mkdir(parents=True)
+        subprocess.run(
+            ["git", "clone", str(remote), str(plugins_dir / "review_me")],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        plugin_dir = plugins_dir / "review_me"
+        old_revision = self._git(plugin_dir, "rev-parse", "HEAD")
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "plugins": {
+                        "enabled": ["review_me"],
+                        "disabled": [],
+                        "entries": {
+                            "review_me": {
+                                "allow_tool_override": True,
+                                "allow_tool_override_revision": old_revision,
+                            }
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return hermes_home, remote, plugin_dir, old_revision
 
-        cmd_update("test-plugin")
-
-        mock_run.assert_called_once()
-        mock_display_after_install.assert_called_once()
+    def _advance_remote(self, remote: Path) -> str:
+        (remote / "__init__.py").write_text(
+            "def register(ctx):\n    ctx.updated = True\n",
+            encoding="utf-8",
+        )
+        self._git(remote, "add", "__init__.py")
+        self._git(
+            remote,
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "update",
+        )
+        return self._git(remote, "rev-parse", "HEAD")
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
@@ -498,59 +547,58 @@ class TestCmdUpdate:
 
         assert exc_info.value.code == 1
 
-    def test_update_changed_enabled_plugin_disables_until_review(self, tmp_path, monkeypatch):
-        from hermes_cli.plugins_cmd import cmd_update
-        import hermes_cli.plugins_cmd as pc
-
-        hermes_home = tmp_path / "hermes"
-        plugins_dir = hermes_home / "plugins"
-        plugin_dir = plugins_dir / "review_me"
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / ".git").mkdir()
-        (plugin_dir / "plugin.yaml").write_text("name: review_me\n", encoding="utf-8")
-        (hermes_home / "config.yaml").write_text(
-            yaml.safe_dump({"plugins": {"enabled": ["review_me"], "disabled": []}}),
-            encoding="utf-8",
-        )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _target: (True, "Fast-forward\n"))
-        monkeypatch.setattr(pc, "_copy_example_files", lambda *_args, **_kw: None)
-        monkeypatch.setattr(pc, "_prompt_plugin_env_vars", lambda *_args, **_kw: None)
-        monkeypatch.setattr(pc, "_display_after_install", lambda *_args, **_kw: None)
-
-        cmd_update("review_me")
-
-        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
-        assert cfg["plugins"]["enabled"] == []
-        assert cfg["plugins"]["disabled"] == ["review_me"]
-
-    def test_dashboard_update_changed_enabled_plugin_reports_review_required(
+    def test_dashboard_update_is_staged_until_exact_revision_is_accepted(
         self, tmp_path, monkeypatch
     ):
         import hermes_cli.plugins_cmd as pc
 
-        hermes_home = tmp_path / "hermes"
-        plugins_dir = hermes_home / "plugins"
-        plugin_dir = plugins_dir / "review_me"
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / ".git").mkdir()
-        (plugin_dir / "plugin.yaml").write_text("name: review_me\n", encoding="utf-8")
-        (hermes_home / "config.yaml").write_text(
-            yaml.safe_dump({"plugins": {"enabled": ["review_me"], "disabled": []}}),
-            encoding="utf-8",
+        hermes_home, remote, plugin_dir, old_revision = self._git_plugin(tmp_path, monkeypatch)
+        new_revision = self._advance_remote(remote)
+        staged = pc.dashboard_update_user_plugin("review_me")
+
+        assert staged["ok"] is True
+        assert staged["review_required"] is True
+        assert staged["candidate_revision"] == new_revision
+        assert staged["changed_files"] == ["M\t__init__.py"]
+        assert self._git(plugin_dir, "rev-parse", "HEAD") == old_revision
+        assert "ctx.updated" not in (plugin_dir / "__init__.py").read_text()
+
+        accepted = pc.dashboard_update_user_plugin(
+            "review_me",
+            review_token=staged["review_token"],
+            renew_tool_override=False,
         )
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _target: (True, "Fast-forward\n"))
-        monkeypatch.setattr(pc, "_copy_example_files", lambda *_args, **_kw: None)
 
-        result = pc.dashboard_update_user_plugin("review_me")
+        assert accepted["accepted"] is True
+        assert accepted["enabled_after_update"] is True
+        assert self._git(plugin_dir, "rev-parse", "HEAD") == new_revision
+        assert "ctx.updated" in (plugin_dir / "__init__.py").read_text()
+        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        assert cfg["plugins"]["enabled"] == ["review_me"]
+        assert cfg["plugins"]["entries"]["review_me"]["allow_tool_override"] is False
+        assert "allow_tool_override_revision" not in cfg["plugins"]["entries"]["review_me"]
+        audit = (hermes_home / ".plugin-updates" / "audit.jsonl").read_text()
+        assert '"action": "STAGED"' in audit
+        assert '"action": "ACCEPTED"' in audit
 
-        assert result["ok"] is True
-        assert result["review_required"] is True
-        assert result["enabled_after_update"] is False
-        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
-        assert cfg["plugins"]["enabled"] == []
-        assert cfg["plugins"]["disabled"] == ["review_me"]
+    def test_staged_update_rejects_live_tree_changes_after_review(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins_cmd as pc
+
+        _home, remote, plugin_dir, old_revision = self._git_plugin(tmp_path, monkeypatch)
+        self._advance_remote(remote)
+        staged = pc.dashboard_update_user_plugin("review_me")
+        (plugin_dir / "local-note.txt").write_text("changed after review")
+
+        rejected = pc.dashboard_update_user_plugin(
+            "review_me",
+            review_token=staged["review_token"],
+        )
+
+        assert rejected["ok"] is False
+        assert "changed after review" in rejected["error"]
+        assert self._git(plugin_dir, "rev-parse", "HEAD") == old_revision
 
 
 # ── cmd_remove tests ─────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -452,10 +452,17 @@ class TestCmdInstall:
 class TestCmdUpdate:
     """Test the update command."""
 
+    @patch("hermes_cli.plugins_cmd._display_after_install")
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(self, mock_run, mock_plugins_dir, mock_sanitize):
+    def test_update_git_pull_success(
+        self,
+        mock_run,
+        mock_plugins_dir,
+        mock_sanitize,
+        mock_display_after_install,
+    ):
         from hermes_cli.plugins_cmd import cmd_update
 
         mock_plugins_dir_val = MagicMock()
@@ -472,6 +479,7 @@ class TestCmdUpdate:
         cmd_update("test-plugin")
 
         mock_run.assert_called_once()
+        mock_display_after_install.assert_called_once()
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
@@ -489,6 +497,60 @@ class TestCmdUpdate:
             cmd_update("nonexistent-plugin")
 
         assert exc_info.value.code == 1
+
+    def test_update_changed_enabled_plugin_disables_until_review(self, tmp_path, monkeypatch):
+        from hermes_cli.plugins_cmd import cmd_update
+        import hermes_cli.plugins_cmd as pc
+
+        hermes_home = tmp_path / "hermes"
+        plugins_dir = hermes_home / "plugins"
+        plugin_dir = plugins_dir / "review_me"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".git").mkdir()
+        (plugin_dir / "plugin.yaml").write_text("name: review_me\n", encoding="utf-8")
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["review_me"], "disabled": []}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _target: (True, "Fast-forward\n"))
+        monkeypatch.setattr(pc, "_copy_example_files", lambda *_args, **_kw: None)
+        monkeypatch.setattr(pc, "_prompt_plugin_env_vars", lambda *_args, **_kw: None)
+        monkeypatch.setattr(pc, "_display_after_install", lambda *_args, **_kw: None)
+
+        cmd_update("review_me")
+
+        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert cfg["plugins"]["enabled"] == []
+        assert cfg["plugins"]["disabled"] == ["review_me"]
+
+    def test_dashboard_update_changed_enabled_plugin_reports_review_required(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.plugins_cmd as pc
+
+        hermes_home = tmp_path / "hermes"
+        plugins_dir = hermes_home / "plugins"
+        plugin_dir = plugins_dir / "review_me"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".git").mkdir()
+        (plugin_dir / "plugin.yaml").write_text("name: review_me\n", encoding="utf-8")
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["review_me"], "disabled": []}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(pc, "_git_pull_plugin_dir", lambda _target: (True, "Fast-forward\n"))
+        monkeypatch.setattr(pc, "_copy_example_files", lambda *_args, **_kw: None)
+
+        result = pc.dashboard_update_user_plugin("review_me")
+
+        assert result["ok"] is True
+        assert result["review_required"] is True
+        assert result["enabled_after_update"] is False
+        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text(encoding="utf-8"))
+        assert cfg["plugins"]["enabled"] == []
+        assert cfg["plugins"]["disabled"] == ["review_me"]
 
 
 # ── cmd_remove tests ─────────────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -940,10 +940,14 @@ export const api = {
       { method: "POST" },
     ),
 
-  updateAgentPlugin: (name: string) =>
+  updateAgentPlugin: (name: string, body: AgentPluginUpdateRequest = {}) =>
     fetchJSON<AgentPluginUpdateResponse>(
       `/api/dashboard/agent-plugins/${pluginPath(name)}/update`,
-      { method: "POST" },
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
     ),
 
   removeAgentPlugin: (name: string) =>
@@ -2535,7 +2539,28 @@ export interface AgentPluginUpdateResponse {
   name?: string;
   output?: string;
   unchanged?: boolean;
+  review_required?: boolean;
+  review_token?: string;
+  candidate_revision?: string;
+  candidate_hash?: string;
+  changed_files?: string[];
+  scan_findings?: Array<{
+    file: string;
+    line: number;
+    pattern: string;
+    description: string;
+  }>;
+  was_enabled?: boolean;
+  tool_override_was_granted?: boolean;
+  accepted?: boolean;
+  enabled_after_update?: boolean;
+  tool_override_renewed?: boolean;
   error?: string;
+}
+
+export interface AgentPluginUpdateRequest {
+  review_token?: string;
+  renew_tool_override?: boolean;
 }
 
 export interface PluginProvidersPutRequest {

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -4,6 +4,7 @@ import type { Translations } from "@/i18n/types";
 import { Link } from "react-router-dom";
 import { api } from "@/lib/api";
 import type {
+  AgentPluginUpdateResponse,
   HubAgentPluginRow,
   MemoryProviderConfig,
   MemoryProviderField,
@@ -928,6 +929,8 @@ function PluginRowCard(props: PluginRowCardProps) {
 
   const busy = rowBusy === row.name;
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [pendingUpdate, setPendingUpdate] = useState<AgentPluginUpdateResponse | null>(null);
+  const [renewToolOverride, setRenewToolOverride] = useState(false);
 
   const badgeTone =
     row.runtime_status === "enabled"
@@ -1016,8 +1019,16 @@ function PluginRowCard(props: PluginRowCardProps) {
                 size="sm"
                 onClick={() => {
                   void setRuntimeLoading(row.name, async () => {
-                    await api.updateAgentPlugin(row.name);
-                    showToast(t.pluginsPage.updateGit, "success");
+                    const result = await api.updateAgentPlugin(row.name);
+                    if (result.review_required) {
+                      setPendingUpdate(result);
+                      setRenewToolOverride(false);
+                      return;
+                    }
+                    showToast(
+                      result.unchanged ? `${row.name} is already up to date` : t.pluginsPage.updateGit,
+                      "success",
+                    );
                   });
                 }}
               >
@@ -1090,6 +1101,82 @@ function PluginRowCard(props: PluginRowCardProps) {
           <p className="text-xs italic text-text-disabled">
             {t.pluginsPage.noDashboardTab}
           </p>
+        ) : null}
+
+        {pendingUpdate?.review_required ? (
+          <div className="grid gap-3 border border-warning/50 bg-warning/5 p-4 text-xs">
+            <div className="grid gap-1">
+              <p className="font-semibold text-warning">Review update before activation</p>
+              <p className="text-text-secondary">
+                The live plugin has not changed. Candidate revision{" "}
+                <span className="font-mono">
+                  {pendingUpdate.candidate_revision?.slice(0, 12)}
+                </span>
+              </p>
+              <p className="break-all font-mono text-text-tertiary">
+                {pendingUpdate.candidate_hash}
+              </p>
+            </div>
+
+            {pendingUpdate.changed_files?.length ? (
+              <div className="max-h-32 overflow-auto border border-border bg-background/40 p-2 font-mono">
+                {pendingUpdate.changed_files.map((file) => (
+                  <div key={file}>{file}</div>
+                ))}
+              </div>
+            ) : null}
+
+            {pendingUpdate.scan_findings?.length ? (
+              <div className="grid gap-1 text-warning">
+                <p>Diagnostic scan findings: {pendingUpdate.scan_findings.length}</p>
+                {pendingUpdate.scan_findings.slice(0, 10).map((finding, index) => (
+                  <p key={`${finding.file}-${finding.line}-${finding.pattern}-${index}`}>
+                    {finding.file}:{finding.line} {finding.pattern} — {finding.description}
+                  </p>
+                ))}
+              </div>
+            ) : (
+              <p className="text-success">Diagnostic scan found no dynamic import/access patterns.</p>
+            )}
+
+            {pendingUpdate.tool_override_was_granted ? (
+              <Label className="flex items-center gap-2">
+                <Switch
+                  checked={renewToolOverride}
+                  onCheckedChange={setRenewToolOverride}
+                />
+                Renew permission for this exact revision to replace built-in tools
+              </Label>
+            ) : null}
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button ghost size="sm" disabled={busy} onClick={() => setPendingUpdate(null)}>
+                Keep current version
+              </Button>
+              <Button
+                size="sm"
+                disabled={busy || !pendingUpdate.review_token}
+                onClick={() => {
+                  const reviewToken = pendingUpdate.review_token;
+                  if (!reviewToken) return;
+                  void setRuntimeLoading(row.name, async () => {
+                    const result = await api.updateAgentPlugin(row.name, {
+                      review_token: reviewToken,
+                      renew_tool_override: renewToolOverride,
+                    });
+                    setPendingUpdate(null);
+                    showToast(
+                      `${row.name} updated; restart Hermes to load the reviewed revision`,
+                      "success",
+                    );
+                    return result;
+                  });
+                }}
+              >
+                Accept reviewed update
+              </Button>
+            </div>
+          </div>
         ) : null}
       </CardContent>
 


### PR DESCRIPTION
## Summary

Plugin updates now use a staged review transaction instead of modifying an enabled plugin in place.

- Copy the installed Git plugin into a private quarantine directory and fast-forward only the staged copy.
- Validate the manifest and exact old/new commits, compute a deterministic staged-content hash, inventory changed files, and run the existing skills AST audit as a diagnostic scan.
- Return the same review payload to the CLI and dashboard, including the candidate revision, content hash, changed files, scan findings, and `after-install.md` content.
- Require explicit acceptance using a review token bound to the plugin key, old commit, new commit, and staged content hash.
- Revalidate both the live and staged trees at acceptance time, then promote atomically with rollback. The live enabled plugin remains unchanged until this succeeds.
- Append `STAGED` and `ACCEPTED` events to a JSONL audit log.
- Bind tool-override consent to the exact installed plugin revision. Updates revoke an earlier grant unless the operator explicitly renews it for the reviewed revision.

Closes #37976

## Review feedback addressed

- The live plugin directory is no longer pulled before review; update preparation occurs in a private quarantine directory.
- CLI and dashboard use one staged transaction and one exact-token acceptance path.
- The dashboard API and UI now surface the review fields and provide explicit accept/cancel controls.
- Tool-override permission is revision-bound and fails closed when plugin content changes.
- End-to-end local-Git coverage proves that staging leaves the live commit/content untouched, exact acceptance promotes the reviewed commit while preserving enabled state, stale or mutated review state is rejected, and override renewal is explicit.

## Tests and validation

- `scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins.py` — 217 passed, 0 failed.
- `npm run typecheck --workspace=web` — passed.
- `cd web && npx eslint src/pages/PluginsPage.tsx src/lib/api.ts` — passed.
- `ruff check hermes_cli/plugins.py hermes_cli/plugins_cmd.py hermes_cli/web_server.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py` — passed.
- `git diff --check` — passed.

Rebased onto `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`; current head is `9b631420294693b0ce82471edad65ec69418b675`.
