### PR TITLE
fix(desktop): skip Enter submit when Chinese IME is composing

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -595,6 +595,7 @@ export function ChatBar({
       }
 
       if (event.key === 'Enter' || event.key === 'Tab') {
+        if ((event.nativeEvent as any).isComposing) {return}
         event.preventDefault()
         triggerKeyConsumedRef.current = true
         const item = triggerItems[triggerActive]
@@ -615,7 +616,7 @@ export function ChatBar({
       }
     }
 
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !(event.nativeEvent as any).isComposing) {
       event.preventDefault()
 
       if (!busy && !hasComposerPayload && queuedPrompts.length > 0) {
@@ -1082,8 +1083,8 @@ export function ChatBar({
     <div className={cn('relative', stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1')}>
       <div
         aria-label="Message"
-        autoCorrect="off"
         autoCapitalize="off"
+        autoCorrect="off"
         className={cn(
           'min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) overflow-y-auto bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
           'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',


### PR DESCRIPTION
## Problem

When using a Chinese input method (IME), pressing Enter to confirm the current composition candidate causes the message to be sent instead — the `isComposing` flag is not checked in the keydown handler.

## Fix

Added `event.nativeEvent.isComposing` guard to both the trigger-popover Enter/Tab handler and the main Enter-to-submit handler in the contentEditable composer, so they return early during IME composition.

## Testing
- `npm run type-check` ✅
- `npm run lint` ✅