### PR TITLE
fix(gateway): guard kanban dispatcher against malformed config and empty summaries

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5383,10 +5383,12 @@ class GatewayRunner:
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
                             if payload_summary:
-                                h = payload_summary.strip().splitlines()[0][:200]
+                                lines = payload_summary.strip().splitlines()
+                                h = lines[0][:200] if lines else payload_summary[:200]
                                 handoff = f"\n{h}"
                             elif task and task.result:
-                                r = task.result.strip().splitlines()[0][:160]
+                                lines = task.result.strip().splitlines()
+                                r = lines[0][:160] if lines else task.result[:160]
                                 handoff = f"\n{r}"
                             msg = (
                                 f"✔ {tag}Kanban {sub['task_id']} done"
@@ -5734,7 +5736,14 @@ class GatewayRunner:
             logger.warning("kanban dispatcher: kanban_db not importable; dispatcher disabled")
             return
 
-        interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
+        try:
+            interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
+        except (ValueError, TypeError):
+            logger.warning(
+                "kanban dispatcher: invalid dispatch_interval_seconds=%r, using default 60",
+                kanban_cfg.get("dispatch_interval_seconds"),
+            )
+            interval = 60.0
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
 
         # Read max_spawn config to limit concurrent kanban tasks


### PR DESCRIPTION
## Problem

Two error handling gaps in the gateway kanban dispatcher (`gateway/run.py`):

1. **Line 5737**: `float(kanban_cfg.get("dispatch_interval_seconds", 60))` crashes with `ValueError` if the config value is a non-numeric string (e.g. `dispatch_interval_seconds: "abc"` in config.yaml). This crashes the kanban dispatcher at gateway startup.

2. **Lines 5386, 5389**: `splitlines()[0]` on `payload_summary` and `task.result` raises `IndexError` when the string is whitespace-only. A string like `"  "` is truthy, but `.strip().splitlines()` returns `[]`, and `[0]` on an empty list crashes.

## Fix

1. Wrap `float()` in `try/except (ValueError, TypeError)`, falling back to the default 60-second interval with a warning log.

2. Guard `splitlines()[0]` by checking if the list is non-empty before indexing, with a fallback to the original string truncated.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `dispatch_interval_seconds: "abc"` | ValueError crash | Warning + default 60s |
| Whitespace-only kanban summary | IndexError crash | Fallback to truncated string |

## Files Changed

- `gateway/run.py` — 12 lines added, 3 lines removed



## Infographic

![kanban-dispatcher-hardening](https://v3b.fal.media/files/b/0a9cf264/fGQLFJHqdCXOUlQH5EI2C_WRgtFtrh.png)
