### PR TITLE
fix: improve Codex timeout and Telegram check-ins

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -333,8 +333,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
         agent._codex_stream_last_progress_ts = None
 
     _call_start = time.time()
+    # ``codex_responses`` is implemented as a streaming Responses API call
+    # inside this "non-streaming" wrapper (the wrapper waits for the assembled
+    # final response).  Long drafts can legitimately stream text for several
+    # minutes.  Track the last real Codex stream event separately so the outer
+    # stale detector measures *inactivity* instead of wall-clock duration.
+    _last_codex_stream_activity = _call_start
     agent._touch_activity("waiting for non-streaming API response")
-
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _poll_count = 0
@@ -450,7 +455,17 @@ def interruptible_api_call(agent, api_kwargs: dict):
             break
 
         # Stale-call detector: kill the connection if no response
-        # arrives within the configured timeout.
+        # arrives within the configured timeout.  For Codex Responses we
+        # receive streamed text inside this wrapper, so treat real stream
+        # activity as progress and only abort after a quiet gap.
+        if agent.api_mode == "codex_responses":
+            activity_desc = getattr(agent, "_last_activity_desc", "")
+            activity_ts = float(getattr(agent, "_last_activity_ts", _call_start) or _call_start)
+            if activity_desc == "receiving stream response" and activity_ts > _last_codex_stream_activity:
+                _last_codex_stream_activity = activity_ts
+            _elapsed = time.time() - _last_codex_stream_activity
+        else:
+            _elapsed = time.time() - _call_start
         if _elapsed > _stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             _silent_hint: Optional[str] = None

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Optional, Set, Any
 logger = logging.getLogger(__name__)
 
 try:
-    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
+    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardRemove
     try:
         from telegram import LinkPreviewOptions
     except ImportError:
@@ -44,6 +44,12 @@ except ImportError:
     Message = Any
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
+
+    class _MockReplyKeyboardRemove:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    ReplyKeyboardRemove = _MockReplyKeyboardRemove
     LinkPreviewOptions = None
     Application = Any
     CommandHandler = Any
@@ -117,7 +123,7 @@ def check_telegram_requirements() -> bool:
     so the adapter's class-level type aliases get rebound.
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
-    global InlineKeyboardMarkup, LinkPreviewOptions, Application
+    global InlineKeyboardMarkup, ReplyKeyboardRemove, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
@@ -129,7 +135,7 @@ def check_telegram_requirements() -> bool:
         return False
     try:
         from telegram import Update as _Update, Bot as _Bot, Message as _Message
-        from telegram import InlineKeyboardButton as _IKB, InlineKeyboardMarkup as _IKM
+        from telegram import InlineKeyboardButton as _IKB, InlineKeyboardMarkup as _IKM, ReplyKeyboardRemove as _RKR
         try:
             from telegram import LinkPreviewOptions as _LPO
         except ImportError:
@@ -149,6 +155,7 @@ def check_telegram_requirements() -> bool:
     Message = _Message
     InlineKeyboardButton = _IKB
     InlineKeyboardMarkup = _IKM
+    ReplyKeyboardRemove = _RKR
     LinkPreviewOptions = _LPO
     Application = _App
     CommandHandler = _CH
@@ -1602,6 +1609,12 @@ class TelegramAdapter(BasePlatformAdapter):
             self._bot = self._app.bot
             
             # Register handlers
+            web_app_filter = getattr(getattr(filters, "StatusUpdate", object()), "WEB_APP_DATA", None)
+            if web_app_filter is not None:
+                self._app.add_handler(TelegramMessageHandler(
+                    web_app_filter,
+                    self._handle_web_app_data
+                ))
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 self._handle_text_message
@@ -3243,6 +3256,85 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Health check-in fallback callbacks (hc:field:value) ---
+        if data.startswith("hc:"):
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                return
+            try:
+                import datetime as _dt
+                import sqlite3 as _sqlite3
+                parts = data.split(":", 2)
+                if len(parts) != 3:
+                    await query.answer(text="Invalid check-in data.")
+                    return
+                field, value = parts[1], parts[2]
+                if field != "energy":
+                    await query.answer(text="Use the mini app for this field.")
+                    return
+                energy = int(value)
+                if not 1 <= energy <= 10:
+                    raise ValueError("energy must be 1–10")
+                date = _dt.date.today().isoformat()
+                from hermes_constants import get_hermes_home
+                db_path = get_hermes_home() / "health" / "withings_health.db"
+                with _sqlite3.connect(db_path) as conn:
+                    conn.execute(
+                        """CREATE TABLE IF NOT EXISTS daily_checkins (
+                          date TEXT PRIMARY KEY,
+                          logged_at INTEGER NOT NULL,
+                          energy INTEGER CHECK (energy BETWEEN 1 AND 10 OR energy IS NULL),
+                          knee_pain INTEGER CHECK (knee_pain BETWEEN 0 AND 10 OR knee_pain IS NULL),
+                          anxiety INTEGER CHECK (anxiety BETWEEN 0 AND 10 OR anxiety IS NULL),
+                          work_stress INTEGER CHECK (work_stress BETWEEN 0 AND 10 OR work_stress IS NULL),
+                          kid_wakeups INTEGER,
+                          caffeine_after_noon INTEGER CHECK (caffeine_after_noon IN (0,1) OR caffeine_after_noon IS NULL),
+                          alcohol INTEGER CHECK (alcohol IN (0,1) OR alcohol IS NULL),
+                          exercise TEXT,
+                          subjective_bedtime TEXT,
+                          subjective_wake_time TEXT,
+                          notes TEXT,
+                          raw_json TEXT
+                        )"""
+                    )
+                    conn.execute(
+                        """INSERT INTO daily_checkins (date, logged_at, energy, raw_json)
+                        VALUES (?, ?, ?, ?)
+                        ON CONFLICT(date) DO UPDATE SET
+                          logged_at=excluded.logged_at,
+                          energy=excluded.energy,
+                          raw_json=excluded.raw_json
+                        """,
+                        (
+                            date,
+                            int(_dt.datetime.now().timestamp()),
+                            energy,
+                            json.dumps({"type": "health_checkin_callback", "energy": energy}, sort_keys=True),
+                        ),
+                    )
+                    conn.commit()
+                await query.answer(text=f"Saved energy {energy}/10")
+                if query.message:
+                    try:
+                        await query.edit_message_reply_markup(reply_markup=None)
+                        await query.message.reply_text(
+                            f"✅ Saved energy {energy}/10 for {date}. "
+                            "You can reply with any extra notes, or use the Mini App next time."
+                        )
+                    except Exception:
+                        pass
+            except Exception as exc:
+                logger.error("[%s] health check-in callback failed: %s", self.name, exc, exc_info=True)
+                await query.answer(text=f"Could not save: {exc}")
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mm:", "mb", "mx", "mg:")):
@@ -5214,6 +5306,204 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = self._clean_bot_trigger_text(event.text)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
+
+    async def _handle_web_app_data(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle Telegram Mini App submissions for the daily health check-in."""
+        msg = self._effective_update_message(update)
+        if not msg:
+            return
+        if not self._should_process_message(msg):
+            return
+
+        wad = getattr(msg, "web_app_data", None)
+        raw_data = getattr(wad, "data", None) if wad else None
+        if not raw_data:
+            return
+
+        try:
+            import datetime as _dt
+            import sqlite3 as _sqlite3
+
+            payload = json.loads(raw_data)
+            if not isinstance(payload, dict) or payload.get("type") != "health_checkin":
+                await msg.reply_text("I received Mini App data, but it was not a health check-in payload.")
+                return
+
+            def _int_range(name: str, low: int, high: int):
+                value = payload.get(name)
+                if value is None or value == "":
+                    return None
+                value = int(value)
+                if not low <= value <= high:
+                    raise ValueError(f"{name} must be between {low} and {high}")
+                return value
+
+            def _yesno(name: str):
+                value = payload.get(name)
+                if value is None or value == "":
+                    return None
+                value = str(value).strip().lower()
+                if value in {"yes", "y", "true", "1"}:
+                    return 1
+                if value in {"no", "n", "false", "0"}:
+                    return 0
+                raise ValueError(f"{name} must be yes/no")
+
+            def _time_or_none(name: str):
+                value = payload.get(name)
+                if not value:
+                    return None
+                value = str(value).strip()
+                if not re.match(r"^\d{2}:\d{2}$", value):
+                    raise ValueError(f"{name} must be HH:MM")
+                return value
+
+            today = _dt.date.today().isoformat()
+            date = str(payload.get("date") or today)
+            if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
+                date = today
+
+            exercise = payload.get("exercise")
+            if exercise is not None:
+                exercise = str(exercise).strip().lower()[:80] or None
+
+            exercise_type = payload.get("exercise_type")
+            if exercise_type is not None:
+                exercise_type = str(exercise_type).strip().lower()[:40] or None
+
+            exercise_effort = payload.get("exercise_effort", payload.get("exercise_intensity"))
+            if exercise_effort is not None:
+                exercise_effort = str(exercise_effort).strip().lower()[:40] or None
+
+            # Backward-compatible parsing for older composite submissions.
+            if exercise and (not exercise_type or exercise_type == "none"):
+                if "_" in exercise:
+                    possible_type, possible_effort = exercise.split("_", 1)
+                    exercise_type = possible_type or exercise_type
+                    exercise_effort = exercise_effort or possible_effort
+                else:
+                    exercise_type = exercise
+            if exercise_type == "none":
+                exercise_effort = None
+                exercise = "none"
+            elif exercise_type:
+                exercise = f"{exercise_type}_{exercise_effort}" if exercise_effort else exercise_type
+            notes = payload.get("notes")
+            if notes is not None:
+                notes = str(notes).strip()[:1000] or None
+
+            values = {
+                "energy": _int_range("energy", 1, 10),
+                "knee_pain": _int_range("knee_pain", 0, 10),
+                "anxiety": _int_range("anxiety", 0, 10),
+                "work_stress": _int_range("work_stress", 0, 10),
+                "libido": _int_range("libido", 0, 10),
+                "kid_wakeups": _int_range("kid_wakeups", 0, 20),
+                "caffeine_after_noon": _yesno("caffeine_after_noon"),
+                "alcohol": _yesno("alcohol"),
+                "exercise": exercise,
+                "exercise_type": exercise_type,
+                "exercise_effort": exercise_effort,
+                "subjective_bedtime": _time_or_none("bedtime"),
+                "subjective_wake_time": _time_or_none("wake"),
+                "notes": notes,
+            }
+
+            from hermes_constants import get_hermes_home
+            db_path = get_hermes_home() / "health" / "withings_health.db"
+            now = int(_dt.datetime.now().timestamp())
+            with _sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """CREATE TABLE IF NOT EXISTS daily_checkins (
+                      date TEXT PRIMARY KEY,
+                      logged_at INTEGER NOT NULL,
+                      energy INTEGER CHECK (energy BETWEEN 1 AND 10 OR energy IS NULL),
+                      knee_pain INTEGER CHECK (knee_pain BETWEEN 0 AND 10 OR knee_pain IS NULL),
+                      anxiety INTEGER CHECK (anxiety BETWEEN 0 AND 10 OR anxiety IS NULL),
+                      work_stress INTEGER CHECK (work_stress BETWEEN 0 AND 10 OR work_stress IS NULL),
+                      libido INTEGER CHECK (libido BETWEEN 0 AND 10 OR libido IS NULL),
+                      kid_wakeups INTEGER,
+                      caffeine_after_noon INTEGER CHECK (caffeine_after_noon IN (0,1) OR caffeine_after_noon IS NULL),
+                      alcohol INTEGER CHECK (alcohol IN (0,1) OR alcohol IS NULL),
+                      exercise TEXT,
+                      exercise_type TEXT,
+                      exercise_effort TEXT,
+                      subjective_bedtime TEXT,
+                      subjective_wake_time TEXT,
+                      notes TEXT,
+                      raw_json TEXT
+                    )"""
+                )
+                cols = {row[1] for row in conn.execute("PRAGMA table_info(daily_checkins)")}
+                if "libido" not in cols:
+                    conn.execute("ALTER TABLE daily_checkins ADD COLUMN libido INTEGER CHECK (libido BETWEEN 0 AND 10 OR libido IS NULL)")
+                if "exercise_type" not in cols:
+                    conn.execute("ALTER TABLE daily_checkins ADD COLUMN exercise_type TEXT")
+                if "exercise_effort" not in cols:
+                    conn.execute("ALTER TABLE daily_checkins ADD COLUMN exercise_effort TEXT")
+                conn.execute(
+                    """INSERT INTO daily_checkins
+                    (date, logged_at, energy, knee_pain, anxiety, work_stress, libido, kid_wakeups,
+                     caffeine_after_noon, alcohol, exercise, exercise_type, exercise_effort,
+                     subjective_bedtime, subjective_wake_time, notes, raw_json)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(date) DO UPDATE SET
+                      logged_at=excluded.logged_at,
+                      energy=COALESCE(excluded.energy, daily_checkins.energy),
+                      knee_pain=COALESCE(excluded.knee_pain, daily_checkins.knee_pain),
+                      anxiety=COALESCE(excluded.anxiety, daily_checkins.anxiety),
+                      work_stress=COALESCE(excluded.work_stress, daily_checkins.work_stress),
+                      libido=COALESCE(excluded.libido, daily_checkins.libido),
+                      kid_wakeups=COALESCE(excluded.kid_wakeups, daily_checkins.kid_wakeups),
+                      caffeine_after_noon=COALESCE(excluded.caffeine_after_noon, daily_checkins.caffeine_after_noon),
+                      alcohol=COALESCE(excluded.alcohol, daily_checkins.alcohol),
+                      exercise=COALESCE(excluded.exercise, daily_checkins.exercise),
+                      exercise_type=COALESCE(excluded.exercise_type, daily_checkins.exercise_type),
+                      exercise_effort=COALESCE(excluded.exercise_effort, daily_checkins.exercise_effort),
+                      subjective_bedtime=COALESCE(excluded.subjective_bedtime, daily_checkins.subjective_bedtime),
+                      subjective_wake_time=COALESCE(excluded.subjective_wake_time, daily_checkins.subjective_wake_time),
+                      notes=COALESCE(excluded.notes, daily_checkins.notes),
+                      raw_json=excluded.raw_json
+                    """,
+                    (
+                        date,
+                        now,
+                        values["energy"],
+                        values["knee_pain"],
+                        values["anxiety"],
+                        values["work_stress"],
+                        values["libido"],
+                        values["kid_wakeups"],
+                        values["caffeine_after_noon"],
+                        values["alcohol"],
+                        values["exercise"],
+                        values["exercise_type"],
+                        values["exercise_effort"],
+                        values["subjective_bedtime"],
+                        values["subjective_wake_time"],
+                        values["notes"],
+                        json.dumps(payload, sort_keys=True),
+                    ),
+                )
+                conn.commit()
+
+            caffeine = "yes" if values["caffeine_after_noon"] == 1 else "no" if values["caffeine_after_noon"] == 0 else "—"
+            alcohol = "yes" if values["alcohol"] == 1 else "no" if values["alcohol"] == 0 else "—"
+            exercise_summary = values['exercise_type'] or values['exercise'] or '—'
+            if values['exercise_effort']:
+                exercise_summary = f"{exercise_summary} ({values['exercise_effort']})"
+            summary = (
+                f"✅ Health check-in saved for {date}\n"
+                f"Energy {values['energy']} · Knee {values['knee_pain']} · "
+                f"Anx {values['anxiety']} · Stress {values['work_stress']} · Libido {values['libido']}\n"
+                f"Kids {values['kid_wakeups']} · Caffeine {caffeine} · "
+                f"Alcohol {alcohol} · Ex {exercise_summary}"
+            )
+            await msg.reply_text(summary, reply_markup=ReplyKeyboardRemove())
+            logger.info("[%s] logged Telegram Mini App health check-in for %s and removed reply keyboard", self.name, date)
+        except Exception as exc:
+            logger.error("[%s] Mini App health check-in failed: %s", self.name, exc, exc_info=True)
+            await msg.reply_text(f"Could not save health check-in: {exc}")
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18020,6 +18020,50 @@ class GatewayRunner:
                 and _interruption_is_fresh
             )
 
+            # Summarize the most recent tool calls so the resumed model knows
+            # what was already attempted and doesn't re-explore from scratch.
+            # Walks back over recent history collecting tool names + brief
+            # arg hints; bounded to avoid bloating the prompt.
+            def _recent_tool_summary(hist: list, limit: int = 12) -> str:
+                if not hist:
+                    return ""
+                names: list[str] = []
+                seen_round: set[str] = set()
+                for row in reversed(hist):
+                    role = row.get("role") if isinstance(row, dict) else None
+                    if role == "assistant":
+                        tcalls = row.get("tool_calls") or []
+                        for tc in tcalls:
+                            try:
+                                fn = (tc.get("function") or {}).get("name") or tc.get("name")
+                            except AttributeError:
+                                fn = None
+                            if not fn:
+                                continue
+                            tag = f"{fn}"
+                            if tag in seen_round:
+                                seen_round.add(tag + "*")
+                            else:
+                                seen_round.add(tag)
+                                names.append(tag)
+                            if len(names) >= limit:
+                                break
+                    if len(names) >= limit:
+                        break
+                if not names:
+                    return ""
+                # Reverse to chronological order for readability.
+                return ", ".join(reversed(names))
+
+            _prior_tools = _recent_tool_summary(agent_history)
+            _prior_tools_line = (
+                f" Tools already executed (most recent first → oldest): "
+                f"{_prior_tools}. Do NOT re-run discovery or re-explore "
+                f"the same files/state — continue from where you left off."
+                if _prior_tools
+                else ""
+            )
+
             if _is_resume_pending:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 _reason_phrase = (
@@ -18034,7 +18078,7 @@ class GatewayRunner:
                     f"by {_reason_phrase}. The conversation history below is intact. "
                     f"If it contains unfinished tool result(s), process them first and "
                     f"summarize what was accomplished, then address the user's new "
-                    f"message below.]\n\n"
+                    f"message below.{_prior_tools_line}]\n\n"
                     + message
                 )
             elif _has_fresh_tool_tail:
@@ -18043,7 +18087,7 @@ class GatewayRunner:
                     "process the last tool result(s). The conversation history contains "
                     "tool outputs you haven't responded to yet. Please finish processing "
                     "those results and summarize what was accomplished, then address the "
-                    "user's new message below.]\n\n"
+                    f"user's new message below.{_prior_tools_line}]\n\n"
                     + message
                 )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10380,6 +10380,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
+        #
+        # In-flight check: if the running gateway is currently servicing an
+        # agent turn, restarting kills it mid-tool-call and the SIGTERM-drain
+        # → systemd-respawn cycle can interrupt the agent's state multiple
+        # times.  Skip the restart unless the caller explicitly opted in
+        # (``--yes`` or invoked from inside the gateway via ``/update``).
+        if not gateway_mode and not assume_yes:
+            try:
+                from gateway.status import read_runtime_status as _rrs
+                _gw_state = _rrs() or {}
+                _active = int(_gw_state.get("active_agents") or 0)
+            except Exception:
+                _active = 0
+            if _active > 0:
+                print()
+                print(
+                    f"⚠ Gateway is currently running {_active} active agent "
+                    f"turn(s). Skipping auto-restart to avoid interrupting "
+                    f"in-flight work."
+                )
+                print(
+                    "  → Code is updated. Restart manually when idle: "
+                    "`hermes gateway restart` (or rerun `hermes update --yes`)."
+                )
+                return
         try:
             from hermes_cli.gateway import (
                 is_macos,

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -306,3 +306,67 @@ def test_explicit_non_stream_stale_timeout_is_honored_for_local_endpoints(monkey
     )
 
     assert agent._compute_non_stream_stale_timeout([]) == 300.0
+
+
+def test_codex_responses_non_stream_wrapper_uses_stream_activity_for_stale_timeout(monkeypatch):
+    """Long Codex drafts stream text inside the non-stream wrapper.
+
+    The wrapper must not abort just because total wall-clock time exceeds the
+    stale timeout while real streamed text is still arriving.
+    """
+    from agent import chat_completion_helpers as helpers
+
+    class FakeTime:
+        now = 0.0
+
+        @classmethod
+        def time(cls):
+            return cls.now
+
+    class FakeThread:
+        def __init__(self, target, daemon=False):
+            self.polls_remaining = 3
+
+        def start(self):
+            return None
+
+        def is_alive(self):
+            return self.polls_remaining > 0
+
+        def join(self, timeout=None):
+            FakeTime.now += 3.0
+            agent._touch_activity("receiving stream response")
+            self.polls_remaining -= 1
+
+    class FakeAgent:
+        api_mode = "codex_responses"
+        model = "gpt-5.5"
+        _interrupt_requested = False
+
+        def __init__(self):
+            self._last_activity_ts = 0.0
+            self._last_activity_desc = ""
+            self.closed = False
+
+        def _compute_non_stream_stale_timeout(self, messages):
+            return 5.0
+
+        def _touch_activity(self, desc):
+            self._last_activity_ts = FakeTime.time()
+            self._last_activity_desc = desc
+
+        def _create_request_openai_client(self, **kwargs):
+            raise AssertionError("fake thread should not execute target")
+
+        def _close_request_openai_client(self, *args, **kwargs):
+            self.closed = True
+
+        def _emit_status(self, message):
+            raise AssertionError(message)
+
+    agent = FakeAgent()
+    monkeypatch.setattr(helpers.time, "time", FakeTime.time)
+    monkeypatch.setattr(helpers.threading, "Thread", FakeThread)
+
+    assert helpers.interruptible_api_call(agent, {"model": "gpt-5.5"}) is None
+    assert agent.closed is False


### PR DESCRIPTION
## Summary
- Treat Codex Responses stream activity as progress for non-stream stale timeouts
- Add Telegram health check-in Mini App handling and fallback callbacks
- Avoid gateway auto-restarts while active agent turns are running
- Add regression coverage for Codex stale-timeout behavior

## Test Plan
- python -m pytest -o addopts='' tests/hermes_cli/test_timeouts.py tests/run_agent/test_run_agent_codex_responses.py