### PR TITLE
fix(launchd): raise gateway file descriptor limit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3581,6 +3581,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 # Launchd (macOS)
 # =============================================================================
 
+LAUNCHD_NUMBER_OF_FILES_LIMIT = 4096
+
 
 def get_launchd_label() -> str:
     """Return the launchd service label, scoped per profile."""
@@ -4043,6 +4045,18 @@ def generate_launchd_plist() -> str:
 
     <key>ExitTimeOut</key>
     <integer>25</integer>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{LAUNCHD_NUMBER_OF_FILES_LIMIT}</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{LAUNCHD_NUMBER_OF_FILES_LIMIT}</integer>
+    </dict>
 
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -991,6 +991,18 @@ class TestProfileArg:
 
 
 
+    def test_launchd_plist_raises_file_descriptor_limit(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>HardResourceLimits</key>" in plist
+        assert plist.count("<key>NumberOfFiles</key>") == 2
+        assert "<integer>4096</integer>" in plist
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)


### PR DESCRIPTION
Fixes #30230.

Summary:
- Add launchd `SoftResourceLimits` and `HardResourceLimits` for `NumberOfFiles=4096` to the generated gateway plist.
- Keep the current main-branch `KeepAlive` shape while adding the fd limits.
- Add a regression test so macOS user-agent installs keep the higher fd limit.

Verification:
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestProfileArg::test_launchd_plist_raises_file_descriptor_limit -q` was the original red test on macOS before the plist change.
- `.venv\\Scripts\\python.exe -m pytest tests/hermes_cli/test_gateway_service.py::TestProfileArg::test_launchd_plist_raises_file_descriptor_limit -q --timeout-method=thread` -> skipped on Windows because the module imports POSIX `pwd`/`grp`.
- `.venv\\Scripts\\python.exe -m pytest tests/hermes_cli/test_gateway_service.py -q -k "launchd or ProfileArg" --timeout-method=thread` -> skipped on Windows for the same module-level POSIX import.
- Direct Windows smoke of `generate_launchd_plist()` -> confirmed `SoftResourceLimits`, `HardResourceLimits`, two `NumberOfFiles` keys, and `<integer>4096</integer>`.
- `.venv\\Scripts\\python.exe -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` -> passed.
- `git diff --check` -> passed.

Note: full `tests/hermes_cli/test_gateway_service.py` still needs a POSIX/macOS host to execute rather than skip.
