### PR TITLE
fix(desktop): stop chat scroll backward-jump from content-growth interim scrolls (#37997)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -182,6 +182,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
   // user-driven upward scroll; re-armed when they reach bottom again.
   const armedRef = useRef(true)
   const lastTopRef = useRef(0)
+  const lastHeightRef = useRef(0)
   // Counter that tracks how many scroll events we expect to be ours rather
   // than the user's. `pinToBottom` writes `el.scrollTop`, which fires an
   // async `scroll` event; without this guard the on-scroll handler can race
@@ -206,6 +207,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
     programmaticScrollPendingRef.current += 1
     el.scrollTop = el.scrollHeight
     lastTopRef.current = el.scrollTop
+    lastHeightRef.current = el.scrollHeight
   }, [scrollerRef])
 
   const jumpToBottom = useCallback(() => {
@@ -250,6 +252,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
       if (programmaticScrollPendingRef.current > 0) {
         programmaticScrollPendingRef.current -= 1
         lastTopRef.current = top
+        lastHeightRef.current = el.scrollHeight
         // Always re-arm — sticky-bottom should hold through clamp races.
         armedRef.current = true
         const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
@@ -258,11 +261,26 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
         return
       }
 
-      if (top + 1 < lastTopRef.current) {
+      // Disarm only when `scrollTop` decreases AND `scrollHeight` did NOT
+      // grow this frame. A bare `top < lastTopRef.current` check is unsafe:
+      // when content grows (virtualizer item measurement, streaming token,
+      // code highlight re-tokenization, composer chip), the browser emits
+      // an interim `scroll` event whose `scrollTop` is smaller than the
+      // previous frame's because `scrollHeight` jumped — this fires before
+      // the rAF-scheduled `pinToBottom` runs, so `programmaticScrollPendingRef`
+      // is 0. Treating that as a user scroll permanently disarmed sticky-bottom
+      // and produced the visible at-rest backward jump (#37997). Gating on a
+      // stable `scrollHeight` keeps real user-driven upward intent — scrollbar
+      // drag, keyboard PgUp, programmatic scrollIntoView — covered without
+      // the false positive. Wheel-up and touchmove still disarm via their
+      // own listeners below.
+      const heightGrew = el.scrollHeight > lastHeightRef.current
+      if (!heightGrew && top + 1 < lastTopRef.current) {
         armedRef.current = false
       }
 
       lastTopRef.current = top
+      lastHeightRef.current = el.scrollHeight
 
       const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
 
@@ -323,8 +341,9 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     const observer = new ResizeObserver(schedulePin)
 
-    observer.observe(el)
-
+    // Observe ONLY the content (firstElementChild), not the scroller `el`
+    // itself. Resizes of the viewport/scroller (window resize, devtools
+    // panel toggle) shouldn't trigger a pin — only content growth should.
     if (el.firstElementChild) {
       observer.observe(el.firstElementChild)
     }


### PR DESCRIPTION
Fixes #37997.

## Problem

`useThreadScrollAnchor` in `apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx` disarmed sticky-bottom whenever `scrollTop` decreased by more than 1px between scroll events. That check was too eager:

When content height grows mid-frame (virtualizer measuring a newly visible turn, streaming token, Streamdown/Shiki re-tokenization, composer chip toggle), the browser fires an interim `scroll` event whose `scrollTop` is smaller than the previous frame's because `scrollHeight` just jumped. The rAF-scheduled `pinToBottom` hasn't run yet, so `programmaticScrollPendingRef` is 0 and the disarm branch fires. Sticky-bottom then stays disarmed and the scroller sits ~50px above bottom — the visible at-rest backward jump #37997 describes.

This is the same root cause as the wheel-scroll-up variant tracked in #37527 (`distFromBottom 0 → 49 within one frame, sticking forever`, per the existing `measure-jump.mjs` repro).

## Fix

1. Track `scrollHeight` per frame (`lastHeightRef`). Disarm on `scrollTop` decrease **only when `scrollHeight` did not grow this frame**. Real upward user intent — scrollbar drag, keyboard PgUp, programmatic `scrollIntoView` — still disarms because it moves `scrollTop` without growing content. Wheel-up and touchmove continue to disarm via their existing listeners.
2. Stop observing the scroller element itself in the `ResizeObserver`; only observe its content child (`firstElementChild`). Viewport-only resizes (window resize, devtools panel toggle) no longer trigger spurious pins.

The original safe-guards (`programmaticScrollPendingRef`, `armedRef`, rAF-coalesced pin) are unchanged.

## Verification

- `cd apps/desktop && npx tsc -b` — clean.
- `cd apps/desktop && npx vitest run --environment jsdom src/components/assistant-ui/streaming.test.tsx` — 9/9 pass, including the existing wheel-up regression test that asserts `scrollTop` stays at `420` after a wheel-up followed by content growth (this guards the user-driven upward-scroll path the change preserves).

## Out of scope

- Wheel-up snap-back (#37527) is the same root mechanism and is addressed by the same `heightGrew` gate, but I scoped the PR to #37997's at-rest variant and its explicit suggested directions (1) and (2). Happy to close #37527 if maintainers prefer.
