### PR TITLE
feat(agent): support Codex Responses WebSocket transport

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -725,6 +725,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             tools=tools_for_api,
             reasoning_config=agent.reasoning_config,
             session_id=getattr(agent, "session_id", None),
+            thread_id=getattr(agent, "_thread_id", None),
+            codex_turn_state=getattr(agent, "_codex_responses_websocket_turn_state", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -181,20 +181,91 @@ def interruptible_api_call(agent, api_kwargs: dict):
         else:
             agent._close_request_openai_client(request_client, reason=reason)
 
+    def _close_codex_websocket_session_once() -> None:
+        if agent.api_mode != "codex_responses":
+            return
+        try:
+            from agent.codex_runtime import close_codex_responses_websocket_session
+            close_codex_responses_websocket_session(agent)
+        except Exception:
+            pass
+
+    def _disable_codex_websocket_for_turn_once(reason: str, error: BaseException | None = None) -> None:
+        if agent.api_mode != "codex_responses":
+            return
+        try:
+            from agent.codex_runtime import (
+                close_codex_responses_websocket_session,
+                codex_responses_websocket_output_committed,
+                disable_codex_responses_websocket_for_turn,
+            )
+            if codex_responses_websocket_output_committed(agent):
+                close_codex_responses_websocket_session(agent)
+                return
+            disable_codex_responses_websocket_for_turn(agent, reason=reason, error=error)
+        except Exception:
+            _close_codex_websocket_session_once()
+
     def _call():
         try:
             if agent.api_mode == "codex_responses":
-                request_client = _set_request_client(
-                    agent._create_request_openai_client(
-                        reason="codex_stream_request",
-                        api_kwargs=api_kwargs,
+                codex_use_websocket = False
+                try:
+                    from agent.codex_runtime import codex_responses_websocket_enabled
+                    codex_use_websocket = codex_responses_websocket_enabled(agent)
+                except Exception:
+                    codex_use_websocket = False
+                request_client = None
+                if codex_use_websocket:
+                    try:
+                        result["response"] = agent._run_codex_stream(
+                            api_kwargs,
+                            client=None,
+                            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+                        )
+                    except Exception as ws_error:
+                        try:
+                            from agent.codex_runtime import (
+                                disable_codex_responses_websocket_for_turn,
+                                should_fallback_codex_responses_websocket_to_http,
+                            )
+                            should_http_fallback = should_fallback_codex_responses_websocket_to_http(
+                                agent,
+                                ws_error,
+                            )
+                        except Exception:
+                            should_http_fallback = False
+                        if not should_http_fallback:
+                            raise
+
+                        disable_codex_responses_websocket_for_turn(
+                            agent,
+                            reason="websocket_transport_error",
+                            error=ws_error,
+                        )
+                        request_client = _set_request_client(
+                            agent._create_request_openai_client(
+                                reason="codex_stream_http_fallback",
+                                api_kwargs=api_kwargs,
+                            )
+                        )
+                        result["response"] = agent._run_codex_stream(
+                            api_kwargs,
+                            client=request_client,
+                            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+                        )
+                else:
+                    request_client = _set_request_client(
+                        agent._create_request_openai_client(
+                            reason="codex_stream_request",
+                            api_kwargs=api_kwargs,
+                        )
                     )
-                )
-                result["response"] = agent._run_codex_stream(
-                    api_kwargs,
-                    client=request_client,
-                    on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-                )
+                    result["response"] = agent._run_codex_stream(
+                        api_kwargs,
+                        client=request_client,
+                        on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+                    )
             elif agent.api_mode == "anthropic_messages":
                 result["response"] = agent._anthropic_messages_create(api_kwargs)
             elif agent.api_mode == "bedrock_converse":
@@ -390,6 +461,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             try:
                 _close_request_client_once("codex_ttfb_kill")
+                _disable_codex_websocket_for_turn_once("codex_ttfb_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -436,6 +508,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             try:
                 _close_request_client_once("codex_stream_idle_kill")
+                _disable_codex_websocket_for_turn_once("codex_stream_idle_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -484,6 +557,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     agent._rebuild_anthropic_client()
                 else:
                     _close_request_client_once("stale_call_kill")
+                    _disable_codex_websocket_for_turn_once("stale_call_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -515,6 +589,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     agent._rebuild_anthropic_client()
                 else:
                     _close_request_client_once("interrupt_abort")
+                    _close_codex_websocket_session_once()
             except Exception:
                 pass
             raise InterruptedError("Agent interrupted during API call")

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -686,6 +686,20 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
+        codex_window_id = None
+        codex_turn_metadata = None
+        try:
+            from agent.codex_runtime import (
+                _codex_responses_turn_metadata_header,
+                _codex_responses_window_id,
+            )
+            codex_window_id = _codex_responses_window_id(agent)
+            codex_turn_metadata = _codex_responses_turn_metadata_header(
+                agent,
+                {"model": agent.model},
+            )
+        except Exception:
+            logger.debug("Failed to build Codex Responses turn metadata", exc_info=True)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
         # in tool schemas (HTTP 400 "Invalid arguments passed to the model").
@@ -727,6 +741,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             session_id=getattr(agent, "session_id", None),
             thread_id=getattr(agent, "_thread_id", None),
             codex_turn_state=getattr(agent, "_codex_responses_websocket_turn_state", None),
+            codex_window_id=codex_window_id,
+            codex_turn_metadata=codex_turn_metadata,
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -190,21 +190,34 @@ def interruptible_api_call(agent, api_kwargs: dict):
         except Exception:
             pass
 
-    def _disable_codex_websocket_for_turn_once(reason: str, error: BaseException | None = None) -> None:
+    def _prepare_codex_websocket_retry_once(reason: str, error: BaseException | None = None) -> None:
         if agent.api_mode != "codex_responses":
             return
         try:
             from agent.codex_runtime import (
                 close_codex_responses_websocket_session,
                 codex_responses_websocket_output_committed,
-                disable_codex_responses_websocket_for_turn,
+                codex_responses_websocket_enabled,
+                prepare_codex_responses_websocket_retry,
             )
             if codex_responses_websocket_output_committed(agent):
                 close_codex_responses_websocket_session(agent)
                 return
-            disable_codex_responses_websocket_for_turn(agent, reason=reason, error=error)
+            if codex_responses_websocket_enabled(agent):
+                prepare_codex_responses_websocket_retry(agent, reason=reason, error=error)
+            else:
+                close_codex_responses_websocket_session(agent)
         except Exception:
             _close_codex_websocket_session_once()
+
+    def _mark_codex_websocket_error_once(error: BaseException) -> None:
+        if agent.api_mode != "codex_responses":
+            return
+        try:
+            from agent.codex_runtime import mark_codex_responses_websocket_error
+            mark_codex_responses_websocket_error(error)
+        except Exception:
+            pass
 
     def _call():
         try:
@@ -226,34 +239,49 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     except Exception as ws_error:
                         try:
                             from agent.codex_runtime import (
-                                disable_codex_responses_websocket_for_turn,
+                                disable_codex_responses_websocket_for_session,
+                                prepare_codex_responses_websocket_retry,
+                                should_immediately_fallback_codex_responses_websocket_to_http,
                                 should_fallback_codex_responses_websocket_to_http,
                             )
-                            should_http_fallback = should_fallback_codex_responses_websocket_to_http(
+                            should_immediate_http_fallback = (
+                                should_immediately_fallback_codex_responses_websocket_to_http(ws_error)
+                            )
+                            should_websocket_retry = should_fallback_codex_responses_websocket_to_http(
                                 agent,
                                 ws_error,
                             )
                         except Exception:
-                            should_http_fallback = False
-                        if not should_http_fallback:
+                            should_immediate_http_fallback = False
+                            should_websocket_retry = False
+                        if not should_websocket_retry:
                             raise
 
-                        disable_codex_responses_websocket_for_turn(
+                        if should_immediate_http_fallback:
+                            disable_codex_responses_websocket_for_session(
+                                agent,
+                                reason="websocket_upgrade_required",
+                                error=ws_error,
+                            )
+                            request_client = _set_request_client(
+                                agent._create_request_openai_client(
+                                    reason="codex_stream_http_fallback",
+                                    api_kwargs=api_kwargs,
+                                )
+                            )
+                            result["response"] = agent._run_codex_stream(
+                                api_kwargs,
+                                client=request_client,
+                                on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+                            )
+                            return
+
+                        prepare_codex_responses_websocket_retry(
                             agent,
                             reason="websocket_transport_error",
                             error=ws_error,
                         )
-                        request_client = _set_request_client(
-                            agent._create_request_openai_client(
-                                reason="codex_stream_http_fallback",
-                                api_kwargs=api_kwargs,
-                            )
-                        )
-                        result["response"] = agent._run_codex_stream(
-                            api_kwargs,
-                            client=request_client,
-                            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-                        )
+                        raise
                 else:
                     request_client = _set_request_client(
                         agent._create_request_openai_client(
@@ -461,7 +489,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             try:
                 _close_request_client_once("codex_ttfb_kill")
-                _disable_codex_websocket_for_turn_once("codex_ttfb_kill")
+                _prepare_codex_websocket_retry_once("codex_ttfb_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -480,6 +508,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
                         f"(TTFB threshold: {int(_ttfb_timeout)}s)"
                     )
+                _mark_codex_websocket_error_once(result["error"])
             break
 
         # Stream-idle detector: the Codex backend emitted at least one SSE
@@ -508,7 +537,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             try:
                 _close_request_client_once("codex_stream_idle_kill")
-                _disable_codex_websocket_for_turn_once("codex_stream_idle_kill")
+                _prepare_codex_websocket_retry_once("codex_stream_idle_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -520,6 +549,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
                     f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
                 )
+                _mark_codex_websocket_error_once(result["error"])
             break
 
         # Stale-call detector: kill the connection if no response
@@ -557,7 +587,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     agent._rebuild_anthropic_client()
                 else:
                     _close_request_client_once("stale_call_kill")
-                    _disable_codex_websocket_for_turn_once("stale_call_kill")
+                    _prepare_codex_websocket_retry_once("stale_call_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -577,6 +607,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
                         f"with no response (threshold: {int(_stale_timeout)}s)"
                     )
+                _mark_codex_websocket_error_once(result["error"])
             break
 
         if agent._interrupt_requested:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -730,6 +730,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,
+            base_url=agent.base_url,
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -354,7 +354,8 @@ def _chat_messages_to_responses_input(
                 if isinstance(codex_reasoning, list):
                     for ri in codex_reasoning:
                         if isinstance(ri, dict) and ri.get("encrypted_content"):
-                            item_id = ri.get("id")
+                            raw_item_id = ri.get("id")
+                            item_id = raw_item_id.strip() if isinstance(raw_item_id, str) else ""
                             if item_id and item_id in seen_item_ids:
                                 continue
                             # Cross-issuer guard: drop reasoning blocks that
@@ -380,17 +381,19 @@ def _chat_messages_to_responses_input(
                                     )
                                     _CROSS_ISSUER_WARN_EMITTED = True
                                 continue
-                            # Strip the "id" field — with store=False the
-                            # Responses API cannot look up items by ID and
-                            # returns 404.  The encrypted_content blob is
-                            # self-contained for reasoning chain continuity.
-                            # Also strip the internal "_issuer_kind" stamp;
-                            # it is a Hermes-side metadata key and not part
-                            # of the Responses API schema.
+                            # Preserve real reasoning IDs: stored assistant
+                            # message IDs can require their paired reasoning
+                            # item IDs when replayed as full Responses input.
+                            # Strip only Hermes-side metadata and transient
+                            # local IDs that were never minted by the API.
                             replay_item = {
                                 k: v for k, v in ri.items()
-                                if k not in ("id", "_issuer_kind")
+                                if k != "_issuer_kind"
                             }
+                            if item_id and not item_id.startswith("rs_tmp_"):
+                                replay_item["id"] = item_id
+                            else:
+                                replay_item.pop("id", None)
                             items.append(replay_item)
                             if item_id:
                                 seen_item_ids.add(item_id)
@@ -639,16 +642,15 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
         if item_type == "reasoning":
             encrypted = item.get("encrypted_content")
             if isinstance(encrypted, str) and encrypted:
-                item_id = item.get("id")
-                if isinstance(item_id, str) and item_id:
+                raw_item_id = item.get("id")
+                item_id = raw_item_id.strip() if isinstance(raw_item_id, str) else ""
+                if item_id:
                     if item_id in seen_ids:
                         continue
                     seen_ids.add(item_id)
                 reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
-                # Do NOT include the "id" in the outgoing item — with
-                # store=False (our default) the API tries to resolve the
-                # id server-side and returns 404.  The id is still used
-                # above for local deduplication via seen_ids.
+                if item_id and not item_id.startswith("rs_tmp_"):
+                    reasoning_item["id"] = item_id
                 summary = item.get("summary")
                 if isinstance(summary, list):
                     reasoning_item["summary"] = summary

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -403,6 +403,23 @@ def _codex_websocket_response_body(api_kwargs: Dict[str, Any]) -> Dict[str, Any]
     return body
 
 
+def _header_present(headers: Dict[str, str], name: str) -> bool:
+    target = name.lower()
+    return any(str(key).lower() == target for key in headers)
+
+
+def _set_header_if_missing(headers: Dict[str, str], name: str, value: str) -> None:
+    if not value or _header_present(headers, name):
+        return
+    headers[name] = value
+
+
+def _codex_responses_session_header_values(agent) -> tuple[str, str]:
+    session_id = str(getattr(agent, "session_id", "") or "").strip()
+    thread_id = str(getattr(agent, "_thread_id", "") or "").strip() or session_id
+    return session_id, thread_id
+
+
 def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str]:
     headers: Dict[str, str] = {}
     extra_headers = api_kwargs.get("extra_headers")
@@ -412,6 +429,11 @@ def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str
             for key, value in extra_headers.items()
             if key and value is not None
         })
+
+    session_id, thread_id = _codex_responses_session_header_values(agent)
+    _set_header_if_missing(headers, "session-id", session_id)
+    _set_header_if_missing(headers, "thread-id", thread_id)
+    _set_header_if_missing(headers, "x-client-request-id", thread_id)
 
     beta_key = next((key for key in headers if key.lower() == "openai-beta"), "OpenAI-Beta")
     beta_values = [

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,11 +16,14 @@ compatibility.
 
 from __future__ import annotations
 
+from copy import deepcopy
 import logging
+import json
 import os
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +205,588 @@ _TERMINAL_EVENT_TYPES = frozenset({
     "response.failed",
 })
 
+_WEBSOCKET_TRUE_VALUES = frozenset({
+    "1",
+    "true",
+    "yes",
+    "on",
+    "enabled",
+    "enable",
+    "websocket",
+    "websocket_mode",
+    "ws",
+    "wss",
+})
+
+_WEBSOCKET_TRANSPORT_VALUES = frozenset({
+    "websocket",
+    "websocket_mode",
+    "ws",
+    "wss",
+})
+
+_WEBSOCKET_BODY_EXCLUDED_KEYS = frozenset({
+    "timeout",
+    "extra_headers",
+    "extra_body",
+    "stream",
+    "background",
+})
+
+_GENERATED_RESPONSE_ITEM_TYPES = frozenset({
+    "function_call",
+    "custom_tool_call",
+    "reasoning",
+})
+
+
+def load_config() -> Dict[str, Any]:
+    """Load Hermes config lazily so tests can monkeypatch this module symbol."""
+    from hermes_cli.config import load_config as _load_config
+    return _load_config()
+
+
+def codex_responses_websocket_url(base_url: str) -> str:
+    """Derive the Responses WebSocket endpoint from a provider base URL."""
+    raw = str(base_url or "").strip().rstrip("/")
+    if not raw:
+        raise ValueError("codex_responses WebSocket transport requires provider base_url")
+
+    parts = urlsplit(raw)
+    scheme = parts.scheme.lower()
+    if scheme == "https":
+        websocket_scheme = "wss"
+    elif scheme == "http":
+        websocket_scheme = "ws"
+    elif scheme in {"ws", "wss"}:
+        websocket_scheme = scheme
+    else:
+        raise ValueError(
+            f"unsupported codex_responses WebSocket base_url scheme: {parts.scheme!r}"
+        )
+    if not parts.netloc:
+        raise ValueError("codex_responses WebSocket base_url must include a host")
+
+    path = parts.path.rstrip("/")
+    if not path.endswith("/responses"):
+        path = f"{path}/responses" if path else "/responses"
+
+    return urlunsplit((websocket_scheme, parts.netloc, path, parts.query, ""))
+
+
+def _normalized_provider_name(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalized_provider_url(value: Any) -> str:
+    return str(value or "").strip().rstrip("/").lower()
+
+
+def _codex_websocket_transport_key(agent) -> tuple[str, str]:
+    return (
+        _normalized_provider_name(getattr(agent, "provider", "")),
+        _normalized_provider_url(getattr(agent, "base_url", "")),
+    )
+
+
+def _entry_base_url(entry: Dict[str, Any]) -> str:
+    for key in ("base_url", "url", "api"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _entry_enables_codex_responses_websocket(entry: Dict[str, Any]) -> bool:
+    raw_flag = entry.get("codex_responses_websocket")
+    if isinstance(raw_flag, bool):
+        return raw_flag
+    if isinstance(raw_flag, str):
+        return raw_flag.strip().lower() in _WEBSOCKET_TRUE_VALUES
+
+    raw_transport = entry.get("codex_responses_transport")
+    if isinstance(raw_transport, bool):
+        return raw_transport
+    if isinstance(raw_transport, str):
+        return raw_transport.strip().lower() in _WEBSOCKET_TRANSPORT_VALUES
+
+    return False
+
+
+def _iter_config_provider_entries(config: Dict[str, Any]):
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        for provider_key, entry in providers.items():
+            if isinstance(entry, dict):
+                yield str(provider_key), entry
+
+    custom_providers = config.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if isinstance(entry, dict):
+                name = entry.get("name")
+                yield str(name or ""), entry
+
+
+def _provider_entry_name_matches_agent(agent, provider_key: str, entry: Dict[str, Any]) -> bool:
+    provider = _normalized_provider_name(getattr(agent, "provider", ""))
+    provider_no_custom = provider.removeprefix("custom:")
+    names = {
+        _normalized_provider_name(provider_key),
+        _normalized_provider_name(entry.get("name")),
+    }
+    names = {name for name in names if name}
+    return bool(provider and (provider in names or provider_no_custom in names))
+
+
+def _provider_entry_url_matches_agent(agent, entry: Dict[str, Any]) -> bool:
+    agent_url = _normalized_provider_url(getattr(agent, "base_url", ""))
+    entry_url = _normalized_provider_url(_entry_base_url(entry))
+    return bool(agent_url and entry_url and agent_url == entry_url)
+
+
+def codex_responses_websocket_enabled(agent) -> bool:
+    """Return True when this codex_responses provider explicitly opts into WebSocket."""
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        return False
+    fallback_key = getattr(agent, "_codex_responses_websocket_http_fallback_key", None)
+    if fallback_key is not None and fallback_key == _codex_websocket_transport_key(agent):
+        return False
+
+    try:
+        config = load_config()
+    except Exception:
+        logger.debug("Unable to load config for codex_responses WebSocket gate", exc_info=True)
+        return False
+    if not isinstance(config, dict):
+        return False
+
+    entries = list(_iter_config_provider_entries(config))
+    name_matches = [
+        entry
+        for provider_key, entry in entries
+        if _provider_entry_name_matches_agent(agent, provider_key, entry)
+    ]
+    if name_matches:
+        return any(_entry_enables_codex_responses_websocket(entry) for entry in name_matches)
+
+    for _provider_key, entry in entries:
+        if _provider_entry_url_matches_agent(agent, entry) and _entry_enables_codex_responses_websocket(entry):
+            return True
+
+    return False
+
+
+def _json_to_namespace(value: Any) -> Any:
+    if isinstance(value, dict):
+        return SimpleNamespace(
+            **{str(key): _json_to_namespace(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return [_json_to_namespace(item) for item in value]
+    return value
+
+
+def _codex_websocket_response_body(api_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    body = {
+        key: value
+        for key, value in api_kwargs.items()
+        if key not in _WEBSOCKET_BODY_EXCLUDED_KEYS and value is not None
+    }
+    extra_body = api_kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        body.update(extra_body)
+    body.pop("stream", None)
+    body.pop("background", None)
+    return body
+
+
+def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    extra_headers = api_kwargs.get("extra_headers")
+    if isinstance(extra_headers, dict):
+        headers.update({
+            str(key): str(value)
+            for key, value in extra_headers.items()
+            if key and value is not None
+        })
+
+    api_key = str(getattr(agent, "api_key", "") or "").strip()
+    has_authorization = any(key.lower() == "authorization" for key in headers)
+    if api_key and not has_authorization:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _connect_responses_websocket(uri: str, **kwargs):
+    try:
+        from websockets.sync.client import connect
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "codex_responses WebSocket transport requires the websockets package"
+        ) from exc
+    return connect(uri, **kwargs)
+
+
+def _safe_snapshot(value: Any) -> Any:
+    try:
+        return deepcopy(value)
+    except Exception:
+        return value
+
+
+def _is_prefix_items(prefix: Any, full: Any) -> bool:
+    if not isinstance(prefix, list) or not isinstance(full, list):
+        return False
+    if len(prefix) > len(full):
+        return False
+    return full[: len(prefix)] == prefix
+
+
+def _is_generated_response_item(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    role = str(item.get("role") or "").strip().lower()
+    if role == "assistant":
+        return True
+    item_type = str(item.get("type") or "").strip()
+    return item_type in _GENERATED_RESPONSE_ITEM_TYPES
+
+
+def _client_incremental_input_items(items: Any) -> List[Any]:
+    if not isinstance(items, list):
+        return items
+    return [item for item in items if not _is_generated_response_item(item)]
+
+
+def _incremental_input_since_previous_response(previous_input: Any, current_input: Any):
+    if not _is_prefix_items(previous_input, current_input):
+        return current_input, False
+    delta = current_input[len(previous_input) :]
+    return _client_incremental_input_items(delta), True
+
+
+class _CodexResponsesWebSocketSession:
+    def __init__(
+        self,
+        *,
+        uri: str,
+        headers: Dict[str, str],
+        open_timeout: float,
+    ) -> None:
+        self.uri = uri
+        self.headers = dict(headers)
+        self.open_timeout = open_timeout
+        self.websocket = None
+        self._context = None
+        self.previous_response_id: Optional[str] = None
+        self.last_full_input: Any = None
+        self.closed = False
+
+    def matches(self, *, uri: str, headers: Dict[str, str], open_timeout: float) -> bool:
+        return (
+            not self.closed
+            and self.uri == uri
+            and self.headers == dict(headers)
+            and self.open_timeout == open_timeout
+        )
+
+    def open(self):
+        if self.websocket is not None and not self.closed:
+            return self.websocket
+        raw = _connect_responses_websocket(
+            self.uri,
+            additional_headers=self.headers,
+            open_timeout=self.open_timeout,
+            close_timeout=10,
+            max_size=None,
+        )
+        self._context = raw
+        if hasattr(raw, "__enter__"):
+            self.websocket = raw.__enter__()
+        else:
+            self.websocket = raw
+        self.closed = False
+        return self.websocket
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        try:
+            if self._context is not None and hasattr(self._context, "__exit__"):
+                self._context.__exit__(None, None, None)
+            elif self.websocket is not None and hasattr(self.websocket, "close"):
+                self.websocket.close()
+        except Exception:
+            logger.debug("Codex Responses WebSocket close failed", exc_info=True)
+        finally:
+            self.websocket = None
+            self._context = None
+            self.previous_response_id = None
+            self.last_full_input = None
+
+    def build_payload(
+        self,
+        api_kwargs: Dict[str, Any],
+        *,
+        force_full_input: bool = False,
+    ) -> tuple[Dict[str, Any], Any, bool]:
+        payload = _codex_websocket_response_body(api_kwargs)
+        payload["type"] = "response.create"
+        full_input = _safe_snapshot(payload.get("input"))
+        used_continuation = False
+
+        if force_full_input:
+            self.previous_response_id = None
+            self.last_full_input = None
+            return payload, full_input, used_continuation
+
+        if self.previous_response_id:
+            incremental_input, can_continue = _incremental_input_since_previous_response(
+                self.last_full_input,
+                payload.get("input"),
+            )
+            if can_continue:
+                payload["previous_response_id"] = self.previous_response_id
+                payload["input"] = incremental_input
+                used_continuation = True
+            else:
+                # The current prompt no longer extends the cached chain
+                # exactly. Start a fresh chain on the same socket with full
+                # input rather than sending an unsafe incremental payload.
+                self.previous_response_id = None
+                self.last_full_input = None
+
+        return payload, full_input, used_continuation
+
+    def record_response(self, final: SimpleNamespace, full_input: Any) -> None:
+        status = str(getattr(final, "status", "") or "").strip().lower()
+        response_id = getattr(final, "id", None)
+        if status in {"failed", "cancelled"} or not isinstance(response_id, str) or not response_id:
+            self.previous_response_id = None
+            self.last_full_input = None
+            return
+        self.previous_response_id = response_id
+        self.last_full_input = _safe_snapshot(full_input)
+
+
+def close_codex_responses_websocket_session(agent) -> None:
+    session = getattr(agent, "_codex_responses_websocket_session", None)
+    if session is not None:
+        try:
+            session.close()
+        finally:
+            agent._codex_responses_websocket_session = None
+
+
+def reset_codex_responses_websocket_turn_fallback(agent) -> None:
+    """Clear one-turn HTTP fallback state while preserving chain invalidation."""
+    agent._codex_responses_websocket_http_fallback_key = None
+    agent._codex_responses_websocket_http_fallback_reason = None
+    agent._codex_responses_websocket_output_committed = False
+
+
+def disable_codex_responses_websocket_for_turn(
+    agent,
+    *,
+    reason: str,
+    error: BaseException | None = None,
+) -> None:
+    """Disable WebSocket for this provider for the current turn.
+
+    The continuation chain is also invalidated so the next WebSocket attempt
+    for the same provider starts with full input instead of reusing stale
+    ``previous_response_id`` state from the failed socket.
+    """
+    key = _codex_websocket_transport_key(agent)
+    close_codex_responses_websocket_session(agent)
+    agent._codex_responses_websocket_http_fallback_key = key
+    agent._codex_responses_websocket_http_fallback_reason = reason
+    agent._codex_responses_websocket_chain_invalidated_key = key
+    logger.debug(
+        "Disabled Codex Responses WebSocket for current turn (%s). %s error=%s",
+        reason,
+        getattr(agent, "_client_log_context", lambda: "")(),
+        error,
+    )
+
+
+def clear_codex_responses_websocket_chain_invalidated(agent) -> None:
+    key = getattr(agent, "_codex_responses_websocket_chain_invalidated_key", None)
+    if key is not None and key == _codex_websocket_transport_key(agent):
+        agent._codex_responses_websocket_chain_invalidated_key = None
+
+
+def _codex_responses_websocket_chain_invalidated(agent) -> bool:
+    key = getattr(agent, "_codex_responses_websocket_chain_invalidated_key", None)
+    return key is not None and key == _codex_websocket_transport_key(agent)
+
+
+def codex_responses_websocket_output_committed(agent) -> bool:
+    return bool(getattr(agent, "_codex_responses_websocket_output_committed", False))
+
+
+def _mark_codex_responses_websocket_output_committed(agent) -> None:
+    agent._codex_responses_websocket_output_committed = True
+
+
+def _get_codex_responses_websocket_session(
+    agent,
+    *,
+    uri: str,
+    headers: Dict[str, str],
+    open_timeout: float,
+) -> _CodexResponsesWebSocketSession:
+    session = getattr(agent, "_codex_responses_websocket_session", None)
+    if isinstance(session, _CodexResponsesWebSocketSession) and session.matches(
+        uri=uri,
+        headers=headers,
+        open_timeout=open_timeout,
+    ):
+        return session
+
+    close_codex_responses_websocket_session(agent)
+    session = _CodexResponsesWebSocketSession(
+        uri=uri,
+        headers=headers,
+        open_timeout=open_timeout,
+    )
+    agent._codex_responses_websocket_session = session
+    return session
+
+
+def _iter_codex_websocket_events(
+    websocket,
+    *,
+    interrupt_check=None,
+    recv_timeout: Optional[float] = 1.0,
+):
+    while True:
+        if interrupt_check is not None and interrupt_check():
+            break
+        try:
+            raw = websocket.recv(timeout=recv_timeout)
+        except TimeoutError:
+            continue
+        except Exception as exc:
+            if exc.__class__.__name__.startswith("ConnectionClosed"):
+                break
+            raise
+
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        event = json.loads(raw)
+        event_type = event.get("type") if isinstance(event, dict) else None
+        yield _json_to_namespace(event)
+        if event_type in _TERMINAL_EVENT_TYPES or event_type == "error":
+            break
+
+
+def run_codex_websocket(
+    agent,
+    api_kwargs: Dict[str, Any],
+    *,
+    on_text_delta=None,
+    on_reasoning_delta=None,
+    on_first_delta=None,
+    on_event=None,
+    interrupt_check=None,
+) -> SimpleNamespace:
+    """Execute one Responses API request over WebSocket mode."""
+    websocket_url = codex_responses_websocket_url(getattr(agent, "base_url", ""))
+    timeout = api_kwargs.get("timeout")
+    open_timeout = (
+        float(timeout)
+        if isinstance(timeout, (int, float)) and not isinstance(timeout, bool) and timeout > 0
+        else 10
+    )
+    headers = _codex_websocket_headers(agent, api_kwargs)
+    force_full_input = _codex_responses_websocket_chain_invalidated(agent)
+    if force_full_input:
+        close_codex_responses_websocket_session(agent)
+    session = _get_codex_responses_websocket_session(
+        agent,
+        uri=websocket_url,
+        headers=headers,
+        open_timeout=open_timeout,
+    )
+
+    def _send_once(
+        active_session: _CodexResponsesWebSocketSession,
+        *,
+        force_full: bool = False,
+    ) -> tuple[SimpleNamespace, bool]:
+        agent._codex_responses_websocket_output_committed = False
+        payload, full_input, used_continuation = active_session.build_payload(
+            api_kwargs,
+            force_full_input=force_full,
+        )
+        websocket = active_session.open()
+        websocket.send(json.dumps(payload))
+
+        def _on_event_with_commit(event: Any) -> None:
+            if _codex_websocket_event_commits_output(event):
+                _mark_codex_responses_websocket_output_committed(agent)
+            if on_event is not None:
+                on_event(event)
+
+        final_response = _consume_codex_event_stream(
+            _iter_codex_websocket_events(
+                websocket,
+                interrupt_check=interrupt_check,
+                recv_timeout=1.0,
+            ),
+            model=api_kwargs.get("model"),
+            on_text_delta=on_text_delta,
+            on_reasoning_delta=on_reasoning_delta,
+            on_first_delta=on_first_delta,
+            on_event=_on_event_with_commit,
+            interrupt_check=interrupt_check,
+        )
+        active_session.record_response(final_response, full_input)
+        if force_full and active_session.previous_response_id:
+            clear_codex_responses_websocket_chain_invalidated(agent)
+        return final_response, used_continuation
+
+    try:
+        final, _used_continuation = _send_once(session, force_full=force_full_input)
+    except Exception:
+        exc = _current_exception()
+        close_codex_responses_websocket_session(agent)
+        if _is_previous_response_missing_error(exc):
+            recovery_session = _get_codex_responses_websocket_session(
+                agent,
+                uri=websocket_url,
+                headers=headers,
+                open_timeout=open_timeout,
+            )
+            final, _used_continuation = _send_once(recovery_session, force_full=True)
+            return final
+        raise
+
+    return final
+
+
+def _current_exception() -> BaseException:
+    import sys
+    exc = sys.exc_info()[1]
+    if isinstance(exc, BaseException):
+        return exc
+    return RuntimeError("unknown exception")
+
+
+def _is_previous_response_missing_error(exc: BaseException) -> bool:
+    code = str(getattr(exc, "code", "") or "").strip().lower()
+    param = str(getattr(exc, "param", "") or "").strip().lower()
+    message = str(getattr(exc, "message", "") or exc).strip().lower()
+    return (
+        code == "previous_response_not_found"
+        or param == "previous_response_id"
+        or "previous_response_not_found" in message
+        or "previous response" in message and "not found" in message
+    )
+
 
 def _event_field(event: Any, name: str, default: Any = None) -> Any:
     """Field access that handles both attr-style (SDK objects) and dict (raw JSON) events."""
@@ -211,6 +796,57 @@ def _event_field(event: Any, name: str, default: Any = None) -> Any:
     return value if value is not None else default
 
 
+def _codex_websocket_event_commits_output(event: Any) -> bool:
+    event_type = _event_field(event, "type", "")
+    if not isinstance(event_type, str):
+        return False
+    if event_type == "response.output_item.done":
+        return _event_field(event, "item") is not None
+    if "output_text.delta" in event_type:
+        return bool(_event_field(event, "delta", ""))
+    if "reasoning" in event_type and "delta" in event_type:
+        return bool(_event_field(event, "delta", ""))
+    return False
+
+
+def should_fallback_codex_responses_websocket_to_http(agent, exc: BaseException) -> bool:
+    """Return True for pre-output WebSocket transport failures only."""
+    if codex_responses_websocket_output_committed(agent):
+        return False
+    if isinstance(exc, InterruptedError):
+        return False
+    if isinstance(exc, ValueError):
+        return False
+    class_name = exc.__class__.__name__.lower()
+    message = str(getattr(exc, "message", None) or exc).lower()
+    if "websocket" in class_name or class_name.startswith("connectionclosed"):
+        return True
+    if isinstance(exc, (TimeoutError, ConnectionError, OSError)):
+        return True
+    if _is_previous_response_missing_error(exc):
+        return False
+    if getattr(exc, "status_code", None) is not None:
+        return False
+    if getattr(exc, "code", None) or getattr(exc, "param", None):
+        return False
+
+    if "did not emit a terminal response" in message:
+        return True
+    return any(
+        phrase in message
+        for phrase in (
+            "connection closed",
+            "connection reset",
+            "connection refused",
+            "network connection",
+            "remote protocol",
+            "timed out",
+            "timeout",
+            "websocket",
+        )
+    )
+
+
 def _raise_stream_error(event: Any) -> None:
     """Raise a ``_StreamErrorEvent`` from a ``type=error`` SSE frame.
 
@@ -218,11 +854,23 @@ def _raise_stream_error(event: Any) -> None:
     pull in ``run_agent`` (e.g. plugin code, doc tools).
     """
     from run_agent import _StreamErrorEvent
-    message = (_event_field(event, "message", "") or "stream emitted error event").strip()
+    nested_error = _event_field(event, "error")
+    if not isinstance(nested_error, dict):
+        nested_error = {
+            "message": getattr(nested_error, "message", None),
+            "code": getattr(nested_error, "code", None),
+            "param": getattr(nested_error, "param", None),
+        } if nested_error is not None else {}
+    message = (
+        _event_field(event, "message", "")
+        or nested_error.get("message")
+        or "stream emitted error event"
+    ).strip()
     raise _StreamErrorEvent(
         message,
-        code=_event_field(event, "code"),
-        param=_event_field(event, "param"),
+        code=_event_field(event, "code") or nested_error.get("code"),
+        param=_event_field(event, "param") or nested_error.get("param"),
+        status_code=_event_field(event, "status"),
     )
 
 
@@ -430,7 +1078,6 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     """
     import httpx as _httpx
 
-    active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
     max_stream_retries = 1
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
@@ -449,6 +1096,31 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _interrupt_check() -> bool:
         return bool(agent._interrupt_requested)
+
+    def _warn_terminal_status(final: SimpleNamespace) -> None:
+        if final.status in {"incomplete", "failed"}:
+            logger.warning(
+                "Codex Responses stream terminal status=%s "
+                "(incomplete_details=%s, error=%s, streamed_chars=%d). %s",
+                final.status, final.incomplete_details, final.error,
+                sum(len(p) for p in agent._codex_streamed_text_parts),
+                agent._client_log_context(),
+            )
+
+    if codex_responses_websocket_enabled(agent):
+        final = run_codex_websocket(
+            agent,
+            api_kwargs,
+            on_text_delta=_on_text_delta,
+            on_reasoning_delta=_on_reasoning_delta,
+            on_first_delta=on_first_delta,
+            on_event=_on_event,
+            interrupt_check=_interrupt_check,
+        )
+        _warn_terminal_status(final)
+        return final
+
+    active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
 
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
@@ -496,14 +1168,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     continue
                 raise
 
-            if final.status in {"incomplete", "failed"}:
-                logger.warning(
-                    "Codex Responses stream terminal status=%s "
-                    "(incomplete_details=%s, error=%s, streamed_chars=%d). %s",
-                    final.status, final.incomplete_details, final.error,
-                    sum(len(p) for p in agent._codex_streamed_text_parts),
-                    agent._client_log_context(),
-                )
+            _warn_terminal_status(final)
 
             return final
         finally:
@@ -530,6 +1195,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
 __all__ = [
     "run_codex_app_server_turn",
     "run_codex_stream",
+    "run_codex_websocket",
     "run_codex_create_stream_fallback",
+    "close_codex_responses_websocket_session",
+    "codex_responses_websocket_enabled",
+    "codex_responses_websocket_url",
+    "disable_codex_responses_websocket_for_turn",
+    "reset_codex_responses_websocket_turn_fallback",
+    "should_fallback_codex_responses_websocket_to_http",
     "_consume_codex_event_stream",
 ]

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -464,6 +464,33 @@ def _connect_responses_websocket(uri: str, **kwargs):
     return connect(uri, **kwargs)
 
 
+def _codex_websocket_user_agent_header(headers: Dict[str, str]) -> Optional[str]:
+    if any(str(key).lower() == "user-agent" for key in headers):
+        return None
+    try:
+        from hermes_cli import __version__ as hermes_version
+    except Exception:
+        hermes_version = "unknown"
+    return f"HermesAgent/{hermes_version}"
+
+
+def _websocket_state_name(websocket: Any) -> Optional[str]:
+    state = getattr(websocket, "state", None)
+    if state is None:
+        return None
+    name = getattr(state, "name", None)
+    if isinstance(name, str):
+        return name.upper()
+    if isinstance(state, str):
+        return state.upper()
+    return None
+
+
+def _websocket_is_open(websocket: Any) -> bool:
+    state_name = _websocket_state_name(websocket)
+    return state_name is None or state_name == "OPEN"
+
+
 def _safe_snapshot(value: Any) -> Any:
     try:
         return deepcopy(value)
@@ -529,10 +556,19 @@ class _CodexResponsesWebSocketSession:
 
     def open(self):
         if self.websocket is not None and not self.closed:
-            return self.websocket
+            if _websocket_is_open(self.websocket):
+                return self.websocket
+            logger.info(
+                "codex_responses_websocket_event=cached_connection_closed "
+                "Codex Responses WebSocket cached connection is no longer open; reconnecting "
+                "with full input (state=%s).",
+                _websocket_state_name(self.websocket) or "unknown",
+            )
+            self.close()
         raw = _connect_responses_websocket(
             self.uri,
             additional_headers=self.headers,
+            user_agent_header=_codex_websocket_user_agent_header(self.headers),
             open_timeout=self.open_timeout,
             close_timeout=10,
             max_size=None,
@@ -779,7 +815,9 @@ def _iter_codex_websocket_events(
             continue
         except Exception as exc:
             if exc.__class__.__name__.startswith("ConnectionClosed"):
-                break
+                raise ConnectionError(
+                    f"websocket closed before response.completed: {exc}"
+                ) from exc
             raise
 
         if isinstance(raw, bytes):
@@ -834,12 +872,12 @@ def run_codex_websocket(
     ) -> tuple[SimpleNamespace, bool]:
         agent._codex_responses_websocket_output_committed = False
         send_state["used_continuation"] = False
+        websocket = active_session.open()
         payload, full_input, used_continuation = active_session.build_payload(
             api_kwargs,
             force_full_input=force_full,
         )
         send_state["used_continuation"] = used_continuation
-        websocket = active_session.open()
         websocket.send(json.dumps(payload))
 
         def _on_event_with_commit(event: Any) -> None:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -498,6 +498,43 @@ def _safe_snapshot(value: Any) -> Any:
         return value
 
 
+def _plain_jsonish(value: Any) -> Any:
+    if isinstance(value, SimpleNamespace):
+        return {
+            key: _plain_jsonish(val)
+            for key, val in vars(value).items()
+        }
+    if isinstance(value, dict):
+        return {
+            key: _plain_jsonish(val)
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [_plain_jsonish(item) for item in value]
+    if isinstance(value, tuple):
+        return [_plain_jsonish(item) for item in value]
+    return value
+
+
+def _safe_plain_snapshot(value: Any) -> Any:
+    return _safe_snapshot(_plain_jsonish(value))
+
+
+def _normalize_codex_response_item_status(
+    value: Any,
+    *,
+    default: str = "completed",
+    allowed: Optional[set[str]] = None,
+) -> str:
+    if allowed is None:
+        allowed = {"completed", "incomplete", "in_progress"}
+    if isinstance(value, str):
+        status = value.strip().lower().replace("-", "_").replace(" ", "_")
+        if status in allowed:
+            return status
+    return default
+
+
 def _is_prefix_items(prefix: Any, full: Any) -> bool:
     if not isinstance(prefix, list) or not isinstance(full, list):
         return False
@@ -522,14 +559,123 @@ def _client_incremental_input_items(items: Any) -> List[Any]:
     return [item for item in items if not _is_generated_response_item(item)]
 
 
-def _incremental_input_since_previous_response(previous_input: Any, current_input: Any):
-    if not _is_prefix_items(previous_input, current_input):
+def _codex_websocket_baseline_input(
+    previous_input: Any,
+    response_output_items: Any = None,
+) -> Any:
+    previous_input = _plain_jsonish(previous_input)
+    response_output_items = _plain_jsonish(response_output_items)
+    if not isinstance(previous_input, list):
+        return previous_input
+    if not isinstance(response_output_items, list) or not response_output_items:
+        return previous_input
+    return previous_input + response_output_items
+
+
+def _incremental_input_since_previous_response(
+    previous_input: Any,
+    current_input: Any,
+    response_output_items: Any = None,
+):
+    baseline_input = _codex_websocket_baseline_input(previous_input, response_output_items)
+    current_input = _plain_jsonish(current_input)
+    if not _is_prefix_items(baseline_input, current_input):
         return current_input, False
-    delta = current_input[len(previous_input) :]
+    delta = current_input[len(baseline_input) :]
     return _client_incremental_input_items(delta), True
 
 
+def _codex_websocket_request_fingerprint(payload: Dict[str, Any]) -> Any:
+    return _safe_plain_snapshot({
+        key: value
+        for key, value in payload.items()
+        if key not in {"input", "previous_response_id"}
+    })
+
+
+def _codex_response_output_items(final: SimpleNamespace) -> List[Any]:
+    output = _plain_jsonish(getattr(final, "output", None))
+    if not isinstance(output, list):
+        return []
+    normalized: List[Any] = []
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "").strip()
+        if item_type == "message":
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            content_parts = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                part_type = str(part.get("type") or "").strip()
+                if part_type not in {"output_text", "text"}:
+                    continue
+                text = part.get("text", "")
+                if text is None:
+                    text = ""
+                if not isinstance(text, str):
+                    text = str(text)
+                content_parts.append({"type": "output_text", "text": text})
+            if not content_parts:
+                continue
+            message_item = {
+                "type": "message",
+                "role": "assistant",
+                "status": _normalize_codex_response_item_status(item.get("status")),
+                "content": content_parts,
+            }
+            item_id = item.get("id")
+            if isinstance(item_id, str) and item_id.strip():
+                message_item["id"] = item_id.strip()
+            phase = item.get("phase")
+            if isinstance(phase, str) and phase.strip():
+                message_item["phase"] = phase.strip()
+            normalized.append(message_item)
+            continue
+        if item_type == "reasoning":
+            encrypted = item.get("encrypted_content")
+            if not isinstance(encrypted, str) or not encrypted:
+                continue
+            reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
+            summary = item.get("summary")
+            reasoning_item["summary"] = _plain_jsonish(summary) if isinstance(summary, list) else []
+            normalized.append(reasoning_item)
+            continue
+        if item_type == "function_call":
+            status = _normalize_codex_response_item_status(
+                item.get("status"),
+                default="",
+                allowed={"queued", "completed", "incomplete", "in_progress"},
+            )
+            if status in {"queued", "in_progress", "incomplete"}:
+                continue
+            name = item.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or not call_id.strip():
+                continue
+            arguments = item.get("arguments", "{}")
+            if isinstance(arguments, dict):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            elif not isinstance(arguments, str):
+                arguments = str(arguments)
+            normalized.append({
+                "type": "function_call",
+                "call_id": call_id.strip(),
+                "name": name.strip(),
+                "arguments": arguments.strip() or "{}",
+            })
+            continue
+    return normalized
+
+
 class _CodexResponsesWebSocketSession:
+    _MAX_CACHED_CHAINS = 16
+
     def __init__(
         self,
         *,
@@ -544,6 +690,10 @@ class _CodexResponsesWebSocketSession:
         self._context = None
         self.previous_response_id: Optional[str] = None
         self.last_full_input: Any = None
+        self.response_output_items: Any = None
+        self._chains: List[Dict[str, Any]] = []
+        self._pending_chain_index: Optional[int] = None
+        self._pending_request_fingerprint: Any = None
         self.closed = False
 
     def matches(self, *, uri: str, headers: Dict[str, str], open_timeout: float) -> bool:
@@ -595,8 +745,69 @@ class _CodexResponsesWebSocketSession:
         finally:
             self.websocket = None
             self._context = None
+            self._clear_chains()
+
+    def _clear_active_chain(self) -> None:
+        self.previous_response_id = None
+        self.last_full_input = None
+        self.response_output_items = None
+        self._pending_chain_index = None
+        self._pending_request_fingerprint = None
+
+    def _clear_chains(self) -> None:
+        self._chains = []
+        self._clear_active_chain()
+
+    def _set_active_chain(self, chain: Optional[Dict[str, Any]]) -> None:
+        if chain is None:
             self.previous_response_id = None
             self.last_full_input = None
+            self.response_output_items = None
+            return
+        self.previous_response_id = chain.get("previous_response_id")
+        self.last_full_input = _safe_snapshot(chain.get("last_full_input"))
+        self.response_output_items = _safe_snapshot(chain.get("response_output_items"))
+
+    def _ensure_legacy_chain(self) -> None:
+        if self._chains or not self.previous_response_id or self.last_full_input is None:
+            return
+        self._chains.append({
+            "previous_response_id": self.previous_response_id,
+            "last_full_input": _safe_plain_snapshot(self.last_full_input),
+            "response_output_items": _safe_plain_snapshot(self.response_output_items or []),
+            "request_fingerprint": None,
+        })
+
+    def _fingerprint_matches(self, chain: Dict[str, Any], request_fingerprint: Any) -> bool:
+        chain_fingerprint = chain.get("request_fingerprint")
+        return chain_fingerprint is None or chain_fingerprint == request_fingerprint
+
+    def _find_continuation_chain(
+        self,
+        *,
+        current_input: Any,
+        request_fingerprint: Any,
+    ) -> tuple[Optional[int], Optional[Dict[str, Any]], Any]:
+        self._ensure_legacy_chain()
+        for index in range(len(self._chains) - 1, -1, -1):
+            chain = self._chains[index]
+            if not self._fingerprint_matches(chain, request_fingerprint):
+                continue
+            incremental_input, can_continue = _incremental_input_since_previous_response(
+                chain.get("last_full_input"),
+                current_input,
+                chain.get("response_output_items"),
+            )
+            if can_continue:
+                return index, chain, incremental_input
+        return None, None, current_input
+
+    def _drop_pending_chain(self) -> None:
+        if self._pending_chain_index is None:
+            return
+        if 0 <= self._pending_chain_index < len(self._chains):
+            del self._chains[self._pending_chain_index]
+        self._clear_active_chain()
 
     def build_payload(
         self,
@@ -606,29 +817,39 @@ class _CodexResponsesWebSocketSession:
     ) -> tuple[Dict[str, Any], Any, bool]:
         payload = _codex_websocket_response_body(api_kwargs)
         payload["type"] = "response.create"
-        full_input = _safe_snapshot(payload.get("input"))
+        full_input = _safe_plain_snapshot(payload.get("input"))
+        request_fingerprint = _codex_websocket_request_fingerprint(payload)
         used_continuation = False
+        self._pending_chain_index = None
+        self._pending_request_fingerprint = request_fingerprint
 
         if force_full_input:
-            self.previous_response_id = None
-            self.last_full_input = None
+            self._clear_chains()
+            self._pending_request_fingerprint = request_fingerprint
             return payload, full_input, used_continuation
 
-        if self.previous_response_id:
-            incremental_input, can_continue = _incremental_input_since_previous_response(
-                self.last_full_input,
-                payload.get("input"),
-            )
-            if can_continue:
-                payload["previous_response_id"] = self.previous_response_id
-                payload["input"] = incremental_input
-                used_continuation = True
-            else:
-                # The current prompt no longer extends the cached chain
-                # exactly. Start a fresh chain on the same socket with full
-                # input rather than sending an unsafe incremental payload.
-                self.previous_response_id = None
-                self.last_full_input = None
+        chain_index, chain, incremental_input = self._find_continuation_chain(
+            current_input=full_input,
+            request_fingerprint=request_fingerprint,
+        )
+        if chain is not None:
+            self._pending_chain_index = chain_index
+            self._set_active_chain(chain)
+            payload["previous_response_id"] = chain["previous_response_id"]
+            payload["input"] = incremental_input
+            used_continuation = True
+        else:
+            # The current prompt no longer extends any cached chain exactly.
+            # Start a fresh chain on the same socket with full input rather
+            # than sending an unsafe incremental payload.
+            self._set_active_chain(None)
+            if self._chains:
+                logger.debug(
+                    "codex_responses_websocket_event=incremental_chain_miss "
+                    "sending full input because no cached chain matched request "
+                    "(chains=%d).",
+                    len(self._chains),
+                )
 
         return payload, full_input, used_continuation
 
@@ -636,11 +857,25 @@ class _CodexResponsesWebSocketSession:
         status = str(getattr(final, "status", "") or "").strip().lower()
         response_id = getattr(final, "id", None)
         if status in {"failed", "cancelled"} or not isinstance(response_id, str) or not response_id:
-            self.previous_response_id = None
-            self.last_full_input = None
+            self._drop_pending_chain()
             return
-        self.previous_response_id = response_id
-        self.last_full_input = _safe_snapshot(full_input)
+        chain = {
+            "previous_response_id": response_id,
+            "last_full_input": _safe_plain_snapshot(full_input),
+            "response_output_items": _safe_plain_snapshot(_codex_response_output_items(final)),
+            "request_fingerprint": _safe_snapshot(self._pending_request_fingerprint),
+        }
+        if (
+            self._pending_chain_index is not None
+            and 0 <= self._pending_chain_index < len(self._chains)
+        ):
+            del self._chains[self._pending_chain_index]
+        self._chains.append(chain)
+        if len(self._chains) > self._MAX_CACHED_CHAINS:
+            self._chains = self._chains[-self._MAX_CACHED_CHAINS :]
+        self._set_active_chain(chain)
+        self._pending_chain_index = None
+        self._pending_request_fingerprint = None
 
 
 def close_codex_responses_websocket_session(agent) -> None:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -616,8 +616,10 @@ def disable_codex_responses_websocket_for_turn(
     agent._codex_responses_websocket_http_fallback_key = key
     agent._codex_responses_websocket_http_fallback_reason = reason
     agent._codex_responses_websocket_chain_invalidated_key = key
-    logger.debug(
-        "Disabled Codex Responses WebSocket for current turn (%s). %s error=%s",
+    logger.warning(
+        "codex_responses_websocket_event=http_fallback "
+        "Codex Responses WebSocket disabled for current turn; falling back to HTTP "
+        "(reason=%s). %s error=%s",
         reason,
         getattr(agent, "_client_log_context", lambda: "")(),
         error,
@@ -716,6 +718,11 @@ def run_codex_websocket(
     headers = _codex_websocket_headers(agent, api_kwargs)
     force_full_input = _codex_responses_websocket_chain_invalidated(agent)
     if force_full_input:
+        logger.info(
+            "codex_responses_websocket_event=restore_full_input "
+            "Codex Responses WebSocket chain invalidated; reopening with full input. %s",
+            getattr(agent, "_client_log_context", lambda: "")(),
+        )
         close_codex_responses_websocket_session(agent)
     session = _get_codex_responses_websocket_session(
         agent,
@@ -763,6 +770,13 @@ def run_codex_websocket(
         active_session.record_response(final_response, full_input)
         if force_full and active_session.previous_response_id:
             clear_codex_responses_websocket_chain_invalidated(agent)
+            logger.info(
+                "codex_responses_websocket_event=restore_full_input_completed "
+                "Codex Responses WebSocket recovered; full-input request completed "
+                "(response_id=%s). %s",
+                active_session.previous_response_id,
+                getattr(agent, "_client_log_context", lambda: "")(),
+            )
         return final_response, used_continuation
 
     try:
@@ -771,6 +785,13 @@ def run_codex_websocket(
         exc = _current_exception()
         close_codex_responses_websocket_session(agent)
         if _is_previous_response_missing_error(exc):
+            logger.warning(
+                "codex_responses_websocket_event=previous_response_rejected "
+                "Codex Responses WebSocket previous_response_id rejected; reopening with full input. "
+                "%s error=%s",
+                getattr(agent, "_client_log_context", lambda: "")(),
+                exc,
+            )
             recovery_session = _get_codex_responses_websocket_session(
                 agent,
                 uri=websocket_url,
@@ -784,6 +805,13 @@ def run_codex_websocket(
             and send_state["used_continuation"]
             and should_fallback_codex_responses_websocket_to_http(agent, exc)
         ):
+            logger.warning(
+                "codex_responses_websocket_event=continuation_reopen_before_http_fallback "
+                "Codex Responses WebSocket continuation failed before output; "
+                "reopening with full input before HTTP fallback. %s error=%s",
+                getattr(agent, "_client_log_context", lambda: "")(),
+                exc,
+            )
             recovery_session = _get_codex_responses_websocket_session(
                 agent,
                 uri=websocket_url,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -21,6 +21,7 @@ import logging
 import json
 import os
 import time
+import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
@@ -229,6 +230,9 @@ _RESPONSES_WEBSOCKETS_BETA_VALUE = "responses_websockets=2026-02-06"
 _WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached"
 _WEBSOCKET_ERROR_MARKER = "_hermes_codex_responses_websocket_error"
 _CODEX_TURN_STATE_HEADER = "x-codex-turn-state"
+_CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
+_CODEX_WINDOW_ID_HEADER = "x-codex-window-id"
+_CODEX_WS_STREAM_REQUEST_START_MS_KEY = "x-codex-ws-stream-request-start-ms"
 
 _WEBSOCKET_BODY_EXCLUDED_KEYS = frozenset({
     "timeout",
@@ -493,6 +497,48 @@ def _codex_responses_session_header_values(agent) -> tuple[str, str]:
     return session_id, thread_id
 
 
+def _codex_responses_window_id(agent) -> str:
+    _session_id, thread_id = _codex_responses_session_header_values(agent)
+    if not thread_id:
+        return ""
+    generation = getattr(agent, "_codex_responses_window_generation", 0)
+    try:
+        generation_int = int(generation)
+    except (TypeError, ValueError):
+        generation_int = 0
+    return f"{thread_id}:{generation_int}"
+
+
+def _codex_responses_turn_metadata_header(agent, api_kwargs: Dict[str, Any]) -> str:
+    cached = getattr(agent, "_codex_responses_websocket_turn_metadata_header", None)
+    if isinstance(cached, str) and cached.strip():
+        return cached.strip()
+
+    session_id, thread_id = _codex_responses_session_header_values(agent)
+    window_id = _codex_responses_window_id(agent)
+    turn_id = str(getattr(agent, "_current_turn_id", "") or "").strip()
+    if not turn_id:
+        turn_id = f"turn_{uuid.uuid4().hex}"
+    metadata: Dict[str, Any] = {
+        "request_kind": "turn",
+        "turn_id": turn_id,
+        "turn_started_at_unix_ms": int(time.time() * 1000),
+    }
+    if session_id:
+        metadata["session_id"] = session_id
+    if thread_id:
+        metadata["thread_id"] = thread_id
+    if window_id:
+        metadata["window_id"] = window_id
+    model = str(api_kwargs.get("model") or "").strip()
+    if model:
+        metadata["model"] = model
+
+    header = json.dumps(metadata, ensure_ascii=True, separators=(",", ":"))
+    agent._codex_responses_websocket_turn_metadata_header = header
+    return header
+
+
 def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str]:
     headers: Dict[str, str] = {}
     extra_headers = api_kwargs.get("extra_headers")
@@ -510,6 +556,12 @@ def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str
     _set_header_if_missing(headers, "session-id", session_id)
     _set_header_if_missing(headers, "thread-id", thread_id)
     _set_header_if_missing(headers, "x-client-request-id", thread_id)
+    _set_header_if_missing(headers, _CODEX_WINDOW_ID_HEADER, _codex_responses_window_id(agent))
+    _set_header_if_missing(
+        headers,
+        _CODEX_TURN_METADATA_HEADER,
+        _codex_responses_turn_metadata_header(agent, api_kwargs),
+    )
 
     beta_key = next((key for key in headers if key.lower() == "openai-beta"), "OpenAI-Beta")
     beta_values = [
@@ -526,6 +578,54 @@ def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str
     if api_key and not has_authorization:
         headers["Authorization"] = f"Bearer {api_key}"
     return headers
+
+
+def _codex_websocket_add_client_metadata(
+    payload: Dict[str, Any],
+    headers: Dict[str, str],
+) -> None:
+    client_metadata = payload.get("client_metadata")
+    if not isinstance(client_metadata, dict):
+        client_metadata = {}
+        payload["client_metadata"] = client_metadata
+    window_id = _headers_get_case_insensitive(headers, _CODEX_WINDOW_ID_HEADER)
+    if window_id:
+        client_metadata.setdefault(_CODEX_WINDOW_ID_HEADER, window_id)
+    turn_metadata = _headers_get_case_insensitive(headers, _CODEX_TURN_METADATA_HEADER)
+    if turn_metadata:
+        client_metadata.setdefault(_CODEX_TURN_METADATA_HEADER, turn_metadata)
+    client_metadata[_CODEX_WS_STREAM_REQUEST_START_MS_KEY] = str(int(time.time() * 1000))
+
+
+def _codex_websocket_idle_timeout(api_kwargs: Dict[str, Any]) -> float:
+    raw_env = os.getenv("HERMES_CODEX_WEBSOCKET_IDLE_TIMEOUT_SECONDS")
+    if raw_env is None:
+        raw_env = os.getenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS")
+    if raw_env is not None:
+        try:
+            value = float(raw_env)
+            if value > 0:
+                return value
+        except (TypeError, ValueError):
+            pass
+    timeout = api_kwargs.get("timeout")
+    if isinstance(timeout, (int, float)) and not isinstance(timeout, bool) and timeout > 0:
+        return float(timeout)
+    return 120.0
+
+
+def _codex_websocket_input_item_count(payload: Dict[str, Any]) -> int:
+    input_items = payload.get("input")
+    if isinstance(input_items, list):
+        return len(input_items)
+    return 0
+
+
+def _codex_websocket_session_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    stable_headers = dict(headers)
+    _pop_header_case_insensitive(stable_headers, _CODEX_TURN_STATE_HEADER)
+    _pop_header_case_insensitive(stable_headers, _CODEX_TURN_METADATA_HEADER)
+    return stable_headers
 
 
 def _connect_responses_websocket(uri: str, **kwargs):
@@ -782,6 +882,7 @@ class _CodexResponsesWebSocketSession:
         self._on_turn_state = on_turn_state or (lambda value: None)
         self.websocket = None
         self._context = None
+        self._dynamic_headers: Dict[str, str] = {}
         self.previous_response_id: Optional[str] = None
         self.last_full_input: Any = None
         self.response_output_items: Any = None
@@ -798,6 +899,13 @@ class _CodexResponsesWebSocketSession:
             and self.open_timeout == open_timeout
         )
 
+    def set_dynamic_headers(self, headers: Dict[str, str]) -> None:
+        self._dynamic_headers = {
+            str(key): str(value)
+            for key, value in headers.items()
+            if key and value is not None
+        }
+
     def open(self):
         if self.websocket is not None and not self.closed:
             if _websocket_is_open(self.websocket):
@@ -810,6 +918,16 @@ class _CodexResponsesWebSocketSession:
             )
             self.close()
         connect_headers = dict(self.headers)
+        turn_metadata = _headers_get_case_insensitive(
+            self._dynamic_headers,
+            _CODEX_TURN_METADATA_HEADER,
+        )
+        if turn_metadata:
+            _set_header_if_missing(
+                connect_headers,
+                _CODEX_TURN_METADATA_HEADER,
+                turn_metadata,
+            )
         turn_state = str(self._turn_state_supplier() or "").strip()
         if turn_state:
             _set_header_if_missing(connect_headers, _CODEX_TURN_STATE_HEADER, turn_state)
@@ -822,6 +940,8 @@ class _CodexResponsesWebSocketSession:
             additional_headers=connect_headers,
             user_agent_header=_codex_websocket_user_agent_header(connect_headers),
             open_timeout=self.open_timeout,
+            ping_interval=None,
+            ping_timeout=None,
             close_timeout=10,
             max_size=None,
         )
@@ -1000,6 +1120,7 @@ def reset_codex_responses_websocket_turn_fallback(agent) -> None:
     """Reset per-turn stream state while preserving session-scoped HTTP fallback."""
     agent._codex_responses_websocket_output_committed = False
     agent._codex_responses_websocket_turn_state = None
+    agent._codex_responses_websocket_turn_metadata_header = None
 
 
 def mark_codex_responses_websocket_error(exc: BaseException) -> None:
@@ -1135,22 +1256,25 @@ def _get_codex_responses_websocket_session(
     headers: Dict[str, str],
     open_timeout: float,
 ) -> _CodexResponsesWebSocketSession:
+    stable_headers = _codex_websocket_session_headers(headers)
     session = getattr(agent, "_codex_responses_websocket_session", None)
     if isinstance(session, _CodexResponsesWebSocketSession) and session.matches(
         uri=uri,
-        headers=headers,
+        headers=stable_headers,
         open_timeout=open_timeout,
     ):
+        session.set_dynamic_headers(headers)
         return session
 
     close_codex_responses_websocket_session(agent)
     session = _CodexResponsesWebSocketSession(
         uri=uri,
-        headers=headers,
+        headers=stable_headers,
         open_timeout=open_timeout,
         turn_state_supplier=lambda: _codex_responses_turn_state(agent),
         on_turn_state=lambda value: _set_codex_responses_turn_state(agent, value),
     )
+    session.set_dynamic_headers(headers)
     agent._codex_responses_websocket_session = session
     return session
 
@@ -1160,13 +1284,23 @@ def _iter_codex_websocket_events(
     *,
     interrupt_check=None,
     recv_timeout: Optional[float] = 1.0,
+    idle_timeout: Optional[float] = None,
 ):
+    last_event_at = time.monotonic()
     while True:
         if interrupt_check is not None and interrupt_check():
             break
         try:
             raw = websocket.recv(timeout=recv_timeout)
         except TimeoutError:
+            if (
+                idle_timeout is not None
+                and idle_timeout >= 0
+                and time.monotonic() - last_event_at >= idle_timeout
+            ):
+                raise TimeoutError(
+                    f"websocket idle timeout waiting for response event ({idle_timeout:.0f}s)"
+                )
             continue
         except Exception as exc:
             if exc.__class__.__name__.startswith("ConnectionClosed"):
@@ -1177,6 +1311,7 @@ def _iter_codex_websocket_events(
 
         if isinstance(raw, bytes):
             raw = raw.decode("utf-8")
+        last_event_at = time.monotonic()
         event = json.loads(raw)
         event_type = event.get("type") if isinstance(event, dict) else None
         yield _json_to_namespace(event)
@@ -1233,6 +1368,21 @@ def run_codex_websocket(
             api_kwargs,
             force_full_input=force_full,
         )
+        _codex_websocket_add_client_metadata(payload, headers)
+        idle_timeout = _codex_websocket_idle_timeout(api_kwargs)
+        logger.info(
+            "codex_responses_websocket_event=request_prepared "
+            "Codex Responses WebSocket request prepared "
+            "(has_window_id=%s has_turn_metadata=%s used_continuation=%s "
+            "force_full_input=%s input_items=%d idle_timeout=%.0f). %s",
+            bool(_headers_get_case_insensitive(headers, _CODEX_WINDOW_ID_HEADER)),
+            bool(_headers_get_case_insensitive(headers, _CODEX_TURN_METADATA_HEADER)),
+            used_continuation,
+            force_full,
+            _codex_websocket_input_item_count(payload),
+            idle_timeout,
+            getattr(agent, "_client_log_context", lambda: "")(),
+        )
         send_state["used_continuation"] = used_continuation
         websocket.send(json.dumps(payload))
 
@@ -1241,6 +1391,7 @@ def run_codex_websocket(
                 websocket,
                 interrupt_check=interrupt_check,
                 recv_timeout=1.0,
+                idle_timeout=idle_timeout,
             ),
             model=api_kwargs.get("model"),
             on_text_delta=on_text_delta,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -228,6 +228,7 @@ _WEBSOCKET_TRANSPORT_VALUES = frozenset({
 _RESPONSES_WEBSOCKETS_BETA_VALUE = "responses_websockets=2026-02-06"
 _WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached"
 _WEBSOCKET_ERROR_MARKER = "_hermes_codex_responses_websocket_error"
+_CODEX_TURN_STATE_HEADER = "x-codex-turn-state"
 
 _WEBSOCKET_BODY_EXCLUDED_KEYS = frozenset({
     "timeout",
@@ -414,6 +415,57 @@ def _set_header_if_missing(headers: Dict[str, str], name: str, value: str) -> No
     if not value or _header_present(headers, name):
         return
     headers[name] = value
+
+
+def _codex_responses_turn_state(agent) -> str:
+    return str(getattr(agent, "_codex_responses_websocket_turn_state", "") or "").strip()
+
+
+def _set_codex_responses_turn_state(agent, value: Any) -> None:
+    turn_state = str(value or "").strip()
+    if not turn_state:
+        return
+    agent._codex_responses_websocket_turn_state = turn_state
+    logger.info(
+        "codex_responses_websocket_event=turn_state_captured "
+        "Codex Responses WebSocket captured same-turn sticky routing token. %s",
+        getattr(agent, "_client_log_context", lambda: "")(),
+    )
+
+
+def _headers_get_case_insensitive(headers: Any, name: str) -> Optional[str]:
+    if headers is None:
+        return None
+    try:
+        value = headers.get(name)
+    except Exception:
+        value = None
+    if value is not None:
+        return str(value).strip()
+    try:
+        items = headers.items()
+    except Exception:
+        return None
+    target = name.lower()
+    for key, value in items:
+        if str(key).lower() == target and value is not None:
+            return str(value).strip()
+    return None
+
+
+def _codex_websocket_response_header(websocket: Any, raw_context: Any, name: str) -> Optional[str]:
+    for source in (websocket, raw_context):
+        response = getattr(source, "response", None)
+        value = _headers_get_case_insensitive(getattr(response, "headers", None), name)
+        if value:
+            return value
+        value = _headers_get_case_insensitive(getattr(source, "response_headers", None), name)
+        if value:
+            return value
+        value = _headers_get_case_insensitive(getattr(source, "headers", None), name)
+        if value:
+            return value
+    return None
 
 
 def _codex_responses_session_header_values(agent) -> tuple[str, str]:
@@ -693,10 +745,14 @@ class _CodexResponsesWebSocketSession:
         uri: str,
         headers: Dict[str, str],
         open_timeout: float,
+        turn_state_supplier=None,
+        on_turn_state=None,
     ) -> None:
         self.uri = uri
         self.headers = dict(headers)
         self.open_timeout = open_timeout
+        self._turn_state_supplier = turn_state_supplier or (lambda: "")
+        self._on_turn_state = on_turn_state or (lambda value: None)
         self.websocket = None
         self._context = None
         self.previous_response_id: Optional[str] = None
@@ -726,10 +782,18 @@ class _CodexResponsesWebSocketSession:
                 _websocket_state_name(self.websocket) or "unknown",
             )
             self.close()
+        connect_headers = dict(self.headers)
+        turn_state = str(self._turn_state_supplier() or "").strip()
+        if turn_state:
+            _set_header_if_missing(connect_headers, _CODEX_TURN_STATE_HEADER, turn_state)
+            logger.info(
+                "codex_responses_websocket_event=turn_state_replayed "
+                "Codex Responses WebSocket replaying same-turn sticky routing token."
+            )
         raw = _connect_responses_websocket(
             self.uri,
-            additional_headers=self.headers,
-            user_agent_header=_codex_websocket_user_agent_header(self.headers),
+            additional_headers=connect_headers,
+            user_agent_header=_codex_websocket_user_agent_header(connect_headers),
             open_timeout=self.open_timeout,
             close_timeout=10,
             max_size=None,
@@ -740,6 +804,13 @@ class _CodexResponsesWebSocketSession:
         else:
             self.websocket = raw
         self.closed = False
+        turn_state = _codex_websocket_response_header(
+            self.websocket,
+            raw,
+            _CODEX_TURN_STATE_HEADER,
+        )
+        if turn_state:
+            self._on_turn_state(turn_state)
         return self.websocket
 
     def close(self) -> None:
@@ -901,6 +972,7 @@ def close_codex_responses_websocket_session(agent) -> None:
 def reset_codex_responses_websocket_turn_fallback(agent) -> None:
     """Reset per-turn stream state while preserving session-scoped HTTP fallback."""
     agent._codex_responses_websocket_output_committed = False
+    agent._codex_responses_websocket_turn_state = None
 
 
 def mark_codex_responses_websocket_error(exc: BaseException) -> None:
@@ -1041,6 +1113,8 @@ def _get_codex_responses_websocket_session(
         uri=uri,
         headers=headers,
         open_timeout=open_timeout,
+        turn_state_supplier=lambda: _codex_responses_turn_state(agent),
+        on_turn_state=lambda value: _set_codex_responses_turn_state(agent, value),
     )
     agent._codex_responses_websocket_session = session
     return session

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -226,6 +226,8 @@ _WEBSOCKET_TRANSPORT_VALUES = frozenset({
 })
 
 _RESPONSES_WEBSOCKETS_BETA_VALUE = "responses_websockets=2026-02-06"
+_WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached"
+_WEBSOCKET_ERROR_MARKER = "_hermes_codex_responses_websocket_error"
 
 _WEBSOCKET_BODY_EXCLUDED_KEYS = frozenset({
     "timeout",
@@ -615,19 +617,54 @@ def close_codex_responses_websocket_session(agent) -> None:
 
 
 def reset_codex_responses_websocket_turn_fallback(agent) -> None:
-    """Clear one-turn HTTP fallback state while preserving chain invalidation."""
-    agent._codex_responses_websocket_http_fallback_key = None
-    agent._codex_responses_websocket_http_fallback_reason = None
+    """Reset per-turn stream state while preserving session-scoped HTTP fallback."""
     agent._codex_responses_websocket_output_committed = False
 
 
-def disable_codex_responses_websocket_for_turn(
+def mark_codex_responses_websocket_error(exc: BaseException) -> None:
+    """Tag an exception as coming from the codex_responses WebSocket transport."""
+    try:
+        setattr(exc, _WEBSOCKET_ERROR_MARKER, True)
+    except Exception:
+        pass
+
+
+def is_codex_responses_websocket_error(exc: BaseException) -> bool:
+    return bool(getattr(exc, _WEBSOCKET_ERROR_MARKER, False))
+
+
+def prepare_codex_responses_websocket_retry(
     agent,
     *,
     reason: str,
     error: BaseException | None = None,
 ) -> None:
-    """Disable WebSocket for this provider for the current turn.
+    """Close the failed socket and force the next WebSocket attempt to send full input."""
+    if error is not None:
+        mark_codex_responses_websocket_error(error)
+    key = _codex_websocket_transport_key(agent)
+    close_codex_responses_websocket_session(agent)
+    agent._codex_responses_websocket_chain_invalidated_key = key
+    agent._codex_responses_websocket_output_committed = False
+    logger.warning(
+        "codex_responses_websocket_event=retry_transport_error "
+        "Codex Responses WebSocket transport failed before output; retrying with a fresh "
+        "WebSocket connection and full input (reason=%s code=%s param=%s). %s error=%s",
+        reason,
+        getattr(error, "code", None),
+        getattr(error, "param", None),
+        getattr(agent, "_client_log_context", lambda: "")(),
+        error,
+    )
+
+
+def disable_codex_responses_websocket_for_session(
+    agent,
+    *,
+    reason: str,
+    error: BaseException | None = None,
+) -> None:
+    """Disable WebSocket for this provider for the current agent session.
 
     The continuation chain is also invalidated so the next WebSocket attempt
     for the same provider starts with full input instead of reusing stale
@@ -638,14 +675,49 @@ def disable_codex_responses_websocket_for_turn(
     agent._codex_responses_websocket_http_fallback_key = key
     agent._codex_responses_websocket_http_fallback_reason = reason
     agent._codex_responses_websocket_chain_invalidated_key = key
+    agent._codex_responses_websocket_output_committed = False
     logger.warning(
         "codex_responses_websocket_event=http_fallback "
-        "Codex Responses WebSocket disabled for current turn; falling back to HTTP "
+        "Codex Responses WebSocket disabled for this session; falling back to HTTP "
         "(reason=%s). %s error=%s",
         reason,
         getattr(agent, "_client_log_context", lambda: "")(),
         error,
     )
+
+
+def disable_codex_responses_websocket_for_turn(
+    agent,
+    *,
+    reason: str,
+    error: BaseException | None = None,
+) -> None:
+    """Backward-compatible wrapper for the now session-scoped HTTP fallback."""
+    disable_codex_responses_websocket_for_session(agent, reason=reason, error=error)
+
+
+def should_immediately_fallback_codex_responses_websocket_to_http(
+    exc: BaseException,
+) -> bool:
+    """Return True for WebSocket handshake errors Codex routes directly to HTTP."""
+    return getattr(exc, "status_code", None) == 426
+
+
+def switch_codex_responses_websocket_to_http_after_retries(
+    agent,
+    exc: BaseException,
+    *,
+    reason: str,
+) -> bool:
+    """Activate Codex-style session HTTP fallback after WebSocket retry exhaustion."""
+    if not is_codex_responses_websocket_error(exc):
+        return False
+    if not codex_responses_websocket_enabled(agent):
+        return False
+    if not should_fallback_codex_responses_websocket_to_http(agent, exc):
+        return False
+    disable_codex_responses_websocket_for_session(agent, reason=reason, error=exc)
+    return True
 
 
 def clear_codex_responses_websocket_chain_invalidated(agent) -> None:
@@ -822,26 +894,6 @@ def run_codex_websocket(
             )
             final, _used_continuation = _send_once(recovery_session, force_full=True)
             return final
-        if (
-            not force_full_input
-            and send_state["used_continuation"]
-            and should_fallback_codex_responses_websocket_to_http(agent, exc)
-        ):
-            logger.warning(
-                "codex_responses_websocket_event=continuation_reopen_before_http_fallback "
-                "Codex Responses WebSocket continuation failed before output; "
-                "reopening with full input before HTTP fallback. %s error=%s",
-                getattr(agent, "_client_log_context", lambda: "")(),
-                exc,
-            )
-            recovery_session = _get_codex_responses_websocket_session(
-                agent,
-                uri=websocket_url,
-                headers=headers,
-                open_timeout=open_timeout,
-            )
-            final, _used_continuation = _send_once(recovery_session, force_full=True)
-            return final
         raise
 
     return final
@@ -904,6 +956,11 @@ def should_fallback_codex_responses_websocket_to_http(agent, exc: BaseException)
         return True
     if _is_previous_response_missing_error(exc):
         return False
+    code = str(getattr(exc, "code", "") or "").strip().lower()
+    if code == _WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE:
+        return True
+    if should_immediately_fallback_codex_responses_websocket_to_http(exc):
+        return True
     if getattr(exc, "status_code", None) is not None:
         return False
     if getattr(exc, "code", None) or getattr(exc, "param", None):
@@ -1279,8 +1336,14 @@ __all__ = [
     "close_codex_responses_websocket_session",
     "codex_responses_websocket_enabled",
     "codex_responses_websocket_url",
+    "disable_codex_responses_websocket_for_session",
     "disable_codex_responses_websocket_for_turn",
+    "is_codex_responses_websocket_error",
+    "mark_codex_responses_websocket_error",
+    "prepare_codex_responses_websocket_retry",
     "reset_codex_responses_websocket_turn_fallback",
+    "should_immediately_fallback_codex_responses_websocket_to_http",
     "should_fallback_codex_responses_websocket_to_http",
+    "switch_codex_responses_websocket_to_http_after_retries",
     "_consume_codex_event_stream",
 ]

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -712,16 +712,20 @@ def run_codex_websocket(
         open_timeout=open_timeout,
     )
 
+    send_state = {"used_continuation": False}
+
     def _send_once(
         active_session: _CodexResponsesWebSocketSession,
         *,
         force_full: bool = False,
     ) -> tuple[SimpleNamespace, bool]:
         agent._codex_responses_websocket_output_committed = False
+        send_state["used_continuation"] = False
         payload, full_input, used_continuation = active_session.build_payload(
             api_kwargs,
             force_full_input=force_full,
         )
+        send_state["used_continuation"] = used_continuation
         websocket = active_session.open()
         websocket.send(json.dumps(payload))
 
@@ -750,11 +754,24 @@ def run_codex_websocket(
         return final_response, used_continuation
 
     try:
-        final, _used_continuation = _send_once(session, force_full=force_full_input)
+        final, used_continuation = _send_once(session, force_full=force_full_input)
     except Exception:
         exc = _current_exception()
         close_codex_responses_websocket_session(agent)
         if _is_previous_response_missing_error(exc):
+            recovery_session = _get_codex_responses_websocket_session(
+                agent,
+                uri=websocket_url,
+                headers=headers,
+                open_timeout=open_timeout,
+            )
+            final, _used_continuation = _send_once(recovery_session, force_full=True)
+            return final
+        if (
+            not force_full_input
+            and send_state["used_continuation"]
+            and should_fallback_codex_responses_websocket_to_http(agent, exc)
+        ):
             recovery_session = _get_codex_responses_websocket_session(
                 agent,
                 uri=websocket_url,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -716,6 +716,11 @@ def _codex_response_output_items(final: SimpleNamespace) -> List[Any]:
             if not isinstance(encrypted, str) or not encrypted:
                 continue
             reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
+            item_id = item.get("id")
+            if isinstance(item_id, str):
+                item_id = item_id.strip()
+                if item_id and not item_id.startswith("rs_tmp_"):
+                    reasoning_item["id"] = item_id
             summary = item.get("summary")
             reasoning_item["summary"] = _plain_jsonish(summary) if isinstance(summary, list) else []
             reasoning_items.append(reasoning_item)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -597,7 +597,9 @@ def _codex_response_output_items(final: SimpleNamespace) -> List[Any]:
     output = _plain_jsonish(getattr(final, "output", None))
     if not isinstance(output, list):
         return []
-    normalized: List[Any] = []
+    reasoning_items: List[Any] = []
+    message_items: List[Any] = []
+    function_call_items: List[Any] = []
     for item in output:
         if not isinstance(item, dict):
             continue
@@ -633,7 +635,7 @@ def _codex_response_output_items(final: SimpleNamespace) -> List[Any]:
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 message_item["phase"] = phase.strip()
-            normalized.append(message_item)
+            message_items.append(message_item)
             continue
         if item_type == "reasoning":
             encrypted = item.get("encrypted_content")
@@ -642,7 +644,7 @@ def _codex_response_output_items(final: SimpleNamespace) -> List[Any]:
             reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
             summary = item.get("summary")
             reasoning_item["summary"] = _plain_jsonish(summary) if isinstance(summary, list) else []
-            normalized.append(reasoning_item)
+            reasoning_items.append(reasoning_item)
             continue
         if item_type == "function_call":
             status = _normalize_codex_response_item_status(
@@ -663,13 +665,22 @@ def _codex_response_output_items(final: SimpleNamespace) -> List[Any]:
                 arguments = json.dumps(arguments, ensure_ascii=False)
             elif not isinstance(arguments, str):
                 arguments = str(arguments)
-            normalized.append({
+            function_call_items.append({
                 "type": "function_call",
                 "call_id": call_id.strip(),
                 "name": name.strip(),
                 "arguments": arguments.strip() or "{}",
             })
             continue
+    # Mirror _chat_messages_to_responses_input(): replay reasoning first,
+    # then assistant content/sentinel, then tool calls. The WebSocket prefix
+    # matcher must see the same sequence the next turn's adapter will emit.
+    normalized: List[Any] = []
+    normalized.extend(reasoning_items)
+    normalized.extend(message_items)
+    if reasoning_items and not message_items:
+        normalized.append({"role": "assistant", "content": ""})
+    normalized.extend(function_call_items)
     return normalized
 
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -411,6 +411,14 @@ def _header_present(headers: Dict[str, str], name: str) -> bool:
     return any(str(key).lower() == target for key in headers)
 
 
+def _pop_header_case_insensitive(headers: Dict[str, str], name: str) -> Optional[str]:
+    target = name.lower()
+    for key in list(headers):
+        if str(key).lower() == target:
+            return headers.pop(key)
+    return None
+
+
 def _set_header_if_missing(headers: Dict[str, str], name: str, value: str) -> None:
     if not value or _header_present(headers, name):
         return
@@ -483,6 +491,9 @@ def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str
             for key, value in extra_headers.items()
             if key and value is not None
         })
+    # This is a dynamic handshake token. Keeping it in the stable session
+    # headers would make later API calls recreate an otherwise reusable socket.
+    _pop_header_case_insensitive(headers, _CODEX_TURN_STATE_HEADER)
 
     session_id, thread_id = _codex_responses_session_header_values(agent)
     _set_header_if_missing(headers, "session-id", session_id)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -225,6 +225,8 @@ _WEBSOCKET_TRANSPORT_VALUES = frozenset({
     "wss",
 })
 
+_RESPONSES_WEBSOCKETS_BETA_VALUE = "responses_websockets=2026-02-06"
+
 _WEBSOCKET_BODY_EXCLUDED_KEYS = frozenset({
     "timeout",
     "extra_headers",
@@ -410,6 +412,16 @@ def _codex_websocket_headers(agent, api_kwargs: Dict[str, Any]) -> Dict[str, str
             for key, value in extra_headers.items()
             if key and value is not None
         })
+
+    beta_key = next((key for key in headers if key.lower() == "openai-beta"), "OpenAI-Beta")
+    beta_values = [
+        value.strip()
+        for value in str(headers.get(beta_key, "") or "").split(",")
+        if value.strip()
+    ]
+    if _RESPONSES_WEBSOCKETS_BETA_VALUE not in beta_values:
+        beta_values.append(_RESPONSES_WEBSOCKETS_BETA_VALUE)
+    headers[beta_key] = ", ".join(beta_values)
 
     api_key = str(getattr(agent, "api_key", "") or "").strip()
     has_authorization = any(key.lower() == "authorization" for key in headers)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -294,6 +294,17 @@ def _codex_websocket_transport_key(agent) -> tuple[str, str]:
     )
 
 
+def _codex_response_issuer_kind_for_agent(agent) -> str:
+    from agent.codex_responses_adapter import _classify_responses_issuer
+
+    return _classify_responses_issuer(
+        is_xai_responses=bool(getattr(agent, "_is_xai_responses", False)),
+        is_github_responses=bool(getattr(agent, "_is_github_responses", False)),
+        is_codex_backend=bool(getattr(agent, "_is_codex_backend", False)),
+        base_url=getattr(agent, "base_url", None),
+    )
+
+
 def _entry_base_url(entry: Dict[str, Any]) -> str:
     for key in ("base_url", "url", "api"):
         value = entry.get(key)
@@ -1097,6 +1108,14 @@ def _codex_responses_websocket_chain_invalidated(agent) -> bool:
 
 
 def codex_responses_websocket_output_committed(agent) -> bool:
+    """Return True only after visible text was delivered outside this request.
+
+    WebSocket streams can receive internal output events (function calls,
+    reasoning items, or buffered text) before ``response.completed``. Those
+    events are safe to retry/fallback when nothing has been sent to the user.
+    The unsafe boundary is external delivery via stream callbacks, because an
+    HTTP retry would duplicate already-visible text.
+    """
     return bool(getattr(agent, "_codex_responses_websocket_output_committed", False))
 
 
@@ -1172,6 +1191,7 @@ def run_codex_websocket(
 ) -> SimpleNamespace:
     """Execute one Responses API request over WebSocket mode."""
     websocket_url = codex_responses_websocket_url(getattr(agent, "base_url", ""))
+    issuer_kind = _codex_response_issuer_kind_for_agent(agent)
     timeout = api_kwargs.get("timeout")
     open_timeout = (
         float(timeout)
@@ -1211,12 +1231,6 @@ def run_codex_websocket(
         send_state["used_continuation"] = used_continuation
         websocket.send(json.dumps(payload))
 
-        def _on_event_with_commit(event: Any) -> None:
-            if _codex_websocket_event_commits_output(event):
-                _mark_codex_responses_websocket_output_committed(agent)
-            if on_event is not None:
-                on_event(event)
-
         final_response = _consume_codex_event_stream(
             _iter_codex_websocket_events(
                 websocket,
@@ -1227,9 +1241,10 @@ def run_codex_websocket(
             on_text_delta=on_text_delta,
             on_reasoning_delta=on_reasoning_delta,
             on_first_delta=on_first_delta,
-            on_event=_on_event_with_commit,
+            on_event=on_event,
             interrupt_check=interrupt_check,
         )
+        final_response.issuer_kind = issuer_kind
         active_session.record_response(final_response, full_input)
         if force_full and active_session.previous_response_id:
             clear_codex_responses_websocket_chain_invalidated(agent)
@@ -1294,19 +1309,6 @@ def _event_field(event: Any, name: str, default: Any = None) -> Any:
     if value is None and isinstance(event, dict):
         value = event.get(name, default)
     return value if value is not None else default
-
-
-def _codex_websocket_event_commits_output(event: Any) -> bool:
-    event_type = _event_field(event, "type", "")
-    if not isinstance(event_type, str):
-        return False
-    if event_type == "response.output_item.done":
-        return _event_field(event, "item") is not None
-    if "output_text.delta" in event_type:
-        return bool(_event_field(event, "delta", ""))
-    if "reasoning" in event_type and "delta" in event_type:
-        return bool(_event_field(event, "delta", ""))
-    return False
 
 
 def should_fallback_codex_responses_websocket_to_http(agent, exc: BaseException) -> bool:
@@ -1589,7 +1591,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _on_text_delta(text: str) -> None:
         agent._codex_streamed_text_parts.append(text)
+        before = getattr(agent, "_current_streamed_assistant_text", "") or ""
         agent._fire_stream_delta(text)
+        after = getattr(agent, "_current_streamed_assistant_text", "") or ""
+        if after != before:
+            _mark_codex_responses_websocket_output_committed(agent)
 
     def _on_reasoning_delta(text: str) -> None:
         agent._fire_reasoning_delta(text)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -415,6 +415,12 @@ def run_conversation(
     # runtime so this turn gets a fresh attempt with the preferred model.
     # No-op when _fallback_activated is False (gateway, first turn, etc.).
     agent._restore_primary_runtime()
+    if agent.api_mode == "codex_responses":
+        try:
+            from agent.codex_runtime import reset_codex_responses_websocket_turn_fallback
+            reset_codex_responses_websocket_turn_fallback(agent)
+        except Exception:
+            logger.debug("Failed to reset Codex Responses WebSocket turn fallback", exc_info=True)
 
     # Sanitize surrogate characters from user input.  Clipboard paste from
     # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3280,6 +3280,25 @@ def run_conversation(
                     }
 
                 if retry_count >= max_retries:
+                    if agent.api_mode == "codex_responses":
+                        try:
+                            from agent.codex_runtime import (
+                                switch_codex_responses_websocket_to_http_after_retries,
+                            )
+                            if switch_codex_responses_websocket_to_http_after_retries(
+                                agent,
+                                api_error,
+                                reason="websocket_transport_error",
+                            ):
+                                retry_count = 0
+                                compression_attempts = 0
+                                primary_recovery_attempted = False
+                                continue
+                        except Exception:
+                            logger.debug(
+                                "Failed to switch Codex Responses WebSocket to HTTP fallback",
+                                exc_info=True,
+                            )
                     # Before falling back, try rebuilding the primary
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,6 +11,38 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+_CODEX_TURN_STATE_HEADER = "x-codex-turn-state"
+
+
+def _header_present(headers: Dict[str, str], name: str) -> bool:
+    target = name.lower()
+    return any(str(key).lower() == target for key in headers)
+
+
+def _set_header_if_missing(headers: Dict[str, str], name: str, value: Any) -> None:
+    value = str(value or "").strip()
+    if not value or _header_present(headers, name):
+        return
+    headers[name] = value
+
+
+def _merge_extra_headers_if_missing(kwargs: Dict[str, Any], headers_to_add: Dict[str, Any]) -> None:
+    existing_extra_headers = kwargs.get("extra_headers")
+    merged_extra_headers: Dict[str, str] = {}
+    if isinstance(existing_extra_headers, dict):
+        merged_extra_headers.update(
+            {
+                str(key): str(value)
+                for key, value in existing_extra_headers.items()
+                if key and value is not None
+            }
+        )
+    for name, value in headers_to_add.items():
+        _set_header_if_missing(merged_extra_headers, name, value)
+    if merged_extra_headers:
+        kwargs["extra_headers"] = merged_extra_headers
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -71,7 +103,9 @@ class ResponsesApiTransport(ProviderTransport):
         params:
             instructions: str — system prompt (extracted from messages[0] if not given)
             reasoning_config: dict | None — {effort, enabled}
-            session_id: str | None — used for prompt_cache_key + xAI conv header
+            session_id: str | None — used for prompt_cache_key + session headers
+            thread_id: str | None — used for Codex session affinity headers
+            codex_turn_state: str | None — same-turn sticky routing token
             max_tokens: int | None — max_output_tokens
             timeout: float | None — per-request timeout forwarded to the SDK
             request_overrides: dict | None — extra kwargs merged in
@@ -217,23 +251,17 @@ class ResponsesApiTransport(ProviderTransport):
         else:
             kwargs.pop("timeout", None)
 
-        if is_codex_backend:
-            prompt_cache_key = kwargs.get("prompt_cache_key")
-            cache_scope_id = str(prompt_cache_key or session_id or "").strip()
-            if cache_scope_id:
-                existing_extra_headers = kwargs.get("extra_headers")
-                merged_extra_headers: Dict[str, str] = {}
-                if isinstance(existing_extra_headers, dict):
-                    merged_extra_headers.update(
-                        {
-                            str(key): str(value)
-                            for key, value in existing_extra_headers.items()
-                            if key and value is not None
-                        }
-                    )
-                merged_extra_headers["session_id"] = cache_scope_id
-                merged_extra_headers["x-client-request-id"] = cache_scope_id
-                kwargs["extra_headers"] = merged_extra_headers
+        if session_id and not is_xai_responses:
+            thread_id = str(params.get("thread_id") or session_id).strip()
+            _merge_extra_headers_if_missing(
+                kwargs,
+                {
+                    "session-id": session_id,
+                    "thread-id": thread_id,
+                    "x-client-request-id": thread_id,
+                    _CODEX_TURN_STATE_HEADER: params.get("codex_turn_state"),
+                },
+            )
 
         max_tokens = params.get("max_tokens")
         if max_tokens is not None and not is_codex_backend:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -5,6 +5,9 @@ This transport owns format conversion and normalization — NOT client lifecycle
 streaming, or the _run_codex_stream() call path.
 """
 
+import json
+import time
+import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
@@ -12,6 +15,8 @@ from agent.transports.types import NormalizedResponse, ToolCall
 
 
 _CODEX_TURN_STATE_HEADER = "x-codex-turn-state"
+_CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
+_CODEX_WINDOW_ID_HEADER = "x-codex-window-id"
 
 
 def _header_present(headers: Dict[str, str], name: str) -> bool:
@@ -41,6 +46,34 @@ def _merge_extra_headers_if_missing(kwargs: Dict[str, Any], headers_to_add: Dict
         _set_header_if_missing(merged_extra_headers, name, value)
     if merged_extra_headers:
         kwargs["extra_headers"] = merged_extra_headers
+
+
+def _codex_window_id(thread_id: str) -> str:
+    thread_id = str(thread_id or "").strip()
+    return f"{thread_id}:0" if thread_id else ""
+
+
+def _codex_turn_metadata(
+    *,
+    model: str,
+    session_id: str,
+    thread_id: str,
+    window_id: str,
+) -> str:
+    metadata: Dict[str, Any] = {
+        "request_kind": "turn",
+        "turn_id": f"turn_{uuid.uuid4().hex}",
+        "turn_started_at_unix_ms": int(time.time() * 1000),
+    }
+    if session_id:
+        metadata["session_id"] = session_id
+    if thread_id:
+        metadata["thread_id"] = thread_id
+    if window_id:
+        metadata["window_id"] = window_id
+    if model:
+        metadata["model"] = model
+    return json.dumps(metadata, ensure_ascii=True, separators=(",", ":"))
 
 
 class ResponsesApiTransport(ProviderTransport):
@@ -106,6 +139,8 @@ class ResponsesApiTransport(ProviderTransport):
             session_id: str | None — used for prompt_cache_key + session headers
             thread_id: str | None — used for Codex session affinity headers
             codex_turn_state: str | None — same-turn sticky routing token
+            codex_window_id: str | None — Codex window affinity header
+            codex_turn_metadata: str | None — stable per-turn Codex metadata header
             max_tokens: int | None — max_output_tokens
             timeout: float | None — per-request timeout forwarded to the SDK
             request_overrides: dict | None — extra kwargs merged in
@@ -253,12 +288,24 @@ class ResponsesApiTransport(ProviderTransport):
 
         if session_id and not is_xai_responses:
             thread_id = str(params.get("thread_id") or session_id).strip()
+            window_id = str(params.get("codex_window_id") or _codex_window_id(thread_id)).strip()
+            turn_metadata = str(
+                params.get("codex_turn_metadata")
+                or _codex_turn_metadata(
+                    model=model,
+                    session_id=str(session_id or "").strip(),
+                    thread_id=thread_id,
+                    window_id=window_id,
+                )
+            ).strip()
             _merge_extra_headers_if_missing(
                 kwargs,
                 {
                     "session-id": session_id,
                     "thread-id": thread_id,
                     "x-client-request-id": thread_id,
+                    _CODEX_WINDOW_ID_HEADER: window_id,
+                    _CODEX_TURN_METADATA_HEADER: turn_metadata,
                     _CODEX_TURN_STATE_HEADER: params.get("codex_turn_state"),
                 },
             )

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -304,7 +304,11 @@ class ResponsesApiTransport(ProviderTransport):
         # otherwise the stash from the matching build_kwargs/convert_messages
         # call. Either way it gets stamped onto reasoning items so future
         # turns can detect a model swap and drop foreign-issuer blobs.
-        issuer_kind = kwargs.get("issuer_kind") or self._last_issuer_kind
+        issuer_kind = (
+            kwargs.get("issuer_kind")
+            or getattr(response, "issuer_kind", None)
+            or self._last_issuer_kind
+        )
         # _normalize_codex_response returns (SimpleNamespace, finish_reason_str)
         msg, finish_reason = _normalize_codex_response(response, issuer_kind=issuer_kind)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3569,6 +3569,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
+        "codex_responses_websocket", "codex_responses_transport",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -3666,6 +3667,14 @@ def _normalize_custom_provider_entry(
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
+
+    codex_responses_websocket = entry.get("codex_responses_websocket")
+    if isinstance(codex_responses_websocket, bool):
+        normalized["codex_responses_websocket"] = codex_responses_websocket
+
+    codex_responses_transport = entry.get("codex_responses_transport")
+    if isinstance(codex_responses_transport, str) and codex_responses_transport.strip():
+        normalized["codex_responses_transport"] = codex_responses_transport.strip()
 
     return normalized
 
@@ -3828,6 +3837,7 @@ _KNOWN_ROOT_KEYS = {
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
+    "codex_responses_websocket", "codex_responses_transport",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "python-dotenv==1.2.2",
   "fire==0.7.1",
   "httpx[socks]==0.28.1",
+  "websockets==15.0.1",
   "rich==14.3.3",
   "tenacity==9.1.4",
   "pyyaml==6.0.3",

--- a/run_agent.py
+++ b/run_agent.py
@@ -2604,6 +2604,12 @@ class AIAgent:
 
         # Close the OpenAI/httpx client to release sockets immediately.
         try:
+            from agent.codex_runtime import close_codex_responses_websocket_session
+            close_codex_responses_websocket_session(self)
+        except Exception:
+            pass
+
+        try:
             client = getattr(self, "client", None)
             if client is not None:
                 self._close_openai_client(client, reason="cache_evict", shared=True)
@@ -2659,6 +2665,12 @@ class AIAgent:
             pass
 
         # 5. Close the OpenAI/httpx client
+        try:
+            from agent.codex_runtime import close_codex_responses_websocket_session
+            close_codex_responses_websocket_session(self)
+        except Exception:
+            pass
+
         try:
             client = getattr(self, "client", None)
             if client is not None:

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -468,6 +468,226 @@ def test_websocket_session_falls_back_to_full_input_when_history_is_not_prefix()
     assert payload["input"] == [{"role": "user", "content": "fresh"}]
 
 
+def test_websocket_session_falls_back_when_non_input_request_fields_change():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    first_input = [{"role": "user", "content": "Remember alpha"}]
+    _payload, full_input, _used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": first_input,
+            "store": False,
+            "tools": [{"type": "function", "name": "terminal"}],
+        }
+    )
+    session.record_response(
+        SimpleNamespace(
+            id="resp_1",
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "alpha noted"}],
+                }
+            ],
+        ),
+        full_input,
+    )
+
+    payload, _full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [
+                *first_input,
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "alpha noted"}],
+                },
+                {"role": "user", "content": "Repeat it"},
+            ],
+            "store": False,
+            "tools": [{"type": "function", "name": "read_file"}],
+        }
+    )
+
+    assert used_continuation is False
+    assert "previous_response_id" not in payload
+    assert "alpha noted" in json.dumps(payload["input"])
+
+
+def test_websocket_session_requires_previous_response_output_prefix_for_continuation():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    first_input = [{"role": "user", "content": "Remember alpha"}]
+    _payload, full_input, _used_continuation = session.build_payload(
+        {"model": "gpt-5-codex", "input": first_input, "store": False}
+    )
+    session.record_response(
+        SimpleNamespace(
+            id="resp_1",
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "alpha noted"}],
+                }
+            ],
+        ),
+        full_input,
+    )
+
+    payload, _full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [
+                *first_input,
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "tampered"}],
+                },
+                {"role": "user", "content": "Repeat it"},
+            ],
+            "store": False,
+        }
+    )
+
+    assert used_continuation is False
+    assert "previous_response_id" not in payload
+    assert "tampered" in json.dumps(payload["input"])
+
+
+def test_websocket_session_projects_function_call_output_items_for_next_turn_baseline():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    first_input = [{"role": "user", "content": "Run pwd"}]
+    _payload, full_input, _used_continuation = session.build_payload(
+        {"model": "gpt-5-codex", "input": first_input, "store": False}
+    )
+    session.record_response(
+        SimpleNamespace(
+            id="resp_1",
+            status="completed",
+            output=[
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "status": "completed",
+                    "call_id": "call_1",
+                    "name": "terminal",
+                    "arguments": "{\"cmd\":\"pwd\"}",
+                }
+            ],
+        ),
+        full_input,
+    )
+
+    payload, _full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [
+                *first_input,
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "terminal",
+                    "arguments": "{\"cmd\":\"pwd\"}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "{\"cwd\":\"/workspace\"}",
+                },
+            ],
+            "store": False,
+        }
+    )
+
+    assert used_continuation is True
+    assert payload["previous_response_id"] == "resp_1"
+    assert payload["input"] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "{\"cwd\":\"/workspace\"}",
+        }
+    ]
+
+
+def test_websocket_session_projects_reasoning_items_for_next_turn_baseline():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    first_input = [{"role": "user", "content": "Think briefly"}]
+    _payload, full_input, _used_continuation = session.build_payload(
+        {"model": "gpt-5-codex", "input": first_input, "store": False}
+    )
+    session.record_response(
+        SimpleNamespace(
+            id="resp_1",
+            status="completed",
+            output=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "encrypted-state",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "done"}],
+                },
+            ],
+        ),
+        full_input,
+    )
+
+    payload, _full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [
+                *first_input,
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "encrypted-state",
+                    "summary": [],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "done"}],
+                },
+                {"role": "user", "content": "Continue"},
+            ],
+            "store": False,
+        }
+    )
+
+    assert used_continuation is True
+    assert payload["previous_response_id"] == "resp_1"
+    assert payload["input"] == [{"role": "user", "content": "Continue"}]
+
+
 def test_websocket_transport_close_with_code_can_fallback_to_http():
     class ConnectionClosedError(Exception):
         code = 1006

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -1,0 +1,383 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import agent.codex_runtime as codex_runtime
+
+
+def test_codex_responses_websocket_url_uses_provider_base_url():
+    assert (
+        codex_runtime.codex_responses_websocket_url("https://api.openai.com/v1")
+        == "wss://api.openai.com/v1/responses"
+    )
+    assert (
+        codex_runtime.codex_responses_websocket_url("http://localhost:8080/v1/")
+        == "ws://localhost:8080/v1/responses"
+    )
+    assert (
+        codex_runtime.codex_responses_websocket_url("wss://relay.example.com/v1/responses")
+        == "wss://relay.example.com/v1/responses"
+    )
+
+
+def test_provider_config_enables_websocket_only_for_codex_responses(monkeypatch):
+    config = {
+        "providers": {
+            "vendor": {
+                "base_url": "https://api.vendor.example.com/v1",
+                "transport": "codex_responses",
+                "codex_responses_websocket": True,
+            }
+        }
+    }
+    monkeypatch.setattr(codex_runtime, "load_config", lambda: config, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1",
+    )
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is True
+
+    agent.api_mode = "chat_completions"
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is False
+
+
+def test_provider_config_transport_string_can_enable_websocket(monkeypatch):
+    config = {
+        "providers": {
+            "vendor": {
+                "base_url": "https://api.vendor.example.com/v1",
+                "transport": "codex_responses",
+                "codex_responses_transport": "websocket",
+            }
+        }
+    }
+    monkeypatch.setattr(codex_runtime, "load_config", lambda: config, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1/",
+    )
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is True
+
+
+def test_provider_config_does_not_stop_at_same_url_without_switch(monkeypatch):
+    config = {
+        "providers": {
+            "plain": {
+                "base_url": "https://api.vendor.example.com/v1",
+                "transport": "codex_responses",
+            },
+            "vendor": {
+                "base_url": "https://api.vendor.example.com/v1",
+                "transport": "codex_responses",
+                "codex_responses_websocket": True,
+            },
+        }
+    }
+    monkeypatch.setattr(codex_runtime, "load_config", lambda: config, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1/",
+    )
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is True
+
+
+def test_provider_name_match_does_not_inherit_same_url_switch(monkeypatch):
+    config = {
+        "providers": {
+            "plain": {
+                "base_url": "https://api.vendor.example.com/v1",
+                "transport": "codex_responses",
+            },
+            "vendor": {
+                "base_url": "https://api.vendor.example.com/v1",
+                "transport": "codex_responses",
+                "codex_responses_websocket": True,
+            },
+        }
+    }
+    monkeypatch.setattr(codex_runtime, "load_config", lambda: config, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="plain",
+        base_url="https://api.vendor.example.com/v1/",
+    )
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is False
+
+
+def test_provider_config_can_fallback_to_base_url_for_custom_provider(monkeypatch):
+    config = {
+        "custom_providers": [
+            {
+                "name": "vendor",
+                "base_url": "https://api.vendor.example.com/v1",
+                "api_mode": "codex_responses",
+                "codex_responses_websocket": True,
+            }
+        ]
+    }
+    monkeypatch.setattr(codex_runtime, "load_config", lambda: config, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="custom",
+        base_url="https://api.vendor.example.com/v1/",
+    )
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is True
+
+
+class _FakeWebSocket:
+    def __init__(self, events):
+        self.events = list(events)
+        self.sent_payloads = []
+        self.recv_timeouts = []
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+        return False
+
+    def send(self, payload):
+        self.sent_payloads.append(json.loads(payload))
+
+    def recv(self, timeout=None):
+        self.recv_timeouts.append(timeout)
+        if not self.events:
+            raise AssertionError("fake websocket received too many recv calls")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch):
+    events = [
+        {"type": "response.output_text.delta", "delta": "hello"},
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "hello"}],
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 1,
+                    "total_tokens": 4,
+                },
+            },
+        },
+    ]
+    fake_ws = _FakeWebSocket(events)
+    connect_calls = []
+
+    def fake_connect(uri, **kwargs):
+        connect_calls.append({"uri": uri, **kwargs})
+        return fake_ws
+
+    monkeypatch.setattr(codex_runtime, "codex_responses_websocket_enabled", lambda agent: True)
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect, raising=False)
+
+    deltas = []
+    touches = []
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1",
+        api_key="sk-test",
+        _interrupt_requested=False,
+        _fire_stream_delta=deltas.append,
+        _fire_reasoning_delta=lambda text: None,
+        _touch_activity=touches.append,
+        _client_log_context=lambda: "test-context",
+    )
+    api_kwargs = {
+        "model": "gpt-5-codex",
+        "instructions": "You are Hermes.",
+        "input": [{"role": "user", "content": "Ping"}],
+        "store": False,
+        "timeout": 30,
+        "stream": True,
+        "extra_headers": {"X-Provider-Header": "abc"},
+        "extra_body": {"metadata": {"tenant": "vendor"}},
+    }
+
+    response = codex_runtime.run_codex_stream(agent, api_kwargs)
+
+    assert connect_calls[0]["uri"] == "wss://api.vendor.example.com/v1/responses"
+    assert connect_calls[0]["additional_headers"]["Authorization"] == "Bearer sk-test"
+    assert connect_calls[0]["additional_headers"]["X-Provider-Header"] == "abc"
+
+    sent = fake_ws.sent_payloads[0]
+    assert sent["type"] == "response.create"
+    assert sent["model"] == "gpt-5-codex"
+    assert sent["metadata"] == {"tenant": "vendor"}
+    assert "extra_body" not in sent
+    assert "extra_headers" not in sent
+    assert "timeout" not in sent
+    assert "stream" not in sent
+
+    assert deltas == ["hello"]
+    assert response.id == "resp_1"
+    assert response.output[0].content[0].text == "hello"
+    assert response.usage.input_tokens == 3
+    assert fake_ws.closed is False
+    codex_runtime.close_codex_responses_websocket_session(agent)
+    assert fake_ws.closed is True
+
+
+def test_websocket_stream_json_events_normalize_function_call_items(monkeypatch):
+    fake_ws = _FakeWebSocket([
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "terminal",
+                "arguments": "{\"cmd\":\"pwd\"}",
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {"id": "resp_1", "status": "completed"},
+        },
+    ])
+
+    monkeypatch.setattr(codex_runtime, "codex_responses_websocket_enabled", lambda agent: True)
+    monkeypatch.setattr(
+        codex_runtime,
+        "_connect_responses_websocket",
+        lambda uri, **kwargs: fake_ws,
+        raising=False,
+    )
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1",
+        api_key="sk-test",
+        _interrupt_requested=False,
+        _fire_stream_delta=lambda text: None,
+        _fire_reasoning_delta=lambda text: None,
+        _touch_activity=lambda reason: None,
+        _client_log_context=lambda: "test-context",
+    )
+    response = codex_runtime.run_codex_stream(
+        agent,
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [{"role": "user", "content": "Ping"}],
+            "store": False,
+        },
+    )
+
+    assert response.output[0].type == "function_call"
+    assert response.output[0].name == "terminal"
+
+
+def test_websocket_session_builds_incremental_previous_response_payload():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    session.previous_response_id = "resp_1"
+    session.last_full_input = [
+        {"role": "user", "content": "Run pwd"},
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "terminal",
+            "arguments": "{\"cmd\":\"pwd\"}",
+        },
+    ]
+
+    payload, full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [
+                {"role": "user", "content": "Run pwd"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "terminal",
+                    "arguments": "{\"cmd\":\"pwd\"}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "{\"cwd\":\"/workspace\"}",
+                },
+            ],
+            "store": False,
+            "stream": True,
+        }
+    )
+
+    assert used_continuation is True
+    assert payload["type"] == "response.create"
+    assert payload["previous_response_id"] == "resp_1"
+    assert payload["input"] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "{\"cwd\":\"/workspace\"}",
+        }
+    ]
+    assert full_input[-1]["type"] == "function_call_output"
+
+
+def test_websocket_session_falls_back_to_full_input_when_history_is_not_prefix():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    session.previous_response_id = "resp_1"
+    session.last_full_input = [{"role": "user", "content": "old"}]
+
+    payload, _full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [{"role": "user", "content": "fresh"}],
+            "store": False,
+        }
+    )
+
+    assert used_continuation is False
+    assert "previous_response_id" not in payload
+    assert payload["input"] == [{"role": "user", "content": "fresh"}]
+
+
+def test_websocket_transport_close_with_code_can_fallback_to_http():
+    class ConnectionClosedError(Exception):
+        code = 1006
+        reason = "abnormal closure"
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1",
+        _codex_responses_websocket_output_committed=False,
+    )
+
+    assert codex_runtime.should_fallback_codex_responses_websocket_to_http(
+        agent,
+        ConnectionClosedError("websocket connection closed"),
+    ) is True

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -236,11 +236,13 @@ def test_provider_config_can_fallback_to_base_url_for_custom_provider(monkeypatc
 
 
 class _FakeWebSocket:
-    def __init__(self, events):
+    def __init__(self, events, *, response_headers=None, state_name=None):
         self.events = list(events)
         self.sent_payloads = []
         self.recv_timeouts = []
         self.closed = False
+        self.response = SimpleNamespace(headers=response_headers or {})
+        self.state = SimpleNamespace(name=state_name) if state_name else None
 
     def __enter__(self):
         return self
@@ -341,6 +343,107 @@ def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch):
     assert fake_ws.closed is False
     codex_runtime.close_codex_responses_websocket_session(agent)
     assert fake_ws.closed is True
+
+
+def test_websocket_captures_and_replays_turn_state_on_same_turn_reconnect(monkeypatch):
+    first_ws = _FakeWebSocket(
+        [
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "first"}],
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_1", "status": "completed"},
+            },
+        ],
+        response_headers={"x-codex-turn-state": "sticky-turn-token"},
+        state_name="OPEN",
+    )
+    second_ws = _FakeWebSocket(
+        [
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "second"}],
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_2", "status": "completed"},
+            },
+        ]
+    )
+    sockets = [first_ws, second_ws]
+    connect_calls = []
+
+    def fake_connect(uri, **kwargs):
+        connect_calls.append({"uri": uri, **kwargs})
+        return sockets.pop(0)
+
+    monkeypatch.setattr(codex_runtime, "codex_responses_websocket_enabled", lambda agent: True)
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1",
+        api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="hermes-thread-456",
+        _interrupt_requested=False,
+        _fire_stream_delta=lambda text: None,
+        _fire_reasoning_delta=lambda text: None,
+        _touch_activity=lambda text: None,
+        _client_log_context=lambda: "test-context",
+    )
+    api_kwargs = {
+        "model": "gpt-5-codex",
+        "instructions": "You are Hermes.",
+        "input": [{"role": "user", "content": "Ping"}],
+        "store": False,
+        "stream": True,
+    }
+
+    codex_runtime.run_codex_stream(agent, api_kwargs)
+    first_ws.state = SimpleNamespace(name="CLOSED")
+    codex_runtime.run_codex_stream(
+        agent,
+        {
+            **api_kwargs,
+            "input": [
+                {"role": "user", "content": "Ping"},
+                {"role": "assistant", "content": "first"},
+                {"role": "user", "content": "Again"},
+            ],
+        },
+    )
+
+    assert "x-codex-turn-state" not in connect_calls[0]["additional_headers"]
+    assert (
+        connect_calls[1]["additional_headers"]["x-codex-turn-state"]
+        == "sticky-turn-token"
+    )
+
+
+def test_websocket_turn_state_resets_at_conversation_turn_boundary():
+    agent = SimpleNamespace(
+        _codex_responses_websocket_output_committed=True,
+        _codex_responses_websocket_turn_state="sticky-turn-token",
+    )
+
+    codex_runtime.reset_codex_responses_websocket_turn_fallback(agent)
+
+    assert agent._codex_responses_websocket_output_committed is False
+    assert agent._codex_responses_websocket_turn_state is None
 
 
 def test_websocket_stream_json_events_normalize_function_call_items(monkeypatch):

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -90,6 +90,48 @@ def test_codex_websocket_headers_include_codex_session_affinity_headers():
     assert headers["x-client-request-id"] == "hermes-thread-456"
 
 
+def test_codex_websocket_headers_include_window_and_turn_metadata():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="hermes-thread-456",
+    )
+
+    headers = codex_runtime._codex_websocket_headers(
+        agent,
+        {"model": "gpt-5.4"},
+    )
+
+    assert headers["x-codex-window-id"] == "hermes-thread-456:0"
+    metadata = json.loads(headers["x-codex-turn-metadata"])
+    assert metadata["request_kind"] == "turn"
+    assert metadata["session_id"] == "hermes-session-123"
+    assert metadata["thread_id"] == "hermes-thread-456"
+    assert metadata["turn_id"]
+    assert metadata["window_id"] == "hermes-thread-456:0"
+    assert metadata["model"] == "gpt-5.4"
+    assert isinstance(metadata["turn_started_at_unix_ms"], int)
+
+
+def test_codex_websocket_headers_keep_turn_metadata_stable_until_reset():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="hermes-thread-456",
+    )
+
+    first = codex_runtime._codex_websocket_headers(agent, {"model": "gpt-5.4"})
+    second = codex_runtime._codex_websocket_headers(agent, {"model": "gpt-5.4"})
+    assert second["x-codex-turn-metadata"] == first["x-codex-turn-metadata"]
+
+    codex_runtime.reset_codex_responses_websocket_turn_fallback(agent)
+    third = codex_runtime._codex_websocket_headers(agent, {"model": "gpt-5.4"})
+    assert third["x-codex-turn-metadata"] != first["x-codex-turn-metadata"]
+    assert json.loads(third["x-codex-turn-metadata"])["turn_id"] != json.loads(
+        first["x-codex-turn-metadata"]
+    )["turn_id"]
+
+
 def test_codex_websocket_headers_fall_back_to_session_id_for_thread_id():
     agent = SimpleNamespace(
         api_key="sk-test",
@@ -161,6 +203,10 @@ def test_codex_websocket_headers_preserve_explicit_session_headers_case_insensit
     assert headers["Session-ID"] == "explicit-session"
     assert headers["Thread-ID"] == "explicit-thread"
     assert headers["X-Client-Request-ID"] == "explicit-request"
+    assert headers["x-codex-window-id"] == "derived-thread:0"
+    metadata = json.loads(headers["x-codex-turn-metadata"])
+    assert metadata["session_id"] == "derived-session"
+    assert metadata["thread_id"] == "derived-thread"
     assert "session-id" not in headers
     assert "thread-id" not in headers
     assert "x-client-request-id" not in headers
@@ -261,7 +307,7 @@ class _FakeWebSocket:
         return json.dumps(self.events.pop(0))
 
 
-def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch):
+def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch, caplog):
     events = [
         {"type": "response.output_text.delta", "delta": "hello"},
         {
@@ -303,6 +349,8 @@ def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch):
         provider="vendor",
         base_url="https://api.vendor.example.com/v1",
         api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="hermes-thread-456",
         _interrupt_requested=False,
         _fire_stream_delta=deltas.append,
         _fire_reasoning_delta=lambda text: None,
@@ -320,21 +368,38 @@ def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch):
         "extra_body": {"metadata": {"tenant": "vendor"}},
     }
 
-    response = codex_runtime.run_codex_stream(agent, api_kwargs)
+    with caplog.at_level("INFO", logger="agent.codex_runtime"):
+        response = codex_runtime.run_codex_stream(agent, api_kwargs)
 
     assert connect_calls[0]["uri"] == "wss://api.vendor.example.com/v1/responses"
     assert connect_calls[0]["additional_headers"]["Authorization"] == "Bearer sk-test"
     assert connect_calls[0]["additional_headers"]["X-Provider-Header"] == "abc"
     assert connect_calls[0]["additional_headers"]["OpenAI-Beta"] == "responses_websockets=2026-02-06"
+    assert connect_calls[0]["ping_interval"] is None
+    assert connect_calls[0]["ping_timeout"] is None
 
     sent = fake_ws.sent_payloads[0]
     assert sent["type"] == "response.create"
     assert sent["model"] == "gpt-5-codex"
     assert sent["metadata"] == {"tenant": "vendor"}
+    assert sent["client_metadata"]["x-codex-window-id"]
+    assert (
+        sent["client_metadata"]["x-codex-turn-metadata"]
+        == connect_calls[0]["additional_headers"]["x-codex-turn-metadata"]
+    )
+    assert sent["client_metadata"]["x-codex-ws-stream-request-start-ms"]
     assert "extra_body" not in sent
     assert "extra_headers" not in sent
     assert "timeout" not in sent
     assert "stream" not in sent
+
+    log_text = caplog.text
+    assert "codex_responses_websocket_event=request_prepared" in log_text
+    assert "has_window_id=True" in log_text
+    assert "has_turn_metadata=True" in log_text
+    assert "used_continuation=False" in log_text
+    assert "force_full_input=False" in log_text
+    assert "idle_timeout=30" in log_text
 
     assert deltas == ["hello"]
     assert response.id == "resp_1"
@@ -521,12 +586,29 @@ def test_websocket_turn_state_resets_at_conversation_turn_boundary():
     agent = SimpleNamespace(
         _codex_responses_websocket_output_committed=True,
         _codex_responses_websocket_turn_state="sticky-turn-token",
+        _codex_responses_websocket_turn_metadata_header="metadata",
     )
 
     codex_runtime.reset_codex_responses_websocket_turn_fallback(agent)
 
     assert agent._codex_responses_websocket_output_committed is False
     assert agent._codex_responses_websocket_turn_state is None
+    assert agent._codex_responses_websocket_turn_metadata_header is None
+
+
+def test_websocket_event_iterator_raises_on_business_idle_timeout():
+    class _SilentWebSocket:
+        def recv(self, timeout=None):
+            raise TimeoutError("no frame yet")
+
+    events = codex_runtime._iter_codex_websocket_events(
+        _SilentWebSocket(),
+        recv_timeout=0,
+        idle_timeout=0,
+    )
+
+    with pytest.raises(TimeoutError, match="websocket idle timeout"):
+        next(events)
 
 
 def test_websocket_stream_json_events_normalize_function_call_items(monkeypatch):

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -76,6 +76,96 @@ def test_codex_websocket_headers_append_responses_websockets_beta():
     assert beta_values == {"assistants=v2", "responses_websockets=2026-02-06"}
 
 
+def test_codex_websocket_headers_include_codex_session_affinity_headers():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="hermes-thread-456",
+    )
+
+    headers = codex_runtime._codex_websocket_headers(agent, {})
+
+    assert headers["session-id"] == "hermes-session-123"
+    assert headers["thread-id"] == "hermes-thread-456"
+    assert headers["x-client-request-id"] == "hermes-thread-456"
+
+
+def test_codex_websocket_headers_fall_back_to_session_id_for_thread_id():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="",
+    )
+
+    headers = codex_runtime._codex_websocket_headers(agent, {})
+
+    assert headers["session-id"] == "hermes-session-123"
+    assert headers["thread-id"] == "hermes-session-123"
+    assert headers["x-client-request-id"] == "hermes-session-123"
+
+
+def test_codex_websocket_headers_fall_back_to_session_id_when_thread_id_missing():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="hermes-session-123",
+    )
+
+    headers = codex_runtime._codex_websocket_headers(agent, {})
+
+    assert headers["session-id"] == "hermes-session-123"
+    assert headers["thread-id"] == "hermes-session-123"
+    assert headers["x-client-request-id"] == "hermes-session-123"
+
+
+def test_codex_websocket_headers_preserve_explicit_session_affinity_headers():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="derived-session",
+        _thread_id="derived-thread",
+    )
+
+    headers = codex_runtime._codex_websocket_headers(
+        agent,
+        {
+            "extra_headers": {
+                "session-id": "explicit-session",
+                "thread-id": "explicit-thread",
+                "x-client-request-id": "explicit-request",
+            }
+        },
+    )
+
+    assert headers["session-id"] == "explicit-session"
+    assert headers["thread-id"] == "explicit-thread"
+    assert headers["x-client-request-id"] == "explicit-request"
+
+
+def test_codex_websocket_headers_preserve_explicit_session_headers_case_insensitively():
+    agent = SimpleNamespace(
+        api_key="sk-test",
+        session_id="derived-session",
+        _thread_id="derived-thread",
+    )
+
+    headers = codex_runtime._codex_websocket_headers(
+        agent,
+        {
+            "extra_headers": {
+                "Session-ID": "explicit-session",
+                "Thread-ID": "explicit-thread",
+                "X-Client-Request-ID": "explicit-request",
+            }
+        },
+    )
+
+    assert headers["Session-ID"] == "explicit-session"
+    assert headers["Thread-ID"] == "explicit-thread"
+    assert headers["X-Client-Request-ID"] == "explicit-request"
+    assert "session-id" not in headers
+    assert "thread-id" not in headers
+    assert "x-client-request-id" not in headers
+
+
 def test_provider_config_does_not_stop_at_same_url_without_switch(monkeypatch):
     config = {
         "providers": {

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -854,6 +854,7 @@ def test_websocket_session_projects_reasoning_items_for_next_turn_baseline():
                 *first_input,
                 {
                     "type": "reasoning",
+                    "id": "rs_1",
                     "encrypted_content": "encrypted-state",
                     "summary": [],
                 },
@@ -914,6 +915,7 @@ def test_websocket_session_projects_reasoning_tool_call_sentinel_for_next_turn_b
                 *first_input,
                 {
                     "type": "reasoning",
+                    "id": "rs_1",
                     "encrypted_content": "encrypted-state",
                     "summary": [],
                 },

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -64,6 +64,18 @@ def test_provider_config_transport_string_can_enable_websocket(monkeypatch):
     assert codex_runtime.codex_responses_websocket_enabled(agent) is True
 
 
+def test_codex_websocket_headers_append_responses_websockets_beta():
+    agent = SimpleNamespace(api_key="sk-test")
+
+    headers = codex_runtime._codex_websocket_headers(
+        agent,
+        {"extra_headers": {"OpenAI-Beta": "assistants=v2"}},
+    )
+
+    beta_values = {value.strip() for value in headers["OpenAI-Beta"].split(",")}
+    assert beta_values == {"assistants=v2", "responses_websockets=2026-02-06"}
+
+
 def test_provider_config_does_not_stop_at_same_url_without_switch(monkeypatch):
     config = {
         "providers": {
@@ -221,6 +233,7 @@ def test_run_codex_stream_uses_provider_websocket_payload(monkeypatch):
     assert connect_calls[0]["uri"] == "wss://api.vendor.example.com/v1/responses"
     assert connect_calls[0]["additional_headers"]["Authorization"] == "Bearer sk-test"
     assert connect_calls[0]["additional_headers"]["X-Provider-Header"] == "abc"
+    assert connect_calls[0]["additional_headers"]["OpenAI-Beta"] == "responses_websockets=2026-02-06"
 
     sent = fake_ws.sent_payloads[0]
     assert sent["type"] == "response.create"

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -688,6 +688,77 @@ def test_websocket_session_projects_reasoning_items_for_next_turn_baseline():
     assert payload["input"] == [{"role": "user", "content": "Continue"}]
 
 
+def test_websocket_session_projects_reasoning_tool_call_sentinel_for_next_turn_baseline():
+    session = codex_runtime._CodexResponsesWebSocketSession(
+        uri="wss://api.vendor.example.com/v1/responses",
+        headers={"Authorization": "Bearer sk-test"},
+        open_timeout=10,
+    )
+    first_input = [{"role": "user", "content": "Run pwd after thinking"}]
+    _payload, full_input, _used_continuation = session.build_payload(
+        {"model": "gpt-5-codex", "input": first_input, "store": False}
+    )
+    session.record_response(
+        SimpleNamespace(
+            id="resp_1",
+            status="completed",
+            output=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "encrypted_content": "encrypted-state",
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "status": "completed",
+                    "call_id": "call_1",
+                    "name": "terminal",
+                    "arguments": "{\"cmd\":\"pwd\"}",
+                },
+            ],
+        ),
+        full_input,
+    )
+
+    payload, _full_input, used_continuation = session.build_payload(
+        {
+            "model": "gpt-5-codex",
+            "input": [
+                *first_input,
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "encrypted-state",
+                    "summary": [],
+                },
+                {"role": "assistant", "content": ""},
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "terminal",
+                    "arguments": "{\"cmd\":\"pwd\"}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "{\"cwd\":\"/workspace\"}",
+                },
+            ],
+            "store": False,
+        }
+    )
+
+    assert used_continuation is True
+    assert payload["previous_response_id"] == "resp_1"
+    assert payload["input"] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "{\"cwd\":\"/workspace\"}",
+        }
+    ]
+
+
 def test_websocket_transport_close_with_code_can_fallback_to_http():
     class ConnectionClosedError(Exception):
         code = 1006

--- a/tests/agent/test_codex_responses_websocket.py
+++ b/tests/agent/test_codex_responses_websocket.py
@@ -434,6 +434,89 @@ def test_websocket_captures_and_replays_turn_state_on_same_turn_reconnect(monkey
     )
 
 
+def test_websocket_turn_state_header_does_not_recreate_open_session(monkeypatch):
+    first_output = {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "first"}],
+    }
+    first_ws = _FakeWebSocket(
+        [
+            {"type": "response.output_item.done", "item": first_output},
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_1", "status": "completed"},
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "second"}],
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_2", "status": "completed"},
+            },
+        ],
+        response_headers={"x-codex-turn-state": "sticky-turn-token"},
+        state_name="OPEN",
+    )
+    second_ws = _FakeWebSocket([])
+    sockets = [first_ws, second_ws]
+    connect_calls = []
+
+    def fake_connect(uri, **kwargs):
+        connect_calls.append({"uri": uri, **kwargs})
+        return sockets.pop(0)
+
+    monkeypatch.setattr(codex_runtime, "codex_responses_websocket_enabled", lambda agent: True)
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect, raising=False)
+
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="vendor",
+        base_url="https://api.vendor.example.com/v1",
+        api_key="sk-test",
+        session_id="hermes-session-123",
+        _thread_id="hermes-thread-456",
+        _interrupt_requested=False,
+        _fire_stream_delta=lambda text: None,
+        _fire_reasoning_delta=lambda text: None,
+        _touch_activity=lambda text: None,
+        _client_log_context=lambda: "test-context",
+    )
+    api_kwargs = {
+        "model": "gpt-5-codex",
+        "instructions": "You are Hermes.",
+        "input": [{"role": "user", "content": "Ping"}],
+        "store": False,
+        "stream": True,
+    }
+
+    codex_runtime.run_codex_stream(agent, api_kwargs)
+    codex_runtime.run_codex_stream(
+        agent,
+        {
+            **api_kwargs,
+            "extra_headers": {"x-codex-turn-state": "sticky-turn-token"},
+            "input": [
+                {"role": "user", "content": "Ping"},
+                first_output,
+                {"role": "user", "content": "Again"},
+            ],
+        },
+    )
+
+    assert len(connect_calls) == 1
+    assert first_ws.sent_payloads[1]["previous_response_id"] == "resp_1"
+    assert first_ws.sent_payloads[1]["input"] == [{"role": "user", "content": "Again"}]
+    assert second_ws.sent_payloads == []
+
+
 def test_websocket_turn_state_resets_at_conversation_turn_boundary():
     agent = SimpleNamespace(
         _codex_responses_websocket_output_committed=True,

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -33,6 +33,8 @@ def _make_codex_agent(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / ".env").write_text("", encoding="utf-8")
     (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+    import run_agent
+    monkeypatch.setattr(run_agent, "_hermes_home", tmp_path)
     from run_agent import AIAgent
 
     agent = AIAgent(
@@ -77,7 +79,11 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
         agent, "_close_request_openai_client",
         lambda c, reason=None: closes.append(reason),
     )
-
+    websocket_closes: list = []
+    monkeypatch.setattr(
+        "agent.codex_runtime.close_codex_responses_websocket_session",
+        lambda closed_agent: websocket_closes.append(closed_agent),
+    )
     stop = {"flag": False}
 
     def fake_hang(api_kwargs, client=None, on_first_delta=None):
@@ -96,8 +102,60 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
         elapsed = time.time() - t0
         assert "TTFB" in str(excinfo.value)
         assert "codex_ttfb_kill" in closes
+        assert websocket_closes == [agent]
         # ~1s cutoff + 2s join grace; must be far under the 60s stale timeout.
         assert elapsed < 15, f"TTFB watchdog took {elapsed:.1f}s"
+    finally:
+        stop["flag"] = True
+
+
+def test_ttfb_kill_disables_websocket_for_current_turn(tmp_path, monkeypatch):
+    """A no-byte WebSocket watchdog kill should make the current turn retry
+    over the same provider's HTTP/SSE path, not reopen the failed WebSocket."""
+    from agent import chat_completion_helpers as h
+    from agent.codex_runtime import (
+        codex_responses_websocket_enabled,
+        reset_codex_responses_websocket_turn_fallback,
+    )
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    agent.provider = "openai-codex"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    (tmp_path / "config.yaml").write_text(
+        """
+providers:
+  openai-codex:
+    base_url: https://chatgpt.com/backend-api/codex
+    codex_responses_websocket: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    reset_codex_responses_websocket_turn_fallback(agent)
+    assert codex_responses_websocket_enabled(agent) is True
+
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_abort_request_openai_client", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+    stop = {"flag": False}
+
+    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
+
+    try:
+        with pytest.raises(TimeoutError):
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+        assert codex_responses_websocket_enabled(agent) is False
+        assert getattr(agent, "_codex_responses_websocket_chain_invalidated_key") == (
+            "openai-codex",
+            "https://chatgpt.com/backend-api/codex",
+        )
     finally:
         stop["flag"] = True
 
@@ -294,7 +352,6 @@ def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
         "_close_request_openai_client",
         lambda c, reason=None: closes.append(reason),
     )
-
     stop = {"flag": False}
 
     def fake_stream(api_kwargs, client=None, on_first_delta=None):

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -109,12 +109,13 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
-def test_ttfb_kill_disables_websocket_for_current_turn(tmp_path, monkeypatch):
-    """A no-byte WebSocket watchdog kill should make the current turn retry
-    over the same provider's HTTP/SSE path, not reopen the failed WebSocket."""
+def test_ttfb_kill_marks_websocket_retry_with_full_input(tmp_path, monkeypatch):
+    """A no-byte WebSocket watchdog kill should make the retry loop reopen
+    WebSocket with full input; HTTP fallback happens only after retry exhaustion."""
     from agent import chat_completion_helpers as h
     from agent.codex_runtime import (
         codex_responses_websocket_enabled,
+        is_codex_responses_websocket_error,
         reset_codex_responses_websocket_turn_fallback,
     )
 
@@ -149,9 +150,10 @@ providers:
     monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
 
     try:
-        with pytest.raises(TimeoutError):
+        with pytest.raises(TimeoutError) as excinfo:
             h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
-        assert codex_responses_websocket_enabled(agent) is False
+        assert codex_responses_websocket_enabled(agent) is True
+        assert is_codex_responses_websocket_error(excinfo.value) is True
         assert getattr(agent, "_codex_responses_websocket_chain_invalidated_key") == (
             "openai-codex",
             "https://chatgpt.com/backend-api/codex",

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -105,6 +105,15 @@ class TestCodexBuildKwargs:
         assert headers["session-id"] == "test-session-123"
         assert headers["thread-id"] == "test-thread-456"
         assert headers["x-client-request-id"] == "test-thread-456"
+        assert headers["x-codex-window-id"] == "test-thread-456:0"
+        metadata = json.loads(headers["x-codex-turn-metadata"])
+        assert metadata["request_kind"] == "turn"
+        assert metadata["session_id"] == "test-session-123"
+        assert metadata["thread_id"] == "test-thread-456"
+        assert metadata["window_id"] == "test-thread-456:0"
+        assert metadata["model"] == "gpt-5.4"
+        assert metadata["turn_id"]
+        assert isinstance(metadata["turn_started_at_unix_ms"], int)
 
     def test_codex_session_headers_preserve_request_overrides(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
@@ -129,6 +138,10 @@ class TestCodexBuildKwargs:
         assert headers["Thread-ID"] == "explicit-thread"
         assert headers["X-Client-Request-ID"] == "explicit-request"
         assert headers["X-Trace"] == "abc"
+        assert headers["x-codex-window-id"] == "derived-thread:0"
+        metadata = json.loads(headers["x-codex-turn-metadata"])
+        assert metadata["session_id"] == "derived-session"
+        assert metadata["thread_id"] == "derived-thread"
         assert "session-id" not in headers
         assert "thread-id" not in headers
         assert "x-client-request-id" not in headers

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -91,6 +91,61 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("prompt_cache_key") == "test-session-123"
 
+    def test_session_id_sets_codex_session_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="test-session-123",
+            thread_id="test-thread-456",
+        )
+
+        headers = kw.get("extra_headers", {})
+        assert headers["session-id"] == "test-session-123"
+        assert headers["thread-id"] == "test-thread-456"
+        assert headers["x-client-request-id"] == "test-thread-456"
+
+    def test_codex_session_headers_preserve_request_overrides(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="derived-session",
+            thread_id="derived-thread",
+            request_overrides={
+                "extra_headers": {
+                    "Session-ID": "explicit-session",
+                    "Thread-ID": "explicit-thread",
+                    "X-Client-Request-ID": "explicit-request",
+                    "X-Trace": "abc",
+                }
+            },
+        )
+
+        headers = kw.get("extra_headers", {})
+        assert headers["Session-ID"] == "explicit-session"
+        assert headers["Thread-ID"] == "explicit-thread"
+        assert headers["X-Client-Request-ID"] == "explicit-request"
+        assert headers["X-Trace"] == "abc"
+        assert "session-id" not in headers
+        assert "thread-id" not in headers
+        assert "x-client-request-id" not in headers
+
+    def test_codex_turn_state_header_is_forwarded_when_present(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="test-session-123",
+            thread_id="test-thread-456",
+            codex_turn_state="sticky-turn-token",
+        )
+
+        assert kw.get("extra_headers", {})["x-codex-turn-state"] == "sticky-turn-token"
+
     def test_github_responses_no_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -102,6 +102,22 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
+    def test_codex_responses_websocket_keys_not_flagged_unknown(self, caplog):
+        """Provider-scoped WebSocket transport switches should be supported schema."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "transport": "codex_responses",
+            "codex_responses_websocket": True,
+            "codex_responses_transport": "websocket",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["codex_responses_websocket"] is True
+        assert result["codex_responses_transport"] == "websocket"
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
+
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""
         entry = {

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -1073,10 +1073,7 @@ class TestCodexReasoningPreflight:
         reasoning_items = [i for i in normalized if i.get("type") == "reasoning"]
         assert len(reasoning_items) == 1
         assert reasoning_items[0]["encrypted_content"] == "abc123encrypted"
-        # Note: "id" is intentionally excluded from normalized output —
-        # with store=False the API returns 404 on server-side id resolution.
-        # The id is only used for local deduplication via seen_ids.
-        assert "id" not in reasoning_items[0]
+        assert reasoning_items[0]["id"] == "r_001"
         assert reasoning_items[0]["summary"] == [{"type": "summary_text", "text": "Thinking about it"}]
 
     def test_reasoning_item_without_id(self, monkeypatch):
@@ -1120,6 +1117,7 @@ class TestCodexReasoningPreflight:
         reasoning_items = [i for i in items if isinstance(i, dict) and i.get("type") == "reasoning"]
         assert len(reasoning_items) == 1
         assert reasoning_items[0]["encrypted_content"] == "enc123"
+        assert reasoning_items[0]["id"] == "r_1"
 
 
 # ── Reasoning effort consistency tests ───────────────────────────────────────

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -300,6 +300,20 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_build_api_kwargs_codex_includes_session_affinity_and_turn_state(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._thread_id = "thread-for-sticky-routing"
+    agent._codex_responses_websocket_turn_state = "turn-state-token"
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    headers = kwargs.get("extra_headers", {})
+    assert headers["session-id"] == agent.session_id
+    assert headers["thread-id"] == "thread-for-sticky-routing"
+    assert headers["x-client-request-id"] == "thread-for-sticky-routing"
+    assert headers["x-codex-turn-state"] == "turn-state-token"
+
+
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     """'minimal' reasoning effort is clamped to 'low' on the Responses API.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2162,9 +2162,47 @@ def test_chat_messages_to_responses_input_deduplicates_reasoning_ids(monkeypatch
     assert encrypted.count("enc_1") == 1
     assert "enc_2" in encrypted
     assert "enc_3" in encrypted
-    # IDs must be stripped — with store=False the API 404s on id lookups.
-    for it in reasoning_items:
-        assert "id" not in it
+    assert [it.get("id") for it in reasoning_items] == ["rs_aaa", "rs_bbb", "rs_ccc"]
+
+
+def test_chat_messages_to_responses_input_keeps_reasoning_id_for_message_replay(monkeypatch):
+    """Stored assistant message IDs require their paired reasoning item IDs."""
+    agent = _build_agent(monkeypatch)
+    messages = [
+        {"role": "user", "content": "check weather"},
+        {
+            "role": "assistant",
+            "content": "I found it.",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_required",
+                    "encrypted_content": "enc_required",
+                    "summary": [],
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "id": "msg_requires_reasoning",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "I found it."}],
+                }
+            ],
+        },
+    ]
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning_idx = next(i for i, it in enumerate(items) if it.get("type") == "reasoning")
+    message_idx = next(i for i, it in enumerate(items) if it.get("type") == "message")
+    assert reasoning_idx < message_idx
+    assert items[reasoning_idx]["id"] == "rs_required"
+    assert items[reasoning_idx]["encrypted_content"] == "enc_required"
+    assert items[message_idx]["id"] == "msg_requires_reasoning"
+    assert items[message_idx]["phase"] == "final_answer"
 
 
 def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
@@ -2187,9 +2225,7 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     encrypted = [it["encrypted_content"] for it in reasoning_items]
     assert encrypted.count("enc_a") == 1
     assert "enc_b" in encrypted
-    # IDs must be stripped — with store=False the API 404s on id lookups.
-    for it in reasoning_items:
-        assert "id" not in it
+    assert [it.get("id") for it in reasoning_items] == ["rs_xyz", "rs_zzz"]
 
 
 def test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -148,6 +148,7 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
         skip_memory=True,
         load_soul_identity=False,
         session_id="codex-responses-ws-e2e",
+        thread_id="codex-responses-ws-thread-e2e",
         reasoning_config={"enabled": False},
         max_tokens=80,
     )
@@ -206,6 +207,12 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
     connection = connections[0]
     assert connection["uri"] == "wss://sub2api.tegical.com/responses"
     assert connection["headers"].get("Authorization") == "Bearer sk-test"
+    assert connection["headers"].get("session-id") == "codex-responses-ws-e2e"
+    assert connection["headers"].get("thread-id") == "codex-responses-ws-thread-e2e"
+    assert (
+        connection["headers"].get("x-client-request-id")
+        == "codex-responses-ws-thread-e2e"
+    )
 
     sends = connection["sends"]
     assert len(sends) == 3

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import sys
 import types
 from types import SimpleNamespace
@@ -492,6 +493,7 @@ def test_run_conversation_codex_responses_does_not_use_websocket_without_provide
 
 def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_to_http_same_provider(
     monkeypatch,
+    caplog,
 ):
     ws_attempts = []
 
@@ -534,7 +536,8 @@ def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_t
     agent = _make_codex_responses_ws_agent("codex-responses-ws-http-fallback")
     agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
 
-    result = agent.run_conversation("Reply http-ok.")
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        result = agent.run_conversation("Reply http-ok.")
 
     assert result["completed"] is True
     assert result["final_response"] == "http-ok"
@@ -544,6 +547,10 @@ def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_t
     assert "previous_response_id" not in http_calls[0]
     request_input = json.dumps(http_calls[0]["input"], ensure_ascii=False)
     assert "Reply http-ok" in request_input
+    assert "Codex Responses WebSocket disabled for current turn" in caplog.text
+    assert "codex_responses_websocket_event=http_fallback" in caplog.text
+    assert "falling back to HTTP" in caplog.text
+    assert "websocket_transport_error" in caplog.text
 
 
 def test_run_conversation_codex_responses_websocket_fallback_keeps_remaining_turn_on_full_http(
@@ -770,6 +777,7 @@ class _RestoredResponsesWebSocket:
 
 def test_run_conversation_codex_responses_websocket_restores_with_full_input_after_http_fallback(
     monkeypatch,
+    caplog,
 ):
     ws_connect_attempts = []
     connections = []
@@ -821,16 +829,17 @@ def test_run_conversation_codex_responses_websocket_restores_with_full_input_aft
     agent = _make_codex_responses_ws_agent("codex-responses-ws-restore-after-http", max_iterations=2)
     agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
 
-    first = agent.run_conversation("Initial turn. Reply http-first.")
-    assert first["completed"] is True
-    assert first["final_response"] == "http-first"
+    with caplog.at_level(logging.INFO, logger="agent.codex_runtime"):
+        first = agent.run_conversation("Initial turn. Reply http-first.")
+        assert first["completed"] is True
+        assert first["final_response"] == "http-first"
 
-    second = agent.run_conversation(
-        "Second turn. Reply ws-restored.",
-        conversation_history=first["messages"],
-    )
-    assert second["completed"] is True
-    assert second["final_response"] == "ws-restored"
+        second = agent.run_conversation(
+            "Second turn. Reply ws-restored.",
+            conversation_history=first["messages"],
+        )
+        assert second["completed"] is True
+        assert second["final_response"] == "ws-restored"
 
     third = agent.run_conversation(
         "Third turn. Reply ws-third.",
@@ -859,6 +868,11 @@ def test_run_conversation_codex_responses_websocket_restores_with_full_input_aft
     assert "Initial turn" not in incremental_input
     assert "http-first" not in incremental_input
     assert "Second turn" not in incremental_input
+    assert "chain invalidated" in caplog.text
+    assert "codex_responses_websocket_event=restore_full_input" in caplog.text
+    assert "codex_responses_websocket_event=restore_full_input_completed" in caplog.text
+    assert "reopening with full input" in caplog.text
+    assert "full-input request completed" in caplog.text
 
 
 class _RecoveringResponsesWebSocket:
@@ -1037,6 +1051,7 @@ class _StaleThenReopenedResponsesWebSocket:
 
 def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_http_fallback(
     monkeypatch,
+    caplog,
 ):
     connections = []
 
@@ -1077,10 +1092,11 @@ def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_
     # first request. The next turn should reopen WebSocket and retry full input.
     connections[0]["fail_send"] = True
 
-    second = agent.run_conversation(
-        "Second turn. Reply second-ok.",
-        conversation_history=first["messages"],
-    )
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        second = agent.run_conversation(
+            "Second turn. Reply second-ok.",
+            conversation_history=first["messages"],
+        )
 
     assert second["completed"] is True
     assert second["final_response"] == "second-ok"
@@ -1098,3 +1114,7 @@ def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_
     assert "First turn" in reopened_input
     assert "first-ok" in reopened_input
     assert "Second turn" in reopened_input
+    assert "continuation failed before output" in caplog.text
+    assert "codex_responses_websocket_event=continuation_reopen_before_http_fallback" in caplog.text
+    assert "reopening with full input before HTTP fallback" in caplog.text
+    assert "stale websocket send failed" in caplog.text

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -214,6 +214,13 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
     assert connection["headers"].get("Authorization") == "Bearer sk-test"
     assert connection["headers"].get("session-id") == "codex-responses-ws-e2e"
     assert connection["headers"].get("thread-id") == "codex-responses-ws-thread-e2e"
+    assert connection["headers"].get("x-codex-window-id") == "codex-responses-ws-thread-e2e:0"
+    handshake_metadata = json.loads(connection["headers"]["x-codex-turn-metadata"])
+    assert handshake_metadata["request_kind"] == "turn"
+    assert handshake_metadata["session_id"] == "codex-responses-ws-e2e"
+    assert handshake_metadata["thread_id"] == "codex-responses-ws-thread-e2e"
+    assert handshake_metadata["window_id"] == "codex-responses-ws-thread-e2e:0"
+    assert handshake_metadata["model"] == "gpt-5.4"
     assert (
         connection["headers"].get("x-client-request-id")
         == "codex-responses-ws-thread-e2e"
@@ -225,6 +232,20 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
     assert all(call["sent"]["type"] == "response.create" for call in sends)
     assert all("stream" not in call["sent"] for call in sends)
     assert all("background" not in call["sent"] for call in sends)
+    metadata_by_turn = [
+        json.loads(call["sent"]["client_metadata"]["x-codex-turn-metadata"])
+        for call in sends
+    ]
+    assert all(
+        metadata["window_id"] == "codex-responses-ws-thread-e2e:0"
+        for metadata in metadata_by_turn
+    )
+    assert len({metadata["turn_id"] for metadata in metadata_by_turn}) == 3
+    assert all(
+        call["sent"]["client_metadata"]["x-codex-window-id"]
+        == "codex-responses-ws-thread-e2e:0"
+        for call in sends
+    )
 
     assert "previous_response_id" not in sends[0]["sent"]
     assert sends[1]["sent"]["previous_response_id"] == "resp_1"

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -15,6 +15,10 @@ import run_agent
 from agent import codex_runtime
 
 
+class ConnectionClosedError(Exception):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def _isolated_hermes_home(monkeypatch, tmp_path):
     hermes_home = tmp_path / "hermes"
@@ -127,6 +131,7 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
         connection = {
             "uri": uri,
             "headers": kwargs.get("additional_headers") or {},
+            "user_agent_header": kwargs.get("user_agent_header"),
             "sends": [],
         }
         connections.append(connection)
@@ -213,6 +218,7 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
         connection["headers"].get("x-client-request-id")
         == "codex-responses-ws-thread-e2e"
     )
+    assert connection["user_agent_header"].startswith("HermesAgent/")
 
     sends = connection["sends"]
     assert len(sends) == 3
@@ -703,7 +709,7 @@ class _PartialThenFailResponsesWebSocket:
     def recv(self, timeout=None):
         if self.events:
             return json.dumps(self.events.pop(0))
-        raise ConnectionError("websocket failed after committed text")
+        raise ConnectionClosedError("websocket closed before response.completed")
 
 
 def test_run_conversation_codex_responses_websocket_does_not_http_fallback_after_committed_text(
@@ -1255,3 +1261,103 @@ def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_
     assert "codex_responses_websocket_event=restore_full_input" in caplog.text
     assert "continuation_reopen_before_http_fallback" not in caplog.text
     assert "stale websocket send failed" in caplog.text
+
+
+class _StateAwareResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.connection["socket"] = self
+        self.events = []
+        self.state = SimpleNamespace(name="OPEN")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+        self.state = SimpleNamespace(name="CLOSED")
+
+    def send(self, payload):
+        if getattr(self.state, "name", None) != "OPEN":
+            self.connection.setdefault("stale_send_attempts", 0)
+            self.connection["stale_send_attempts"] += 1
+            raise ConnectionClosedError("websocket is already closed")
+
+        sent = json.loads(payload)
+        response_id = f"{self.connection['name']}_resp_{len(self.connection['sends']) + 1}"
+        self.connection["sends"].append({"id": response_id, "sent": sent})
+        input_text = json.dumps(sent.get("input", []), ensure_ascii=False)
+        response_text = "state-second-ok" if "Second state turn" in input_text else "state-first-ok"
+        self.events = [
+            {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": response_text},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": response_text}],
+                },
+            },
+            {"type": "response.completed", "response": {"id": response_id, "status": "completed"}},
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_conversation_codex_responses_websocket_reopens_when_cached_socket_state_is_closed(
+    monkeypatch,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "name": f"state-conn{len(connections) + 1}",
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _StateAwareResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-state-reopen", max_iterations=2)
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("closed cached WebSocket should reopen before HTTP fallback")
+        )
+    )
+
+    first = agent.run_conversation("First state turn. Reply state-first-ok.")
+    assert first["completed"] is True
+    assert first["final_response"] == "state-first-ok"
+
+    connections[0]["socket"].state = SimpleNamespace(name="CLOSED")
+
+    second = agent.run_conversation(
+        "Second state turn. Reply state-second-ok.",
+        conversation_history=first["messages"],
+    )
+
+    assert second["completed"] is True
+    assert second["final_response"] == "state-second-ok"
+    assert len(connections) == 2
+    assert len(connections[0]["sends"]) == 1
+    assert connections[0].get("stale_send_attempts", 0) == 0
+    assert connections[0].get("closed") is True
+
+    reopened_payload = connections[1]["sends"][0]["sent"]
+    reopened_input = json.dumps(reopened_payload["input"], ensure_ascii=False)
+    assert "previous_response_id" not in reopened_payload
+    assert "First state turn" in reopened_input
+    assert "state-first-ok" in reopened_input
+    assert "Second state turn" in reopened_input

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -246,6 +246,158 @@ def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
     assert connection.get("closed") is True
 
 
+class _InterleavedConversationResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        call = {
+            "id": f"resp_{len(self.connection['sends']) + 1}",
+            "sent": sent,
+        }
+        self.connection["sends"].append(call)
+        response_text = self._response_for(sent)
+        self.events = [
+            {"type": "response.created", "response": {"id": call["id"], "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": response_text},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": response_text}],
+                },
+            },
+            {"type": "response.completed", "response": {"id": call["id"], "status": "completed"}},
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+    @staticmethod
+    def _response_for(sent):
+        input_text = json.dumps(sent.get("input", []), ensure_ascii=False)
+        if "Conversation A turn 3" in input_text:
+            return "answer-a3"
+        if "Conversation B turn 2" in input_text:
+            return "answer-b2"
+        if "Conversation A turn 2" in input_text:
+            return "answer-a2"
+        if "Conversation B turn 1" in input_text:
+            return "answer-b1"
+        if "Conversation A turn 1" in input_text:
+            return "answer-a1"
+        return "unexpected"
+
+
+def test_run_conversation_codex_responses_websocket_keeps_incremental_state_per_interleaved_history(
+    monkeypatch,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _InterleavedConversationResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    agent = _make_codex_responses_ws_agent(
+        "codex-responses-ws-interleaved-histories",
+        max_iterations=2,
+    )
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("codex_responses WebSocket path must not create an HTTP request client")
+        )
+    )
+
+    history_a = []
+    history_b = []
+
+    a1 = agent.run_conversation(
+        "Conversation A turn 1. Reply answer-a1.",
+        conversation_history=history_a,
+    )
+    history_a = a1["messages"]
+    b1 = agent.run_conversation(
+        "Conversation B turn 1. Reply answer-b1.",
+        conversation_history=history_b,
+    )
+    history_b = b1["messages"]
+    a2 = agent.run_conversation(
+        "Conversation A turn 2. Reply answer-a2.",
+        conversation_history=history_a,
+    )
+    history_a = a2["messages"]
+    b2 = agent.run_conversation(
+        "Conversation B turn 2. Reply answer-b2.",
+        conversation_history=history_b,
+    )
+    history_b = b2["messages"]
+    a3 = agent.run_conversation(
+        "Conversation A turn 3. Reply answer-a3.",
+        conversation_history=history_a,
+    )
+
+    assert [a1["final_response"], b1["final_response"], a2["final_response"]] == [
+        "answer-a1",
+        "answer-b1",
+        "answer-a2",
+    ]
+    assert [b2["final_response"], a3["final_response"]] == ["answer-b2", "answer-a3"]
+
+    assert len(connections) == 1
+    sends = connections[0]["sends"]
+    assert len(sends) == 5
+
+    assert "previous_response_id" not in sends[0]["sent"]
+    assert "previous_response_id" not in sends[1]["sent"]
+    assert sends[2]["sent"]["previous_response_id"] == "resp_1"
+    assert sends[3]["sent"]["previous_response_id"] == "resp_2"
+    assert sends[4]["sent"]["previous_response_id"] == "resp_3"
+
+    second_a_input = json.dumps(sends[2]["sent"]["input"], ensure_ascii=False)
+    second_b_input = json.dumps(sends[3]["sent"]["input"], ensure_ascii=False)
+    third_a_input = json.dumps(sends[4]["sent"]["input"], ensure_ascii=False)
+
+    assert "Conversation A turn 2" in second_a_input
+    assert "Conversation A turn 1" not in second_a_input
+    assert "answer-a1" not in second_a_input
+    assert "Conversation B turn" not in second_a_input
+
+    assert "Conversation B turn 2" in second_b_input
+    assert "Conversation B turn 1" not in second_b_input
+    assert "answer-b1" not in second_b_input
+    assert "Conversation A turn" not in second_b_input
+
+    assert "Conversation A turn 3" in third_a_input
+    assert "Conversation A turn 1" not in third_a_input
+    assert "Conversation A turn 2" not in third_a_input
+    assert "answer-a1" not in third_a_input
+    assert "answer-a2" not in third_a_input
+    assert "Conversation B turn" not in third_a_input
+
+
 class _HermesToolResponsesWebSocket:
     def __init__(self, connection):
         self.connection = connection

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -1,0 +1,989 @@
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+from agent import codex_runtime
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  provider: sub2api-test
+  default: gpt-5.4
+  base_url: https://sub2api.tegical.com
+  api_mode: codex_responses
+providers:
+  sub2api-test:
+    base_url: https://sub2api.tegical.com
+    transport: codex_responses
+    codex_responses_websocket: true
+agent:
+  task_completion_guidance: false
+skills:
+  enabled: false
+memory:
+  enabled: false
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(run_agent, "_hermes_home", hermes_home)
+
+
+@pytest.fixture(autouse=True)
+def _patch_agent_bootstrap(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+
+
+class _HermesResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        call = {
+            "id": f"resp_{len(self.connection['sends']) + 1}",
+            "sent": sent,
+        }
+        self.connection["sends"].append(call)
+        response_text = self._response_for(sent)
+        self.events = [
+            {"type": "response.created", "response": {"id": call["id"], "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": response_text},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": response_text}],
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": call["id"],
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 3,
+                        "total_tokens": 13,
+                    },
+                },
+            },
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        event = self.events.pop(0)
+        self.connection.setdefault("events", []).append(event["type"])
+        return json.dumps(event)
+
+    @staticmethod
+    def _response_for(sent):
+        input_text = json.dumps(sent.get("input", []), ensure_ascii=False)
+        if "Append -done" in input_text:
+            return "cobalt-otter-17-done"
+        if "What nonce" in input_text:
+            return "cobalt-otter-17"
+        if "Remember the nonce" in input_text:
+            return "noted"
+        return "unexpected"
+
+
+def test_run_conversation_codex_responses_websocket_multi_turn_e2e(monkeypatch):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _HermesResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="sub2api-test",
+        api_mode="codex_responses",
+        base_url="https://sub2api.tegical.com",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=3,
+        enabled_toolsets=[],
+        disabled_toolsets=["terminal", "web", "browser", "memory", "todo"],
+        skip_context_files=True,
+        skip_memory=True,
+        load_soul_identity=False,
+        session_id="codex-responses-ws-e2e",
+        reasoning_config={"enabled": False},
+        max_tokens=80,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is True
+
+    class _FailResponsesClient:
+        def create(self, *args, **kwargs):
+            raise AssertionError("codex_responses WebSocket path must not use responses.create()")
+
+    class _FailOpenAIClient:
+        responses = _FailResponsesClient()
+
+        def close(self):
+            pass
+
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("codex_responses WebSocket path must not create an HTTP request client")
+        )
+    )
+    agent._ensure_primary_openai_client = lambda *args, **kwargs: _FailOpenAIClient()
+
+    history = None
+    turn_specs = [
+        (
+            "Remember the nonce cobalt-otter-17. Reply exactly: noted",
+            "noted",
+        ),
+        (
+            "What nonce did I ask you to remember? Reply only the nonce.",
+            "cobalt-otter-17",
+        ),
+        (
+            "Append -done to that nonce and reply only the result.",
+            "cobalt-otter-17-done",
+        ),
+    ]
+
+    for prompt, expected in turn_specs:
+        chunks = []
+        result = agent.run_conversation(
+            prompt,
+            conversation_history=history,
+            stream_callback=chunks.append,
+        )
+        assert result["completed"] is True
+        assert result["api_calls"] == 1
+        assert result["final_response"] == expected
+        assert "".join(chunks) == expected
+        history = result["messages"]
+
+    assert len(connections) == 1
+    connection = connections[0]
+    assert connection["uri"] == "wss://sub2api.tegical.com/responses"
+    assert connection["headers"].get("Authorization") == "Bearer sk-test"
+
+    sends = connection["sends"]
+    assert len(sends) == 3
+    assert all(call["sent"]["type"] == "response.create" for call in sends)
+    assert all("stream" not in call["sent"] for call in sends)
+    assert all("background" not in call["sent"] for call in sends)
+
+    assert "previous_response_id" not in sends[0]["sent"]
+    assert sends[1]["sent"]["previous_response_id"] == "resp_1"
+    assert sends[2]["sent"]["previous_response_id"] == "resp_2"
+
+    first_input = json.dumps(sends[0]["sent"]["input"], ensure_ascii=False)
+    second_input = json.dumps(sends[1]["sent"]["input"], ensure_ascii=False)
+    third_input = json.dumps(sends[2]["sent"]["input"], ensure_ascii=False)
+    assert "cobalt-otter-17" in first_input
+    assert "cobalt-otter-17" not in second_input
+    assert "noted" not in second_input
+    assert "Remember the nonce" not in second_input
+    assert "cobalt-otter-17" not in third_input
+    assert "noted" not in third_input
+    assert "What nonce" not in third_input
+    assert "cobalt-otter-17-done" not in third_input
+
+    agent.release_clients()
+    assert connection.get("closed") is True
+
+
+class _HermesToolResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        index = len(self.connection["sends"])
+        call = {
+            "id": f"resp_tool_{index + 1}",
+            "sent": sent,
+        }
+        self.connection["sends"].append(call)
+        if index == 0:
+            self.events = [
+                {"type": "response.created", "response": {"id": call["id"], "status": "in_progress"}},
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "function_call",
+                        "id": "fc_1",
+                        "call_id": "call_1",
+                        "name": "terminal",
+                        "arguments": "{\"cmd\":\"pwd\"}",
+                    },
+                },
+                {"type": "response.completed", "response": {"id": call["id"], "status": "completed"}},
+            ]
+        elif index == 1:
+            self.events = [
+                {"type": "response.created", "response": {"id": call["id"], "status": "in_progress"}},
+                {"type": "response.output_text.delta", "delta": "done"},
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "done"}],
+                    },
+                },
+                {"type": "response.completed", "response": {"id": call["id"], "status": "completed"}},
+            ]
+        else:
+            raise AssertionError("unexpected third WebSocket response.create")
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        event = self.events.pop(0)
+        self.connection.setdefault("events", []).append(event["type"])
+        return json.dumps(event)
+
+
+def test_run_conversation_codex_responses_websocket_tool_round_trip_uses_incremental_input(monkeypatch):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _HermesToolResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="sub2api-test",
+        api_mode="codex_responses",
+        base_url="https://sub2api.tegical.com",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=3,
+        enabled_toolsets=[],
+        disabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+        load_soul_identity=False,
+        session_id="codex-responses-ws-tool-e2e",
+        reasoning_config={"enabled": False},
+        max_tokens=80,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("codex_responses WebSocket path must not create an HTTP request client")
+        )
+    )
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": '{"cwd":"/workspace"}',
+                }
+            )
+
+    agent._execute_tool_calls = _fake_execute_tool_calls
+
+    result = agent.run_conversation("run pwd")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert len(connections) == 1
+
+    sends = connections[0]["sends"]
+    assert len(sends) == 2
+    assert "previous_response_id" not in sends[0]["sent"]
+    assert sends[1]["sent"]["previous_response_id"] == "resp_tool_1"
+
+    replay_input = sends[1]["sent"]["input"]
+    assert replay_input == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": '{"cwd":"/workspace"}',
+        }
+    ]
+
+
+class _FakeCreateStream:
+    def __init__(self, events):
+        self.events = list(events)
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self.events)
+
+    def close(self):
+        self.closed = True
+
+
+def _make_codex_responses_ws_agent(session_id, *, max_iterations=2, disabled_toolsets=None):
+    if disabled_toolsets is None:
+        disabled_toolsets = ["terminal", "web", "browser", "memory", "todo"]
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="sub2api-test",
+        api_mode="codex_responses",
+        base_url="https://sub2api.tegical.com",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=max_iterations,
+        enabled_toolsets=[],
+        disabled_toolsets=disabled_toolsets,
+        skip_context_files=True,
+        skip_memory=True,
+        load_soul_identity=False,
+        session_id=session_id,
+        reasoning_config={"enabled": False},
+        max_tokens=80,
+    )
+    agent._api_max_retries = 1
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    return agent
+
+
+def test_run_conversation_codex_responses_does_not_use_websocket_without_provider_switch(monkeypatch):
+    def fail_if_websocket_used(*args, **kwargs):
+        raise AssertionError("WebSocket must not be used without provider opt-in")
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fail_if_websocket_used)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            return _FakeCreateStream(
+                [
+                    {"type": "response.output_text.delta", "delta": "http-ok"},
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{"type": "output_text", "text": "http-ok"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_http_1", "status": "completed"},
+                    },
+                ]
+            )
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="plain-provider",
+        api_mode="codex_responses",
+        base_url="https://plain.example.com/v1",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=2,
+        enabled_toolsets=[],
+        disabled_toolsets=["terminal", "web", "browser", "memory", "todo"],
+        skip_context_files=True,
+        skip_memory=True,
+        load_soul_identity=False,
+        session_id="codex-responses-no-ws-e2e",
+        reasoning_config={"enabled": False},
+        max_tokens=80,
+    )
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is False
+
+    result = agent.run_conversation("ping")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "http-ok"
+    assert len(http_calls) == 1
+    assert http_calls[0]["stream"] is True
+
+
+def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_to_http_same_provider(
+    monkeypatch,
+):
+    ws_attempts = []
+
+    def fake_connect(uri, **kwargs):
+        ws_attempts.append({"uri": uri, "headers": kwargs.get("additional_headers") or {}})
+        raise ConnectionError("websocket connect failed")
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            return _FakeCreateStream(
+                [
+                    {"type": "response.output_text.delta", "delta": "http-ok"},
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{"type": "output_text", "text": "http-ok"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_http_1", "status": "completed"},
+                    },
+                ]
+            )
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-http-fallback")
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    result = agent.run_conversation("Reply http-ok.")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "http-ok"
+    assert len(ws_attempts) == 1
+    assert len(http_calls) == 1
+    assert http_calls[0]["stream"] is True
+    assert "previous_response_id" not in http_calls[0]
+    request_input = json.dumps(http_calls[0]["input"], ensure_ascii=False)
+    assert "Reply http-ok" in request_input
+
+
+def test_run_conversation_codex_responses_websocket_fallback_keeps_remaining_turn_on_full_http(
+    monkeypatch,
+):
+    ws_attempts = []
+
+    def fake_connect(uri, **kwargs):
+        ws_attempts.append(uri)
+        raise ConnectionError("websocket recv failed before output")
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            if len(http_calls) == 1:
+                return _FakeCreateStream(
+                    [
+                        {
+                            "type": "response.output_item.done",
+                            "item": SimpleNamespace(
+                                type="function_call",
+                                id="fc_http_1",
+                                call_id="call_http_1",
+                                name="terminal",
+                                arguments="{\"cmd\":\"pwd\"}",
+                            ),
+                        },
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_http_1", "status": "completed"},
+                        },
+                    ]
+                )
+            if len(http_calls) == 2:
+                return _FakeCreateStream(
+                    [
+                        {"type": "response.output_text.delta", "delta": "done"},
+                        {
+                            "type": "response.output_item.done",
+                            "item": {
+                                "type": "message",
+                                "role": "assistant",
+                                "status": "completed",
+                                "content": [{"type": "output_text", "text": "done"}],
+                            },
+                        },
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_http_2", "status": "completed"},
+                        },
+                    ]
+                )
+            raise AssertionError("unexpected third HTTP fallback request")
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent(
+        "codex-responses-ws-http-fallback-tool",
+        max_iterations=3,
+        disabled_toolsets=[],
+    )
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": '{"cwd":"/workspace"}',
+                }
+            )
+
+    agent._execute_tool_calls = _fake_execute_tool_calls
+
+    result = agent.run_conversation("run pwd")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert len(ws_attempts) == 1
+    assert len(http_calls) == 2
+    assert all("previous_response_id" not in call for call in http_calls)
+
+    second_input = json.dumps(http_calls[1]["input"], ensure_ascii=False)
+    assert "run pwd" in second_input
+    assert "call_http_1" in second_input
+    assert any(
+        item.get("type") == "function_call_output"
+        and item.get("call_id") == "call_http_1"
+        and json.loads(item.get("output", "{}")) == {"cwd": "/workspace"}
+        for item in http_calls[1]["input"]
+    )
+
+
+class _PartialThenFailResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        self.connection["sends"].append({"sent": sent})
+        self.events = [
+            {"type": "response.created", "response": {"id": "resp_partial", "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": "partial-"},
+        ]
+
+    def recv(self, timeout=None):
+        if self.events:
+            return json.dumps(self.events.pop(0))
+        raise ConnectionError("websocket failed after committed text")
+
+
+def test_run_conversation_codex_responses_websocket_does_not_http_fallback_after_committed_text(
+    monkeypatch,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {"uri": uri, "sends": []}
+        connections.append(connection)
+        return _PartialThenFailResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            raise AssertionError("HTTP fallback must not run after text was streamed")
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-no-fallback-after-text")
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    chunks = []
+    result = agent.run_conversation("stream partial then fail", stream_callback=chunks.append)
+
+    assert result["completed"] is False
+    assert chunks == ["partial-"]
+    assert http_calls == []
+
+
+class _RestoredResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        index = len(self.connection["sends"])
+        response_id = f"resp_ws_restored_{index + 1}"
+        self.connection["sends"].append({"id": response_id, "sent": sent})
+        input_text = json.dumps(sent.get("input", []), ensure_ascii=False)
+        response_text = "ws-third" if "Third turn" in input_text else "ws-restored"
+        self.events = [
+            {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": response_text},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": response_text}],
+                },
+            },
+            {"type": "response.completed", "response": {"id": response_id, "status": "completed"}},
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_conversation_codex_responses_websocket_restores_with_full_input_after_http_fallback(
+    monkeypatch,
+):
+    ws_connect_attempts = []
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        ws_connect_attempts.append(uri)
+        if len(ws_connect_attempts) == 1:
+            raise ConnectionError("initial websocket unavailable")
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _RestoredResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            return _FakeCreateStream(
+                [
+                    {"type": "response.output_text.delta", "delta": "http-first"},
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{"type": "output_text", "text": "http-first"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_http_first", "status": "completed"},
+                    },
+                ]
+            )
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-restore-after-http", max_iterations=2)
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    first = agent.run_conversation("Initial turn. Reply http-first.")
+    assert first["completed"] is True
+    assert first["final_response"] == "http-first"
+
+    second = agent.run_conversation(
+        "Second turn. Reply ws-restored.",
+        conversation_history=first["messages"],
+    )
+    assert second["completed"] is True
+    assert second["final_response"] == "ws-restored"
+
+    third = agent.run_conversation(
+        "Third turn. Reply ws-third.",
+        conversation_history=second["messages"],
+    )
+    assert third["completed"] is True
+    assert third["final_response"] == "ws-third"
+
+    assert len(http_calls) == 1
+    assert len(ws_connect_attempts) == 2
+    assert len(connections) == 1
+    sends = connections[0]["sends"]
+    assert len(sends) == 2
+
+    restored_payload = sends[0]["sent"]
+    restored_input = json.dumps(restored_payload["input"], ensure_ascii=False)
+    assert "previous_response_id" not in restored_payload
+    assert "Initial turn" in restored_input
+    assert "http-first" in restored_input
+    assert "Second turn" in restored_input
+
+    incremental_payload = sends[1]["sent"]
+    incremental_input = json.dumps(incremental_payload["input"], ensure_ascii=False)
+    assert incremental_payload["previous_response_id"] == "resp_ws_restored_1"
+    assert "Third turn" in incremental_input
+    assert "Initial turn" not in incremental_input
+    assert "http-first" not in incremental_input
+    assert "Second turn" not in incremental_input
+
+
+class _RecoveringResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        call = {
+            "id": f"{self.connection['name']}_resp_{len(self.connection['sends']) + 1}",
+            "sent": sent,
+        }
+        self.connection["sends"].append(call)
+        if self.connection["name"] == "primary" and len(self.connection["sends"]) == 2:
+            self.events = [
+                {
+                    "type": "error",
+                    "status": 400,
+                    "error": {
+                        "code": "previous_response_not_found",
+                        "message": "Previous response with id 'primary_resp_1' not found.",
+                        "param": "previous_response_id",
+                    },
+                }
+            ]
+            return
+
+        input_text = json.dumps(sent.get("input", []), ensure_ascii=False)
+        text = "recovered-ok" if "Second turn" in input_text else "first-ok"
+        self.events = [
+            {"type": "response.created", "response": {"id": call["id"], "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": text},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": text}],
+                },
+            },
+            {"type": "response.completed", "response": {"id": call["id"], "status": "completed"}},
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_conversation_codex_responses_websocket_recovers_with_full_input_when_previous_id_is_missing(
+    monkeypatch,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "name": "primary" if not connections else f"reconnect-{len(connections)}",
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _RecoveringResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="sub2api-test",
+        api_mode="codex_responses",
+        base_url="https://sub2api.tegical.com",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=2,
+        enabled_toolsets=[],
+        disabled_toolsets=["terminal", "web", "browser", "memory", "todo"],
+        skip_context_files=True,
+        skip_memory=True,
+        load_soul_identity=False,
+        session_id="codex-responses-ws-recover-e2e",
+        reasoning_config={"enabled": False},
+        max_tokens=80,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("codex_responses WebSocket path must not create an HTTP request client")
+        )
+    )
+
+    first = agent.run_conversation("First turn. Reply first-ok.")
+    assert first["completed"] is True
+    assert first["final_response"] == "first-ok"
+
+    second = agent.run_conversation(
+        "Second turn. Reply recovered-ok.",
+        conversation_history=first["messages"],
+    )
+
+    assert second["completed"] is True
+    assert second["final_response"] == "recovered-ok"
+    assert len(connections) == 2
+    assert connections[0].get("closed") is True
+
+    failed_continuation = connections[0]["sends"][1]["sent"]
+    assert failed_continuation["previous_response_id"] == "primary_resp_1"
+    assert "First turn" not in json.dumps(failed_continuation["input"])
+
+    recovered_payload = connections[1]["sends"][0]["sent"]
+    recovered_input = json.dumps(recovered_payload["input"], ensure_ascii=False)
+    assert "previous_response_id" not in recovered_payload
+    assert "First turn" in recovered_input
+    assert "first-ok" in recovered_input
+    assert "Second turn" in recovered_input

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -987,3 +987,114 @@ def test_run_conversation_codex_responses_websocket_recovers_with_full_input_whe
     assert "First turn" in recovered_input
     assert "first-ok" in recovered_input
     assert "Second turn" in recovered_input
+
+
+class _StaleThenReopenedResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        if self.connection.get("fail_send"):
+            self.connection["sends"].append({"sent": sent, "failed": True})
+            raise ConnectionError("stale websocket send failed")
+
+        response_id = f"{self.connection['name']}_resp_{len(self.connection['sends']) + 1}"
+        self.connection["sends"].append({"id": response_id, "sent": sent})
+        input_text = json.dumps(sent.get("input", []), ensure_ascii=False)
+        response_text = "second-ok" if "Second turn" in input_text else "first-ok"
+        self.events = [
+            {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": response_text},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": response_text}],
+                },
+            },
+            {"type": "response.completed", "response": {"id": response_id, "status": "completed"}},
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_http_fallback(
+    monkeypatch,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "name": f"conn{len(connections) + 1}",
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+            "fail_send": len(connections) == 0 and len(connections[0]["sends"]) == 1 if connections else False,
+        }
+        connections.append(connection)
+        return _StaleThenReopenedResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            raise AssertionError("stale websocket should reopen once before HTTP fallback")
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-stale-reopen", max_iterations=2)
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    first = agent.run_conversation("First turn. Reply first-ok.")
+    assert first["completed"] is True
+    assert first["final_response"] == "first-ok"
+
+    # Simulate a provider/proxy that closed the persistent socket after the
+    # first request. The next turn should reopen WebSocket and retry full input.
+    connections[0]["fail_send"] = True
+
+    second = agent.run_conversation(
+        "Second turn. Reply second-ok.",
+        conversation_history=first["messages"],
+    )
+
+    assert second["completed"] is True
+    assert second["final_response"] == "second-ok"
+    assert http_calls == []
+    assert len(connections) == 2
+    assert connections[0].get("closed") is True
+
+    stale_attempt = connections[0]["sends"][1]["sent"]
+    assert stale_attempt["previous_response_id"] == "conn1_resp_1"
+    assert "First turn" not in json.dumps(stale_attempt["input"], ensure_ascii=False)
+
+    reopened_payload = connections[1]["sends"][0]["sent"]
+    reopened_input = json.dumps(reopened_payload["input"], ensure_ascii=False)
+    assert "previous_response_id" not in reopened_payload
+    assert "First turn" in reopened_input
+    assert "first-ok" in reopened_input
+    assert "Second turn" in reopened_input

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -498,7 +498,7 @@ def test_run_conversation_codex_responses_does_not_use_websocket_without_provide
     assert http_calls[0]["stream"] is True
 
 
-def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_to_http_same_provider(
+def test_run_conversation_codex_responses_websocket_connect_failure_retries_then_falls_back_to_http_same_provider(
     monkeypatch,
     caplog,
 ):
@@ -541,6 +541,7 @@ def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_t
             pass
 
     agent = _make_codex_responses_ws_agent("codex-responses-ws-http-fallback")
+    agent._api_max_retries = 2
     agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
 
     with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
@@ -548,13 +549,14 @@ def test_run_conversation_codex_responses_websocket_connect_failure_falls_back_t
 
     assert result["completed"] is True
     assert result["final_response"] == "http-ok"
-    assert len(ws_attempts) == 1
+    assert len(ws_attempts) == 2
     assert len(http_calls) == 1
     assert http_calls[0]["stream"] is True
     assert "previous_response_id" not in http_calls[0]
     request_input = json.dumps(http_calls[0]["input"], ensure_ascii=False)
     assert "Reply http-ok" in request_input
-    assert "Codex Responses WebSocket disabled for current turn" in caplog.text
+    assert "codex_responses_websocket_event=retry_transport_error" in caplog.text
+    assert "Codex Responses WebSocket disabled for this session" in caplog.text
     assert "codex_responses_websocket_event=http_fallback" in caplog.text
     assert "falling back to HTTP" in caplog.text
     assert "websocket_transport_error" in caplog.text
@@ -641,6 +643,7 @@ def test_run_conversation_codex_responses_websocket_fallback_keeps_remaining_tur
         max_iterations=3,
         disabled_toolsets=[],
     )
+    agent._api_max_retries = 2
     agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
 
     def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=0):
@@ -659,7 +662,7 @@ def test_run_conversation_codex_responses_websocket_fallback_keeps_remaining_tur
 
     assert result["completed"] is True
     assert result["final_response"] == "done"
-    assert len(ws_attempts) == 1
+    assert len(ws_attempts) == 2
     assert len(http_calls) == 2
     assert all("previous_response_id" not in call for call in http_calls)
 
@@ -782,7 +785,7 @@ class _RestoredResponsesWebSocket:
         return json.dumps(self.events.pop(0))
 
 
-def test_run_conversation_codex_responses_websocket_restores_with_full_input_after_http_fallback(
+def test_run_conversation_codex_responses_websocket_http_fallback_is_session_scoped(
     monkeypatch,
     caplog,
 ):
@@ -808,16 +811,17 @@ def test_run_conversation_codex_responses_websocket_restores_with_full_input_aft
     class _HTTPResponses:
         def create(self, **kwargs):
             http_calls.append(kwargs)
+            text = "http-first" if len(http_calls) == 1 else "http-second"
             return _FakeCreateStream(
                 [
-                    {"type": "response.output_text.delta", "delta": "http-first"},
+                    {"type": "response.output_text.delta", "delta": text},
                     {
                         "type": "response.output_item.done",
                         "item": {
                             "type": "message",
                             "role": "assistant",
                             "status": "completed",
-                            "content": [{"type": "output_text", "text": "http-first"}],
+                            "content": [{"type": "output_text", "text": text}],
                         },
                     },
                     {
@@ -836,50 +840,25 @@ def test_run_conversation_codex_responses_websocket_restores_with_full_input_aft
     agent = _make_codex_responses_ws_agent("codex-responses-ws-restore-after-http", max_iterations=2)
     agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
 
-    with caplog.at_level(logging.INFO, logger="agent.codex_runtime"):
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
         first = agent.run_conversation("Initial turn. Reply http-first.")
         assert first["completed"] is True
         assert first["final_response"] == "http-first"
+        assert codex_runtime.codex_responses_websocket_enabled(agent) is False
 
         second = agent.run_conversation(
-            "Second turn. Reply ws-restored.",
+            "Second turn. Reply http-second.",
             conversation_history=first["messages"],
         )
         assert second["completed"] is True
-        assert second["final_response"] == "ws-restored"
+        assert second["final_response"] == "http-second"
+        assert codex_runtime.codex_responses_websocket_enabled(agent) is False
 
-    third = agent.run_conversation(
-        "Third turn. Reply ws-third.",
-        conversation_history=second["messages"],
-    )
-    assert third["completed"] is True
-    assert third["final_response"] == "ws-third"
-
-    assert len(http_calls) == 1
-    assert len(ws_connect_attempts) == 2
-    assert len(connections) == 1
-    sends = connections[0]["sends"]
-    assert len(sends) == 2
-
-    restored_payload = sends[0]["sent"]
-    restored_input = json.dumps(restored_payload["input"], ensure_ascii=False)
-    assert "previous_response_id" not in restored_payload
-    assert "Initial turn" in restored_input
-    assert "http-first" in restored_input
-    assert "Second turn" in restored_input
-
-    incremental_payload = sends[1]["sent"]
-    incremental_input = json.dumps(incremental_payload["input"], ensure_ascii=False)
-    assert incremental_payload["previous_response_id"] == "resp_ws_restored_1"
-    assert "Third turn" in incremental_input
-    assert "Initial turn" not in incremental_input
-    assert "http-first" not in incremental_input
-    assert "Second turn" not in incremental_input
-    assert "chain invalidated" in caplog.text
-    assert "codex_responses_websocket_event=restore_full_input" in caplog.text
-    assert "codex_responses_websocket_event=restore_full_input_completed" in caplog.text
-    assert "reopening with full input" in caplog.text
-    assert "full-input request completed" in caplog.text
+    assert len(http_calls) == 2
+    assert len(ws_connect_attempts) == 1
+    assert connections == []
+    assert "codex_responses_websocket_event=http_fallback" in caplog.text
+    assert "Codex Responses WebSocket disabled for this session" in caplog.text
 
 
 class _RecoveringResponsesWebSocket:
@@ -1010,6 +989,156 @@ def test_run_conversation_codex_responses_websocket_recovers_with_full_input_whe
     assert "Second turn" in recovered_input
 
 
+class _ConnectionLimitThenOkResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        self.connection["sends"].append({"sent": sent})
+        if self.connection["limit_error"]:
+            self.events = [
+                {
+                    "type": "error",
+                    "error": {
+                        "code": "websocket_connection_limit_reached",
+                        "message": "websocket connection limit reached",
+                    },
+                }
+            ]
+            return
+        self.events = [
+            {"type": "response.created", "response": {"id": "resp_after_limit", "status": "in_progress"}},
+            {"type": "response.output_text.delta", "delta": "limit-recovered"},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "limit-recovered"}],
+                },
+            },
+            {"type": "response.completed", "response": {"id": "resp_after_limit", "status": "completed"}},
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_conversation_codex_responses_websocket_connection_limit_retries_websocket(
+    monkeypatch,
+    caplog,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+            "limit_error": not connections,
+        }
+        connections.append(connection)
+        return _ConnectionLimitThenOkResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-connection-limit")
+    agent._api_max_retries = 2
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("connection-limit recovery should retry WebSocket, not HTTP fallback")
+        )
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        result = agent.run_conversation("Reply limit-recovered.")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "limit-recovered"
+    assert len(connections) == 2
+    assert connections[0].get("closed") is True
+    assert len(connections[0]["sends"]) == 1
+    assert len(connections[1]["sends"]) == 1
+    assert "codex_responses_websocket_event=retry_transport_error" in caplog.text
+    assert "websocket_connection_limit_reached" in caplog.text
+
+
+def test_run_conversation_codex_responses_websocket_upgrade_required_immediately_falls_back_to_http(
+    monkeypatch,
+    caplog,
+):
+    class _UpgradeRequiredError(ConnectionError):
+        status_code = 426
+
+    ws_attempts = []
+
+    def fake_connect(uri, **kwargs):
+        ws_attempts.append(uri)
+        raise _UpgradeRequiredError("426 Upgrade Required")
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            return _FakeCreateStream(
+                [
+                    {"type": "response.output_text.delta", "delta": "http-426"},
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{"type": "output_text", "text": "http-426"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_http_426", "status": "completed"},
+                    },
+                ]
+            )
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-upgrade-required")
+    agent._api_max_retries = 3
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        result = agent.run_conversation("Reply http-426.")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "http-426"
+    assert len(ws_attempts) == 1
+    assert len(http_calls) == 1
+    assert codex_runtime.codex_responses_websocket_enabled(agent) is False
+    assert "codex_responses_websocket_event=http_fallback" in caplog.text
+    assert "websocket_upgrade_required" in caplog.text
+
+
 class _StaleThenReopenedResponsesWebSocket:
     def __init__(self, connection):
         self.connection = connection
@@ -1089,6 +1218,7 @@ def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_
             pass
 
     agent = _make_codex_responses_ws_agent("codex-responses-ws-stale-reopen", max_iterations=2)
+    agent._api_max_retries = 2
     agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
 
     first = agent.run_conversation("First turn. Reply first-ok.")
@@ -1099,7 +1229,7 @@ def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_
     # first request. The next turn should reopen WebSocket and retry full input.
     connections[0]["fail_send"] = True
 
-    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+    with caplog.at_level(logging.INFO, logger="agent.codex_runtime"):
         second = agent.run_conversation(
             "Second turn. Reply second-ok.",
             conversation_history=first["messages"],
@@ -1121,7 +1251,7 @@ def test_run_conversation_codex_responses_websocket_reopens_stale_socket_before_
     assert "First turn" in reopened_input
     assert "first-ok" in reopened_input
     assert "Second turn" in reopened_input
-    assert "continuation failed before output" in caplog.text
-    assert "codex_responses_websocket_event=continuation_reopen_before_http_fallback" in caplog.text
-    assert "reopening with full input before HTTP fallback" in caplog.text
+    assert "codex_responses_websocket_event=retry_transport_error" in caplog.text
+    assert "codex_responses_websocket_event=restore_full_input" in caplog.text
+    assert "continuation_reopen_before_http_fallback" not in caplog.text
     assert "stale websocket send failed" in caplog.text

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -908,6 +908,111 @@ def test_run_conversation_codex_responses_websocket_does_not_http_fallback_after
     assert http_calls == []
 
 
+class _ToolCallThenKeepaliveTimeoutResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        self.connection["sends"].append({"sent": sent})
+        self.events = [
+            {"type": "response.created", "response": {"id": "resp_keepalive", "status": "in_progress"}},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "name": "weather",
+                    "call_id": "call_weather_1",
+                    "arguments": "{}",
+                },
+            },
+        ]
+
+    def recv(self, timeout=None):
+        if self.events:
+            return json.dumps(self.events.pop(0))
+        raise ConnectionClosedError(
+            "sent 1011 (internal error) keepalive ping timeout; no close frame received"
+        )
+
+
+def test_run_conversation_codex_responses_websocket_falls_back_after_keepalive_timeout_without_visible_output(
+    monkeypatch,
+    caplog,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _ToolCallThenKeepaliveTimeoutResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    http_calls = []
+
+    class _HTTPResponses:
+        def create(self, **kwargs):
+            http_calls.append(kwargs)
+            return _FakeCreateStream(
+                [
+                    {"type": "response.output_text.delta", "delta": "http-weather"},
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{"type": "output_text", "text": "http-weather"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {"id": "resp_http_keepalive", "status": "completed"},
+                    },
+                ]
+            )
+
+    class _HTTPOpenAIClient:
+        responses = _HTTPResponses()
+
+        def close(self):
+            pass
+
+    agent = _make_codex_responses_ws_agent("codex-responses-ws-keepalive-http")
+    agent._api_max_retries = 2
+    agent._create_request_openai_client = lambda *args, **kwargs: _HTTPOpenAIClient()
+
+    with caplog.at_level(logging.WARNING, logger="agent.codex_runtime"):
+        result = agent.run_conversation("Find weather and summarize it.")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "http-weather"
+    assert len(connections) == 2
+    assert len(http_calls) == 1
+    assert "previous_response_id" not in http_calls[0]
+    request_input = json.dumps(http_calls[0]["input"], ensure_ascii=False)
+    assert "Find weather and summarize it." in request_input
+    assert "codex_responses_websocket_event=retry_transport_error" in caplog.text
+    assert "codex_responses_websocket_event=http_fallback" in caplog.text
+    assert "keepalive ping timeout" in caplog.text
+
+
 class _RestoredResponsesWebSocket:
     def __init__(self, connection):
         self.connection = connection
@@ -1084,6 +1189,130 @@ class _RecoveringResponsesWebSocket:
         if not self.events:
             raise AssertionError("Hermes consumed past terminal WebSocket event")
         return json.dumps(self.events.pop(0))
+
+
+class _ReasoningTextResponsesWebSocket:
+    def __init__(self, connection):
+        self.connection = connection
+        self.events = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.connection["closed"] = True
+        return False
+
+    def close(self):
+        self.connection["closed"] = True
+
+    def send(self, payload):
+        sent = json.loads(payload)
+        self.connection["sends"].append({"sent": sent})
+        call_number = len(self.connection["sends"])
+        response_id = f"resp_{call_number}"
+        message_id = f"msg_{call_number}"
+        reasoning_id = f"rs_{call_number}"
+        text = "first-ok" if call_number == 1 else "second-ok"
+        self.events = [
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "reasoning",
+                    "id": reasoning_id,
+                    "encrypted_content": f"encrypted-{call_number}",
+                    "summary": [],
+                },
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "id": message_id,
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": text}],
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {"id": response_id, "status": "completed"},
+            },
+        ]
+
+    def recv(self, timeout=None):
+        if not self.events:
+            raise AssertionError("Hermes consumed past terminal WebSocket event")
+        return json.dumps(self.events.pop(0))
+
+
+def test_run_conversation_codex_responses_websocket_preserves_custom_issuer_reasoning_chain(
+    monkeypatch,
+):
+    connections = []
+
+    def fake_connect(uri, **kwargs):
+        connection = {
+            "uri": uri,
+            "headers": kwargs.get("additional_headers") or {},
+            "sends": [],
+        }
+        connections.append(connection)
+        return _ReasoningTextResponsesWebSocket(connection)
+
+    monkeypatch.setattr(codex_runtime, "_connect_responses_websocket", fake_connect)
+
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="sub2api-test",
+        api_mode="codex_responses",
+        base_url="https://sub2api.tegical.com/v1",
+        api_key="sk-test",
+        quiet_mode=True,
+        max_iterations=3,
+        enabled_toolsets=[],
+        disabled_toolsets=["terminal", "web", "browser", "memory", "todo"],
+        skip_context_files=True,
+        skip_memory=True,
+        load_soul_identity=False,
+        session_id="codex-responses-ws-custom-issuer-e2e",
+        reasoning_config={"enabled": True, "effort": "low"},
+        max_tokens=80,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._create_request_openai_client = (
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("codex_responses WebSocket path must not create an HTTP request client")
+        )
+    )
+
+    first = agent.run_conversation("First turn. Reply first-ok.")
+    assert first["completed"] is True
+    assert first["final_response"] == "first-ok"
+
+    reasoning_items = first["messages"][1].get("codex_reasoning_items")
+    assert reasoning_items
+    assert reasoning_items[0]["_issuer_kind"] == "other:https://sub2api.tegical.com/v1"
+
+    second = agent.run_conversation(
+        "Second turn. Reply second-ok.",
+        conversation_history=first["messages"],
+    )
+
+    assert second["completed"] is True
+    assert second["final_response"] == "second-ok"
+    assert len(connections) == 1
+
+    sends = connections[0]["sends"]
+    assert len(sends) == 2
+    assert "previous_response_id" not in sends[0]["sent"]
+    assert sends[1]["sent"]["previous_response_id"] == "resp_1"
+    second_input = json.dumps(sends[1]["sent"]["input"], ensure_ascii=False)
+    assert "Second turn" in second_input
+    assert "First turn" not in second_input
+    assert "first-ok" not in second_input
 
 
 def test_run_conversation_codex_responses_websocket_recovers_with_full_input_when_previous_id_is_missing(

--- a/tests/run_agent/test_run_agent_codex_responses_websocket.py
+++ b/tests/run_agent/test_run_agent_codex_responses_websocket.py
@@ -427,6 +427,14 @@ class _HermesToolResponsesWebSocket:
                 {
                     "type": "response.output_item.done",
                     "item": {
+                        "type": "reasoning",
+                        "id": "rs_1",
+                        "encrypted_content": "encrypted-state",
+                    },
+                },
+                {
+                    "type": "response.output_item.done",
+                    "item": {
                         "type": "function_call",
                         "id": "fc_1",
                         "call_id": "call_1",

--- a/uv.lock
+++ b/uv.lock
@@ -1622,6 +1622,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -1899,6 +1900,7 @@ requires-dist = [
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
+    { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
 provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Codex Responses WebSocket transport for providers using the `codex_responses` protocol. The transport reuses a persistent WebSocket when healthy, sends incremental `previous_response_id` payloads after completed responses, and falls back safely when the WebSocket path is unavailable or unhealthy.

It also hardens the connection lifecycle against the failure modes seen with sticky multi-instance backends:

- Sends the Responses WebSocket beta header and stable `session-id`, `thread-id`, and `x-client-request-id` headers on the WebSocket handshake.
- Treats `ConnectionClosed*` before `response.completed` as a transport error instead of silently accepting a truncated stream.
- Checks cached socket state before reuse and reconnects with full input when the underlying socket has closed.
- Keeps HTTP fallback session-scoped after retry exhaustion and logs retry/fallback/recovery events for debugging.

## Related Issue

No issue found that covers this exact transport. Related prior PR found during duplicate search: #18436.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_runtime.py`: add the WebSocket transport, persistent session state, incremental/full-input recovery, header construction, fallback classification, and connection reuse hardening.
- `agent/chat_completion_helpers.py` and `agent/conversation_loop.py`: integrate WebSocket retry/fallback with existing Codex Responses request flow and watchdog activity tracking.
- `hermes_cli/config.py` and provider validation tests: add provider-level `codex_responses_websocket` opt-in validation.
- `pyproject.toml` and `uv.lock`: add the pinned `websockets==15.0.1` runtime dependency.
- Tests cover multi-turn WebSocket reuse, tool round-trips, stale socket reopen, connection-limit retry, 426 fallback, session headers, close-before-completed handling, HTTP fallback scoping, and TTFB watchdog behavior.

## How to Test

1. `python -m pytest tests/run_agent/test_run_agent_codex_responses_websocket.py tests/agent/test_codex_responses_websocket.py tests/agent/test_codex_ttfb_watchdog.py tests/run_agent/test_api_max_retries_config.py tests/run_agent/test_31273_402_not_retried.py tests/gateway/test_telegram_noise_filter.py tests/hermes_cli/test_provider_config_validation.py -q -o 'addopts='`
2. `git diff --check`
3. `python -m py_compile agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses_websocket.py tests/agent/test_codex_responses_websocket.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5, Python 3.13.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test run:

```text
72 passed in 122.87s (0:02:02)
```

Live smoke against a Codex Responses WebSocket-compatible endpoint also verified three consecutive Hermes turns over a single WebSocket connection with no HTTP fallback.
