### PR TITLE
fix(tools): add raise_for_status for MiniMax t2a_v2 TTS path

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1261,6 +1261,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
     if is_t2a_v2:
         # t2a_v2 returns JSON with hex-encoded audio
+        response.raise_for_status()
         result = response.json()
         base_resp = result.get("base_resp", {})
         status_code = base_resp.get("status_code", -1)


### PR DESCRIPTION
## Problem

In `tools/tts_tool.py`, the MiniMax t2a_v2 TTS code path calls `response.json()` without first checking the HTTP status code. If the API returns HTTP 4xx/5xx with non-JSON content, `response.json()` raises an opaque `JSONDecodeError` instead of a clear `HTTPError`.

The non-t2a_v2 path already has `response.raise_for_status()` at line 1299.

## Fix

Add `response.raise_for_status()` before `response.json()` in the t2a_v2 path.

## Files Changed

- `tools/tts_tool.py` — 1 line added
