### PR TITLE
fix(web_server): reap finished action subprocesses to prevent zombie accumulation

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1385,6 +1385,13 @@ async def get_action_status(name: str, lines: int = 200):
         exit_code = proc.poll()
         running = exit_code is None
         pid = proc.pid
+        if not running:
+            # Reap the finished child to prevent zombie accumulation.
+            try:
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+            _ACTION_PROCS.pop(name, None)
 
     return {
         "name": name,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -613,6 +613,40 @@ class TestWebServerEndpoints:
         assert resp.json() == {"ok": True, "pid": 12345, "name": "hermes-update"}
         assert calls == [(["update"], "hermes-update")]
 
+    def test_finished_action_proc_is_reaped_and_removed(self):
+        """Processes that have exited are reaped via .wait() and removed
+        from _ACTION_PROCS so they do not accumulate as zombies."""
+        import hermes_cli.web_server as web_server
+
+        waited = []
+
+        class FinishedProc:
+            pid = 99999
+
+            def poll(self):
+                return 0
+
+            def wait(self, timeout=None):
+                waited.append(timeout)
+                return 0
+
+        name = "gateway-restart"
+        proc = FinishedProc()
+        web_server._ACTION_PROCS[name] = proc
+        web_server._ACTION_RESULTS.pop(name, None)
+        try:
+            status = self.client.get(f"/api/actions/{name}/status")
+            assert status.status_code == 200
+            data = status.json()
+            assert data["running"] is False
+            assert data["exit_code"] == 0
+            assert data["pid"] == 99999
+            # The proc should have been reaped and removed.
+            assert waited, "proc.wait() was not called"
+            assert name not in web_server._ACTION_PROCS
+        finally:
+            web_server._ACTION_PROCS.pop(name, None)
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## What does this PR do?

Reaps finished dashboard action subprocesses in `get_action_status()` to prevent zombie process accumulation. Previously, `proc.poll()` was called to check liveness but `proc.wait()` was never issued, leaving every completed action as a `<defunct>` zombie for the lifetime of the web server.

## Related Issue

Fixes #38032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: After `proc.poll()` returns a non-None exit code, call `proc.wait(timeout=1)` to reap the child process and `.pop()` the handle from `_ACTION_PROCS`. This prevents zombie accumulation for all dashboard actions (gateway-restart, hermes-update, etc.).
- `tests/hermes_cli/test_web_server.py`: Added `test_finished_action_proc_is_reaped_and_removed` — injects a mock `FinishedProc` into `_ACTION_PROCS`, calls the status endpoint, and asserts that `proc.wait()` was called and the entry was removed from the dict.

## How to Test

1. Run the new test: `pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_finished_action_proc_is_reaped_and_removed -xvs`
2. Run related action tests: `pytest tests/hermes_cli/test_web_server.py -k "action" -xvs`
3. Verify no regressions: `pytest tests/hermes_cli/test_web_server.py -x`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_web_server.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/web_server.py:get_action_status()` (caller: FastAPI route handler, flows: dashboard action status polling)
- Blast radius: LOW — localized to action status endpoint; no behavioral change for running processes
- Related patterns: `_ACTION_RESULTS` dict already handles completed non-spawned actions; this fix extends the same cleanup to spawned subprocesses
