### PR TITLE
fix(install): recover from unborn Windows install repos

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1010,9 +1010,12 @@ function Install-Repository {
         # directory OR a symlink OR a submodule-style gitfile -- and also when
         # it's a broken stub left over from a failed previous install (e.g.
         # a partial Remove-Item that couldn't delete a locked index.lock).
-        # Validate the repo properly by asking git itself.  Two checks
-        # belt-and-braces: rev-parse AND git status.  If either fails the
-        # repo is broken and we fall through to a fresh clone.
+        # Validate the repo properly by asking git itself.  Three checks
+        # belt-and-braces: rev-parse, git status, and a real HEAD commit.
+        # If any fails the repo is broken and we fall through to a fresh
+        # clone.  The HEAD check catches ZIP-fallback/partial installs that
+        # initialized .git but never created a commit; otherwise the update
+        # path later fails at "git checkout main".
         $repoValid = $false
         if (Test-Path "$InstallDir\.git") {
             Push-Location $InstallDir
@@ -1027,7 +1030,11 @@ function Install-Repository {
                 $null = & git -c windows.appendAtomically=false status --short 2>&1
                 $statusOk = ($LASTEXITCODE -eq 0)
 
-                if ($revParseOk -and $statusOk) {
+                $global:LASTEXITCODE = 0
+                $null = & git -c windows.appendAtomically=false rev-parse --verify HEAD 2>&1
+                $headOk = ($LASTEXITCODE -eq 0)
+
+                if ($revParseOk -and $statusOk -and $headOk) {
                     $repoValid = $true
                 }
             } catch {}

--- a/tests/test_install_ps1_repository_recovery.py
+++ b/tests/test_install_ps1_repository_recovery.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def test_install_ps1_rejects_unborn_git_repo_before_update_path() -> None:
+    script = INSTALL_PS1.read_text(encoding="utf-8")
+
+    assert "rev-parse --verify HEAD" in script
+    assert "$headOk = ($LASTEXITCODE -eq 0)" in script
+    assert "$revParseOk -and $statusOk -and $headOk" in script
+    assert 'later fails at "git checkout main"' in script


### PR DESCRIPTION
## What does this PR do?

Hardens the Windows installer repository stage for failed or ZIP-fallback installs that leave an initialized `.git` directory without any commit history. Those directories used to pass the existing repo probe and then fail in the update path at `git checkout main`; now they are treated as invalid and replaced through the existing fresh-clone flow.

## Related Issue

Fixes #37827

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1`: require `git rev-parse --verify HEAD` when validating an existing install repo before the update path.
- `tests/test_install_ps1_repository_recovery.py`: add a regression guard for the PowerShell installer validation check.

## How to Test

1. `$VIRTUAL_ENV/bin/pytest tests/test_install_ps1_repository_recovery.py -q` passes.
2. `ruff check tests/test_install_ps1_repository_recovery.py` and `ruff format --check tests/test_install_ps1_repository_recovery.py` pass.
3. `$VIRTUAL_ENV/bin/python scripts/check-windows-footguns.py tests/test_install_ps1_repository_recovery.py` passes.
4. `git diff --check` passes.
5. `$VIRTUAL_ENV/bin/pytest tests/ -q -x --timeout=60` currently stops at pre-existing `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`. I reran the same broad command after temporarily reverting the `scripts/install.ps1` patch and it failed at the same test, while that isolated ACP test passes on its own.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

N/A.

<!-- autocontrib:worker-id=issue-new-68934d9c kind=pr-open -->