### PR TITLE
fix(slack): approval and confirm buttons ignore configured authorization

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2810,16 +2810,13 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = body.get("user", {}).get("id", "")
 
         # Authorization — reuse the exec-approval allowlist.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
-                    user_name,
-                    user_id,
-                )
-                return
+        if not self._is_slack_button_user_authorized(channel_id, user_id):
+            logger.warning(
+                "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
+                user_name,
+                user_id,
+            )
+            return
 
         # Parse session_key|confirm_id back out
         if "|" not in value:
@@ -2920,16 +2917,13 @@ class SlackAdapter(BasePlatformAdapter):
         # Only authorized users may click approval buttons.  Button clicks
         # bypass the normal message auth flow in gateway/run.py, so we must
         # check here as well.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized approval click by %s (%s) — ignoring",
-                    user_name,
-                    user_id,
-                )
-                return
+        if not self._is_slack_button_user_authorized(channel_id, user_id):
+            logger.warning(
+                "[Slack] Unauthorized approval click by %s (%s) — ignoring",
+                user_name,
+                user_id,
+            )
+            return
 
         # Map action_id to approval choice
         choice_map = {
@@ -3004,6 +2998,48 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         # (approval state already consumed by atomic pop above)
+
+    def _is_slack_button_user_authorized(self, channel_id: str, user_id: str) -> bool:
+        """Authorize Slack interactive callbacks against configured gateway access."""
+        if not user_id:
+            return False
+
+        if os.getenv("SLACK_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            return True
+
+        pairing_store = getattr(self, "pairing_store", None)
+        is_approved = getattr(pairing_store, "is_approved", None)
+        if callable(is_approved):
+            try:
+                if is_approved(Platform.SLACK.value, user_id):
+                    return True
+            except Exception:
+                logger.debug("[Slack] pairing-store authorization check failed", exc_info=True)
+
+        configured_allowlists = [
+            os.getenv("SLACK_ALLOWED_USERS", "").strip(),
+            os.getenv("GATEWAY_ALLOWED_USERS", "").strip(),
+        ]
+        allowed_ids = {
+            value.strip()
+            for raw in configured_allowlists
+            for value in raw.split(",")
+            if value.strip()
+        }
+
+        if not allowed_ids:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {
+                "true",
+                "1",
+                "yes",
+            }
+        if "*" in allowed_ids:
+            return True
+
+        check_ids = {user_id}
+        if "@" in user_id:
+            check_ids.add(user_id.split("@", 1)[0])
+        return bool(check_ids & allowed_ids)
 
     # ----- Thread context fetching -----
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2095,6 +2095,11 @@ class GatewayRunner:
             )
 
 
+    def _bind_adapter_runtime(self, adapter: BasePlatformAdapter) -> None:
+        """Attach shared gateway runtime services used by adapter callbacks."""
+        adapter.pairing_store = self.pairing_store
+
+
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
         """Warn when Docker-backed gateways lack an explicit export mount.
 
@@ -4499,6 +4504,7 @@ class GatewayRunner:
                 continue
             
             # Set up message + fatal error handlers
+            self._bind_adapter_runtime(adapter)
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
@@ -6242,6 +6248,7 @@ class GatewayRunner:
                         del self._failed_platforms[platform]
                         continue
 
+                    self._bind_adapter_runtime(adapter)
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -42,7 +43,8 @@ def _ensure_slack_mock():
 _ensure_slack_mock()
 
 from gateway.platforms.slack import SlackAdapter
-from gateway.config import PlatformConfig
+from gateway.config import GatewayConfig, PlatformConfig
+from gateway.run import GatewayRunner
 
 
 def _make_adapter():
@@ -55,6 +57,15 @@ def _make_adapter():
     adapter._team_bot_user_ids = {"T1": "U_BOT"}
     adapter._channel_team = {"C1": "T1"}
     return adapter
+
+
+def test_gateway_runner_binds_pairing_store_to_slack_adapter():
+    runner = GatewayRunner(GatewayConfig())
+    adapter = _make_adapter()
+
+    runner._bind_adapter_runtime(adapter)
+
+    assert adapter.pairing_store is runner.pairing_store
 
 
 # ===========================================================================
@@ -154,6 +165,9 @@ class TestSlackApprovalAction:
     async def test_resolves_approval(self):
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = False
+        adapter.pairing_store = SimpleNamespace(
+            is_approved=lambda platform, user_id: platform == "slack" and user_id == "U_NORBERT"
+        )
 
         ack = AsyncMock()
         body = {
@@ -165,7 +179,7 @@ class TestSlackApprovalAction:
                 ],
             },
             "channel": {"id": "C1"},
-            "user": {"name": "norbert"},
+            "user": {"name": "norbert", "id": "U_NORBERT"},
         }
         action = {
             "action_id": "hermes_approve_once",
@@ -185,6 +199,216 @@ class TestSlackApprovalAction:
         mock_client.chat_update.assert_called_once()
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Approved once by norbert" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_resolves_approval_for_global_allowed_user(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_AUTHORIZED")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "approved", "id": "U_AUTHORIZED"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_called_once_with("agent:main:slack:group:C1:1111", "once")
+        mock_client.chat_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_approval_for_global_denied_user(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_AUTHORIZED")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "intruder", "id": "U_ATTACKER"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gateway_allow_all_does_not_bypass_explicit_allowlist(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_AUTHORIZED")
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "intruder", "id": "U_ATTACKER"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gateway_allow_all_permits_when_no_allowlists_exist(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "approved", "id": "U_ANYONE"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_called_once_with("agent:main:slack:group:C1:1111", "once")
+        mock_client.chat_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolves_approval_for_paired_user_with_global_allowlist(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        adapter.pairing_store = SimpleNamespace(
+            is_approved=lambda platform, user_id: platform == "slack" and user_id == "U_PAIRED"
+        )
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_AUTHORIZED")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "paired", "id": "U_PAIRED"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_called_once_with("agent:main:slack:group:C1:1111", "once")
+        mock_client.chat_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolves_approval_for_paired_user_without_env_allowlists(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        adapter.pairing_store = SimpleNamespace(
+            is_approved=lambda platform, user_id: platform == "slack" and user_id == "U_PAIRED"
+        )
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "paired", "id": "U_PAIRED"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_called_once_with("agent:main:slack:group:C1:1111", "once")
+        mock_client.chat_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_unpaired_approval_when_pairing_store_is_available(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        adapter.pairing_store = SimpleNamespace(is_approved=lambda platform, user_id: False)
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "intruder", "id": "U_ATTACKER"},
+        }
+        action = {
+            "action_id": "hermes_approve_once",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_prevents_double_click(self):
@@ -213,6 +437,9 @@ class TestSlackApprovalAction:
     async def test_deny_action(self):
         adapter = _make_adapter()
         adapter._approval_resolved["1.2"] = False
+        adapter.pairing_store = SimpleNamespace(
+            is_approved=lambda platform, user_id: platform == "slack" and user_id == "U_ALICE"
+        )
 
         ack = AsyncMock()
         body = {
@@ -220,7 +447,7 @@ class TestSlackApprovalAction:
                 {"type": "section", "text": {"type": "mrkdwn", "text": "cmd"}},
             ]},
             "channel": {"id": "C1"},
-            "user": {"name": "alice"},
+            "user": {"name": "alice", "id": "U_ALICE"},
         }
         action = {"action_id": "hermes_deny", "value": "session-key"}
 
@@ -233,6 +460,88 @@ class TestSlackApprovalAction:
         mock_resolve.assert_called_once_with("session-key", "deny")
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Denied by alice" in update_kwargs["text"]
+
+
+# ===========================================================================
+# _handle_slash_confirm_action — button click handler
+# ===========================================================================
+
+class TestSlackSlashConfirmAction:
+    """Test the slash-confirm button click handler."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_slash_confirm_for_global_denied_user(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_AUTHORIZED")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "intruder", "id": "U_ATTACKER"},
+        }
+        action = {
+            "action_id": "hermes_confirm_once",
+            "value": "agent:main:slack:group:C1:1111|confirm-123",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_awaited()
+        mock_client.chat_update.assert_not_called()
+        mock_client.chat_postMessage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolves_slash_confirm_for_paired_user_without_env_allowlists(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter.pairing_store = SimpleNamespace(
+            is_approved=lambda platform, user_id: platform == "slack" and user_id == "U_PAIRED"
+        )
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "1234.5678",
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": "confirm?"}},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "paired", "id": "U_PAIRED"},
+        }
+        action = {
+            "action_id": "hermes_confirm_once",
+            "value": "agent:main:slack:group:C1:1111|confirm-123",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock()
+
+        with patch(
+            "tools.slash_confirm.resolve",
+            new_callable=AsyncMock,
+            return_value="confirmed",
+        ) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_awaited_once_with(
+            "agent:main:slack:group:C1:1111", "confirm-123", "once"
+        )
+        mock_client.chat_update.assert_called_once()
+        mock_client.chat_postMessage.assert_called_once()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
An unauthorized Slack user who can see a pending approval or slash-confirm message in a shared channel or thread can approve, deny, or persist another caller's dangerous-command decision when the operator relies on `GATEWAY_ALLOWED_USERS` or pairing instead of `SLACK_ALLOWED_USERS`.

That changes protected approval state and can unblock execution or destructive slash-command handling across the Slack external surface.

- Approval and slash-confirm buttons bypass the normal Slack message authorization path.
- The callbacks only check `SLACK_ALLOWED_USERS`; when unset, there is no caller authorization check.
- The callbacks then resolve session approval or destructive slash-confirm state.
- A visible but unauthorized Slack user can decide another session's blocked command or slash-confirm prompt.

Route Slack interactive callbacks through the same authorization helper used for normal Slack messages, or require the callback user to satisfy an equivalent combined allowlist/pairing decision before resolving approvals.

## Linked context
Closes #38068

## Real behavior proof (required for external PRs)
### Affected component (issue scope)
**File:** `gateway/platforms/slack.py:2812-2822,2920-2932`

```python
        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
        if allowed_csv:
            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
            if "*" not in allowed_ids and user_id not in allowed_ids:
                return
        result_text = await _slash_confirm_mod.resolve(session_key, confirm_id, choice)
        count = resolve_gateway_approval(session_key, choice)
```

Secondary paths: `gateway/platforms/slack.py:2740-2799` posts slash-confirm buttons; `gateway/platforms/slack.py:2666-2719` posts approval buttons; `gateway/run.py:7073-7154` defines the broader gateway authorization set.

### Files changed in this PR
- `gateway/run.py`
- `gateway/platforms/slack.py`
- `tests/gateway/test_slack_approval_buttons.py`

### Behavior reproduced or verified
1. Against current `main` commit `e2ea648a08265164ef103005d533ed28ec58ceb8`, configure Slack with `GATEWAY_ALLOWED_USERS=U_AUTHORIZED` and leave `SLACK_ALLOWED_USERS` unset.
2. Place `U_AUTHORIZED` and `U_ATTACKER` in the same Slack channel.
3. Have `U_AUTHORIZED` trigger a dangerous command or destructive slash confirmation so Slack posts the callback buttons.
4. Click Allow Once, Deny, Confirm Once, or Always Confirm as `U_ATTACKER` and observe that the callback reaches `resolve_gateway_approval(...)` or `slash_confirm.resolve(...)`.
5. Expected: the callback rejects users outside the gateway authorization set before changing approval or confirmation state.

### Expected fixed behavior
Route Slack interactive callbacks through the same authorization helper used for normal Slack messages, or require the callback user to satisfy an equivalent combined allowlist/pairing decision before resolving approvals.

## Tests and validation
- `bash scripts/run_tests.sh tests/gateway/test_slack_approval_buttons.py`
- Result: 1 files, 33 tests passed, 0 failed (100% complete) in 1.5s (20 workers) ===

## Environment
Verified against latest upstream `main` via source receipt (`source_ready`, `upstream-main`, `e2ea648a08265164ef103005d533ed28ec58ceb8`). Full-public submit-fix route is declared by candidate metadata. Redaction checked: no secrets, tokens, credentials, private logs, or unrelated local paths are included.

## Risk checklist
- Security/auth/secrets impact: Yes; this is a full-public security route.
- Approval gate: Current-turn full-public approval evidence was confirmed before live publication.
- Public disclosure safety: Redaction and public-body validation run before GitHub mutation.
- Regression risk: Scoped to the linked fix branch and covered by the tests above.
- Issue-body contract: Unchanged; the linked issue carries the canonical security disclosure.
