### PR TITLE
refactor(skills): rename shop-app skill to shop

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/optional-skills-catalog.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/optional-skills-catalog.md
@@ -152,7 +152,7 @@ hermes skills uninstall <skill-name>
 | [**canvas**](/user-guide/skills/optional/productivity/productivity-canvas) | Canvas LMS 集成 — 使用 API token 认证获取已注册课程和作业。 |
 | [**here.now**](/user-guide/skills/optional/productivity/productivity-here-now) | 将静态站点发布至 &#123;slug&#125;.here.now，并将私有文件存储在云端 Drive 中以供 agent 间交接。 |
 | [**memento-flashcards**](/user-guide/skills/optional/productivity/productivity-memento-flashcards) | 间隔重复闪卡系统。从事实或文本创建卡片，通过 agent 评分的自由文本回答与闪卡对话，从 YouTube 字幕生成测验，使用自适应调度复习到期卡片，并支持导出/导入。 |
-| [**shop-app**](/user-guide/skills/optional/productivity/productivity-shop-app) | Shop.app：商品搜索、订单追踪、退货、重新下单。 |
+| [**shop**](/user-guide/skills/optional/productivity/productivity-shop) | Shop.app：商品搜索、订单追踪、退货、重新下单。 |
 | [**shopify**](/user-guide/skills/optional/productivity/productivity-shopify) | 通过 curl 使用 Shopify Admin 和 Storefront GraphQL API。支持商品、订单、客户、库存、元字段。 |
 | [**siyuan**](/user-guide/skills/optional/productivity/productivity-siyuan) | 通过 curl 使用 SiYuan Note API，在自托管知识库中搜索、读取、创建和管理块与文档。 |
 | [**telephony**](/user-guide/skills/optional/productivity/productivity-telephony) | 为 Hermes 添加电话能力，无需修改核心工具。配置并持久化 Twilio 号码，发送和接收 SMS/MMS，拨打直接通话，并通过 Bland.ai 或 Vapi 发起 AI 驱动的外呼。 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/optional/productivity/productivity-shop.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/optional/productivity/productivity-shop.md
@@ -1,12 +1,12 @@
 ---
-title: "Shop App — Shop"
-sidebar_label: "Shop App"
-description: "Shop"
+title: "Shop — Shop.app：商品搜索、订单追踪、退货、重新下单"
+sidebar_label: "Shop"
+description: "Shop.app：商品搜索、订单追踪、退货、重新下单"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
-# Shop App
+# Shop
 
 Shop.app：商品搜索、订单追踪、退货、重新下单。
 
@@ -14,8 +14,8 @@ Shop.app：商品搜索、订单追踪、退货、重新下单。
 
 | | |
 |---|---|
-| 来源 | 可选 — 使用 `hermes skills install official/productivity/shop-app` 安装 |
-| 路径 | `optional-skills/productivity/shop-app` |
+| 来源 | 可选 — 使用 `hermes skills install official/productivity/shop` 安装 |
+| 路径 | `optional-skills/productivity/shop` |
 | 版本 | `0.0.28` |
 | 作者 | community |
 | 许可证 | MIT |


### PR DESCRIPTION
## Summary
Renames the optional `shop-app` skill to `shop` — matches the openclaw naming and rewrites the frontmatter description so agent skill-selection actually fires on shopping intent.

## Changes
- `optional-skills/productivity/shop-app/` → `shop/`; `name: shop-app` → `shop`, version `0.0.28` → `0.0.29`
- Description rewritten to lead with intent verbs (`search and buy products… track orders, manage returns, re-order…`) with `(powered by Shop.app)` trailing. The frontmatter `description` is the biggest lever on agent skill selection, and the old `Shop.app: …` form also produced a broken docs title (`Shop App — Shop`) because the docs generator splits the description on the first `.`
- Regenerated the EN docs page (`productivity-shop.md`), catalog, and sidebar via `generate-skill-docs.py`; removed the old `productivity-shop-app.md`
- Updated the zh-Hans i18n page + catalog row by hand (the generator doesn't touch i18n)

## Validation
| | Before | After |
|---|---|---|
| Install command | `…/shop-app` | `…/shop` |
| Docs title | `Shop App — Shop` | `Shop` |
| Description | `Shop.app: product search, order tracking, returns, reorder.` | intent-first, shopping-verb-led |

Context: raised in Slack — an agent couldn't surface the skill, request to rename to `shop` for naming consistency, and a note that the frontmatter description drives selection. This addresses all three.

## Infographic
![shop skill rename infographic](https://v3b.fal.media/files/b/0a9ccda8/d5hLnWHFdLZhAaVt2UGCc_QL2j1H0K.png)
