### PR TITLE
fix(security): gate cp/mv/install into ~/.ssh, credential, and shell-rc files

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -595,6 +595,43 @@ class TestProjectSensitiveCopyPattern:
         assert desc is None
 
 
+class TestSensitiveCopyMovePattern:
+    """cp/mv/install OVERWRITING ~/.ssh/*, credential files (~/.netrc etc.),
+    shell rc files, or ~/.hermes/config.yaml/.env must require approval — the
+    tee/redirection forms were already gated (#14639 family / commit 4e9d886d),
+    but cp/mv/install on these targets was an unpaired half-door (key implant /
+    shell-rc command injection slipped through auto-approve)."""
+
+    def test_cp_to_ssh_authorized_keys(self):
+        dangerous, key, desc = detect_dangerous_command("cp /tmp/evil ~/.ssh/authorized_keys")
+        assert dangerous is True
+        assert key is not None
+
+    def test_mv_to_ssh_private_key(self):
+        dangerous, key, desc = detect_dangerous_command("mv /tmp/k ~/.ssh/id_rsa")
+        assert dangerous is True
+
+    def test_install_to_netrc(self):
+        dangerous, key, desc = detect_dangerous_command("install -m600 /tmp/c ~/.netrc")
+        assert dangerous is True
+
+    def test_cp_to_bashrc(self):
+        dangerous, key, desc = detect_dangerous_command("cp /tmp/e ~/.bashrc")
+        assert dangerous is True
+
+    def test_cp_to_hermes_config(self):
+        dangerous, key, desc = detect_dangerous_command("cp /tmp/evil.yaml ~/.hermes/config.yaml")
+        assert dangerous is True
+
+    def test_cp_from_ssh_is_safe(self):
+        dangerous, key, desc = detect_dangerous_command("cp ~/.ssh/config /tmp/x")
+        assert dangerous is False
+
+    def test_cp_unrelated_files_safe(self):
+        dangerous, key, desc = detect_dangerous_command("cp a.txt b.txt")
+        assert dangerous is False
+
+
 class TestProjectSensitiveTeePattern:
     def test_tee_to_local_dotenv_requires_approval(self):
         dangerous, key, desc = detect_dangerous_command("printenv | tee .env.local")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -435,6 +435,20 @@ DANGEROUS_PATTERNS = [
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),
     (rf'\b(cp|mv|install)\b.*\s["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config file"),
+    # cp/mv/install OVERWRITING a sensitive credential/SSH/shell-rc/Hermes file.
+    # The tee/redirection patterns above already gate _SENSITIVE_WRITE_TARGET
+    # (~/.ssh/*, ~/.netrc/.pgpass/.npmrc/.pypirc, shell rc files,
+    # ~/.hermes/config.yaml/.env), but cp/mv/install was only paired for /etc and
+    # project-relative env/config — so `cp evil ~/.ssh/authorized_keys` (key
+    # implant), `cp creds ~/.netrc`, and `cp evil ~/.bashrc` (login-time command
+    # injection) slipped through with auto-approve. Same unpaired-door rationale
+    # as #14639 / the sed-tee-redirect pairing on these targets.
+    # Anchor the sensitive target to the command tail so this fires on the
+    # DESTINATION (last arg) only — `cp evil ~/.ssh/authorized_keys` is gated,
+    # but reading OUT of a sensitive path (`cp ~/.ssh/config /tmp/x`) stays safe.
+    # The trailing `[^\s"\']*` consumes the rest of the destination filename
+    # (e.g. `authorized_keys` after the `~/.ssh/` fragment).
+    (rf'\b(cp|mv|install)\b.*\s["\']?{_SENSITIVE_WRITE_TARGET}[^\s"\']*["\']?{_COMMAND_TAIL}', "copy/move file into sensitive credential/SSH/shell-rc path"),
     (rf'\bsed\s+-[^\s]*i.*\s{_SYSTEM_CONFIG_PATH}', "in-place edit of system config"),
     (rf'\bsed\s+--in-place\b.*\s{_SYSTEM_CONFIG_PATH}', "in-place edit of system config (long flag)"),
     # In-place edit of a Hermes-managed security file (~/.hermes/config.yaml or


### PR DESCRIPTION
## This is a sibling follow-up to commit 4e9d886d (fix(approval): pair terminal-side gate for ~/.hermes/config.yaml writes)

- **4e9d886d covered:** terminal-side pairing (`sed -i` / `tee` / `>`) for `~/.hermes/config.yaml` writes, pairing the file_tools write_file/patch deny.
- **4e9d886d did NOT touch:** the `cp`/`mv`/`install` verbs on the broader `_SENSITIVE_WRITE_TARGET` set — `~/.ssh/`, credential files (`~/.netrc`/`.pgpass`/`.npmrc`/`.pypirc`), and shell rc files (`~/.bashrc` etc.). Those verbs were only paired for `/etc` and project-relative env/config.
- **This PR adds** the `cp`/`mv`/`install` pairing for those targets — the same unpaired-door pattern, but it reaches a worse resource (SSH-key implant / login-time shell-rc command injection).

## What does this PR do?

`tools/approval.py` already gates `tee`/`>`/`>>` writes to every `_SENSITIVE_WRITE_TARGET` (DANGEROUS_PATTERNS, the `tee`/redirection rules). But `cp`/`mv`/`install` were only gated for `_SYSTEM_CONFIG_PATH` and `_PROJECT_SENSITIVE_WRITE_TARGET`, so `cp evil ~/.ssh/authorized_keys`, `cp creds ~/.netrc`, and `cp evil ~/.bashrc` slipped through with auto-approve while the `tee`/`>` forms were denied. An unpaired write deny is theater (per the parent commit / SECURITY.md). This adds one cp/mv/install pattern over the existing `_SENSITIVE_WRITE_TARGET` fragment.

The new pattern is anchored to the command tail (`_COMMAND_TAIL`) so it fires on the **destination** (last argument) only: copying *out of* a sensitive path (`cp ~/.ssh/config /tmp/x`) stays auto-approved, only writes *into* one are gated. A trailing `[^\s"']*` consumes the rest of the destination filename (e.g. `authorized_keys` after the `~/.ssh/` fragment). The description string differs from the existing system-config cp entry, so the two keep **distinct approval keys** — approving a `/etc` copy does not silently auto-approve an `~/.ssh` copy.

## Related Issue

N/A — sibling-widening of commit 4e9d886d; no separate tracking issue.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py`: add a `(cp|mv|install)` DANGEROUS_PATTERNS entry targeting `_SENSITIVE_WRITE_TARGET` (`~/.ssh/`, credential files, shell rc, `~/.hermes/config.yaml`/`.env`), anchored on the destination, pairing the existing tee/redirection coverage.
- `tests/tools/test_approval.py`: add `TestSensitiveCopyMovePattern` — 5 positive cases (ssh authorized_keys / ssh private key via mv / netrc via install / bashrc / hermes config) + 2 negative guards (copy FROM ssh, unrelated copy).

## How to Test

1. `detect_dangerous_command("cp /tmp/evil ~/.ssh/authorized_keys")` -> dangerous on this branch; `False` on main.
2. `detect_dangerous_command("cp ~/.ssh/config /tmp/x")` -> stays `False` (read-out is safe).
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/tools/test_approval.py -q` -> 204 passed.

Regression guard (verified both directions): with the prod hunk reverted, the ssh/netrc/bashrc positives go RED while the 2 negatives stay green; restore -> all 7 green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test file and all tests pass (`tests/tools/test_approval.py`: 204 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (regex matches `~`/`$HOME` forms; no platform-specific paths added)