### PR TITLE
fix(whatsapp): scrub operator environment from bridge subprocess

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -622,22 +622,38 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Build bridge subprocess environment.
             # Pass WHATSAPP_REPLY_PREFIX from config.yaml so the Node bridge
             # can use it without the user needing to set a separate env var.
-            # with_hermes_node_path() copies os.environ when called with no arg.
-            bridge_env = with_hermes_node_path()
-            if self._reply_prefix is not None:
-                bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
-            # Pass the profile-aware cache directories so the bridge writes
-            # media where the Python side reads it.  Without these the bridge
-            # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges
-            # under HERMES_HOME overrides, profiles, and the new cache/ layout.
+            from tools.environments.local import (
+                _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+                _sanitize_subprocess_env,
+            )
             from gateway.platforms.base import (
                 get_audio_cache_dir as _get_audio_dir,
                 get_document_cache_dir as _get_doc_dir,
                 get_image_cache_dir as _get_img_dir,
             )
-            bridge_env["HERMES_IMAGE_CACHE_DIR"] = str(_get_img_dir())
-            bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
-            bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
+
+            # Only explicitly restore values consumed by the bridge. The
+            # allowlist is blocklisted for ordinary subprocesses, so its force
+            # prefix is required here; the sanitizer removes the prefix before
+            # returning the child environment.
+            bridge_extra_env = {
+                "HERMES_IMAGE_CACHE_DIR": str(_get_img_dir()),
+                "HERMES_AUDIO_CACHE_DIR": str(_get_audio_dir()),
+                "HERMES_DOCUMENT_CACHE_DIR": str(_get_doc_dir()),
+            }
+            if self._reply_prefix is not None:
+                bridge_extra_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
+            allowed_users = os.getenv("WHATSAPP_ALLOWED_USERS")
+            if allowed_users is not None:
+                bridge_extra_env[
+                    f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}WHATSAPP_ALLOWED_USERS"
+                ] = allowed_users
+
+            # Preserve managed Node discovery, but apply it to the filtered
+            # environment instead of letting it copy the operator environment.
+            bridge_env = with_hermes_node_path(
+                _sanitize_subprocess_env(os.environ, bridge_extra_env)
+            )
 
             self._bridge_process = subprocess.Popen(
                 [

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -13,7 +13,9 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 """
 
 import asyncio
+import os
 import signal
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -190,6 +192,62 @@ class TestDataInitialized:
 
 class TestFileHandleClosedOnError:
     """Verify the bridge log file handle is closed on every failure path."""
+
+    @pytest.mark.asyncio
+    async def test_bridge_env_scrubs_operator_credentials(self, monkeypatch):
+        """Bridge gets required runtime config, not operator credentials."""
+        adapter = _make_adapter()
+        adapter._reply_prefix = "Hermes:"
+
+        monkeypatch.setenv("OPENAI_API_KEY", "blocked-openai-value")
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "attacker")
+        monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "+15555550123")
+        monkeypatch.setenv("MODAL_TOKEN_SECRET", "blocked-modal-value")
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+        mock_fh = MagicMock()
+        mock_client_cls = _mock_aiohttp(status=503, json_data={})
+        patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+        def _with_node_path(env=None):
+            merged = dict(os.environ if env is None else env)
+            merged["PATH"] = f"/hermes/node/bin{os.pathsep}{merged.get('PATH', '')}"
+            return merged
+
+        node_path = MagicMock(side_effect=_with_node_path)
+
+        with ExitStack() as stack:
+            for item in (*patches[:4], *patches[5:]):
+                stack.enter_context(item)
+            popen = stack.enter_context(patch("subprocess.Popen", return_value=mock_proc))
+            stack.enter_context(
+                patch(
+                    "plugins.platforms.whatsapp.adapter.with_hermes_node_path",
+                    node_path,
+                )
+            )
+            result = await adapter.connect()
+
+        assert result is False
+        bridge_env = popen.call_args.kwargs["env"]
+        assert bridge_env["WHATSAPP_REPLY_PREFIX"] == "Hermes:"
+        assert bridge_env["PATH"] == f"/hermes/node/bin{os.pathsep}/usr/bin"
+        assert bridge_env["HERMES_IMAGE_CACHE_DIR"]
+        assert bridge_env["HERMES_AUDIO_CACHE_DIR"]
+        assert bridge_env["HERMES_DOCUMENT_CACHE_DIR"]
+        assert "OPENAI_API_KEY" not in bridge_env
+        assert bridge_env["WHATSAPP_ALLOWED_USERS"] == "+15555550123"
+        assert "GATEWAY_ALLOWED_USERS" not in bridge_env
+        assert "MODAL_TOKEN_SECRET" not in bridge_env
+
+        sanitized_before_node_path = node_path.call_args.args[0]
+        assert sanitized_before_node_path["PATH"] == "/usr/bin"
+        assert "OPENAI_API_KEY" not in sanitized_before_node_path
+        assert "GATEWAY_ALLOWED_USERS" not in sanitized_before_node_path
+        assert "MODAL_TOKEN_SECRET" not in sanitized_before_node_path
 
     @pytest.mark.asyncio
     async def test_closed_when_bridge_dies_phase1(self):


### PR DESCRIPTION
## Summary

The plugin-based WhatsApp adapter now launches its long-lived Node bridge with the shared sanitized subprocess environment instead of a copy of the full gateway environment.

- Filter Hermes-managed provider, gateway, platform, and remote-compute credentials through `_sanitize_subprocess_env` before bridge launch.
- Explicitly restore only bridge-consumed values: `WHATSAPP_REPLY_PREFIX`, the force-prefixed `WHATSAPP_ALLOWED_USERS` intake allowlist, and the three profile-aware media cache directories.
- Apply `with_hermes_node_path()` to the already-sanitized environment so current managed-Node discovery and PATH behavior remain intact.
- Preserve the current plugin adapter architecture and Windows subprocess launch behavior.

Closes #38079

## Review feedback addressed

- Ported the fix from the deleted `gateway/platforms/whatsapp.py` path to `plugins/platforms/whatsapp/adapter.py`.
- Ported the regression test to the current plugin-backed test setup.
- Preserved managed Node PATH injection by passing the sanitized dictionary into `with_hermes_node_path()`.
- Preserved the bridge-side `WHATSAPP_ALLOWED_USERS` contract through the sanitizer's force-prefix mechanism.
- Preserved profile-aware image, audio, and document cache paths introduced after the original branch was opened.

## Tests and validation

- `scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_whatsapp_stale_bridge.py` — 49 passed, 0 failed.
- `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py` — 51 passed, 0 failed.
- `ruff check plugins/platforms/whatsapp/adapter.py tests/gateway/test_whatsapp_connect.py` — passed.
- `git diff --check` — passed.

The bridge regression verifies that provider, gateway, and remote-compute credentials are absent; the WhatsApp reply prefix, allowlist, profile-aware cache paths, and managed Node PATH are retained; and sanitization occurs before Node PATH augmentation.

Rebased onto `477c08b44766ace8b890faa72bf82ecbcf2b3ba8`; current head is `a28bcac074ad44e2b28363bf357e290a41627a48`.
