### PR TITLE
fix(gateway): avoid transcript rewrite on hygiene compression no-op

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -751,6 +751,30 @@ def _collect_auto_append_media_tags(
 
     return media_tags, has_voice_directive
 
+
+def _should_persist_hygiene_compression_result(
+    *,
+    old_session_id: str,
+    new_session_id: str,
+    original_messages: List[Dict[str, Any]],
+    compressed_messages: List[Dict[str, Any]],
+    compressor: Any,
+) -> bool:
+    """Return True when gateway hygiene actually produced a transcript update.
+
+    ``AIAgent._compress_context`` returns the input messages unchanged when
+    compression aborts or cannot acquire the per-session lock. Gateway hygiene
+    passes a filtered user/assistant transcript into that helper, so blindly
+    writing an unchanged result back to the active session can erase tool rows
+    and richer recent context from the canonical DB transcript.
+    """
+    if compressor is not None and getattr(compressor, "_last_compress_aborted", False):
+        return False
+    if new_session_id and new_session_id != old_session_id:
+        return True
+    return compressed_messages != original_messages
+
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -9177,42 +9201,27 @@ class GatewayRunner:
                                         ),
                                     )
 
+                                    _comp = getattr(_hyg_agent, "context_compressor", None)
+
                                     # _compress_context ends the old session and creates
                                     # a new session_id.  Write compressed messages into
                                     # the NEW session so the old transcript stays intact
                                     # and searchable via session_search.
                                     _hyg_new_sid = _hyg_agent.session_id
-                                    if _hyg_new_sid != session_entry.session_id:
+                                    _hyg_should_persist = _should_persist_hygiene_compression_result(
+                                        old_session_id=session_entry.session_id,
+                                        new_session_id=_hyg_new_sid,
+                                        original_messages=_hyg_msgs,
+                                        compressed_messages=_compressed,
+                                        compressor=_comp,
+                                    )
+
+                                    if _hyg_should_persist and _hyg_new_sid != session_entry.session_id:
                                         session_entry.session_id = _hyg_new_sid
                                         self.session_store._save()
                                         self._sync_telegram_topic_binding(
                                             source, session_entry,
                                             reason="hygiene-compression",
-                                        )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
-                                    # Reset stored token count — transcript was rewritten
-                                    session_entry.last_prompt_tokens = 0
-                                    history = _compressed
-                                    _new_count = len(_compressed)
-                                    _new_tokens = estimate_messages_tokens_rough(
-                                        _compressed
-                                    )
-
-                                    logger.info(
-                                        "Session hygiene: compressed %s → %s msgs, "
-                                        "~%s → ~%s tokens",
-                                        _msg_count, _new_count,
-                                        f"{_approx_tokens:,}", f"{_new_tokens:,}",
-                                    )
-
-                                    if _new_tokens >= _warn_token_threshold:
-                                        logger.warning(
-                                            "Session hygiene: still ~%s tokens after "
-                                            "compression",
-                                            f"{_new_tokens:,}",
                                         )
 
                                     # If summary generation failed, the
@@ -9224,7 +9233,6 @@ class GatewayRunner:
                                     # is "frozen" at the current size and can
                                     # /compress to retry or /reset to start
                                     # fresh.
-                                    _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
                                         _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
                                         _warn_msg = (
@@ -9243,6 +9251,31 @@ class GatewayRunner:
                                             logger.warning(
                                                 "Failed to deliver compression-failure warning to user: %s",
                                                 _werr,
+                                            )
+                                    elif _hyg_should_persist:
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                        # Reset stored token count — transcript was rewritten
+                                        session_entry.last_prompt_tokens = 0
+                                        history = _compressed
+                                        _new_count = len(_compressed)
+                                        _new_tokens = estimate_messages_tokens_rough(
+                                            _compressed
+                                        )
+
+                                        logger.info(
+                                            "Session hygiene: compressed %s → %s msgs, "
+                                            "~%s → ~%s tokens",
+                                            _msg_count, _new_count,
+                                            f"{_approx_tokens:,}", f"{_new_tokens:,}",
+                                        )
+
+                                        if _new_tokens >= _warn_token_threshold:
+                                            logger.warning(
+                                                "Session hygiene: still ~%s tokens after "
+                                                "compression",
+                                                f"{_new_tokens:,}",
                                             )
                                     # Separately: if the user's CONFIGURED aux
                                     # model failed and we recovered by falling

--- a/tests/gateway/test_hygiene_compression.py
+++ b/tests/gateway/test_hygiene_compression.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from gateway.run import _should_persist_hygiene_compression_result
+
+
+def test_hygiene_compression_abort_is_not_persisted():
+    """Aborted hygiene compression must not rewrite the canonical transcript."""
+    messages = [
+        {"role": "user", "content": "recent request"},
+        {"role": "assistant", "content": "recent answer"},
+    ]
+
+    assert not _should_persist_hygiene_compression_result(
+        old_session_id="sid-old",
+        new_session_id="sid-old",
+        original_messages=messages,
+        compressed_messages=messages,
+        compressor=SimpleNamespace(_last_compress_aborted=True),
+    )
+
+
+def test_hygiene_compression_unchanged_same_session_is_not_persisted():
+    messages = [
+        {"role": "user", "content": "recent request"},
+        {"role": "assistant", "content": "recent answer"},
+    ]
+
+    assert not _should_persist_hygiene_compression_result(
+        old_session_id="sid-old",
+        new_session_id="sid-old",
+        original_messages=messages,
+        compressed_messages=list(messages),
+        compressor=SimpleNamespace(_last_compress_aborted=False),
+    )
+
+
+def test_hygiene_compression_persists_rotated_session():
+    messages = [{"role": "user", "content": "old"}]
+
+    assert _should_persist_hygiene_compression_result(
+        old_session_id="sid-old",
+        new_session_id="sid-new",
+        original_messages=messages,
+        compressed_messages=messages,
+        compressor=SimpleNamespace(_last_compress_aborted=False),
+    )
+
+
+def test_hygiene_compression_persists_changed_same_session_result():
+    original = [{"role": "user", "content": "old"}]
+    compressed = [{"role": "user", "content": "summary\n\nrecent"}]
+
+    assert _should_persist_hygiene_compression_result(
+        old_session_id="sid-old",
+        new_session_id="sid-old",
+        original_messages=original,
+        compressed_messages=compressed,
+        compressor=SimpleNamespace(_last_compress_aborted=False),
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes gateway session hygiene so an aborted or unchanged context-compression attempt does not rewrite the active transcript. The hygiene path builds a filtered user/assistant-only message list before calling `_compress_context`; if compression fails or no-ops, persisting that filtered list can drop tool rows and richer recent context from the canonical session history, matching the reported memory loss after compression.

## Related Issue

Fixes #9413

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: Adds a hygiene-compression persistence guard and uses it before rotating session bindings or rewriting transcripts.
- `tests/gateway/test_hygiene_compression.py`: Covers aborted compression, unchanged same-session no-ops, rotated continuations, and changed same-session results.

## How to Test

1. `$VIRTUAL_ENV/bin/python -m pytest tests/gateway/test_hygiene_compression.py -q`
2. `$VIRTUAL_ENV/bin/python -m pytest tests/acp/test_approval_isolation.py tests/gateway/test_hygiene_compression.py -q --timeout=60`
3. `BASE=$(git merge-base origin/main HEAD); CHANGED_PY=$( { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u ); NEW_PY=$( { git diff --name-only --diff-filter=A "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u ); [ -n "$CHANGED_PY" ] && printf '%s\n' "$CHANGED_PY" | xargs $VIRTUAL_ENV/bin/ruff check; [ -n "$NEW_PY" ] && printf '%s\n' "$NEW_PY" | xargs $VIRTUAL_ENV/bin/ruff format --check`
4. `$VIRTUAL_ENV/bin/python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_hygiene_compression.py`
5. `git diff --check`
6. `$VIRTUAL_ENV/bin/python -m pytest tests/ -q -x --timeout=60` was attempted; it stopped at `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback` after 6 passes, 2 skips, and 57 deselected. That test is outside this gateway hygiene diff and passes both by itself and when run together with the new gateway tests, so this appears order-dependent/pre-existing rather than a regression from this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a gateway transcript persistence fix covered by unit tests.

<!-- autocontrib:worker-id=issue-new-b15b9679 kind=pr-open -->