### PR TITLE
fix(windows): remove stale submodule references that break Git-for-Windows clone

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,8 +58,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
@@ -194,8 +192,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ This isn't a quality bar — it's a coupling-and-maintenance decision. Memory pr
 ### Clone and install
 
 ```bash
-git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 
 # Create venv with Python 3.11

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1105,7 +1105,7 @@ function Install-Repository {
         Write-Info "Trying SSH clone..."
         $env:GIT_SSH_COMMAND = "ssh -o BatchMode=yes -o ConnectTimeout=5"
         try {
-            git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlSsh $InstallDir
+            git -c windows.appendAtomically=false clone --branch $Branch $RepoUrlSsh $InstallDir
             if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
         } catch { }
         $env:GIT_SSH_COMMAND = $null
@@ -1114,7 +1114,7 @@ function Install-Repository {
             if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
             Write-Info "SSH failed, trying HTTPS..."
             try {
-                git -c windows.appendAtomically=false clone --branch $Branch --recurse-submodules $RepoUrlHttps $InstallDir
+                git -c windows.appendAtomically=false clone --branch $Branch $RepoUrlHttps $InstallDir
                 if ($LASTEXITCODE -eq 0) { $cloneSuccess = $true }
             } catch { }
         }
@@ -1209,16 +1209,6 @@ function Install-Repository {
             $ErrorActionPreference = $prevEAP
         }
     }
-
-    # Ensure submodules are initialized and updated
-    Write-Info "Initializing submodules..."
-    git -c windows.appendAtomically=false submodule update --init --recursive 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        Write-Warn "Submodule init failed (terminal/RL tools may need manual setup)"
-    } else {
-        Write-Success "Submodules ready"
-    }
-    Pop-Location
 
     Write-Success "Repository ready"
 }

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -80,14 +80,8 @@ Why these packages?
 ### 2. Clone Hermes
 
 ```bash
-git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-```
-
-If you already cloned without submodules:
-
-```bash
-git submodule update --init --recursive
 ```
 
 ### 3. Create a virtual environment

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -195,7 +195,6 @@ git log --oneline -10
 
 # Roll back to a specific commit
 git checkout <commit-hash>
-git submodule update --init --recursive
 uv pip install -e ".[all]"
 
 # Restart the gateway if running
@@ -206,7 +205,6 @@ To roll back to a specific release tag (substitute your previous tag — e.g. a 
 
 ```bash
 git checkout vX.Y.Z
-git submodule update --init --recursive
 uv pip install -e ".[all]"
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
@@ -80,14 +80,8 @@ pkg install -y git python clang rust make pkg-config libffi openssl nodejs ripgr
 ### 2. 克隆 Hermes
 
 ```bash
-git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
+git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-```
-
-如果你已经克隆但未包含子模块：
-
-```bash
-git submodule update --init --recursive
 ```
 
 ### 3. 创建虚拟环境

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/updating.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/updating.md
@@ -183,7 +183,6 @@ git log --oneline -10
 
 # Roll back to a specific commit
 git checkout <commit-hash>
-git submodule update --init --recursive
 uv pip install -e ".[all]"
 
 # Restart the gateway if running
@@ -194,7 +193,6 @@ hermes gateway restart
 
 ```bash
 git checkout v0.6.0
-git submodule update --init --recursive
 uv pip install -e ".[all]"
 ```
 


### PR DESCRIPTION
## What does this PR do?

Removes all stale git submodule references from the codebase. The repo hasn't had a `.gitmodules` file since the Atropos RL submodule was removed (PR #26106), but `--recurse-submodules` flags and `submodule update` commands were left behind in the installer, CI workflows, and docs. On Windows, `git clone --recurse-submodules` on a repo with zero submodules triggers a known Git-for-Windows bug that can hang or fail the clone — this was the original motivation for the fix.

## Related Issue

closes https://github.com/NousResearch/hermes-agent/issues/37746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `.github/workflows/docker-publish.yml` — removed `submodules: recursive` from both `actions/checkout` steps (2 jobs)
- `CONTRIBUTING.md` — removed `--recurse-submodules` from the clone command
- `scripts/install.ps1` — removed `--recurse-submodules` from SSH and HTTPS clone commands; removed the entire post-clone "Initializing submodules…" block (7 lines)
- `website/docs/getting-started/termux.md` — removed `--recurse-submodules` from clone; removed the "if you already cloned without submodules" fallback section
- `website/docs/getting-started/updating.md` — removed `git submodule update --init --recursive` from rollback and version-checkout instructions (2 occurrences)
- `website/i18n/zh-Hans/…/termux.md` — same as English termux doc above
- `website/i18n/zh-Hans/…/updating.md` — same as English updating doc above

## How to Test

1. On a Windows machine, run the PowerShell installer (`scripts/install.ps1`) — clone should succeed without the `--recurse-submodules` hang
2. Verify the Docker CI workflow still checks out correctly (no submodules to init)
3. Follow the updated CONTRIBUTING.md clone steps on a fresh machine — should work identically since there are no submodules to recurse

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: removing dead code, no test surface
- [x] I've tested on my platform: Windows 11 (original bug report), NixOS (branch verification)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
