### PR TITLE
feat(agent): support per-model compression overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -30,6 +30,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 
+from agent.compression_config import resolve_compression_settings
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
@@ -1265,50 +1266,21 @@ def init_agent(
 
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
-    # Configuration via config.yaml (compression section)
+    # Configuration via config.yaml (compression and model.compression sections)
+    _model_cfg = _agent_cfg.get("model", {})
     _compression_cfg = _agent_cfg.get("compression", {})
     if not isinstance(_compression_cfg, dict):
         _compression_cfg = {}
-    compression_threshold = float(_compression_cfg.get("threshold", 0.50))
-    # Per-model/route compaction-threshold override. Codex gpt-5.5 raises to
-    # 85% (the Codex backend caps the window at 272K, so the default 50% would
-    # compact at ~136K — half the usable context). Gated by an opt-out config
-    # flag so the user can fall back to the global threshold; when the override
-    # fires we stash a one-time notification (replayed on the first turn) that
-    # tells the user what changed and how to revert.
-    _codex_gpt55_autoraise = str(
-        _compression_cfg.get("codex_gpt55_autoraise", True)
-    ).lower() in {"true", "1", "yes"}
-    agent._compression_threshold_autoraised = None
-    try:
-        from agent.auxiliary_client import (
-            _compression_threshold_for_model as _cthresh_fn,
-            _is_codex_gpt55 as _is_codex_gpt55_fn,
-        )
-        _model_cthresh = _cthresh_fn(
-            agent.model,
-            agent.provider,
-            allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
-        )
-        if _model_cthresh is not None:
-            _prev_threshold = compression_threshold
-            compression_threshold = _model_cthresh
-            # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
-            # override is a long-standing silent default). Skip the notice when
-            # the user's global threshold already meets/exceeds the raised
-            # value, since nothing actually changed for them.
-            if (
-                _is_codex_gpt55_fn(agent.model, agent.provider)
-                and _model_cthresh > _prev_threshold + 1e-9
-            ):
-                agent._compression_threshold_autoraised = {
-                    "from": _prev_threshold,
-                    "to": _model_cthresh,
-                }
-    except Exception:
-        pass
+    _compression_settings = resolve_compression_settings(
+        model=agent.model,
+        provider=agent.provider,
+        compression_cfg=_compression_cfg,
+        model_cfg=_model_cfg,
+    )
+    compression_threshold = _compression_settings.threshold
+    agent._compression_threshold_autoraised = _compression_settings.threshold_autoraised
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
-    compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
+    compression_target_ratio = _compression_settings.target_ratio
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
@@ -1343,7 +1315,6 @@ def init_agent(
 
     # Read explicit model output-token override from config when the
     # caller did not pass one directly.
-    _model_cfg = _agent_cfg.get("model", {})
     if agent.max_tokens is None and isinstance(_model_cfg, dict):
         _config_max_tokens = _model_cfg.get("max_tokens")
         if _config_max_tokens is not None:

--- a/agent/compression_config.py
+++ b/agent/compression_config.py
@@ -1,0 +1,83 @@
+"""Helpers for resolving compression settings from config.yaml."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+from agent.auxiliary_client import _compression_threshold_for_model, _is_codex_gpt55
+
+
+@dataclass(frozen=True)
+class CompressionSettings:
+    threshold: float
+    threshold_autoraised: Optional[Dict[str, float]]
+    target_ratio: float
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _float_or_default(value: Any, default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
+def _model_compression_cfg(model_cfg: Any) -> Mapping[str, Any]:
+    cfg = _mapping(model_cfg)
+    return _mapping(cfg.get("compression"))
+
+
+def resolve_compression_settings(
+    *,
+    model: Optional[str],
+    provider: Optional[str] = None,
+    compression_cfg: Any,
+    model_cfg: Any,
+) -> CompressionSettings:
+    """Resolve effective compression threshold and summary target ratio.
+
+    Precedence for ``threshold``:
+    1. ``model.compression.threshold`` when explicitly configured.
+    2. Built-in model-specific default, if any.
+    3. Global ``compression.threshold``.
+
+    ``target_ratio`` has no built-in model defaults, so
+    ``model.compression.target_ratio`` overrides only the global
+    ``compression.target_ratio``.
+    """
+    global_cfg = _mapping(compression_cfg)
+    model_comp_cfg = _model_compression_cfg(model_cfg)
+
+    global_threshold = _float_or_default(global_cfg.get("threshold"), 0.50)
+    threshold_autoraised = None
+    if model_comp_cfg.get("threshold") is not None:
+        threshold = float(model_comp_cfg["threshold"])
+    else:
+        allow_codex_gpt55_autoraise = str(
+            global_cfg.get("codex_gpt55_autoraise", True)
+        ).strip().lower() in {"true", "1", "yes"}
+        threshold = _compression_threshold_for_model(
+            model,
+            provider,
+            allow_codex_gpt55_autoraise=allow_codex_gpt55_autoraise,
+        )
+        if threshold is None:
+            threshold = global_threshold
+        elif _is_codex_gpt55(model, provider) and threshold > global_threshold + 1e-9:
+            threshold_autoraised = {
+                "from": global_threshold,
+                "to": threshold,
+            }
+
+    target_ratio = _float_or_default(global_cfg.get("target_ratio"), 0.20)
+    if model_comp_cfg.get("target_ratio") is not None:
+        target_ratio = float(model_comp_cfg["target_ratio"])
+
+    return CompressionSettings(
+        threshold=threshold,
+        threshold_autoraised=threshold_autoraised,
+        target_ratio=target_ratio,
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11996,6 +11996,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
         ("model", "context_length"),
         ("model", "max_tokens"),
+        ("model", "compression"),
         ("compression", "enabled"),
         ("compression", "threshold"),
         ("compression", "target_ratio"),
@@ -12106,8 +12107,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``cache_keys`` is an optional flat dict of additional config values
         that should invalidate the cache when they change.  Callers pass
         the output of ``_extract_cache_busting_config(user_config)`` so
-        edits to model.context_length / compression.* in config.yaml are
-        picked up on the next gateway message without a manual restart.
+        edits to model.context_length / model.compression / compression.* in
+        config.yaml are picked up on the next gateway message without a manual
+        restart.
 
         ``user_id`` and ``user_id_alt`` are the runtime user identities
         carried by the current message's gateway source.  They participate

--- a/tests/agent/test_compression_config.py
+++ b/tests/agent/test_compression_config.py
@@ -1,0 +1,116 @@
+"""Tests for model-specific compression config overrides."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent.compression_config import resolve_compression_settings
+
+
+def test_global_compression_settings_remain_the_default() -> None:
+    settings = resolve_compression_settings(
+        model="claude-sonnet-4.6",
+        compression_cfg={"threshold": 0.42, "target_ratio": 0.30},
+        model_cfg={},
+    )
+
+    assert settings.threshold == 0.42
+    assert settings.target_ratio == 0.30
+
+
+def test_model_compression_overrides_global_threshold_and_target_ratio() -> None:
+    settings = resolve_compression_settings(
+        model="deepseek-v4-pro",
+        compression_cfg={"threshold": 0.50, "target_ratio": 0.20},
+        model_cfg={"compression": {"threshold": 0.15, "target_ratio": 0.25}},
+    )
+
+    assert settings.threshold == 0.15
+    assert settings.target_ratio == 0.25
+
+
+def test_hardcoded_model_threshold_still_applies_without_user_override() -> None:
+    settings = resolve_compression_settings(
+        model="arcee-ai/trinity-large-thinking",
+        provider="openrouter",
+        compression_cfg={"threshold": 0.50, "target_ratio": 0.20},
+        model_cfg={},
+    )
+
+    assert settings.threshold == 0.75
+    assert settings.threshold_autoraised is None
+    assert settings.target_ratio == 0.20
+
+
+def test_explicit_model_threshold_wins_over_hardcoded_model_default() -> None:
+    settings = resolve_compression_settings(
+        model="arcee-ai/trinity-large-thinking",
+        provider="openrouter",
+        compression_cfg={"threshold": 0.50, "target_ratio": 0.20},
+        model_cfg={"compression": {"threshold": 0.60}},
+    )
+
+    assert settings.threshold == 0.60
+    assert settings.threshold_autoraised is None
+    assert settings.target_ratio == 0.20
+
+
+def test_codex_gpt55_autoraise_is_preserved_for_codex_provider() -> None:
+    settings = resolve_compression_settings(
+        model="gpt-5.5",
+        provider="openai-codex",
+        compression_cfg={"threshold": 0.50, "target_ratio": 0.20},
+        model_cfg={},
+    )
+
+    assert settings.threshold == 0.85
+    assert settings.threshold_autoraised == {"from": 0.50, "to": 0.85}
+    assert settings.target_ratio == 0.20
+
+
+def test_model_threshold_override_suppresses_codex_gpt55_autoraise() -> None:
+    settings = resolve_compression_settings(
+        model="gpt-5.5",
+        provider="openai-codex",
+        compression_cfg={"threshold": 0.50, "target_ratio": 0.20},
+        model_cfg={"compression": {"threshold": 0.60}},
+    )
+
+    assert settings.threshold == 0.60
+    assert settings.threshold_autoraised is None
+    assert settings.target_ratio == 0.20
+
+
+def test_agent_init_passes_model_compression_settings_to_context_compressor() -> None:
+    from run_agent import AIAgent
+
+    compressor = MagicMock()
+    compressor.context_length = 1_000_000
+    compressor.threshold_tokens = 150_000
+    cfg = {
+        "model": {
+            "default": "deepseek-v4-pro",
+            "compression": {"threshold": 0.15, "target_ratio": 0.25},
+        },
+        "compression": {"threshold": 0.50, "target_ratio": 0.20},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.agent_init.ContextCompressor", return_value=compressor) as mock_compressor,
+    ):
+        AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="deepseek-v4-pro",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    kwargs = mock_compressor.call_args.kwargs
+    assert kwargs["threshold_percent"] == 0.15
+    assert kwargs["summary_target_ratio"] == 0.25

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -153,6 +153,34 @@ class TestAgentConfigSignature:
         )
         assert sig1 != sig2
 
+    def test_model_compression_change_busts_cache(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig1 = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"model.compression": {"threshold": 0.15, "target_ratio": 0.20}},
+        )
+        sig2 = GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+            cache_keys={"model.compression": {"threshold": 0.30, "target_ratio": 0.20}},
+        )
+        assert sig1 != sig2
+
+    def test_extract_cache_keys_reads_model_compression(self):
+        from gateway.run import GatewayRunner
+
+        keys = GatewayRunner._extract_cache_busting_config({
+            "model": {
+                "compression": {"threshold": 0.15, "target_ratio": 0.20},
+            },
+        })
+
+        assert keys["model.compression"] == {
+            "threshold": 0.15,
+            "target_ratio": 0.20,
+        }
+
     def test_compression_enabled_toggle_busts_cache(self):
         from gateway.run import GatewayRunner
 
@@ -342,11 +370,13 @@ class TestExtractCacheBustingConfig:
 
     def test_honcho_cache_busting_config_memoized_by_mtime(self, monkeypatch, tmp_path):
         """Repeated Honcho extraction for unchanged honcho.json should reuse parse result."""
+        import os
         from types import SimpleNamespace
         from gateway.run import GatewayRunner
 
         config_path = tmp_path / "honcho.json"
         config_path.write_text("{}")
+        initial_mtime_ns = config_path.stat().st_mtime_ns
         parse_calls = []
 
         class FakeConfig:
@@ -376,6 +406,8 @@ class TestExtractCacheBustingConfig:
         assert parse_calls == [config_path]
 
         config_path.write_text("{\n  \"changed\": true\n}")
+        stat = config_path.stat()
+        os.utime(config_path, ns=(stat.st_atime_ns, initial_mtime_ns + 1_000_000_000))
         third = GatewayRunner._extract_honcho_cache_busting_config()
 
         assert third == first


### PR DESCRIPTION
## Summary
- Add a small resolver for effective compression settings from global `compression` and nested `model.compression` config.
- Let `model.compression.threshold` override both the global threshold and built-in model defaults, while `model.compression.target_ratio` overrides the global target ratio.
- Include `model.compression` in the gateway agent cache signature so config edits rebuild cached agents.

Closes #37630.

## Tests
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m pytest tests/agent/test_compression_config.py tests/agent/test_arcee_trinity_overrides.py tests/gateway/test_agent_cache.py -q`
- `/Users/cornna/project/hermes-agent/.venv/bin/python -m ruff check agent/compression_config.py agent/agent_init.py gateway/run.py tests/agent/test_compression_config.py tests/gateway/test_agent_cache.py`
- `git diff --check`
