### PR TITLE
feat(onebot): add shared OneBot client

### DIFF
--- a/tests/tools/test_onebot_client.py
+++ b/tests/tools/test_onebot_client.py
@@ -1,0 +1,278 @@
+"""Tests for the shared OneBot v11 client.
+
+Exercises real logic — URL/token configuration, availability gating, and
+both the HTTP and WebSocket transports' success / failure / error paths —
+with mocked HTTP and a fake WebSocket server so no network is touched.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.onebot_client import (
+    onebot_access_token,
+    onebot_base_url,
+    onebot_call,
+    onebot_configured,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP response
+# ---------------------------------------------------------------------------
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for the object returned by urllib.request.urlopen."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Fake WebSocket server
+# ---------------------------------------------------------------------------
+
+class _FakeWS:
+    """A fake OneBot WebSocket connection for _ws_roundtrip tests.
+
+    Replies to the action request with our echo, optionally preceded by a
+    burst of pushed events (no echo) to exercise the skip-until-echo loop.
+    """
+
+    def __init__(self, data=None, status="ok", retcode=0, message=None,
+                 lead_events=0):
+        self._data = data
+        self._status = status
+        self._retcode = retcode
+        self._message = message
+        self._lead_events = lead_events
+        self.sent = []
+        self._answered = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def recv(self):
+        if self._lead_events > 0:
+            self._lead_events -= 1
+            return json.dumps(
+                {"post_type": "meta_event", "meta_event_type": "heartbeat"}
+            )
+        if self._answered:  # the round-trip should have returned by now
+            await asyncio.sleep(3600)
+        self._answered = True
+        echo = json.loads(self.sent[-1])["echo"]
+        reply = {"status": self._status, "retcode": self._retcode, "echo": echo}
+        if self._message is not None:
+            reply["message"] = self._message
+        if self._status != "failed" and self._data is not None:
+            reply["data"] = self._data
+        return json.dumps(reply)
+
+
+def _fake_connect(fake_ws):
+    """Build a websockets.connect replacement that yields *fake_ws*."""
+
+    def _connect(uri, **kwargs):
+        _connect.last_uri = uri
+        return fake_ws
+
+    _connect.last_uri = None
+    return _connect
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class TestConfig:
+    def test_base_url_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000/")
+        assert onebot_base_url() == "http://127.0.0.1:3000"
+
+    def test_base_url_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "  http://host:3000  ")
+        assert onebot_base_url() == "http://host:3000"
+
+    def test_base_url_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        assert onebot_base_url() == ""
+
+    def test_base_url_falls_back_to_ws_url(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        assert onebot_base_url() == "ws://127.0.0.1:3001"
+
+    def test_http_url_wins_over_ws_url(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        assert onebot_base_url() == "http://127.0.0.1:3000"
+
+    def test_access_token_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_ACCESS_TOKEN", "  tok123  ")
+        assert onebot_access_token() == "tok123"
+
+    def test_access_token_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        assert onebot_access_token() == ""
+
+
+# ---------------------------------------------------------------------------
+# Availability gating
+# ---------------------------------------------------------------------------
+
+class TestConfigured:
+    def test_configured_when_http_url_set(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        assert onebot_configured() is True
+
+    def test_configured_when_only_ws_url_set(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        assert onebot_configured() is True
+
+    def test_not_configured_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        assert onebot_configured() is False
+
+    def test_not_configured_when_blank(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "   ")
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        assert onebot_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+class TestOnebotCallHTTP:
+    def test_raises_when_url_unconfigured(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        with pytest.raises(RuntimeError, match="ONEBOT_HTTP_URL"):
+            onebot_call("get_login_info")
+
+    def test_returns_data_on_success(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps(
+            {"status": "ok", "retcode": 0, "data": {"message_id": 7}}
+        ).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            data = onebot_call("send_msg", {"message": []})
+        assert data == {"message_id": 7}
+
+    def test_raises_on_failed_status(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps(
+            {"status": "failed", "retcode": 1404, "message": "no login"}
+        ).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            with pytest.raises(RuntimeError, match="no login"):
+                onebot_call("send_msg")
+
+    def test_raises_on_missing_data(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps({"status": "ok", "retcode": 0}).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            with pytest.raises(RuntimeError, match="no data"):
+                onebot_call("send_msg")
+
+    def test_raises_on_non_json(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeHTTPResponse(b"<html>502 Bad Gateway</html>"),
+        ):
+            with pytest.raises(RuntimeError, match="non-JSON"):
+                onebot_call("send_msg")
+
+    def test_auth_header_sent_when_token_configured(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        monkeypatch.setenv("ONEBOT_ACCESS_TOKEN", "secret")
+        body = json.dumps({"status": "ok", "data": {"ok": 1}}).encode()
+        captured = {}
+
+        def _fake_urlopen(req, timeout=None):
+            captured["auth"] = req.headers.get("Authorization")
+            return _FakeHTTPResponse(body)
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            onebot_call("get_status")
+        assert captured["auth"] == "Bearer secret"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket transport
+# ---------------------------------------------------------------------------
+
+class TestOnebotCallWS:
+    def test_returns_data_on_success(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        fake = _FakeWS(data={"user_id": 42}, lead_events=3)
+        with patch("websockets.connect", _fake_connect(fake)):
+            data = onebot_call("get_login_info")
+        assert data == {"user_id": 42}
+        # The action request was actually sent.
+        sent = json.loads(fake.sent[-1])
+        assert sent["action"] == "get_login_info"
+
+    def test_uses_ws_url_fallback(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        fake = _FakeWS(data={"message_id": 9})
+        with patch("websockets.connect", _fake_connect(fake)):
+            data = onebot_call("send_msg", {"message": []})
+        assert data == {"message_id": 9}
+
+    def test_raises_on_failed_status(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        fake = _FakeWS(status="failed", retcode=1400, message="bad request")
+        with patch("websockets.connect", _fake_connect(fake)):
+            with pytest.raises(RuntimeError, match="bad request"):
+                onebot_call("send_msg")
+
+    def test_raises_on_missing_data(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        fake = _FakeWS(data=None)  # status ok but no data field
+        with patch("websockets.connect", _fake_connect(fake)):
+            with pytest.raises(RuntimeError, match="no data"):
+                onebot_call("get_login_info")
+
+    def test_access_token_in_uri(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        monkeypatch.setenv("ONEBOT_ACCESS_TOKEN", "s3cr3t")
+        fake = _FakeWS(data={"ok": 1})
+        connect = _fake_connect(fake)
+        with patch("websockets.connect", connect):
+            onebot_call("get_status")
+        assert "access_token=s3cr3t" in connect.last_uri
+
+    def test_no_access_token_in_uri_when_absent(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        fake = _FakeWS(data={"ok": 1})
+        connect = _fake_connect(fake)
+        with patch("websockets.connect", connect):
+            onebot_call("get_status")
+        assert "access_token" not in connect.last_uri

--- a/tools/onebot_client.py
+++ b/tools/onebot_client.py
@@ -1,0 +1,245 @@
+"""Shared OneBot v11 client for QQ integrations (HTTP or WebSocket).
+
+Several Hermes tools talk to a running OneBot v11 implementation
+(NapCat / Lagrange.Core): the ``qzone`` tool borrows the logged-in QQ
+session to publish 说说, and the ``qq_voice`` tool sends synthesized
+speech as a native QQ voice message. Both need the same plumbing, so it
+lives here in one place rather than being duplicated per tool.
+
+Transport is chosen automatically from the configured endpoint's URL
+scheme:
+
+* ``http://`` / ``https://`` — the OneBot v11 HTTP API (one POST per action).
+* ``ws://`` / ``wss://``     — the OneBot v11 WebSocket API. Many NapCat /
+  Lagrange deployments expose *only* a WebSocket server; each call opens a
+  short-lived connection, sends one action, and reads the matching reply
+  (skipping any pushed events).
+
+Configuration (environment variables):
+- ``ONEBOT_HTTP_URL``     -- OneBot endpoint, ``http(s)://`` or ``ws(s)://``.
+- ``ONEBOT_WS_URL``       -- used as a fallback when ``ONEBOT_HTTP_URL`` is
+                             unset (lets a WS-only deployment configure just
+                             the one URL it has).
+- ``ONEBOT_ACCESS_TOKEN`` -- optional bearer / access token.
+
+This is a plain helper module — it registers no tools, so the registry's
+module scan never imports it as a tool. Tools import the functions here.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Default per-request timeout (seconds). Callers doing heavier work (e.g.
+# uploading media) may pass a larger value.
+ONEBOT_TIMEOUT = 15
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def onebot_base_url() -> str:
+    """Return the configured OneBot endpoint URL (no trailing slash).
+
+    Prefers ``ONEBOT_HTTP_URL``; falls back to ``ONEBOT_WS_URL`` so a
+    WebSocket-only deployment can configure just the one URL it has.
+    """
+    url = os.getenv("ONEBOT_HTTP_URL", "").strip()
+    if not url:
+        url = os.getenv("ONEBOT_WS_URL", "").strip()
+    return url.rstrip("/")
+
+
+def onebot_access_token() -> str:
+    """Return the optional OneBot access token."""
+    return os.getenv("ONEBOT_ACCESS_TOKEN", "").strip()
+
+
+def onebot_configured() -> bool:
+    """Return True when a OneBot endpoint is configured.
+
+    Used as the ``check_fn`` for OneBot-backed tools so they are gated out
+    of the model's schema entirely when no OneBot connection is set up.
+    """
+    return bool(onebot_base_url())
+
+
+def _is_ws_url(url: str) -> bool:
+    """Return True when *url* is a WebSocket endpoint."""
+    return url.lower().startswith(("ws://", "wss://"))
+
+
+# ---------------------------------------------------------------------------
+# Shared response handling
+# ---------------------------------------------------------------------------
+
+def _check_onebot_payload(payload: dict, action: str) -> dict:
+    """Validate a OneBot response envelope and return its ``data`` object.
+
+    Raises ``RuntimeError`` on a ``failed`` status or a missing ``data``
+    field so callers can surface one clear message to the model.
+    """
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"OneBot action '{action}' returned a non-object response.")
+    if payload.get("status") == "failed":
+        msg = payload.get("message") or payload.get("wording") or "unknown error"
+        raise RuntimeError(
+            f"OneBot action '{action}' failed: {msg} "
+            f"(retcode={payload.get('retcode')})"
+        )
+    data = payload.get("data")
+    if data is None:
+        raise RuntimeError(f"OneBot action '{action}' returned no data.")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def onebot_call(
+    action: str,
+    params: dict | None = None,
+    *,
+    timeout: int = ONEBOT_TIMEOUT,
+) -> dict:
+    """Invoke a OneBot v11 action and return its ``data`` object.
+
+    Picks the HTTP or WebSocket transport from the configured endpoint's
+    URL scheme. Raises ``RuntimeError`` on transport errors, a ``failed``
+    status, or a missing ``data`` field.
+    """
+    base = onebot_base_url()
+    if not base:
+        raise RuntimeError("ONEBOT_HTTP_URL is not configured.")
+    if _is_ws_url(base):
+        return _onebot_call_ws(base, action, params or {}, timeout)
+    return _onebot_call_http(base, action, params or {}, timeout)
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+def _onebot_call_http(base: str, action: str, params: dict, timeout: int) -> dict:
+    """Invoke a OneBot action over the HTTP API."""
+    url = f"{base}/{action}"
+    body = json.dumps(params).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = onebot_access_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:  # noqa: BLE001 — best-effort detail only
+            pass
+        raise RuntimeError(
+            f"OneBot HTTP {e.code} for action '{action}'. {detail}".strip()
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Cannot reach OneBot at {base} — is NapCat/Lagrange running? ({e.reason})"
+        ) from e
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"OneBot action '{action}' returned non-JSON: {raw[:200]}"
+        ) from e
+
+    return _check_onebot_payload(payload, action)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket transport
+# ---------------------------------------------------------------------------
+
+def _onebot_call_ws(base: str, action: str, params: dict, timeout: int) -> dict:
+    """Invoke a OneBot action over the WebSocket API (sync wrapper).
+
+    Each call opens its own short-lived connection — these tools are
+    low-frequency, so a fresh connect per action keeps the sync API simple
+    and stateless.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No event loop in this thread — safe to drive one directly.
+        return asyncio.run(_ws_roundtrip(base, action, params, timeout))
+
+    # Already inside a running loop — isolate the round-trip in a worker
+    # thread so we never block or nest event loops.
+    import concurrent.futures  # noqa: PLC0415 — only needed on this path
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(
+            lambda: asyncio.run(_ws_roundtrip(base, action, params, timeout))
+        )
+        return future.result(timeout=timeout + 15)
+
+
+async def _ws_roundtrip(base: str, action: str, params: dict, timeout: int) -> dict:
+    """Open a WS connection, send one action, and return its ``data``.
+
+    NapCat/Lagrange push unsolicited events on the same socket; this reads
+    until the reply carrying our ``echo`` arrives, skipping everything else.
+    """
+    try:
+        import websockets  # noqa: PLC0415 — optional dep, imported on demand
+    except ImportError as e:
+        raise RuntimeError(
+            "OneBot WebSocket transport needs the 'websockets' package — "
+            "run `pip install websockets`, or point ONEBOT_HTTP_URL at an "
+            "http:// endpoint instead."
+        ) from e
+
+    uri = base
+    token = onebot_access_token()
+    if token:
+        sep = "&" if "?" in uri else "?"
+        uri = f"{uri}{sep}access_token={urllib.parse.quote(token)}"
+
+    echo = f"hermes-{action}-{os.urandom(4).hex()}"
+    request = json.dumps({"action": action, "params": params, "echo": echo})
+
+    try:
+        async with websockets.connect(uri, max_size=None, open_timeout=timeout) as ws:
+            await ws.send(request)
+            # Skip pushed events; stop when our echo comes back.
+            for _ in range(500):
+                raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+                try:
+                    msg = json.loads(raw)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    continue
+                if isinstance(msg, dict) and msg.get("echo") == echo:
+                    return _check_onebot_payload(msg, action)
+    except RuntimeError:
+        raise
+    except (OSError, asyncio.TimeoutError) as e:
+        raise RuntimeError(
+            f"Cannot reach OneBot at {base} — is NapCat/Lagrange running? ({e})"
+        ) from e
+    except Exception as e:  # noqa: BLE001 — surface one clear message
+        raise RuntimeError(
+            f"OneBot WebSocket action '{action}' failed: {e}"
+        ) from e
+
+    raise RuntimeError(
+        f"OneBot action '{action}' got no matching reply (echo timeout)."
+    )


### PR DESCRIPTION
## Summary

Split the shared OneBot v11 transport helper out of #32140 as a small standalone foundation PR.

This adds `tools/onebot_client.py`, which provides:
- environment-based OneBot endpoint resolution
- HTTP action calls
- WebSocket action round-trips with echo matching
- access-token handling
- shared response validation for OneBot-backed tools

No Hermes tool is registered in this PR. Follow-up PRs can layer `qzone_publish` and `qq_send_voice` on top without duplicating transport code.

## Validation

- `.venv\\Scripts\\python.exe -m pytest tests\\tools\\test_onebot_client.py -q --timeout-method=thread` (23 passed)
- `.venv\\Scripts\\ruff.exe check tools\\onebot_client.py tests\\tools\\test_onebot_client.py`
- `git diff --check upstream/main...HEAD`