### PR TITLE
fix(gateway): keep adapter exception details out of chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5455,16 +5455,15 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
-            # Send the error to the user so they aren't left with radio silence
+            # The full exception is already in the server-side log above. Keep
+            # raw types and messages out of chat, matching GatewayRunner's
+            # exception boundary, while still avoiding user-facing silence.
             try:
-                error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
+                        "Sorry, I encountered an unexpected error.\n"
                         "Try again or use /reset to start a fresh session."
                     ),
                     metadata=_thread_metadata,

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -185,10 +185,11 @@ class TestBasePlatformTopicSessions:
     @pytest.mark.asyncio
     async def test_process_message_background_marks_exception_unsuccessful(self):
         adapter = DummyTelegramAdapter()
+        secret = "sk-live_abcdefghijklmnopqrstuvwxyz1234567890"
 
         async def handler(_event):
             await asyncio.sleep(0)
-            raise RuntimeError("boom")
+            raise RuntimeError(f"Incorrect API key provided: {secret}")
 
         async def hold_typing(_chat_id, interval=2.0, metadata=None):
             await asyncio.Event().wait()
@@ -203,6 +204,19 @@ class TestBasePlatformTopicSessions:
             ("start", "1"),
             ("complete", "1", ProcessingOutcome.FAILURE),
         ]
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": (
+                    "Sorry, I encountered an unexpected error.\n"
+                    "Try again or use /reset to start a fresh session."
+                ),
+                "reply_to": None,
+                "metadata": {"thread_id": "17585"},
+            }
+        ]
+        assert secret not in adapter.sent[0]["content"]
+        assert "Incorrect API key provided" not in adapter.sent[0]["content"]
 
     @pytest.mark.asyncio
     async def test_process_message_background_marks_cancellation_unsuccessful(self):


### PR DESCRIPTION
## Summary

The issue was closed after #53907 fixed the normal outbound response path, but that change did not cover the base-adapter exception fallback. Current `main` still sends `str(e)[:300]` from `BasePlatformAdapter._process_message_background()` directly to chat when a platform message handler raises.

This PR is rebased and narrowed to that remaining path:

- Keep the full exception and traceback in server-side logs.
- Send a generic user-facing failure from the base-adapter fallback, matching the existing `GatewayRunner` exception boundary.
- Exercise the real handler-to-`send()` path with a secret-bearing exception and assert that neither the credential nor raw provider message reaches chat.
- Drop the stale normal-response and runner-exception changes already implemented on `main`.

## Linked context

Closes #38012.

#53907 fixed cross-platform redaction for ordinary gateway final responses. This patch completes the separate base-adapter exception boundary identified in the July 13 review.

## Current behavior proof

On current `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`:

1. `gateway/run.py` sanitizes ordinary final responses across human-facing chat surfaces.
2. The runner-level exception path returns a generic error without raw exception text.
3. `gateway/platforms/base.py` still formats the adapter fallback from `type(e).__name__` and `str(e)[:300]`.
4. A handler exception containing provider credential material therefore reaches the adapter's outbound `send()` call.

After this patch, the exception remains available in the existing server-side log entry, while the outbound chat message contains no raw exception type, provider text, or credential.

## Files changed

- `gateway/platforms/base.py`
- `tests/gateway/test_base_topic_sessions.py`

## Tests and validation

- `scripts/run_tests.sh tests/gateway/test_base_topic_sessions.py tests/gateway/test_telegram_noise_filter.py -q`
  - 2 files, 220 tests passed, 0 failed
- `.venv/bin/ruff check gateway/platforms/base.py tests/gateway/test_base_topic_sessions.py`
  - All checks passed
- `git diff --check`
  - Passed

## Source state

- Base: `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`
- Head: `131efb452e2f9e8a410855f184791afc43557c8b`
- One contributor-authored commit directly atop current `main`.

## Risk

This removes raw exception detail from a user-facing fallback. Diagnostics remain in the existing server-side traceback log, and users still receive an actionable retry/reset message instead of radio silence.