### PR TITLE
fix(skills): stop blocked updates from force installing

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -502,7 +502,8 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
-               name_override: str = "") -> None:
+               name_override: str = "",
+               reinstall_existing: bool = False) -> None:
     """Fetch, quarantine, scan, confirm, and install a skill.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
@@ -511,6 +512,9 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     triggers a prompt instead; ``skip_confirm=True`` means "non-interactive"
     (so pair it with ``name_override`` when installing from a URL that has
     no frontmatter).
+
+    ``reinstall_existing`` lets update flows replace an already installed
+    skill without also treating the scan as a forced install.
     """
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
@@ -620,7 +624,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     existing = lock.get_installed(bundle.name)
     if existing:
         c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
-        if not force:
+        if not (force or reinstall_existing):
             c.print("Use --force to reinstall.\n")
             return
 
@@ -1054,13 +1058,33 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
         c.print("[dim]No updates available.[/]\n")
         return
 
+    updated_count = 0
+    blocked_updates = []
     for entry in updates:
         installed = lock.get_installed(entry["name"])
         category = _derive_category_from_install_path(installed.get("install_path", "")) if installed else ""
         c.print(f"[bold]Updating:[/] {entry['name']}")
-        do_install(entry["identifier"], category=category, force=True, console=c)
+        do_install(
+            entry["identifier"],
+            category=category,
+            force=False,
+            console=c,
+            skip_confirm=True,
+            reinstall_existing=True,
+        )
 
-    c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
+        expected_hash = entry.get("latest_hash")
+        refreshed = lock.get_installed(entry["name"]) or {}
+        if expected_hash and refreshed.get("content_hash") != expected_hash:
+            blocked_updates.append(entry["name"])
+        else:
+            updated_count += 1
+
+    if updated_count:
+        c.print(f"[bold green]Updated {updated_count} skill(s).[/]")
+    if blocked_updates:
+        c.print(f"[bold yellow]Skipped {len(blocked_updates)} blocked update(s):[/] {', '.join(blocked_updates)}")
+    c.print()
 
 
 def do_audit(name: Optional[str] = None, console: Optional[Console] = None,

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -80,7 +80,7 @@ def _capture_check(monkeypatch, results, name=None) -> str:
     return sink.getvalue()
 
 
-def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, bool]]]:
+def _capture_update(monkeypatch, results) -> tuple[str, list[dict[str, object]]]:
     import tools.skills_hub as hub
     import hermes_cli.skills_hub as cli_hub
 
@@ -92,7 +92,25 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
     monkeypatch.setattr(hub, "HubLockFile", lambda: type("L", (), {
         "get_installed": lambda self, name: {"install_path": "category/" + name}
     })())
-    monkeypatch.setattr(cli_hub, "do_install", lambda identifier, category="", force=False, console=None: installs.append((identifier, category, force)))
+    def fake_do_install(
+        identifier,
+        category="",
+        force=False,
+        console=None,
+        skip_confirm=False,
+        reinstall_existing=False,
+    ):
+        installs.append(
+            {
+                "identifier": identifier,
+                "category": category,
+                "force": force,
+                "skip_confirm": skip_confirm,
+                "reinstall_existing": reinstall_existing,
+            }
+        )
+
+    monkeypatch.setattr(cli_hub, "do_install", fake_do_install)
 
     do_update(console=console)
     return sink.getvalue(), installs
@@ -245,8 +263,56 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
         {"name": "other-skill", "identifier": "github/example/other-skill", "status": "up_to_date"},
     ])
 
-    assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
+    assert installs == [
+        {
+            "identifier": "skills-sh/example/repo/hub-skill",
+            "category": "category",
+            "force": False,
+            "skip_confirm": True,
+            "reinstall_existing": True,
+        }
+    ]
     assert "Updated 1 skill" in output
+
+
+def test_do_update_reports_blocked_update_when_lock_hash_stays_stale(monkeypatch):
+    import tools.skills_hub as hub
+    import hermes_cli.skills_hub as cli_hub
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    installs = []
+
+    class _Lock:
+        def get_installed(self, name):
+            return {"install_path": "category/" + name, "content_hash": "sha256:old"}
+
+    monkeypatch.setattr(
+        hub,
+        "check_for_skill_updates",
+        lambda **_kwargs: [
+            {
+                "name": "hub-skill",
+                "identifier": "skills-sh/example/repo/hub-skill",
+                "status": "update_available",
+                "latest_hash": "sha256:new",
+            }
+        ],
+    )
+    monkeypatch.setattr(hub, "HubLockFile", _Lock)
+    monkeypatch.setattr(
+        cli_hub,
+        "do_install",
+        lambda identifier, **kwargs: installs.append((identifier, kwargs)),
+    )
+
+    do_update(console=console)
+
+    assert installs
+    output = sink.getvalue()
+    assert "Updated 1 skill" not in output
+    assert "Skipped 1 blocked update" in output
+    assert "hub-skill" in output
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
@@ -483,6 +549,59 @@ def test_url_install_uses_name_override_on_non_interactive_surface(monkeypatch, 
     )
 
     assert installs == [{"name": "my-url-skill", "category": ""}]
+
+
+def test_reinstall_existing_does_not_force_scan_policy(monkeypatch, tmp_path, hub_env):
+    import tools.skills_guard as guard
+    import tools.skills_hub as hub
+
+    installs = _install_mocks(
+        monkeypatch,
+        tmp_path,
+        _make_url_bundle_fetcher(name="existing-skill", awaiting_name=False),
+    )
+    force_args = []
+
+    monkeypatch.setattr(
+        hub,
+        "HubLockFile",
+        lambda: type(
+            "Lock",
+            (),
+            {"get_installed": lambda self, name: {"install_path": f"category/{name}"}},
+        )(),
+    )
+    monkeypatch.setattr(
+        guard,
+        "scan_skill",
+        lambda skill_path, source="community": guard.ScanResult(
+            skill_name="existing-skill",
+            source=source,
+            trust_level="community",
+            verdict="caution",
+            findings=[guard.Finding("x", "high", "c", "f", 1, "m", "d")],
+        ),
+    )
+    monkeypatch.setattr(guard, "format_scan_report", lambda result: "scan blocked")
+
+    def block_without_force(result, force=False):
+        force_args.append(force)
+        return False, "Blocked by scan"
+
+    monkeypatch.setattr(guard, "should_allow_install", block_without_force)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_install(
+        "https://example.com/existing-skill/SKILL.md",
+        console=console,
+        skip_confirm=True,
+        reinstall_existing=True,
+    )
+
+    assert force_args == [False]
+    assert installs == []
+    assert "Installation blocked" in sink.getvalue()
 
 
 def test_url_install_rejects_invalid_name_override(monkeypatch, tmp_path, hub_env):
@@ -780,4 +899,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-


### PR DESCRIPTION
## Summary

Routine skill updates could display a Skills Guard decision of `BLOCKED` and then install the update anyway. `do_update()` passed `force=True` solely to replace an existing skill, but that same flag also overrode the scan policy in `should_allow_install()`.

This PR separates those two concerns:

- Add `reinstall_existing` so update flows may replace an installed skill without forcing the security-policy decision.
- Run updates with `force=False`, `skip_confirm=True`, and `reinstall_existing=True`.
- Compare the post-install lock hash with the fetched update hash so a policy-blocked update is reported as skipped instead of falsely counted as updated.
- Cover both the update-call contract and the end-to-end install-policy boundary with behavior tests.

## Linked issue

Closes #38041

## Current behavior proof

Verified against upstream `main` at `477c08b44766ace8b890faa72bf82ecbcf2b3ba8` before rebasing:

1. `do_update()` still called `do_install(..., force=True)` for every available update.
2. `do_install()` rendered the scan report using the normal policy but executed `should_allow_install(result, force=force)`.
3. For a community skill with a policy-blocked `caution` result, the visible report could therefore say `BLOCKED` while the update path supplied the override needed to continue installing it.

After this change, update replacement permission no longer changes the scan-policy input: a blocked scan remains blocked, the installed hash remains unchanged, and the update summary reports the skill as skipped.

## Files changed

- `hermes_cli/skills_hub.py`
- `tests/hermes_cli/test_skills_hub.py`

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_skills_hub.py -q` — 30 passed, 0 failed
- `.venv/bin/ruff check hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py` — passed
- `.venv/bin/python scripts/check-windows-footguns.py --diff origin/main` — passed (2 files scanned)
- `git diff --check` — passed

## Rebase receipt

- Current upstream base: `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`
- Rebased PR head: `cc5b5805c`
- Existing contributor branch and PR preserved; no replacement PR was created.

## Risk

The change is limited to skill reinstall/update control flow and its tests. Explicit user-requested `--force` installs retain their existing behavior; routine updates no longer receive that policy override implicitly.
