### PR TITLE
fix(mcp): reject mutable catalog refs at runtime

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -47,6 +47,7 @@ from hermes_cli.config import (
 from hermes_cli.cli_output import prompt as _prompt_input
 
 _MANIFEST_VERSION = 1
+_FULL_GIT_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
 
 # Substituted at install time inside `transport.command` / `transport.args`.
 _INSTALL_DIR_VAR = "${INSTALL_DIR}"
@@ -95,7 +96,7 @@ class InstallSpec:
     """
     type: str  # "git"
     url: str
-    ref: str  # commit/tag/branch — pinned, never floats
+    ref: str  # immutable 40-character commit SHA
     bootstrap: List[str] = field(default_factory=list)
 
 
@@ -255,6 +256,11 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         ref = install_raw.get("ref") or ""
         if not url or not ref:
             raise CatalogError(f"{path}: install.url and install.ref are required")
+        if not isinstance(ref, str) or not _FULL_GIT_SHA_RE.fullmatch(ref):
+            raise CatalogError(
+                f"{path}: install.ref must be a full 40-character commit SHA "
+                "(branches and tags are mutable and cannot be bootstrapped)"
+            )
         bootstrap = install_raw.get("bootstrap") or []
         if not isinstance(bootstrap, list):
             raise CatalogError(f"{path}: install.bootstrap must be a list")
@@ -406,32 +412,12 @@ def _do_git_install(entry: CatalogEntry) -> Path:
 
     print(color(f"  Cloning {install.url} ({install.ref}) → {dest}", Colors.CYAN))
 
-    # `git clone --branch` only accepts branches and tags, NOT commit SHAs.
-    # Detecting SHA-shaped refs upfront avoids a guaranteed stderr leak on
-    # the fast path (the --branch attempt would always fail noisily for a
-    # SHA ref before we fall back to full-clone-then-checkout).
-    is_sha_ref = bool(re.fullmatch(r"[0-9a-f]{7,40}", install.ref))
-
-    if not is_sha_ref:
-        proc = subprocess.run(
-            [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
-        )
-        if proc.returncode == 0:
-            pass
-        else:
-            # Branch/tag form failed (unlikely for valid manifests; possible if
-            # the ref was deleted upstream). Fall through to the full-clone path.
-            if dest.exists():
-                shutil.rmtree(dest)
-            is_sha_ref = True  # treat the same as a SHA ref from here
-
-    if is_sha_ref:
-        proc = subprocess.run([git, "clone", install.url, str(dest)])
-        if proc.returncode != 0:
-            raise CatalogError(f"git clone failed for {install.url}")
-        proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref])
-        if proc.returncode != 0:
-            raise CatalogError(f"git checkout {install.ref} failed")
+    proc = subprocess.run([git, "clone", install.url, str(dest)])
+    if proc.returncode != 0:
+        raise CatalogError(f"git clone failed for {install.url}")
+    proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref])
+    if proc.returncode != 0:
+        raise CatalogError(f"git checkout {install.ref} failed")
 
     if install.bootstrap:
         _run_bootstrap(dest, install.bootstrap)

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -149,7 +149,7 @@ class TestManifestParsing:
             install={
                 "type": "git",
                 "url": "https://example.com/demo.git",
-                "ref": "v1.0.0",
+                "ref": "abc1234567890abcdef1234567890abcdef12345",
                 "bootstrap": ["pip install -r requirements.txt"],
             },
             transport={
@@ -164,8 +164,40 @@ class TestManifestParsing:
         e = list_catalog()[0]
         assert e.install is not None
         assert e.install.url == "https://example.com/demo.git"
-        assert e.install.ref == "v1.0.0"
+        assert e.install.ref == "abc1234567890abcdef1234567890abcdef12345"
         assert e.install.bootstrap == ["pip install -r requirements.txt"]
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "main",
+            "v1.0.0",
+            "a" * 39,
+            "a" * 41,
+            f" {'a' * 40}",
+            1234567890123456789012345678901234567890,
+        ],
+    )
+    def test_install_ref_must_be_full_commit_sha(self, catalog_dir, ref):
+        body = _basic_manifest(
+            install={
+                "type": "git",
+                "url": "https://example.com/demo.git",
+                "ref": ref,
+                "bootstrap": [],
+            },
+            transport={
+                "type": "stdio",
+                "command": "${INSTALL_DIR}/run.sh",
+                "args": [],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import catalog_diagnostics, list_catalog
+
+        assert list_catalog() == []
+        assert catalog_diagnostics()
+        assert "full 40-character commit SHA" in catalog_diagnostics()[0][2]
 
     def test_invalid_manifest_skipped(self, catalog_dir):
         # Broken: wrong manifest_version
@@ -271,7 +303,7 @@ class TestInstall:
             install={
                 "type": "git",
                 "url": "https://example.com/demo.git",
-                "ref": "main",
+                "ref": "abc1234567890abcdef1234567890abcdef12345",
                 "bootstrap": [],
             },
             transport={
@@ -667,15 +699,13 @@ class TestCustomMcpRows:
 
 
 # ---------------------------------------------------------------------------
-# Git install — SHA ref detection
+# Git install — immutable SHA checkout
 # ---------------------------------------------------------------------------
 
 
 class TestGitInstallShaRef:
-    def test_sha_ref_skips_branch_attempt(self, catalog_dir, monkeypatch, tmp_path):
-        """When install.ref is a SHA-shaped hex string, _do_git_install
-        skips the `git clone --branch <ref>` attempt (which would always fail
-        noisily for SHAs) and goes straight to clone + checkout."""
+    def test_sha_ref_uses_plain_clone_then_checkout(self, catalog_dir, monkeypatch, tmp_path):
+        """Git catalog installs use immutable SHAs and never try branch clone."""
         body = _basic_manifest(
             install={
                 "type": "git",
@@ -713,26 +743,24 @@ class TestGitInstallShaRef:
         assert entry is not None
         _do_git_install(entry)
 
-        # Should have called clone (no --branch) then checkout — NOT clone --branch
+        # Should have called clone (no --branch) then checkout.
         branch_attempts = [c for c in calls if "--branch" in c]
         assert branch_attempts == [], (
-            "SHA refs must NOT trigger a --branch clone attempt — that would "
-            "always fail noisily before falling back. Calls were: " + repr(calls)
+            "catalog installs must not use branch/tag clone for immutable refs. "
+            "Calls were: " + repr(calls)
         )
-        # Confirm we DID do plain clone + checkout
         clone_calls = [c for c in calls if "clone" in c and "--branch" not in c]
         checkout_calls = [c for c in calls if "checkout" in c]
         assert len(clone_calls) == 1, calls
         assert len(checkout_calls) == 1, calls
 
-    def test_branch_ref_uses_branch_clone(self, catalog_dir, monkeypatch):
-        """When install.ref is a branch/tag (not SHA-shaped), the fast
-        `git clone --depth 1 --branch <ref>` path is used."""
+    def test_branch_ref_is_rejected_before_install(self, catalog_dir):
+        """Mutable branches and tags are rejected during manifest parsing."""
         body = _basic_manifest(
             install={
                 "type": "git",
                 "url": "https://example.com/x.git",
-                "ref": "v1.0.0",  # Tag-shaped
+                "ref": "v1.0.0",
                 "bootstrap": [],
             },
             transport={
@@ -743,25 +771,11 @@ class TestGitInstallShaRef:
         )
         _write_manifest(catalog_dir, "demo", body)
 
-        from hermes_cli import mcp_catalog
-        from hermes_cli.mcp_catalog import _do_git_install, get_entry
+        from hermes_cli.mcp_catalog import catalog_diagnostics, get_entry, list_catalog
 
-        calls = []
-
-        class _FakeProc:
-            def __init__(self, returncode):
-                self.returncode = returncode
-
-        def fake_run(argv, *args, **kwargs):
-            calls.append(list(argv))
-            return _FakeProc(returncode=0)
-
-        monkeypatch.setattr(mcp_catalog.subprocess, "run", fake_run)
-        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda x: "/usr/bin/git")
-
-        _do_git_install(get_entry("demo"))
-        branch_attempts = [c for c in calls if "--branch" in c]
-        assert len(branch_attempts) == 1, calls
+        assert list_catalog() == []
+        assert get_entry("demo") is None
+        assert "branches and tags are mutable" in catalog_diagnostics()[0][2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The shipped-catalog exposure reported in #38017 was independently fixed by #64463 / `9df5f879b`: n8n now pins the same full commit SHA proposed here, and a catalog-wide CI contract rejects mutable Git refs in every shipped manifest.

This PR is narrowed to the remaining runtime defense-in-depth boundary. It enforces the documented full-SHA policy while parsing install manifests, so malformed or stale packaged catalog data is rejected before clone or bootstrap.

- Require `install.ref` to be a string containing exactly 40 hexadecimal characters.
- Reject branches, tags, abbreviated SHAs, whitespace-padded values, and non-string values during manifest parsing.
- Retain the plain-clone plus exact-checkout path for valid commit objects.
- Remove the now-unreachable branch/tag clone fallback.
- Do not duplicate the n8n manifest pin or the shipped-catalog contract already on `main`.

## Linked context
Follow-up defense in depth for #38017. The original shipped-catalog condition is fixed by #64463.

## Current behavior proof
1. Rebased onto current `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`.
2. Current `main` documents that Git catalog installs require full commit SHAs and tests every shipped manifest against that invariant.
3. Current `_parse_manifest()` still accepts any non-empty `install.ref`, including branches and tags.
4. Current `_do_git_install()` still contains the mutable `git clone --branch` path and will bootstrap it.
5. This patch rejects the mutable value during parsing, before the install entry can reach clone or bootstrap.

## Files changed
- `hermes_cli/mcp_catalog.py`
- `tests/hermes_cli/test_mcp_catalog.py`

## Tests and validation
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q`
- Result: 1 file, 45 tests passed, 0 failed (100% complete) in 2.9s
- `.venv/bin/ruff check hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py`
- Result: all checks passed
- `git diff --check`
- Result: passed

## Source state
- Base: `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`
- Head: `41634e3a44d743fb5ba6b28272826a623c459a05`
- The head has current `main` as its sole parent.

## Risk
This intentionally makes the documented full-SHA catalog policy fail closed at runtime. Package-manager-provided catalog data that still contains a branch, tag, abbreviated SHA, padded value, or non-string ref will be diagnosed as invalid instead of being cloned and bootstrapped.
