### PR TITLE
Add installer mirror support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+# China mirror preset:
+# curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
 ```
 
 ### Windows (native, PowerShell)
@@ -44,6 +46,9 @@ Run this in PowerShell:
 
 ```powershell
 iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+# China mirror preset:
+# Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 -OutFile install.ps1
+# .\install.ps1 -Mirror china
 ```
 
 The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). Hermes uses this bundled Git Bash to run shell commands.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,6 +16,13 @@ param(
     [switch]$NoVenv,
     [switch]$SkipSetup,
     [string]$Branch = "main",
+    [string]$Mirror = $(if ($env:HERMES_INSTALL_MIRROR) { $env:HERMES_INSTALL_MIRROR } else { "" }),
+    [string]$GithubMirror = $(if ($env:HERMES_GITHUB_MIRROR) { $env:HERMES_GITHUB_MIRROR } else { "" }),
+    [string]$PypiIndexUrl = $(if ($env:HERMES_PYPI_INDEX_URL) { $env:HERMES_PYPI_INDEX_URL } else { "" }),
+    [string]$NpmRegistry = $(if ($env:HERMES_NPM_REGISTRY) { $env:HERMES_NPM_REGISTRY } else { "" }),
+    [string]$NodeDistMirror = $(if ($env:HERMES_NODE_DIST_MIRROR) { $env:HERMES_NODE_DIST_MIRROR } else { "" }),
+    [string]$PlaywrightDownloadHost = $(if ($env:HERMES_PLAYWRIGHT_DOWNLOAD_HOST) { $env:HERMES_PLAYWRIGHT_DOWNLOAD_HOST } else { "" }),
+    [string]$UvInstallerUrl = $(if ($env:HERMES_UV_INSTALLER_URL) { $env:HERMES_UV_INSTALLER_URL } else { "" }),
     # -Commit and -Tag are higher-precedence variants of -Branch for users
     # who need reproducible installs (desktop installer pinning, CI, release
     # bundles).  When set, the repository stage clones $Branch (faster than
@@ -185,6 +192,72 @@ function Write-Err {
     Write-Host "[X] $Message" -ForegroundColor Red
 }
 
+function Join-UrlPrefix {
+    param([string]$Prefix, [string]$Url)
+    if (-not $Prefix) { return $Url }
+    if ($Prefix.EndsWith("/")) { return "$Prefix$Url" }
+    return "$Prefix/$Url"
+}
+
+function Resolve-GithubUrl {
+    param([string]$Url)
+    return (Join-UrlPrefix -Prefix $script:GithubMirror -Url $Url)
+}
+
+function Get-NodeDistUrl {
+    $base = if ($script:NodeDistMirror) { $script:NodeDistMirror } else { "https://nodejs.org/dist" }
+    $base = $base.TrimEnd("/")
+    return "$base/latest-v${NodeVersion}.x/"
+}
+
+function Configure-InstallMirrors {
+    switch ($Mirror.ToLowerInvariant()) {
+        "" {}
+        "none" {}
+        "official" {}
+        "china" {
+            if (-not $script:GithubMirror) { $script:GithubMirror = "https://gh-proxy.com/" }
+            if (-not $script:PypiIndexUrl) { $script:PypiIndexUrl = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+            if (-not $script:NpmRegistry) { $script:NpmRegistry = "https://registry.npmmirror.com" }
+            if (-not $script:NodeDistMirror) { $script:NodeDistMirror = "https://npmmirror.com/mirrors/node" }
+            if (-not $script:PlaywrightDownloadHost) { $script:PlaywrightDownloadHost = "https://npmmirror.com/mirrors/playwright" }
+        }
+        "cn" {
+            if (-not $script:GithubMirror) { $script:GithubMirror = "https://gh-proxy.com/" }
+            if (-not $script:PypiIndexUrl) { $script:PypiIndexUrl = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+            if (-not $script:NpmRegistry) { $script:NpmRegistry = "https://registry.npmmirror.com" }
+            if (-not $script:NodeDistMirror) { $script:NodeDistMirror = "https://npmmirror.com/mirrors/node" }
+            if (-not $script:PlaywrightDownloadHost) { $script:PlaywrightDownloadHost = "https://npmmirror.com/mirrors/playwright" }
+        }
+        default {
+            Write-Err "Unknown mirror preset: $Mirror"
+            Write-Info "Supported presets: china, none"
+            throw "unknown mirror preset"
+        }
+    }
+
+    if ($script:PypiIndexUrl) {
+        $env:PIP_INDEX_URL = $script:PypiIndexUrl
+        $env:UV_DEFAULT_INDEX = $script:PypiIndexUrl
+    }
+    if ($script:NpmRegistry) { $env:npm_config_registry = $script:NpmRegistry }
+    if ($script:PlaywrightDownloadHost) { $env:PLAYWRIGHT_DOWNLOAD_HOST = $script:PlaywrightDownloadHost }
+    if ($script:GithubMirror) { $env:HERMES_GITHUB_MIRROR = $script:GithubMirror }
+    if ($script:NodeDistMirror) { $env:HERMES_NODE_DIST_MIRROR = $script:NodeDistMirror }
+    if ($script:UvInstallerUrl) { $env:HERMES_UV_INSTALLER_URL = $script:UvInstallerUrl }
+
+    if ($Mirror -or $script:GithubMirror -or $script:PypiIndexUrl -or $script:NpmRegistry -or $script:NodeDistMirror -or $script:PlaywrightDownloadHost -or $script:UvInstallerUrl) {
+        Write-Info "Download mirrors configured:"
+        if ($Mirror) { Write-Info "  preset: $Mirror" }
+        if ($script:GithubMirror) { Write-Info "  GitHub: $script:GithubMirror" }
+        if ($script:PypiIndexUrl) { Write-Info "  PyPI: $script:PypiIndexUrl" }
+        if ($script:NpmRegistry) { Write-Info "  npm: $script:NpmRegistry" }
+        if ($script:NodeDistMirror) { Write-Info "  Node.js: $script:NodeDistMirror" }
+        if ($script:PlaywrightDownloadHost) { Write-Info "  Playwright: $script:PlaywrightDownloadHost" }
+        if ($script:UvInstallerUrl) { Write-Info "  uv installer: $script:UvInstallerUrl" }
+    }
+}
+
 # --- Ensure-mode helpers ---
 
 function Resolve-NpmCmd {
@@ -311,7 +384,12 @@ function Install-Uv {
     try {
         $ErrorActionPreference = "Continue"
         $env:UV_INSTALL_DIR = Join-Path $HermesHome "bin"
-        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Out-Null
+        $installerUrl = if ($script:UvInstallerUrl) { $script:UvInstallerUrl } else { "https://astral.sh/uv/install.ps1" }
+        $tmpInstaller = Join-Path $env:TEMP "hermes-uv-install-$(Get-Random).ps1"
+        Write-Info "Downloading uv installer from $installerUrl ..."
+        Invoke-WebRequest -Uri $installerUrl -OutFile $tmpInstaller -UseBasicParsing
+        powershell -ExecutionPolicy ByPass -File $tmpInstaller 2>&1 | Out-Null
+        Remove-Item -Force $tmpInstaller -ErrorAction SilentlyContinue
         $ErrorActionPreference = $prevEAP
 
         if (Test-Path $managedUv) {
@@ -587,7 +665,7 @@ function Install-Git {
             $downloadIsZip = $false
         }
 
-        $downloadUrl = "https://github.com/git-for-windows/git/releases/download/$gitTag/$assetName"
+        $downloadUrl = Resolve-GithubUrl "https://github.com/git-for-windows/git/releases/download/$gitTag/$assetName"
         $downloadExt = if ($downloadIsZip) { "zip" } else { "7z.exe" }
         $tmpFile = "$env:TEMP\$assetName"
         $gitDir = "$HermesHome\git"
@@ -748,7 +826,7 @@ function Test-Node {
     Write-Info "(no admin rights required; isolated from any system Node install)"
     try {
         $arch = Get-WindowsArch
-        $indexUrl = "https://nodejs.org/dist/latest-v${NodeVersion}.x/"
+        $indexUrl = Get-NodeDistUrl
         $indexPage = Invoke-WebRequest -Uri $indexUrl -UseBasicParsing
         $zipName = ($indexPage.Content | Select-String -Pattern "node-v${NodeVersion}\.\d+\.\d+-win-${arch}\.zip" -AllMatches).Matches[0].Value
 
@@ -1037,6 +1115,10 @@ function Install-Repository {
         if ($repoValid) {
             Write-Info "Existing installation found, updating..."
             Push-Location $InstallDir
+            if ($script:GithubMirror) {
+                Write-Info "Using mirrored GitHub remote for update"
+                git -c windows.appendAtomically=false remote set-url origin (Resolve-GithubUrl $RepoUrlHttps) 2>$null
+            }
             # Wrap the entire fetch+checkout block in EAP=Continue so git's
             # routine stderr output (e.g. 'From <url>' info lines emitted by
             # `git fetch`) doesn't terminate the script under the global
@@ -1101,20 +1183,23 @@ function Install-Repository {
         $env:GIT_CONFIG_VALUE_0 = "false"
         git config --global windows.appendAtomically false 2>$null
 
-        # Try SSH first, then HTTPS, with -c flag for atomic write fix
-        Write-Info "Trying SSH clone..."
-        $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
-        try {
-            git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlSsh $InstallDir
-            if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
-        } catch { }
-        $env:GIT_SSH_COMMAND = $null
+        # Try SSH first, then HTTPS, with -c flag for atomic write fix.
+        # Mirror/proxy URLs only apply to HTTPS, so skip SSH when one is set.
+        if (-not $script:GithubMirror) {
+            Write-Info "Trying SSH clone..."
+            $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
+            try {
+                git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlSsh $InstallDir
+                if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
+            } catch { }
+            $env:GIT_SSH_COMMAND = $null
+        }
 
         if (-not $cloneSuccess) {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
-            Write-Info "SSH failed, trying HTTPS..."
+            if ($script:GithubMirror) { Write-Info "Trying mirrored HTTPS clone..." } else { Write-Info "SSH failed, trying HTTPS..." }
             try {
-                git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlHttps $InstallDir
+                git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules (Resolve-GithubUrl $RepoUrlHttps) $InstallDir
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }
@@ -1128,13 +1213,13 @@ function Install-Repository {
                 # for.  GitHub supports archive URLs for commits, tags, and
                 # branches; we honour Commit > Tag > Branch.
                 if ($Commit) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/$Commit.zip"
+                    $zipUrl = Resolve-GithubUrl "https://github.com/NousResearch/hermes-agent/archive/$Commit.zip"
                     $zipLabel = $Commit
                 } elseif ($Tag) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/$Tag.zip"
+                    $zipUrl = Resolve-GithubUrl "https://github.com/NousResearch/hermes-agent/archive/refs/tags/$Tag.zip"
                     $zipLabel = $Tag
                 } else {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/heads/$Branch.zip"
+                    $zipUrl = Resolve-GithubUrl "https://github.com/NousResearch/hermes-agent/archive/refs/heads/$Branch.zip"
                     $zipLabel = $Branch
                 }
                 $zipPath = "$env:TEMP\hermes-agent-$zipLabel.zip"
@@ -1155,7 +1240,7 @@ function Install-Repository {
                     Push-Location $InstallDir
                     git -c windows.appendAtomically=false init 2>$null
                     git -c windows.appendAtomically=false config windows.appendAtomically false 2>$null
-                    git remote add origin $RepoUrlHttps 2>$null
+                    git remote add origin (Resolve-GithubUrl $RepoUrlHttps) 2>$null
                     Pop-Location
                     Write-Success "Git repo initialized for future updates"
 
@@ -2675,6 +2760,7 @@ function Invoke-PostInstallMode {
 
 function Main {
     Write-Banner
+    Configure-InstallMirrors
     Invoke-AllStages
     if (-not $Json) {
         Write-Completion
@@ -2697,10 +2783,12 @@ try {
             Write-Err "Cannot use -Ensure and -Stage simultaneously"
             exit 1
         }
+        Configure-InstallMirrors
         Invoke-EnsureMode -Deps $Ensure
         exit 0
     }
     if ($PostInstall) {
+        Configure-InstallMirrors
         Invoke-PostInstallMode
         exit 0
     }
@@ -2732,6 +2820,7 @@ try {
     # operation.  Empty string is a contract violation; surface it as
     # unknown-stage exit 2 with a structured JSON frame.
     if ($PSBoundParameters.ContainsKey("Stage")) {
+        Configure-InstallMirrors
         $def = Get-InstallStage -Name $Stage
         if (-not $def) {
             $err = @{

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,7 @@ USE_VENV=true
 RUN_SETUP=true
 SKIP_BROWSER=false
 NO_SKILLS=false
+INSTALL_MIRROR="${HERMES_INSTALL_MIRROR:-}"
 BRANCH="main"
 INSTALL_COMMIT=""
 ENSURE_DEPS=""
@@ -108,6 +109,38 @@ while [[ $# -gt 0 ]]; do
         --no-skills)
             NO_SKILLS=true
             shift
+            ;;
+        --mirror)
+            INSTALL_MIRROR="$2"
+            shift 2
+            ;;
+        --china-mirror|--cn-mirror)
+            INSTALL_MIRROR="china"
+            shift
+            ;;
+        --github-mirror)
+            HERMES_GITHUB_MIRROR="$2"
+            shift 2
+            ;;
+        --pypi-index-url)
+            HERMES_PYPI_INDEX_URL="$2"
+            shift 2
+            ;;
+        --npm-registry)
+            HERMES_NPM_REGISTRY="$2"
+            shift 2
+            ;;
+        --node-dist-mirror)
+            HERMES_NODE_DIST_MIRROR="$2"
+            shift 2
+            ;;
+        --playwright-download-host)
+            HERMES_PLAYWRIGHT_DOWNLOAD_HOST="$2"
+            shift 2
+            ;;
+        --uv-installer-url)
+            HERMES_UV_INSTALLER_URL="$2"
+            shift 2
             ;;
         --branch|-Branch)
             BRANCH="$2"
@@ -166,6 +199,20 @@ while [[ $# -gt 0 ]]; do
             echo "  --no-skills    Start with a blank slate — seed no bundled skills, and"
             echo "                   write \$HERMES_HOME/.no-bundled-skills so future"
             echo "                   'hermes update' runs never inject bundled skills either"
+            echo "  --mirror NAME  Use a mirror preset for downloads (supported: china, none)"
+            echo "  --china-mirror Shortcut for --mirror china"
+            echo "  --github-mirror URL"
+            echo "                 Prefix GitHub URLs with a mirror/proxy URL"
+            echo "  --pypi-index-url URL"
+            echo "                 Use this PyPI/simple index for pip and uv"
+            echo "  --npm-registry URL"
+            echo "                 Use this npm registry"
+            echo "  --node-dist-mirror URL"
+            echo "                 Use this Node.js dist mirror (default: https://nodejs.org/dist)"
+            echo "  --playwright-download-host URL"
+            echo "                 Use this Playwright browser download mirror"
+            echo "  --uv-installer-url URL"
+            echo "                 Download the uv installer from this URL"
             echo "  --branch NAME  Git branch to install (default: main)"
             echo "  --commit SHA   Pin checkout to a specific commit after clone/update"
             echo "  --manifest     Print desktop bootstrap stage manifest as JSON"
@@ -239,6 +286,75 @@ json_escape() {
     printf '%s' "$1" | tr '\n' ' ' | sed \
         -e 's/\\/\\\\/g' \
         -e 's/"/\\"/g'
+}
+
+append_slash() {
+    case "$1" in
+        */) printf '%s' "$1" ;;
+        *) printf '%s/' "$1" ;;
+    esac
+}
+
+github_url() {
+    local url="$1"
+    if [ -n "${HERMES_GITHUB_MIRROR:-}" ]; then
+        printf '%s%s' "$(append_slash "$HERMES_GITHUB_MIRROR")" "$url"
+    else
+        printf '%s' "$url"
+    fi
+}
+
+node_dist_url() {
+    local base="${HERMES_NODE_DIST_MIRROR:-https://nodejs.org/dist}"
+    printf '%s/latest-v%s.x/' "$(printf '%s' "$base" | sed 's#/*$##')" "$NODE_VERSION"
+}
+
+configure_install_mirrors() {
+    case "$INSTALL_MIRROR" in
+        ""|none|official)
+            ;;
+        china|cn)
+            HERMES_GITHUB_MIRROR="${HERMES_GITHUB_MIRROR:-https://gh-proxy.com/}"
+            HERMES_PYPI_INDEX_URL="${HERMES_PYPI_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
+            HERMES_NPM_REGISTRY="${HERMES_NPM_REGISTRY:-https://registry.npmmirror.com}"
+            HERMES_NODE_DIST_MIRROR="${HERMES_NODE_DIST_MIRROR:-https://npmmirror.com/mirrors/node}"
+            HERMES_PLAYWRIGHT_DOWNLOAD_HOST="${HERMES_PLAYWRIGHT_DOWNLOAD_HOST:-https://npmmirror.com/mirrors/playwright}"
+            ;;
+        *)
+            log_error "Unknown mirror preset: $INSTALL_MIRROR"
+            log_info "Supported presets: china, none"
+            exit 1
+            ;;
+    esac
+
+    if [ -n "${HERMES_PYPI_INDEX_URL:-}" ]; then
+        export PIP_INDEX_URL="$HERMES_PYPI_INDEX_URL"
+        export UV_DEFAULT_INDEX="$HERMES_PYPI_INDEX_URL"
+    fi
+    if [ -n "${HERMES_NPM_REGISTRY:-}" ]; then
+        export npm_config_registry="$HERMES_NPM_REGISTRY"
+    fi
+    if [ -n "${HERMES_PLAYWRIGHT_DOWNLOAD_HOST:-}" ]; then
+        export PLAYWRIGHT_DOWNLOAD_HOST="$HERMES_PLAYWRIGHT_DOWNLOAD_HOST"
+    fi
+    export HERMES_GITHUB_MIRROR="${HERMES_GITHUB_MIRROR:-}"
+    export HERMES_NODE_DIST_MIRROR="${HERMES_NODE_DIST_MIRROR:-}"
+    export HERMES_UV_INSTALLER_URL="${HERMES_UV_INSTALLER_URL:-}"
+
+    if [ -n "$INSTALL_MIRROR" ] || [ -n "${HERMES_GITHUB_MIRROR:-}" ] \
+        || [ -n "${HERMES_PYPI_INDEX_URL:-}" ] || [ -n "${HERMES_NPM_REGISTRY:-}" ] \
+        || [ -n "${HERMES_NODE_DIST_MIRROR:-}" ] || [ -n "${HERMES_PLAYWRIGHT_DOWNLOAD_HOST:-}" ] \
+        || [ -n "${HERMES_UV_INSTALLER_URL:-}" ]; then
+        log_info "Download mirrors configured:"
+        [ -n "$INSTALL_MIRROR" ] && log_info "  preset: $INSTALL_MIRROR"
+        [ -n "${HERMES_GITHUB_MIRROR:-}" ] && log_info "  GitHub: $HERMES_GITHUB_MIRROR"
+        [ -n "${HERMES_PYPI_INDEX_URL:-}" ] && log_info "  PyPI: $HERMES_PYPI_INDEX_URL"
+        [ -n "${HERMES_NPM_REGISTRY:-}" ] && log_info "  npm: $HERMES_NPM_REGISTRY"
+        [ -n "${HERMES_NODE_DIST_MIRROR:-}" ] && log_info "  Node.js: $HERMES_NODE_DIST_MIRROR"
+        [ -n "${HERMES_PLAYWRIGHT_DOWNLOAD_HOST:-}" ] && log_info "  Playwright: $HERMES_PLAYWRIGHT_DOWNLOAD_HOST"
+        [ -n "${HERMES_UV_INSTALLER_URL:-}" ] && log_info "  uv installer: $HERMES_UV_INSTALLER_URL"
+    fi
+    return 0
 }
 
 # npm rewrites tracked package-lock.json files non-deterministically during
@@ -497,8 +613,21 @@ install_uv() {
     local _uv_install_log _uv_installer
     _uv_install_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
     _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_install_log"; then
-        log_error "Failed to download uv installer from https://astral.sh/uv/install.sh"
+    local _uv_url _uv_urls _uv_downloaded=false
+    _uv_urls="${HERMES_UV_INSTALLER_URL:-https://astral.sh/uv/install.sh}"
+    if [ -z "${HERMES_UV_INSTALLER_URL:-}" ] && [ -n "${HERMES_GITHUB_MIRROR:-}" ]; then
+        _uv_urls="$_uv_urls $(github_url "https://astral.sh/uv/install.sh")"
+    fi
+    for _uv_url in $_uv_urls; do
+        : > "$_uv_install_log"
+        log_info "Downloading uv installer from $_uv_url ..."
+        if curl -LsSf "$_uv_url" -o "$_uv_installer" 2>"$_uv_install_log"; then
+            _uv_downloaded=true
+            break
+        fi
+    done
+    if [ "$_uv_downloaded" = false ]; then
+        log_error "Failed to download uv installer"
         log_info "curl output:"
         sed 's/^/    /' "$_uv_install_log" >&2
         log_info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
@@ -770,7 +899,8 @@ install_node() {
     esac
 
     # Resolve the latest v22.x.x tarball name from the index page
-    local index_url="https://nodejs.org/dist/latest-v${NODE_VERSION}.x/"
+    local index_url
+    index_url="$(node_dist_url)"
     local tarball_name
     tarball_name=$(curl -fsSL "$index_url" \
         | grep -oE "node-v${NODE_VERSION}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
@@ -843,7 +973,12 @@ check_network_prerequisites() {
 
     local url
     local failed=false
-    local checks=("https://pypi.org/simple/" "https://duckduckgo.com/")
+    local checks=("${PIP_INDEX_URL:-https://pypi.org/simple/}" "https://duckduckgo.com/")
+    case "$INSTALL_MIRROR" in
+        china|cn)
+            checks=("${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}" "${HERMES_NPM_REGISTRY:-https://registry.npmmirror.com}")
+            ;;
+    esac
 
     if ! command -v curl >/dev/null 2>&1; then
         log_warn "curl not found; skipping connectivity probes"
@@ -1075,6 +1210,10 @@ clone_repo() {
         if [ -d "$INSTALL_DIR/.git" ]; then
             log_info "Existing installation found, updating..."
             cd "$INSTALL_DIR"
+            if [ -n "${HERMES_GITHUB_MIRROR:-}" ]; then
+                log_info "Using mirrored GitHub remote for update"
+                git remote set-url origin "$(github_url "$REPO_URL_HTTPS")" 2>/dev/null || true
+            fi
 
             local autostash_ref=""
             if [ -n "$(git status --porcelain)" ]; then
@@ -1126,17 +1265,28 @@ clone_repo() {
             exit 1
         fi
     else
-        # Try SSH first (for private repo access), fall back to HTTPS
+        # Try SSH first (for private repo access), fall back to HTTPS.
+        # Mirror/proxy URLs only apply to HTTPS, so skip SSH when one is set.
         # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
         # so SSH fails fast instead of hanging when no key is configured.
-        log_info "Trying SSH clone..."
-        if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
-            log_success "Cloned via SSH"
+        if [ -z "${HERMES_GITHUB_MIRROR:-}" ]; then
+            log_info "Trying SSH clone..."
+            if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
+               git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
+                log_success "Cloned via SSH"
+            else
+                rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
+                log_info "SSH failed, trying HTTPS..."
+                if git clone --branch "$BRANCH" "$(github_url "$REPO_URL_HTTPS")" "$INSTALL_DIR"; then
+                    log_success "Cloned via HTTPS"
+                else
+                    log_error "Failed to clone repository"
+                    exit 1
+                fi
+            fi
         else
-            rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
-            log_info "SSH failed, trying HTTPS..."
-            if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+            log_info "Trying mirrored HTTPS clone..."
+            if git clone --branch "$BRANCH" "$(github_url "$REPO_URL_HTTPS")" "$INSTALL_DIR"; then
                 log_success "Cloned via HTTPS"
             else
                 log_error "Failed to clone repository"
@@ -2447,6 +2597,7 @@ run_stage_body() {
 
 run_stage_protocol() {
     local stage="$1"
+    configure_install_mirrors
     if [ -z "$stage" ]; then
         log_error "--stage requires a stage name"
         if [ "$JSON_OUTPUT" = true ]; then
@@ -2490,6 +2641,7 @@ run_stage_protocol() {
 
 main() {
     print_banner
+    configure_install_mirrors
 
     detect_os
     resolve_install_layout
@@ -2523,8 +2675,10 @@ if [ "$MANIFEST_MODE" = true ]; then
 elif [ -n "$STAGE_NAME" ]; then
     run_stage_protocol "$STAGE_NAME"
 elif [ -n "$ENSURE_DEPS" ]; then
+    configure_install_mirrors
     ensure_mode
 elif [ "$POSTINSTALL_MODE" = true ]; then
+    configure_install_mirrors
     postinstall_mode
 else
     main

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -21,6 +21,7 @@
 #   HERMES_NODE_MIN_VERSION   (default: 20)   — accepted on PATH
 #   HERMES_NODE_TARGET_MAJOR  (default: 22)   — installed when we install
 #   HERMES_HOME               (default: $HOME/.hermes)
+#   HERMES_NODE_DIST_MIRROR   (default: https://nodejs.org/dist)
 # ============================================================================
 
 HERMES_NODE_MIN_VERSION="${HERMES_NODE_MIN_VERSION:-20}"
@@ -53,6 +54,11 @@ _nb_node_major() {
 _nb_have_modern_node() {
     command -v node >/dev/null 2>&1 || return 1
     [ "$(_nb_node_major)" -ge "$HERMES_NODE_MIN_VERSION" ]
+}
+
+_nb_node_dist_url() {
+    local base="${HERMES_NODE_DIST_MIRROR:-https://nodejs.org/dist}"
+    printf '%s/latest-v%s.x/' "$(printf '%s' "$base" | sed 's#/*$##')" "$HERMES_NODE_TARGET_MAJOR"
 }
 
 # ---------------------------------------------------------------------------
@@ -145,7 +151,8 @@ _nb_install_bundled_node() {
             ;;
     esac
 
-    local index_url="https://nodejs.org/dist/latest-v${HERMES_NODE_TARGET_MAJOR}.x/"
+    local index_url
+    index_url="$(_nb_node_dist_url)"
     local tarball
     tarball=$(curl -fsSL "$index_url" \
         | grep -oE "node-v${HERMES_NODE_TARGET_MAJOR}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -26,6 +26,20 @@ For a git-based install that tracks `main` and gives you the latest changes imme
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
+For users behind slow or blocked international routes, the installer supports a mirror preset:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
+```
+
+If `raw.githubusercontent.com` itself is unreachable, fetch the script through the same GitHub proxy:
+
+```bash
+curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
+```
+
+The `china` preset switches GitHub downloads through a proxy and uses China-friendly defaults for PyPI, npm, Node.js, and Playwright. You can override any source with `--github-mirror`, `--pypi-index-url`, `--npm-registry`, `--node-dist-mirror`, `--playwright-download-host`, or `--uv-installer-url`.
+
 ### Windows (native, PowerShell)
 
 Native Windows runs Hermes without WSL — the CLI, gateway, TUI, and tools all work natively. (Both native and WSL2 installs coexist cleanly; see the feature note below for the one WSL2-only feature.) Found a bug? Please [file issues](https://github.com/NousResearch/hermes-agent/issues).
@@ -35,6 +49,15 @@ Open PowerShell and run:
 ```powershell
 iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
 ```
+
+China-friendly mirrors are available with `-Mirror china`:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Mirror china
+```
+
+If GitHub raw downloads are blocked, replace the first URL with `https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1`.
 
 The installer handles **everything**: `uv`, Python 3.11, Node.js 22, `ripgrep`, `ffmpeg`, **and a portable Git Bash** (PortableGit — a self-contained Git-for-Windows distribution that ships `bash.exe` and the full POSIX toolchain Hermes uses for shell commands; on 32-bit Windows the installer falls back to MinGit, which lacks bash and disables terminal-tool / agent-browser features).  It clones the repo under `%LOCALAPPDATA%\hermes\hermes-agent`, creates a virtualenv, and adds `hermes` to your **User PATH**.  Restart your terminal (or open a new PowerShell window) after the install so PATH picks up.
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -62,6 +62,8 @@ PyPI releases track tagged versions (major/minor releases), not every commit on 
 ```bash
 # Linux / macOS / WSL2 / Android (Termux)
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+# China mirror preset:
+# curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
 ```
 
 Prefer native installers for desktop use?

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -18,6 +18,20 @@ description: "在 Linux、macOS、WSL2、原生 Windows 或通过 Termux 在 And
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
+如果国际网络较慢或被阻断，可以使用内置镜像预设：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
+```
+
+如果 `raw.githubusercontent.com` 本身也无法访问，可先通过同一个 GitHub 代理获取脚本：
+
+```bash
+curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
+```
+
+`china` 预设会将 GitHub 下载走代理，并为 PyPI、npm、Node.js 和 Playwright 使用更适合中国网络的默认源。也可以用 `--github-mirror`、`--pypi-index-url`、`--npm-registry`、`--node-dist-mirror`、`--playwright-download-host` 或 `--uv-installer-url` 单独覆盖任一下载源。
+
 ### Windows（原生，PowerShell）
 
 原生 Windows 无需 WSL 即可运行 Hermes——CLI、gateway、TUI 和工具均可原生运行。（原生安装与 WSL2 安装可干净共存；唯一仅限 WSL2 的功能见下方功能说明。）遇到 bug 请[提交 issue](https://github.com/NousResearch/hermes-agent/issues)。
@@ -27,6 +41,15 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 ```powershell
 iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
 ```
+
+中国网络环境可使用 `-Mirror china`：
+
+```powershell
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Mirror china
+```
+
+如果 GitHub raw 下载被阻断，可将第一条命令里的 URL 替换为 `https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1`。
 
 安装程序处理**一切**：`uv`、Python 3.11、Node.js 22、`ripgrep`、`ffmpeg`，**以及一个便携式 Git Bash**（PortableGit——一个自包含的 Git-for-Windows 发行版，附带 `bash.exe` 和 Hermes 用于 shell 命令的完整 POSIX 工具链；在 32 位 Windows 上安装程序会回退到 MinGit，后者缺少 bash，终端工具和 agent 浏览器功能将被禁用）。它将仓库克隆到 `%LOCALAPPDATA%\hermes\hermes-agent`，创建虚拟环境，并将 `hermes` 添加到**用户 PATH**。安装完成后请重启终端（或打开新的 PowerShell 窗口）以使 PATH 生效。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -62,6 +62,8 @@ PyPI 发布版本跟踪带标签的版本（主/次版本发布），而非 `mai
 ```bash
 # Linux / macOS / WSL2 / Android (Termux)
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+# 中国镜像预设：
+# curl -fsSL https://gh-proxy.com/https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --mirror china
 ```
 
 :::tip Android / Termux


### PR DESCRIPTION
## What does this PR do?

Adds mirror selection support to the one-line installers for users on slow or blocked international routes, especially mainland China.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `--mirror china` / `--china-mirror` to `scripts/install.sh`.
- Added `-Mirror china` to `scripts/install.ps1`.
- Added per-source overrides for GitHub, PyPI, npm, Node.js, Playwright, and the uv installer.
- Wired mirror env vars into uv/pip, npm, Playwright, GitHub clone/update, and Node binary downloads.
- Updated README and installation/quickstart docs, including zh-Hans docs.

## How to Test

1. `bash -n scripts/install.sh && bash -n scripts/lib/node-bootstrap.sh`
2. `scripts/install.sh --manifest | python -m json.tool`
3. `scripts/install.sh --mirror china --ensure __noop__` to verify the mirror configuration path without installing dependencies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS shell syntax checks; PowerShell parser unavailable locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A