### PR TITLE
fix(copilot): use explicit utf-8 for ACP file shim

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -637,7 +637,7 @@ class CopilotACPClient:
                 if block_error:
                     raise PermissionError(block_error)
                 try:
-                    content = path.read_text()
+                    content = path.read_text(encoding="utf-8")
                 except FileNotFoundError:
                     content = ""
                 line = params.get("line")
@@ -666,7 +666,7 @@ class CopilotACPClient:
                         f"Write denied: '{path}' is a protected system/credential file."
                     )
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(str(params.get("content") or ""))
+                path.write_text(str(params.get("content") or ""), encoding="utf-8")
                 response = {
                     "jsonrpc": "2.0",
                     "id": message_id,

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -145,6 +145,60 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertIn("error", response)
         self.assertFalse(outside.exists())
 
+    def test_text_file_shim_uses_utf8_for_non_ascii_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            target = root / "notes.txt"
+            content = "Hermes handles 中文 and emoji ⚕"
+            original_read_text = Path.read_text
+            original_write_text = Path.write_text
+
+            def read_text_with_cp1252_default(path, encoding=None, errors=None):
+                return original_read_text(
+                    path,
+                    encoding=encoding or "cp1252",
+                    errors=errors,
+                )
+
+            def write_text_with_cp1252_default(path, data, encoding=None, errors=None, newline=None):
+                return original_write_text(
+                    path,
+                    data,
+                    encoding=encoding or "cp1252",
+                    errors=errors,
+                    newline=newline,
+                )
+
+            with patch.object(Path, "read_text", read_text_with_cp1252_default), \
+                 patch.object(Path, "write_text", write_text_with_cp1252_default):
+                write_response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 6,
+                        "method": "fs/write_text_file",
+                        "params": {
+                            "path": str(target),
+                            "content": content,
+                        },
+                    },
+                    cwd=str(root),
+                )
+
+                self.assertNotIn("error", write_response)
+                self.assertEqual(target.read_bytes(), content.encode("utf-8"))
+
+                read_response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 7,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(target)},
+                    },
+                    cwd=str(root),
+                )
+
+        self.assertEqual((read_response.get("result") or {}).get("content"), content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Uses explicit UTF-8 encoding for the Copilot ACP `fs/read_text_file` and `fs/write_text_file` shim so non-ASCII text is handled consistently even when the platform default encoding is not UTF-8.

Fixes #38119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `agent/copilot_acp_client.py` to pass `encoding="utf-8"` for ACP text file reads/writes.
- Added a regression test in `tests/agent/test_copilot_acp_client.py` that simulates a cp1252 default encoding and verifies non-ASCII content is written/read as UTF-8.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_copilot_acp_client.py`
2. `.venv/bin/ruff check agent/copilot_acp_client.py tests/agent/test_copilot_acp_client.py`

## Verification

- `scripts/run_tests.sh tests/agent/test_copilot_acp_client.py`: 8/8 passed
- `.venv/bin/ruff check agent/copilot_acp_client.py tests/agent/test_copilot_acp_client.py`: All checks passed
- `git diff --check`: no whitespace errors
