### PR TITLE
fix(gateway): block gateway self-systemctl commands

### DIFF
--- a/tests/tools/test_live_system_guard.py
+++ b/tests/tools/test_live_system_guard.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+
+from tools import approval
+from tools.live_system_guard import check_live_gateway_system_command
+
+
+def test_guard_inactive_outside_gateway(monkeypatch):
+    monkeypatch.delenv("HERMES_LIVE_SYSTEM_GUARD", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    assert check_live_gateway_system_command(
+        "/usr/bin/systemctl restart hermes-gateway"
+    ) is None
+
+
+def test_blocks_absolute_systemctl_restart_inside_gateway(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+
+    result = check_live_gateway_system_command(
+        "/usr/bin/systemctl restart hermes-gateway"
+    )
+
+    assert result is not None
+    assert result["pattern_key"] == "live_gateway_system_guard"
+    assert "safe-restart" in result["message"]
+
+
+def test_blocks_wrapped_systemctl_stop_inside_gateway(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+
+    result = check_live_gateway_system_command(
+        "bash -lc 'sudo /usr/bin/systemctl stop hermes-gateway.service'"
+    )
+
+    assert result is not None
+    assert "systemctl stop" in result["description"]
+
+
+def test_blocks_service_restart_inside_gateway(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+
+    result = check_live_gateway_system_command("service hermes-gateway restart")
+
+    assert result is not None
+    assert "service hermes-gateway restart" in result["description"]
+
+
+def test_blocks_process_killers_inside_gateway(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+
+    assert check_live_gateway_system_command("pkill -f hermes-gateway") is not None
+    assert check_live_gateway_system_command("killall hermes") is not None
+
+
+def test_allows_readonly_status_and_safe_helper_inside_gateway(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+
+    assert check_live_gateway_system_command("systemctl status hermes-gateway") is None
+    assert check_live_gateway_system_command(
+        "/usr/local/sbin/hermes-gateway-safe-restart"
+    ) is None
+    assert check_live_gateway_system_command("systemctl restart nginx") is None
+
+
+def test_terminal_tool_blocks_before_execution(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    from tools import terminal_tool
+
+    result = json.loads(
+        terminal_tool.terminal_tool("/usr/bin/systemctl restart hermes-gateway")
+    )
+
+    assert result["status"] == "blocked"
+    assert result["pattern_key"] == "live_gateway_system_guard"
+
+
+def test_execute_code_guard_blocks_obvious_systemctl_even_when_approval_off(
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "off")
+
+    result = approval.check_execute_code_guard(
+        "import subprocess\n"
+        "subprocess.run(['/usr/bin/systemctl', 'restart', 'hermes-gateway'])",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "live_gateway_system_guard"
+
+
+def test_execute_code_guard_allows_isolated_backends(monkeypatch):
+    monkeypatch.setenv("HERMES_LIVE_SYSTEM_GUARD", "1")
+
+    result = approval.check_execute_code_guard(
+        "import subprocess\n"
+        "subprocess.run(['/usr/bin/systemctl', 'restart', 'hermes-gateway'])",
+        "docker",
+    )
+
+    assert result["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1503,6 +1503,19 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
         return {"approved": True, "message": None}
 
+    from tools.live_system_guard import check_live_gateway_system_code
+
+    live_system_guard = check_live_gateway_system_code(code)
+    if live_system_guard:
+        return {
+            "approved": False,
+            "message": live_system_guard["message"],
+            "pattern_key": live_system_guard["pattern_key"],
+            "description": live_system_guard["description"],
+            "outcome": "blocked",
+            "user_consent": False,
+        }
+
     # --yolo or approvals.mode=off: bypass (session- or process-scoped).
     approval_mode = _get_approval_mode()
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":

--- a/tools/live_system_guard.py
+++ b/tools/live_system_guard.py
@@ -1,0 +1,252 @@
+"""Runtime guard for commands that can kill the live Hermes gateway.
+
+This is intentionally narrower than the dangerous-command approval layer:
+it only blocks self-management commands while the current Python process is
+running inside a Hermes gateway service. Approvals/yolo are not bypasses here;
+the safe path is to schedule a restart outside the gateway cgroup.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Iterable
+
+from utils import is_truthy_value
+
+_FORCE_ENV = "HERMES_LIVE_SYSTEM_GUARD"
+_DISABLE_ENV = "HERMES_DISABLE_LIVE_SYSTEM_GUARD"
+
+_GATEWAY_TOKENS = (
+    "hermes-gateway",
+    "hermes.service",
+    "hermes_cli.main gateway",
+    "hermes_cli/main.py gateway",
+    "gateway/run.py",
+)
+
+_SYSTEMCTL_MUTATING_VERBS = {
+    "restart",
+    "try-restart",
+    "reload-or-restart",
+    "try-reload-or-restart",
+    "stop",
+    "kill",
+    "reload",
+}
+
+_SERVICE_MUTATING_VERBS = {
+    "restart",
+    "stop",
+    "force-stop",
+    "kill",
+    "reload",
+}
+
+_PROCESS_KILLERS = {"pkill", "killall", "taskkill", "skill", "fuser"}
+
+
+def _cmd_to_string(command) -> str:
+    if command is None:
+        return ""
+    if isinstance(command, (bytes, bytearray)):
+        return bytes(command).decode(errors="replace")
+    if isinstance(command, str):
+        return command
+    if isinstance(command, (list, tuple)):
+        return " ".join(str(part) for part in command)
+    return str(command)
+
+
+def _tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _basenames(tokens: Iterable[str]) -> list[str]:
+    return [token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1] for token in tokens]
+
+
+def _mentions_gateway(command: str) -> bool:
+    lower = command.lower()
+    return any(token in lower for token in _GATEWAY_TOKENS)
+
+
+def _read_proc_text(path: str) -> str:
+    try:
+        return Path(path).read_text(errors="replace")
+    except Exception:
+        return ""
+
+
+def running_inside_gateway_service() -> bool:
+    """Return True when this process appears to be the live gateway service."""
+    if is_truthy_value(os.getenv(_DISABLE_ENV, "")):
+        return False
+    if is_truthy_value(os.getenv(_FORCE_ENV, "")):
+        return True
+
+    cgroup = _read_proc_text("/proc/self/cgroup").lower()
+    if "hermes-gateway" in cgroup:
+        return True
+
+    cmdline = _read_proc_text("/proc/self/cmdline").replace("\x00", " ").lower()
+    if "hermes" in cmdline and "gateway" in cmdline:
+        return True
+
+    # systemd sets INVOCATION_ID on services. Treat it as gateway-only when the
+    # gateway session marker is also present, to avoid catching unrelated units.
+    if os.getenv("INVOCATION_ID") and (
+        os.getenv("HERMES_GATEWAY_SESSION")
+        or os.getenv("HERMES_SESSION_PLATFORM")
+    ):
+        return True
+
+    return False
+
+
+def _shell_script_args(tokens: list[str]) -> Iterable[str]:
+    names = _basenames(token.lower() for token in tokens)
+    for index, name in enumerate(names):
+        if name not in {"bash", "sh", "zsh", "ksh"}:
+            continue
+        for opt_index in range(index + 1, len(tokens)):
+            opt = tokens[opt_index]
+            if not opt.startswith("-"):
+                continue
+            if "c" in opt and opt_index + 1 < len(tokens):
+                yield tokens[opt_index + 1]
+                break
+
+
+def _matches_systemctl_gateway_mutation(
+    command: str,
+    *,
+    _depth: int = 0,
+) -> str | None:
+    if "systemctl" not in command.lower() or not _mentions_gateway(command):
+        return None
+    tokens = _tokens(command.lower())
+    names = _basenames(tokens)
+    if "systemctl" not in names:
+        if _depth < 2:
+            for script in _shell_script_args(tokens):
+                nested = _matches_systemctl_gateway_mutation(
+                    script,
+                    _depth=_depth + 1,
+                )
+                if nested:
+                    return nested
+        return None
+    for verb in _SYSTEMCTL_MUTATING_VERBS:
+        if verb in names:
+            return f"systemctl {verb} targeting hermes-gateway"
+    return None
+
+
+def _matches_service_gateway_mutation(command: str) -> str | None:
+    names = _basenames(_tokens(command.lower()))
+    if "service" in names and "hermes-gateway" in names:
+        for verb in _SERVICE_MUTATING_VERBS:
+            if verb in names:
+                return f"service hermes-gateway {verb}"
+
+    lower = command.lower()
+    if re.search(r"(?:^|\s)/etc/init\.d/hermes-gateway\b", lower):
+        for verb in _SERVICE_MUTATING_VERBS:
+            if re.search(rf"\b{re.escape(verb)}\b", lower):
+                return f"/etc/init.d/hermes-gateway {verb}"
+    return None
+
+
+def _matches_hermes_gateway_cli_mutation(command: str) -> str | None:
+    names = _basenames(_tokens(command.lower()))
+    if "hermes" in names and "gateway" in names:
+        for verb in ("restart", "stop"):
+            if verb in names:
+                return f"hermes gateway {verb}"
+    return None
+
+
+def _matches_process_killer(command: str) -> str | None:
+    names = _basenames(_tokens(command.lower()))
+    if not any(name in _PROCESS_KILLERS for name in names):
+        return None
+    lower = command.lower()
+    if "hermes" in lower or "gateway" in lower or ("python" in lower and "-f" in names):
+        return "process-killer command targeting hermes/python"
+    return None
+
+
+def _match_live_gateway_mutation(command: str) -> str | None:
+    return (
+        _matches_systemctl_gateway_mutation(command)
+        or _matches_service_gateway_mutation(command)
+        or _matches_hermes_gateway_cli_mutation(command)
+        or _matches_process_killer(command)
+    )
+
+
+def _match_live_gateway_mutation_in_code(code: str) -> str | None:
+    lower = _cmd_to_string(code).lower()
+    if "systemctl" in lower and _mentions_gateway(lower):
+        for verb in _SYSTEMCTL_MUTATING_VERBS:
+            if re.search(rf"\b{re.escape(verb)}\b", lower):
+                return f"systemctl {verb} targeting hermes-gateway"
+    if re.search(r"\bservice\b", lower) and "hermes-gateway" in lower:
+        for verb in _SERVICE_MUTATING_VERBS:
+            if re.search(rf"\b{re.escape(verb)}\b", lower):
+                return f"service hermes-gateway {verb}"
+    if re.search(r"\b(pkill|killall|taskkill|skill|fuser)\b", lower):
+        if "hermes" in lower or "gateway" in lower or "python" in lower:
+            return "process-killer command targeting hermes/python"
+    return None
+
+
+def _blocked_result(reason: str, message: str) -> dict:
+    return {
+        "approved": False,
+        "status": "blocked",
+        "pattern_key": "live_gateway_system_guard",
+        "description": reason,
+        "message": message,
+    }
+
+
+def check_live_gateway_system_command(command: str) -> dict | None:
+    """Return a blocked-result dict if *command* would self-kill the gateway."""
+    command_text = _cmd_to_string(command)
+    reason = _match_live_gateway_mutation(command_text)
+    if not reason or not running_inside_gateway_service():
+        return None
+    return _blocked_result(
+        reason,
+        (
+            "BLOCKED: this command would mutate the live Hermes gateway from "
+            "inside hermes-gateway.service. systemd can kill the child command "
+            "with the gateway cgroup and leave the service stopped. Use "
+            "/usr/local/sbin/hermes-gateway-safe-restart for restarts, or run "
+            "stop/kill from an external shell."
+        ),
+    )
+
+
+def check_live_gateway_system_code(code: str) -> dict | None:
+    """Static preflight for execute_code scripts before local Python starts."""
+    code_text = _cmd_to_string(code)
+    reason = _match_live_gateway_mutation_in_code(code_text)
+    if not reason or not running_inside_gateway_service():
+        return None
+    return _blocked_result(
+        reason,
+        (
+            "BLOCKED: this execute_code script appears to mutate the live "
+            "Hermes gateway from inside hermes-gateway.service. systemd can "
+            "kill the child command with the gateway cgroup and leave the "
+            "service stopped. Use /usr/local/sbin/hermes-gateway-safe-restart "
+            "for restarts, or run stop/kill from an external shell."
+        ),
+    )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1816,6 +1816,20 @@ def terminal_tool(
         config = _get_env_config()
         env_type = config["env_type"]
 
+        if env_type == "local":
+            from tools.live_system_guard import check_live_gateway_system_command
+
+            live_system_guard = check_live_gateway_system_command(command)
+            if live_system_guard:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": live_system_guard["message"],
+                    "status": "blocked",
+                    "pattern_key": live_system_guard["pattern_key"],
+                    "description": live_system_guard["description"],
+                }, ensure_ascii=False)
+
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with


### PR DESCRIPTION
## What does this PR do?

Adds a runtime guard that blocks Hermes gateway self-management commands while
the current process is running inside `hermes-gateway.service`.

This prevents a gateway task from executing commands such as
`/usr/bin/systemctl restart hermes-gateway`, `systemctl stop hermes-gateway`,
`service hermes-gateway restart`, or `pkill -f hermes-gateway`. Those commands
can kill the child command together with the gateway cgroup and leave the
service stopped. Read-only probes and the explicit safe restart helper remain
allowed.

The guard runs before local `terminal` commands and before local `execute_code`
scripts. It intentionally skips isolated backends such as Docker, Modal,
Singularity, Daytona, and Vercel sandbox.

## Related Issue

N/A - operational hardening from a live gateway restart incident.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tools/live_system_guard.py` with narrow gateway self-management command detection.
- Added a local-terminal preflight block in `tools/terminal_tool.py`.
- Added a local `execute_code` static preflight block in `tools/approval.py`.
- Added regression coverage in `tests/tools/test_live_system_guard.py`.

## How to Test

1. Run targeted tests:
   `scripts/run_tests.sh tests/tools/test_live_system_guard.py tests/tools/test_terminal_none_command_guard.py tests/tools/test_execute_code_approval_cluster.py`
2. Confirm gateway-context command checks block mutating commands and allow read-only/safe-helper commands:
   `/usr/bin/systemctl restart hermes-gateway` blocks, `systemctl status hermes-gateway` allows, `/usr/local/sbin/hermes-gateway-safe-restart` allows.
3. Confirm `execute_code` blocks an obvious local `subprocess.run(["/usr/bin/systemctl", "restart", "hermes-gateway"])` script when the gateway guard context is active.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / systemd 255 via WARTZ targeted test clone

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation:

```text
scripts/run_tests.sh tests/tools/test_live_system_guard.py tests/tools/test_terminal_none_command_guard.py tests/tools/test_execute_code_approval_cluster.py

Summary: 3 files, 28 tests passed, 0 failed
```
