### PR TITLE
fix(models): canonicalize GLM-5.2 for NVIDIA NIM

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -18,6 +18,8 @@ Different LLM providers expect model identifiers in different formats:
   Hermes revisions folded every non-reasoner input into
   ``deepseek-chat``, which on aggregators routes to V3 — so a user
   picking V4 Pro was silently downgraded.
+- **NVIDIA NIM** requires vendor-qualified model IDs such as
+  ``z-ai/glm-5.2`` even when users select the bare ``glm-5.2`` name.
 - **Custom** and remaining providers pass the name through as-is.
 
 This module centralises that translation so callers can simply write::
@@ -86,6 +88,10 @@ _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
 _AUTHORITATIVE_NATIVE_PROVIDERS: frozenset[str] = frozenset({
     "huggingface",
 })
+
+_NVIDIA_MODEL_ALIASES: dict[str, str] = {
+    "glm-5.2": "z-ai/glm-5.2",
+}
 
 # Direct providers that accept bare native names but should repair a matching
 # provider/ prefix when users copy the aggregator form into config.yaml.
@@ -388,6 +394,10 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         return name
 
     provider = _normalize_provider_alias(target_provider)
+
+    # --- NVIDIA NIM: canonical vendor-qualified identifiers ---
+    if provider == "nvidia":
+        return _NVIDIA_MODEL_ALIASES.get(name.lower(), name)
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2004,6 +2004,14 @@ def detect_provider_for_model(
     if not name:
         return None
 
+    normalized_current = normalize_provider(current_provider)
+    if normalized_current == "nvidia":
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        canonical = normalize_model_for_provider(name, normalized_current)
+        if canonical != name:
+            return normalized_current, canonical
+
     static_match = detect_static_provider_for_model(name, current_provider)
     if static_match:
         return static_match

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -164,6 +164,12 @@ class TestAggregatorProviders:
         assert result == "anthropic/claude-sonnet-4.6"
 
 
+class TestNvidiaNimModelNormalization:
+    @pytest.mark.parametrize("provider", ["nvidia", "nvidia-nim", "nim"])
+    def test_glm_5_2_uses_live_nim_identifier(self, provider):
+        assert normalize_model_for_provider("glm-5.2", provider) == "z-ai/glm-5.2"
+
+
 class TestIssue6211NativeProviderPrefixNormalization:
     @pytest.mark.parametrize("model,target_provider,expected", [
         ("zai/glm-5.1", "zai", "glm-5.1"),

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -259,6 +259,15 @@ class TestDetectProviderForModel:
         """Models belonging to the current provider should not trigger a switch."""
         assert detect_provider_for_model("gpt-5.3-codex", "openai-codex") is None
 
+    def test_nvidia_bare_glm_stays_on_nim_with_canonical_identifier(self):
+        assert detect_provider_for_model("glm-5.2", "nvidia") == (
+            "nvidia",
+            "z-ai/glm-5.2",
+        )
+
+    def test_nvidia_qualified_glm_stays_on_current_provider(self):
+        assert detect_provider_for_model("z-ai/glm-5.2", "nvidia") is None
+
     def test_short_alias_resolves_to_static_model(self):
         """Short aliases (e.g. sonnet) should resolve without network lookups."""
         with patch(


### PR DESCRIPTION
## Summary

Canonicalizes the current NVIDIA NIM GLM identifier without changing transport selection:

- `glm-5.2` becomes `z-ai/glm-5.2` when the active provider is NVIDIA NIM.
- `/model glm-5.2` stays on `nvidia` instead of being reclassified as direct `zai`.
- Already-qualified `z-ai/glm-5.2` remains on the current NVIDIA provider.
- Provider aliases (`nvidia-nim`, `nim`) share the same normalization.

## Root cause

Hermes detects bare `glm-*` names as Z.AI models before the NVIDIA-specific model identifier is canonicalized. NVIDIA's API requires the vendor-qualified model string, so a bare selection could switch providers or reach NIM with the wrong identifier.

## Scope

This revision intentionally removes the earlier global `/v1` and `api_mode` guards. Current main already prevents persisted modes from crossing provider identities, and xAI's explicit Responses route remains untouched.

The fix is limited to provider-aware model normalization and provider detection.

## Verification

- NVIDIA's official NIM reference documents `z-ai/glm-5.2` as the compatible model string: https://docs.api.nvidia.com/nim/reference/z-ai-glm-5.2-infer
- A live authenticated `GET https://integrate.api.nvidia.com/v1/models` returned `z-ai/glm-5.2`.
- Shared `switch_model()` path produced: `nvidia` / `z-ai/glm-5.2` / `chat_completions`.
- `192 passed` across:
  - `tests/hermes_cli/test_models.py`
  - `tests/hermes_cli/test_model_normalize.py`
  - `tests/hermes_cli/test_detect_api_mode_for_url.py`
- `ruff check` passed on all four changed files.
- `py_compile`, `git diff --check`, and added-line security scan passed.

Final scope: one commit, four files, 33 additions, zero deletions.
