### PR TITLE
fix: Windows dashboard serve JS files with correct javascript MIME type 

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7189,6 +7189,20 @@ def mount_spa(application: FastAPI):
                 css = css.replace(f"url('{asset_dir}", f"url('{prefix}{asset_dir}")
         return Response(content=css, media_type="text/css")
 
+    @application.get("/assets/{filename}.js")
+    async def serve_js(filename: str, request: Request):
+        """Serve .js assets with correct application/javascript MIME type.
+
+        Prevents blank Dashboard on Windows where stdlib mimetypes may map
+        .js to text/plain, causing browsers to reject module scripts.
+        """
+        js_path = WEB_DIST / "assets" / f"{filename}.js"
+        if not js_path.is_file() or not js_path.resolve().is_relative_to(
+            WEB_DIST.resolve()
+        ):
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return Response(content=js_path.read_bytes(), media_type="application/javascript")
+
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 
     @application.get("/{full_path:path}")


### PR DESCRIPTION
**## Problem:**

On Windows, the Hermes dashboard displays a blank white page. The browser console shows:

> Failed to load module script: A JavaScript module script was expected, but the server responded with a MIME type of “text/plain”.

**## Cause：**

Hermes uses FastAPI’s StaticFiles to serve assets built with Vite. On Windows, Python’s mimetypes module may incorrectly assign the .js file extension to the text/plain media type. Browsers require that <script type="module"> tags be accompanied by the application/javascript media type in order to execute the script properly. Without this specification, browsers refuse to execute the script, resulting in a blank page.

**## Fix** 

A dedicated /assets/{filename}.js route was added in mount_spa(). This route serves JS files with the media_type “application/javascript”, matching the existing pattern used for CSS assets. This route is registered before the general StaticFiles mount, so it takes precedence over other routes.

**## Verification**

After applying the fix on Windows and restarting the dashboard:
- curl -sI http://127.0.0.1:9119/assets/index-*.js now returns “Content-Type: application/javascript”.
- The dashboard loads and renders correctly in the browser.

**## Risk**

Low – affects only paths like /assets/*.js. It includes path traversal protection and follows the same pattern as the existing serve_css route.