### PR TITLE
fix(tui): force UTF-8 output encoding in PowerShell clipboard read

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -20,9 +20,25 @@ describe('readClipboardText', () => {
     await expect(readClipboardText('win32', run)).resolves.toBe('from windows\r\n')
     expect(run).toHaveBeenCalledWith(
       'powershell',
-      ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'],
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard -Raw'
+      ],
       expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
     )
+  })
+
+  it('sets UTF-8 output encoding on Windows to preserve emoji', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: '🎉 emoji test\n' })
+
+    await expect(readClipboardText('win32', run)).resolves.toBe('🎉 emoji test\n')
+    const calledArgs = (run.mock.calls[0] as string[])[1]
+    const commandIdx = calledArgs.indexOf('-Command')
+    const script = calledArgs[commandIdx + 1] as string
+    expect(script).toContain('[Console]::OutputEncoding = [System.Text.Encoding]::UTF8')
+    expect(script).toContain('Get-Clipboard -Raw')
   })
 
   it('tries powershell.exe first on WSL', async () => {
@@ -33,7 +49,12 @@ describe('readClipboardText', () => {
     )
     expect(run).toHaveBeenCalledWith(
       'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'],
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard -Raw'
+      ],
       expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
     )
   })

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -3,7 +3,15 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
-const POWERSHELL_ARGS = ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'] as const
+// Force UTF-8 output encoding so emoji and CJK characters survive the pipe.
+// Without this, PowerShell defaults to the system ANSI code page (e.g. CP936)
+// and multi-byte characters are mangled to '?' on non-English Windows.
+const POWERSHELL_ARGS = [
+  '-NoProfile',
+  '-NonInteractive',
+  '-Command',
+  '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard -Raw'
+] as const
 
 type ClipboardRun = typeof execFileAsync
 


### PR DESCRIPTION
## What does this PR do?

Forces UTF-8 output encoding in the PowerShell clipboard read command so that emoji and CJK characters are preserved instead of being mangled to `?` on non-English Windows.

## Related Issue

Fixes #38077

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/lib/clipboard.ts`: Prefix the `-Command` script with `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8` before `Get-Clipboard -Raw`. Without this, PowerShell defaults to the system ANSI code page (e.g. CP936) and multi-byte characters are mangled to `?` when piped through stdout.
- `ui-tui/src/__tests__/clipboard.test.ts`: Updated existing Windows and WSL test assertions to match the new args. Added a dedicated regression test (`sets UTF-8 output encoding on Windows to preserve emoji`) that verifies the encoding prefix is present.

## How to Test

1. On Windows 11 with PowerShell 7 and Windows Terminal, copy an emoji string (e.g. `🎉 hello 🫶`) to the clipboard.
2. Launch `hermes --tui` and paste into the composer — the emoji should appear correctly, not as `??`.
3. Run `cd ui-tui && npx vitest run src/__tests__/clipboard.test.ts` — all 20 tests should pass (including the new `sets UTF-8 output encoding on Windows to preserve emoji` test).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run src/__tests__/clipboard.test.ts` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (TypeScript test suite, Windows-specific behavior verified via test mocks)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `ui-tui/src/lib/clipboard.ts` — `POWERSHELL_ARGS` constant, used by `readClipboardCommands()` (3 call sites: win32, WSL via WSL_INTEROP, WSL via WSL_DISTRO_NAME)
- Blast radius: LOW — single constant change, PowerShell-only code path, read-only (no side effects)
- Related patterns: The write path already handles UTF-8 via base64 encoding (`_powershellWriteScript`). This fix addresses the read path asymmetry. `isUsableClipboardText()` already handles null bytes and replacement characters as safety net.
