### PR TITLE
fix(desktop): add ES2023 lib for findLast/findLastIndex types

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022", "ES2023"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Add ES2023 to apps/desktop/tsconfig.json compilerOptions.lib
- Fixes desktop bootstrap/build failures after recent composer/session changes started using Array.prototype.findLast / findLastIndex

## Problem
Windows Hermes Desktop bootstrap reaches the desktop build step and fails with:

Property findLast does not exist on type ChatMessage[]
Property findLastIndex does not exist on type ChatMessage[]
Try changing the lib compiler option to es2023 or later.

Affected files already on main:
- apps/desktop/src/app/chat/composer/index.tsx
- apps/desktop/src/app/session/hooks/use-session-actions.ts

## Fix
Keep target ES2022 and add ES2023 to lib so TypeScript knows about the ES2023 array helpers without changing emit target.

## Test plan
- [ ] cd apps/desktop && npm run build
- [ ] Windows Hermes Desktop bootstrap completes the desktop stage without TS2550 errors