### PR TITLE
fix(desktop): keep updater out of install mode

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/lib.rs
+++ b/apps/bootstrap-installer/src-tauri/src/lib.rs
@@ -11,8 +11,8 @@
 mod bootstrap;
 mod events;
 mod install_script;
-mod powershell;
 mod paths;
+mod powershell;
 mod update;
 
 use std::sync::Arc;
@@ -64,6 +64,14 @@ where
         .any(|a| a.as_ref() == "--reinstall" || a.as_ref() == "--repair")
 }
 
+/// A bare installer launch should behave like a launcher once a complete
+/// desktop install exists. This keeps accidental install-mode starts from
+/// re-running the destructive repository stage. `--update` keeps its dedicated
+/// update flow, and `--repair` / `--reinstall` still force setup.
+fn should_launch_existing_desktop(mode: AppMode, force_setup: bool, installed: bool) -> bool {
+    mode == AppMode::Install && !force_setup && installed
+}
+
 /// Process-wide install state, shared across Tauri commands.
 ///
 /// The bootstrap is a one-shot, single-tenant process — we only need one
@@ -113,42 +121,36 @@ pub fn run() {
         .manage(Arc::new(AppState::new(mode)))
         .setup(move |app| {
             use tauri::Manager;
-            // Launcher fast path (macOS only): a bare ("Install") launch when
-            // Hermes is already installed should NOT show the installer or
-            // rebuild — it should just open the app, so the /Applications
-            // "Hermes" doubles as a normal launcher (first run installs, every
-            // later run launches instantly). The window is kept hidden until
-            // here via `"visible": false` so this path never flashes a window.
-            //
-            // Gated to macOS deliberately: on Windows/Linux the installer keeps
-            // its existing behavior (Windows users relaunch via the Start
-            // Menu/Desktop "Hermes" shortcuts that install.ps1 creates, and a
-            // reliable detached relaunch there needs the DETACHED_PROCESS +
-            // startup-grace handling used by launch_hermes_desktop — out of
-            // scope here). So this is a pure no-op on non-macOS.
+            // Launcher fast path: a bare ("Install") launch when Hermes is
+            // already installed should NOT show the installer or rebuild — it
+            // should just open the app. This also prevents an accidentally
+            // bare updater hand-off from re-entering install mode and
+            // mutating the checkout via scripts/install.*.
             //
             // `--reinstall`/`--repair` opts out so a broken install can be
             // repaired by re-running setup instead of launching the bad app.
-            if cfg!(target_os = "macos") && mode == AppMode::Install && !force_setup {
-                let install_root = paths::hermes_home().join("hermes-agent");
-                if bootstrap::hermes_is_installed(&install_root) {
-                    match bootstrap::spawn_installed_desktop(&install_root) {
-                        Ok(()) => {
-                            // Brief grace so the spawned app is registered
-                            // before we exit (mirrors launch_hermes_desktop).
-                            std::thread::sleep(std::time::Duration::from_millis(200));
-                            tracing::info!(
-                                "hermes already installed — relaunched desktop; exiting installer"
-                            );
-                            app.handle().exit(0);
-                            return Ok(());
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                ?err,
-                                "relaunch of installed desktop failed; showing installer UI"
-                            );
-                        }
+            let install_root = paths::hermes_home().join("hermes-agent");
+            if should_launch_existing_desktop(
+                mode,
+                force_setup,
+                bootstrap::hermes_is_installed(&install_root),
+            ) {
+                match bootstrap::spawn_installed_desktop(&install_root) {
+                    Ok(()) => {
+                        // Brief grace so the spawned app is registered
+                        // before we exit (mirrors launch_hermes_desktop).
+                        std::thread::sleep(std::time::Duration::from_millis(200));
+                        tracing::info!(
+                            "hermes already installed — relaunched desktop; exiting installer"
+                        );
+                        app.handle().exit(0);
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            ?err,
+                            "relaunch of installed desktop failed; showing installer UI"
+                        );
                     }
                 }
             }
@@ -160,7 +162,9 @@ pub fn run() {
                     }
                 }
                 None => {
-                    tracing::error!("main installer window not found; installer UI will not appear");
+                    tracing::error!(
+                        "main installer window not found; installer UI will not appear"
+                    );
                 }
             }
             Ok(())
@@ -187,7 +191,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{force_setup_from_args, AppMode};
+    use super::{force_setup_from_args, should_launch_existing_desktop, AppMode};
 
     #[test]
     fn bare_args_are_install() {
@@ -228,5 +232,33 @@ mod tests {
             AppMode::from_args(["--update", "--reinstall"]),
             AppMode::Update
         );
+    }
+
+    #[test]
+    fn bare_installer_launch_reopens_existing_desktop() {
+        assert!(should_launch_existing_desktop(
+            AppMode::Install,
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn update_and_repair_never_take_launcher_fast_path() {
+        assert!(!should_launch_existing_desktop(
+            AppMode::Update,
+            false,
+            true
+        ));
+        assert!(!should_launch_existing_desktop(
+            AppMode::Install,
+            true,
+            true
+        ));
+        assert!(!should_launch_existing_desktop(
+            AppMode::Install,
+            false,
+            false
+        ));
     }
 }

--- a/apps/bootstrap-installer/src/routes/progress.tsx
+++ b/apps/bootstrap-installer/src/routes/progress.tsx
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react'
 import { Button } from '../components/button'
 import {
   cancelInstall,
+  $mode,
   $progress,
   type BootstrapStateModel,
   type StageState
@@ -21,6 +22,7 @@ interface ProgressProps {
  */
 export default function ProgressScreen({ bootstrap }: ProgressProps) {
   const progress = useStore($progress)
+  const mode = useStore($mode)
   const [showLogs, setShowLogs] = useState(false)
   const logEndRef = useRef<HTMLDivElement>(null)
 
@@ -50,7 +52,9 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
                   : 'Preparing\u2026'
                 : bootstrap.status === 'completed'
                   ? 'Done'
-                  : 'Installing'}
+                  : mode === 'update'
+                    ? 'Updating'
+                    : 'Installing'}
             </span>
           </div>
           <div className="text-muted-foreground">
@@ -144,13 +148,13 @@ export default function ProgressScreen({ bootstrap }: ProgressProps) {
           />
         </button>
 
-        {bootstrap.status === 'running' && (
+        {bootstrap.status === 'running' && mode !== 'update' && (
           <Button
             variant="outline"
             size="sm"
             onClick={() => void cancelInstall()}
           >
-            Cancel
+            Cancel install
           </Button>
         )}
       </div>


### PR DESCRIPTION
Fixes #38046.

Summary:
- Treat a bare Hermes Setup launch as a launcher when a complete desktop install already exists, so accidental install-mode starts cannot re-run the repository install stage.
- Keep `--update` and `--repair`/`--reinstall` on their explicit paths.
- Make the progress screen update-aware and hide install cancellation during update handoff.

Windows updater handoff review:
- The rebase kept the final diff scoped to `apps/bootstrap-installer/src-tauri/src/lib.rs` and `apps/bootstrap-installer/src/routes/progress.tsx`.
- The unit-testable decision point is `should_launch_existing_desktop(AppMode::Install, false, installed=true) == true`; `AppMode::Update` and repair/reinstall do not take that launcher fast path.
- This is the path needed for the reported Windows failure: an accidental bare `Hermes-Setup.exe` handoff on an existing complete install relaunches Desktop instead of running setup/install mode again.

Verification:
- `npm run build` in `apps/bootstrap-installer` -> success (`tsc -b && vite build`)
- `git diff --check upstream/main...HEAD`
- `rg -n "should_launch_existing_desktop|AppMode|start_update|start_bootstrap|mode === 'update'" apps/bootstrap-installer/src-tauri/src/lib.rs apps/bootstrap-installer/src/routes apps/bootstrap-installer/src -g "*.tsx" -g "*.ts"`

Note: this Windows host and its WSL environment do not currently have `cargo`/`rustc`, so I could not rerun the Rust lib tests locally after this rebase. The previous pre-rebase validation reported `cargo +1.95.0 test --manifest-path apps/bootstrap-installer/src-tauri/Cargo.toml --lib` passing, and the new branch is waiting on GitHub check-runs for full CI coverage.