### PR TITLE
fix(kanban): fail closed when dashboard token is missing

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -68,20 +68,18 @@ def _check_ws_token(provided: Optional[str]) -> bool:
 
     Imported lazily so the plugin still loads in test contexts where the
     dashboard web_server module isn't importable (e.g. the bare-FastAPI
-    test harness).
+    test harness), but authentication still fails closed if the dashboard
+    token source is unavailable.
     """
     if not provided:
         return False
     try:
         from hermes_cli import web_server as _ws
     except Exception:
-        # No dashboard context (tests). Accept so the tail loop is still
-        # testable; in production the dashboard module always imports
-        # cleanly because it's the caller.
-        return True
+        return False
     expected = getattr(_ws, "_SESSION_TOKEN", None)
     if not expected:
-        return True
+        return False
     return hmac.compare_digest(str(provided), str(expected))
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -25,8 +25,8 @@ from hermes_cli import kanban_db as kb
 # ---------------------------------------------------------------------------
 
 
-def _load_plugin_router():
-    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py."""
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
@@ -38,7 +38,12 @@ def _load_plugin_router():
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    return mod.router
+    return mod
+
+
+def _load_plugin_router():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    return _load_plugin_module().router
 
 
 @pytest.fixture
@@ -772,6 +777,36 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
         "/api/plugins/kanban/events?token=secret-xyz"
     ) as ws:
         assert ws is not None  # handshake succeeded
+
+
+def test_ws_token_fails_closed_when_dashboard_module_unavailable(monkeypatch):
+    """If the dashboard token source cannot be imported, auth must not accept callers."""
+    import builtins
+
+    mod = _load_plugin_module()
+    original_import = builtins.__import__
+
+    def fail_web_server_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "hermes_cli" and "web_server" in fromlist:
+            raise RuntimeError("dashboard module unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_web_server_import)
+
+    assert mod._check_ws_token("anything") is False
+
+
+def test_ws_token_fails_closed_when_dashboard_session_token_missing(monkeypatch):
+    """A missing dashboard session token is an auth setup failure, not public access."""
+    import hermes_cli
+    import types
+
+    mod = _load_plugin_module()
+    stub = types.SimpleNamespace(_SESSION_TOKEN=None)
+    monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
+
+    assert mod._check_ws_token("anything") is False
 
 
 def test_ws_events_board_query_param_default_overrides_current_board_pointer(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
The kanban dashboard exposes `/api/plugins/kanban/events`, a WebSocket stream of task lifecycle events including task IDs, run IDs, event kinds, payload JSON, comments, authors, and timing. If `_check_ws_token()` hits either fail-open branch, a caller without the dashboard session token can connect to the event stream and receive live kanban output.

- The attacker-controlled input is the WebSocket upgrade query token.
- The protected resource is the live kanban task event stream behind the dashboard session-token boundary.
- Current `origin/main` still contains `except Exception: return True` and `if not expected: return True` in `_check_ws_token()`.

Make `_check_ws_token()` fail closed when the dashboard module cannot be imported or when `_SESSION_TOKEN` is missing, and keep testability by injecting a test token or monkeypatch hook rather than authenticating all callers in production code paths.

## Linked context
Closes #37981

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/plugins/kanban/dashboard/plugin_api.py:66-85`
- `hermes-agent/hermes_cli/web_server.py:89-95`
- `hermes-agent/SECURITY.md:193-205`

### Files changed in this PR
- `plugins/kanban/dashboard/plugin_api.py`
- `tests/plugins/test_kanban_dashboard_plugin.py`

### Behavior reproduced or verified
1. Use Hermes Agent latest upstream `main` at source receipt commit `e114b31edaec8588e085e6748582672356529170`.
2. Run the dashboard with the in-tree kanban plugin mounted and connect to `ws://127.0.0.1:<port>/api/plugins/kanban/events?token=anything`.
3. Trigger path A by making `from hermes_cli import web_server as _ws` raise in a harness; `_check_ws_token()` returns `True`.
4. Trigger path B by presenting a dashboard context where `_SESSION_TOKEN` is unset or falsey; `_check_ws_token()` returns `True`.
5. Expected result: both edge cases fail closed and `stream_events()` closes the WebSocket with `WS_1008_POLICY_VIOLATION`.

### Expected fixed behavior
Make `_check_ws_token()` fail closed when the dashboard module cannot be imported or when `_SESSION_TOKEN` is missing, and keep testability by injecting a test token or monkeypatch hook rather than authenticating all callers in production code paths.

## Tests and validation
- `bash scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py`
- Result: 1 files, 96 tests passed, 0 failed (100% complete) in 8.7s (20 workers) ===

## Environment
Hermes latest-main source receipt: `e114b31edaec8588e085e6748582672356529170` on current `main`. Runtime prerequisite: dashboard with the kanban plugin mounted; loopback-only binding limits reachability unless the operator exposes the dashboard. Redaction complete; no secrets, tokens, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness receipt: `source_ready` for `upstream-main` at `e114b31edaec8588e085e6748582672356529170` via `/tmp/hermes-source-receipt.json`; affected paths exist in the prepared latest-main checkout.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
