### PR TITLE
fix(desktop): ignore IME composition Enter in composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/ime.ts
+++ b/apps/desktop/src/app/chat/composer/ime.ts
@@ -1,0 +1,13 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+
+/**
+ * Browser/Electron IME composition sends keydown events while the candidate
+ * string is still being committed. Enter during that phase means "accept the
+ * IME candidate", not "submit the chat message".
+ */
+export function isImeCompositionKey(event: ReactKeyboardEvent<HTMLElement>) {
+  const syntheticEvent = event as ReactKeyboardEvent<HTMLElement> & { isComposing?: boolean }
+  const nativeEvent = event.nativeEvent as KeyboardEvent & { isComposing?: boolean }
+
+  return Boolean(syntheticEvent.isComposing || nativeEvent.isComposing || nativeEvent.keyCode === 229)
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -54,6 +54,7 @@ import { useAtCompletions } from './hooks/use-at-completions'
 import { useSlashCompletions } from './hooks/use-slash-completions'
 import { useVoiceConversation } from './hooks/use-voice-conversation'
 import { useVoiceRecorder } from './hooks/use-voice-recorder'
+import { isImeCompositionKey } from './ime'
 import { dragHasAttachments, droppedFileInlineRef, insertInlineRefsIntoEditor } from './inline-refs'
 import { QueuePanel } from './queue-panel'
 import {
@@ -545,6 +546,10 @@ export function ChatBar({
   }
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isImeCompositionKey(event)) {
+      return
+    }
+
     if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'k') {
       event.preventDefault()
 

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/app/chat/composer/focus'
 import { useAtCompletions } from '@/app/chat/composer/hooks/use-at-completions'
 import { useSlashCompletions } from '@/app/chat/composer/hooks/use-slash-completions'
+import { isImeCompositionKey } from '@/app/chat/composer/ime'
 import { dragHasAttachments, droppedFileInlineRef, insertInlineRefsIntoEditor } from '@/app/chat/composer/inline-refs'
 import {
   composerPlainText,
@@ -1195,6 +1196,10 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isImeCompositionKey(event)) {
+      return
+    }
+
     if (trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()


### PR DESCRIPTION
## Summary\n- Add a shared desktop composer helper that detects active IME composition events.\n- Skip Enter submit handling while IME composition is active, so Enter can confirm CJK candidates without sending the message.\n- Apply the guard to both the main chat composer and user edit composer.\n\n## Test Plan\n- [x] cd apps/desktop && npm run type-check\n- [x] cd apps/desktop && npm run pack