### PR TITLE
fix(agent): preserve real HOME for session tools

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -69,7 +69,7 @@ def _resolve_args() -> list[str]:
 
 
 def _resolve_home_dir() -> str:
-    """Return a stable HOME for child ACP processes."""
+    """Return the real HOME for child ACP processes."""
 
     try:
         from hermes_constants import get_subprocess_home

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -44,10 +44,9 @@ _PROFILE_DIRS = [
     "plans",
     "workspace",
     "cron",
-    # Per-profile HOME for subprocesses: isolates system tool configs (git,
-    # ssh, gh, npm …) so credentials don't bleed between profiles.  In Docker
-    # this also ensures tool configs land inside the persistent volume.
-    # See hermes_constants.get_subprocess_home() and issue #4426.
+    # Back-compat/Docker HOME for tool subprocesses. Host subprocesses keep
+    # the user's real HOME so normal CLI credentials remain visible (#36144);
+    # containers still use this directory for persistent HOME state.
     "home",
 ]
 

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -298,7 +298,7 @@ TIPS = [
     "Any website can expose skills via /.well-known/skills/index.json — the skills hub discovers them automatically.",
     "The skills audit log at ~/.hermes/skills/.hub/audit.log tracks every install and removal operation.",
     "Stale git worktrees are auto-cleaned: 24-72h old with no unpushed commits get pruned on startup.",
-    "Each profile gets its own subprocess HOME at HERMES_HOME/home/ — isolated git, ssh, npm, gh configs.",
+    "Host tool subprocesses keep your real HOME for git/ssh/gh/npm; Docker stores tool HOME under HERMES_HOME/home/.",
     "HERMES_HOME_MODE env var (octal, e.g. 0701) sets custom directory permissions for web server traversal.",
     "Container mode: place .container-mode in HERMES_HOME and the host CLI auto-execs into the container.",
     "Ctrl+C has 5 priority tiers: cancel recording → cancel prompts → cancel picker → interrupt agent → exit.",
@@ -484,4 +484,3 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -283,28 +283,77 @@ def secure_parent_dir(path: Path) -> None:
 
 
 def get_subprocess_home() -> str | None:
-    """Return a per-profile HOME directory for subprocesses, or None.
+    """Return a subprocess HOME override, if one should be applied.
 
-    When ``{HERMES_HOME}/home/`` exists on disk, subprocesses should use it
-    as ``HOME`` so system tools (git, ssh, gh, npm …) write their configs
-    inside the Hermes data directory instead of the OS-level ``/root`` or
-    ``~/``.  This provides:
+    On normal host installs, tool subprocesses should use the user's real home
+    so CLIs find ``~/.gitconfig``, ``~/.ssh``, ``~/.azure``, npm state, etc.
+    If the parent process already has that HOME, no override is needed.
 
-    * **Docker persistence** — tool configs land inside the persistent volume.
-    * **Profile isolation** — each profile gets its own git identity, SSH
-      keys, gh tokens, etc.
-
-    The Python process's own ``os.environ["HOME"]`` and ``Path.home()`` are
-    **never** modified — only subprocess environments should inject this value.
-    Activation is directory-based: if the ``home/`` subdirectory doesn't
-    exist, returns ``None`` and behavior is unchanged.
+    Docker/Podman keeps the older ``{HERMES_HOME}/home`` behavior because the
+    container's persistent volume is the only durable home-like location.
     """
+    explicit = os.getenv("HERMES_REAL_HOME", "").strip()
+    if explicit:
+        return explicit
+
     hermes_home = get_hermes_home_override() or os.getenv("HERMES_HOME")
     if not hermes_home:
         return None
+
     profile_home = os.path.join(hermes_home, "home")
-    if os.path.isdir(profile_home):
+    if not os.path.isdir(profile_home):
+        return None
+
+    if is_container():
         return profile_home
+
+    current_home = os.getenv("HOME", "").strip()
+    try:
+        current_resolved = os.path.normcase(os.path.abspath(os.path.expanduser(current_home)))
+        profile_resolved = os.path.normcase(os.path.abspath(profile_home))
+    except Exception:
+        current_resolved = current_home
+        profile_resolved = profile_home
+
+    if not current_home:
+        return None
+
+    if current_home and current_resolved != profile_resolved:
+        return None
+
+    def is_real_home_candidate(candidate: str) -> bool:
+        candidate = candidate.strip()
+        if not candidate:
+            return False
+        try:
+            return os.path.normcase(os.path.abspath(candidate)) != profile_resolved
+        except Exception:
+            return candidate != profile_home
+
+    try:
+        import pwd
+
+        real_home = pwd.getpwuid(os.getuid()).pw_dir.strip()
+    except Exception:
+        real_home = ""
+
+    if is_real_home_candidate(real_home):
+        return real_home
+
+    real_home = os.getenv("USERPROFILE", "").strip()
+    if is_real_home_candidate(real_home):
+        return real_home
+
+    home_drive = os.getenv("HOMEDRIVE", "").strip()
+    home_path = os.getenv("HOMEPATH", "").strip()
+    if home_drive and home_path:
+        if home_path.startswith(("\\", "/")):
+            real_home = f"{home_drive}{home_path}"
+        else:
+            real_home = os.path.join(home_drive, home_path)
+        if is_real_home_candidate(real_home):
+            return real_home
+
     return None
 
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -174,12 +174,14 @@ def _fake_popen_capture(captured):
     return _fake
 
 
-def test_run_prompt_prefers_profile_home_when_available(monkeypatch, tmp_path):
+def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch, tmp_path):
     hermes_home = tmp_path / "hermes"
     profile_home = hermes_home / "home"
     profile_home.mkdir(parents=True)
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
 
-    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("HOME", str(real_home))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     captured = {}
@@ -189,7 +191,7 @@ def test_run_prompt_prefers_profile_home_when_available(monkeypatch, tmp_path):
         with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
             client._run_prompt("hello", timeout_seconds=1)
 
-    assert captured["kwargs"]["env"]["HOME"] == str(profile_home)
+    assert captured["kwargs"]["env"]["HOME"] == str(real_home)
 
 
 def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):

--- a/tests/run_agent/test_strict_api_validation.py
+++ b/tests/run_agent/test_strict_api_validation.py
@@ -40,6 +40,7 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
     monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search", "terminal"))
     monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
     monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    monkeypatch.setattr("agent.context_compressor.get_model_context_length", lambda *a, **k: 128_000)
     return AIAgent(
         api_key="test",
         base_url=base_url,

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -1,21 +1,31 @@
-"""Tests for per-profile subprocess HOME isolation (#4426).
+"""Tests for subprocess HOME handling.
 
-Verifies that subprocesses (terminal, execute_code, background processes)
-receive a per-profile HOME directory while the Python process's own HOME
-and Path.home() remain unchanged.
+Subprocesses should inherit the user's real HOME. Hermes profile state stays
+isolated via HERMES_HOME, but common CLIs such as git, ssh, gh, npm, and az need
+``~`` to resolve to the same directory the user's normal shell sees.
 
-See: https://github.com/NousResearch/hermes-agent/issues/4426
+See: https://github.com/NousResearch/hermes-agent/issues/36144
 """
 
 import os
+import sys
+from types import ModuleType, SimpleNamespace
 import threading
 from pathlib import Path
 
+import hermes_constants
+import pytest
 
 
 # ---------------------------------------------------------------------------
 # get_subprocess_home()
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_container_cache(monkeypatch):
+    monkeypatch.setattr(hermes_constants, "_container_detected", False)
+
 
 class TestGetSubprocessHome:
     """Unit tests for hermes_constants.get_subprocess_home()."""
@@ -33,27 +43,93 @@ class TestGetSubprocessHome:
         from hermes_constants import get_subprocess_home
         assert get_subprocess_home() is None
 
-    def test_returns_path_when_home_dir_exists(self, tmp_path, monkeypatch):
+    def test_returns_none_when_profile_home_exists_but_home_is_real(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         profile_home = hermes_home / "home"
         profile_home.mkdir()
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", str(real_home))
         from hermes_constants import get_subprocess_home
-        assert get_subprocess_home() == str(profile_home)
+        assert get_subprocess_home() is None
 
-    def test_returns_profile_specific_path(self, tmp_path, monkeypatch):
-        """Named profiles get their own isolated HOME."""
+    def test_profile_home_env_is_corrected_to_account_home(self, tmp_path, monkeypatch):
+        """If the parent HOME already points at profile home, repair it."""
         profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
         profile_dir.mkdir(parents=True)
         profile_home = profile_dir / "home"
         profile_home.mkdir()
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
+        fake_pwd = ModuleType("pwd")
+        fake_pwd.getpwuid = lambda _uid: SimpleNamespace(pw_dir=str(real_home))
+        monkeypatch.setitem(sys.modules, "pwd", fake_pwd)
+        monkeypatch.setattr(hermes_constants.os, "getuid", lambda: 1000, raising=False)
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() == str(real_home)
+
+    def test_profile_home_env_is_corrected_to_userprofile_when_pwd_unavailable(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home = profile_dir / "home"
+        profile_home.mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setenv("USERPROFILE", str(real_home))
+        monkeypatch.delenv("HOMEDRIVE", raising=False)
+        monkeypatch.delenv("HOMEPATH", raising=False)
+        monkeypatch.setitem(sys.modules, "pwd", None)
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() == str(real_home)
+
+    def test_profile_home_env_is_corrected_to_home_drive_path_when_pwd_unavailable(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home = profile_dir / "home"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        monkeypatch.setenv("HOMEDRIVE", "C:")
+        monkeypatch.setenv("HOMEPATH", "\\Users\\real-home")
+        monkeypatch.setitem(sys.modules, "pwd", None)
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() == "C:\\Users\\real-home"
+
+    def test_explicit_real_home_override_wins(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_home = profile_dir / "home"
+        profile_home.mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        from hermes_constants import get_subprocess_home
+        assert get_subprocess_home() == str(real_home)
+
+    def test_container_keeps_persistent_profile_home(self, tmp_path, monkeypatch):
+        docker_home = tmp_path / "opt" / "data"
+        profile_home = docker_home / "home"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(docker_home))
+        monkeypatch.setenv("HOME", str(docker_home))
+        monkeypatch.setattr(hermes_constants, "_container_detected", True)
         from hermes_constants import get_subprocess_home
         assert get_subprocess_home() == str(profile_home)
 
-    def test_two_profiles_get_different_homes(self, tmp_path, monkeypatch):
+    def test_two_profiles_do_not_override_home(self, tmp_path, monkeypatch):
         base = tmp_path / ".hermes" / "profiles"
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        monkeypatch.setenv("HOME", str(real_home))
         for name in ("alpha", "beta"):
             p = base / name
             p.mkdir(parents=True)
@@ -67,11 +143,8 @@ class TestGetSubprocessHome:
         monkeypatch.setenv("HERMES_HOME", str(base / "beta"))
         home_b = get_subprocess_home()
 
-        assert home_a is not None
-        assert home_b is not None
-        assert home_a != home_b
-        assert home_a.endswith("alpha/home")
-        assert home_b.endswith("beta/home")
+        assert home_a is None
+        assert home_b is None
 
     def test_context_override_is_thread_local(self, tmp_path, monkeypatch):
         root = tmp_path / "root"
@@ -117,20 +190,23 @@ class TestGetSubprocessHome:
 # ---------------------------------------------------------------------------
 
 class TestMakeRunEnvHomeInjection:
-    """Verify _make_run_env() injects HOME into subprocess envs."""
+    """Verify _make_run_env() preserves real HOME in subprocess envs."""
 
-    def test_injects_home_when_profile_home_exists(self, tmp_path, monkeypatch):
+    def test_preserves_home_when_profile_home_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hermes_constants, "_container_detected", False)
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
         (hermes_home / "home").mkdir()
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("HOME", str(real_home))
         monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
         from tools.environments.local import _make_run_env
         result = _make_run_env({})
 
-        assert result["HOME"] == str(hermes_home / "home")
+        assert result["HOME"] == str(real_home)
 
     def test_no_injection_when_home_dir_missing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -156,6 +232,7 @@ class TestMakeRunEnvHomeInjection:
         assert result["HOME"] == "/home/user"
 
     def test_context_override_bridges_to_subprocess_env(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hermes_constants, "_container_detected", False)
         root = tmp_path / "root"
         profile = tmp_path / "profile"
         root.mkdir()
@@ -175,7 +252,7 @@ class TestMakeRunEnvHomeInjection:
             reset_hermes_home_override(token)
 
         assert result["HERMES_HOME"] == str(profile)
-        assert result["HOME"] == str(profile / "home")
+        assert result["HOME"] == "/root"
 
 
 # ---------------------------------------------------------------------------
@@ -183,9 +260,10 @@ class TestMakeRunEnvHomeInjection:
 # ---------------------------------------------------------------------------
 
 class TestSanitizeSubprocessEnvHomeInjection:
-    """Verify _sanitize_subprocess_env() injects HOME for background procs."""
+    """Verify _sanitize_subprocess_env() preserves HOME for background procs."""
 
-    def test_injects_home_when_profile_home_exists(self, tmp_path, monkeypatch):
+    def test_preserves_home_when_profile_home_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hermes_constants, "_container_detected", False)
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
         (hermes_home / "home").mkdir()
@@ -195,7 +273,7 @@ class TestSanitizeSubprocessEnvHomeInjection:
         from tools.environments.local import _sanitize_subprocess_env
         result = _sanitize_subprocess_env(base_env)
 
-        assert result["HOME"] == str(hermes_home / "home")
+        assert result["HOME"] == "/root"
 
     def test_no_injection_when_home_dir_missing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -209,6 +287,7 @@ class TestSanitizeSubprocessEnvHomeInjection:
         assert result["HOME"] == "/root"
 
     def test_context_override_bridges_to_background_env(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hermes_constants, "_container_detected", False)
         root = tmp_path / "root"
         profile = tmp_path / "profile"
         root.mkdir()
@@ -227,7 +306,7 @@ class TestSanitizeSubprocessEnvHomeInjection:
             reset_hermes_home_override(token)
 
         assert result["HERMES_HOME"] == str(profile)
-        assert result["HOME"] == str(profile / "home")
+        assert result["HOME"] == "/root"
 
 
 # ---------------------------------------------------------------------------
@@ -274,7 +353,7 @@ class TestPythonProcessUnchanged:
         from hermes_constants import get_subprocess_home
         sub_home = get_subprocess_home()
 
-        # Subprocess home is set but Python HOME stays the same
-        assert sub_home is not None
+        # Subprocess HOME is no longer redirected away from the real HOME.
+        assert sub_home is None
         assert os.environ.get("HOME") == original_home
         assert str(Path.home()) == original_path_home

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1261,8 +1261,9 @@ def execute_code(
             child_env["TZ"] = _tz_name
         child_env.pop("HERMES_TIMEZONE", None)
 
-        # Per-profile HOME isolation: redirect system tool configs into
-        # {HERMES_HOME}/home/ when that directory exists.
+        # Preserve subprocess HOME unless a future compatibility hook provides
+        # an explicit override; Hermes profile isolation is carried by
+        # HERMES_HOME, not by rewriting "~" for system tools.
         from hermes_constants import get_subprocess_home
         _profile_home = get_subprocess_home()
         if _profile_home:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -226,7 +226,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
     _inject_context_hermes_home(sanitized)
 
-    # Per-profile HOME isolation for background processes (same as _make_run_env).
+    # Preserve the user's HOME for background processes; HERMES_HOME carries
+    # profile isolation without hiding real ~/.gitconfig, ~/.ssh, ~/.azure, etc.
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
@@ -328,9 +329,8 @@ def _make_run_env(env: dict) -> dict:
 
     _inject_context_hermes_home(run_env)
 
-    # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
-    # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
-    # subprocess sees the override — the Python process keeps the real HOME.
+    # Preserve the user's HOME for terminal subprocesses; HERMES_HOME carries
+    # profile isolation without hiding real ~/.gitconfig, ~/.ssh, ~/.azure, etc.
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:


### PR DESCRIPTION
Fixes #36144.

## Summary
- keep host tool subprocesses on the user's real `HOME` so `git`, `ssh`, `gh`, `npm`, `az`, and similar CLIs can find existing credentials/config
- repair `HOME` back to the OS account home when the parent process already points at a Hermes profile home, with `HERMES_REAL_HOME` as an explicit override
- add Windows fallback repair through `USERPROFILE` and `HOMEDRIVE`/`HOMEPATH` when Unix `pwd` is unavailable
- preserve Docker/Podman behavior by continuing to use `{HERMES_HOME}/home` inside containers for persistent tool state
- update local env, code execution, ACP child env, profile docs, CLI tips, and regression coverage
- isolate strict API validation tests from live provider metadata lookups so CI does not depend on `api.fireworks.ai`

## Verification
- `.venv\\Scripts\\python.exe -m pytest tests/test_subprocess_home_isolation.py::TestGetSubprocessHome::test_profile_home_env_is_corrected_to_userprofile_when_pwd_unavailable -q --timeout-method=thread` -> 1 passed after failing before the fix
- `.venv\\Scripts\\python.exe -m pytest tests/test_subprocess_home_isolation.py::TestGetSubprocessHome tests/test_subprocess_home_isolation.py::TestSanitizeSubprocessEnvHomeInjection tests/test_subprocess_home_isolation.py::TestPythonProcessUnchanged -q --timeout-method=thread` -> 14 passed
- `.venv\\Scripts\\python.exe -m pytest tests/test_subprocess_home_isolation.py tests/agent/test_copilot_acp_client.py tests/tools/test_env_passthrough.py tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py tests/cron/test_cron_profile.py -q --timeout-method=thread` -> 124 passed, 43 skipped
- `.venv\\Scripts\\python.exe -m pytest tests/run_agent/test_strict_api_validation.py -q --timeout-method=thread` -> 4 passed
- `.venv\\Scripts\\python.exe -m ruff check hermes_constants.py hermes_cli/profiles.py hermes_cli/tips.py tools/environments/local.py tools/code_execution_tool.py agent/copilot_acp_client.py cron/scheduler.py tests/test_subprocess_home_isolation.py tests/agent/test_copilot_acp_client.py tests/cron/test_cron_profile.py tests/test_hermes_constants.py tests/run_agent/test_strict_api_validation.py` -> passed
- `.venv\\Scripts\\python.exe -m py_compile hermes_constants.py hermes_cli/profiles.py hermes_cli/tips.py tools/environments/local.py tools/code_execution_tool.py agent/copilot_acp_client.py cron/scheduler.py tests/test_subprocess_home_isolation.py` -> passed
- `git diff --check` -> passed

Note: the broader local Windows run that also included `tests/tools/test_local_env_blocklist.py` and all of `tests/test_hermes_constants.py` still has three environment/platform-specific failures unrelated to this diff: Homebrew PATH assertion on Windows, Windows native default Hermes root expectation, and symlink creation without Windows developer/admin privileges.
