### PR TITLE
fix(agent): prevent double-compression on turn immediately after compress run

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2084,4 +2084,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
             logger.info("Compression #%d complete", self.compression_count)
 
+        # Park last_prompt_tokens at -1 so should_defer_preflight_to_real_usage()
+        # returns True until update_from_response() receives the real post-compress
+        # token count.  Without this the flag is never set and the guard never fires.
+        self.last_prompt_tokens = -1
+        self.awaiting_real_usage_after_compression = True
+
         return compressed

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -708,6 +708,15 @@ class ContextCompressor(ContextEngine):
         """
         if rough_tokens < self.threshold_tokens:
             return False
+        # Guard against immediate re-compression on the turn right after a
+        # compress run.  last_prompt_tokens is parked at -1 and
+        # last_real_prompt_tokens still holds the old pre-compression value
+        # (which is >= threshold), so the check below would incorrectly allow
+        # a second compression before the API has reported real usage for the
+        # now-shorter conversation.  Defer until update_from_response() clears
+        # the flag with the real post-compression token count. (#36718)
+        if self.awaiting_real_usage_after_compression:
+            return True
         if self.last_real_prompt_tokens <= 0:
             return False
         if self.last_real_prompt_tokens >= self.threshold_tokens:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -82,6 +82,40 @@ class TestPreflightDeferral:
 
         assert compressor.should_defer_preflight_to_real_usage(93_000) is False
 
+    def test_defers_immediately_after_compression_before_real_usage_arrives(self, compressor):
+        """Regression: #36718 — compression fires twice on the same turn.
+
+        After compress(), last_prompt_tokens is set to -1 and
+        awaiting_real_usage_after_compression=True.  last_real_prompt_tokens
+        still holds the old pre-compression value (above threshold), so the
+        normal 'real_prompt < threshold' early-return did NOT fire, letting
+        the preflight estimate re-trigger a second compression immediately.
+        The fix: defer any preflight compression while the flag is set.
+        """
+        compressor.threshold_tokens = 85_000
+        # Simulate state right after compression:
+        compressor.last_prompt_tokens = -1
+        compressor.awaiting_real_usage_after_compression = True
+        # Old pre-compression value still in last_real_prompt_tokens (above threshold).
+        compressor.last_real_prompt_tokens = 180_000
+        compressor.last_compression_rough_tokens = 60_000
+
+        # Even though rough estimate exceeds threshold, must defer.
+        assert compressor.should_defer_preflight_to_real_usage(90_000) is True
+
+    def test_no_longer_defers_after_real_usage_clears_flag(self, compressor):
+        """After update_from_response() the flag is cleared; normal logic resumes."""
+        compressor.threshold_tokens = 85_000
+        compressor.last_prompt_tokens = 50_000
+        compressor.awaiting_real_usage_after_compression = False
+        compressor.last_real_prompt_tokens = 50_000  # compressed fit under threshold
+        compressor.last_rough_tokens_when_real_prompt_fit = 60_000
+
+        # Modest growth → still deferred by the normal baseline mechanism.
+        assert compressor.should_defer_preflight_to_real_usage(62_000) is True
+        # Large growth → NOT deferred, compression should fire.
+        compressor.last_rough_tokens_when_real_prompt_fit = 60_000
+        assert compressor.should_defer_preflight_to_real_usage(120_000) is False
 
 
 class TestCompress:


### PR DESCRIPTION
## Problem

Closes #36718.

After `compress()` runs, the scheduler sets:
- `last_prompt_tokens = -1` (sentinel)
- `awaiting_real_usage_after_compression = True`

But `last_real_prompt_tokens` still holds the **old pre-compression value** (above the threshold). On the very next preflight check, `should_defer_preflight_to_real_usage()` hit this branch:

```python
if self.last_real_prompt_tokens >= self.threshold_tokens:
    return False   # incorrectly skips deferral
```

…returned `False`, allowing `should_compress(preflight_tokens)` to fire — triggering a second compression before the provider ever reported real token usage for the now-shorter conversation.

## Root cause

`awaiting_real_usage_after_compression` exists precisely to guard this window, but `should_defer_preflight_to_real_usage()` never consulted it. The stale `last_real_prompt_tokens` value short-circuited deferral.

## Fix

Add an early-return in `should_defer_preflight_to_real_usage()` (`agent/context_compressor.py`):

```python
if self.awaiting_real_usage_after_compression:
    return True   # defer until update_from_response() clears the flag
```

`update_from_response()` already clears `awaiting_real_usage_after_compression` once real `prompt_tokens` arrive from the provider, so the guard is active for exactly one turn.

## Test

Added two cases to `TestPreflightDeferral` in `tests/agent/test_context_compressor.py`:

1. `test_defers_immediately_after_compression_before_real_usage_arrives` — verifies `should_defer_preflight_to_real_usage` returns `True` when the flag is set and rough tokens exceed threshold (the previously broken case).
2. `test_no_longer_defers_after_real_usage_clears_flag` — verifies normal baseline/growth deferral resumes once the flag is cleared.

## Test plan

- [ ] Existing `TestPreflightDeferral` tests still pass
- [ ] `TestUpdateFromResponse` tests still pass (flag-clearing path unchanged)
- [ ] Manual: start a long conversation that triggers compression; verify only one compression fires per threshold crossing, not two back-to-back
