### PR TITLE
fix(weixin): refresh typing ticket on expiry in send/stop_typing

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1621,6 +1621,33 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] voice download failed: %s", self.name, exc)
             return None
 
+    async def _ensure_typing_ticket(self, user_id: str) -> Optional[str]:
+        """Return a valid typing ticket, refreshing from iLink if cached ticket expired."""
+        ticket = self._typing_cache.get(user_id)
+        if ticket:
+            return ticket
+        if not self._poll_session or not self._token:
+            return None
+        try:
+            context_token = self._token_store.get(self._account_id, user_id)
+            response = await _get_config(
+                self._poll_session,
+                base_url=self._base_url,
+                token=self._token,
+                user_id=user_id,
+                context_token=context_token or None,
+            )
+            ticket = str(response.get("typing_ticket") or "")
+            if ticket:
+                self._typing_cache.set(user_id, ticket)
+                return ticket
+        except Exception as exc:
+            logger.warning(
+                "[%s] typing ticket refresh failed for %s: %s",
+                self.name, _safe_id(user_id), exc,
+            )
+        return None
+
     async def _maybe_fetch_typing_ticket(self, user_id: str, context_token: Optional[str]) -> None:
         if not self._poll_session or not self._token:
             return
@@ -1811,7 +1838,7 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         if not self._send_session or not self._token:
             return
-        typing_ticket = self._typing_cache.get(chat_id)
+        typing_ticket = await self._ensure_typing_ticket(chat_id)
         if not typing_ticket:
             return
         try:
@@ -1829,8 +1856,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def stop_typing(self, chat_id: str) -> None:
         if not self._send_session or not self._token:
             return
-        typing_ticket = self._typing_cache.get(chat_id)
+        typing_ticket = await self._ensure_typing_ticket(chat_id)
         if not typing_ticket:
+            logger.warning(
+                "[%s] Cannot stop typing for %s: no typing ticket (will retry on next message)",
+                self.name, _safe_id(chat_id),
+            )
             return
         try:
             await _send_typing(


### PR DESCRIPTION
## Problem

The `TypingTicketCache` in the Weixin adapter has a 600-second (10 min) TTL. When an agent session exceeds this duration — which happens regularly with hyperframes rendering, long tool chains, background approvals, etc. — the cached typing ticket expires mid-session.

After expiry, both `send_typing` and `stop_typing` read the cache, get `None`, and silently return:

```python
typing_ticket = self._typing_cache.get(chat_id)
if not typing_ticket:
    return  # ← never sends TYPING_STOP=2
```

The WeChat iLink server never receives the `TYPING_STOP` signal, so the client continues displaying the typing indicator **indefinitely** — even after the agent has finished responding.

## Fix

Three changes in `WeixinAdapter` (`gateway/platforms/weixin.py`):

1. **New method `_ensure_typing_ticket()`** — returns the cached ticket if still valid; otherwise fetches a fresh one from iLink via `_get_config`. Uses `context_token` from the token store to maintain session continuity.

2. **`send_typing()`** — calls `await self._ensure_typing_ticket(chat_id)` instead of `self._typing_cache.get(chat_id)`.

3. **`stop_typing()`** — same change, plus logs a `WARNING` when a ticket is still unavailable after the refresh attempt, so operators can detect persistent issues.

## Testing

- Reproduced the bug: started a session lasting >10 min (hyperframes video rendering), confirmed typing indicator remained after response delivery.
- After fix: typing clears normally even after long sessions. Ticket refresh happens transparently on the first `send_typing`/`stop_typing` call post-expiry.
- Regression: short sessions (<10 min) continue working identically — `_ensure_typing_ticket` returns the cached ticket immediately.