### PR TITLE
feat(gateway): batch rapid ingress messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -51,6 +51,17 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
+def _coerce_float(value, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp_seconds(value: float, *, minimum: float = 0.0, maximum: float = 5.0) -> float:
+    return max(minimum, min(value, maximum))
+
+
 def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
     """Build platform-aware thread metadata for adapter sends.
 
@@ -1481,6 +1492,16 @@ class TextDebounceState:
     last_ts: float
 
 
+@dataclass
+class IngressBatchState:
+    event: MessageEvent
+    session_key: str
+    task: asyncio.Task | None
+    first_ts: float
+    last_ts: float
+    item_count: int = 1
+
+
 _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?gateway[.!?\s]*$", re.IGNORECASE),
     re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?hermes\s+gateway[.!?\s]*$", re.IGNORECASE),
@@ -1807,6 +1828,43 @@ class BasePlatformAdapter(ABC):
             "HERMES_GATEWAY_BUSY_TEXT_HARD_CAP_SECONDS", 1.0
         )
         self._text_debounce: dict[str, TextDebounceState] = {}
+        config_extra = getattr(self.config, "extra", {})
+        if not isinstance(config_extra, dict):
+            config_extra = {}
+        ingress_window_default = _float_env("HERMES_GATEWAY_INGRESS_BATCH_SECONDS", 0.0)
+        ingress_hard_cap_default = _float_env(
+            "HERMES_GATEWAY_INGRESS_BATCH_HARD_CAP_SECONDS",
+            max(ingress_window_default, 0.0),
+        )
+        ingress_window_config = _coerce_float(
+            config_extra.get("ingress_batch_seconds", ingress_window_default),
+            ingress_window_default,
+        )
+        ingress_hard_cap_config = _coerce_float(
+            config_extra.get(
+                "ingress_batch_hard_cap_seconds",
+                ingress_hard_cap_default,
+            ),
+            ingress_hard_cap_default,
+        )
+        self._ingress_batch_seconds = _clamp_seconds(
+            _float_env(
+                "HERMES_GATEWAY_INGRESS_BATCH_SECONDS",
+                ingress_window_config,
+            )
+        )
+        self._ingress_batch_hard_cap_seconds = _clamp_seconds(
+            _float_env(
+                "HERMES_GATEWAY_INGRESS_BATCH_HARD_CAP_SECONDS",
+                ingress_hard_cap_config,
+            )
+        )
+        if (
+            self._ingress_batch_seconds > 0
+            and self._ingress_batch_hard_cap_seconds <= 0
+        ):
+            self._ingress_batch_hard_cap_seconds = self._ingress_batch_seconds
+        self._ingress_batches: dict[str, IngressBatchState] = {}
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -3519,6 +3577,229 @@ class BasePlatformAdapter(ABC):
         if state is not None and state.task is not None and not state.task.done():
             state.task.cancel()
 
+    def _ingress_batch_store(self) -> dict[str, IngressBatchState]:
+        store = getattr(self, "_ingress_batches", None)
+        if store is None:
+            store = {}
+            self._ingress_batches = store
+        return store
+
+    def _active_profile_for_ingress_key(self) -> str:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            return get_active_profile_name() or "default"
+        except Exception:
+            return os.environ.get("HERMES_PROFILE") or os.environ.get("HERMES_ACTIVE_PROFILE") or "default"
+
+    def _build_ingress_batch_key(self, event: MessageEvent, session_key: str | None = None) -> str:
+        source = getattr(event, "source", None)
+        platform = _platform_name(getattr(source, "platform", self.platform))
+        profile = self._active_profile_for_ingress_key()
+        if session_key is None and source is not None:
+            session_key = build_session_key(
+                source,
+                group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            )
+        chat_id = getattr(source, "chat_id", None) or getattr(source, "chat_id_alt", None) or ""
+        thread_id = getattr(source, "thread_id", None) or ""
+        user_id = getattr(source, "user_id_alt", None) or getattr(source, "user_id", None) or ""
+        return ":".join(str(part) for part in (platform, profile, session_key or "", chat_id, thread_id, user_id))
+
+    def _is_ingress_batch_candidate(self, event: MessageEvent) -> bool:
+        if getattr(event, "internal", False):
+            return False
+        if self._ingress_batch_seconds <= 0:
+            return False
+        if event.is_command() or event.message_type == MessageType.COMMAND:
+            return False
+        return bool((event.text or "").strip() or event.media_urls)
+
+    def _merge_ingress_batch_event(self, existing: MessageEvent, event: MessageEvent) -> None:
+        if event.text:
+            existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+        if event.media_urls:
+            existing.media_urls.extend(event.media_urls)
+            existing.media_types.extend(event.media_types)
+        if event.message_type != MessageType.TEXT:
+            existing.message_type = event.message_type
+        latest_message_id = getattr(event, "message_id", None)
+        latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
+        if latest_message_id is not None:
+            existing.message_id = str(latest_message_id)
+        if latest_anchor is not None:
+            existing.reply_to_message_id = str(latest_anchor)
+
+    def _ingress_batch_delay(self, batch_key: str) -> float:
+        state = self._ingress_batch_store().get(batch_key)
+        if state is None:
+            return 0.0
+        now = time.monotonic()
+        window_deadline = state.last_ts + self._ingress_batch_seconds
+        hard_cap = self._ingress_batch_hard_cap_seconds or self._ingress_batch_seconds
+        hard_cap_deadline = state.first_ts + hard_cap
+        return max(0.0, min(window_deadline, hard_cap_deadline) - now)
+
+    async def _queue_ingress_batch(self, batch_key: str, session_key: str, event: MessageEvent) -> None:
+        store = self._ingress_batch_store()
+        state = store.get(batch_key)
+        if state is not None and state.session_key != session_key:
+            await self._flush_ingress_batch_now(batch_key)
+            state = None
+        now = time.monotonic()
+        if state is not None:
+            hard_cap = self._ingress_batch_hard_cap_seconds or self._ingress_batch_seconds
+            if hard_cap > 0 and now >= state.first_ts + hard_cap:
+                await self._flush_ingress_batch_now(batch_key)
+                state = None
+
+        if session_key in self._active_sessions:
+            await self._flush_ingress_batches_for_session(
+                session_key,
+                exclude_batch_key=batch_key,
+            )
+            merge_pending_message_event(
+                self._pending_messages,
+                session_key,
+                event,
+                merge_text=event.message_type == MessageType.TEXT,
+            )
+            logger.info(
+                "ingress_batch_add type=%s session=%s queued=busy",
+                event.message_type.value,
+                session_key,
+            )
+            return
+
+        if state is None:
+            await self._flush_ingress_batches_for_session(
+                session_key,
+                exclude_batch_key=batch_key,
+            )
+            if session_key in self._active_sessions:
+                merge_pending_message_event(
+                    self._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=event.message_type == MessageType.TEXT,
+                )
+                logger.info(
+                    "ingress_batch_add type=%s session=%s queued=busy",
+                    event.message_type.value,
+                    session_key,
+                )
+                return
+            state = IngressBatchState(
+                event=event,
+                session_key=session_key,
+                task=None,
+                first_ts=now,
+                last_ts=now,
+                item_count=1,
+            )
+            store[batch_key] = state
+        else:
+            self._merge_ingress_batch_event(state.event, event)
+            state.last_ts = now
+            state.item_count += 1
+
+        if state.task is not None and not state.task.done():
+            state.task.cancel()
+        delay = self._ingress_batch_delay(batch_key)
+        state.task = asyncio.create_task(self._flush_ingress_batch(batch_key, delay))
+        logger.info(
+            "ingress_batch_add type=%s session=%s items=%d",
+            event.message_type.value,
+            session_key,
+            state.item_count,
+        )
+
+    async def _flush_ingress_batch(self, batch_key: str, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            await self._flush_ingress_batch_now(batch_key)
+        except asyncio.CancelledError:
+            return
+        finally:
+            current = asyncio.current_task()
+            state = self._ingress_batch_store().get(batch_key)
+            if state is not None and state.task is current:
+                state.task = None
+
+    async def _flush_ingress_batch_now(self, batch_key: str) -> bool:
+        store = self._ingress_batch_store()
+        state = store.pop(batch_key, None)
+        if state is None:
+            return False
+        current = asyncio.current_task()
+        if state.task is not None and state.task is not current and not state.task.done():
+            state.task.cancel()
+        state.task = None
+
+        event = state.event
+        session_key = state.session_key
+        text_parts = len([p for p in (event.text or "").split("\n") if p.strip()])
+        image_count = sum(1 for t in event.media_types if str(t).startswith("image/"))
+        file_count = len(event.media_urls) - image_count
+        logger.info(
+            "ingress_batch_flush session=%s items=%d text_parts=%d attachments=%d images=%d",
+            session_key,
+            state.item_count,
+            text_parts,
+            file_count,
+            image_count,
+        )
+        if session_key in self._active_sessions:
+            merge_pending_message_event(
+                self._pending_messages,
+                session_key,
+                event,
+                merge_text=event.message_type == MessageType.TEXT,
+            )
+            return True
+        if self._start_session_processing(event, session_key):
+            logger.info("agent_turn_created source=batch session=%s", session_key)
+        return True
+
+    async def _flush_ingress_batches_for_session(
+        self,
+        session_key: str,
+        *,
+        exclude_batch_key: str | None = None,
+    ) -> int:
+        flushed = 0
+        for batch_key, state in list(self._ingress_batch_store().items()):
+            if batch_key == exclude_batch_key or state.session_key != session_key:
+                continue
+            if await self._flush_ingress_batch_now(batch_key):
+                flushed += 1
+        return flushed
+
+    def _discard_ingress_batches_for_session(self, session_key: str, *, reason: str) -> int:
+        discarded = 0
+        store = self._ingress_batch_store()
+        for batch_key, state in list(store.items()):
+            if state.session_key != session_key:
+                continue
+            if state.task is not None and not state.task.done():
+                state.task.cancel()
+            store.pop(batch_key, None)
+            discarded += 1
+        if discarded:
+            logger.info(
+                "ingress_batch_discard session=%s batches=%d reason=%s",
+                session_key,
+                discarded,
+                reason,
+            )
+        return discarded
+
+    def _discard_ingress_batches(self) -> None:
+        for state in list(self._ingress_batch_store().values()):
+            if state.task is not None and not state.task.done():
+                state.task.cancel()
+        self._ingress_batch_store().clear()
+
     # ------------------------------------------------------------------
     # Session task + guard ownership helpers
     # ------------------------------------------------------------------
@@ -3792,6 +4073,12 @@ class BasePlatformAdapter(ABC):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+        incoming_cmd = event.get_command()
+        if incoming_cmd:
+            self._discard_ingress_batches_for_session(
+                session_key,
+                reason=f"command:{incoming_cmd}",
+            )
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
@@ -3813,7 +4100,7 @@ class BasePlatformAdapter(ABC):
             # response.  Do NOT use _process_message_background — it manages
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
-            cmd = event.get_command()
+            cmd = incoming_cmd
             from hermes_cli.commands import should_bypass_active_session
 
             if should_bypass_active_session(cmd):
@@ -3913,6 +4200,15 @@ class BasePlatformAdapter(ABC):
                         )
                     return
 
+            if not cmd:
+                batch_key = self._build_ingress_batch_key(event, session_key)
+                await self._flush_ingress_batches_for_session(
+                    session_key,
+                    exclude_batch_key=batch_key,
+                )
+                if batch_key in self._ingress_batch_store():
+                    await self._flush_ingress_batch_now(batch_key)
+
             if self._busy_session_handler is not None:
                 try:
                     if await self._busy_session_handler(event, session_key):
@@ -3952,6 +4248,14 @@ class BasePlatformAdapter(ABC):
                 )
             return  # Don't process now - will be handled after current task finishes
         
+        # Short ingress debounce for idle sessions: messages from the same
+        # platform/profile/chat/thread/user that arrive almost together become
+        # one agent turn. Active sessions still use the busy queue above.
+        if self._is_ingress_batch_candidate(event):
+            batch_key = self._build_ingress_batch_key(event, session_key)
+            await self._queue_ingress_batch(batch_key, session_key, event)
+            return
+
         # Mark session as active BEFORE spawning background task to close
         # the race window where a second message arriving before the task
         # starts would also pass the _active_sessions check and spawn a
@@ -4580,6 +4884,7 @@ class BasePlatformAdapter(ABC):
             if state.task is not None and not state.task.done():
                 state.task.cancel()
         self._text_debounce_store().clear()
+        self._discard_ingress_batches()
 
     def has_pending_interrupt(self, session_key: str) -> bool:
         """Check if there's a pending interrupt for a session."""

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -104,6 +104,9 @@ def _make_adapter() -> BasePlatformAdapter:
     adapter._busy_text_debounce_seconds = 0.1
     adapter._busy_text_hard_cap_seconds = 1.0
     adapter._text_debounce = {}
+    adapter._ingress_batch_seconds = 0.0
+    adapter._ingress_batch_hard_cap_seconds = 0.0
+    adapter._ingress_batches = {}
     adapter._auto_tts_default = False
     adapter._auto_tts_enabled_chats = set()
     adapter._auto_tts_disabled_chats = set()
@@ -113,6 +116,319 @@ def _make_adapter() -> BasePlatformAdapter:
 
 def _debounced_event(adapter: BasePlatformAdapter, session_key: str) -> MessageEvent:
     return adapter._text_debounce[session_key].event
+
+
+def _make_media_event(
+    text: str,
+    path: str,
+    media_type: str,
+    *,
+    message_type: MessageType = MessageType.DOCUMENT,
+    chat_id: str = "12345",
+    user_id: str = "u1",
+    thread_id: str | None = None,
+) -> MessageEvent:
+    event = _make_event(
+        text,
+        chat_id=chat_id,
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+    event.message_type = message_type
+    event.media_urls = [path]
+    event.media_types = [media_type]
+    return event
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_batches_three_text_messages_before_starting_turn():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    adapter._ingress_batch_hard_cap_seconds = 0.5
+    started: list[MessageEvent] = []
+
+    def _fake_start(event, session_key, *, interrupt_event=None):
+        started.append(event)
+        return True
+
+    adapter._start_session_processing = _fake_start  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("one"))
+    await adapter.handle_message(_make_event("two"))
+    await adapter.handle_message(_make_event("three"))
+
+    assert started == []
+    await asyncio.sleep(0.12)
+
+    assert len(started) == 1
+    assert started[0].text == "one\ntwo\nthree"
+    assert started[0].media_urls == []
+    assert adapter._ingress_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_batches_text_and_file_into_one_turn():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    started: list[MessageEvent] = []
+    adapter._start_session_processing = lambda event, session_key, *, interrupt_event=None: started.append(event) or True  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("task text"))
+    await adapter.handle_message(_make_media_event("file caption", "/tmp/a.pdf", "application/pdf"))
+
+    await asyncio.sleep(0.12)
+
+    assert len(started) == 1
+    assert started[0].text == "task text\nfile caption"
+    assert started[0].media_urls == ["/tmp/a.pdf"]
+    assert started[0].media_types == ["application/pdf"]
+    assert started[0].message_type == MessageType.DOCUMENT
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_batches_text_and_image_into_one_turn():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    started: list[MessageEvent] = []
+    adapter._start_session_processing = lambda event, session_key, *, interrupt_event=None: started.append(event) or True  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("look at this"))
+    await adapter.handle_message(
+        _make_media_event(
+            "image caption",
+            "/tmp/image.jpg",
+            "image/jpeg",
+            message_type=MessageType.PHOTO,
+        )
+    )
+
+    await asyncio.sleep(0.12)
+
+    assert len(started) == 1
+    assert started[0].text == "look at this\nimage caption"
+    assert started[0].media_urls == ["/tmp/image.jpg"]
+    assert started[0].media_types == ["image/jpeg"]
+    assert started[0].message_type == MessageType.PHOTO
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_batch_keys_include_user_and_thread():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    started: list[MessageEvent] = []
+    adapter._start_session_processing = lambda event, session_key, *, interrupt_event=None: started.append(event) or True  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("alice t1", chat_type="group", user_id="alice", thread_id="topic-1"))
+    await adapter.handle_message(_make_event("bob t1", chat_type="group", user_id="bob", thread_id="topic-1"))
+    await adapter.handle_message(_make_event("alice t2", chat_type="group", user_id="alice", thread_id="topic-2"))
+
+    await asyncio.sleep(0.12)
+
+    assert sorted(event.text for event in started) == ["alice t1", "alice t2", "bob t1"]
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_discards_pending_batch_when_reset_command_arrives():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    started: list[MessageEvent] = []
+    adapter._start_session_processing = lambda event, session_key, *, interrupt_event=None: started.append(event) or True  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("stale task text"))
+    await adapter.handle_message(_make_event("/new"))
+
+    await asyncio.sleep(0.12)
+
+    assert [event.text for event in started] == ["/new"]
+    assert adapter._ingress_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_preserves_order_when_session_becomes_busy_before_next_event():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.2
+    adapter._busy_text_mode = ""  # expose direct active-session pending merge order
+    first = _make_event("first")
+    session_key = build_session_key(first.source)
+
+    await adapter.handle_message(first)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    await adapter.handle_message(_make_event("second"))
+
+    await asyncio.sleep(0.25)
+
+    assert adapter._pending_messages[session_key].text == "first\nsecond"
+    assert adapter._ingress_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_ingress_batch_cleanup_in_cancel_background_tasks():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 1.0
+    started: list[MessageEvent] = []
+    adapter._start_session_processing = lambda event, session_key, *, interrupt_event=None: started.append(event) or True  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("cleanup ingress"))
+    assert adapter._ingress_batches
+
+    await adapter.cancel_background_tasks()
+    await asyncio.sleep(0.05)
+
+    assert adapter._ingress_batches == {}
+    assert started == []
+
+
+def test_ingress_batch_config_ignores_malformed_values():
+    adapter = _DummyAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "ingress_batch_seconds": "not-a-float",
+                "ingress_batch_hard_cap_seconds": "also-bad",
+            },
+        ),
+        Platform.TELEGRAM,
+    )
+
+    assert adapter._ingress_batch_seconds == 0.0
+    assert adapter._ingress_batch_hard_cap_seconds == 0.0
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_flush_queues_if_session_becomes_busy():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    event = _make_event("queued after busy")
+    session_key = build_session_key(event.source)
+
+    await adapter.handle_message(event)
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await asyncio.sleep(0.12)
+
+    assert session_key in adapter._pending_messages
+    assert adapter._pending_messages[session_key].text == "queued after busy"
+    assert adapter._ingress_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_batch_hard_cap_splits_late_message():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.2
+    adapter._ingress_batch_hard_cap_seconds = 0.05
+    started: list[MessageEvent] = []
+
+    def _fake_start(event, session_key, *, interrupt_event=None):
+        started.append(event)
+        adapter._active_sessions[session_key] = interrupt_event or asyncio.Event()
+        return True
+
+    adapter._start_session_processing = _fake_start  # type: ignore[method-assign]
+
+    await adapter.handle_message(_make_event("first"))
+    await asyncio.sleep(0.08)
+    await adapter.handle_message(_make_event("late"))
+    await asyncio.sleep(0.12)
+
+    assert [event.text for event in started] == ["first"]
+    # The second event arrived after the first batch's hard cap and is queued
+    # behind the now-active session instead of being merged into the first turn.
+    assert build_session_key(_make_event("late").source) in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_preserves_order_for_distinct_users_in_shared_thread_session():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.2
+    started: list[str] = []
+
+    def _fake_start(event, session_key, *, interrupt_event=None):
+        started.append(event.text)
+        adapter._active_sessions[session_key] = interrupt_event or asyncio.Event()
+        return True
+
+    adapter._start_session_processing = _fake_start  # type: ignore[method-assign]
+
+    alice = _make_event(
+        "alice first",
+        chat_id="group-1",
+        chat_type="group",
+        user_id="alice",
+        thread_id="topic-1",
+    )
+    bob = _make_event(
+        "bob second",
+        chat_id="group-1",
+        chat_type="group",
+        user_id="bob",
+        thread_id="topic-1",
+    )
+    session_key = build_session_key(alice.source)
+    assert session_key == build_session_key(bob.source)
+    assert adapter._build_ingress_batch_key(alice) != adapter._build_ingress_batch_key(bob)
+
+    await adapter.handle_message(alice)
+    await adapter.handle_message(bob)
+
+    assert started == ["alice first"]
+    assert adapter._pending_messages[session_key].text == "bob second"
+    assert adapter._ingress_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_preserves_order_for_distinct_users_when_group_sessions_shared():
+    adapter = _make_adapter()
+    adapter.config.extra["group_sessions_per_user"] = False
+    adapter._ingress_batch_seconds = 0.2
+    started: list[str] = []
+
+    def _fake_start(event, session_key, *, interrupt_event=None):
+        started.append(event.text)
+        adapter._active_sessions[session_key] = interrupt_event or asyncio.Event()
+        return True
+
+    adapter._start_session_processing = _fake_start  # type: ignore[method-assign]
+
+    alice = _make_event("alice first", chat_id="group-1", chat_type="group", user_id="alice")
+    bob = _make_event("bob second", chat_id="group-1", chat_type="group", user_id="bob")
+    session_key = build_session_key(alice.source, group_sessions_per_user=False)
+    assert session_key == build_session_key(bob.source, group_sessions_per_user=False)
+    assert adapter._build_ingress_batch_key(alice) != adapter._build_ingress_batch_key(bob)
+
+    await adapter.handle_message(alice)
+    await adapter.handle_message(bob)
+
+    assert started == ["alice first"]
+    assert adapter._pending_messages[session_key].text == "bob second"
+    assert adapter._ingress_batches == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_ingress_key_includes_session_key_to_prevent_cross_session_merge():
+    adapter = _make_adapter()
+    adapter._ingress_batch_seconds = 0.05
+    started: list[tuple[str, str]] = []
+
+    def _fake_start(event, session_key, *, interrupt_event=None):
+        started.append((session_key, event.text))
+        return True
+
+    adapter._start_session_processing = _fake_start  # type: ignore[method-assign]
+
+    dm_event = _make_event("dm text", chat_id="same", chat_type="dm", user_id="u1")
+    group_event = _make_event("group text", chat_id="same", chat_type="group", user_id="u1")
+    dm_session = build_session_key(dm_event.source)
+    group_session = build_session_key(group_event.source)
+    assert dm_session != group_session
+    assert adapter._build_ingress_batch_key(dm_event, dm_session) != adapter._build_ingress_batch_key(group_event, group_session)
+
+    await adapter.handle_message(dm_event)
+    await adapter.handle_message(group_event)
+    await asyncio.sleep(0.12)
+
+    assert started == [(dm_session, "dm text"), (group_session, "group text")]
+    assert adapter._ingress_batches == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Batch rapid idle ingress messages into a single gateway turn
- Merge text and attachments before session start
- Preserve ordering when sessions become active
- Add regression coverage for text, files, images, session keys, cleanup, and hard cap behavior

## Test Plan
- `python -m pytest tests/gateway/test_active_session_text_merge.py -q -o 'addopts='`
- `python -m py_compile gateway/platforms/base.py tests/gateway/test_active_session_text_merge.py`
- `git diff --check origin/main..HEAD`
