### PR TITLE
Fix desktop clipboard and scroll edge cases

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { detectTrigger } from './text-utils'
+import { detectTrigger, extractClipboardImageBlobs } from './text-utils'
 
 describe('detectTrigger', () => {
   it('detects a bare slash trigger with an empty query', () => {
@@ -21,5 +21,28 @@ describe('detectTrigger', () => {
 
   it('returns null for plain text', () => {
     expect(detectTrigger('hello there')).toBeNull()
+  })
+})
+
+describe('extractClipboardImageBlobs', () => {
+  it('does not duplicate a screenshot exposed through both items and files', () => {
+    const image = new File(['png'], 'screenshot.png', { type: 'image/png' })
+    const duplicateImage = new File(['png'], 'screenshot.png', { type: 'image/png' })
+    const clipboard = {
+      files: {
+        item: (index: number) => (index === 0 ? duplicateImage : null),
+        length: 1
+      },
+      getData: () => '',
+      items: [
+        {
+          getAsFile: () => image,
+          kind: 'file',
+          type: 'image/png'
+        }
+      ]
+    } as unknown as DataTransfer
+
+    expect(extractClipboardImageBlobs(clipboard)).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -10,14 +10,20 @@ const TRIGGER_RE = /(?:^|[\s])([@/])([^\s@/]*)$/
 
 export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   const blobs: Blob[] = []
-  const seen = new Set<Blob>()
+  const seen = new Set<string>()
 
   const push = (blob: Blob | null) => {
-    if (!blob || blob.size === 0 || seen.has(blob)) {
+    if (!blob || blob.size === 0) {
       return
     }
 
-    seen.add(blob)
+    const key = `${blob.type}:${blob.size}`
+
+    if (seen.has(key)) {
+      return
+    }
+
+    seen.add(key)
     blobs.push(blob)
   }
 
@@ -29,7 +35,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
     }
   }
 
-  if (clipboard.files?.length) {
+  if (blobs.length === 0 && clipboard.files?.length) {
     for (let i = 0; i < clipboard.files.length; i += 1) {
       const file = clipboard.files.item(i)
 

--- a/apps/desktop/src/components/assistant-ui/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/streaming.test.tsx
@@ -415,6 +415,44 @@ describe('assistant-ui streaming renderer', () => {
     expect(viewport.scrollTop).toBe(420)
   })
 
+  it('keeps sticky-bottom armed when scrollTop moves up without wheel or touch intent', async () => {
+    const { container } = render(<StreamingHarness />)
+
+    const content = container.querySelector('[data-slot="aui_thread-content"]') as HTMLDivElement
+    const viewport = content.parentElement as HTMLDivElement
+    let scrollHeight = 1_000
+
+    Object.defineProperty(viewport, 'clientHeight', { configurable: true, value: 200 })
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await wait(80)
+
+    await act(async () => {
+      viewport.scrollTop = 800
+      fireEvent.scroll(viewport)
+    })
+    await wait(0)
+
+    await act(async () => {
+      viewport.scrollTop = 760
+      fireEvent.scroll(viewport)
+    })
+
+    scrollHeight = 1_200
+
+    await act(async () => {
+      for (const observer of resizeObservers) {
+        observer.trigger(1_200)
+      }
+    })
+    await wait(0)
+
+    expect(viewport.scrollTop).toBe(1_200)
+  })
+
   it('renders reasoning text without a leading token space', () => {
     const { container } = render(<ReasoningHarness />)
 

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -8,6 +8,7 @@ import { setThreadScrolledUp } from '@/store/thread-scroll'
 const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
 const AT_BOTTOM_THRESHOLD = 4
+const USER_SCROLL_INTENT_MS = 500
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -194,6 +195,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
   const programmaticScrollPendingRef = useRef(0)
   const prevSessionKeyRef = useRef(sessionKey)
   const prevGroupCountRef = useRef(0)
+  const userScrollIntentUntilRef = useRef(0)
 
   const pinToBottom = useCallback(() => {
     const el = scrollerRef.current
@@ -237,6 +239,10 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
       armedRef.current = false
     }
 
+    const noteUserScrollIntent = () => {
+      userScrollIntentUntilRef.current = Date.now() + USER_SCROLL_INTENT_MS
+    }
+
     const onScroll = () => {
       const top = el.scrollTop
 
@@ -258,7 +264,7 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
         return
       }
 
-      if (top + 1 < lastTopRef.current) {
+      if (top + 1 < lastTopRef.current && Date.now() <= userScrollIntentUntilRef.current) {
         armedRef.current = false
       }
 
@@ -275,18 +281,24 @@ function useThreadScrollAnchor({ enabled, groupCount, scrollerRef, sessionKey, v
 
     const onWheel = (event: WheelEvent) => {
       if (event.deltaY < 0) {
+        noteUserScrollIntent()
         disarm()
       }
     }
 
+    const onTouchMove = () => {
+      noteUserScrollIntent()
+      disarm()
+    }
+
     el.addEventListener('scroll', onScroll, { passive: true })
     el.addEventListener('wheel', onWheel, { passive: true })
-    el.addEventListener('touchmove', disarm, { passive: true })
+    el.addEventListener('touchmove', onTouchMove, { passive: true })
 
     return () => {
       el.removeEventListener('scroll', onScroll)
       el.removeEventListener('wheel', onWheel)
-      el.removeEventListener('touchmove', disarm)
+      el.removeEventListener('touchmove', onTouchMove)
     }
   }, [scrollerRef])
 


### PR DESCRIPTION
## What does this PR do?

Fixes two desktop chat edge cases observed on Windows/Electron:

- Pasting a screenshot can attach it twice because the same image may be exposed through both `DataTransfer.items` and `DataTransfer.files` as different `File` objects.
- The thread viewport can lose sticky-bottom behavior when a programmatic scroll/virtualizer measurement moves `scrollTop` upward without an actual user scroll gesture.

The clipboard fix dedupes images by stable metadata and only falls back to `clipboard.files` when `clipboard.items` did not provide image blobs. The scroll fix only treats upward scroll movement as user intent when it follows recent wheel/touch input.

## Related Issue

N/A - no linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/text-utils.ts`: dedupe pasted image blobs by `type:size` and avoid double-reading `clipboard.files` when `clipboard.items` already yielded images.
- `apps/desktop/src/app/chat/composer/text-utils.test.ts`: add regression coverage for duplicate screenshot paste paths.
- `apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx`: require recent wheel/touch intent before disarming sticky-bottom due to upward `scrollTop` movement.
- `apps/desktop/src/components/assistant-ui/streaming.test.tsx`: add regression coverage for programmatic upward scroll movement while sticky-bottom remains armed.

## How to Test

1. Run `npm run test:ui -- src/app/chat/composer/text-utils.test.ts src/components/assistant-ui/streaming.test.tsx`.
2. Run `npm run type-check`.
3. On Windows desktop, copy a screenshot to the clipboard and paste it into the composer; it should attach once.
4. During streaming, allow the thread to stay at bottom while content grows; virtualizer/programmatic scroll movement should not leave the viewport detached from the bottom unless the user scrolls up.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Targeted test output:

```text
Test Files  2 passed (2)
Tests       16 passed (16)
```

Also verified `npm run type-check` passes.