### PR TITLE
fix(gateway): require allowlists before adapter dispatch

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6920,29 +6920,67 @@ class GatewayRunner:
 
         return None
 
-    def _adapter_enforces_own_access_policy(self, platform: Optional[Platform]) -> bool:
-        """Whether the adapter for *platform* gates access at intake itself.
+    def _adapter_enforces_configured_allowlist(self, source: SessionSource) -> bool:
+        """Whether the adapter already enforced a configured caller allowlist.
 
-        Mirrors ``BasePlatformAdapter.enforces_own_access_policy``. Adapters
-        such as WeCom, Weixin, Yuanbao, QQBot, and WhatsApp evaluate their
-        documented ``dm_policy`` / ``group_policy`` / ``allow_from`` config before a
-        message is dispatched to the gateway, so a message that reaches
-        ``_is_user_authorized`` has already been authorized by the adapter.
-        Defaults to ``False`` when the adapter is unknown or doesn't expose
-        the flag.
+        Some adapters evaluate ``dm_policy`` / ``group_policy`` plus
+        ``allow_from`` / ``group_allow_from`` before a message reaches the
+        gateway. That adapter-local decision is only a security authorization
+        when it is backed by an actual allowlist for the current message shape;
+        a default ``open`` policy is not enough.
         """
+        platform = source.platform
         if not platform:
             return False
-        # Some test helpers build a bare GatewayRunner via object.__new__ and
-        # never set ``adapters``; treat a missing/empty map as "no adapter"
-        # rather than raising (see pitfalls.md #17).
         adapters = getattr(self, "adapters", None)
         if not adapters:
             return False
         adapter = adapters.get(platform)
         if adapter is None:
             return False
-        return bool(getattr(adapter, "enforces_own_access_policy", False))
+        if not bool(getattr(adapter, "enforces_own_access_policy", False)):
+            return False
+
+        config = getattr(self, "config", None)
+        platform_cfg = config.platforms.get(platform) if config and hasattr(config, "platforms") else None
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+        if not isinstance(extra, dict):
+            extra = {}
+
+        def configured_values(*names: str) -> set[str]:
+            values: set[str] = set()
+            for name in names:
+                raw = extra.get(name)
+                if raw is None:
+                    continue
+                if isinstance(raw, str):
+                    values.update(part.strip() for part in raw.split(",") if part.strip())
+                elif isinstance(raw, (list, tuple, set)):
+                    values.update(str(part).strip() for part in raw if str(part).strip())
+            return values
+
+        def configured_policy(name: str, default: str = "open") -> str:
+            return str(extra.get(name) or default).strip().lower()
+
+        if source.chat_type in {"group", "forum", "channel"}:
+            group_policy = configured_policy("group_policy")
+            group_allow = configured_values("group_allow_from", "groupAllowFrom")
+            groups = extra.get("groups")
+            if isinstance(groups, dict) and source.chat_id in groups and isinstance(groups[source.chat_id], dict):
+                raw_group_allow = (
+                    groups[source.chat_id].get("allow_from")
+                    or groups[source.chat_id].get("allowFrom")
+                    or []
+                )
+                if isinstance(raw_group_allow, str):
+                    group_allow.update(part.strip() for part in raw_group_allow.split(",") if part.strip())
+                else:
+                    group_allow.update(str(part).strip() for part in raw_group_allow if str(part).strip())
+            return group_policy == "allowlist" and bool(group_allow)
+
+        dm_policy = configured_policy("dm_policy")
+        dm_allow = configured_values("allow_from", "allowFrom", "dm_allow_from", "dmAllowFrom")
+        return dm_policy == "allowlist" and bool(dm_allow)
 
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
@@ -7083,14 +7121,10 @@ class GatewayRunner:
         global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
-            # No env allowlists configured. Adapters that own their own
-            # config-driven access policy (dm_policy / group_policy /
-            # allow_from / group_allow_from) already gated this message at
-            # intake — it would not have reached the gateway otherwise — so
-            # honor that decision instead of falling through to the
-            # env-only default-deny below, which would silently break
-            # `dm_policy: open` and config-only allowlists. (#34515)
-            if self._adapter_enforces_own_access_policy(source.platform):
+            # Adapter-local policy can satisfy the network-surface allowlist
+            # requirement only when it is backed by a configured allowlist for
+            # this message. Default-open adapter policy must still fail closed.
+            if self._adapter_enforces_configured_allowlist(source):
                 return True
             # No allowlists configured -- check global allow-all flag
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -1,23 +1,12 @@
 """Tests for config-driven platform access policies at the gateway layer.
 
-Background (#34515): WeCom, Weixin, Yuanbao, QQBot, and WhatsApp expose a
-documented config-driven access surface (``dm_policy`` / ``group_policy`` /
-``allow_from`` / ``group_allow_from`` in ``PlatformConfig.extra``) and enforce
-it at intake —
-a message is dropped inside the adapter and never reaches the gateway unless it
-already passed that policy.
-
-The gateway's env-based allowlist check (``_is_user_authorized``) runs *after*
-the adapter. Before the fix it fell through to an env-only default-deny when no
-``PLATFORM_ALLOWED_USERS`` env var was set, silently rejecting ``dm_policy:
-open`` and config-only allowlists even though the adapter had already
-authorized the sender.
-
-The fix is a single drift-proof contract: adapters that own their access policy
-declare ``enforces_own_access_policy`` (a ``BasePlatformAdapter`` property,
-default ``False``). The gateway trusts that flag and skips the env-only
-default-deny for those platforms, rather than re-implementing each adapter's
-policy logic a second time.
+WeCom, Weixin, Yuanbao, QQBot, and WhatsApp expose a config-driven access
+surface (``dm_policy`` / ``group_policy`` / ``allow_from`` /
+``group_allow_from``) and enforce it before dispatching to the gateway. Hermes'
+security policy requires an operator-configured allowlist for enabled
+network-exposed adapters, so the gateway may trust adapter-local authorization
+only when that adapter-local policy is backed by a configured allowlist.
+Default-open adapter policy must still fail closed.
 """
 
 from types import SimpleNamespace
@@ -128,15 +117,40 @@ def test_own_policy_adapters_declare_the_flag(module_path, class_name):
 
 
 @pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
-def test_own_policy_platform_authorized_without_env_allowlist(monkeypatch, platform):
-    """A message reaching the gateway from an own-policy adapter is trusted.
-
-    With no env allowlist set, the gateway must NOT default-deny — the adapter
-    already authorized the sender at intake (e.g. ``dm_policy: open``).
-    """
+def test_own_policy_platform_default_open_denies_without_allowlist(monkeypatch, platform):
+    """Default-open adapter policy is not an authorization boundary."""
     _clear_auth_env(monkeypatch)
     config = GatewayConfig(
         platforms={platform: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(_source(platform)) is False
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_platform_default_open_group_denies_without_allowlist(monkeypatch, platform):
+    """Default-open group policy also fails closed."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, extra={"group_policy": "open"})}
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._is_user_authorized(_source(platform, chat_type="group")) is False
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_own_policy_platform_config_allowlist_authorizes_without_env(monkeypatch, platform):
+    """Adapter-local allowlists remain valid authorization evidence."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                extra={"dm_policy": "allowlist", "allow_from": ["some-user"]},
+            )
+        }
     )
     runner, _adapter = _make_runner(platform, config, enforces=True)
 
@@ -144,11 +158,16 @@ def test_own_policy_platform_authorized_without_env_allowlist(monkeypatch, platf
 
 
 @pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
-def test_own_policy_platform_authorized_for_group_chat(monkeypatch, platform):
-    """Group traffic from an own-policy adapter is trusted the same way."""
+def test_own_policy_platform_config_group_allowlist_authorizes_without_env(monkeypatch, platform):
+    """Adapter-local group allowlists are trusted for group messages."""
     _clear_auth_env(monkeypatch)
     config = GatewayConfig(
-        platforms={platform: PlatformConfig(enabled=True, extra={"group_policy": "open"})}
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                extra={"group_policy": "allowlist", "group_allow_from": ["some-chat"]},
+            )
+        }
     )
     runner, _adapter = _make_runner(platform, config, enforces=True)
 
@@ -199,7 +218,7 @@ def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):
     runner, _adapter = _make_runner(Platform.WECOM, config, enforces=True)
     runner.adapters = {}  # nothing registered
 
-    assert runner._adapter_enforces_own_access_policy(Platform.WECOM) is False
+    assert runner._adapter_enforces_configured_allowlist(_source(Platform.WECOM)) is False
     assert runner._is_user_authorized(_source(Platform.WECOM)) is False
 
 


### PR DESCRIPTION
## Summary
Hermes security documentation says enabled network-exposed adapters require allowlists before dispatch, but WeCom, Weixin, QQBot, WhatsApp, and Yuanbao still ship open adapter-local defaults on current `main`. Once an adapter-local open check passes, the gateway treats the sender as authorized even when no operator allowlist contains that sender.

On Yuanbao the same fail-open shape also applies to group messages, so any member of a joined group can dispatch work and receive agent output in the shared channel when `group_policy` stays at its default `open` value.

- Gateway authorization trusts adapter-local policy as sufficient for external-surface access.
- Adapter-local default `dm_policy: open` or `group_policy: open` means there may be no configured authorization set to enforce.
- Yuanbao group delivery broadens the blast radius because agent output is returned to the entire joined group channel.

Require every enabled network-exposed adapter to fail closed until an operator-configured caller allowlist satisfies the `SECURITY.md` section 2.6 authorization boundary, even when the adapter also offers local open-policy knobs. The gateway should not trust `enforces_own_access_policy` when the adapter's effective DM or group policy is still `open`.

## Linked context
Closes #37992

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/gateway/run.py:7005-7016`
- `hermes-agent/gateway/platforms/base.py:1851-1871`
- `hermes-agent/gateway/platforms/wecom.py:163-174,858-868`
- `hermes-agent/gateway/platforms/weixin.py:1175-1176,1453-1462`
- `hermes-agent/gateway/platforms/qqbot/adapter.py:211-215,273-275`
- `hermes-agent/gateway/platforms/whatsapp.py:263-266,383-403`; `hermes-agent/gateway/platforms/yuanbao.py:1527-1533,1549-1566,4633-4655,4694-4697`

### Files changed in this PR
- `gateway/run.py`
- `tests/gateway/test_config_driven_access_policy.py`

### Behavior reproduced or verified
1. Use Hermes Agent latest upstream `main` at source receipt commit `e114b31edaec8588e085e6748582672356529170`.
2. Enable WeCom, Weixin, QQBot, WhatsApp, or Yuanbao with required credentials only.
3. Leave `dm_policy`, `group_policy`, adapter allowlists, and gateway allowlist env vars unset.
4. Send an inbound DM from a sender outside any configured authorization set, or on Yuanbao send a group message from a member outside any configured group allowlist.
5. Observe the adapter's default `open` policy pass intake and the gateway trust `enforces_own_access_policy`; expected result is fail-closed denial until an allowlist exists.

### Expected fixed behavior
Require every enabled network-exposed adapter to fail closed until an operator-configured caller allowlist satisfies the `SECURITY.md` section 2.6 authorization boundary, even when the adapter also offers local open-policy knobs. The gateway should not trust `enforces_own_access_policy` when the adapter's effective DM or group policy is still `open`.

## Tests and validation
- `bash scripts/run_tests.sh tests/gateway/test_config_driven_access_policy.py`
- Result: 1 files, 33 tests passed, 0 failed (100% complete) in 1.1s (20 workers) ===

## Environment
Hermes latest-main source receipt: `e114b31edaec8588e085e6748582672356529170` on current `main`. Runtime prerequisite: enabled network adapter with no operator allowlist and default-open adapter policy. Safe local proof also exists in `hermes-agent/tests/gateway/test_config_driven_access_policy.py`. Redaction complete; no secrets, tokens, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness receipt: `source_ready` for `upstream-main` at `e114b31edaec8588e085e6748582672356529170` via `/tmp/hermes-source-receipt.json`; affected paths exist in the prepared latest-main checkout.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Confirm current-turn approval evidence before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
