### PR TITLE
fix(api-server): guard json.loads against corrupted SQLite data in response cache

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -423,7 +423,19 @@ class ResponseStore:
             (time.time(), response_id),
         )
         self._conn.commit()
-        return json.loads(row[0])
+        try:
+            return json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Corrupted JSON in response store for id=%s, evicting entry",
+                response_id,
+            )
+            self._conn.execute(
+                "DELETE FROM responses WHERE response_id = ?",
+                (response_id,),
+            )
+            self._conn.commit()
+            return None
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""


### PR DESCRIPTION
## Problem

`ResponseStore.get()` in `gateway/platforms/api_server.py` calls `json.loads(row[0])` without any error handling. If the SQLite `responses` table contains corrupted JSON data (e.g. from a crash mid-write or disk corruption), this raises an unhandled `JSONDecodeError` that propagates to the caller and can crash the gateway's Responses API handler.

## Fix

Wrap `json.loads(row[0])` in `try/except (json.JSONDecodeError, TypeError)`:

- On parse failure, log a `logger.warning` with the corrupted response ID
- Evict the corrupted entry from the cache (`DELETE FROM responses WHERE response_id = ?`)
- Return `None` (consistent with the function's `Optional[Dict[str, Any]]` return type)

This follows the same guard pattern already used in `gateway/status.py:235-237` and other gateway modules.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Corrupted JSON in response cache | `JSONDecodeError` crash | Warning logged, corrupted entry evicted, `None` returned |
| Valid JSON in response cache | Works normally | No change |

## Files Changed

- `gateway/platforms/api_server.py` — 13 lines added, 1 line removed
