### PR TITLE
feat(gateway): add session metadata runtime footer fields

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9487,14 +9487,39 @@ class GatewayRunner:
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    build_footer_line as _bfl,
+                    resolve_footer_config as _rfc,
+                )
+                _footer_config = _load_gateway_config()
+                _footer_platform = _platform_config_key(source.platform)
+                _footer_effective = _rfc(_footer_config, _footer_platform)
+                _footer_session_title = None
+                if (
+                    _footer_effective.get("enabled")
+                    and "session_title" in (_footer_effective.get("fields") or ())
+                    and self._session_db
+                ):
+                    try:
+                        _footer_session_title = self._session_db.get_session_title(
+                            session_entry.session_id,
+                        )
+                    except Exception:
+                        logger.debug("runtime_footer session title lookup failed", exc_info=True)
                 _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
+                    user_config=_footer_config,
+                    platform_key=_footer_platform,
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    session_title=_footer_session_title,
+                    session_id=session_entry.session_id,
+                    profile=self._active_profile_name(),
+                    platform=_footer_platform,
+                    chat=source.chat_name or source.chat_id,
+                    thread_id=source.thread_id,
+                    topic=source.chat_topic,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -53,6 +53,23 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _session_id_short(session_id: Optional[str]) -> str:
+    """Return a compact session id for footer display."""
+    if not session_id:
+        return ""
+    value = str(session_id)
+    parts = value.split("_")
+    if len(parts) >= 3 and parts[0] and parts[-1]:
+        return f"{parts[0]}-{parts[-1][:6]}"
+    return value[:8]
+
+
+def _string_value(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -95,6 +112,13 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    session_title: Optional[str] = None,
+    session_id: Optional[str] = None,
+    profile: Optional[str] = None,
+    platform: Optional[str] = None,
+    chat: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    topic: Optional[str] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -115,6 +139,38 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "session_title":
+            value = _string_value(session_title)
+            if value:
+                parts.append(value)
+        elif field == "session_id":
+            value = _string_value(session_id)
+            if value:
+                parts.append(value)
+        elif field == "session_id_short":
+            value = _session_id_short(session_id)
+            if value:
+                parts.append(value)
+        elif field == "profile":
+            value = _string_value(profile)
+            if value:
+                parts.append(value)
+        elif field in {"platform", "source"}:
+            value = _string_value(platform)
+            if value:
+                parts.append(value)
+        elif field == "chat":
+            value = _string_value(chat)
+            if value:
+                parts.append(value)
+        elif field == "thread":
+            value = _string_value(thread_id)
+            if value:
+                parts.append(f"thread:{value}")
+        elif field == "topic":
+            value = _string_value(topic)
+            if value:
+                parts.append(value)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,6 +186,13 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    session_title: Optional[str] = None,
+    session_id: Optional[str] = None,
+    profile: Optional[str] = None,
+    platform: Optional[str] = None,
+    chat: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    topic: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -146,4 +209,11 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        session_title=session_title,
+        session_id=session_id,
+        profile=profile,
+        platform=platform,
+        chat=chat,
+        thread_id=thread_id,
+        topic=topic,
     )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -147,6 +147,34 @@ def test_format_footer_unknown_field_silently_ignored():
     assert out == "gpt-5.4 · 50%"
 
 
+def test_format_footer_session_metadata_fields():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50,
+        context_length=100,
+        cwd="/x",
+        fields=(
+            "session_title",
+            "session_id_short",
+            "profile",
+            "platform",
+            "thread",
+            "topic",
+            "model",
+        ),
+        session_title="slack-to-notion-sync",
+        session_id="20260603_101530_a1b2c3d4",
+        profile="default",
+        platform="telegram",
+        thread_id="17585",
+        topic="maeve-main",
+    )
+    assert out == (
+        "slack-to-notion-sync · 20260603-a1b2c3 · default · telegram · "
+        "thread:17585 · maeve-main · gpt-5.4"
+    )
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
@@ -229,6 +257,29 @@ def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
     (tmp_path / "proj").mkdir(exist_ok=True)
     assert "gpt-5.4" in out
     assert "25%" in out
+
+
+def test_build_footer_renders_configured_session_metadata():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["session_title", "session_id_short", "profile", "source"],
+                },
+            },
+        },
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=25,
+        context_length=100,
+        cwd="/tmp/proj",
+        session_title="Research notes",
+        session_id="20260603_101530_a1b2c3d4",
+        profile="coder",
+        platform="telegram",
+    )
+    assert out == "Research notes · 20260603-a1b2c3 · coder · telegram"
 
 
 def test_build_footer_per_platform_off_suppresses():


### PR DESCRIPTION
## Summary
- add `session_title`, `session_id`, `session_id_short`, `profile`, `platform`/`source`, `chat`, `thread`, and `topic` runtime footer fields
- pass gateway session/profile/platform metadata into final-response footer rendering
- avoid session title DB lookup unless the footer is enabled and `session_title` is configured

Fixes #37820.

## Verification
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_runtime_footer.py -q` -> 27 passed
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check gateway/runtime_footer.py gateway/run.py tests/gateway/test_runtime_footer.py` -> All checks passed
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m py_compile gateway/runtime_footer.py gateway/run.py tests/gateway/test_runtime_footer.py`
- `git diff --check HEAD~1 HEAD`