### PR TITLE
fix(tui): resync terminal columns on resize trailing edge (#36666)

### DIFF
--- a/ui-tui/src/__tests__/terminalColumns.test.ts
+++ b/ui-tui/src/__tests__/terminalColumns.test.ts
@@ -1,0 +1,99 @@
+import { EventEmitter } from 'node:events'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type ColumnsStream, RESIZE_SETTLE_MS, subscribeColumns } from '../lib/terminalColumns.js'
+
+class FakeStdout extends EventEmitter implements ColumnsStream {
+  columns: number | undefined = 80
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('subscribeColumns', () => {
+  it('reads the new width on the leading edge of a resize', () => {
+    const stdout = new FakeStdout()
+    const seen: number[] = []
+    const unsubscribe = subscribeColumns(stdout, c => seen.push(c))
+
+    stdout.columns = 120
+    stdout.emit('resize')
+
+    expect(seen[0]).toBe(120)
+    unsubscribe()
+  })
+
+  // Regression for #36666: Ghostty settles `columns` AFTER the final resize
+  // event, so a leading-edge-only read latches a stale, larger width and the
+  // status bar lays out wider than the terminal (it wraps). The trailing
+  // re-read must converge to the settled width.
+  it('converges to the settled width when columns updates after the final resize event', () => {
+    const stdout = new FakeStdout()
+    stdout.columns = 200
+    const seen: number[] = []
+    const unsubscribe = subscribeColumns(stdout, c => seen.push(c))
+
+    // The final resize event arrives while columns still reports the old width…
+    stdout.emit('resize')
+    expect(seen.at(-1)).toBe(200)
+
+    // …the terminal then settles narrower, with no further resize event.
+    stdout.columns = 100
+    vi.advanceTimersByTime(RESIZE_SETTLE_MS)
+
+    expect(seen.at(-1)).toBe(100)
+    unsubscribe()
+  })
+
+  it('coalesces a burst of resize events into a single trailing read', () => {
+    const stdout = new FakeStdout()
+    const seen: number[] = []
+    const unsubscribe = subscribeColumns(stdout, c => seen.push(c))
+
+    for (const w of [120, 110, 100, 90]) {
+      stdout.columns = w
+      stdout.emit('resize')
+    }
+
+    // One leading read per event so far.
+    expect(seen).toEqual([120, 110, 100, 90])
+
+    stdout.columns = 84
+    vi.advanceTimersByTime(RESIZE_SETTLE_MS)
+
+    // Exactly one trailing read, picking up the settled width.
+    expect(seen).toEqual([120, 110, 100, 90, 84])
+    unsubscribe()
+  })
+
+  it('stops reading after unsubscribe', () => {
+    const stdout = new FakeStdout()
+    const seen: number[] = []
+    const unsubscribe = subscribeColumns(stdout, c => seen.push(c))
+
+    unsubscribe()
+    stdout.columns = 50
+    stdout.emit('resize')
+    vi.advanceTimersByTime(RESIZE_SETTLE_MS)
+
+    expect(seen).toEqual([])
+  })
+
+  it('falls back to 80 columns when the width is unavailable', () => {
+    const stdout = new FakeStdout()
+    stdout.columns = undefined
+    const seen: number[] = []
+    const unsubscribe = subscribeColumns(stdout, c => seen.push(c))
+
+    stdout.emit('resize')
+
+    expect(seen[0]).toBe(80)
+    unsubscribe()
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -23,6 +23,7 @@ import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import { subscribeColumns } from '../lib/terminalColumns.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
 import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
@@ -144,16 +145,14 @@ export function useMainApp(gw: GatewayClient) {
       return
     }
 
-    const sync = () => setCols(stdout.columns ?? 80)
-
-    stdout.on('resize', sync)
+    const unsubscribeColumns = subscribeColumns(stdout, setCols)
 
     if (stdout.isTTY) {
       stdout.write(BRACKET_PASTE_ON)
     }
 
     return () => {
-      stdout.off('resize', sync)
+      unsubscribeColumns()
 
       if (stdout.isTTY) {
         stdout.write(BRACKET_PASTE_OFF)

--- a/ui-tui/src/lib/terminalColumns.ts
+++ b/ui-tui/src/lib/terminalColumns.ts
@@ -1,0 +1,41 @@
+const DEFAULT_COLUMNS = 80
+
+// Some terminals settle `stdout.columns` to the final width slightly AFTER the
+// last `resize` event fires (observed with Ghostty). A leading-edge-only read
+// then latches the stale pre-settle width and is never corrected, so
+// fixed-width chrome — notably the status bar — stays laid out wider than the
+// real terminal and wraps/fragments across lines (#36666).
+//
+// Read on the leading edge so width tracking stays responsive, AND re-read on a
+// trailing debounce so the settled width always wins. This mirrors the
+// `terminal.resize` debounce already used in useMainApp.
+export const RESIZE_SETTLE_MS = 100
+
+export interface ColumnsStream {
+  columns?: number
+  off: (event: 'resize', listener: () => void) => void
+  on: (event: 'resize', listener: () => void) => void
+}
+
+export function subscribeColumns(
+  stdout: ColumnsStream,
+  onColumns: (columns: number) => void,
+  settleMs: number = RESIZE_SETTLE_MS
+): () => void {
+  const read = () => onColumns(stdout.columns ?? DEFAULT_COLUMNS)
+
+  let settleTimer: ReturnType<typeof setTimeout> | undefined
+
+  const onResize = () => {
+    read()
+    clearTimeout(settleTimer)
+    settleTimer = setTimeout(read, settleMs)
+  }
+
+  stdout.on('resize', onResize)
+
+  return () => {
+    clearTimeout(settleTimer)
+    stdout.off('resize', onResize)
+  }
+}


### PR DESCRIPTION
# fix(tui): resync terminal columns on the resize trailing edge (#36666)

## What does this PR do?

The TUI status bar can fragment across two lines after a terminal resize —
parts of the bar appear indented on the line below (#36666, reported on
Ghostty). This fixes the width source that feeds the status bar so it reflows
to the real terminal width.

## Root cause

The status bar (`StatusRule` in `components/appChrome.tsx`) lays out entirely
from its `cols` prop, which flows from a single `cols` state in
`app/useMainApp.ts`:

```ts
const sync = () => setCols(stdout.columns ?? 80)
stdout.on('resize', sync)
```

`cols` is only read on the **leading edge** of a `resize` event. The status
bar's own width math is already correct and tested — `statusRuleWidths` keeps
`leftWidth + separatorWidth + rightWidth <= cols` (see `__tests__/statusRule.test.ts`).
So the bar only overflows (and wraps) when `cols` itself is **larger than the
real terminal width**.

That is exactly what happens on some terminals: `stdout.columns` settles to the
final width slightly **after** the last `resize` event fires. The leading-only
read latches the stale, larger pre-settle width, and because no further
`resize` event arrives, `cols` is never corrected — so the status bar stays laid
out wider than the terminal and fragments onto a second line.

This is the same reliability gap the sibling effect in `useMainApp` already
guards against: it debounces 100 ms before reading `stdout.columns` for the
`terminal.resize` RPC. The `cols` state did not get the same treatment.

## Change

- New `lib/terminalColumns.ts`: `subscribeColumns(stdout, onColumns)` reads the
  width on the leading edge (responsive) **and** re-reads on a 100 ms trailing
  debounce (so the settled width always wins). Bursts during a drag coalesce
  into one trailing read.
- `app/useMainApp.ts`: the resize effect now uses `subscribeColumns(stdout, setCols)`
  instead of the leading-only inline `sync`. No behavioural change on terminals
  that already report a settled width on the event — they just get one extra,
  idempotent read.

No change to `appChrome.tsx` (its width math was already correct).

## How to test

```bash
cd ui-tui
npm ci
npx vitest run src/__tests__/terminalColumns.test.ts
```

The new `converges to the settled width when columns updates after the final
resize event` case **fails without the trailing re-read** (the leading-only
read stays stuck at the stale width) and passes with this change. Neighbour
suites are unaffected:

```bash
npx vitest run src/__tests__/statusRule.test.ts src/__tests__/appChromeStatusRule.test.ts
npx tsc -p tsconfig.json --noEmit
npx eslint src/lib/terminalColumns.ts src/__tests__/terminalColumns.test.ts src/app/useMainApp.ts
```

Manual (Ghostty): run `hermes --tui`, start a tool call, drag-resize the window
narrower during/after the call — the status bar reflows to one line instead of
fragmenting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Related

Fixes #36666. Same class as the resize/reflow issues #24137, #18260.
