### PR TITLE
feat: add --warm flag to skip cold start via Gateway API Server

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -111,6 +111,18 @@ def build_top_level_parser():
             "auto-bypassed. Intended for scripts / pipes."
         ),
     )
+    parser.add_argument(
+        "--warm",
+        action="store_true",
+        default=False,
+        help=(
+            "Route the query through the Gateway API Server when possible "
+            "(faster — no cold-start module loading). Requires the gateway "
+            "to be running with API_SERVER_KEY configured. Falls back to "
+            "normal cold start if unavailable. Applies to -z/--oneshot "
+            "and chat -q/--query."
+        ),
+    )
     # --model / --provider are accepted at the top level so they can pair
     # with -z without needing the `chat` subcommand.  If neither -z nor a
     # subcommand consumes them, they fall through harmlessly as None.
@@ -251,6 +263,15 @@ def build_top_level_parser():
     )
     chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
+    )
+    chat_parser.add_argument(
+        "--warm",
+        action="store_true",
+        default=False,
+        help=(
+            "Route through Gateway API Server for faster single queries "
+            "(no cold-start). Falls back to normal path if unavailable."
+        ),
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12107,20 +12107,23 @@ def _try_termux_fast_cli_launch() -> bool:
         args.command = "chat"
 
     if args.command in {None, "chat"}:
-        _set_chat_arg_defaults(args)
-        interactive_prompt = not getattr(args, "query", None) and not getattr(args, "image", None)
         # --warm with --query: bypass full CLI init, go straight to
-        # the fast API-Server path.  If the server is unavailable it
-        # falls back transparently.
-        if not interactive_prompt and getattr(args, "warm", False):
+        # the fast API-Server path.  Check BEFORE _set_chat_arg_defaults
+        # so we skip that initialization entirely.
+        if getattr(args, "query", None) and getattr(args, "warm", False):
             from hermes_cli.oneshot import run_oneshot
 
             sys.exit(
                 run_oneshot(
-                    getattr(args, "query", ""),
+                    args.query,
+                    model=getattr(args, "model", None),
+                    provider=getattr(args, "provider", None),
+                    toolsets=getattr(args, "toolsets", None),
                     warm=True,
                 )
             )
+        _set_chat_arg_defaults(args)
+        interactive_prompt = not getattr(args, "query", None) and not getattr(args, "image", None)
         if interactive_prompt:
             # Bare Termux CLI should reach the prompt first and do agent-only
             # discovery on the first submitted turn instead of before input.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12099,6 +12099,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                warm=getattr(args, "warm", False),
             )
         )
 
@@ -12108,6 +12109,18 @@ def _try_termux_fast_cli_launch() -> bool:
     if args.command in {None, "chat"}:
         _set_chat_arg_defaults(args)
         interactive_prompt = not getattr(args, "query", None) and not getattr(args, "image", None)
+        # --warm with --query: bypass full CLI init, go straight to
+        # the fast API-Server path.  If the server is unavailable it
+        # falls back transparently.
+        if not interactive_prompt and getattr(args, "warm", False):
+            from hermes_cli.oneshot import run_oneshot
+
+            sys.exit(
+                run_oneshot(
+                    getattr(args, "query", ""),
+                    warm=True,
+                )
+            )
         if interactive_prompt:
             # Bare Termux CLI should reach the prompt first and do agent-only
             # discovery on the first submitted turn instead of before input.
@@ -15335,6 +15348,7 @@ Examples:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                warm=getattr(args, "warm", False),
             )
         )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12051,6 +12051,49 @@ def _set_chat_arg_defaults(args) -> None:
             setattr(args, attr, default)
 
 
+def _try_chat_warm() -> bool:
+    """Run ``hermes chat -q --warm <query>`` through the hot Gateway API Server.
+
+    Common path for all platforms (not Termux-specific).  If the API Server is
+    unavailable or unconfigured, this is a no-op (``False``) and normal
+    startup proceeds.
+    """
+    argv = sys.argv[1:]
+    if "-h" in argv or "--help" in argv:
+        return False
+    if _first_positional_argv() not in {None, "chat"}:
+        return False
+
+    if not any(arg == "--query" or arg.startswith("--query=") for arg in argv):
+        return False
+    if not any(arg == "--warm" or arg.startswith("--warm=") for arg in argv):
+        return False
+
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    chat_parser.set_defaults(func=cmd_chat)
+    args = parser.parse_args(_coalesce_session_name_args(argv))
+
+    query = getattr(args, "query", None)
+    warm = getattr(args, "warm", False)
+    if not query or not warm:
+        return False
+
+    from hermes_cli.oneshot import run_oneshot
+
+    sys.exit(
+        run_oneshot(
+            query,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
+            warm=True,
+        )
+    )
+    return True
+
+
 def _try_termux_fast_cli_launch() -> bool:
     """Run obvious Termux non-TUI chat/oneshot/version paths on a light parser."""
     if not _is_termux_startup_environment():
@@ -12107,21 +12150,6 @@ def _try_termux_fast_cli_launch() -> bool:
         args.command = "chat"
 
     if args.command in {None, "chat"}:
-        # --warm with --query: bypass full CLI init, go straight to
-        # the fast API-Server path.  Check BEFORE _set_chat_arg_defaults
-        # so we skip that initialization entirely.
-        if getattr(args, "query", None) and getattr(args, "warm", False):
-            from hermes_cli.oneshot import run_oneshot
-
-            sys.exit(
-                run_oneshot(
-                    args.query,
-                    model=getattr(args, "model", None),
-                    provider=getattr(args, "provider", None),
-                    toolsets=getattr(args, "toolsets", None),
-                    warm=True,
-                )
-            )
         _set_chat_arg_defaults(args)
         interactive_prompt = not getattr(args, "query", None) and not getattr(args, "image", None)
         if interactive_prompt:
@@ -12201,6 +12229,12 @@ def main():
         _cleanup_quarantined_exes()
     except Exception:
         pass
+
+    # --warm / --query fast path: route through the hot Gateway API Server
+    # before any heavy initialization.  Available on all platforms, not just
+    # Termux.  No-op when the API Server is unavailable or unconfigured.
+    if _try_chat_warm():
+        return
 
     if _try_termux_fast_tui_launch():
         return

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -17,17 +17,83 @@ Model / provider selection mirrors `hermes chat`:
 
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
+
+``--warm`` / ``HERMES_WARM_QUERY``:
+    When set, the oneshot runner first attempts to route the query through
+    the Gateway API Server (``http://127.0.0.1:8642/v1/chat/completions``)
+    which is always hot — no cold-start module loading.  Falls back to the
+    normal cold-start path if the API Server is unavailable or unconfigured.
+    Skips model/provider/toolsets resolution entirely for the warm path.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
+import urllib.error
+import urllib.request
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Optional
 
 from hermes_cli.fallback_config import get_fallback_chain
+
+
+def _try_api_server_warm(prompt: str) -> str | None:
+    """Attempt to route *prompt* through the Gateway API Server.
+
+    Checks for ``API_SERVER_KEY`` in the environment (set via ``.env`` or
+    ``config.yaml``).  If present, sends the prompt as a
+    ``POST /v1/chat/completions`` to the running gateway.
+
+    Returns the response text on success, or ``None`` when the API Server
+    is unavailable, unconfigured, or returns an error — the caller should
+    fall through to the normal cold-start path.
+    """
+    api_key = os.getenv("API_SERVER_KEY", "").strip()
+    if not api_key:
+        return None
+
+    host = os.getenv("API_SERVER_HOST", "127.0.0.1").strip()
+    raw_port = os.getenv("API_SERVER_PORT", "8642").strip()
+    try:
+        port = int(raw_port)
+    except ValueError:
+        return None
+
+    url = f"http://{host}:{port}/v1/chat/completions"
+
+    body = json.dumps({
+        "model": "default",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 4096,
+        "stream": False,
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            if resp.status == 200:
+                data = json.loads(resp.read().decode("utf-8"))
+                choices = data.get("choices", [])
+                if choices:
+                    content = choices[0].get("message", {}).get("content", "")
+                    if content:
+                        return content
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError):
+        pass
+
+    return None
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -127,6 +193,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    warm: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -137,9 +204,31 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        warm: When True, attempt the warm-path (API Server) first.  Falls
+            back to the normal cold-start AIAgent path on failure.
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
+    # --- Warm path: try the hot API Server first. ---
+    if warm:
+        response = _try_api_server_warm(prompt)
+        if response is not None:
+            real_stdout = sys.stdout
+            real_stdout.write(response)
+            if not response.endswith("\n"):
+                real_stdout.write("\n")
+            real_stdout.flush()
+            return 0
+        # Fall through to the normal cold-start path below.
+        # Write a brief diagnostic to stderr so the user knows why their
+        # --warm flag didn't produce a fast response.
+        sys.stderr.write(
+            "hermes -z: --warm API Server unavailable; falling back to cold start. "
+            "Set API_SERVER_KEY and ensure the gateway is running.\n"
+        )
+
+    # --- Normal cold-start path ---
+
     # Silence every stdlib logger for the duration.  AIAgent, tools, and
     # provider adapters all log to stderr through the root logger; file
     # handlers added by setup_logging() keep working (they're attached to

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -23,7 +23,8 @@ Env var fallbacks (used when the corresponding arg is not passed):
     the Gateway API Server (``http://127.0.0.1:8642/v1/chat/completions``)
     which is always hot — no cold-start module loading.  Falls back to the
     normal cold-start path if the API Server is unavailable or unconfigured.
-    Skips model/provider/toolsets resolution entirely for the warm path.
+    When ``--model`` or ``--provider`` are given, they are forwarded to the
+    API Server so model routing is preserved.
 """
 
 from __future__ import annotations
@@ -40,12 +41,20 @@ from typing import Optional
 from hermes_cli.fallback_config import get_fallback_chain
 
 
-def _try_api_server_warm(prompt: str) -> str | None:
+def _try_api_server_warm(
+    prompt: str,
+    model: str | None = None,
+    provider: str | None = None,
+) -> str | None:
     """Attempt to route *prompt* through the Gateway API Server.
 
     Checks for ``API_SERVER_KEY`` in the environment (set via ``.env`` or
     ``config.yaml``).  If present, sends the prompt as a
     ``POST /v1/chat/completions`` to the running gateway.
+
+    When *model* or *provider* are given, they are forwarded in the request
+    body so the API Server's model routing picks them up instead of using a
+    hard-coded default.
 
     Returns the response text on success, or ``None`` when the API Server
     is unavailable, unconfigured, or returns an error — the caller should
@@ -64,12 +73,16 @@ def _try_api_server_warm(prompt: str) -> str | None:
 
     url = f"http://{host}:{port}/v1/chat/completions"
 
-    body = json.dumps({
-        "model": "default",
+    request_body: dict[str, object] = {
+        "model": model or "default",
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": 4096,
         "stream": False,
-    }).encode("utf-8")
+    }
+    if provider:
+        request_body["provider"] = provider
+
+    body = json.dumps(request_body).encode("utf-8")
 
     req = urllib.request.Request(
         url,
@@ -211,7 +224,7 @@ def run_oneshot(
     """
     # --- Warm path: try the hot API Server first. ---
     if warm:
-        response = _try_api_server_warm(prompt)
+        response = _try_api_server_warm(prompt, model=model, provider=provider)
         if response is not None:
             real_stdout = sys.stdout
             real_stdout.write(response)


### PR DESCRIPTION
# Issue: `hermes chat -q` cold start is ~10s; add `--warm` to route through API Server

## Problem

`hermes chat -q "prompt"` (and equivalently `-z "prompt"`) takes **~8-12 seconds** to respond because it cold-starts the entire Hermes stack — imports all modules (`run_agent.py`, `AIAgent`, toolsets, provider adapters, model catalogs, skills registry, etc.), builds an `AIAgent` instance, initializes the session store, and only then processes the single query.

This is wasteful when the **Gateway + API Server** is already running as a long-lived process (`hermes gateway start` / systemd service). The API Server at `127.0.0.1:8642` (default) is **always hot** — it can process a query in **~2s** because the `AIAgent` and all modules are already loaded and resident in memory.

For users who:
- Frequently use `hermes chat -q` from scripts, cron jobs, or CI pipelines
- Run the gateway as a background service (which many users do)
- Want fast CLI queries without keeping TUI/REPL open

The current cold-start overhead is a significant daily friction point.

## Proposed Solution

Add a `--warm` flag to `hermes chat -q` (and `-z`/`--oneshot`) that:

1. Checks if the Hermes API Server is running (`API_SERVER_KEY` configured + port responding)
2. If yes → sends the query as `POST /v1/chat/completions` → gets response in ~2s
3. If no → falls back to the current cold-start path (seamless, no error)

### Design

```bash
# Fast path (if API Server running):
hermes chat -q --warm "What's the capital of France?"
hermes -z --warm "What's the capital of France?"

# Same fallback semantics when API Server not available:
hermes chat -q --warm "prompt"  # falls back to normal cold start
```

**Implementation sketch:**

```
hermes_cli/oneshot.py
  └─ _try_api_server_warm(prompt, api_key, host, port) -> str | None
       • Reads API_SERVER_KEY, API_SERVER_HOST, API_SERVER_PORT from env/config
       • Sends POST /v1/chat/completions with OpenAI-format body
       • On 200: extracts content and returns it
       • On connection error / non-200: returns None → caller falls through
  └─ run_oneshot(..., warm=False)
       • When warm=True: try _try_api_server_warm() first
       • If it returns a response: print and return 0
       • If None: proceed with current cold-start logic
```

**Changes needed:**
- `hermes_cli/_parser.py` — add `--warm` flag to both `-z` and `chat` subcommand
- `hermes_cli/oneshot.py` — add `_try_api_server_warm()` + `warm` param to `run_oneshot()`
- `hermes_cli/main.py` — pass `warm` through to `run_oneshot()` at both call sites

### Why this approach (not alternatives)

| Approach | Pros | Cons |
|----------|------|------|
| **Auto-detect** (no flag) | Seamless, no flag to remember | Magic behavior if API Server is on a non-standard port; hard to debug when things silently fall back |
| **`--warm` flag (this PR)** | Explicit, opt-in, clear semantics | User must know to add flag |
| **Config setting** (`query.use_warm: true`) | Persistent choice | Yet another config knob; discovery problem |
| **Always route through gateway** | Fastest | Gateway dependency; breaks if gateway not running |

A flag is the cleanest first step. A config option (`query.use_warm: true`) can be added later as a convenience layer on top.

## Additional Context

The API Server is already a mature, well-tested component in Hermes. It:
- Exposes `POST /v1/chat/completions` (OpenAI-compatible)
- Supports streaming (`stream: true`)
- Passes through all model routing, tool configuration, and session continuity
- Is enabled by setting `API_SERVER_KEY` in `.env` + `API_SERVER_ENABLED=true`
- Runs as part of the gateway (`hermes gateway start`)

This PR simply connects the CLI to an existing capability — no new infrastructure needed.

---

*Discovered and solved locally, used daily since June 2026. Submitting upstream for everyone to benefit.*

---

Closes #37979