### PR TITLE
fix(cli): route local control commands offline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
 import logging
 import os
 import shutil
+import shlex
 import sys
 import json
 import re
@@ -3003,6 +3004,65 @@ def _looks_like_slash_command(text: str) -> bool:
     # After stripping the leading /, a command name has no slashes.
     # A path like /Users/foo/bar.md always does.
     return "/" not in first_word[1:]
+
+
+_LOCAL_HERMES_COMMANDS: dict[str, set[str] | None] = {
+    "config": None,
+    "debug": None,
+    "model": None,
+    "gateway": {"stop", "status", "list"},
+}
+
+
+def _split_local_hermes_command(text: str) -> list[str] | None:
+    """Return argv for local Hermes control commands typed in chat.
+
+    A user with an exhausted model account can still need local commands like
+    ``hermes gateway stop`` or ``hermes config set ...``.  Without this guard,
+    the classic REPL sends those shell-looking strings to the LLM first, which
+    deadlocks on provider 402s before the terminal tool can run anything.
+    """
+    try:
+        parts = shlex.split(text)
+    except ValueError:
+        return None
+    if len(parts) < 2 or parts[0] != "hermes":
+        return None
+
+    command = parts[1]
+    allowed_subcommands = _LOCAL_HERMES_COMMANDS.get(command)
+    if command not in _LOCAL_HERMES_COMMANDS:
+        return None
+    if allowed_subcommands is not None:
+        subcommand = parts[2] if len(parts) > 2 else "run"
+        if subcommand not in allowed_subcommands:
+            return None
+    return parts[1:]
+
+
+def _run_local_hermes_command_from_prompt(text: str) -> bool:
+    argv = _split_local_hermes_command(text)
+    if argv is None:
+        return False
+
+    import subprocess
+
+    _cprint(f"\n⚙️  hermes {' '.join(shlex.quote(part) for part in argv)}")
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", *argv],
+            check=False,
+        )
+    except KeyboardInterrupt:
+        _cprint("\n[dim]Command interrupted.[/dim]")
+        return True
+    except OSError as exc:
+        _cprint(f"  {_DIM}✗ Could not run local hermes command: {_escape(str(exc))}{_RST}")
+        return True
+
+    if completed.returncode:
+        _cprint(f"  {_DIM}local hermes command exited with {completed.returncode}{_RST}")
+    return True
 
 
 # ============================================================================
@@ -12846,6 +12906,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             user_input = _seed
                         else:
                             continue
+
+                    if (
+                        not _file_drop
+                        and isinstance(user_input, str)
+                        and _run_local_hermes_command_from_prompt(user_input)
+                    ):
+                        continue
                     
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')

--- a/tests/cli/test_local_hermes_command_passthrough.py
+++ b/tests/cli/test_local_hermes_command_passthrough.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+import subprocess
+
+import cli
+
+
+def test_split_local_hermes_command_allows_offline_config_and_gateway_stop():
+    assert cli._split_local_hermes_command(
+        "hermes config set model.provider deepseek"
+    ) == [
+        "config",
+        "set",
+        "model.provider",
+        "deepseek",
+    ]
+    assert cli._split_local_hermes_command("hermes gateway stop") == [
+        "gateway",
+        "stop",
+    ]
+
+
+def test_split_local_hermes_command_rejects_general_shell_commands():
+    assert cli._split_local_hermes_command("echo hermes gateway stop") is None
+    assert cli._split_local_hermes_command("hermes gateway run") is None
+    assert cli._split_local_hermes_command("hermes update") is None
+
+
+def test_run_local_hermes_command_uses_python_module_without_shell(monkeypatch):
+    calls = []
+
+    def fake_run(argv, *, check):
+        calls.append((argv, check))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", lambda msg: printed.append(msg))
+
+    assert cli._run_local_hermes_command_from_prompt("hermes gateway stop")
+
+    assert calls == [
+        ([cli.sys.executable, "-m", "hermes_cli.main", "gateway", "stop"], False)
+    ]
+    assert any("hermes gateway stop" in msg for msg in printed)
+
+
+def test_run_local_hermes_command_ignores_chat_text(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected run")),
+    )
+
+    assert not cli._run_local_hermes_command_from_prompt("please stop the gateway")


### PR DESCRIPTION
## What does this PR do?

Routes selected local Hermes control commands typed in the classic interactive CLI prompt through the local CLI instead of sending them to the agent. This lets users run `hermes config ...`, `hermes gateway stop/status/list`, `hermes debug ...`, and `hermes model` without first making a model API call, which avoids the 402 deadlock reported in #37858.

## Related Issue

Fixes #37858

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: add an allowlisted `hermes ...` prompt fast path before regular chat dispatch, using `shlex.split` and argv-based `subprocess.run` without a shell.
- `tests/cli/test_local_hermes_command_passthrough.py`: cover allowlisted config/gateway commands, rejection of unrelated shell text, and subprocess argv dispatch.

## How to Test

1. `pytest tests/cli/test_local_hermes_command_passthrough.py -q` -> 4 passed.
2. `pytest tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_set_config_value.py -q -x --timeout=60` -> 99 passed.
3. `ruff check cli.py tests/cli/test_local_hermes_command_passthrough.py` and `ruff format --check tests/cli/test_local_hermes_command_passthrough.py` -> passed.
4. `python scripts/check-windows-footguns.py cli.py tests/cli/test_local_hermes_command_passthrough.py` -> passed.
5. `git diff --check` -> passed.
6. `pytest tests/ -q -x --timeout=60` was attempted, but local collection stopped before this change was exercised because `tests/hermes_cli/test_dashboard_auth_401_reauth.py` imports missing optional dependency `fastapi`.
7. `pytest tests/cli -q -x --timeout=60` was attempted as fallback coverage; it reached 283 passes, then timed out in unrelated `tests/cli/test_cli_preloaded_skills.py::test_show_banner_does_not_print_skills` while lazy dependency installs and auxiliary provider/account failures were logged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-fb9d36d8 kind=pr-open -->