### PR TITLE
fix(agent): evict stale computer_use screenshots on the chat-completions path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,6 +33,7 @@ from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
+from agent.tool_dispatch_helpers import _is_multimodal_tool_result
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname
 
@@ -524,6 +525,57 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _evict_old_computer_use_screenshots(messages: list, keep: int = 3) -> list:
+    """Replace all but the most recent ``keep`` computer_use screenshots with a
+    text placeholder so a long vision session does not re-send every accumulated
+    image on every turn (super-linear prompt growth / latency).
+
+    This is the chat-completions-path counterpart to
+    ``anthropic_adapter._evict_old_screenshots`` — same ``keep`` budget and the
+    same ``"[screenshot removed to save context]"`` placeholder — so non-Anthropic
+    providers (OpenAI-compatible, local endpoints, OpenRouter, Bedrock, etc.) get
+    the same context hygiene the Anthropic path already enjoys. Copy-on-write: the
+    input list and its messages are never mutated.
+    """
+
+    def _is_image_part(part) -> bool:
+        return isinstance(part, dict) and part.get("type") == "image_url"
+
+    def _has_screenshot(message) -> bool:
+        content = message.get("content") if isinstance(message, dict) else None
+        if _is_multimodal_tool_result(content):
+            return any(_is_image_part(p) for p in content["content"])
+        if isinstance(content, list):
+            return any(_is_image_part(p) for p in content)
+        return False
+
+    screenshot_indices = [i for i, m in enumerate(messages) if _has_screenshot(m)]
+    if len(screenshot_indices) <= keep:
+        return messages
+
+    to_strip = set(screenshot_indices[:-keep])
+    placeholder = {"type": "text", "text": "[screenshot removed to save context]"}
+
+    def _strip_images(parts: list) -> list:
+        return [placeholder if _is_image_part(p) else p for p in parts]
+
+    new_messages = []
+    for i, message in enumerate(messages):
+        if i not in to_strip:
+            new_messages.append(message)
+            continue
+        new_message = dict(message)
+        content = message.get("content")
+        if _is_multimodal_tool_result(content):
+            new_content = dict(content)
+            new_content["content"] = _strip_images(content["content"])
+            new_message["content"] = new_content
+        elif isinstance(content, list):
+            new_message["content"] = _strip_images(content)
+        new_messages.append(new_message)
+    return new_messages
+
+
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
@@ -549,6 +601,12 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
         )
+
+    # Every path below feeds a non-Anthropic transport. The Anthropic path
+    # (returned above) evicts stale computer_use screenshots in
+    # anthropic_adapter; mirror that here so vision sessions on OpenAI-compatible
+    # providers don't re-send every accumulated screenshot each turn.
+    api_messages = _evict_old_computer_use_screenshots(api_messages)
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
     # The adapter handles message/tool conversion and boto3 calls directly.

--- a/tests/agent/test_chat_screenshot_eviction.py
+++ b/tests/agent/test_chat_screenshot_eviction.py
@@ -1,0 +1,125 @@
+"""Tests for computer_use screenshot eviction on the chat-completions path.
+
+Covers ``agent.chat_completion_helpers._evict_old_computer_use_screenshots``,
+the non-Anthropic counterpart to ``anthropic_adapter._evict_old_screenshots``.
+"""
+
+import copy
+
+import pytest
+
+from agent.chat_completion_helpers import _evict_old_computer_use_screenshots
+
+PLACEHOLDER = {"type": "text", "text": "[screenshot removed to save context]"}
+
+
+def _multimodal_screenshot(n: int) -> dict:
+    """A computer_use tool result carrying one screenshot, in the
+    ``_multimodal`` envelope shape produced by tools/computer_use/tool.py."""
+    return {
+        "role": "tool",
+        "tool_call_id": f"call_{n}",
+        "content": {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": f"screenshot {n}"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,AAAA{n}"},
+                },
+            ],
+            "text_summary": f"screenshot {n}",
+            "meta": {},
+        },
+    }
+
+
+def _plain_list_screenshot(n: int) -> dict:
+    """A vision message whose content is a bare list of parts (no envelope)."""
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": f"look {n}"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,BBBB{n}"}},
+        ],
+    }
+
+
+def _image_parts(content) -> list:
+    parts = content["content"] if isinstance(content, dict) else content
+    return [p for p in parts if isinstance(p, dict) and p.get("type") == "image_url"]
+
+
+def test_keeps_only_last_three_screenshots():
+    messages = [{"role": "user", "content": "hi"}]
+    messages += [_multimodal_screenshot(i) for i in range(5)]
+
+    out = _evict_old_computer_use_screenshots(messages)
+
+    kept = [m for m in out if _image_parts(m["content"])]
+    # screenshots 2, 3, 4 keep their image; 0 and 1 are stripped.
+    assert len(kept) == 3
+    assert [m["tool_call_id"] for m in kept] == ["call_2", "call_3", "call_4"]
+
+
+def test_old_screenshots_replaced_with_placeholder():
+    messages = [_multimodal_screenshot(i) for i in range(4)]
+
+    out = _evict_old_computer_use_screenshots(messages)
+
+    stripped = out[0]["content"]["content"]
+    assert PLACEHOLDER in stripped
+    assert not _image_parts(stripped)
+    # The text part of the stripped message is preserved.
+    assert {"type": "text", "text": "screenshot 0"} in stripped
+
+
+def test_under_budget_is_identity():
+    messages = [_multimodal_screenshot(i) for i in range(3)]
+    out = _evict_old_computer_use_screenshots(messages)
+    assert out is messages
+
+
+def test_plain_list_content_is_evicted_too():
+    messages = [_plain_list_screenshot(i) for i in range(4)]
+
+    out = _evict_old_computer_use_screenshots(messages)
+
+    kept = [m for m in out if _image_parts(m["content"])]
+    assert len(kept) == 3
+    assert PLACEHOLDER in out[0]["content"]
+
+
+def test_input_is_not_mutated():
+    messages = [_multimodal_screenshot(i) for i in range(5)]
+    snapshot = copy.deepcopy(messages)
+
+    _evict_old_computer_use_screenshots(messages)
+
+    assert messages == snapshot
+
+
+def test_non_screenshot_messages_untouched():
+    messages = [
+        {"role": "system", "content": "you are helpful"},
+        _multimodal_screenshot(0),
+        {"role": "assistant", "content": "ok"},
+        _multimodal_screenshot(1),
+        _multimodal_screenshot(2),
+        _multimodal_screenshot(3),
+    ]
+
+    out = _evict_old_computer_use_screenshots(messages)
+
+    # Only screenshot 0 is over budget; the text messages pass through by identity.
+    assert out[0] is messages[0]
+    assert out[2] is messages[2]
+    assert not _image_parts(out[1]["content"])
+
+
+def test_custom_keep_budget():
+    messages = [_multimodal_screenshot(i) for i in range(4)]
+    out = _evict_old_computer_use_screenshots(messages, keep=1)
+    kept = [m for m in out if _image_parts(m["content"])]
+    assert len(kept) == 1
+    assert kept[0]["tool_call_id"] == "call_3"


### PR DESCRIPTION
## What
The Anthropic Messages path already trims old `computer_use` screenshots via
`anthropic_adapter._evict_old_screenshots` (keep the last 3, replace older ones
with a `[screenshot removed to save context]` placeholder). Every **non-Anthropic**
path in `build_api_kwargs` — OpenAI-compatible providers, local endpoints,
OpenRouter, Bedrock, `codex_responses` — has no equivalent, so it re-sends every
accumulated screenshot on every turn.

## Why
In a long vision / computer-use session this grows the prompt super-linearly:
turn N re-uploads N screenshots the model no longer needs, wasting tokens, money,
and latency, and pushing toward the context limit faster than necessary. The
Anthropic path is immune; the rest of the providers are not, which is an
inconsistency rather than an intentional design choice.

## How
Add `_evict_old_computer_use_screenshots()` mirroring the Anthropic evictor —
same keep budget (3) and same placeholder text — and call it once, right after
the Anthropic early-return, so it covers all remaining transports. It handles
both the `_multimodal` tool-result envelope and bare list content, reusing the
existing `_is_multimodal_tool_result` detector. Copy-on-write: the caller's
message list is never mutated.

## Testing
- New `tests/agent/test_chat_screenshot_eviction.py` (7 tests): last-3 retention,
  placeholder substitution, under-budget identity, plain-list content, no-mutation,
  pass-through of non-screenshot messages, custom keep budget.
- `pytest tests/agent/test_chat_screenshot_eviction.py` -> 7 passed.
- Re-ran existing `build_api_kwargs` consumers (ctx-halving, codex responses,
  provider profiles, ttfb watchdog) -> 150 passed, no regression.

## Platforms
Pure Python, OS-agnostic. No new dependencies.
