### PR TITLE
fix(gateway): start Matrix client syncer

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -28,6 +28,7 @@ Environment variables:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import mimetypes
 import os
@@ -132,6 +133,7 @@ _CRYPTO_DB_PATH = _STORE_DIR / "crypto.db"
 
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
+_MAINTENANCE_INTERVAL_SECONDS = 30
 
 _OUTBOUND_MENTION_RE = re.compile(
     r"(?<![\w/])(@[0-9A-Za-z._=/-]+:[0-9A-Za-z.-]+(?::\d+)?)"
@@ -958,7 +960,16 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.warning("Matrix: initial key share failed: %s", exc)
 
-        # Start the sync loop.
+        # Start mautrix's syncer so registered event handlers are dispatched.
+        # Manual client.sync() calls return data but do not drive the dispatcher
+        # continuously, which made Matrix receive paths appear connected but
+        # one-way (#7914).
+        start_result = client.start(None)
+        if inspect.isawaitable(start_result):
+            await start_result
+
+        # Start lightweight maintenance. The mautrix syncer owns /sync event
+        # dispatch and token advancement from here onward.
         self._sync_task = asyncio.create_task(self._sync_loop())
         self._mark_connected()
         return True
@@ -990,6 +1001,12 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.debug("Matrix: could not close crypto DB on disconnect: %s", exc)
 
         if self._client:
+            try:
+                stop_result = self._client.stop()
+                if inspect.isawaitable(stop_result):
+                    await stop_result
+            except Exception as exc:
+                logger.debug("Matrix: could not stop syncer on disconnect: %s", exc)
             try:
                 await self._client.api.session.close()
             except Exception:
@@ -1437,77 +1454,24 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _sync_loop(self) -> None:
-        """Continuously sync with the homeserver."""
+        """Run Matrix maintenance while mautrix owns event syncing."""
         client = self._client
-        # Resume from the token stored during the initial sync.
-        next_batch = await client.sync_store.get_next_batch()
         while not self._closing:
             try:
-                # Wrap in asyncio.wait_for to guard against TCP-level hangs
-                # that the Matrix long-poll timeout cannot catch. Long-poll
-                # is 30s, so 45s gives 15s slack for network drain.
-                sync_data = await asyncio.wait_for(
-                    client.sync(
-                        since=next_batch,
-                        timeout=30000,
-                    ),
-                    timeout=45.0,
-                )
+                await asyncio.sleep(_MAINTENANCE_INTERVAL_SECONDS)
+                if self._closing:
+                    return
 
-                # nio returns SyncError objects (not exceptions) for auth
-                # failures like M_UNKNOWN_TOKEN.  Detect and stop immediately.
-                _sync_msg = getattr(sync_data, "message", None)
-                if _sync_msg and isinstance(_sync_msg, str):
-                    _lower = _sync_msg.lower()
-                    if "m_unknown_token" in _lower or "unknown_token" in _lower:
-                        logger.error(
-                            "Matrix: permanent auth error from sync: %s — stopping",
-                            _sync_msg,
-                        )
-                        return
-
-                if isinstance(sync_data, dict):
-                    # Update joined rooms from sync response.
-                    rooms_join = sync_data.get("rooms", {}).get("join", {})
-                    if rooms_join:
-                        self._joined_rooms.update(rooms_join.keys())
-
-                    # Advance the sync token so the next request is
-                    # incremental instead of a full initial sync.
-                    nb = sync_data.get("next_batch")
-                    if nb:
-                        next_batch = nb
-                        await client.sync_store.put_next_batch(nb)
-
-                    # Dispatch events to registered handlers so that
-                    # _on_room_message / _on_reaction / _on_invite fire.
-                    try:
-                        tasks = client.handle_sync(sync_data)
-                        if tasks:
-                            await asyncio.gather(*tasks)
-                    except Exception as exc:
-                        logger.warning("Matrix: sync event dispatch error: %s", exc)
-                    await self._join_pending_invites(sync_data)
+                await self._refresh_dm_cache()
+                if self._encryption and getattr(client, "crypto", None):
+                    await client.crypto.share_keys()
 
             except asyncio.CancelledError:
                 return
             except Exception as exc:
                 if self._closing:
                     return
-                # Detect permanent auth/permission failures.
-                err_str = str(exc).lower()
-                if (
-                    "401" in err_str
-                    or "403" in err_str
-                    or "unauthorized" in err_str
-                    or "forbidden" in err_str
-                ):
-                    logger.error(
-                        "Matrix: permanent auth error: %s — stopping sync", exc
-                    )
-                    return
-                logger.warning("Matrix: sync error: %s — retrying in 5s", exc)
-                await asyncio.sleep(5)
+                logger.warning("Matrix: maintenance error: %s", exc)
 
     # ------------------------------------------------------------------
     # Event callbacks

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -907,6 +907,7 @@ class TestMatrixAccessTokenAuth:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.start = MagicMock(return_value=None)
         mock_client.query_keys = AsyncMock(return_value={
             "device_keys": {"@bot:example.org": {"DEV123": {
                 "keys": {"ed25519:DEV123": "fake_ed25519_key"},
@@ -938,6 +939,7 @@ class TestMatrixAccessTokenAuth:
                         assert await adapter.connect() is True
 
         mock_client.whoami.assert_awaited_once()
+        mock_client.start.assert_called_once_with(None)
         assert adapter._user_id == "@bot:example.org"
 
         await adapter.disconnect()
@@ -1133,6 +1135,7 @@ class TestMatrixDeviceId:
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.start = MagicMock(return_value=None)
         mock_client.query_keys = AsyncMock(return_value={
             "device_keys": {"@bot:example.org": {"MY_STABLE_DEVICE": {
                 "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
@@ -1197,6 +1200,8 @@ class TestMatrixPasswordLoginDeviceId:
         mock_client.login = AsyncMock(return_value=MagicMock(device_id="STABLE_PW_DEVICE", access_token="tok"))
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
         mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.start = MagicMock(return_value=None)
         mock_client.api = MagicMock()
         mock_client.api.token = ""
         mock_client.api.session = MagicMock()
@@ -1245,73 +1250,158 @@ class TestMatrixDeviceIdConfig:
 
 class TestMatrixSyncLoop:
     @pytest.mark.asyncio
-    async def test_sync_loop_dispatches_events_and_stores_token(self):
-        """_sync_loop should call handle_sync() and persist next_batch."""
+    async def test_sync_loop_runs_maintenance_without_manual_sync(self):
+        """Maintenance must not race mautrix's syncer for /sync tokens."""
         adapter = _make_adapter()
         adapter._encryption = True
         adapter._closing = False
 
-        call_count = 0
-
-        async def _sync_once(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 1:
-                adapter._closing = True
-            return {"rooms": {"join": {"!room:example.org": {}}}, "next_batch": "s1234"}
+        async def _refresh_once():
+            adapter._closing = True
 
         mock_crypto = MagicMock()
-
-        mock_sync_store = MagicMock()
-        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
-        mock_sync_store.put_next_batch = AsyncMock()
+        mock_crypto.share_keys = AsyncMock()
 
         fake_client = MagicMock()
-        fake_client.sync = AsyncMock(side_effect=_sync_once)
+        fake_client.sync = AsyncMock()
         fake_client.crypto = mock_crypto
-        fake_client.sync_store = mock_sync_store
-        fake_client.handle_sync = MagicMock(return_value=[])
+        fake_client.handle_sync = MagicMock()
         adapter._client = fake_client
 
-        await adapter._sync_loop()
+        with patch("gateway.platforms.matrix.asyncio.sleep", AsyncMock()):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock(side_effect=_refresh_once)) as refresh:
+                await adapter._sync_loop()
 
-        fake_client.sync.assert_awaited_once()
-        fake_client.handle_sync.assert_called_once()
-        mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
+        refresh.assert_awaited_once()
+        mock_crypto.share_keys.assert_awaited_once()
+        fake_client.sync.assert_not_called()
+        fake_client.handle_sync.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_sync_loop_reconciles_pending_invites(self):
-        """Pending rooms.invite entries should be joined if callbacks were missed."""
-        adapter = _make_adapter()
-        adapter._closing = False
+    async def test_connect_starts_mautrix_syncer_for_event_dispatch(self):
+        """connect() must start mautrix's dispatcher-backed syncer."""
+        from gateway.platforms.matrix import MatrixAdapter
 
-        async def _sync_once(**kwargs):
-            adapter._closing = True
-            return {
-                "rooms": {
-                    "join": {"!joined:example.org": {}},
-                    "invite": {"!invited:example.org": {}},
-                },
-                "next_batch": "s1234",
-            }
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
 
         mock_sync_store = MagicMock()
-        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
         mock_sync_store.put_next_batch = AsyncMock()
 
-        fake_client = MagicMock()
-        fake_client.sync = AsyncMock(side_effect=_sync_once)
-        fake_client.join_room = AsyncMock()
-        fake_client.sync_store = mock_sync_store
-        fake_client.handle_sync = MagicMock(return_value=[])
-        adapter._client = fake_client
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.sync_store = mock_sync_store
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.sync = AsyncMock(return_value={
+            "rooms": {"join": {"!room:example.org": {}}},
+            "next_batch": "s1234",
+        })
+        mock_client.add_event_handler = MagicMock()
+        mock_client.add_dispatcher = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.start = MagicMock(return_value=None)
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
 
-        with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-            await adapter._sync_loop()
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
 
-        fake_client.join_room.assert_awaited_once()
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
+        mock_client.handle_sync.assert_called_once()
+        mock_client.start.assert_called_once_with(None)
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_initial_sync_reconciles_pending_invites(self):
+        """Pending rooms.invite entries are joined during startup catch-up."""
+        from gateway.platforms.matrix import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.sync_store = mock_sync_store
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.sync = AsyncMock(return_value={
+            "rooms": {
+                "join": {"!joined:example.org": {}},
+                "invite": {"!invited:example.org": {}},
+            },
+            "next_batch": "s1234",
+        })
+        mock_client.join_room = AsyncMock()
+        mock_client.add_event_handler = MagicMock()
+        mock_client.add_dispatcher = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.start = MagicMock(return_value=None)
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        mock_client.join_room.assert_awaited_once()
         assert "!joined:example.org" in adapter._joined_rooms
         assert "!invited:example.org" in adapter._joined_rooms
+
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_stops_mautrix_syncer(self):
+        """disconnect() should stop the SDK syncer before closing the session."""
+        adapter = _make_adapter()
+        adapter._sync_task = None
+
+        fake_client = MagicMock()
+        fake_client.stop = MagicMock(return_value=None)
+        fake_client.api = MagicMock()
+        fake_client.api.session = MagicMock()
+        fake_client.api.session.close = AsyncMock()
+        adapter._client = fake_client
+
+        await adapter.disconnect()
+
+        fake_client.stop.assert_called_once_with()
+        fake_client.api.session.close.assert_awaited_once()
 
 
 class TestMatrixUploadAndSend:


### PR DESCRIPTION
## What does this PR do?

Starts the mautrix Matrix client syncer after the adapter's initial catch-up sync so registered `add_event_handler(...)` callbacks keep receiving room events. The old Hermes `_sync_loop` no longer performs competing manual `/sync` calls; it remains as a lightweight maintenance loop for DM cache refreshes and E2EE key sharing.

## Related Issue

Fixes #7914

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py`: starts `client.start(None)` after initial sync, stops the mautrix syncer during disconnect, and changes `_sync_loop` into maintenance-only work so mautrix owns event dispatch and sync token advancement.
- `tests/gateway/test_matrix.py`: adds regression tests for syncer startup/shutdown, startup invite reconciliation, and the maintenance loop not calling manual `client.sync()` / `handle_sync()`.

## How to Test

1. `$VIRTUAL_ENV/bin/pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py -q -x --timeout=60` (204 passed)
2. `pytest tests/gateway/test_matrix.py -q -x --timeout=60` (152 passed)
3. `$VIRTUAL_ENV/bin/ruff check gateway/platforms/matrix.py tests/gateway/test_matrix.py`
4. `git diff --check`
5. `python scripts/check-windows-footguns.py gateway/platforms/matrix.py tests/gateway/test_matrix.py`
6. `$VIRTUAL_ENV/bin/pytest tests/ -q -x --timeout=60` stops before Matrix coverage in unrelated `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS/Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=issue-new-9c3508e5 kind=pr-open -->