### PR TITLE
fix(gateway): visually expire Discord interactive views on timeout #38022

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4067,6 +4067,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:
@@ -4106,6 +4107,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -4183,6 +4185,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 view = None
 
             msg = await channel.send(embed=embed, view=view) if view else await channel.send(embed=embed)
+            if view:
+                view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
@@ -4218,6 +4222,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
             )
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             return SendResult(success=False, error=str(e))
@@ -4277,6 +4282,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             msg = await channel.send(embed=embed, view=view)
+            view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:
@@ -5102,6 +5108,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass  # message deleted or too old to edit
 
     class SlashConfirmView(discord.ui.View):
         """Three-button view for generic slash-command confirmations.
@@ -5206,6 +5223,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
     class UpdatePromptView(discord.ui.View):
         """Interactive Yes/No buttons for ``hermes update`` prompts.
@@ -5291,6 +5319,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
     class ModelPickerView(discord.ui.View):
         """Interactive select-menu view for model switching.
@@ -5516,6 +5555,18 @@ def _define_discord_view_classes() -> None:
         async def on_timeout(self):
             self.resolved = True
             self.clear_items()
+            # Visually update the Discord message so it appears expired.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = discord.Embed(
+                        title="⚙ Model Configuration",
+                        description="⏱ Selection expired — no model change.",
+                        color=discord.Color.greyple(),
+                    )
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 
 
     class ClarifyChoiceView(discord.ui.View):
@@ -5701,6 +5752,17 @@ def _define_discord_view_classes() -> None:
             self.resolved = True
             for child in self.children:
                 child.disabled = True
+            # Visually update the Discord message so buttons appear disabled.
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
 if DISCORD_AVAILABLE:
     _define_discord_view_classes()
 


### PR DESCRIPTION
## Summary

All Discord interactive views (ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView) now edit their message when the view times out, visually disabling buttons and updating the embed to show a 'Prompt expired' footer.

## Problem

Previously, when a Discord interactive view timed out, only in-memory state was updated (, buttons disabled in the View object). The actual Discord message was never edited, so buttons remained visually clickable in the UI. Users clicking expired buttons got Discord's generic 'Interaction failed' error with no explanation.

## Changes

1. **Store message reference**: After , store the message on the view via  so  can access it.

2. **Edit message on timeout**: Each view's  now:
   - Disables all buttons (as before)
   - Edits the Discord message to show a grey embed with a '⏱ Prompt expired' footer
   - Wrapped in try/except since the message may be deleted or too old to edit

## Testing

- All 14 existing  tests pass
- All 19 existing  tests pass

## Related

Fixes #38022