### PR TITLE
fix(acp): pin utf-8 for fs/read_text_file + fs/write_text_file

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -637,7 +637,7 @@ class CopilotACPClient:
                 if block_error:
                     raise PermissionError(block_error)
                 try:
-                    content = path.read_text()
+                    content = path.read_text(encoding="utf-8")
                 except FileNotFoundError:
                     content = ""
                 line = params.get("line")
@@ -666,7 +666,7 @@ class CopilotACPClient:
                         f"Write denied: '{path}' is a protected system/credential file."
                     )
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(str(params.get("content") or ""))
+                path.write_text(str(params.get("content") or ""), encoding="utf-8")
                 response = {
                     "jsonrpc": "2.0",
                     "id": message_id,

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -121,6 +121,70 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertIn("error", response)
         self.assertFalse(target.exists())
 
+    def test_read_text_file_passes_explicit_utf8(self) -> None:
+        # The actual Windows-cp1252-mojibake scenario can't be reproduced
+        # under PEP 686 UTF-8 mode on POSIX without forking the interpreter,
+        # so spy on Path.read_text and confirm the shim forwards the
+        # encoding kwarg the underlying open() needs.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            f = root / "utf8.txt"
+            f.write_bytes("café — 中文 ✓".encode("utf-8"))
+
+            captured: list[dict] = []
+            real_read_text = Path.read_text
+
+            def _spy(self, *args, **kwargs):
+                if self == f.resolve():
+                    captured.append(kwargs)
+                return real_read_text(self, *args, **kwargs)
+
+            with patch.object(Path, "read_text", _spy):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 6,
+                        "method": "fs/read_text_file",
+                        "params": {"path": str(f)},
+                    },
+                    cwd=str(root),
+                )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertEqual(content, "café — 中文 ✓")
+        self.assertEqual(captured, [{"encoding": "utf-8"}])
+
+    def test_write_text_file_passes_explicit_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            f = root / "out.txt"
+
+            captured: list[dict] = []
+            real_write_text = Path.write_text
+
+            def _spy(self, *args, **kwargs):
+                if self == f.resolve():
+                    captured.append(kwargs)
+                return real_write_text(self, *args, **kwargs)
+
+            with patch.object(Path, "write_text", _spy):
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 7,
+                        "method": "fs/write_text_file",
+                        "params": {
+                            "path": str(f),
+                            "content": "café — 中文 ✓",
+                        },
+                    },
+                    cwd=str(root),
+                )
+
+            self.assertNotIn("error", response)
+            self.assertEqual(captured, [{"encoding": "utf-8"}])
+            self.assertEqual(f.read_bytes(), "café — 中文 ✓".encode("utf-8"))
+
     def test_write_text_file_respects_safe_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## What does this PR do?

`agent/copilot_acp_client.py::_handle_server_message` calls `Path.read_text()` / `Path.write_text(...)` without an explicit encoding for the ACP `fs/read_text_file` and `fs/write_text_file` handlers. With no `encoding` kwarg, Python's text I/O falls back to `locale.getencoding()` — `cp1252` on Windows — and silently corrupts (or rejects on write) any non-ASCII content the Copilot ACP client tries to hand the agent.

The rest of the codebase already pins `encoding=\"utf-8\"` for agent-visible text I/O (`agent/prompt_builder.py`, `agent/curator.py`, `agent/skill_commands.py`, etc.). This aligns the ACP shim with that convention.

## Related Issue

Fixes #38119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/copilot_acp_client.py` — add `encoding=\"utf-8\"` to the `path.read_text()` call at line 640 and the `path.write_text(...)` call at line 669.
- `tests/agent/test_copilot_acp_client.py` — two regression tests (`test_read_text_file_passes_explicit_utf8`, `test_write_text_file_passes_explicit_utf8`) that spy on `Path.read_text` / `Path.write_text` to assert the encoding kwarg is forwarded and round-trip non-ASCII content (`café — 中文 ✓`).

## How to Test

1. `uv run --extra dev pytest tests/agent/test_copilot_acp_client.py -q` — 9 passed locally.
2. Revert the two lines in `agent/copilot_acp_client.py` and re-run — the two new tests fail with \`AssertionError: Lists differ: [{}] != [{'encoding': 'utf-8'}]\`, confirming they actually catch the bug.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run \`pytest tests/ -q\` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A