### PR TITLE
fix: only apply USER_OWNED_EXCLUDE at staged-tree root in copytree (#37954)

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -557,6 +557,23 @@ def _copy_dist_payload(
     """
     target.mkdir(parents=True, exist_ok=True)
 
+    staged_resolved = staged.resolve()
+
+    def _copytree_ignore(directory: str, names: list) -> list:
+        """Only apply USER_OWNED_EXCLUDE at the staged-tree root.
+
+        Nested directories that happen to share names like ``bin``,
+        ``logs``, or ``cache`` must be copied verbatim — the exclude
+        list only protects the host installation's top-level
+        infrastructure dirs (e.g. ``~/.hermes/bin/``).
+        """
+        try:
+            if Path(directory).resolve() == staged_resolved:
+                return [n for n in names if n in USER_OWNED_EXCLUDE]
+        except (OSError, ValueError):
+            pass
+        return []
+
     for entry in staged.iterdir():
         name = entry.name
 
@@ -576,7 +593,7 @@ def _copy_dist_payload(
             shutil.copytree(
                 entry,
                 dest,
-                ignore=lambda d, names: [n for n in names if n in USER_OWNED_EXCLUDE],
+                ignore=_copytree_ignore,
             )
         else:
             shutil.copy2(entry, dest)

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -497,6 +497,35 @@ class TestSecurity:
         assert not (target / "skills" / "demo" / "leak.txt").exists()
 
 
+
+    def test_nested_dirs_matching_exclude_are_not_filtered(self, profile_env):
+        """Nested directories whose names match USER_OWNED_EXCLUDE entries
+        (e.g. tools/bin/, scripts/logs/) must be copied verbatim.
+
+        Regression test for #37954 -- the old copytree lambda applied
+        USER_OWNED_EXCLUDE recursively, silently dropping nested dirs.
+        """
+        staged = _make_staging_dir(profile_env, "src")
+        # Create nested dirs that share names with USER_OWNED_EXCLUDE
+        (staged / "tools" / "bin").mkdir(parents=True)
+        (staged / "tools" / "bin" / "tool.py").write_text("# tool\n")
+        (staged / "scripts" / "logs").mkdir(parents=True)
+        (staged / "scripts" / "logs" / "run.log").write_text("log\n")
+        (staged / "control" / "cache").mkdir(parents=True)
+        (staged / "control" / "cache" / "data.json").write_text("{}\n")
+
+        plan = install_distribution(str(staged), name="nested-test")
+        target = plan.target_dir
+
+        # All nested dirs must be present -- not filtered by USER_OWNED_EXCLUDE
+        assert (target / "tools" / "bin").is_dir(), "tools/bin/ was filtered"
+        assert (target / "tools" / "bin" / "tool.py").exists()
+        assert (target / "scripts" / "logs").is_dir(), "scripts/logs/ was filtered"
+        assert (target / "scripts" / "logs" / "run.log").exists()
+        assert (target / "control" / "cache").is_dir(), "control/cache/ was filtered"
+        assert (target / "control" / "cache" / "data.json").exists()
+
+
 # ===========================================================================
 # Install-time metadata (installed_at stamp)
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes #37954

shutil.copytree's ignore callback fires at every directory depth. The old lambda in _copy_dist_payload applied USER_OWNED_EXCLUDE recursively, silently dropping nested directories whose names matched (e.g. tools/bin/, scripts/logs/, control/cache/).

## Changes

- **hermes_cli/profile_distribution.py**: Replace the lambda with a closure (_copytree_ignore) that checks whether the current directory matches the resolved staged-tree root before applying exclusions. This matches the existing two-tier pattern used by _clone_all_copytree_ignore and _default_export_ignore in profiles.py.

- **tests/hermes_cli/test_profile_distribution.py**: Added regression test test_nested_dirs_matching_exclude_are_not_filtered that creates nested dirs with names from USER_OWNED_EXCLUDE and verifies they are copied verbatim.

## Verification

All 65 tests in test_profile_distribution.py pass, including the new regression test.

## Notes

The fix is minimal and follows the established pattern already used elsewhere in the codebase (profiles.py:140-158). The two-tier approach — root-level exclusions only at the staged tree root, nothing at deeper levels — is the correct semantic: USER_OWNED_EXCLUDE protects the host installation's infrastructure dirs (~/.hermes/bin/, ~/.hermes/logs/), not arbitrary nested directories in distribution payloads.