### PR TITLE
fix(desktop): ignore IME composition enter

### DIFF
--- a/apps/desktop/src/app/chat/composer/ime.test.ts
+++ b/apps/desktop/src/app/chat/composer/ime.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { isImeCompositionKeyEvent } from './ime'
+
+describe('isImeCompositionKeyEvent', () => {
+  it('treats Enter keydown during IME composition as composing so it does not submit', () => {
+    const event = {
+      key: 'Enter',
+      nativeEvent: { isComposing: true }
+    }
+
+    expect(isImeCompositionKeyEvent(event)).toBe(true)
+  })
+
+  it('treats macOS IME composition Enter with keyCode 229 as composing', () => {
+    const event = {
+      key: 'Enter',
+      nativeEvent: { isComposing: false, keyCode: 229 }
+    }
+
+    expect(isImeCompositionKeyEvent(event)).toBe(true)
+  })
+
+  it('does not treat normal Enter as composing', () => {
+    const event = {
+      key: 'Enter',
+      nativeEvent: { isComposing: false, keyCode: 13 }
+    }
+
+    expect(isImeCompositionKeyEvent(event)).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/ime.ts
+++ b/apps/desktop/src/app/chat/composer/ime.ts
@@ -1,0 +1,12 @@
+interface ImeCompositionKeyEvent {
+  nativeEvent?: {
+    isComposing?: boolean
+    keyCode?: number
+  }
+}
+
+const IME_PROCESSING_KEY_CODE = 229
+
+export function isImeCompositionKeyEvent(event: ImeCompositionKeyEvent) {
+  return Boolean(event.nativeEvent?.isComposing || event.nativeEvent?.keyCode === IME_PROCESSING_KEY_CODE)
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -54,6 +54,7 @@ import { useAtCompletions } from './hooks/use-at-completions'
 import { useSlashCompletions } from './hooks/use-slash-completions'
 import { useVoiceConversation } from './hooks/use-voice-conversation'
 import { useVoiceRecorder } from './hooks/use-voice-recorder'
+import { isImeCompositionKeyEvent } from './ime'
 import { dragHasAttachments, droppedFileInlineRef, insertInlineRefsIntoEditor } from './inline-refs'
 import { QueuePanel } from './queue-panel'
 import {
@@ -545,6 +546,10 @@ export function ChatBar({
   }
 
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isImeCompositionKeyEvent(event)) {
+      return
+    }
+
     if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'k') {
       event.preventDefault()
 
@@ -1024,8 +1029,8 @@ export function ChatBar({
     <div className={cn('relative', stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1')}>
       <div
         aria-label="Message"
-        autoCorrect="off"
         autoCapitalize="off"
+        autoCorrect="off"
         className={cn(
           'min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) overflow-y-auto bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
           'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',


### PR DESCRIPTION
## What does this PR do?

This fixes Hermes Desktop submitting a chat message when users press Enter to confirm Japanese/Chinese/Korean IME conversion.

The desktop composer currently handles every non-Shift Enter keydown as submit. During IME composition, the conversion-confirmation Enter also reaches the composer as a keydown event, so confirming text can accidentally send the unfinished message.

This PR adds a small IME composition guard before the submit shortcut runs. It checks both `nativeEvent.isComposing` and the browser IME processing key code `229`, which covers the common macOS/Electron path where composition Enter may not be represented as a normal Enter event. Normal Enter submission remains unchanged.

## Related Issue

Fixes #37483

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`
  - Skip composer keydown shortcuts while an IME composition event is active, preventing conversion-confirmation Enter from submitting the message.
- `apps/desktop/src/app/chat/composer/ime.ts`
  - Add `isImeCompositionKeyEvent()` helper for `nativeEvent.isComposing` and IME processing `keyCode === 229`.
- `apps/desktop/src/app/chat/composer/ime.test.ts`
  - Add regression tests for IME composition Enter, macOS/Electron `keyCode === 229`, and normal Enter behavior.

## How to Test

1. In Hermes Desktop on macOS, focus the chat composer and enable a Japanese IME.
2. Type text that requires conversion, then press Enter to confirm the conversion.
   - Expected: the converted text stays in the composer and is not submitted.
3. Press Enter again after composition has ended.
   - Expected: the message submits normally.

Automated checks run locally:

```text
npm run test:ui -- src/app/chat/composer
npm run type-check
npx eslint src/app/chat/composer/ime.ts src/app/chat/composer/ime.test.ts src/app/chat/composer/index.tsx
npm run build
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2 / Hermes Desktop Electron app

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
> hermes@0.15.1 test:ui
> vitest run --environment jsdom src/app/chat/composer

✓ src/app/chat/composer/ime.test.ts (3 tests)
✓ src/app/chat/composer/rich-editor.test.ts (1 test)

Test Files  2 passed (2)
Tests       4 passed (4)
```

```text
> hermes@0.15.1 type-check
> tsc -b
```

```text
npx eslint src/app/chat/composer/ime.ts src/app/chat/composer/ime.test.ts src/app/chat/composer/index.tsx
# passed
```

```text
npm run build
# built successfully
```
