### PR TITLE
feat(qzone): add QZone publish tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2786,6 +2786,23 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "ONEBOT_HTTP_URL": {
+        "description": "OneBot HTTP API URL for QQ/QZone tools (NapCat or Lagrange)",
+        "prompt": "OneBot HTTP URL (e.g. http://127.0.0.1:3000)",
+        "url": None,
+        "tools": ["qzone_publish"],
+        "password": False,
+        "category": "tool",
+    },
+    "ONEBOT_ACCESS_TOKEN": {
+        "description": "OneBot access token for QQ/QZone tools (optional)",
+        "prompt": "OneBot access token (optional)",
+        "url": None,
+        "tools": ["qzone_publish"],
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
     "SEARXNG_URL": {
         "description": "URL of your SearXNG instance for free self-hosted web search",
         "prompt": "SearXNG URL (e.g. http://localhost:8080)",

--- a/tests/tools/test_onebot_client.py
+++ b/tests/tools/test_onebot_client.py
@@ -1,0 +1,278 @@
+"""Tests for the shared OneBot v11 client.
+
+Exercises real logic — URL/token configuration, availability gating, and
+both the HTTP and WebSocket transports' success / failure / error paths —
+with mocked HTTP and a fake WebSocket server so no network is touched.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.onebot_client import (
+    onebot_access_token,
+    onebot_base_url,
+    onebot_call,
+    onebot_configured,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP response
+# ---------------------------------------------------------------------------
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for the object returned by urllib.request.urlopen."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Fake WebSocket server
+# ---------------------------------------------------------------------------
+
+class _FakeWS:
+    """A fake OneBot WebSocket connection for _ws_roundtrip tests.
+
+    Replies to the action request with our echo, optionally preceded by a
+    burst of pushed events (no echo) to exercise the skip-until-echo loop.
+    """
+
+    def __init__(self, data=None, status="ok", retcode=0, message=None,
+                 lead_events=0):
+        self._data = data
+        self._status = status
+        self._retcode = retcode
+        self._message = message
+        self._lead_events = lead_events
+        self.sent = []
+        self._answered = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def recv(self):
+        if self._lead_events > 0:
+            self._lead_events -= 1
+            return json.dumps(
+                {"post_type": "meta_event", "meta_event_type": "heartbeat"}
+            )
+        if self._answered:  # the round-trip should have returned by now
+            await asyncio.sleep(3600)
+        self._answered = True
+        echo = json.loads(self.sent[-1])["echo"]
+        reply = {"status": self._status, "retcode": self._retcode, "echo": echo}
+        if self._message is not None:
+            reply["message"] = self._message
+        if self._status != "failed" and self._data is not None:
+            reply["data"] = self._data
+        return json.dumps(reply)
+
+
+def _fake_connect(fake_ws):
+    """Build a websockets.connect replacement that yields *fake_ws*."""
+
+    def _connect(uri, **kwargs):
+        _connect.last_uri = uri
+        return fake_ws
+
+    _connect.last_uri = None
+    return _connect
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class TestConfig:
+    def test_base_url_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000/")
+        assert onebot_base_url() == "http://127.0.0.1:3000"
+
+    def test_base_url_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "  http://host:3000  ")
+        assert onebot_base_url() == "http://host:3000"
+
+    def test_base_url_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        assert onebot_base_url() == ""
+
+    def test_base_url_falls_back_to_ws_url(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        assert onebot_base_url() == "ws://127.0.0.1:3001"
+
+    def test_http_url_wins_over_ws_url(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        assert onebot_base_url() == "http://127.0.0.1:3000"
+
+    def test_access_token_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_ACCESS_TOKEN", "  tok123  ")
+        assert onebot_access_token() == "tok123"
+
+    def test_access_token_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        assert onebot_access_token() == ""
+
+
+# ---------------------------------------------------------------------------
+# Availability gating
+# ---------------------------------------------------------------------------
+
+class TestConfigured:
+    def test_configured_when_http_url_set(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        assert onebot_configured() is True
+
+    def test_configured_when_only_ws_url_set(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        assert onebot_configured() is True
+
+    def test_not_configured_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        assert onebot_configured() is False
+
+    def test_not_configured_when_blank(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "   ")
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        assert onebot_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+class TestOnebotCallHTTP:
+    def test_raises_when_url_unconfigured(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.delenv("ONEBOT_WS_URL", raising=False)
+        with pytest.raises(RuntimeError, match="ONEBOT_HTTP_URL"):
+            onebot_call("get_login_info")
+
+    def test_returns_data_on_success(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps(
+            {"status": "ok", "retcode": 0, "data": {"message_id": 7}}
+        ).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            data = onebot_call("send_msg", {"message": []})
+        assert data == {"message_id": 7}
+
+    def test_raises_on_failed_status(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps(
+            {"status": "failed", "retcode": 1404, "message": "no login"}
+        ).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            with pytest.raises(RuntimeError, match="no login"):
+                onebot_call("send_msg")
+
+    def test_raises_on_missing_data(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps({"status": "ok", "retcode": 0}).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            with pytest.raises(RuntimeError, match="no data"):
+                onebot_call("send_msg")
+
+    def test_raises_on_non_json(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeHTTPResponse(b"<html>502 Bad Gateway</html>"),
+        ):
+            with pytest.raises(RuntimeError, match="non-JSON"):
+                onebot_call("send_msg")
+
+    def test_auth_header_sent_when_token_configured(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        monkeypatch.setenv("ONEBOT_ACCESS_TOKEN", "secret")
+        body = json.dumps({"status": "ok", "data": {"ok": 1}}).encode()
+        captured = {}
+
+        def _fake_urlopen(req, timeout=None):
+            captured["auth"] = req.headers.get("Authorization")
+            return _FakeHTTPResponse(body)
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            onebot_call("get_status")
+        assert captured["auth"] == "Bearer secret"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket transport
+# ---------------------------------------------------------------------------
+
+class TestOnebotCallWS:
+    def test_returns_data_on_success(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        fake = _FakeWS(data={"user_id": 42}, lead_events=3)
+        with patch("websockets.connect", _fake_connect(fake)):
+            data = onebot_call("get_login_info")
+        assert data == {"user_id": 42}
+        # The action request was actually sent.
+        sent = json.loads(fake.sent[-1])
+        assert sent["action"] == "get_login_info"
+
+    def test_uses_ws_url_fallback(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        monkeypatch.setenv("ONEBOT_WS_URL", "ws://127.0.0.1:3001")
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        fake = _FakeWS(data={"message_id": 9})
+        with patch("websockets.connect", _fake_connect(fake)):
+            data = onebot_call("send_msg", {"message": []})
+        assert data == {"message_id": 9}
+
+    def test_raises_on_failed_status(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        fake = _FakeWS(status="failed", retcode=1400, message="bad request")
+        with patch("websockets.connect", _fake_connect(fake)):
+            with pytest.raises(RuntimeError, match="bad request"):
+                onebot_call("send_msg")
+
+    def test_raises_on_missing_data(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        fake = _FakeWS(data=None)  # status ok but no data field
+        with patch("websockets.connect", _fake_connect(fake)):
+            with pytest.raises(RuntimeError, match="no data"):
+                onebot_call("get_login_info")
+
+    def test_access_token_in_uri(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        monkeypatch.setenv("ONEBOT_ACCESS_TOKEN", "s3cr3t")
+        fake = _FakeWS(data={"ok": 1})
+        connect = _fake_connect(fake)
+        with patch("websockets.connect", connect):
+            onebot_call("get_status")
+        assert "access_token=s3cr3t" in connect.last_uri
+
+    def test_no_access_token_in_uri_when_absent(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "ws://127.0.0.1:3001")
+        monkeypatch.delenv("ONEBOT_ACCESS_TOKEN", raising=False)
+        fake = _FakeWS(data={"ok": 1})
+        connect = _fake_connect(fake)
+        with patch("websockets.connect", connect):
+            onebot_call("get_status")
+        assert "access_token" not in connect.last_uri

--- a/tests/tools/test_qzone_tool.py
+++ b/tests/tools/test_qzone_tool.py
@@ -1,0 +1,638 @@
+"""Tests for the QQ空间 (QZone) 说说 publishing tool.
+
+Tests real logic: g_tk computation, cookie parsing, publish-form building,
+QZone response parsing, availability gating, the OneBot HTTP client, and
+handler validation — all with mocked HTTP so no network is touched.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools import qzone_tool as qz
+from tools.qzone_tool import (
+    _build_publish_form,
+    _build_richval,
+    _build_upload_form,
+    _check_qzone_available,
+    _compute_gtk,
+    _download_image,
+    _extract_cookie_value,
+    _extract_pic_info,
+    _generate_image,
+    _handle_qzone_publish,
+    _load_image_reference,
+    _onebot_call,
+    _parse_publish_response,
+    _parse_upload_response,
+    _read_image_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP response
+# ---------------------------------------------------------------------------
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for the object returned by urllib.request.urlopen."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# g_tk computation
+# ---------------------------------------------------------------------------
+
+class TestComputeGtk:
+    def test_empty_skey_is_seed(self):
+        # With no characters the hash stays at the DJB seed 5381.
+        assert _compute_gtk("") == 5381
+
+    def test_known_value(self):
+        # Locked-in regression value for the standard QZone hash.
+        assert _compute_gtk("test") == 2090756197
+
+    def test_result_fits_31_bits(self):
+        for skey in ("p_skey_abc", "ZZZZZZZZZZ", "@#$%^&*()"):
+            assert 0 <= _compute_gtk(skey) <= 0x7FFFFFFF
+
+    def test_deterministic(self):
+        assert _compute_gtk("abc123") == _compute_gtk("abc123")
+
+
+# ---------------------------------------------------------------------------
+# Cookie parsing
+# ---------------------------------------------------------------------------
+
+class TestExtractCookieValue:
+    COOKIE = "uin=o0010001; skey=@abcDEF; p_skey=PpKkEeYy; pt4_token=tok123"
+
+    def test_extracts_middle_key(self):
+        assert _extract_cookie_value(self.COOKIE, "skey") == "@abcDEF"
+
+    def test_extracts_p_skey(self):
+        assert _extract_cookie_value(self.COOKIE, "p_skey") == "PpKkEeYy"
+
+    def test_extracts_first_key(self):
+        assert _extract_cookie_value(self.COOKIE, "uin") == "o0010001"
+
+    def test_missing_key_returns_none(self):
+        assert _extract_cookie_value(self.COOKIE, "nope") is None
+
+    def test_empty_string_returns_none(self):
+        assert _extract_cookie_value("", "p_skey") is None
+
+    def test_value_containing_equals_sign(self):
+        # partition() keeps everything after the first '=' in the value.
+        assert _extract_cookie_value("token=a=b=c; x=1", "token") == "a=b=c"
+
+
+# ---------------------------------------------------------------------------
+# Publish form building
+# ---------------------------------------------------------------------------
+
+class TestBuildPublishForm:
+    def test_text_goes_into_con(self):
+        form = _build_publish_form("今天天气真好", "10001")
+        assert form["con"] == "今天天气真好"
+
+    def test_hostuin_is_stringified(self):
+        form = _build_publish_form("hi", 10001)
+        assert form["hostuin"] == "10001"
+
+    def test_qzreferrer_includes_uin(self):
+        form = _build_publish_form("hi", "10001")
+        assert form["qzreferrer"] == "https://user.qzone.qq.com/10001"
+
+    def test_format_is_json(self):
+        assert _build_publish_form("hi", "10001")["format"] == "json"
+
+    def test_no_images_keeps_richtype_empty(self):
+        form = _build_publish_form("hi", "10001")
+        assert form["richtype"] == ""
+        assert form["richval"] == ""
+
+    def test_with_images_sets_richtype_and_richval(self):
+        pics = [{"albumid": "a1", "lloc": "l1", "sloc": "s1", "type": 0,
+                 "width": 800, "height": 600}]
+        form = _build_publish_form("hi", "10001", pics)
+        assert form["richtype"] == "1"
+        assert form["richval"] != ""
+        assert "a1" in form["richval"]
+
+
+# ---------------------------------------------------------------------------
+# QZone response parsing
+# ---------------------------------------------------------------------------
+
+class TestParsePublishResponse:
+    def test_success_with_tid(self):
+        result = _parse_publish_response(b'{"ret":0,"tid":"feedtid123"}')
+        assert result["ok"] is True
+        assert result["tid"] == "feedtid123"
+
+    def test_success_t1_tid_fallback(self):
+        result = _parse_publish_response(b'{"ret":0,"t1_tid":"alt456"}')
+        assert result["ok"] is True
+        assert result["tid"] == "alt456"
+
+    def test_success_str_input(self):
+        result = _parse_publish_response('{"ret":0,"tid":"x"}')
+        assert result["ok"] is True
+
+    def test_jsonp_callback_wrapper_is_stripped(self):
+        raw = b'_Callback({"ret":0,"tid":"wrapped789"});'
+        result = _parse_publish_response(raw)
+        assert result["ok"] is True
+        assert result["tid"] == "wrapped789"
+
+    def test_error_ret_nonzero(self):
+        result = _parse_publish_response(b'{"ret":-3000,"msg":"need verify"}')
+        assert result["ok"] is False
+        assert result["code"] == -3000
+        assert "need verify" in result["error"]
+
+    def test_error_nonzero_subcode(self):
+        result = _parse_publish_response(b'{"ret":0,"subcode":-4001,"msg":"bad"}')
+        assert result["ok"] is False
+
+    def test_unparseable_response(self):
+        result = _parse_publish_response(b"<html>403 Forbidden</html>")
+        assert result["ok"] is False
+        assert "unparseable" in result["error"]
+
+    def test_empty_response(self):
+        result = _parse_publish_response(b"")
+        assert result["ok"] is False
+
+    def test_success_with_code_field(self):
+        # Verified live: emotion_cgi_publish_v6 returns `code` (no `ret`).
+        raw = b'{"attach":"","code":0,"subcode":0,"tid":"1cbe3d3c17","feedinfo":"<li>"}'
+        result = _parse_publish_response(raw)
+        assert result["ok"] is True
+        assert result["tid"] == "1cbe3d3c17"
+
+    def test_error_code_nonzero(self):
+        result = _parse_publish_response(
+            b'{"code":-10000,"message":"\xe4\xbd\xbf\xe7\x94\xa8\xe4\xba\xba\xe6\x95\xb0\xe8\xbf\x87\xe5\xa4\x9a"}'
+        )
+        assert result["ok"] is False
+        assert result["code"] == -10000
+
+    def test_code_success_with_bad_subcode(self):
+        # A non-zero subcode is still an error even when code is 0.
+        result = _parse_publish_response(b'{"code":0,"subcode":-4001,"msg":"verify"}')
+        assert result["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Availability gating
+# ---------------------------------------------------------------------------
+
+class TestCheckAvailable:
+    def test_available_when_url_set(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        assert _check_qzone_available() is True
+
+    def test_unavailable_when_url_unset(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        assert _check_qzone_available() is False
+
+    def test_unavailable_when_url_blank(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "   ")
+        assert _check_qzone_available() is False
+
+
+# ---------------------------------------------------------------------------
+# OneBot HTTP client
+# ---------------------------------------------------------------------------
+
+class TestOnebotCall:
+    def test_raises_when_url_unconfigured(self, monkeypatch):
+        monkeypatch.delenv("ONEBOT_HTTP_URL", raising=False)
+        with pytest.raises(RuntimeError, match="ONEBOT_HTTP_URL"):
+            _onebot_call("get_login_info")
+
+    def test_returns_data_on_success(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps({"status": "ok", "retcode": 0, "data": {"user_id": 42}}).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            data = _onebot_call("get_login_info")
+        assert data == {"user_id": 42}
+
+    def test_raises_on_failed_status(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps({"status": "failed", "retcode": 1404, "message": "no login"}).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            with pytest.raises(RuntimeError, match="no login"):
+                _onebot_call("get_login_info")
+
+    def test_raises_on_missing_data(self, monkeypatch):
+        monkeypatch.setenv("ONEBOT_HTTP_URL", "http://127.0.0.1:3000")
+        body = json.dumps({"status": "ok", "retcode": 0}).encode()
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(body)):
+            with pytest.raises(RuntimeError, match="no data"):
+                _onebot_call("get_login_info")
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+_GOOD_COOKIE = "uin=o0010001; skey=@abc; p_skey=PSKEYVALUE; pt4_token=t"
+
+
+class TestHandler:
+    def test_empty_text_no_images_rejected(self):
+        result = json.loads(_handle_qzone_publish({"text": "   "}))
+        assert "error" in result
+        assert "'text', 'images', or 'generate'" in result["error"]
+
+    def test_no_args_rejected(self):
+        result = json.loads(_handle_qzone_publish({}))
+        assert "error" in result
+        assert "'text', 'images', or 'generate'" in result["error"]
+
+    def test_happy_path(self):
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE), \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":0,"tid":"feed999"}') as post:
+            result = json.loads(_handle_qzone_publish({"text": "hello world"}))
+        assert result["success"] is True
+        assert result["tid"] == "feed999"
+        assert result["uin"] == "10001"
+        # g_tk passed to the request must be the hash of p_skey from the cookie.
+        assert post.call_args.args[1] == _compute_gtk("PSKEYVALUE")
+
+    def test_onebot_unreachable(self):
+        with patch.object(qz, "_get_login_uin", side_effect=RuntimeError("connection refused")):
+            result = json.loads(_handle_qzone_publish({"text": "hi"}))
+        assert "error" in result
+        assert "borrow QQ login state" in result["error"]
+
+    def test_missing_p_skey(self):
+        cookie_without_pskey = "uin=o0010001; skey=@abc"
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=cookie_without_pskey):
+            result = json.loads(_handle_qzone_publish({"text": "hi"}))
+        assert "error" in result
+        assert "p_skey not found" in result["error"]
+
+    def test_qzone_rejects_post(self):
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE), \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":-4001,"msg":"login expired"}'):
+            result = json.loads(_handle_qzone_publish({"text": "hi"}))
+        assert "error" in result
+        assert "login expired" in result["error"]
+        assert result["code"] == -4001
+
+    def test_qzone_request_exception(self):
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE), \
+             patch.object(qz, "_qzone_publish_post", side_effect=RuntimeError("timeout")):
+            result = json.loads(_handle_qzone_publish({"text": "hi"}))
+        assert "error" in result
+        assert "publish request failed" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Local image files
+# ---------------------------------------------------------------------------
+
+class TestReadImageFile:
+    def test_reads_valid_image(self, tmp_path):
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-data")
+        data, name = _read_image_file(str(img))
+        assert data == b"\x89PNG\r\n\x1a\nfake-image-data"
+        assert name == "pic.png"
+
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(ValueError, match="not found"):
+            _read_image_file(str(tmp_path / "nope.png"))
+
+    def test_unsupported_extension(self, tmp_path):
+        bad = tmp_path / "doc.pdf"
+        bad.write_bytes(b"data")
+        with pytest.raises(ValueError, match="unsupported image type"):
+            _read_image_file(str(bad))
+
+    def test_empty_file(self, tmp_path):
+        empty = tmp_path / "empty.jpg"
+        empty.write_bytes(b"")
+        with pytest.raises(ValueError, match="empty"):
+            _read_image_file(str(empty))
+
+    def test_oversized_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(qz, "_MAX_IMAGE_BYTES", 4)
+        big = tmp_path / "big.jpg"
+        big.write_bytes(b"way too many bytes")
+        with pytest.raises(ValueError, match="too large"):
+            _read_image_file(str(big))
+
+
+# ---------------------------------------------------------------------------
+# Image upload form + response parsing
+# ---------------------------------------------------------------------------
+
+class TestBuildUploadForm:
+    def test_picfile_carries_base64(self):
+        form = _build_upload_form("BASE64DATA", "p.png", "10001", "sk", "psk", 123)
+        assert form["picfile"] == "BASE64DATA"
+        assert form["base64"] == "1"
+
+    def test_uin_fields_populated(self):
+        form = _build_upload_form("x", "p.png", "10001", "sk", "psk", 123)
+        assert form["uin"] == form["p_uin"] == form["zzpaneluin"] == "10001"
+
+    def test_url_includes_gtk(self):
+        form = _build_upload_form("x", "p.png", "10001", "sk", "psk", 999)
+        assert form["url"].endswith("g_tk=999")
+
+
+class TestParseUploadResponse:
+    def test_success_extracts_pic(self):
+        raw = (b'frameElement.callback({"ret":0,"data":'
+               b'{"albumid":"al1","lloc":"ll1","sloc":"sl1","width":800,"height":600}});')
+        result = _parse_upload_response(raw)
+        assert result["ok"] is True
+        assert result["pic"]["albumid"] == "al1"
+        assert result["pic"]["width"] == 800
+
+    def test_error_ret_nonzero(self):
+        result = _parse_upload_response(b'{"ret":-1000,"msg":"upload denied"}')
+        assert result["ok"] is False
+        assert "upload denied" in result["error"]
+
+    def test_unparseable(self):
+        result = _parse_upload_response(b"<html>500</html>")
+        assert result["ok"] is False
+        assert "unparseable" in result["error"]
+
+
+class TestExtractPicInfo:
+    def test_direct_fields(self):
+        pic = _extract_pic_info({"albumid": "a", "lloc": "l", "sloc": "s",
+                                 "width": 100, "height": 200})
+        assert pic == {"albumid": "a", "lloc": "l", "sloc": "s", "type": 0,
+                       "width": 100, "height": 200, "url": ""}
+
+    def test_photoid_fallback_for_lloc_sloc(self):
+        pic = _extract_pic_info({"albumid": "a", "photoid": "pid"})
+        assert pic["lloc"] == "pid"
+        assert pic["sloc"] == "pid"
+
+    def test_pre_fallback_for_url(self):
+        pic = _extract_pic_info({"pre": "https://img/pre.jpg"})
+        assert pic["url"] == "https://img/pre.jpg"
+
+
+class TestBuildRichval:
+    def test_single_image_segment(self):
+        rv = _build_richval([{"albumid": "a1", "lloc": "l1", "sloc": "s1",
+                              "type": 0, "width": 800, "height": 600}])
+        assert rv == ",a1,l1,s1,0,600,800,,600,800"
+
+    def test_multiple_images_tab_joined(self):
+        pics = [
+            {"albumid": "a1", "lloc": "l1", "sloc": "s1", "type": 0,
+             "width": 1, "height": 2},
+            {"albumid": "a2", "lloc": "l2", "sloc": "s2", "type": 0,
+             "width": 3, "height": 4},
+        ]
+        rv = _build_richval(pics)
+        assert rv.count("\t") == 1
+        assert rv.split("\t")[1] == ",a2,l2,s2,0,4,3,,4,3"
+
+    def test_empty_list(self):
+        assert _build_richval([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Handler — image attachments
+# ---------------------------------------------------------------------------
+
+_GOOD_COOKIE_IMG = "uin=o0010001; skey=SKEYVAL; p_skey=PSKEYVALUE; pt4_token=t"
+_FAKE_PIC = {"albumid": "a1", "lloc": "l1", "sloc": "s1", "type": 0,
+             "width": 800, "height": 600}
+
+
+class TestHandlerImages:
+    def _make_image(self, tmp_path, name="pic.png"):
+        img = tmp_path / name
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        return str(img)
+
+    def test_image_only_post_allowed(self, tmp_path):
+        path = self._make_image(tmp_path)
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE_IMG), \
+             patch.object(qz, "_upload_image", return_value=_FAKE_PIC), \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":0,"tid":"t1"}'):
+            result = json.loads(_handle_qzone_publish({"images": [path]}))
+        assert result["success"] is True
+        assert result["images"] == 1
+
+    def test_text_and_images(self, tmp_path):
+        paths = [self._make_image(tmp_path, "a.png"), self._make_image(tmp_path, "b.jpg")]
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE_IMG), \
+             patch.object(qz, "_upload_image", return_value=_FAKE_PIC) as up, \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":0,"tid":"t1"}'):
+            result = json.loads(_handle_qzone_publish({"text": "看图", "images": paths}))
+        assert result["success"] is True
+        assert result["images"] == 2
+        assert up.call_count == 2
+
+    def test_single_image_path_as_string(self, tmp_path):
+        path = self._make_image(tmp_path)
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE_IMG), \
+             patch.object(qz, "_upload_image", return_value=_FAKE_PIC), \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":0,"tid":"t1"}'):
+            result = json.loads(_handle_qzone_publish({"text": "hi", "images": path}))
+        assert result["success"] is True
+
+    def test_bad_image_path_fails_before_network(self, tmp_path):
+        # No OneBot patch — if it tried the network the test would error out.
+        result = json.loads(_handle_qzone_publish(
+            {"text": "hi", "images": [str(tmp_path / "missing.png")]}))
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    def test_too_many_images_rejected(self):
+        result = json.loads(_handle_qzone_publish(
+            {"text": "hi", "images": [f"/tmp/{i}.png" for i in range(10)]}))
+        assert "error" in result
+        assert "at most" in result["error"]
+
+    def test_upload_failure_surfaced(self, tmp_path):
+        path = self._make_image(tmp_path)
+        with patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE_IMG), \
+             patch.object(qz, "_upload_image", side_effect=RuntimeError("album full")):
+            result = json.loads(_handle_qzone_publish({"text": "hi", "images": [path]}))
+        assert "error" in result
+        assert "album full" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# AI image generation
+# ---------------------------------------------------------------------------
+
+class TestDownloadImage:
+    def test_downloads_and_names_from_url(self):
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(b"imgdata")):
+            data, name = _download_image("https://img.example.com/path/cat.png")
+        assert data == b"imgdata"
+        assert name == "cat.png"
+
+    def test_non_image_extension_falls_back(self):
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(b"x")):
+            _, name = _download_image("https://img.example.com/render?id=9")
+        assert name == "generated.png"
+
+    def test_empty_download_rejected(self):
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(b"")):
+            with pytest.raises(RuntimeError, match="empty"):
+                _download_image("https://img.example.com/a.png")
+
+    def test_oversized_download_rejected(self, monkeypatch):
+        monkeypatch.setattr(qz, "_MAX_IMAGE_BYTES", 4)
+        with patch("urllib.request.urlopen", return_value=_FakeHTTPResponse(b"too many bytes")):
+            with pytest.raises(RuntimeError, match="too large"):
+                _download_image("https://img.example.com/a.png")
+
+
+class TestLoadImageReference:
+    def test_http_url_delegates_to_download(self):
+        with patch.object(qz, "_download_image", return_value=(b"d", "n.png")) as dl:
+            result = _load_image_reference("https://img.example.com/n.png")
+        assert result == (b"d", "n.png")
+        dl.assert_called_once()
+
+    def test_local_path_delegates_to_read(self, tmp_path):
+        img = tmp_path / "local.png"
+        img.write_bytes(b"\x89PNGlocal")
+        data, name = _load_image_reference(str(img))
+        assert data == b"\x89PNGlocal"
+        assert name == "local.png"
+
+    def test_unusable_reference_raises(self):
+        with pytest.raises(RuntimeError, match="unusable reference"):
+            _load_image_reference("not-a-url-or-file")
+
+
+class TestGenerateImage:
+    def test_success_with_dict_result(self):
+        with patch("tools.image_generation_tool.check_image_generation_requirements",
+                   return_value=True), \
+             patch("tools.image_generation_tool._handle_image_generate",
+                   return_value={"success": True, "image": "https://img/x.png"}), \
+             patch.object(qz, "_load_image_reference", return_value=(b"gen", "x.png")):
+            data, name = _generate_image("a red panda", "square")
+        assert data == b"gen"
+        assert name == "x.png"
+
+    def test_success_with_json_string_result(self):
+        payload = json.dumps({"success": True, "image": "/tmp/gen.png"})
+        with patch("tools.image_generation_tool.check_image_generation_requirements",
+                   return_value=True), \
+             patch("tools.image_generation_tool._handle_image_generate",
+                   return_value=payload), \
+             patch.object(qz, "_load_image_reference", return_value=(b"gen", "gen.png")):
+            data, name = _generate_image("prompt", "square")
+        assert (data, name) == (b"gen", "gen.png")
+
+    def test_no_backend_configured(self):
+        with patch("tools.image_generation_tool.check_image_generation_requirements",
+                   return_value=False):
+            with pytest.raises(RuntimeError, match="no image-generation backend"):
+                _generate_image("prompt", "square")
+
+    def test_backend_error_surfaced(self):
+        with patch("tools.image_generation_tool.check_image_generation_requirements",
+                   return_value=True), \
+             patch("tools.image_generation_tool._handle_image_generate",
+                   return_value={"error": "quota exceeded", "image": None}):
+            with pytest.raises(RuntimeError, match="quota exceeded"):
+                _generate_image("prompt", "square")
+
+    def test_no_image_in_result(self):
+        with patch("tools.image_generation_tool.check_image_generation_requirements",
+                   return_value=True), \
+             patch("tools.image_generation_tool._handle_image_generate",
+                   return_value={"success": True, "image": None}):
+            with pytest.raises(RuntimeError, match="no image"):
+                _generate_image("prompt", "square")
+
+
+# ---------------------------------------------------------------------------
+# Handler — AI-generated images
+# ---------------------------------------------------------------------------
+
+class TestHandlerGenerate:
+    def test_generate_only_post(self):
+        with patch.object(qz, "_generate_image", return_value=(b"gen", "g.png")), \
+             patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE_IMG), \
+             patch.object(qz, "_upload_image", return_value=_FAKE_PIC), \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":0,"tid":"t1"}'):
+            result = json.loads(_handle_qzone_publish({"generate": "a sunset"}))
+        assert result["success"] is True
+        assert result["images"] == 1
+        assert result["generated"] is True
+
+    def test_generate_with_text(self):
+        with patch.object(qz, "_generate_image", return_value=(b"gen", "g.png")) as gen, \
+             patch.object(qz, "_get_login_uin", return_value="10001"), \
+             patch.object(qz, "_get_qzone_cookie_string", return_value=_GOOD_COOKIE_IMG), \
+             patch.object(qz, "_upload_image", return_value=_FAKE_PIC), \
+             patch.object(qz, "_qzone_publish_post", return_value=b'{"ret":0,"tid":"t1"}'):
+            result = json.loads(_handle_qzone_publish(
+                {"text": "今天的画", "generate": "a landscape", "aspect_ratio": "landscape"}))
+        assert result["success"] is True
+        # aspect_ratio must be forwarded to image generation.
+        assert gen.call_args.args == ("a landscape", "landscape")
+
+    def test_generation_failure_surfaced(self):
+        with patch.object(qz, "_generate_image", side_effect=RuntimeError("model down")):
+            result = json.loads(_handle_qzone_publish({"generate": "a cat"}))
+        assert "error" in result
+        assert "Image generation failed" in result["error"]
+        assert "model down" in result["error"]
+
+    def test_generate_plus_images_counts_toward_limit(self):
+        # 9 attached images + 1 generated = 10, over the cap — rejected on
+        # the count check before any file read or generation.
+        args = {"images": [f"/tmp/{i}.png" for i in range(9)], "generate": "extra"}
+        result = json.loads(_handle_qzone_publish(args))
+        assert "error" in result
+        assert "at most" in result["error"]
+
+    def test_non_string_generate_rejected(self):
+        result = json.loads(_handle_qzone_publish({"generate": 123}))
+        assert "error" in result
+        assert "must be a text prompt" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_tool_is_registered(self):
+        from tools.registry import registry
+        assert registry.get_toolset_for_tool("qzone_publish") == "qzone"

--- a/tools/onebot_client.py
+++ b/tools/onebot_client.py
@@ -1,0 +1,245 @@
+"""Shared OneBot v11 client for QQ integrations (HTTP or WebSocket).
+
+Several Hermes tools talk to a running OneBot v11 implementation
+(NapCat / Lagrange.Core): the ``qzone`` tool borrows the logged-in QQ
+session to publish 说说, and the ``qq_voice`` tool sends synthesized
+speech as a native QQ voice message. Both need the same plumbing, so it
+lives here in one place rather than being duplicated per tool.
+
+Transport is chosen automatically from the configured endpoint's URL
+scheme:
+
+* ``http://`` / ``https://`` — the OneBot v11 HTTP API (one POST per action).
+* ``ws://`` / ``wss://``     — the OneBot v11 WebSocket API. Many NapCat /
+  Lagrange deployments expose *only* a WebSocket server; each call opens a
+  short-lived connection, sends one action, and reads the matching reply
+  (skipping any pushed events).
+
+Configuration (environment variables):
+- ``ONEBOT_HTTP_URL``     -- OneBot endpoint, ``http(s)://`` or ``ws(s)://``.
+- ``ONEBOT_WS_URL``       -- used as a fallback when ``ONEBOT_HTTP_URL`` is
+                             unset (lets a WS-only deployment configure just
+                             the one URL it has).
+- ``ONEBOT_ACCESS_TOKEN`` -- optional bearer / access token.
+
+This is a plain helper module — it registers no tools, so the registry's
+module scan never imports it as a tool. Tools import the functions here.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Default per-request timeout (seconds). Callers doing heavier work (e.g.
+# uploading media) may pass a larger value.
+ONEBOT_TIMEOUT = 15
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def onebot_base_url() -> str:
+    """Return the configured OneBot endpoint URL (no trailing slash).
+
+    Prefers ``ONEBOT_HTTP_URL``; falls back to ``ONEBOT_WS_URL`` so a
+    WebSocket-only deployment can configure just the one URL it has.
+    """
+    url = os.getenv("ONEBOT_HTTP_URL", "").strip()
+    if not url:
+        url = os.getenv("ONEBOT_WS_URL", "").strip()
+    return url.rstrip("/")
+
+
+def onebot_access_token() -> str:
+    """Return the optional OneBot access token."""
+    return os.getenv("ONEBOT_ACCESS_TOKEN", "").strip()
+
+
+def onebot_configured() -> bool:
+    """Return True when a OneBot endpoint is configured.
+
+    Used as the ``check_fn`` for OneBot-backed tools so they are gated out
+    of the model's schema entirely when no OneBot connection is set up.
+    """
+    return bool(onebot_base_url())
+
+
+def _is_ws_url(url: str) -> bool:
+    """Return True when *url* is a WebSocket endpoint."""
+    return url.lower().startswith(("ws://", "wss://"))
+
+
+# ---------------------------------------------------------------------------
+# Shared response handling
+# ---------------------------------------------------------------------------
+
+def _check_onebot_payload(payload: dict, action: str) -> dict:
+    """Validate a OneBot response envelope and return its ``data`` object.
+
+    Raises ``RuntimeError`` on a ``failed`` status or a missing ``data``
+    field so callers can surface one clear message to the model.
+    """
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"OneBot action '{action}' returned a non-object response.")
+    if payload.get("status") == "failed":
+        msg = payload.get("message") or payload.get("wording") or "unknown error"
+        raise RuntimeError(
+            f"OneBot action '{action}' failed: {msg} "
+            f"(retcode={payload.get('retcode')})"
+        )
+    data = payload.get("data")
+    if data is None:
+        raise RuntimeError(f"OneBot action '{action}' returned no data.")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def onebot_call(
+    action: str,
+    params: dict | None = None,
+    *,
+    timeout: int = ONEBOT_TIMEOUT,
+) -> dict:
+    """Invoke a OneBot v11 action and return its ``data`` object.
+
+    Picks the HTTP or WebSocket transport from the configured endpoint's
+    URL scheme. Raises ``RuntimeError`` on transport errors, a ``failed``
+    status, or a missing ``data`` field.
+    """
+    base = onebot_base_url()
+    if not base:
+        raise RuntimeError("ONEBOT_HTTP_URL is not configured.")
+    if _is_ws_url(base):
+        return _onebot_call_ws(base, action, params or {}, timeout)
+    return _onebot_call_http(base, action, params or {}, timeout)
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+def _onebot_call_http(base: str, action: str, params: dict, timeout: int) -> dict:
+    """Invoke a OneBot action over the HTTP API."""
+    url = f"{base}/{action}"
+    body = json.dumps(params).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = onebot_access_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:  # noqa: BLE001 — best-effort detail only
+            pass
+        raise RuntimeError(
+            f"OneBot HTTP {e.code} for action '{action}'. {detail}".strip()
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Cannot reach OneBot at {base} — is NapCat/Lagrange running? ({e.reason})"
+        ) from e
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"OneBot action '{action}' returned non-JSON: {raw[:200]}"
+        ) from e
+
+    return _check_onebot_payload(payload, action)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket transport
+# ---------------------------------------------------------------------------
+
+def _onebot_call_ws(base: str, action: str, params: dict, timeout: int) -> dict:
+    """Invoke a OneBot action over the WebSocket API (sync wrapper).
+
+    Each call opens its own short-lived connection — these tools are
+    low-frequency, so a fresh connect per action keeps the sync API simple
+    and stateless.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No event loop in this thread — safe to drive one directly.
+        return asyncio.run(_ws_roundtrip(base, action, params, timeout))
+
+    # Already inside a running loop — isolate the round-trip in a worker
+    # thread so we never block or nest event loops.
+    import concurrent.futures  # noqa: PLC0415 — only needed on this path
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(
+            lambda: asyncio.run(_ws_roundtrip(base, action, params, timeout))
+        )
+        return future.result(timeout=timeout + 15)
+
+
+async def _ws_roundtrip(base: str, action: str, params: dict, timeout: int) -> dict:
+    """Open a WS connection, send one action, and return its ``data``.
+
+    NapCat/Lagrange push unsolicited events on the same socket; this reads
+    until the reply carrying our ``echo`` arrives, skipping everything else.
+    """
+    try:
+        import websockets  # noqa: PLC0415 — optional dep, imported on demand
+    except ImportError as e:
+        raise RuntimeError(
+            "OneBot WebSocket transport needs the 'websockets' package — "
+            "run `pip install websockets`, or point ONEBOT_HTTP_URL at an "
+            "http:// endpoint instead."
+        ) from e
+
+    uri = base
+    token = onebot_access_token()
+    if token:
+        sep = "&" if "?" in uri else "?"
+        uri = f"{uri}{sep}access_token={urllib.parse.quote(token)}"
+
+    echo = f"hermes-{action}-{os.urandom(4).hex()}"
+    request = json.dumps({"action": action, "params": params, "echo": echo})
+
+    try:
+        async with websockets.connect(uri, max_size=None, open_timeout=timeout) as ws:
+            await ws.send(request)
+            # Skip pushed events; stop when our echo comes back.
+            for _ in range(500):
+                raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+                try:
+                    msg = json.loads(raw)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    continue
+                if isinstance(msg, dict) and msg.get("echo") == echo:
+                    return _check_onebot_payload(msg, action)
+    except RuntimeError:
+        raise
+    except (OSError, asyncio.TimeoutError) as e:
+        raise RuntimeError(
+            f"Cannot reach OneBot at {base} — is NapCat/Lagrange running? ({e})"
+        ) from e
+    except Exception as e:  # noqa: BLE001 — surface one clear message
+        raise RuntimeError(
+            f"OneBot WebSocket action '{action}' failed: {e}"
+        ) from e
+
+    raise RuntimeError(
+        f"OneBot action '{action}' got no matching reply (echo timeout)."
+    )

--- a/tools/qzone_tool.py
+++ b/tools/qzone_tool.py
@@ -1,0 +1,651 @@
+"""QQ空间 (QZone) 说说 publishing tool.
+
+Registers one LLM-callable tool, ``qzone_publish``, which posts a 说说
+(status update) — text, attached local images, and/or an AI-generated
+image — to the configured QQ account's QQ空间. Image generation reuses
+Hermes's existing ``image_generate`` backend (FAL / OpenAI / xAI); no new
+model integration is introduced.
+
+QQ has no official open API for publishing 说说 — the old QZone OpenAPI
+``emotion`` interface was deprecated years ago. This tool therefore drives
+the QZone *web* endpoints (``cgi_upload_image`` + ``emotion_cgi_publish_v6``)
+directly, which need a logged-in QQ session (cookies) plus a ``g_tk`` CSRF
+token.
+
+Rather than running its own QR login, the tool *borrows* the login state
+from a running OneBot implementation (NapCat / Lagrange.Core). OneBot v11
+exposes ``get_login_info`` and ``get_cookies`` actions; NapCat/Lagrange
+return real QZone cookies (including ``p_skey`` / ``skey``) for the QQ
+account the bot is signed in as. The ``g_tk`` token is then computed
+locally from ``p_skey`` with the standard QZone hash.
+
+Configuration (environment variables):
+- ``ONEBOT_HTTP_URL``    -- base URL of the OneBot HTTP API, e.g.
+                            ``http://127.0.0.1:3000`` (required).
+- ``ONEBOT_ACCESS_TOKEN``-- optional bearer token if the OneBot HTTP
+                            server has ``access-token`` configured.
+
+Caveats: this relies on reverse-engineered web endpoints. Cookies expire,
+Tencent risk-control may require a captcha, and automated posting violates
+Tencent's Terms of Service and carries an account-ban risk. The image
+upload + ``richval`` wire format in particular is community-reverse-
+engineered and may need adjustment if Tencent changes it. Failures are
+surfaced verbatim to the model; the tool never silently retries.
+
+Only included in the ``qzone`` toolset, so it has zero cost for users on
+other platforms.
+"""
+
+import base64
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from tools.onebot_client import (
+    onebot_base_url as _onebot_base_url,
+    onebot_call as _onebot_call,
+)
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+# QZone web endpoints. Fixed constants — never built from user input, so
+# there is no SSRF surface here.
+QZONE_PUBLISH_URL = (
+    "https://user.qzone.qq.com/proxy/domain/taotao.qzone.qq.com"
+    "/cgi-bin/emotion_cgi_publish_v6"
+)
+QZONE_UPLOAD_URL = "https://up.qzone.qq.com/cgi-bin/upload/cgi_upload_image"
+
+# The QZone cookie domain to request from OneBot. NapCat/Lagrange return the
+# *.qq.com cookie jar (uin / skey / p_skey / ...) for this domain.
+_QZONE_COOKIE_DOMAIN = "user.qzone.qq.com"
+
+# A desktop UA — QZone serves a different (mobile) flow to mobile UAs.
+_DESKTOP_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# Image attachment limits. QZone说说 accepts at most 9 images.
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+_MAX_IMAGES = 9
+_MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MiB
+
+# Default aspect ratio for AI-generated 说说 images. QZone shows feed
+# images best near-square, so this differs from image_generate's own default.
+_DEFAULT_GEN_ASPECT = "square"
+
+_QZONE_TIMEOUT = 20
+_QZONE_UPLOAD_TIMEOUT = 60
+
+
+# ---------------------------------------------------------------------------
+# OneBot credentials
+#
+# The OneBot v11 HTTP client (``_onebot_call`` / ``_onebot_base_url``) is
+# imported from ``tools.onebot_client`` so it is shared with the qq_voice tool
+# rather than duplicated. The helpers below borrow the QZone-specific login
+# state (uin + cookies) from that connection.
+# ---------------------------------------------------------------------------
+
+
+def _get_login_uin() -> str:
+    """Return the QQ number (uin) the OneBot instance is logged in as."""
+    data = _onebot_call("get_login_info")
+    uin = data.get("user_id")
+    if not uin:
+        raise RuntimeError("OneBot get_login_info returned no user_id.")
+    return str(uin)
+
+
+def _get_qzone_cookie_string() -> str:
+    """Return the raw QZone cookie string from OneBot's get_cookies action."""
+    data = _onebot_call("get_cookies", {"domain": _QZONE_COOKIE_DOMAIN})
+    cookies = (data.get("cookies") or "").strip()
+    if not cookies:
+        raise RuntimeError(
+            "OneBot get_cookies returned an empty cookie string — the QQ "
+            "login state may be stale; re-login the NapCat/Lagrange client."
+        )
+    return cookies
+
+
+# ---------------------------------------------------------------------------
+# QZone primitives (pure, unit-tested)
+# ---------------------------------------------------------------------------
+
+def _compute_gtk(p_skey: str) -> int:
+    """Compute the QZone ``g_tk`` CSRF token from the ``p_skey`` cookie.
+
+    This is the long-standing QZone hash (DJB-style) over ``p_skey``.
+    """
+    h = 5381
+    for ch in p_skey:
+        h += (h << 5) + ord(ch)
+    return h & 0x7FFFFFFF
+
+
+def _extract_cookie_value(cookie_str: str, key: str) -> str | None:
+    """Return the value of ``key`` from a ``k=v; k2=v2`` cookie string."""
+    for part in cookie_str.split(";"):
+        name, sep, value = part.strip().partition("=")
+        if sep and name == key:
+            return value
+    return None
+
+
+def _extract_pic_info(data: dict) -> dict:
+    """Pull the fields needed for ``richval`` out of an upload response.
+
+    QZone has shipped several response shapes over the years; values are
+    fetched leniently with fallbacks so a missing optional field degrades
+    gracefully rather than raising.
+    """
+    return {
+        "albumid": data.get("albumid", ""),
+        "lloc": data.get("lloc") or data.get("photoid", ""),
+        "sloc": data.get("sloc") or data.get("photoid", ""),
+        "type": data.get("type", 0),
+        "width": data.get("width", 0),
+        "height": data.get("height", 0),
+        "url": data.get("url") or data.get("pre", ""),
+    }
+
+
+def _build_richval(pic_infos: list) -> str:
+    """Build the ``richval`` string for an image 说说.
+
+    Reverse-engineered wire format: one comma-delimited segment per image,
+    segments joined by a TAB. If Tencent changes the format, this is the
+    single place to fix.
+    """
+    segments = []
+    for pic in pic_infos:
+        segments.append(
+            ",{albumid},{lloc},{sloc},{type},{height},{width},,{height},{width}".format(
+                albumid=pic.get("albumid", ""),
+                lloc=pic.get("lloc", ""),
+                sloc=pic.get("sloc", ""),
+                type=pic.get("type", 0),
+                height=pic.get("height", 0),
+                width=pic.get("width", 0),
+            )
+        )
+    return "\t".join(segments)
+
+
+def _build_publish_form(text: str, uin: str, pic_infos: list | None = None) -> dict:
+    """Build the form body for the QZone emotion_publish endpoint."""
+    form = {
+        "syn_tweet_verson": "1",
+        "paramstr": "1",
+        "pic_template": "",
+        "richtype": "",
+        "richval": "",
+        "special_url": "",
+        "subrichtype": "",
+        "who": "1",
+        "con": text,
+        "feedversion": "1",
+        "ver": "1",
+        "ugc_right": "1",
+        "to_sign": "0",
+        "hostuin": str(uin),
+        "code_version": "1",
+        "format": "json",
+        "qzreferrer": f"https://user.qzone.qq.com/{uin}",
+    }
+    if pic_infos:
+        form["richtype"] = "1"
+        form["richval"] = _build_richval(pic_infos)
+    return form
+
+
+def _build_upload_form(
+    image_b64: str, filename: str, uin: str, skey: str, p_skey: str, gtk: int
+) -> dict:
+    """Build the form body for the QZone cgi_upload_image endpoint."""
+    return {
+        "filename": filename,
+        "uploadtype": "1",
+        "albumtype": "7",
+        "exttype": "0",
+        "refer": "shuoshuo",
+        "output_type": "json",
+        "charset": "utf-8",
+        "output_charset": "utf-8",
+        "upload_hd": "1",
+        "hd_width": "2048",
+        "hd_height": "10000",
+        "hd_quality": "96",
+        "backUrls": (
+            "http://upbak.photo.qzone.qq.com/cgi-bin/upload/cgi_upload_image,"
+            "http://119.147.64.75/cgi-bin/upload/cgi_upload_image"
+        ),
+        "url": f"{QZONE_UPLOAD_URL}?g_tk={gtk}",
+        "base64": "1",
+        "zzpaneluin": str(uin),
+        "p_uin": str(uin),
+        "uin": str(uin),
+        "skey": skey,
+        "p_skey": p_skey,
+        "qzonetoken": "",
+        "picfile": image_b64,
+    }
+
+
+def _parse_publish_response(raw: bytes | str) -> dict:
+    """Parse the QZone emotion_publish response.
+
+    Returns ``{"ok": True, "tid": ...}`` on success or
+    ``{"ok": False, "error": ..., "code": ...}`` otherwise. QZone wraps the
+    JSON body in a ``_Callback(...)`` shim in some flows, so the JSON object
+    is located by a permissive search rather than parsed from offset 0.
+
+    ``emotion_cgi_publish_v6`` reports success two ways depending on the
+    account / endpoint variant: the classic ``{"ret":0,"tid":...}`` shape and
+    a newer ``{"code":0,"tid":...,"feedinfo":...}`` shape (verified live —
+    NapCat/QZone returns ``code`` with no ``ret``). Either zero status, with a
+    non-error ``subcode``, counts as success.
+    """
+    obj = _extract_json_object(raw)
+    if obj is None:
+        text = _as_text(raw)
+        return {"ok": False, "error": f"unparseable QZone response: {text[:200]}"}
+
+    ret = obj.get("ret")
+    code = obj.get("code")
+    subcode = obj.get("subcode", 0)
+    # Newer QZone responses carry `code` instead of `ret`; fall back to it so
+    # a successful post is never mis-reported as a failure.
+    status = ret if ret is not None else code
+    if status == 0 and subcode in (0, None):
+        return {"ok": True, "tid": obj.get("tid") or obj.get("t1_tid"), "raw": obj}
+
+    err = (obj.get("msg") or obj.get("message")
+           or f"ret={ret}, code={code}, subcode={subcode}")
+    return {"ok": False, "code": status, "error": err, "raw": obj}
+
+
+def _parse_upload_response(raw: bytes | str) -> dict:
+    """Parse the QZone cgi_upload_image response.
+
+    Returns ``{"ok": True, "pic": {...}}`` on success or
+    ``{"ok": False, "error": ...}`` otherwise. The response is wrapped in a
+    ``frameElement.callback(...)`` shim.
+    """
+    obj = _extract_json_object(raw)
+    if obj is None:
+        text = _as_text(raw)
+        return {"ok": False, "error": f"unparseable upload response: {text[:200]}"}
+
+    ret = obj.get("ret")
+    if ret != 0:
+        err = obj.get("msg") or obj.get("message") or f"ret={ret}"
+        return {"ok": False, "code": ret, "error": err}
+
+    data = obj.get("data") or {}
+    return {"ok": True, "pic": _extract_pic_info(data)}
+
+
+def _as_text(raw: bytes | str) -> str:
+    """Decode a response body to text."""
+    if isinstance(raw, (bytes, bytearray)):
+        return raw.decode("utf-8", errors="replace").strip()
+    return (raw or "").strip()
+
+
+def _extract_json_object(raw: bytes | str) -> dict | None:
+    """Locate and parse the first ``{...}`` JSON object in a response body.
+
+    QZone wraps payloads in JSONP-style shims (``_Callback({...})``,
+    ``frameElement.callback({...})``); this finds the JSON regardless.
+    """
+    text = _as_text(raw)
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return None
+    try:
+        obj = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# Local image files
+# ---------------------------------------------------------------------------
+
+def _read_image_file(path: str) -> tuple[bytes, str]:
+    """Read a local image file, returning ``(bytes, basename)``.
+
+    Raises ``ValueError`` with a human-readable reason for any problem so
+    the handler can fail fast before touching the network.
+    """
+    resolved = os.path.expanduser(str(path))
+    if not os.path.isfile(resolved):
+        raise ValueError("file not found")
+    ext = os.path.splitext(resolved)[1].lower()
+    if ext not in _IMAGE_EXTS:
+        raise ValueError(
+            f"unsupported image type '{ext}' (allowed: {sorted(_IMAGE_EXTS)})"
+        )
+    size = os.path.getsize(resolved)
+    if size == 0:
+        raise ValueError("file is empty")
+    if size > _MAX_IMAGE_BYTES:
+        raise ValueError(
+            f"image too large ({size} bytes; max {_MAX_IMAGE_BYTES})"
+        )
+    with open(resolved, "rb") as fh:
+        return fh.read(), os.path.basename(resolved)
+
+
+# ---------------------------------------------------------------------------
+# AI image generation
+# ---------------------------------------------------------------------------
+
+def _download_image(url: str) -> tuple[bytes, str]:
+    """Download a generated image from a URL, returning ``(bytes, filename)``."""
+    req = urllib.request.Request(url, headers={"User-Agent": _DESKTOP_UA})
+    try:
+        with urllib.request.urlopen(req, timeout=_QZONE_UPLOAD_TIMEOUT) as resp:
+            data = resp.read()
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        raise RuntimeError(f"could not download generated image: {e}") from e
+
+    if not data:
+        raise RuntimeError("downloaded generated image is empty")
+    if len(data) > _MAX_IMAGE_BYTES:
+        raise RuntimeError(
+            f"generated image too large ({len(data)} bytes; max {_MAX_IMAGE_BYTES})"
+        )
+
+    name = os.path.basename(urllib.parse.urlparse(url).path)
+    if not name or os.path.splitext(name)[1].lower() not in _IMAGE_EXTS:
+        name = "generated.png"
+    return data, name
+
+
+def _load_image_reference(ref: str) -> tuple[bytes, str]:
+    """Resolve an image_generate result (URL or local path) to bytes."""
+    ref = str(ref).strip()
+    if ref.startswith(("http://", "https://")):
+        return _download_image(ref)
+    if os.path.isfile(os.path.expanduser(ref)):
+        return _read_image_file(ref)
+    raise RuntimeError(f"image_generate returned an unusable reference: {ref[:200]}")
+
+
+def _generate_image(prompt: str, aspect_ratio: str) -> tuple[bytes, str]:
+    """Generate an image via Hermes's configured image_generate backend.
+
+    Reuses the in-tree image generation tool (FAL / OpenAI / xAI — whichever
+    the user has configured), so no new model integration is introduced.
+    Returns ``(bytes, filename)``; raises ``RuntimeError`` on any failure.
+    """
+    # Imported lazily: image_generation_tool pulls in heavier deps, and a
+    # module-level import would couple qzone_tool's import to it.
+    from tools.image_generation_tool import (  # noqa: PLC0415 — intentional lazy import
+        _handle_image_generate,
+        check_image_generation_requirements,
+    )
+
+    if not check_image_generation_requirements():
+        raise RuntimeError(
+            "no image-generation backend is configured — set one up via "
+            "`hermes tools` → Image Generation (FAL / OpenAI / xAI)."
+        )
+
+    raw = _handle_image_generate({"prompt": prompt, "aspect_ratio": aspect_ratio})
+    if isinstance(raw, str):
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"image_generate returned non-JSON: {raw[:200]}") from e
+    elif isinstance(raw, dict):
+        result = raw
+    else:
+        raise RuntimeError(
+            f"image_generate returned an unexpected type: {type(raw).__name__}"
+        )
+
+    if result.get("error"):
+        raise RuntimeError(result["error"])
+    image_ref = result.get("image")
+    if not image_ref:
+        raise RuntimeError("image_generate produced no image.")
+    return _load_image_reference(image_ref)
+
+
+# ---------------------------------------------------------------------------
+# QZone HTTP requests
+# ---------------------------------------------------------------------------
+
+def _qzone_post(url: str, form: dict, cookie: str, uin: str, timeout: int) -> bytes:
+    """POST a form-urlencoded body to a QZone endpoint and return the body."""
+    data = urllib.parse.urlencode(form).encode("utf-8")
+    headers = {
+        "Cookie": cookie,
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Referer": f"https://user.qzone.qq.com/{uin}",
+        "User-Agent": _DESKTOP_UA,
+    }
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:  # noqa: BLE001 — best-effort detail only
+            pass
+        raise RuntimeError(f"QZone HTTP {e.code}. {body}".strip()) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Cannot reach QZone: {e.reason}") from e
+
+
+def _qzone_publish_post(form: dict, gtk: int, cookie: str, uin: str) -> bytes:
+    """POST a 说说 to QZone and return the raw response body."""
+    url = f"{QZONE_PUBLISH_URL}?g_tk={gtk}"
+    return _qzone_post(url, form, cookie, uin, _QZONE_TIMEOUT)
+
+
+def _upload_image(
+    image_bytes: bytes, filename: str, uin: str, skey: str, p_skey: str,
+    gtk: int, cookie: str,
+) -> dict:
+    """Upload one image to QZone and return its parsed pic info.
+
+    Raises ``RuntimeError`` if QZone rejects the upload.
+    """
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+    form = _build_upload_form(image_b64, filename, uin, skey, p_skey, gtk)
+    url = f"{QZONE_UPLOAD_URL}?g_tk={gtk}"
+    raw = _qzone_post(url, form, cookie, uin, _QZONE_UPLOAD_TIMEOUT)
+    result = _parse_upload_response(raw)
+    if not result.get("ok"):
+        raise RuntimeError(result.get("error", "unknown upload error"))
+    return result["pic"]
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def _handle_qzone_publish(args: dict, **kw) -> str:
+    """Handler for the qzone_publish tool."""
+    text = (args.get("text") or "").strip()
+    images = args.get("images") or []
+    if isinstance(images, str):  # tolerate a single path passed as a string
+        images = [images]
+    if not isinstance(images, list):
+        return tool_error("qzone_publish 'images' must be a list of file paths.")
+
+    generate = args.get("generate")
+    if generate is not None and not isinstance(generate, str):
+        return tool_error("qzone_publish 'generate' must be a text prompt string.")
+    generate = (generate or "").strip()
+    aspect_ratio = (args.get("aspect_ratio") or _DEFAULT_GEN_ASPECT).strip()
+
+    if not text and not images and not generate:
+        return tool_error("qzone_publish requires 'text', 'images', or 'generate'.")
+
+    total_images = len(images) + (1 if generate else 0)
+    if total_images > _MAX_IMAGES:
+        return tool_error(
+            f"QZone说说 supports at most {_MAX_IMAGES} images "
+            f"(requested {total_images})."
+        )
+
+    # Read all local image files up front so a bad path fails before any
+    # network call or image generation.
+    image_payloads: list[tuple[bytes, str]] = []
+    for path in images:
+        try:
+            image_payloads.append(_read_image_file(path))
+        except ValueError as e:
+            return tool_error(f"Image '{path}': {e}")
+
+    # Generate an image from the prompt, if requested. Done before touching
+    # QZone so a generation failure aborts cleanly.
+    if generate:
+        try:
+            image_payloads.append(_generate_image(generate, aspect_ratio))
+        except Exception as e:  # noqa: BLE001 — surface one clear message
+            logger.error("qzone_publish: image generation failed: %s", e)
+            return tool_error(f"Image generation failed: {e}")
+
+    try:
+        uin = _get_login_uin()
+        cookie = _get_qzone_cookie_string()
+    except Exception as e:  # noqa: BLE001 — surface one clear message to the model
+        logger.error("qzone_publish: OneBot credential fetch failed: %s", e)
+        return tool_error(f"Could not borrow QQ login state from OneBot: {e}")
+
+    p_skey = _extract_cookie_value(cookie, "p_skey")
+    if not p_skey:
+        return tool_error(
+            "p_skey not found in OneBot cookies — the QQ login state may be "
+            "stale or the OneBot client is not fully logged in to QZone."
+        )
+    skey = _extract_cookie_value(cookie, "skey") or ""
+    gtk = _compute_gtk(p_skey)
+
+    # Upload images (if any), collecting pic info for the publish form.
+    pic_infos: list[dict] = []
+    for image_bytes, filename in image_payloads:
+        try:
+            pic_infos.append(
+                _upload_image(image_bytes, filename, uin, skey, p_skey, gtk, cookie)
+            )
+        except Exception as e:  # noqa: BLE001 — surface one clear message
+            logger.error("qzone_publish: image upload failed (%s): %s", filename, e)
+            return tool_error(f"Image upload failed for '{filename}': {e}")
+
+    form = _build_publish_form(text, uin, pic_infos)
+    try:
+        raw = _qzone_publish_post(form, gtk, cookie, uin)
+    except Exception as e:  # noqa: BLE001 — surface one clear message to the model
+        logger.error("qzone_publish: QZone request failed: %s", e)
+        return tool_error(f"QZone publish request failed: {e}")
+
+    result = _parse_publish_response(raw)
+    if result.get("ok"):
+        return json.dumps({
+            "success": True,
+            "tid": result.get("tid"),
+            "uin": uin,
+            "images": len(pic_infos),
+            "generated": bool(generate),
+            "message": "说说 published to QQ空间.",
+        })
+    return tool_error(
+        f"QZone rejected the post: {result.get('error')}",
+        code=result.get("code"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def _check_qzone_available() -> bool:
+    """Tool is only exposed when an OneBot HTTP URL is configured."""
+    return bool(_onebot_base_url())
+
+
+# ---------------------------------------------------------------------------
+# Tool schema
+# ---------------------------------------------------------------------------
+
+QZONE_PUBLISH_SCHEMA = {
+    "name": "qzone_publish",
+    "description": (
+        "Publish a 说说 (status update) to the configured QQ account's QQ空间 "
+        "(QZone). Supports text, attached local images, and/or an AI-generated "
+        "image from a prompt. The QQ login state is borrowed from a running "
+        "OneBot (NapCat / Lagrange) instance — no QQ password is needed. Note: "
+        "this drives unofficial QZone web endpoints, so it can fail if the "
+        "login state is stale or Tencent risk-control intervenes."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": (
+                    "The 说说 body text. May be empty when 'images' or "
+                    "'generate' is provided; otherwise required."
+                ),
+            },
+            "images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of local image file paths to attach "
+                    f"(max {_MAX_IMAGES}). Allowed types: JPG, PNG, GIF, WebP, BMP."
+                ),
+            },
+            "generate": {
+                "type": "string",
+                "description": (
+                    "Optional text prompt — generates an image with the "
+                    "configured image-generation backend (FAL / OpenAI / xAI) "
+                    "and attaches it to the 说说. Counts toward the "
+                    f"{_MAX_IMAGES}-image limit alongside 'images'."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["square", "landscape", "portrait"],
+                "description": (
+                    "Aspect ratio for the generated image. Only used with "
+                    "'generate'. Default: square."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="qzone_publish",
+    toolset="qzone",
+    schema=QZONE_PUBLISH_SCHEMA,
+    handler=_handle_qzone_publish,
+    check_fn=_check_qzone_available,
+    requires_env=["ONEBOT_HTTP_URL"],
+    emoji="🐧",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -255,6 +255,15 @@ TOOLSETS = {
         "includes": []
     },
 
+    "qzone": {
+        "description": (
+            "QQ空间 (QZone) publishing — post text/image 说说 status updates "
+            "by borrowing QQ login state from a running OneBot instance."
+        ),
+        "tools": ["qzone_publish"],
+        "includes": []
+    },
+
     "kanban": {
         "description": (
             "Kanban multi-agent coordination — only active when the agent "


### PR DESCRIPTION
Stacked on #38037. Please review the final qzone commit; after #38037 merges this branch can be rebased so the diff excludes tools/onebot_client.py and tests/tools/test_onebot_client.py.\n\nScope:\n- add qzone_publish in a dedicated qzone toolset\n- borrow QQ login state through the shared OneBot HTTP client\n- support text, local image attachments, and optional generated image attachment\n- add ONEBOT_HTTP_URL / ONEBOT_ACCESS_TOKEN setup metadata for the tool\n\nIntentionally excluded from this split:\n- qq_send_voice\n- image-with-references changes\n- .env.example broad QQ/QZone examples from the original large branch\n\nRisk notes:\n- QZone has no supported public publish API; this uses fixed QZone web endpoints and can break if Tencent changes them or risk-control intervenes.\n- Endpoint URLs are constants, not model/user supplied. Local image paths are validated by extension, existence, non-empty size, and a 20 MiB limit.\n\nVerification:\n- python -m pytest -o addopts='' tests/tools/test_onebot_client.py tests/tools/test_qzone_tool.py (105 passed)\n- python -m ruff check tools/onebot_client.py tools/qzone_tool.py tests/tools/test_onebot_client.py tests/tools/test_qzone_tool.py toolsets.py hermes_cli/config.py\n- git diff --cached --check