### PR TITLE
fix(gateway): gate session prompt messaging sections on send_message availability

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -228,6 +228,30 @@ def _discord_tools_loaded() -> bool:
         return False
 
 
+def _send_message_loaded(platform: Platform) -> bool:
+    """True if the ``send_message`` tool is available for *platform*.
+
+    Checks whether the ``messaging`` toolset is enabled in the user's
+    ``platform_toolsets`` config for the given platform.  When the user
+    explicitly restricts toolsets (e.g. ``[terminal, file, vision, cronjob]``),
+    the ``messaging`` toolset is absent and ``send_message`` is not
+    registered — so the session prompt must not promise messaging
+    capabilities.
+
+    Returns False (safe default — no messaging promises) on any error.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+        cfg = load_config()
+        enabled = _get_platform_tools(
+            cfg, platform.value, include_default_mcp_servers=False,
+        )
+        return "messaging" in enabled
+    except Exception:
+        return False
+
+
 def build_session_context_prompt(
     context: SessionContext,
     *,
@@ -367,14 +391,22 @@ def build_session_context_prompt(
         )
     elif context.source.platform == Platform.YUANBAO:
         lines.append("")
-        lines.append(
-            "**Platform notes:** You are running inside Yuanbao. "
-            "You CAN send private (DM) messages via the send_message tool. "
-            "Use target='yuanbao:direct:<account_id>' for DM "
-            "and target='yuanbao:group:<group_code>' for group chat."
-        )
+        if _send_message_loaded(Platform.YUANBAO):
+            lines.append(
+                "**Platform notes:** You are running inside Yuanbao. "
+                "You CAN send private (DM) messages via the send_message tool. "
+                "Use target='yuanbao:direct:<account_id>' for DM "
+                "and target='yuanbao:group:<group_code>' for group chat."
+            )
+        else:
+            lines.append(
+                "**Platform notes:** You are running inside Yuanbao. "
+                "You do NOT have access to Yuanbao-specific APIs — you cannot "
+                "send messages, manage contacts, or interact with groups. "
+                "Do not promise to perform these actions."
+            )
 
-    # Connected platforms
+    # Connected platforms — always show (informational, no messaging promise)
     platforms_list = ["local (files on this machine)"]
     for p in context.connected_platforms:
         if p != Platform.LOCAL:
@@ -382,8 +414,10 @@ def build_session_context_prompt(
 
     lines.append(f"**Connected Platforms:** {', '.join(platforms_list)}")
 
-    # Home channels
-    if context.home_channels:
+    # Home channels — only show when send_message is available so we don't
+    # imply the agent can deliver to messaging targets it lacks.
+    _has_send_message = _send_message_loaded(context.source.platform)
+    if context.home_channels and _has_send_message:
         lines.append("")
         lines.append("**Home Channels (default destinations):**")
         for platform, home in context.home_channels.items():
@@ -410,13 +444,15 @@ def build_session_context_prompt(
         f"- `\"local\"` → Save to local files only ({display_hermes_home()}/cron/output/)"
     )
 
-    # Platform home channels
-    for platform, home in context.home_channels.items():
-        lines.append(f"- `\"{platform.value}\"` → Home channel ({home.name})")
+    # Platform home channels — only when send_message is available
+    if _has_send_message:
+        for platform, home in context.home_channels.items():
+            lines.append(f"- `\"{platform.value}\"` → Home channel ({home.name})")
 
-    # Note about explicit targeting
-    lines.append("")
-    lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")
+    # Note about explicit targeting — only when send_message is available
+    if _has_send_message:
+        lines.append("")
+        lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")
 
     return "\n".join(lines)
 

--- a/tests/gateway/test_session_context_send_message_gate.py
+++ b/tests/gateway/test_session_context_send_message_gate.py
@@ -1,0 +1,141 @@
+"""Tests for send_message tool gating in build_session_context_prompt.
+
+Regression test for #38101: the session prompt should not promise
+messaging capabilities (Home Channels, delivery targets, Yuanbao DM
+instructions) when the ``messaging`` toolset is not enabled for the
+current platform.
+"""
+
+from unittest.mock import patch
+
+from gateway.session import (
+    SessionContext,
+    SessionSource,
+    build_session_context_prompt,
+    _send_message_loaded,
+)
+from gateway.config import Platform, HomeChannel
+
+
+def _make_context(
+    platform=Platform.TELEGRAM,
+    chat_id="telegram:99999",
+    home_channels=None,
+):
+    source = SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id="user-123",
+    )
+    return SessionContext(
+        source=source,
+        connected_platforms=[platform],
+        home_channels=home_channels or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _send_message_loaded helper
+# ---------------------------------------------------------------------------
+
+class TestSendMessageLoaded:
+    def test_returns_false_on_exception(self):
+        """Safe default when config/tools_config is unavailable."""
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError):
+            assert _send_message_loaded(Platform.TELEGRAM) is False
+
+    def test_returns_true_when_messaging_toolset_enabled(self):
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("hermes_cli.tools_config._get_platform_tools",
+                    return_value={"messaging", "terminal", "file"}):
+            assert _send_message_loaded(Platform.TELEGRAM) is True
+
+    def test_returns_false_when_messaging_toolset_absent(self):
+        with patch("hermes_cli.config.load_config", return_value={}), \
+             patch("hermes_cli.tools_config._get_platform_tools",
+                    return_value={"terminal", "file", "vision", "cronjob"}):
+            assert _send_message_loaded(Platform.TELEGRAM) is False
+
+
+# ---------------------------------------------------------------------------
+# Home Channels gating
+# ---------------------------------------------------------------------------
+
+class TestHomeChannelsGating:
+    HC = {Platform.TELEGRAM: HomeChannel(
+        name="General", chat_id="telegram:12345", platform=Platform.TELEGRAM,
+    )}
+
+    def test_home_channels_absent_when_send_message_disabled(self):
+        ctx = _make_context(home_channels=self.HC)
+        with patch("gateway.session._send_message_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
+        assert "Home Channels" not in prompt
+        assert "telegram:12345" not in prompt
+
+    def test_home_channels_present_when_send_message_enabled(self):
+        ctx = _make_context(home_channels=self.HC)
+        with patch("gateway.session._send_message_loaded", return_value=True):
+            prompt = build_session_context_prompt(ctx)
+        assert "Home Channels" in prompt
+        assert "General" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Delivery options gating
+# ---------------------------------------------------------------------------
+
+class TestDeliveryOptionsGating:
+    HC = {Platform.TELEGRAM: HomeChannel(
+        name="General", chat_id="telegram:12345", platform=Platform.TELEGRAM,
+    )}
+
+    def test_platform_delivery_targets_absent_when_disabled(self):
+        ctx = _make_context(home_channels=self.HC)
+        with patch("gateway.session._send_message_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
+        # Platform-specific home channel delivery line should be absent
+        assert "Home channel" not in prompt
+        # Explicit targeting note should be absent
+        assert "explicit targeting" not in prompt.lower()
+
+    def test_platform_delivery_targets_present_when_enabled(self):
+        ctx = _make_context(home_channels=self.HC)
+        with patch("gateway.session._send_message_loaded", return_value=True):
+            prompt = build_session_context_prompt(ctx)
+        assert "Home channel" in prompt
+        assert "explicit targeting" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Yuanbao platform notes gating
+# ---------------------------------------------------------------------------
+
+class TestYuanbaoPlatformNotes:
+    def test_yuanbao_disclaimer_when_send_message_disabled(self):
+        ctx = _make_context(platform=Platform.YUANBAO, chat_id="yuanbao:123")
+        with patch("gateway.session._send_message_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
+        assert "do NOT have access" in prompt
+        assert "send_message" not in prompt
+
+    def test_yuanbao_messaging_instructions_when_enabled(self):
+        ctx = _make_context(platform=Platform.YUANBAO, chat_id="yuanbao:123")
+        with patch("gateway.session._send_message_loaded", return_value=True):
+            prompt = build_session_context_prompt(ctx)
+        assert "send_message tool" in prompt
+        assert "yuanbao:direct:" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Connected Platforms always shown (informational)
+# ---------------------------------------------------------------------------
+
+class TestConnectedPlatformsAlwaysShown:
+    def test_connected_platforms_present_regardless(self):
+        ctx = _make_context(platform=Platform.TELEGRAM)
+        with patch("gateway.session._send_message_loaded", return_value=False):
+            prompt = build_session_context_prompt(ctx)
+        assert "Connected Platforms" in prompt
+        assert "telegram: Connected" in prompt


### PR DESCRIPTION
## What does this PR do?

Gates the session context prompt's messaging-related sections (Home Channels, delivery targets, Yuanbao DM instructions) on whether the `send_message` tool is actually available in the session's enabled toolsets. Previously, these sections were injected unconditionally, causing the model to hallucinate messaging capabilities when the user had restricted toolsets to non-messaging tools.

## Related Issue

Fixes #38101

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: Added `_send_message_loaded(platform)` helper that checks whether the `messaging` toolset is enabled for the current platform (mirrors the existing `_discord_tools_loaded()` pattern). Gated Home Channels section, platform-specific delivery targets, explicit targeting note, and Yuanbao DM instructions behind this check. Connected Platforms section remains unconditional (informational, no messaging promise).
- `tests/gateway/test_session_context_send_message_gate.py`: 10 regression tests covering the helper function, Home Channels gating, delivery options gating, Yuanbao platform notes gating, and Connected Platforms always-shown invariant.

## How to Test

1. Configure a platform with restricted toolsets (e.g., `platform_toolsets: telegram: [terminal, file, vision, cronjob]`)
2. Send a message via that platform's gateway session
3. Verify the system prompt does NOT contain "Home Channels", platform delivery targets, or Yuanbao DM instructions
4. Re-enable the `messaging` toolset for the platform
5. Verify the system prompt now includes Home Channels and delivery targets
6. Run `pytest tests/gateway/test_session_context_send_message_gate.py tests/gateway/test_pii_redaction.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_session_context_send_message_gate.py tests/gateway/test_pii_redaction.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/session.py:build_session_context_prompt` (callers: 1 in `gateway/run.py:8519`)
- Blast radius: LOW — only affects system prompt content, no behavioral change to tools or routing
- Related patterns: `_discord_tools_loaded()` (same gating pattern for Discord toolset availability)
