### PR TITLE
fix(desktop): reduce screen flicker by batching theme CSS writes and throttling titlebar IPC

### DIFF
--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -184,8 +184,24 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
 
   try {
     const status = await bridge.check()
-    $updateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    const prev = $updateStatus.get()
+
+    // Only update the store when the status actually changed to avoid
+    // triggering unnecessary React re-renders via useStore subscriptions.
+    // A naive $updateStatus.set(status) on every 30-minute poll tick would
+    // cascade through every component reading the store, causing style
+    // recalculations that manifest as a visible flash.
+    if (
+      status?.behind !== prev?.behind ||
+      status?.supported !== prev?.supported ||
+      status?.error !== prev?.error ||
+      status?.currentSha !== prev?.currentSha ||
+      status?.targetSha !== prev?.targetSha
+    ) {
+      $updateStatus.set(status)
+      maybeNotifyUpdateAvailable(status)
+    }
+
     // The update check pulls the latest hermes_cli + bundled package metadata
     // into place. Re-read the running version so About reflects the now-fresh
     // checkout rather than the one captured at process start.

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -9,7 +9,7 @@
  * The two are persisted independently. Shift+X toggles light/dark.
  */
 
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { matchesQuery, useMediaQuery } from '@/hooks/use-media-query'
 
@@ -148,6 +148,45 @@ function renderedModeFor(colors: DesktopThemeColors, mode: 'light' | 'dark'): 'l
 
 // ─── CSS application ────────────────────────────────────────────────────────
 
+// Throttled titlebar IPC: the OS titlebar overlay repaints are expensive, so
+// coalesce calls within a 100ms window to avoid triggering a paint on every
+// style recalculation.
+let lastTitlebarIpcAt = 0
+let pendingTitlebarTheme: { background: string; foreground: string } | null = null
+let titlebarIpcTimer: ReturnType<typeof setTimeout> | null = null
+
+function flushTitlebarTheme() {
+  if (pendingTitlebarTheme) {
+    window.hermesDesktop?.setTitleBarTheme?.(pendingTitlebarTheme)
+    lastTitlebarIpcAt = Date.now()
+    pendingTitlebarTheme = null
+  }
+
+  titlebarIpcTimer = null
+}
+
+function setTitleBarThemeThrottled(colors: { background: string; foreground: string }) {
+  const now = Date.now()
+
+  if (now - lastTitlebarIpcAt >= 100) {
+    // Flush any pending, then send immediately
+    if (titlebarIpcTimer) {
+      clearTimeout(titlebarIpcTimer)
+      titlebarIpcTimer = null
+    }
+
+    window.hermesDesktop?.setTitleBarTheme?.(colors)
+    lastTitlebarIpcAt = now
+  } else {
+    // Coalesce into the next flush
+    pendingTitlebarTheme = colors
+
+    if (!titlebarIpcTimer) {
+      titlebarIpcTimer = setTimeout(flushTitlebarTheme, 100 - (now - lastTitlebarIpcAt))
+    }
+  }
+}
+
 // Per-mode mix knobs. Light/dark fallbacks live in styles.css `:root` /
 // `:root.dark`; setting them inline keeps active-skin overrides surviving
 // the boot-time paint.
@@ -216,7 +255,7 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     root.style.setProperty(k, v)
   }
 
-  window.hermesDesktop?.setTitleBarTheme?.({
+  setTitleBarThemeThrottled({
     background: c.background,
     foreground: c.foreground
   })
@@ -276,7 +315,35 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const resolvedMode = resolveMode(mode, systemDark)
   const activeTheme = useMemo(() => deriveTheme(themeName, resolvedMode), [themeName, resolvedMode])
 
-  useEffect(() => applyTheme(activeTheme, resolvedMode), [activeTheme, resolvedMode])
+  // Schedule CSS variable application via requestAnimationFrame to batch
+  // multiple style property writes into a single layout/paint cycle.  Without
+  // this, every call to applyTheme triggers 20+ independent style recalculations
+  // that cascade through color-mix() consumers, causing a visible flash.
+  const scheduledThemeRef = useRef<{ theme: DesktopTheme; mode: 'light' | 'dark' } | null>(null)
+  const rafIdRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    scheduledThemeRef.current = { theme: activeTheme, mode: resolvedMode }
+
+    if (rafIdRef.current === null) {
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null
+        const pending = scheduledThemeRef.current
+        scheduledThemeRef.current = null
+
+        if (pending) {
+          applyTheme(pending.theme, pending.mode)
+        }
+      })
+    }
+
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+    }
+  }, [activeTheme, resolvedMode])
 
   const setTheme = useCallback((name: string) => {
     const next = normalizeSkin(name)


### PR DESCRIPTION
## Problem

The desktop app flickers every few seconds - a visible flash in the window content.

## Root Cause (3 sources)

1. CSS variable cascade - applyTheme() sets 20+ CSS custom properties synchronously, each triggering independent style recalculations through color-mix() consumers.
2. Unthrottled titlebar IPC - every applyTheme call sends setTitleBarTheme IPC to the main process, repainting the OS titlebar overlay on every tick.
3. Unconditional store updates on poll ticks - 30-minute poller always called $updateStatus.set() even when nothing changed.

## Changes

### themes/context.tsx
- rAF batching: use requestAnimationFrame to coalesce multiple React render cycles into one paint.
- Titlebar IPC throttle: limit setTitleBarTheme IPC to at most once per 100ms.

### store/updates.ts
- Change-detection guard: only call $updateStatus.set() when behind/supported/error/SHA actually changed.

## Testing
- npm run type-check - passes
- npm run lint - 0 errors/warnings from changed files