### PR TITLE
fix(opencode-go): never send extra_body for Kimi K2 models

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -56,24 +56,29 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape.
+            # The API rejects having both 'thinking' and 'reasoning_effort'
+            # in the same request — pick one path:
+            #   - effort specified → reasoning_effort only
+            #   - no effort / disabled → thinking toggle only
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max"}:
-                top_level["reasoning_effort"] = "high"
-            elif effort in {"low", "medium", "high"}:
+            if effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+            elif effort in {"xhigh", "max"}:
+                top_level["reasoning_effort"] = "high"
+            else:
+                # No explicit effort — just toggle thinking on
+                extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -56,29 +56,23 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape.
-            # The API rejects having both 'thinking' and 'reasoning_effort'
-            # in the same request — pick one path:
+            # Kimi K2 on OpenCode Go proxies to Fireworks, which rejects
+            # extra_body entirely ("Extra inputs are not permitted"). Only
+            # reasoning_effort as a top-level field is accepted.
             #   - effort specified → reasoning_effort only
-            #   - no effort / disabled → thinking toggle only
+            #   - disabled / no config → nothing (server defaults, no reasoning)
             if not isinstance(reasoning_config, dict):
-                # No config → leave server defaults alone.
                 return extra_body, top_level
 
-            enabled = reasoning_config.get("enabled") is not False
-
-            if not enabled:
-                extra_body["thinking"] = {"type": "disabled"}
+            if reasoning_config.get("enabled") is False:
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
-            elif effort in {"xhigh", "max"}:
+            if effort in {"xhigh", "max"}:
                 top_level["reasoning_effort"] = "high"
-            else:
-                # No explicit effort — just toggle thinking on
-                extra_body["thinking"] = {"type": "enabled"}
+            elif effort in {"low", "medium", "high"}:
+                top_level["reasoning_effort"] = effort
+            # No explicit effort → leave reasoning off (server defaults)
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -24,7 +24,9 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        # Kimi rejects having both 'thinking' and 'reasoning_effort'.
+        # When effort is specified, only reasoning_effort is emitted.
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -56,7 +58,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_low_and_medium_pass_through(self, opencode_go_profile):
@@ -65,7 +67,7 @@ class TestOpenCodeGoKimiReasoning:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": effort}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
@@ -160,7 +162,8 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        # When effort is specified, no extra_body thinking toggle is emitted.
+        assert "extra_body" not in kwargs or kwargs["extra_body"] == {}
         assert kwargs["reasoning_effort"] == "high"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -17,33 +17,33 @@ def opencode_go_profile():
 
 
 class TestOpenCodeGoKimiReasoning:
-    """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
+    """Kimi K2 models on OpenCode Go use reasoning_effort only — extra_body is
+    rejected by the Fireworks backend ("Extra inputs are not permitted")."""
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    def test_high_effort_emits_effort_only(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        # Kimi rejects having both 'thinking' and 'reasoning_effort'.
-        # When effort is specified, only reasoning_effort is emitted.
+        # Fireworks rejects extra_body entirely — only reasoning_effort is emitted.
         assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
-    def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
+    def test_disabled_emits_nothing(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": False},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert extra_body == {}
         assert top_level == {}
 
-    def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
+    def test_minimal_effort_emits_nothing(self, opencode_go_profile):
+        # "minimal" is not a supported effort value — drop it entirely.
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "minimal"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {}
 
     @pytest.mark.parametrize(
@@ -151,7 +151,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_uses_effort_only(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -162,8 +162,8 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        # When effort is specified, no extra_body thinking toggle is emitted.
-        assert "extra_body" not in kwargs or kwargs["extra_body"] == {}
+        # Fireworks rejects extra_body entirely — only reasoning_effort emitted.
+        assert kwargs.get("extra_body", {}) == {}
         assert kwargs["reasoning_effort"] == "high"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(


### PR DESCRIPTION
## Problem

Kimi K2.5/K2.6 models on opencode-go fail with HTTP 400 when reasoning is enabled:

```
Error from provider: Extra inputs are not permitted, field: 'extra_body'
```

**Root cause:** OpenCode Go proxies Kimi K2 requests to Fireworks, which rejects `extra_body` entirely — not just the combo of `thinking` + `reasoning_effort`. Even `extra_body` alone with `{"thinking": {"type": "disabled"}}` fails.

## Verification (curl against live opencode-go endpoint)

| Test case | Result |
|---|---|
| baseline (no params) | 200 ✅ |
| `extra_body` alone (any value) | 400 ❌ |
| `reasoning_effort` alone | 200 ✅ |
| both together | 400 ❌ |

## Fix

Strip ALL `extra_body` from the Kimi K2 path in `OpenCodeGoProfile.build_api_kwargs_extras()`. Only `reasoning_effort` as a top-level field is accepted.

- Effort specified (`low`/`medium`/`high`) → emit `reasoning_effort`
- `xhigh`/`max` → clamp to `high` (Moonshot's max)
- Disabled / no config / no explicit effort → emit nothing (server defaults, no reasoning)
- DeepSeek path unchanged

## Files changed

- `plugins/model-providers/opencode-zen/__init__.py` — remove `extra_body.thinking` from Kimi K2 path
- `tests/plugins/model_providers/test_opencode_go_profile.py` — update 8 tests to expect empty `extra_body`

## Related

Closes #32223, #31636, #32040, #37439
Supersedes #31637, #31679, #35180 (all still leak `extra_body` in disabled/no-effort cases)

## Checklist

- [x] All 21 tests pass
- [x] Verified with curl against live opencode-go endpoint
- [x] DeepSeek path unaffected (verified via existing tests)