### PR TITLE
fix(gateway): expand  references in fallback_providers config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1221,6 +1221,7 @@ def _try_resolve_fallback_provider() -> dict | None:
             return None
         with open(cfg_path, encoding="utf-8") as _f:
             cfg = _y.safe_load(_f) or {}
+            cfg = _expand_env_vars(cfg)
         fb_list = get_fallback_chain(cfg)
         if not fb_list:
             return None
@@ -3276,6 +3277,7 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
+                    cfg = _expand_env_vars(cfg)
                 fb = get_fallback_chain(cfg)
                 if fb:
                     return fb


### PR DESCRIPTION
## Problem

`_load_fallback_model()` and `_try_resolve_fallback_provider()` in `gateway/run.py` read `config.yaml` with `yaml.safe_load()` but do not call `_expand_env_vars()` afterward. This causes `${VAR}` references in `fallback_providers.api_key` to be passed as literal strings to the fallback provider, resulting in HTTP 401 authentication failures.

## Steps to Reproduce

1. Configure `fallback_providers` with `${VAR}` syntax:
```
fallback_providers:
  - provider: deepseek
     model: deepseek-v4-flash
     base_url: https://api.deepseek.com/v1
     api_key: ${DEEPSEEK_API_KEY}
```
2. Set `DEEPSEEK_API_KEY` in `.env`
3. Trigger a fallback (primary model returns 401)
4. Fallback also fails — DeepSeek receives the literal string `${DEEPSEEK_API_KEY}`

## Fix

Added `_expand_env_vars()` after `yaml.safe_load()` in both functions, consistent with how other config loading paths in the gateway handle env var expansion.

## Workaround (before this fix)

Use `key_env` instead of `api_key`:
```
fallback_providers:
  - provider: deepseek
    model: deepseek-v4-flash
    base_url: https://api.deepseek.com/v1
    key_env: DEEPSEEK_API_KEY
```