### PR TITLE
Align session list pagination counts

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -32,6 +32,7 @@ import type {
   ProfileSetupCommand,
   ProfileSoul,
   ProfilesResponse,
+  SessionInfo,
   SessionMessagesResponse,
   SessionSearchResponse,
   SkillInfo,
@@ -117,13 +118,23 @@ export async function listSessions(
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent'
 ): Promise<PaginatedSessions> {
-  const result = await window.hermesDesktop.api<PaginatedSessions>({
-    path: `/api/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}&archived=${archived}&order=${order}`
+  const result = await window.hermesDesktop.api<
+    PaginatedSessions & { data?: SessionInfo[]; has_more?: boolean }
+  >({
+    path: `/api/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}&archived=${archived}&order=${order}&include_children=true`
   })
+  const sessions = result.sessions ?? result.data ?? []
+  const total =
+    typeof result.total === 'number'
+      ? result.total
+      : result.has_more
+        ? Math.max(limit + 1, sessions.length)
+        : sessions.length
 
   return {
     ...result,
-    sessions: result.sessions.slice(0, limit),
+    sessions: sessions.slice(0, limit),
+    total,
     offset: 0
   }
 }

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1314,21 +1314,40 @@ class APIServerAdapter(BasePlatformAdapter):
 
         limit = self._parse_nonnegative_int(request.query.get("limit"), default=50, maximum=200)
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
+        min_messages = self._parse_nonnegative_int(request.query.get("min_messages"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
+        archived = (request.query.get("archived") or "exclude").strip().lower()
+        if archived not in {"exclude", "include", "only"}:
+            return web.json_response(_openai_error("Invalid archived filter", code="invalid_archived_filter"), status=400)
+        order = (request.query.get("order") or "recent").strip().lower()
+        if order not in {"created", "recent"}:
+            return web.json_response(_openai_error("Invalid session order", code="invalid_session_order"), status=400)
         sessions = db.list_sessions_rich(
             source=source,
             limit=limit,
             offset=offset,
             include_children=include_children,
-            order_by_last_active=True,
+            min_message_count=min_messages,
+            order_by_last_active=(order == "recent"),
+            include_archived=(archived == "include"),
+            archived_only=(archived == "only"),
+        )
+        total = db.count_sessions_rich(
+            source=source,
+            include_children=include_children,
+            min_message_count=min_messages,
+            include_archived=(archived == "include"),
+            archived_only=(archived == "only"),
         )
         return web.json_response({
             "object": "list",
+            "sessions": [self._session_response(s) for s in sessions],
             "data": [self._session_response(s) for s in sessions],
             "limit": limit,
             "offset": offset,
-            "has_more": len(sessions) == limit,
+            "total": total,
+            "has_more": offset + len(sessions) < total,
         })
 
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1402,6 +1402,7 @@ async def get_sessions(
     min_messages: int = 0,
     archived: str = "exclude",
     order: str = "created",
+    include_children: bool = False,
 ):
     """List sessions.
 
@@ -1435,16 +1436,25 @@ async def get_sessions(
             sessions = db.list_sessions_rich(
                 limit=limit,
                 offset=offset,
+                include_children=include_children,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
                 order_by_last_active=order == "recent",
             )
-            total = db.session_count(
-                min_message_count=min_message_count,
-                include_archived=include_archived,
-                archived_only=archived_only,
-            )
+            if hasattr(db, "count_sessions_rich"):
+                total = db.count_sessions_rich(
+                    include_children=include_children,
+                    min_message_count=min_message_count,
+                    include_archived=include_archived,
+                    archived_only=archived_only,
+                )
+            else:
+                total = db.session_count(
+                    min_message_count=min_message_count,
+                    include_archived=include_archived,
+                    archived_only=archived_only,
+                )
             now = time.time()
             for s in sessions:
                 s["is_active"] = (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1753,6 +1753,56 @@ class SessionDB:
 
         return sessions
 
+    def count_sessions_rich(
+        self,
+        source: str = None,
+        exclude_sources: List[str] = None,
+        include_children: bool = False,
+        min_message_count: int = 0,
+        include_archived: bool = False,
+        archived_only: bool = False,
+    ) -> int:
+        """Count rows that would be eligible for ``list_sessions_rich``.
+
+        This mirrors the list filter contract so paginated desktop clients can
+        show an accurate "loaded / total" label and decide whether "load more"
+        should be visible.
+        """
+        where_clauses = []
+        params = []
+
+        if not include_children:
+            where_clauses.append(
+                "(s.parent_session_id IS NULL"
+                " OR EXISTS (SELECT 1 FROM sessions p"
+                "            WHERE p.id = s.parent_session_id"
+                "            AND p.end_reason = 'branched'"
+                "            AND s.started_at >= p.ended_at))"
+            )
+
+        if source:
+            where_clauses.append("s.source = ?")
+            params.append(source)
+        if exclude_sources:
+            placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            params.extend(exclude_sources)
+        if min_message_count > 0:
+            where_clauses.append("s.message_count >= ?")
+            params.append(min_message_count)
+        if archived_only:
+            where_clauses.append("s.archived = 1")
+        elif not include_archived:
+            where_clauses.append("s.archived = 0")
+
+        where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+
+        with self._lock:
+            cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s {where_sql}", params)
+            row = cursor.fetchone()
+
+        return int(row[0] if row else 0)
+
     def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Fetch a single session with the same enriched columns as
         ``list_sessions_rich`` (preview + last_active). Returns None if the

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -279,12 +279,14 @@ class TestWebServerEndpoints:
             def __init__(self, *args, **kwargs):
                 pass
 
-            def list_sessions_rich(self, limit, offset, min_message_count=0, **kwargs):
+            def list_sessions_rich(self, limit, offset, min_message_count=0, include_children=False, **kwargs):
                 captured["list"] = min_message_count
+                captured["include_children"] = include_children
                 return []
 
-            def session_count(self, min_message_count=0, **kwargs):
+            def count_sessions_rich(self, min_message_count=0, include_children=False, **kwargs):
                 captured["count"] = min_message_count
+                captured["count_include_children"] = include_children
                 return 0
 
             def close(self):
@@ -292,10 +294,12 @@ class TestWebServerEndpoints:
 
         monkeypatch.setattr("hermes_state.SessionDB", _FakeDB)
 
-        resp = self.client.get("/api/sessions?limit=5&offset=0&min_messages=3")
+        resp = self.client.get("/api/sessions?limit=5&offset=0&min_messages=3&include_children=true")
         assert resp.status_code == 200
         assert captured["list"] == 3
         assert captured["count"] == 3
+        assert captured["include_children"] is True
+        assert captured["count_include_children"] is True
 
     def test_rename_session_updates_title(self):
         """PATCH /api/sessions/{id} renames a session (regression: the route


### PR DESCRIPTION
## What does this PR do?

Fixes a session-list pagination mismatch where the desktop sidebar can show a loaded/total count such as `2/5`, but clicking `Load more` cannot reveal the remaining sessions.

The root cause is that session rows and total counts can use different filter semantics. `list_sessions_rich()` excludes child sessions by default, while the previous total path could count rows with a broader filter. This PR adds a rich count helper that mirrors the list filters, forwards `include_children`, and makes desktop request child sessions explicitly for the session manager view.

## Related Issue

N/A - no linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: add `count_sessions_rich()` to mirror `list_sessions_rich()` filters for pagination totals.
- `hermes_cli/web_server.py`: accept and forward `include_children`; use `count_sessions_rich()` for a total count that matches listed rows.
- `gateway/platforms/api_server.py`: align session list response shape and filtering with the dashboard API, including `min_messages`, `archived`, `order`, `sessions`, `total`, and accurate `has_more`.
- `apps/desktop/src/hermes.ts`: make desktop session list requests include child sessions and tolerate both `sessions` and legacy `data` response shapes.
- `tests/hermes_cli/test_web_server.py`: cover forwarding of `min_messages` and `include_children` into both list and count calls.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_web_server.py -k "get_sessions" --timeout-method=thread`.
2. Run `npm run type-check` from `apps/desktop`.
3. Create or load a database with root sessions and child sessions.
4. Open the desktop session sidebar or Sessions panel and confirm the displayed total matches the rows that can actually be loaded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Local database verification during debugging:

```text
include_children=False -> 2 rows, total 2
include_children=True  -> 5 rows, total 5
```

Targeted test output:

```text
tests/hermes_cli/test_web_server.py ...... [100%]
6 passed, 205 deselected
```

Also verified `npm run type-check` passes.