### PR TITLE
fix(version): bump main branch to 0.15.2 to match latest release tag v2026.5.29.2

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

The `main` branch reports version `0.15.1` / `2026.5.29` while the latest published release tag `v2026.5.29.2` reports `0.15.2` / `2026.5.29.2`. Since `main` has advanced beyond the release tag, source installs tracking `origin/main` appear stale/downgraded when running `hermes --version`.

## Changes

Version metadata bumped from `0.15.1` → `0.15.2` and `2026.5.29` → `2026.5.29.2` in:

- `pyproject.toml`
- `hermes_cli/__init__.py`
- `acp_registry/agent.json`

## Verification

Version consistency check (`#35142`) passes — all three files now agree and match the release tag.

Fixes #38093