### PR TITLE
feat(prompt): surface profile isolation in environment hints

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -764,6 +764,52 @@ def _clear_backend_probe_cache() -> None:
     _BACKEND_PROBE_CACHE.clear()
 
 
+def _build_profile_scope_hint() -> Optional[str]:
+    """Describe Hermes profile isolation so the agent doesn't fork shared state.
+
+    Hermes profiles are isolated ``HERMES_HOME`` directories under
+    ``<root>/profiles/<name>``. The host/backend block above reports the
+    OS-level home and cwd, but says nothing about profile scoping — so an
+    agent (or a tool/subprocess that resolves paths from ``$HOME`` / ``~``)
+    can silently read or write the *wrong* profile and fork shared state.
+
+    Emitted only under a non-default profile; returns ``None`` for the
+    default profile or on any resolution failure, leaving the environment
+    block unchanged otherwise. This derives the same awareness automatically
+    that an operator could supply by hand via ``HERMES_ENVIRONMENT_HINT``,
+    and mirrors the cross-profile write guard in ``agent.file_safety`` and
+    the ``HERMES_HOME`` fallback warning in ``hermes_constants`` (see #18594),
+    on the agent-facing prompt side.
+    """
+    try:
+        from agent.file_safety import _resolve_active_profile_name
+        from hermes_constants import get_default_hermes_root
+
+        profile = _resolve_active_profile_name()
+        if not profile or profile == "default":
+            return None
+        profile_home = get_hermes_home().resolve()
+        root = get_default_hermes_root().resolve()
+    except Exception as e:
+        logger.debug("Could not build profile-scope hint: %s", e)
+        return None
+
+    return (
+        f"Hermes profile: {profile} — you are running under an isolated, "
+        f"per-profile Hermes home, not the shared root.\n"
+        f"Profile home (HERMES_HOME): {profile_home}\n"
+        f"Shared Hermes root (all profiles): {root}\n"
+        "Per-profile state (skills, plugins, cron, memories) lives under the "
+        "profile home; shared or cross-profile resources live under the shared "
+        "root. Tools and subprocesses may run with a per-profile HOME, so paths "
+        "built from $HOME / ~ can resolve INTO this profile rather than the "
+        "shared root. Do NOT override HOME or HERMES_HOME at runtime to work "
+        "around a path that looks wrong — that masks a real path bug and can "
+        "silently fork shared state. Use absolute paths under the shared root "
+        "for shared resources, and report path bugs instead."
+    )
+
+
 def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
 
@@ -846,6 +892,10 @@ def build_environment_hints() -> str:
                 f"them, probe directly with a terminal call like "
                 f"`uname -a && whoami && pwd`."
             )
+
+    profile_hint = _build_profile_scope_hint()
+    if profile_hint:
+        hints.append(profile_hint)
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1024,6 +1024,37 @@ class TestEnvironmentHints:
         result = _pb.build_environment_hints()
         assert "Host:" in result
 
+    def test_build_environment_hints_includes_profile_scope_when_non_default(self, monkeypatch):
+        """Under a non-default profile, the agent is told it is profile-scoped."""
+        from pathlib import Path
+        import agent.prompt_builder as _pb
+        import agent.file_safety as _fs
+        import hermes_constants as _hc
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setattr(_fs, "_resolve_active_profile_name", lambda: "coder")
+        monkeypatch.setattr(_pb, "get_hermes_home", lambda: Path("/srv/hermes/profiles/coder"))
+        monkeypatch.setattr(_hc, "get_default_hermes_root", lambda: Path("/srv/hermes"))
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hermes profile: coder" in result
+        assert "Profile home (HERMES_HOME): /srv/hermes/profiles/coder" in result
+        assert "Shared Hermes root (all profiles): /srv/hermes" in result
+        assert "Do NOT override HOME or HERMES_HOME" in result
+        # The factual host block must still come first.
+        assert result.index("Host:") < result.index("Hermes profile:")
+
+    def test_build_environment_hints_omits_profile_scope_for_default(self, monkeypatch):
+        """The default profile is not profile-scoped — no profile block is added."""
+        import agent.prompt_builder as _pb
+        import agent.file_safety as _fs
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setattr(_fs, "_resolve_active_profile_name", lambda: "default")
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Hermes profile:" not in result
+
 
 # =========================================================================
 # Conditional skill activation


### PR DESCRIPTION
## What

When Hermes runs under a non-default profile, `build_environment_hints()` now
adds a short block telling the agent it is profile-scoped: the profile name, its
`HERMES_HOME`, the shared Hermes root, and a warning not to override
`HOME` / `HERMES_HOME` at runtime. For the default profile the environment block
is unchanged.

Closes #38008.

## Why

`build_environment_hints()` reported the OS-level home and cwd but never
mentioned profile scoping. Under a non-default profile, the active `HERMES_HOME`
is `<root>/profiles/<name>` while shared/cross-profile state lives under the
root — and the agent (or any tool/subprocess resolving paths from `$HOME` / `~`)
could silently read/write the wrong profile and fork shared state.

This mirrors guards that already exist on the *write* side — the cross-profile
write guard in `agent/file_safety.py` and the `HERMES_HOME` fallback warning in
`hermes_constants.get_hermes_home()` (#18594) — and closes the agent-facing
**prompt** gap. It also complements the operator-supplied
`HERMES_ENVIRONMENT_HINT` by deriving the same awareness automatically.

## Before / After

Run as a non-default profile (`HERMES_HOME=~/.hermes/profiles/coder`):

**Before**
```
Host: WSL (Windows Subsystem for Linux)
User home directory: /home/user
Current working directory: /home/user/work
```

**After**
```
Host: WSL (Windows Subsystem for Linux)
User home directory: /home/user
Current working directory: /home/user/work

Hermes profile: coder — you are running under an isolated, per-profile Hermes home, not the shared root.
Profile home (HERMES_HOME): /home/user/.hermes/profiles/coder
Shared Hermes root (all profiles): /home/user/.hermes
Per-profile state (skills, plugins, cron, memories) lives under the profile home; shared or cross-profile resources live under the shared root. Tools and subprocesses may run with a per-profile HOME, so paths built from $HOME / ~ can resolve INTO this profile rather than the shared root. Do NOT override HOME or HERMES_HOME at runtime to work around a path that looks wrong — that masks a real path bug and can silently fork shared state. Use absolute paths under the shared root for shared resources, and report path bugs instead.
```

## Implementation

- New helper `_build_profile_scope_hint()` in `agent/prompt_builder.py`. It
  reuses existing detection — `file_safety._resolve_active_profile_name()`,
  `hermes_constants.get_hermes_home()` / `get_default_hermes_root()`.
- Returns `None` for the default profile or on any resolution failure (wrapped
  in `try/except`, logged at debug), so the environment block is never broken by
  this addition.
- Appended in `build_environment_hints()` after the host/backend block and
  before the WSL/embedder hints, so the factual host block still comes first.

## Testing

- Added `tests/agent/test_prompt_builder.py`:
  `test_build_environment_hints_includes_profile_scope_when_non_default`
  and `test_build_environment_hints_omits_profile_scope_for_default`.
- `python -m pytest tests/agent/test_prompt_builder.py` → **132 passed**.
- Verified end-to-end by running `build_environment_hints()` with
  `HERMES_HOME` set to a profile dir (output shown above) and to the default
  root (no profile block emitted).

> Based on `main` at `30a7a941`.
