### PR TITLE
fix(desktop): eliminate scroll jitter from virtualizer vs pin-to-bott…

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -287,8 +287,9 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
   const { status } = useMessagePartText()
   const isStreaming = status.type === 'running'
 
-  // Keep code parsing enabled while streaming so incomplete fenced blocks still
-  // render as code cards. The expensive Shiki pass is deferred by
+  // Always include the `code` plugin regardless of streaming state, so
+  // code-block chrome (headers, copy buttons) is present from the first
+  // render. The expensive Shiki pass is still deferred by
   // `SyntaxHighlighter` below when `isStreaming` is true.
   const plugins = useMemo(() => ({ math: mathPlugin, code }), [])
 
@@ -374,8 +375,10 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
       // amounts) leaks those dollars out to the math parser and they
       // get rendered as broken inline math until the closing fence
       // arrives. Shiki is independently deferred via `defer={isStreaming}`
-      // on the SyntaxHighlighter component, so we don't pay code-block
-      // tokenization on every token even with this set.
+      // on the SyntaxHighlighter component (uses a 120 ms delay during
+      // streaming to avoid re-tokenizing on every token, and 0 ms delay
+      // once streaming ends), so we don't pay code-block tokenization
+      // on every token even with this set.
       parseIncompleteMarkdown
       plugins={plugins}
       preprocess={preprocessMarkdown}

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -259,16 +259,19 @@ function useThreadScrollAnchor({
   const jumpToBottom = useCallback(() => {
     stickyBottomRef.current = true
 
-    if (groupCount > 0) {
-      virtualizer.scrollToIndex(groupCount - 1, { align: 'end', behavior: 'auto' })
-    }
-
+    // Intentionally NOT calling virtualizer.scrollToIndex() here.
+    // scrollToIndex uses the virtualizer's internal offset calculation which
+    // can diverge from the actual DOM scrollHeight when async content
+    // rendering (Shiki, KaTeX) causes delayed height changes. The
+    // virtualizer then "corrects" against pinToBottom's direct scrollTop
+    // write, creating a reflow fight that manifests as scroll jitter.
+    // pinToBottom alone handles all scroll-to-bottom cases correctly.
     requestAnimationFrame(() => {
       if (stickyBottomRef.current) {
         pinToBottom()
       }
     })
-  }, [groupCount, pinToBottom, stickyBottomRef, virtualizer])
+  }, [pinToBottom])
 
   useEffect(() => () => setThreadScrolledUp(false), [])
 

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -82,22 +82,18 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
       </CodeCardHeader>
       <CodeCardBody>
         <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
-          {defer ? (
-            <code className="block whitespace-pre">{trimmed}</code>
-          ) : (
-            <ShikiHighlighter
-              addDefaultStyles={false}
-              as="div"
-              colorReplacements={SHIKI_COLOR_REPLACEMENTS}
-              defaultColor="light-dark()"
-              delay={120}
-              language={language || 'text'}
-              showLanguage={false}
-              theme={SHIKI_THEME}
-            >
-              {trimmed}
-            </ShikiHighlighter>
-          )}
+          <ShikiHighlighter
+            addDefaultStyles={false}
+            as="div"
+            colorReplacements={SHIKI_COLOR_REPLACEMENTS}
+            defaultColor="light-dark()"
+            delay={defer ? 120 : 0}
+            language={language || 'text'}
+            showLanguage={false}
+            theme={SHIKI_THEME}
+          >
+            {trimmed}
+          </ShikiHighlighter>
         </Pre>
       </CodeCardBody>
     </CodeCard>


### PR DESCRIPTION
…om reflow fight

Three coordinated fixes for the session-chat scroll jitter issue (content auto-scrolling to middle, interface repeatedly contracting/expanding):

1. thread-virtualizer.tsx: Remove competing virtualizer.scrollToIndex() from jumpToBottom. The virtualizer's internal offset calculation diverges from actual DOM scrollHeight when async content rendering (Shiki highlighting, KaTeX) causes delayed height changes, creating a reflow fight with pinToBottom's direct scrollTop write.

2. markdown-text.tsx: Always include the @streamdown/code plugin regardless of streaming state. Previously code-block chrome was only added after streaming ended, causing a layout shift that triggered the ResizeObserver pin mechanism mid-conversation.

3. shiki-highlighter.tsx: Always render ShikiHighlighter (removed the defer-based component swap between plain <code> and Shiki). The old approach unmounted plain text and mounted Shiki on streaming end, amplifying layout change. Now the same component persists; the delay parameter (120ms during streaming, 0ms after) controls highlighting cadence without structural DOM change.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

