### PR TITLE
feat: add Browser Use Cloud agent tool

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -228,7 +228,7 @@ _LEGACY_TOOLSET_MAP = {
         "browser_navigate", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",
         "browser_press", "browser_get_images",
-        "browser_vision", "browser_console"
+        "browser_vision", "browser_console", "browser_use_agent"
     ],
     "cronjob_tools": ["cronjob"],
     "file_tools": ["read_file", "write_file", "patch", "search_files"],

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 import threading
 import uuid
 from typing import Any, Dict, Optional
@@ -45,11 +46,22 @@ logger = logging.getLogger(__name__)
 # original idempotency key so the gateway can deduplicate. Cleared on
 # success or terminal failure.
 _pending_create_keys: Dict[str, str] = {}
+_pending_agent_task_keys: Dict[str, str] = {}
 _pending_create_keys_lock = threading.Lock()
 
 _BASE_URL = "https://api.browser-use.com/api/v3"
 _DEFAULT_MANAGED_TIMEOUT_MINUTES = 5
 _DEFAULT_MANAGED_PROXY_COUNTRY_CODE = "us"
+_TERMINAL_AGENT_STATUSES = {"idle", "stopped", "error", "timed_out"}
+_SUCCESS_AGENT_STATUSES = {"idle", "stopped"}
+
+
+def _get_first_present(payload: Dict[str, Any], *keys: str) -> Any:
+    """Return the first present Browser Use field, handling SDK/API casing."""
+    for key in keys:
+        if key in payload:
+            return payload.get(key)
+    return None
 
 
 def _get_or_create_pending_create_key(task_id: str) -> str:
@@ -66,6 +78,28 @@ def _get_or_create_pending_create_key(task_id: str) -> str:
 def _clear_pending_create_key(task_id: str) -> None:
     with _pending_create_keys_lock:
         _pending_create_keys.pop(task_id, None)
+
+
+def _agent_task_pending_key(task_id: Optional[str], task_text: str) -> str:
+    return f"{task_id or 'default'}:{task_text}"
+
+
+def _get_or_create_pending_agent_task_key(task_id: Optional[str], task_text: str) -> str:
+    pending_key = _agent_task_pending_key(task_id, task_text)
+    with _pending_create_keys_lock:
+        existing = _pending_agent_task_keys.get(pending_key)
+        if existing:
+            return existing
+
+        created = f"browser-use-agent-task:{uuid.uuid4().hex}"
+        _pending_agent_task_keys[pending_key] = created
+        return created
+
+
+def _clear_pending_agent_task_key(task_id: Optional[str], task_text: str) -> None:
+    pending_key = _agent_task_pending_key(task_id, task_text)
+    with _pending_create_keys_lock:
+        _pending_agent_task_keys.pop(pending_key, None)
 
 
 def _should_preserve_pending_create_key(response: requests.Response) -> bool:
@@ -249,6 +283,129 @@ class BrowserUseBrowserProvider(BrowserProvider):
             "features": {"browser_use": True},
             "external_call_id": external_call_id,
         }
+
+    def run_agent_task(
+        self,
+        task: str,
+        *,
+        task_id: str = None,
+        poll_interval_seconds: float = 2.0,
+        timeout_seconds: int = 600,
+    ) -> Dict[str, Any]:
+        """Run a Browser Use Cloud v3 agent session and return its output."""
+        task_text = (task or "").strip()
+        if not task_text:
+            raise ValueError("Browser Use agent task cannot be empty.")
+
+        config = self._get_config()
+        managed_mode = bool(config.get("managed_mode"))
+        headers = self._headers(config)
+        if managed_mode:
+            headers["X-Idempotency-Key"] = _get_or_create_pending_agent_task_key(
+                task_id,
+                task_text,
+            )
+
+        try:
+            response = requests.post(
+                f"{config['base_url']}/sessions",
+                headers=headers,
+                json={"task": task_text},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            if managed_mode:
+                raise
+            raise RuntimeError(
+                f"Browser Use agent API connection failed: {exc}"
+            ) from exc
+
+        if not response.ok:
+            if managed_mode and not _should_preserve_pending_create_key(response):
+                _clear_pending_agent_task_key(task_id, task_text)
+            raise RuntimeError(
+                f"Failed to create Browser Use agent session: "
+                f"{response.status_code} {response.text}"
+            )
+
+        session = response.json()
+        if managed_mode:
+            _clear_pending_agent_task_key(task_id, task_text)
+        session_id = str(session.get("id") or "")
+        if not session_id:
+            raise RuntimeError(
+                f"Browser Use agent session response missing id: {session!r}"
+            )
+
+        deadline = time.monotonic() + max(float(timeout_seconds), 1.0)
+        poll_interval = max(float(poll_interval_seconds), 0.1)
+        last_session = session
+
+        while True:
+            status = str(last_session.get("status") or "").lower()
+            if status in _TERMINAL_AGENT_STATUSES:
+                output = last_session.get("output")
+                task_success = _get_first_present(
+                    last_session,
+                    "isTaskSuccessful",
+                    "is_task_successful",
+                )
+                result = {
+                    "session_id": session_id,
+                    "status": status,
+                    "output": output,
+                }
+                if task_success is not None:
+                    result["is_task_successful"] = task_success
+                live_url = _get_first_present(last_session, "liveUrl", "live_url")
+                if live_url is not None:
+                    result["live_url"] = live_url
+                recording_urls = _get_first_present(
+                    last_session,
+                    "recordingUrls",
+                    "recording_urls",
+                    "recordingUrl",
+                    "recording_url",
+                )
+                if recording_urls is not None:
+                    result["recording_urls"] = recording_urls
+
+                if status in _SUCCESS_AGENT_STATUSES and task_success is not False:
+                    return result
+                error = (
+                    last_session.get("error")
+                    or last_session.get("message")
+                    or output
+                    or f"Browser Use agent session ended with status {status}."
+                )
+                raise RuntimeError(str(error))
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Browser Use agent session {session_id} did not finish "
+                    f"within {int(timeout_seconds)} seconds; last status={status or 'unknown'}."
+                )
+
+            time.sleep(poll_interval)
+            try:
+                poll_response = requests.get(
+                    f"{config['base_url']}/sessions/{session_id}",
+                    headers=headers,
+                    timeout=30,
+                )
+            except requests.RequestException as exc:
+                if managed_mode:
+                    raise
+                raise RuntimeError(
+                    f"Browser Use agent API polling failed: {exc}"
+                ) from exc
+
+            if not poll_response.ok:
+                raise RuntimeError(
+                    f"Failed to poll Browser Use agent session {session_id}: "
+                    f"{poll_response.status_code} {poll_response.text}"
+                )
+            last_session = poll_response.json()
 
     def close_session(self, session_id: str) -> bool:
         try:

--- a/tests/tools/test_browser_use_agent.py
+++ b/tests/tools/test_browser_use_agent.py
@@ -1,0 +1,192 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+class _Response:
+    def __init__(self, payload, *, status_code=200, text="", headers=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_browser_use_agent_posts_task_and_polls_until_success(monkeypatch):
+    from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "direct-key")
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    monkeypatch.delenv("BROWSER_USE_GATEWAY_URL", raising=False)
+    monkeypatch.setattr("tools.tool_backend_helpers.prefers_gateway", lambda _tool: False)
+
+    post_response = _Response({"id": "session-1", "status": "running"})
+    poll_response = _Response({
+        "id": "session-1",
+        "status": "idle",
+        "output": "Found the invoice total.",
+        "isTaskSuccessful": True,
+        "liveUrl": "https://browser-use.example/live/session-1",
+        "recordingUrls": ["https://browser-use.example/recording/session-1.mp4"],
+    })
+
+    with (
+        patch("plugins.browser.browser_use.provider.requests.post", return_value=post_response) as post,
+        patch("plugins.browser.browser_use.provider.requests.get", return_value=poll_response) as get,
+        patch("plugins.browser.browser_use.provider.time.sleep") as sleep,
+    ):
+        result = BrowserUseBrowserProvider().run_agent_task(
+            "Find the invoice total",
+            task_id="task-1",
+            poll_interval_seconds=0.1,
+            timeout_seconds=5,
+        )
+
+    assert result["session_id"] == "session-1"
+    assert result["status"] == "idle"
+    assert result["output"] == "Found the invoice total."
+    assert result["is_task_successful"] is True
+    assert result["live_url"] == "https://browser-use.example/live/session-1"
+    assert result["recording_urls"] == ["https://browser-use.example/recording/session-1.mp4"]
+    post.assert_called_once()
+    assert post.call_args.args[0] == "https://api.browser-use.com/api/v3/sessions"
+    assert post.call_args.kwargs["headers"] == {
+        "Content-Type": "application/json",
+        "X-Browser-Use-API-Key": "direct-key",
+    }
+    assert post.call_args.kwargs["json"] == {"task": "Find the invoice total"}
+    get.assert_called_once_with(
+        "https://api.browser-use.com/api/v3/sessions/session-1",
+        headers={
+            "Content-Type": "application/json",
+            "X-Browser-Use-API-Key": "direct-key",
+        },
+        timeout=30,
+    )
+    sleep.assert_called_once_with(0.1)
+
+
+def test_browser_use_agent_uses_managed_gateway_auth(monkeypatch):
+    from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+    monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+    monkeypatch.setenv("BROWSER_USE_GATEWAY_URL", "http://127.0.0.1:3009/")
+    monkeypatch.setattr(
+        "tools.managed_tool_gateway.managed_nous_tools_enabled",
+        lambda: True,
+    )
+
+    post_response = _Response({"id": "session-2", "status": "stopped", "output": "Done"})
+
+    with patch("plugins.browser.browser_use.provider.requests.post", return_value=post_response) as post:
+        result = BrowserUseBrowserProvider().run_agent_task("Summarize the page", task_id="abc123")
+
+    assert result["status"] == "stopped"
+    assert result["output"] == "Done"
+    assert post.call_args.args[0] == "http://127.0.0.1:3009/sessions"
+    headers = post.call_args.kwargs["headers"]
+    assert headers["X-Browser-Use-API-Key"] == "nous-token"
+    assert headers["X-Idempotency-Key"].startswith("browser-use-agent-task:")
+
+
+def test_browser_use_agent_terminal_failure_raises(monkeypatch):
+    from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "direct-key")
+    monkeypatch.setattr("tools.tool_backend_helpers.prefers_gateway", lambda _tool: False)
+
+    post_response = _Response({"id": "session-3", "status": "running"})
+    poll_response = _Response({
+        "id": "session-3",
+        "status": "error",
+        "error": "Navigation failed",
+        "output": "Partial output",
+    })
+
+    with (
+        patch("plugins.browser.browser_use.provider.requests.post", return_value=post_response),
+        patch("plugins.browser.browser_use.provider.requests.get", return_value=poll_response),
+        patch("plugins.browser.browser_use.provider.time.sleep"),
+    ):
+        with pytest.raises(RuntimeError, match="Navigation failed"):
+            BrowserUseBrowserProvider().run_agent_task("Open a broken URL", timeout_seconds=5)
+
+
+def test_browser_use_agent_unsuccessful_stopped_session_raises(monkeypatch):
+    from plugins.browser.browser_use.provider import BrowserUseBrowserProvider
+
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "direct-key")
+    monkeypatch.setattr("tools.tool_backend_helpers.prefers_gateway", lambda _tool: False)
+
+    post_response = _Response({
+        "id": "session-4",
+        "status": "stopped",
+        "output": "I could not find the requested account.",
+        "isTaskSuccessful": False,
+    })
+
+    with patch("plugins.browser.browser_use.provider.requests.post", return_value=post_response):
+        with pytest.raises(RuntimeError, match="could not find"):
+            BrowserUseBrowserProvider().run_agent_task("Find a missing account")
+
+
+def test_browser_use_agent_auth_availability(monkeypatch):
+    from tools import browser_tool
+
+    monkeypatch.setattr(
+        browser_tool.BrowserUseProvider,
+        "is_configured",
+        lambda _self: False,
+    )
+    assert browser_tool.check_browser_use_agent_requirements() is False
+
+    monkeypatch.setattr(
+        browser_tool.BrowserUseProvider,
+        "is_configured",
+        lambda _self: True,
+    )
+    assert browser_tool.check_browser_use_agent_requirements() is True
+
+
+def test_browser_use_agent_tool_returns_json(monkeypatch):
+    from tools.browser_tool import browser_use_agent
+
+    class _Provider:
+        def run_agent_task(self, task, *, task_id=None, timeout_seconds=600):
+            return {
+                "session_id": "session-tool",
+                "status": "idle",
+                "output": f"done: {task}",
+            }
+
+    monkeypatch.setattr("tools.browser_tool.BrowserUseProvider", _Provider)
+
+    result = json.loads(browser_use_agent("Check the dashboard", task_id="task-tool"))
+
+    assert result == {
+        "success": True,
+        "session_id": "session-tool",
+        "status": "idle",
+        "output": "done: Check the dashboard",
+    }
+
+
+def test_browser_use_agent_registration_and_schema():
+    from model_tools import _LEGACY_TOOLSET_MAP
+    from toolsets import TOOLSETS, _HERMES_CORE_TOOLS
+    from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+    from tools.registry import registry
+    from tools import browser_tool  # noqa: F401
+
+    schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_use_agent")
+    assert schema["parameters"]["required"] == ["task"]
+    assert "timeout_seconds" in schema["parameters"]["properties"]
+    assert "browser_use_agent" in TOOLSETS["browser"]["tools"]
+    assert "browser_use_agent" in _HERMES_CORE_TOOLS
+    assert "browser_use_agent" in _LEGACY_TOOLSET_MAP["browser_tools"]
+    assert "browser_use_agent" in registry._tools

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1614,6 +1614,25 @@ BROWSER_TOOL_SCHEMAS = [
             "required": []
         }
     },
+    {
+        "name": "browser_use_agent",
+        "description": "Run a complete web task using Browser Use Cloud v3's hosted AI browser agent. Use this as a cloud alternative to manual Browserbase-style browser sessions when you want Browser Use to navigate, click, extract, and summarize autonomously from a natural-language task. Returns the terminal agent output.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Natural-language browser task for the hosted Browser Use agent to complete."
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "default": 600,
+                    "description": "Maximum seconds to poll for completion before timing out."
+                }
+            },
+            "required": ["task"]
+        }
+    },
 ]
 
 
@@ -3716,6 +3735,29 @@ def check_browser_vision_requirements() -> bool:
     return check_vision_requirements()
 
 
+def check_browser_use_agent_requirements() -> bool:
+    """Whether Browser Use Cloud agent sessions can be created."""
+    try:
+        return BrowserUseProvider().is_configured()
+    except Exception:
+        return False
+
+
+def browser_use_agent(
+    task: str,
+    timeout_seconds: int = 600,
+    task_id: str = None,
+) -> str:
+    """Run a task through Browser Use Cloud's hosted v3 browser agent."""
+    provider = BrowserUseProvider()
+    result = provider.run_agent_task(
+        task,
+        task_id=task_id,
+        timeout_seconds=timeout_seconds,
+    )
+    return json.dumps({"success": True, **result}, ensure_ascii=False)
+
+
 # ============================================================================
 # Module Test
 # ============================================================================
@@ -3860,4 +3902,16 @@ registry.register(
     handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="🖥️",
+)
+registry.register(
+    name="browser_use_agent",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_use_agent"],
+    handler=lambda args, **kw: browser_use_agent(
+        task=args.get("task", ""),
+        timeout_seconds=args.get("timeout_seconds", 600),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_browser_use_agent_requirements,
+    emoji="🌐",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -43,7 +43,8 @@ _HERMES_CORE_TOOLS = [
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
     "browser_press", "browser_get_images",
-    "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
+    "browser_vision", "browser_console", "browser_use_agent",
+    "browser_cdp", "browser_dialog",
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
@@ -173,7 +174,7 @@ TOOLSETS = {
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp",
+            "browser_vision", "browser_console", "browser_use_agent", "browser_cdp",
             "browser_dialog", "web_search"
         ],
         "includes": []

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -58,7 +58,9 @@ To use Browser Use as your cloud browser provider, add:
 BROWSER_USE_API_KEY=***
 ```
 
-Get your API key at [browser-use.com](https://browser-use.com). Browser Use provides a cloud browser via its REST API. If both Browserbase and Browser Use credentials are set, Browserbase takes priority.
+Get your API key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1). Browser Use provides both raw cloud browser sessions via CDP and hosted Browser Use Cloud v3 agent sessions through its REST API. If both Browserbase and Browser Use credentials are set and no provider is explicitly configured, Hermes auto-detects Browser Use first, then Browserbase.
+
+For high-level tasks where you want Browser Use to navigate, click, extract, and summarize autonomously, the browser toolset exposes `browser_use_agent` when `BROWSER_USE_API_KEY` or a managed Nous Browser Use gateway is available. It follows the Browser Use Cloud quickstart shape, `POST /api/v3/sessions` with `{ "task": "..." }`, then polls the session until completion. Use the lower-level `browser_navigate`, `browser_click`, and related tools when Hermes needs step-by-step control of a page.
 
 ### Firecrawl cloud mode
 


### PR DESCRIPTION
## Feature description
- Adds Browser Use Cloud v3 hosted agent sessions as a new `browser_use_agent` tool, using REST instead of adding a browser-use SDK dependency.
- Reuses the existing Browser Use provider auth path so both direct `BROWSER_USE_API_KEY` and managed Nous gateway sessions work.
- Preserves existing raw Browser Use browser-session support and Browserbase behavior.
- Registers the new tool in browser toolsets and legacy model tool mapping.
- Documents Browser Use Cloud v3 agent-session behavior in the browser feature docs.

## Testing and validation
```bash
scripts/run_tests.sh tests/tools/test_browser_use_agent.py tests/tools/test_managed_browserbase_and_modal.py tests/plugins/browser/test_browser_provider_plugins.py tests/tools/test_browser_console.py tests/test_model_tools.py tests/test_toolset_distributions.py
venv/bin/python -m py_compile plugins/browser/browser_use/provider.py tools/browser_tool.py tests/tools/test_browser_use_agent.py
git diff --check
```

Result: 117 targeted tests passed locally, py_compile passed, and git diff whitespace checks passed.

## Notes
- Browser Use live-call validation was not run because `BROWSER_USE_API_KEY` is not set in this environment.
- Existing untracked Matcha ownership files were not staged or included in this PR.
