### PR TITLE
fix(tui): stop phantom scroll-jump during streaming

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint src/ packages/ --fix",
     "fmt": "prettier --write 'src/**/*.{ts,tsx}' 'packages/**/*.{ts,tsx}'",
     "fix": "npm run lint:fix && npm run fmt",
-    "test": "vitest run",
+    "test": "npm run build --prefix packages/hermes-ink && vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -786,19 +786,13 @@ function renderNodeToOutput(
           node.scrollTop = maxScroll
           node.pendingScrollDelta = undefined
 
-          // Sync flag so useVirtualScroll's isSticky() agrees with positional
-          // state — sticky-broken-but-at-bottom (wheel tremor, click-select
-          // at max) otherwise leaves useVirtualScroll's clamp holding the
-          // viewport short of new streaming content. scrollTo/scrollBy set
-          // false; this restores true, same as scrollToBottom() would.
-          // Only restore when (a) positionally at bottom and (b) the flag
-          // was explicitly broken (===false) by scrollTo/scrollBy. When
-          // undefined (never set by user action) leave it alone — setting it
-          // would make the sticky flag sticky-by-default and lock out
-          // direct scrollTop writes (e.g. the alt-screen-perf test).
-          if (node.stickyScroll === false && scrollTopBeforeFollow >= prevMaxScroll) {
-            node.stickyScroll = true
-          }
+          // Do NOT silently re-enable stickyScroll here. When a user scrolls
+          // up to read older content, scrollTop can land exactly at
+          // prevMaxScroll while new streaming content arrives; re-locking
+          // sticky permanently pins the viewport to the bottom. stickyScroll
+          // is only (re)enabled by the initial prop or an explicit
+          // scrollToBottom(); positional follow above still pins scrollTop
+          // for transient at-bottom states without re-locking the flag.
         }
 
         const followDelta = (node.scrollTop ?? 0) - scrollTopBeforeFollow

--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -20,8 +20,12 @@ describe('virtual height estimates', () => {
   it('uses compound user prompt width when estimating user message wrapping', () => {
     const msg: Msg = { role: 'user', text: 'x'.repeat(21) }
 
-    expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: '❯' })).toBe(3)
-    expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
+    // transcriptBodyWidth reserves 4 cols on desktop (padding + scrollbar).
+    // At cols=26 both prompts floor to 20 and wrap identically; cols=27 is
+    // the first width where a narrow prompt fits on one line and a wide one
+    // wraps to two.
+    expect(estimatedMsgHeight(msg, 27, { compact: false, details: false, userPrompt: '❯' })).toBe(3)
+    expect(estimatedMsgHeight(msg, 27, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
   })
 
   it('adds one row for a group-boundary lead gap', () => {

--- a/ui-tui/src/__tests__/wheelAccel.test.ts
+++ b/ui-tui/src/__tests__/wheelAccel.test.ts
@@ -30,20 +30,23 @@ describe('wheelAccel — native path', () => {
     expect(computeWheelStep(s, 1, 2000)).toBe(1)
   })
 
-  it('direction flip defers one event for bounce detection', () => {
+  it('direction flip defers two events for confirmation', () => {
     const s = initWheelAccel(false, 1)
 
     computeWheelStep(s, 1, 1000)
 
     expect(computeWheelStep(s, -1, 1050)).toBe(0)
+    expect(computeWheelStep(s, -1, 1060)).toBeGreaterThanOrEqual(1)
   })
 
-  it('flip-back within bounce window engages wheelMode', () => {
+  it('flip-back within bounce window engages wheelMode (2-event confirmation)', () => {
     const s = initWheelAccel(false, 1)
 
     computeWheelStep(s, 1, 1000)
     computeWheelStep(s, -1, 1050)
+    computeWheelStep(s, -1, 1060)
     computeWheelStep(s, 1, 1100)
+    computeWheelStep(s, 1, 1110)
 
     expect(s.wheelMode).toBe(true)
   })
@@ -53,9 +56,26 @@ describe('wheelAccel — native path', () => {
 
     computeWheelStep(s, 1, 1000)
     computeWheelStep(s, -1, 1050)
+    computeWheelStep(s, -1, 1060)
     computeWheelStep(s, 1, 1400)
+    computeWheelStep(s, 1, 1410)
 
     expect(s.wheelMode).toBe(false)
+  })
+
+  it('single spurious opposite-direction event is ignored (no flip)', () => {
+    const s = initWheelAccel(false, 1)
+
+    computeWheelStep(s, 1, 1000)
+    computeWheelStep(s, 1, 1020)
+
+    expect(computeWheelStep(s, -1, 1040)).toBe(0)
+
+    const rows = computeWheelStep(s, 1, 1060)
+
+    expect(rows).toBeGreaterThanOrEqual(1)
+    expect(s.wheelMode).toBe(false)
+    expect(s.dir).toBe(1)
   })
 
   it('5 consecutive sub-5ms events disengage wheelMode (trackpad signature)', () => {

--- a/ui-tui/src/lib/wheelAccel.ts
+++ b/ui-tui/src/lib/wheelAccel.ts
@@ -9,7 +9,7 @@
 //   gap 80-500ms (xterm.js)   → mult = 1 + (mult-1)·0.5^(gap/150) + 5·decay
 //                               cap 3 slow / 6 fast
 //   gap > 500ms               → reset (deliberate click stays responsive)
-//   flip + flip-back ≤200ms   → encoder bounce → engage wheel-mode (sticky cap)
+//   flip + flip-back ≤60ms    → encoder bounce → engage wheel-mode (sticky cap)
 //   5 consecutive <5ms events → trackpad flick → disengage wheel-mode
 //
 // Native terminals (Ghostty, iTerm2) and xterm.js embedders (VS Code,
@@ -23,11 +23,14 @@ const WHEEL_ACCEL_STEP = 0.3
 const WHEEL_ACCEL_MAX = 6
 
 // ── Encoder bounce / wheel-mode (mechanical wheels) ────────────────────
-const WHEEL_BOUNCE_GAP_MAX_MS = 200
-const WHEEL_MODE_STEP = 15
-const WHEEL_MODE_CAP = 15
-const WHEEL_MODE_RAMP = 3
-const WHEEL_MODE_IDLE_DISENGAGE_MS = 1500
+// Gap tightened from 200→60ms: Windows focus/blur and ConPTY glitches
+// produce phantom wheel events that pair with real events within 200ms,
+// falsely engaging wheelMode and causing sudden 15-row jumps.
+const WHEEL_BOUNCE_GAP_MAX_MS = 60
+const WHEEL_MODE_STEP = 8
+const WHEEL_MODE_CAP = 8
+const WHEEL_MODE_RAMP = 1
+const WHEEL_MODE_IDLE_DISENGAGE_MS = 1000
 
 // ── xterm.js (VS Code / Cursor / browser terminals) ────────────────────
 const WHEEL_DECAY_HALFLIFE_MS = 150
@@ -50,18 +53,41 @@ export type WheelAccelState = {
   /** Native baseline rows/event. Reset on idle/reversal; ramp builds on
    *  top. xterm.js path ignores. */
   base: number
-  /** Deferred direction flip (native): bounce vs reversal — next event
-   *  decides. */
-  pendingFlip: boolean
   /** Sticky once a flip-then-flip-back fires within the bounce window.
    *  Cleared by idle disengage or trackpad burst. */
   wheelMode: boolean
-  /** Consecutive <5ms events. ≥5 → trackpad flick → disengage. */
+  /** Consecutive <5ms events. Trackpad flick ≥5 → disengage wheelMode. */
   burstCount: number
+  /**
+   * Direction-change debounce. A single spurious event (common on Windows
+   * when focus changes or mouse-tracking glitches fire a lone wheel event)
+   * should not trigger a pending-flip → wheelMode chain. Two consecutive
+   * events in the new direction are required to confirm a real reversal.
+   */
+  pendingDir: 0 | 1 | -1
+  /** Consecutive events seen in `pendingDir`. Confirmed at ≥2. */
+  pendingCount: number
+  /** Saved direction before the pending reversal started — bounce-back detection. */
+  savedDir: 0 | 1 | -1
+  /** Timestamp when `savedDir` was first established. */
+  savedTime: number
 }
 
 export function initWheelAccel(xtermJs = false, base = 1): WheelAccelState {
-  return { burstCount: 0, base, dir: 0, frac: 0, mult: base, pendingFlip: false, time: 0, wheelMode: false, xtermJs }
+  return {
+    base,
+    burstCount: 0,
+    dir: 0,
+    frac: 0,
+    mult: base,
+    pendingCount: 0,
+    pendingDir: 0,
+    savedDir: 0,
+    savedTime: 0,
+    time: 0,
+    wheelMode: false,
+    xtermJs
+  }
 }
 
 /** HERMES_TUI_SCROLL_SPEED (or CLAUDE_CODE_SCROLL_SPEED for portability).
@@ -92,29 +118,51 @@ function nativeStep(state: WheelAccelState, dir: -1 | 1, now: number): number {
     state.mult = state.base
   }
 
-  if (state.pendingFlip) {
-    state.pendingFlip = false
-
-    if (dir !== state.dir || now - state.time > WHEEL_BOUNCE_GAP_MAX_MS) {
-      // Real reversal (flip persisted OR flip-back too late). Commit.
-      // The deferred event's 1 row is lost — acceptable latency.
-      state.dir = dir
-      state.time = now
-      state.mult = state.base
-
-      return Math.floor(state.mult)
-    }
-
-    state.wheelMode = true
-  }
-
   const gap = now - state.time
 
+  // Single spurious events must not trigger pending-flip → wheelMode.
+  // Require 2+ consecutive events in the new direction to confirm reversal.
   if (dir !== state.dir && state.dir !== 0) {
-    state.pendingFlip = true
+    if (dir === state.pendingDir) {
+      state.pendingCount++
+
+      if (state.pendingCount >= 2) {
+        if (dir === state.savedDir && now - state.savedTime <= WHEEL_BOUNCE_GAP_MAX_MS) {
+          state.wheelMode = true
+        } else {
+          state.mult = state.base
+        }
+
+        state.dir = dir
+        state.time = now
+        state.pendingDir = 0
+        state.pendingCount = 0
+
+        return Math.floor(state.mult)
+      }
+
+      state.time = now
+
+      return 0
+    }
+
+    if (state.savedDir === 0) {
+      state.savedDir = state.dir
+      state.savedTime = now
+    }
+
+    state.pendingDir = dir
+    state.pendingCount = 1
     state.time = now
 
     return 0
+  }
+
+  if (state.pendingCount > 0) {
+    state.pendingDir = 0
+    state.pendingCount = 0
+    state.savedDir = 0
+    state.savedTime = 0
   }
 
   state.dir = dir


### PR DESCRIPTION
## Summary
- Stop silently re-enabling `stickyScroll` during at-bottom follow — scrolling up during assistant streaming no longer snaps back to the bottom
- Debounce native wheel direction changes (2-event confirmation) to ignore spurious encoder glitches on Windows
- Fix `virtualHeights` test regression after desktop scrollbar reserve (`horizontalReserve` 2→4); update fixture cols 26→27
- Build `@hermes/ink` before `vitest run` so fresh checkouts pass without a manual prebuild

## Related
- Overlaps scroll-jump fix in #37987 (same root cause). This PR additionally fixes the failing `virtualHeights` test and vitest prebuild on clean checkouts.

## Changes
- `ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts` — remove stickyScroll auto re-lock on at-bottom follow
- `ui-tui/src/lib/wheelAccel.ts` + `wheelAccel.test.ts` — 2-event direction debounce, tighter bounce window
- `ui-tui/src/__tests__/virtualHeights.test.ts` — cols 26→27 after scrollbar reserve change
- `ui-tui/package.json` — `npm test` builds hermes-ink first

## Test plan
- [x] `cd ui-tui && npm test` — 947 passed, 4 skipped
- [ ] Manual: `hermes --tui`, scroll up while assistant is streaming — viewport stays put
- [ ] Manual: mechanical mouse wheel — no sudden multi-row jumps from single spurious reverse events

## Platform tested
- macOS (vitest)