### PR TITLE
fix(approval): check is_interrupted() in blocking gateway approval wa…

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -19,6 +19,7 @@ import unicodedata
 from typing import Optional
 from hermes_cli.config import cfg_get
 
+from tools.interrupt import is_interrupted
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -1234,6 +1235,17 @@ def check_all_command_guards(command: str, env_type: str,
             _activity_state = {"last_touch": _now, "start": _now}
             resolved = False
             while True:
+                # Respect interrupt signals (e.g. /stop from user) so the
+                # approval wait doesn't keep the session blocked until timeout.
+                if is_interrupted():
+                    logger.info(
+                        "Approval wait interrupted by user signal — "
+                        "returning deny for session %s", session_key
+                    )
+                    entry.result = "deny"
+                    entry.event.set()
+                    resolved = True
+                    break
                 _remaining = _deadline - time.monotonic()
                 if _remaining <= 0:
                     break


### PR DESCRIPTION
…it loop

When a dangerous command triggers the gateway approval flow, the agent thread blocks on threading.Event.wait() in _check_all_guards(). Unlike _wait_for_process() which polls is_interrupted() every iteration, this loop never checks for interrupts — so /stop and user messages are silently consumed with zero feedback until the 5-minute timeout expires.

Add an is_interrupted() check at the top of the poll loop alongside the existing deadline check. When interrupted, the pending approval is resolved as 'deny' so the agent loop sees a normal denial and continues without wedging the session.

Fixes: #8697, #27848

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

