### PR TITLE
fix(tui): phantom scroll-jump during streaming

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -273,9 +273,30 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
       setThreadScrolledUp(!atBottom)
     }
 
+    // Debounce wheel-up disarm: a single spurious wheel event (common on
+    // Windows focus/blur, ConPTY glitches, Electron input quirks) should
+    // not immediately break sticky-bottom.  Require 2 consecutive wheel-up
+    // events within 150ms to confirm intentional upward scroll.
+    let wheelUpCount = 0
+    let lastWheelUpAt = 0
+
     const onWheel = (event: WheelEvent) => {
       if (event.deltaY < 0) {
-        disarm()
+        const now = Date.now()
+
+        if (now - lastWheelUpAt > 150) {
+          wheelUpCount = 1
+        } else {
+          wheelUpCount++
+        }
+
+        lastWheelUpAt = now
+
+        if (wheelUpCount >= 2) {
+          disarm()
+        }
+      } else if (event.deltaY > 0) {
+        wheelUpCount = 0
       }
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -786,19 +786,22 @@ function renderNodeToOutput(
           node.scrollTop = maxScroll
           node.pendingScrollDelta = undefined
 
-          // Sync flag so useVirtualScroll's isSticky() agrees with positional
-          // state — sticky-broken-but-at-bottom (wheel tremor, click-select
-          // at max) otherwise leaves useVirtualScroll's clamp holding the
-          // viewport short of new streaming content. scrollTo/scrollBy set
-          // false; this restores true, same as scrollToBottom() would.
-          // Only restore when (a) positionally at bottom and (b) the flag
-          // was explicitly broken (===false) by scrollTo/scrollBy. When
-          // undefined (never set by user action) leave it alone — setting it
-          // would make the sticky flag sticky-by-default and lock out
-          // direct scrollTop writes (e.g. the alt-screen-perf test).
-          if (node.stickyScroll === false && scrollTopBeforeFollow >= prevMaxScroll) {
-            node.stickyScroll = true
-          }
+          // Do NOT silently re-enable stickyScroll here.
+          //
+          // Previous code: `if (node.stickyScroll === false && scrollTopBeforeFollow >= prevMaxScroll) { node.stickyScroll = true }`
+          // This caused phantom scrolling: when a user scrolled up to read
+          // older content, their scrollTop could land exactly at prevMaxScroll
+          // (the old bottom) while new content arrived. The positional at-bottom
+          // follow would fire AND re-engage sticky, permanently locking the
+          // viewport to the bottom for every subsequent streaming frame — even
+          // though the user never explicitly requested scrollToBottom().
+          //
+          // Instead, stickyScroll is only (re)enabled by:
+          //   1. The initial `stickyScroll` prop on the component (cold start)
+          //   2. An explicit scrollToBottom() call
+          // The positional follow above (scrollTop = maxScroll when at-bottom)
+          // still works for transient "at bottom" states — it just doesn't
+          // permanently re-lock the sticky flag.
         }
 
         const followDelta = (node.scrollTop ?? 0) - scrollTopBeforeFollow

--- a/ui-tui/src/__tests__/wheelAccel.test.ts
+++ b/ui-tui/src/__tests__/wheelAccel.test.ts
@@ -30,20 +30,27 @@ describe('wheelAccel — native path', () => {
     expect(computeWheelStep(s, 1, 2000)).toBe(1)
   })
 
-  it('direction flip defers one event for bounce detection', () => {
+  it('direction flip defers two events for confirmation', () => {
     const s = initWheelAccel(false, 1)
 
     computeWheelStep(s, 1, 1000)
 
+    // First event in new direction: sets pendingDir, no scroll yet
     expect(computeWheelStep(s, -1, 1050)).toBe(0)
+    // Second event in same new direction: confirms reversal, now scrolling
+    expect(computeWheelStep(s, -1, 1060)).toBeGreaterThanOrEqual(1)
   })
 
-  it('flip-back within bounce window engages wheelMode', () => {
+  it('flip-back within bounce window engages wheelMode (2-event confirmation)', () => {
     const s = initWheelAccel(false, 1)
 
     computeWheelStep(s, 1, 1000)
+    // Scroll up confirmed (2 events) — reversal
     computeWheelStep(s, -1, 1050)
+    computeWheelStep(s, -1, 1060)
+    // Now scroll down — first event sets new pending, second confirms bounce-back
     computeWheelStep(s, 1, 1100)
+    computeWheelStep(s, 1, 1110)
 
     expect(s.wheelMode).toBe(true)
   })
@@ -52,10 +59,31 @@ describe('wheelAccel — native path', () => {
     const s = initWheelAccel(false, 1)
 
     computeWheelStep(s, 1, 1000)
+    // Scroll up confirmed (2 events) — reversal
     computeWheelStep(s, -1, 1050)
+    computeWheelStep(s, -1, 1060)
+    // Scroll down outside bounce window (gap > 60ms from savedTime at t=1050)
     computeWheelStep(s, 1, 1400)
+    computeWheelStep(s, 1, 1410)
 
+    // Bounce-back was outside the 60ms window — no wheelMode
     expect(s.wheelMode).toBe(false)
+  })
+
+  it('single spurious opposite-direction event is ignored (no flip)', () => {
+    const s = initWheelAccel(false, 1)
+
+    computeWheelStep(s, 1, 1000)
+    computeWheelStep(s, 1, 1020)
+
+    // A single spurious "up" event — sets pending, returns 0
+    expect(computeWheelStep(s, -1, 1040)).toBe(0)
+
+    // Next event is back to original direction — pending cleared, normal scroll
+    const rows = computeWheelStep(s, 1, 1060)
+    expect(rows).toBeGreaterThanOrEqual(1)
+    expect(s.wheelMode).toBe(false)
+    expect(s.dir).toBe(1) // stayed in original direction
   })
 
   it('5 consecutive sub-5ms events disengage wheelMode (trackpad signature)', () => {

--- a/ui-tui/src/lib/wheelAccel.ts
+++ b/ui-tui/src/lib/wheelAccel.ts
@@ -23,11 +23,14 @@ const WHEEL_ACCEL_STEP = 0.3
 const WHEEL_ACCEL_MAX = 6
 
 // ── Encoder bounce / wheel-mode (mechanical wheels) ────────────────────
-const WHEEL_BOUNCE_GAP_MAX_MS = 200
-const WHEEL_MODE_STEP = 15
-const WHEEL_MODE_CAP = 15
-const WHEEL_MODE_RAMP = 3
-const WHEEL_MODE_IDLE_DISENGAGE_MS = 1500
+// Gap tightened from 200→60ms: Windows focus/blur and ConPTY glitches
+// produce phantom wheel events that pair with real events within 200ms,
+// falsely engaging wheelMode and causing sudden 15-row jumps.
+const WHEEL_BOUNCE_GAP_MAX_MS = 60
+const WHEEL_MODE_STEP = 8
+const WHEEL_MODE_CAP = 8
+const WHEEL_MODE_RAMP = 1
+const WHEEL_MODE_IDLE_DISENGAGE_MS = 1000
 
 // ── xterm.js (VS Code / Cursor / browser terminals) ────────────────────
 const WHEEL_DECAY_HALFLIFE_MS = 150
@@ -50,18 +53,30 @@ export type WheelAccelState = {
   /** Native baseline rows/event. Reset on idle/reversal; ramp builds on
    *  top. xterm.js path ignores. */
   base: number
-  /** Deferred direction flip (native): bounce vs reversal — next event
-   *  decides. */
-  pendingFlip: boolean
   /** Sticky once a flip-then-flip-back fires within the bounce window.
    *  Cleared by idle disengage or trackpad burst. */
   wheelMode: boolean
-  /** Consecutive <5ms events. ≥5 → trackpad flick → disengage. */
+  /** Consecutive <5ms events.  Trackpad flick ≥5 → disengage wheelMode. */
   burstCount: number
+  /**
+   * Direction-change debounce.  A single spurious event (common on Windows
+   * when focus changes or mouse-tracking glitches fire a lone wheel event)
+   * should not trigger a pending-flip → wheelMode chain.  Two consecutive
+   * events in the new direction are required to confirm a real reversal.
+   */
+  pendingDir: 0 | 1 | -1
+  /** Consecutive events seen in `pendingDir`. Confirmed at ≥2. */
+  pendingCount: number
+  /** Saved direction *before* the pending reversal started — used for
+   *  bounce-back detection (encoder-bounce → wheelMode). */
+  savedDir: 0 | 1 | -1
+  /** Timestamp when `savedDir` was first established.  Bounce-back must
+   *  occur within WHEEL_BOUNCE_GAP_MAX_MS of this time, not the last event. */
+  savedTime: number
 }
 
 export function initWheelAccel(xtermJs = false, base = 1): WheelAccelState {
-  return { burstCount: 0, base, dir: 0, frac: 0, mult: base, pendingFlip: false, time: 0, wheelMode: false, xtermJs }
+  return { burstCount: 0, base, dir: 0, frac: 0, mult: base, pendingCount: 0, pendingDir: 0, savedDir: 0, savedTime: 0, time: 0, wheelMode: false, xtermJs }
 }
 
 /** HERMES_TUI_SCROLL_SPEED (or CLAUDE_CODE_SCROLL_SPEED for portability).
@@ -92,29 +107,59 @@ function nativeStep(state: WheelAccelState, dir: -1 | 1, now: number): number {
     state.mult = state.base
   }
 
-  if (state.pendingFlip) {
-    state.pendingFlip = false
-
-    if (dir !== state.dir || now - state.time > WHEEL_BOUNCE_GAP_MAX_MS) {
-      // Real reversal (flip persisted OR flip-back too late). Commit.
-      // The deferred event's 1 row is lost — acceptable latency.
-      state.dir = dir
-      state.time = now
-      state.mult = state.base
-
-      return Math.floor(state.mult)
-    }
-
-    state.wheelMode = true
-  }
-
   const gap = now - state.time
 
+  // ── Direction-change debounce ──────────────────────────────────────
+  // Single spurious events (common on Windows focus changes, mouse-tracking
+  // glitches) must not trigger a pending-flip → wheelMode chain.  Require
+  // 2+ consecutive events in the new direction to confirm a real reversal.
   if (dir !== state.dir && state.dir !== 0) {
-    state.pendingFlip = true
-    state.time = now
+    if (dir === state.pendingDir) {
+      // Another event in the pending direction — confirm.
+      state.pendingCount++
+      if (state.pendingCount >= 2) {
+        // Confirmed reversal.  Did we bounce back to the ORIGINAL direction
+        // (the one saved when the first direction-change occurred) within
+        // the bounce window?  If so it's encoder bounce → wheelMode.
+        // Use savedTime (anchored at first direction change) rather than
+        // state.time (which advances with every pending event).
+        if (dir === state.savedDir && now - state.savedTime <= WHEEL_BOUNCE_GAP_MAX_MS) {
+          state.wheelMode = true
+        } else {
+          // Genuine sustained reversal — full reset.
+          state.mult = state.base
+        }
+        state.dir = dir
+        state.time = now
+        state.pendingDir = 0
+        state.pendingCount = 0
+        // Keep savedDir — it anchors the original direction for
+        // multi-hop bounce detection (down→up→down within window).
+        return Math.floor(state.mult)
+      }
+      // Still collecting — no-scroll, but update time so the gap tracks.
+      state.time = now
+      return 0
+    }
 
+    // First event in a new direction (or a third direction).
+    // Only set savedDir/savedTime on the VERY first direction change.
+    if (state.savedDir === 0) {
+      state.savedDir = state.dir         // remember where we came from
+      state.savedTime = now              // anchor the bounce window start
+    }
+    state.pendingDir = dir               // track the new candidate direction
+    state.pendingCount = 1
+    state.time = now
     return 0
+  }
+
+  // Same direction — clear pending state and reset bounce anchor.
+  if (state.pendingCount > 0) {
+    state.pendingDir = 0
+    state.pendingCount = 0
+    state.savedDir = 0
+    state.savedTime = 0
   }
 
   state.dir = dir


### PR DESCRIPTION
## What does this PR do?

Fixes phantom scroll-jump during streaming on Windows (and occasionally other platforms). Three independent fixes address the same user-visible symptom from different layers:

### 1. Desktop GUI: debounce wheel-up disarm (`thread-virtualizer.tsx`)

**Root cause for desktop users.** A single spurious wheel-up event (common on Windows focus/blur, ConPTY glitches, Electron input quirks) immediately broke sticky-bottom mode via `disarm()`. Once disarmed, the viewport stops following new streaming content — the user sees the view "scroll away" from the bottom.

**Fix:** Require 2 consecutive wheel-up events within 150ms to confirm intentional upward scroll before disarming. Single phantom events are absorbed silently.

### 2. Ink TUI: remove silent stickyScroll re-enable (`render-node-to-output.ts`)

When a user scrolls up to read older content and their `scrollTop` lands at the old `prevMaxScroll` while new content arrives, the at-bottom follow code silently sets `stickyScroll = true`. Every subsequent streaming frame then forces `scrollTop = maxScroll`.

**Fix:** Remove the silent re-engage. `stickyScroll` is now only (re)enabled by the initial component prop or an explicit `scrollToBottom()` call.

### 3. Ink TUI: wheel acceleration debounce (`wheelAccel.ts`)

The encoder-bounce detection fires on a single spurious direction-change event, falsely engaging `wheelMode` and causing sudden 15-row scroll jumps.

**Fix:** Direction change requires 2+ consecutive events to confirm. Single spurious events are absorbed. Bounce window tightened: 200→60ms, cap 15→8 rows.

## Related Issue

Fixes phantom scroll behavior on Windows where the view randomly jumps while reading content during agent streaming.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] CI/CD
- [ ] Other

## Changes Made

| File | Layer | Change |
|------|-------|--------|
| `apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx` | Desktop GUI | Debounce wheel-up disarm (2 events / 150ms) |
| `ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts` | Ink TUI | Remove silent stickyScroll re-enable |
| `ui-tui/src/lib/wheelAccel.ts` | Ink TUI | 2-event direction-change debounce, tighter constants |
| `ui-tui/src/__tests__/wheelAccel.test.ts` | Tests | Updated 3 + added 1 new test |

## How to Test

1. Open Hermes desktop GUI on Windows
2. Start an agent turn that produces a long streaming response
3. While streaming, scroll up to read older content
4. Verify the viewport stays at the scrolled position
5. Scroll back down — verify new content continues to appear
6. Run `npx vitest run src/__tests__/wheelAccel.test.ts src/__tests__/scroll.test.ts` — all 18 tests should pass

## Checklist

### Code
- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings or errors

### Documentation & Housekeeping
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have checked that there aren't other open [PRs](https://github.com/NousResearch/hermes-agent/pulls) for the same update/change
- [ ] My changes do not introduce breaking changes
- [ ] I have checked the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/COMPATIBILITY.md) (if applicable)

## Screenshots / Logs

All 18 scroll-related tests pass:

```
✓ wheelAccel — native path (9 tests)
✓ wheelAccel — xterm.js path (5 tests)
✓ scroll.test.ts (4 tests)
  18 passed, 0 failed
```
