### PR TITLE
fix(matrix): sanitize raw HTML before adapter delivery

### DIFF
--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1659,6 +1659,44 @@ class TestMatrixMarkdownHtmlSecurity:
         assert "<script>" not in result
 
 
+class TestStandaloneMatrixSendHtmlSecurity:
+    """Regression coverage for the standalone send_message Matrix path."""
+
+    @pytest.mark.asyncio
+    async def test_formatted_body_escapes_raw_html(self):
+        """Standalone Matrix sends must not ship raw model-controlled HTML."""
+
+        from tools.send_message_tool import _send_matrix
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"event_id": "$evt123"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.put = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await _send_matrix(
+                "test_token",
+                {"homeserver": "https://matrix.example.org"},
+                "!room:matrix.org",
+                '# title\nhi <img src=x onerror="alert(1)"> **bold**',
+            )
+
+        assert result["success"] is True
+        payload = mock_session.put.call_args.kwargs["json"]
+        assert payload["format"] == "org.matrix.custom.html"
+        assert "<img" not in payload["formatted_body"]
+        assert "&lt;img" in payload["formatted_body"]
+        assert "<h1>" not in payload["formatted_body"]
+        assert "<strong>title</strong>" in payload["formatted_body"]
+        assert "<strong>bold</strong>" in payload["formatted_body"]
+
+
 # ---------------------------------------------------------------------------
 # Markdown to HTML: extended formatting tests
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1373,8 +1373,8 @@ async def _send_sms(auth_token, chat_id, message):
 async def _send_matrix(token, extra, chat_id, message):
     """Send via Matrix Client-Server API.
 
-    Converts markdown to HTML for rich rendering in Matrix clients.
-    Falls back to plain text if the ``markdown`` library is not installed.
+    Converts markdown to Matrix-compatible HTML for rich rendering in Matrix
+    clients while preserving the gateway adapter's HTML escaping stance.
     """
     try:
         import aiohttp
@@ -1391,11 +1391,12 @@ async def _send_matrix(token, extra, chat_id, message):
         url = f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/send/m.room.message/{txn_id}"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
-        # Build message payload with optional HTML formatted_body.
+        # Build message payload with escaped HTML formatted_body.
         payload = {"msgtype": "m.text", "body": message}
         try:
-            import markdown as _md
-            html = _md.markdown(message, extensions=["fenced_code", "tables"])
+            from gateway.platforms.matrix import MatrixAdapter
+
+            html = MatrixAdapter._markdown_to_html_fallback(message)
             # Convert h1-h6 to bold for Element X compatibility.
             html = re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html)
             payload["format"] = "org.matrix.custom.html"


### PR DESCRIPTION
## Summary
The agent-callable `send_message` tool can send Matrix messages through a helper path that converts LLM-supplied message text to `org.matrix.custom.html` when `markdown` is importable. That bypasses the Matrix adapter's documented HTML-escaping stance and can alter rendered Matrix room content.

- The helper path renders LLM-controlled message content to HTML before sending to Matrix.
- The gateway Matrix adapter has a separate documented escaping pipeline that this helper bypasses.

Route `_send_matrix` through the Matrix adapter's escaping and sanitization pipeline, or disable formatted HTML in the standalone helper unless it can apply the same trust-model-preserving transformations.

## Linked context
Closes #38035

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
- `hermes-agent/tools/send_message_tool.py:1373-1404`
- `hermes-agent/gateway/platforms/matrix.py:2723-2750`

### Files changed in this PR
- `tools/send_message_tool.py`
- `tests/gateway/test_matrix.py`

### Behavior reproduced or verified
1. Use Hermes Agent latest upstream `main` at source receipt commit `f019a9c491b5f263d98c1966d54afff9914b15e8`.
2. Confirm the `markdown` package is importable in the running Hermes environment.
3. Call `send_message` with Matrix target settings and a message containing HTML-significant Markdown or inline HTML.
4. Observe `_send_matrix` send `formatted_body` as `org.matrix.custom.html` from the rendered message.
5. Expected result: standalone Matrix sending uses the same HTML escaping and sanitization posture as the gateway Matrix adapter.

### Expected fixed behavior
Route `_send_matrix` through the Matrix adapter's escaping and sanitization pipeline, or disable formatted HTML in the standalone helper unless it can apply the same trust-model-preserving transformations.

## Tests and validation
- `bash scripts/run_tests.sh tests/gateway/test_matrix.py`
- Result: 1 files, 151 tests passed, 0 failed (100% complete) in 4.6s (20 workers) ===

## Environment
Hermes latest-main source receipt: `f019a9c491b5f263d98c1966d54afff9914b15e8` on current `main`. Runtime prerequisite: Matrix send-message configuration with `markdown` importable. Redaction complete; no secrets, tokens, private logs, or unrelated local paths are included. Public route status: public issue plus linked review-ready PR through `public_security_full_disclosure`; redaction checked.
Source freshness receipt: `source_ready` for `upstream-main` at `f019a9c491b5f263d98c1966d54afff9914b15e8`; affected paths exist in the prepared latest-main checkout.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Current-turn full-public approval evidence was confirmed before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
