### PR TITLE
Preserve clarify draft across remounts

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,0 +1,42 @@
+import { type ToolCallMessagePartProps } from '@assistant-ui/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { $clarifyRequest } from '@/store/clarify'
+
+import { ClarifyTool } from './clarify-tool'
+
+function clarifyProps(toolCallId: string): ToolCallMessagePartProps {
+  return {
+    args: { question: 'How should Hermes continue?' },
+    isError: false,
+    result: undefined,
+    toolCallId,
+    toolName: 'clarify'
+  } as ToolCallMessagePartProps
+}
+
+describe('ClarifyTool', () => {
+  it('preserves freeform draft text across remounts for the same tool call', () => {
+    $clarifyRequest.set({
+      choices: null,
+      question: 'How should Hermes continue?',
+      requestId: 'clarify-request-1',
+      sessionId: 'session-1'
+    })
+
+    const first = render(<ClarifyTool {...clarifyProps('tool-call-1')} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Type your answer…'), {
+      target: { value: 'Use the official API endpoint.' }
+    })
+
+    first.unmount()
+
+    render(<ClarifyTool {...clarifyProps('tool-call-1')} />)
+
+    expect((screen.getByPlaceholderText('Type your answer…') as HTMLTextAreaElement).value).toBe(
+      'Use the official API endpoint.'
+    )
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -19,6 +19,8 @@ interface ClarifyArgs {
   choices?: string[] | null
 }
 
+const clarifyDrafts = new Map<string, string>()
+
 function readClarifyArgs(args: unknown): ClarifyArgs {
   if (!args || typeof args !== 'object') {
     return {}
@@ -45,7 +47,7 @@ export const ClarifyTool = (props: ToolCallMessagePartProps) => {
   return <ClarifyToolPending {...props} />
 }
 
-function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
+function ClarifyToolPending({ args, toolCallId }: ToolCallMessagePartProps) {
   const request = useStore($clarifyRequest)
   const gateway = useStore($gateway)
   const fromArgs = useMemo(() => readClarifyArgs(args), [args])
@@ -70,11 +72,25 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const hasChoices = choices.length > 0
+  const draftKey = toolCallId || question || 'clarify'
 
   const [typing, setTyping] = useState(false)
-  const [draft, setDraft] = useState('')
+  const [draft, setDraft] = useState(() => clarifyDrafts.get(draftKey) ?? '')
   const [submitting, setSubmitting] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const updateDraft = useCallback(
+    (value: string) => {
+      setDraft(value)
+
+      if (value) {
+        clarifyDrafts.set(draftKey, value)
+      } else {
+        clarifyDrafts.delete(draftKey)
+      }
+    },
+    [draftKey]
+  )
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Show the question (from
@@ -103,6 +119,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
           answer
         })
         triggerHaptic('submit')
+        clarifyDrafts.delete(draftKey)
         clearClarifyRequest(matchingRequest.requestId)
         // The matching tool.complete will land shortly after, swapping this
         // panel for the ToolFallback view above.
@@ -111,7 +128,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
         setSubmitting(false)
       }
     },
-    [gateway, matchingRequest, ready]
+    [draftKey, gateway, matchingRequest, ready]
   )
 
   const handleTextareaKey = useCallback(
@@ -229,7 +246,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
           <Textarea
             className="min-h-20 resize-y rounded-lg border-border/70 bg-background/60 text-sm"
             disabled={submitting}
-            onChange={event => setDraft(event.target.value)}
+            onChange={event => updateDraft(event.target.value)}
             onKeyDown={handleTextareaKey}
             placeholder="Type your answer…"
             ref={textareaRef}
@@ -243,7 +260,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                   disabled={submitting}
                   onClick={() => {
                     setTyping(false)
-                    setDraft('')
+                    updateDraft('')
                   }}
                   size="sm"
                   type="button"


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop chat bug where text typed into a pending `clarify` prompt can disappear while the assistant message continues updating.

The pending clarify UI is rendered inside a streaming/tool-call message. During message or tool state updates, the inline tool component can remount. The freeform answer draft was previously stored only in component-local state, so a remount reset the textarea to an empty string.

This PR persists pending clarify drafts by `toolCallId` until the user submits, skips, or clears the draft.

## Related Issue

N/A - no linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx`: cache freeform clarify drafts by `toolCallId` and restore them on remount; clear cached drafts when the response is submitted or the draft is cleared.
- `apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx`: add regression coverage for preserving freeform draft text across remounts for the same tool call.

## How to Test

1. Run `npm run test:ui -- src/components/assistant-ui/clarify-tool.test.tsx`.
2. Run `npm run type-check` from `apps/desktop`.
3. In desktop chat, trigger a pending `clarify` prompt, start typing a freeform answer, and let the message/tool state continue updating; the typed answer should remain in the textarea.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Targeted test output:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

Also verified `npm run type-check` passes.