### PR TITLE
feat(discord): support silent progress notifications

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -817,6 +817,20 @@ def load_gateway_config() -> GatewayConfig:
 
             _merge_platform_map(gateway_platforms)
             _merge_platform_map(yaml_cfg.get("platforms"))
+
+            # Display notification settings are consumed by platform adapters
+            # at startup, so bridge them into the platform ``extra`` dict here.
+            # Runtime display resolution still owns the defaults/precedence;
+            # this only makes explicit config visible to adapters.
+            display_cfg = yaml_cfg.get("display")
+            display_platforms = display_cfg.get("platforms") if isinstance(display_cfg, dict) else None
+            if isinstance(display_platforms, dict):
+                for plat_name, display_platform_cfg in display_platforms.items():
+                    if not isinstance(display_platform_cfg, dict) or "notifications" not in display_platform_cfg:
+                        continue
+                    plat_data, extra = _ensure_platform_extra_dict(platforms_data, str(plat_name))
+                    extra["notifications"] = display_platform_cfg["notifications"]
+
             if platforms_data:
                 gw_data["platforms"] = platforms_data
             # Iterate built-in platforms plus any registered plugin platforms
@@ -903,6 +917,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "notifications" in platform_cfg:
+                    bridged["notifications"] = platform_cfg["notifications"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -46,6 +46,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Push-notification delivery mode for platforms that support per-message
+    # notification flags. "all" preserves legacy behavior; "important" sends
+    # progress/status messages silently while final/blocked messages notify.
+    "notifications": "all",
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -615,6 +615,16 @@ class DiscordAdapter(BasePlatformAdapter):
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._notifications_mode: str = str(
+            self.config.extra.get("notifications", "all") or "all"
+        ).strip().lower()
+        if self._notifications_mode not in {"all", "important"}:
+            logger.warning(
+                "[%s] Invalid notifications mode %r; using 'all'",
+                self.name,
+                self._notifications_mode,
+            )
+            self._notifications_mode = "all"
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
         # In-memory cache of the bot's last message ID per channel, used by
         # history backfill to skip the full scan on hot paths.  Falls back to
@@ -1402,6 +1412,24 @@ class DiscordAdapter(BasePlatformAdapter):
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
 
+    def _notification_kwargs(
+        self,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return Discord send kwargs for the configured notification mode.
+
+        ``notifications: important`` mirrors Telegram's important-notification
+        mode: intermediate progress/status messages are still sent to the
+        channel/thread, but Discord receives ``silent=True`` so clients do not
+        emit push notifications.  Final responses pass ``metadata["notify"]``
+        from the shared gateway delivery path and therefore notify normally.
+        """
+        if self._notifications_mode != "important":
+            return {}
+        if (metadata or {}).get("notify"):
+            return {}
+        return {"silent": True}
+
     async def send(
         self,
         chat_id: str,
@@ -1448,6 +1476,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            notification_kwargs = self._notification_kwargs(metadata)
 
             message_ids = []
             reference = None
@@ -1471,6 +1500,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        **notification_kwargs,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -1493,6 +1523,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            **notification_kwargs,
                         )
                     else:
                         raise

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -346,6 +346,25 @@ class TestLoadGatewayConfig:
         # Env value preserved, not clobbered by yaml.
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
 
+    def test_bridges_discord_display_notifications_to_platform_extra(self, tmp_path, monkeypatch):
+        """display.platforms.discord.notifications should reach DiscordAdapter config."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n"
+            "  platforms:\n"
+            "    discord:\n"
+            "      notifications: important\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["notifications"] == "important"
+
     def test_bridges_discord_allow_from_from_config_yaml(self, tmp_path, monkeypatch):
         """discord.allow_from should populate DISCORD_ALLOWED_USERS for auth."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -84,6 +84,69 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
 
 
 @pytest.mark.asyncio
+async def test_send_suppresses_push_notifications_in_important_mode():
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"notifications": "important"},
+        )
+    )
+
+    sent_msg = SimpleNamespace(id=1234)
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "progress update")
+
+    assert result.success is True
+    assert channel.send.await_args.kwargs["silent"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_suppress_push_when_notify_metadata_is_set():
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"notifications": "important"},
+        )
+    )
+
+    sent_msg = SimpleNamespace(id=1234)
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "final answer", metadata={"notify": True})
+
+    assert result.success is True
+    assert "silent" not in channel.send.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_send_uses_legacy_push_notifications_by_default():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    sent_msg = SimpleNamespace(id=1234)
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "normal message")
+
+    assert result.success is True
+    assert "silent" not in channel.send.await_args.kwargs
+
+
+@pytest.mark.asyncio
 async def test_send_retries_without_reference_when_reply_target_is_deleted():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -54,6 +54,20 @@ class TestResolveDisplaySetting:
         # Unknown platform, no config → global default "all"
         assert resolve_display_setting(config, "unknown_platform", "tool_progress") == "all"
 
+    def test_notifications_can_be_configured_per_platform(self):
+        """display.platforms.<platform>.notifications controls push noise."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "discord": {"notifications": "important"},
+                },
+            }
+        }
+        assert resolve_display_setting(config, "discord", "notifications") == "important"
+        assert resolve_display_setting({}, "discord", "notifications") == "all"
+
     def test_fallback_parameter_used_last(self):
         """Explicit fallback is used when nothing else matches."""
         from gateway.display_config import resolve_display_setting


### PR DESCRIPTION
## Summary
- add `display.platforms.discord.notifications: important` for Discord silent progress/status messages
- keep final/notify-worthy messages as normal push notifications via `metadata["notify"]`
- bridge the display config into the Discord adapter and preserve legacy `all` behavior by default

## Tests
- `python -m pytest tests/gateway/test_discord_send.py tests/gateway/test_display_config.py tests/gateway/test_config.py -q -o 'addopts='`\n\n## Notes\nThere is an existing broader open PR (#20463) for priority-aware notifications. This PR is intentionally scoped to only the Discord configurable silent-progress behavior.